### PR TITLE
Wrap tools with withToolLogging

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
@@ -67,7 +67,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_agent", agentLoopContext },
+      {
+        toolNameForMonitoring: "agent_management_create_agent",
+        agentLoopContext,
+      },
       async ({
         name,
         description,

--- a/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
@@ -4,10 +4,7 @@ import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { AgentCreationResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import {
-  makeInternalMCPServer,
-  makeMCPToolTextError,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import apiConfig from "@app/lib/api/config";
@@ -138,7 +135,8 @@ const createServer = (
           );
         }
 
-        const { agentConfiguration: agent, subAgentConfiguration } = result.value;
+        const { agentConfiguration: agent, subAgentConfiguration } =
+          result.value;
         const agentUrl = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/w/${owner.sId}/builder/agents/${agent.sId}`;
 
         // Prepare the structured output resource

--- a/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
@@ -2,16 +2,19 @@ import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { AgentCreationResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   makeInternalMCPServer,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+import { Err, Ok } from "@app/types";
 
 const createServer = (
   auth: Authenticator,
@@ -65,99 +68,104 @@ const createServer = (
           "An emoji character to use as the sub-agent's avatar (e.g., '🤔'). If not provided, defaults to '🤖'"
         ),
     },
-    async ({
-      name,
-      description,
-      instructions,
-      emoji,
-      sub_agent_name,
-      sub_agent_description,
-      sub_agent_instructions,
-      sub_agent_emoji,
-    }) => {
-      const owner = auth.workspace();
-      if (!owner) {
-        return makeMCPToolTextError("Workspace not found");
-      }
-
-      const user = auth.user();
-      if (!user) {
-        return makeMCPToolTextError("User not found");
-      }
-
-      if (sub_agent_instructions) {
-        if (!sub_agent_name || sub_agent_name.trim() === "") {
-          return makeMCPToolTextError(
-            "sub_agent_name is required when sub_agent_instructions is provided"
-          );
-        }
-        if (!sub_agent_description || sub_agent_description.trim() === "") {
-          return makeMCPToolTextError(
-            "sub_agent_description is required when sub_agent_instructions is provided"
-          );
-        }
-      }
-
-      const prodCredentials = await prodAPICredentialsForOwner(owner);
-      const api = new DustAPI(
-        apiConfig.getDustAPIConfig(),
-        {
-          ...prodCredentials,
-          extraHeaders: {
-            // Needed to add the user as editor of the agent.
-            "x-api-user-email": user.email,
-          },
-        },
-        logger
-      );
-
-      const result = await api.createGenericAgentConfiguration({
+    withToolLogging(
+      auth,
+      { toolName: "create_agent", agentLoopContext },
+      async ({
         name,
         description,
         instructions,
         emoji,
-        subAgentName: sub_agent_name,
-        subAgentDescription: sub_agent_description,
-        subAgentInstructions: sub_agent_instructions,
-        subAgentEmoji: sub_agent_emoji,
-      });
+        sub_agent_name,
+        sub_agent_description,
+        sub_agent_instructions,
+        sub_agent_emoji,
+      }) => {
+        const owner = auth.workspace();
+        if (!owner) {
+          return new Err(new MCPError("Workspace not found"));
+        }
 
-      if (result.isErr()) {
-        return makeMCPToolTextError(
-          `Failed to create agent: ${result.error.message}`
+        const user = auth.user();
+        if (!user) {
+          return new Err(new MCPError("User not found"));
+        }
+
+        if (sub_agent_instructions) {
+          if (!sub_agent_name || sub_agent_name.trim() === "") {
+            return new Err(
+              new MCPError(
+                "sub_agent_name is required when sub_agent_instructions is provided"
+              )
+            );
+          }
+          if (!sub_agent_description || sub_agent_description.trim() === "") {
+            return new Err(
+              new MCPError(
+                "sub_agent_description is required when sub_agent_instructions is provided"
+              )
+            );
+          }
+        }
+
+        const prodCredentials = await prodAPICredentialsForOwner(owner);
+        const api = new DustAPI(
+          apiConfig.getDustAPIConfig(),
+          {
+            ...prodCredentials,
+            extraHeaders: {
+              // Needed to add the user as editor of the agent.
+              "x-api-user-email": user.email,
+            },
+          },
+          logger
         );
-      }
 
-      const { agentConfiguration: agent, subAgentConfiguration } = result.value;
-      const agentUrl = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/w/${owner.sId}/builder/agents/${agent.sId}`;
+        const result = await api.createGenericAgentConfiguration({
+          name,
+          description,
+          instructions,
+          emoji,
+          subAgentName: sub_agent_name,
+          subAgentDescription: sub_agent_description,
+          subAgentInstructions: sub_agent_instructions,
+          subAgentEmoji: sub_agent_emoji,
+        });
 
-      // Prepare the structured output resource
-      const agentCreationResource: AgentCreationResultResourceType = {
-        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_CREATION_RESULT,
-        text: `Created agent: ${name}`,
-        uri: agentUrl,
-        mainAgent: {
-          id: agent.sId,
-          name: name,
-          description: description,
-          pictureUrl: agent.pictureUrl,
-          url: agentUrl,
-        },
-        subAgent: subAgentConfiguration
-          ? {
-              id: subAgentConfiguration.sId,
-              name: subAgentConfiguration.name,
-              description: subAgentConfiguration.description,
-              pictureUrl: subAgentConfiguration.pictureUrl,
-              url: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/w/${owner.sId}/builder/agents/${subAgentConfiguration.sId}`,
-            }
-          : undefined,
-      };
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Failed to create agent: ${result.error.message}`)
+          );
+        }
 
-      // Return both structured data and a text message
-      return {
-        isError: false,
-        content: [
+        const { agentConfiguration: agent, subAgentConfiguration } = result.value;
+        const agentUrl = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/w/${owner.sId}/builder/agents/${agent.sId}`;
+
+        // Prepare the structured output resource
+        const agentCreationResource: AgentCreationResultResourceType = {
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_CREATION_RESULT,
+          text: `Created agent: ${name}`,
+          uri: agentUrl,
+          mainAgent: {
+            id: agent.sId,
+            name: name,
+            description: description,
+            pictureUrl: agent.pictureUrl,
+            url: agentUrl,
+          },
+          subAgent: subAgentConfiguration
+            ? {
+                id: subAgentConfiguration.sId,
+                name: subAgentConfiguration.name,
+                description: subAgentConfiguration.description,
+                pictureUrl: subAgentConfiguration.pictureUrl,
+                url: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/w/${owner.sId}/builder/agents/${subAgentConfiguration.sId}`,
+              }
+            : undefined,
+        };
+
+        // Return both structured data and a text message
+        return new Ok([
           {
             type: "resource" as const,
             resource: agentCreationResource,
@@ -171,9 +179,9 @@ const createServer = (
               (sub_agent_name ? `\n- Run @${sub_agent_name} sub-agent` : "") +
               `\n\nView and edit it at: ${agentUrl}`,
           },
-        ],
-      };
-    }
+        ]);
+      }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
@@ -67,7 +67,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "create_agent", agentLoopContext },
+      { toolNameForMonitoring: "create_agent", agentLoopContext },
       async ({
         name,
         description,

--- a/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
@@ -2,13 +2,10 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import assert from "assert";
 import { z } from "zod";
 
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
-import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
-import { Err, Ok } from "@app/types";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 
 const createServer = (
@@ -64,15 +61,17 @@ const createServer = (
         // shared_across_users:
         //   ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN],
       },
-      withToolLogging(
-        auth,
-        { toolName: "memory_not_available", agentLoopContext },
-        async () => {
-          return new Err(
-            new MCPError("No user memory available as there is no user authenticated.")
-          );
-        }
-      )
+      async () => {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "No user memory available as there is no user authenticated.",
+            },
+          ],
+        };
+      }
     );
     return server;
   }
@@ -113,23 +112,19 @@ const createServer = (
       // shared_across_users:
       //   ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN],
     },
-    withToolLogging(
-      auth,
-      { toolName: "retrieve", agentLoopContext },
-      async () => {
-        assert(
-          agentLoopContext?.runContext,
-          "agentLoopContext is required to run the memory retrieve tool"
-        );
-        const { agentConfiguration } = agentLoopContext.runContext;
+    async () => {
+      assert(
+        agentLoopContext?.runContext,
+        "agentLoopContext is required to run the memory retrieve tool"
+      );
+      const { agentConfiguration } = agentLoopContext.runContext;
 
-        const memory = await AgentMemoryResource.retrieveMemory(auth, {
-          agentConfiguration,
-          user: user.toJSON(),
-        });
-        return new Ok(renderMemory(memory).content);
-      }
-    )
+      const memory = await AgentMemoryResource.retrieveMemory(auth, {
+        agentConfiguration,
+        user: user.toJSON(),
+      });
+      return renderMemory(memory);
+    }
   );
 
   server.tool(
@@ -142,24 +137,20 @@ const createServer = (
         .array(z.string())
         .describe("The array of new memory entries to record."),
     },
-    withToolLogging(
-      auth,
-      { toolName: "record_entries", agentLoopContext },
-      async ({ entries }) => {
-        assert(
-          agentLoopContext?.runContext,
-          "agentLoopContext is required to run the memory record_entries tool"
-        );
-        const { agentConfiguration } = agentLoopContext.runContext;
+    async ({ entries }) => {
+      assert(
+        agentLoopContext?.runContext,
+        "agentLoopContext is required to run the memory record_entries tool"
+      );
+      const { agentConfiguration } = agentLoopContext.runContext;
 
-        const memory = await AgentMemoryResource.recordEntries(auth, {
-          agentConfiguration,
-          user: user.toJSON(),
-          entries,
-        });
-        return new Ok(renderMemory(memory).content);
-      }
-    )
+      const memory = await AgentMemoryResource.recordEntries(auth, {
+        agentConfiguration,
+        user: user.toJSON(),
+        entries,
+      });
+      return renderMemory(memory);
+    }
   );
 
   server.tool(
@@ -172,24 +163,20 @@ const createServer = (
         .array(z.number())
         .describe("The indexes of the memory entries to erase."),
     },
-    withToolLogging(
-      auth,
-      { toolName: "erase_entries", agentLoopContext },
-      async ({ indexes }) => {
-        assert(
-          agentLoopContext?.runContext,
-          "agentLoopContext is required to run the memory erase_entries tool"
-        );
-        const { agentConfiguration } = agentLoopContext.runContext;
+    async ({ indexes }) => {
+      assert(
+        agentLoopContext?.runContext,
+        "agentLoopContext is required to run the memory erase_entries tool"
+      );
+      const { agentConfiguration } = agentLoopContext.runContext;
 
-        const memory = await AgentMemoryResource.eraseEntries(auth, {
-          agentConfiguration,
-          user: user.toJSON(),
-          indexes,
-        });
-        return new Ok(renderMemory(memory).content);
-      }
-    )
+      const memory = await AgentMemoryResource.eraseEntries(auth, {
+        agentConfiguration,
+        user: user.toJSON(),
+        indexes,
+      });
+      return renderMemory(memory);
+    }
   );
 
   server.tool(
@@ -211,24 +198,20 @@ const createServer = (
         )
         .describe("The array of memory entries to edit."),
     },
-    withToolLogging(
-      auth,
-      { toolName: "edit_entries", agentLoopContext },
-      async ({ edits }) => {
-        assert(
-          agentLoopContext?.runContext,
-          "agentLoopContext is required to run the memory edit_entries tool"
-        );
-        const { agentConfiguration } = agentLoopContext.runContext;
+    async ({ edits }) => {
+      assert(
+        agentLoopContext?.runContext,
+        "agentLoopContext is required to run the memory edit_entries tool"
+      );
+      const { agentConfiguration } = agentLoopContext.runContext;
 
-        const memory = await AgentMemoryResource.editEntries(auth, {
-          agentConfiguration,
-          user: user.toJSON(),
-          edits,
-        });
-        return new Ok(renderMemory(memory).content);
-      }
-    )
+      const memory = await AgentMemoryResource.editEntries(auth, {
+        agentConfiguration,
+        user: user.toJSON(),
+        edits,
+      });
+      return renderMemory(memory);
+    }
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
@@ -1,12 +1,17 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
+import type { MCPError } from "@app/lib/actions/mcp_errors";
 import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 const createServer = (
   auth: Authenticator,
@@ -78,31 +83,22 @@ const createServer = (
 
   const renderMemory = (
     memory: { lastUpdated: Date; content: string }[]
-  ): {
-    isError: boolean;
-    content: { type: "text"; text: string }[];
-  } => {
+  ): Result<CallToolResult["content"], MCPError> => {
     if (memory.length === 0) {
-      return {
-        isError: false,
-        content: [
-          {
-            type: "text",
-            text: "(memory empty)",
-          },
-        ],
-      };
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "(memory empty)",
+        },
+      ]);
     }
 
-    return {
-      isError: false,
-      content: [
-        {
-          type: "text",
-          text: memory.map((entry, i) => `[${i}] ${entry.content}`).join("\n"),
-        },
-      ],
-    };
+    return new Ok([
+      {
+        type: "text" as const,
+        text: memory.map((entry, i) => `[${i}] ${entry.content}`).join("\n"),
+      },
+    ]);
   };
 
   server.tool(
@@ -112,19 +108,23 @@ const createServer = (
       // shared_across_users:
       //   ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN],
     },
-    async () => {
-      assert(
-        agentLoopContext?.runContext,
-        "agentLoopContext is required to run the memory retrieve tool"
-      );
-      const { agentConfiguration } = agentLoopContext.runContext;
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "agent_memory", agentLoopContext },
+      async () => {
+        assert(
+          agentLoopContext?.runContext,
+          "agentLoopContext is required to run the memory retrieve tool"
+        );
+        const { agentConfiguration } = agentLoopContext.runContext;
 
-      const memory = await AgentMemoryResource.retrieveMemory(auth, {
-        agentConfiguration,
-        user: user.toJSON(),
-      });
-      return renderMemory(memory);
-    }
+        const memory = await AgentMemoryResource.retrieveMemory(auth, {
+          agentConfiguration,
+          user: user.toJSON(),
+        });
+        return renderMemory(memory);
+      }
+    )
   );
 
   server.tool(
@@ -137,20 +137,24 @@ const createServer = (
         .array(z.string())
         .describe("The array of new memory entries to record."),
     },
-    async ({ entries }) => {
-      assert(
-        agentLoopContext?.runContext,
-        "agentLoopContext is required to run the memory record_entries tool"
-      );
-      const { agentConfiguration } = agentLoopContext.runContext;
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "agent_memory", agentLoopContext },
+      async ({ entries }) => {
+        assert(
+          agentLoopContext?.runContext,
+          "agentLoopContext is required to run the memory record_entries tool"
+        );
+        const { agentConfiguration } = agentLoopContext.runContext;
 
-      const memory = await AgentMemoryResource.recordEntries(auth, {
-        agentConfiguration,
-        user: user.toJSON(),
-        entries,
-      });
-      return renderMemory(memory);
-    }
+        const memory = await AgentMemoryResource.recordEntries(auth, {
+          agentConfiguration,
+          user: user.toJSON(),
+          entries,
+        });
+        return renderMemory(memory);
+      }
+    )
   );
 
   server.tool(
@@ -163,20 +167,24 @@ const createServer = (
         .array(z.number())
         .describe("The indexes of the memory entries to erase."),
     },
-    async ({ indexes }) => {
-      assert(
-        agentLoopContext?.runContext,
-        "agentLoopContext is required to run the memory erase_entries tool"
-      );
-      const { agentConfiguration } = agentLoopContext.runContext;
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "agent_memory", agentLoopContext },
+      async ({ indexes }) => {
+        assert(
+          agentLoopContext?.runContext,
+          "agentLoopContext is required to run the memory erase_entries tool"
+        );
+        const { agentConfiguration } = agentLoopContext.runContext;
 
-      const memory = await AgentMemoryResource.eraseEntries(auth, {
-        agentConfiguration,
-        user: user.toJSON(),
-        indexes,
-      });
-      return renderMemory(memory);
-    }
+        const memory = await AgentMemoryResource.eraseEntries(auth, {
+          agentConfiguration,
+          user: user.toJSON(),
+          indexes,
+        });
+        return renderMemory(memory);
+      }
+    )
   );
 
   server.tool(
@@ -198,20 +206,24 @@ const createServer = (
         )
         .describe("The array of memory entries to edit."),
     },
-    async ({ edits }) => {
-      assert(
-        agentLoopContext?.runContext,
-        "agentLoopContext is required to run the memory edit_entries tool"
-      );
-      const { agentConfiguration } = agentLoopContext.runContext;
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "agent_memory", agentLoopContext },
+      async ({ edits }) => {
+        assert(
+          agentLoopContext?.runContext,
+          "agentLoopContext is required to run the memory edit_entries tool"
+        );
+        const { agentConfiguration } = agentLoopContext.runContext;
 
-      const memory = await AgentMemoryResource.editEntries(auth, {
-        agentConfiguration,
-        user: user.toJSON(),
-        edits,
-      });
-      return renderMemory(memory);
-    }
+        const memory = await AgentMemoryResource.editEntries(auth, {
+          agentConfiguration,
+          user: user.toJSON(),
+          edits,
+        });
+        return renderMemory(memory);
+      }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
@@ -11,7 +11,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Ok } from "@app/types";
 
 const createServer = (
   auth: Authenticator,

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -4,10 +4,7 @@ import { z } from "zod";
 
 import { DEFAULT_AGENT_ROUTER_ACTION_NAME } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-  makeMCPToolTextError,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getSuggestedAgentsForContent } from "@app/lib/api/assistant/agent_suggestion";
@@ -37,51 +34,51 @@ const createServer = (
       auth,
       { toolName: LIST_ALL_AGENTS_TOOL_NAME, agentLoopContext },
       async () => {
-      const owner = auth.getNonNullableWorkspace();
-      const requestedGroupIds = auth.groups().map((g) => g.sId);
+        const owner = auth.getNonNullableWorkspace();
+        const requestedGroupIds = auth.groups().map((g) => g.sId);
 
-      const prodCredentials = await prodAPICredentialsForOwner(owner);
-      const api = new DustAPI(
-        apiConfig.getDustAPIConfig(),
-        {
-          ...prodCredentials,
-          extraHeaders: {
-            ...getHeaderFromGroupIds(requestedGroupIds),
+        const prodCredentials = await prodAPICredentialsForOwner(owner);
+        const api = new DustAPI(
+          apiConfig.getDustAPIConfig(),
+          {
+            ...prodCredentials,
+            extraHeaders: {
+              ...getHeaderFromGroupIds(requestedGroupIds),
+            },
           },
-        },
-        logger
-      );
+          logger
+        );
 
-      // We cannot call the internal getAgentConfigurations() here because it causes a circular dependency.
-      // Instead, we call the public API endpoint.
-      // Since this endpoint is using the workspace credentials we do not have the user and as a result
-      // we cannot use the "list" view, meaning we do not have the user's unpublished agents.
-      const res = await api.getAgentConfigurations({
-        view: "all",
-      });
-      if (res.isErr()) {
-        return new Err(new MCPError("Error fetching agent configurations"));
-      }
+        // We cannot call the internal getAgentConfigurations() here because it causes a circular dependency.
+        // Instead, we call the public API endpoint.
+        // Since this endpoint is using the workspace credentials we do not have the user and as a result
+        // we cannot use the "list" view, meaning we do not have the user's unpublished agents.
+        const res = await api.getAgentConfigurations({
+          view: "all",
+        });
+        if (res.isErr()) {
+          return new Err(new MCPError("Error fetching agent configurations"));
+        }
 
-      const agents = res.value;
-      const formattedAgents = agents.map((agent) => {
-        return {
-          name: agent.name,
-          mention: `:mention[${agent.name}]{sId=${agent.sId}}`,
-          description: agent.description,
-        };
-      });
+        const agents = res.value;
+        const formattedAgents = agents.map((agent) => {
+          return {
+            name: agent.name,
+            mention: `:mention[${agent.name}]{sId=${agent.sId}}`,
+            description: agent.description,
+          };
+        });
 
-      return new Ok([
-        {
-          type: "text",
-          text: "List of published agents successfully fetched",
-        },
-        {
-          type: "text",
-          text: JSON.stringify(formattedAgents),
-        },
-      ]);
+        return new Ok([
+          {
+            type: "text",
+            text: "List of published agents successfully fetched",
+          },
+          {
+            type: "text",
+            text: JSON.stringify(formattedAgents),
+          },
+        ]);
       }
     )
   );
@@ -99,72 +96,73 @@ const createServer = (
       auth,
       { toolName: SUGGEST_AGENTS_TOOL_NAME, agentLoopContext },
       async ({ userMessage }) => {
-      const owner = auth.getNonNullableWorkspace();
-      const requestedGroupIds = auth.groups().map((g) => g.sId);
+        const owner = auth.getNonNullableWorkspace();
+        const requestedGroupIds = auth.groups().map((g) => g.sId);
 
-      const prodCredentials = await prodAPICredentialsForOwner(owner);
-      const api = new DustAPI(
-        apiConfig.getDustAPIConfig(),
-        {
-          ...prodCredentials,
-          extraHeaders: {
-            ...getHeaderFromGroupIds(requestedGroupIds),
+        const prodCredentials = await prodAPICredentialsForOwner(owner);
+        const api = new DustAPI(
+          apiConfig.getDustAPIConfig(),
+          {
+            ...prodCredentials,
+            extraHeaders: {
+              ...getHeaderFromGroupIds(requestedGroupIds),
+            },
           },
-        },
-        logger
-      );
+          logger
+        );
 
-      // We cannot call the internal getAgentConfigurations() here because it causes a circular dependency.
-      // Instead, we call the public API endpoint.
-      // Since this endpoint is using the workspace credentials we do not have the user and as a result
-      // we cannot use the "list" view, meaning we do not have the user's unpublished agents.
-      const getAgentsRes = await api.getAgentConfigurations({
-        view: "all",
-      });
-      if (getAgentsRes.isErr()) {
-        return new Err(new MCPError("Error fetching agent configurations"));
-      }
-      const agents = getAgentsRes.value as LightAgentConfigurationType[];
+        // We cannot call the internal getAgentConfigurations() here because it causes a circular dependency.
+        // Instead, we call the public API endpoint.
+        // Since this endpoint is using the workspace credentials we do not have the user and as a result
+        // we cannot use the "list" view, meaning we do not have the user's unpublished agents.
+        const getAgentsRes = await api.getAgentConfigurations({
+          view: "all",
+        });
+        if (getAgentsRes.isErr()) {
+          return new Err(new MCPError("Error fetching agent configurations"));
+        }
+        const agents = getAgentsRes.value as LightAgentConfigurationType[];
 
-      const suggestedAgentsRes = await getSuggestedAgentsForContent(auth, {
-        agents,
-        content: userMessage,
-      });
-
-      if (suggestedAgentsRes.isErr()) {
-        return new Err(new MCPError(
-          `Error suggesting agents: ${suggestedAgentsRes.error}`
-        ));
-      }
-
-      const suggestedAgents = suggestedAgentsRes.value;
-      const formattedSuggestedAgents = suggestedAgents
-        .filter((agent) => agent.sId !== "dust")
-        .map((agent) => {
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          const instructions = agent.instructions || "";
-          const truncatedInstructions =
-            instructions.length > MAX_INSTRUCTIONS_LENGTH
-              ? instructions.slice(0, MAX_INSTRUCTIONS_LENGTH) + " (truncated)"
-              : instructions;
-
-          return {
-            mention: `:mention[${agent.name}]{sId=${agent.sId}}`,
-            description: agent.description,
-            instructions: truncatedInstructions,
-          };
+        const suggestedAgentsRes = await getSuggestedAgentsForContent(auth, {
+          agents,
+          content: userMessage,
         });
 
-      return new Ok([
-        {
-          type: "text",
-          text: "Suggested agents successfully fetched",
-        },
-        {
-          type: "text",
-          text: JSON.stringify(formattedSuggestedAgents),
-        },
-      ]);
+        if (suggestedAgentsRes.isErr()) {
+          return new Err(
+            new MCPError(`Error suggesting agents: ${suggestedAgentsRes.error}`)
+          );
+        }
+
+        const suggestedAgents = suggestedAgentsRes.value;
+        const formattedSuggestedAgents = suggestedAgents
+          .filter((agent) => agent.sId !== "dust")
+          .map((agent) => {
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            const instructions = agent.instructions || "";
+            const truncatedInstructions =
+              instructions.length > MAX_INSTRUCTIONS_LENGTH
+                ? instructions.slice(0, MAX_INSTRUCTIONS_LENGTH) +
+                  " (truncated)"
+                : instructions;
+
+            return {
+              mention: `:mention[${agent.name}]{sId=${agent.sId}}`,
+              description: agent.description,
+              instructions: truncatedInstructions,
+            };
+          });
+
+        return new Ok([
+          {
+            type: "text",
+            text: "Suggested agents successfully fetched",
+          },
+          {
+            type: "text",
+            text: JSON.stringify(formattedSuggestedAgents),
+          },
+        ]);
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -32,7 +32,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: LIST_ALL_AGENTS_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: "agent_router", agentLoopContext },
       async () => {
         const owner = auth.getNonNullableWorkspace();
         const requestedGroupIds = auth.groups().map((g) => g.sId);
@@ -94,7 +94,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SUGGEST_AGENTS_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: "agent_router", agentLoopContext },
       async ({ userMessage }) => {
         const owner = auth.getNonNullableWorkspace();
         const requestedGroupIds = auth.groups().map((g) => g.sId);

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -32,7 +32,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolName: LIST_ALL_AGENTS_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: LIST_ALL_AGENTS_TOOL_NAME, agentLoopContext },
       async () => {
         const owner = auth.getNonNullableWorkspace();
         const requestedGroupIds = auth.groups().map((g) => g.sId);
@@ -94,7 +94,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: SUGGEST_AGENTS_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: SUGGEST_AGENTS_TOOL_NAME, agentLoopContext },
       async ({ userMessage }) => {
         const owner = auth.getNonNullableWorkspace();
         const requestedGroupIds = auth.groups().map((g) => g.sId);

--- a/front/lib/actions/mcp_internal_actions/servers/confluence/confluence_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/confluence_api_helper.ts
@@ -113,7 +113,7 @@ export const withAuth = async ({
   }
 };
 
-export async function getConfluenceBaseUrl(
+async function getConfluenceBaseUrl(
   accessToken: string
 ): Promise<string | null> {
   const resourceInfo = await getConfluenceResourceInfo(accessToken);

--- a/front/lib/actions/mcp_internal_actions/servers/confluence/confluence_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/confluence_api_helper.ts
@@ -113,7 +113,7 @@ export const withAuth = async ({
   }
 };
 
-async function getConfluenceBaseUrl(
+export async function getConfluenceBaseUrl(
   accessToken: string
 ): Promise<string | null> {
   const resourceInfo = await getConfluenceResourceInfo(accessToken);

--- a/front/lib/actions/mcp_internal_actions/servers/confluence/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/server.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   createPage,
   getCurrentUser,
@@ -13,44 +12,29 @@ import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { Authenticator } from "@app/lib/auth";
-import { Err, normalizeError, Ok } from "@app/types";
 
-const createServer = (auth: Authenticator): McpServer => {
+const createServer = (): McpServer => {
   const server = makeInternalMCPServer("confluence");
 
   server.tool(
     "get_current_user",
     "Get information about the currently authenticated Confluence user including account ID, display name, and email.",
     {},
-    withToolLogging(
-      auth,
-      { toolName: "get_current_user" },
-      async (_, { authInfo }) => {
-        try {
-          const result = await withAuth({
-            action: async (baseUrl, accessToken) => {
-              const result = await getCurrentUser(baseUrl, accessToken);
-              if (result.isErr()) {
-                throw new Error(`Error getting current user: ${result.error}`);
-              }
-              return makeMCPToolJSONSuccess({
-                message: "Current user information retrieved successfully",
-                result: result.value,
-              });
-            },
-            authInfo,
+    async (_, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          const result = await getCurrentUser(baseUrl, accessToken);
+          if (result.isErr()) {
+            throw new Error(`Error getting current user: ${result.error}`);
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Current user information retrieved successfully",
+            result: result.value,
           });
-          return new Ok(result.content);
-        } catch (error) {
-          return new Err(
-            new MCPError(`Error: ${normalizeError(error).message}`)
-          );
-        }
-      }
-    )
-    )
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -71,36 +55,24 @@ const createServer = (auth: Authenticator): McpServer => {
         .optional()
         .describe("Number of results per page (default 25)"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_pages" },
-      async (params, { authInfo }) => {
-        try {
-          const result = await withAuth({
-            action: async (baseUrl, accessToken) => {
-              const result = await listPages(baseUrl, accessToken, params);
-              if (result.isErr()) {
-                throw new Error(`Error listing pages: ${result.error}`);
-              }
-              return makeMCPToolJSONSuccess({
-                message:
-                  result.value.results.length === 0
-                    ? "No pages found"
-                    : `Found ${result.value.results.length} page(s)`,
-                result: result.value,
-              });
-            },
-            authInfo,
+    async (params, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          const result = await listPages(baseUrl, accessToken, params);
+          if (result.isErr()) {
+            throw new Error(`Error listing pages: ${result.error}`);
+          }
+          return makeMCPToolJSONSuccess({
+            message:
+              result.value.results.length === 0
+                ? "No pages found"
+                : `Found ${result.value.results.length} page(s)`,
+            result: result.value,
           });
-          return new Ok(result.content);
-        } catch (error) {
-          return new Err(
-            new MCPError(`Error: ${normalizeError(error).message}`)
-          );
-        }
-      }
-    )
-    )
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -132,33 +104,21 @@ const createServer = (auth: Authenticator): McpServer => {
         .optional()
         .describe("Page body content"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "create_page" },
-      async (params, { authInfo }) => {
-        try {
-          const result = await withAuth({
-            action: async (baseUrl, accessToken) => {
-              const result = await createPage(baseUrl, accessToken, params);
-              if (result.isErr()) {
-                throw new Error(`Error creating page: ${result.error}`);
-              }
-              return makeMCPToolJSONSuccess({
-                message: "Page created successfully",
-                result: result.value,
-              });
-            },
-            authInfo,
+    async (params, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          const result = await createPage(baseUrl, accessToken, params);
+          if (result.isErr()) {
+            throw new Error(`Error creating page: ${result.error}`);
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Page created successfully",
+            result: result.value,
           });
-          return new Ok(result.content);
-        } catch (error) {
-          return new Err(
-            new MCPError(`Error: ${normalizeError(error).message}`)
-          );
-        }
-      }
-    )
-    )
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -204,33 +164,21 @@ const createServer = (auth: Authenticator): McpServer => {
         .optional()
         .describe("New parent page ID to move the page under"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "update_page" },
-      async (params, { authInfo }) => {
-        try {
-          const result = await withAuth({
-            action: async (baseUrl, accessToken) => {
-              const result = await updatePage(baseUrl, accessToken, params);
-              if (result.isErr()) {
-                throw new Error(`Error updating page: ${result.error}`);
-              }
-              return makeMCPToolJSONSuccess({
-                message: "Page updated successfully",
-                result: result.value,
-              });
-            },
-            authInfo,
+    async (params, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          const result = await updatePage(baseUrl, accessToken, params);
+          if (result.isErr()) {
+            throw new Error(`Error updating page: ${result.error}`);
+          }
+          return makeMCPToolJSONSuccess({
+            message: "Page updated successfully",
+            result: result.value,
           });
-          return new Ok(result.content);
-        } catch (error) {
-          return new Err(
-            new MCPError(`Error: ${normalizeError(error).message}`)
-          );
-        }
-      }
-    )
-    )
+        },
+        authInfo,
+      });
+    }
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -67,7 +67,7 @@ function createServer(
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
+        toolNameForMonitoring: "jit_include_file",
         agentLoopContext,
       },
       async ({ fileId }) => {
@@ -150,7 +150,7 @@ function createServer(
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
+        toolNameForMonitoring: "jit_list_files",
         agentLoopContext,
       },
       async () => {
@@ -221,7 +221,7 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "cat", agentLoopContext },
+      { toolNameForMonitoring: "jit_cat_file", agentLoopContext },
       async ({ fileId, offset, limit, grep }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(new MCPError("No conversation context available"));

--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -67,7 +67,7 @@ function createServer(
     withToolLogging(
       auth,
       {
-        toolName: DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
+        toolNameForMonitoring: DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
         agentLoopContext,
       },
       async ({ fileId }) => {
@@ -150,7 +150,7 @@ function createServer(
     withToolLogging(
       auth,
       {
-        toolName: DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
+        toolNameForMonitoring: DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
         agentLoopContext,
       },
       async () => {
@@ -221,7 +221,7 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolName: "cat", agentLoopContext },
+      { toolNameForMonitoring: "cat", agentLoopContext },
       async ({ fileId, offset, limit, grep }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(new MCPError("No conversation context available"));

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -396,7 +396,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: FILESYSTEM_FIND_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: FILESYSTEM_FIND_TOOL_NAME, agentLoopContext },
       async ({
         query,
         dataSources,
@@ -501,7 +501,7 @@ const createServer = (
       SearchToolInputSchema.shape,
       withToolLogging(
         auth,
-        { toolName: SEARCH_TOOL_NAME, agentLoopContext },
+        { toolNameForMonitoring: SEARCH_TOOL_NAME, agentLoopContext },
         async (params) => searchCallback(auth, agentLoopContext, params)
       )
     );
@@ -540,7 +540,7 @@ const createServer = (
       },
       withToolLogging(
         auth,
-        { toolName: SEARCH_TOOL_NAME, agentLoopContext },
+        { toolNameForMonitoring: SEARCH_TOOL_NAME, agentLoopContext },
         async (params) =>
           searchCallback(auth, agentLoopContext, params, {
             tagsIn: params.tagsIn,
@@ -565,7 +565,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
+        agentLoopContext,
+      },
       async ({ nodeId, dataSources }) => {
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
         const fetchResult = await getAgentDataSourceConfigurations(

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
@@ -78,7 +78,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
       async ({ nodeId, limit, nextPageCursor, dataSources }) => {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
@@ -181,7 +181,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
       async ({ query, rootNodeId, limit, nextPageCursor, dataSources }) => {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
@@ -257,7 +257,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
       async ({ dataSources, tableIds }) => {
         const dataSourceConfigurationsResult =
           await getAgentDataSourceConfigurations(
@@ -352,7 +352,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
       async ({ dataSources, tableIds, query, fileName }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(

--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -30,7 +30,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolName: "handoff", agentLoopContext },
+      { toolNameForMonitoring: "handoff", agentLoopContext },
       async () => {
         if (!agentLoopContext?.runContext) {
           return new Err(new MCPError("No conversation context available"));

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -223,10 +223,12 @@ const createServer = (
 
           return new Ok(content);
         } catch (e) {
-          return new Err(new MCPError(
-            `There was an error generating your file: ${normalizeError(e)}. ` +
-              "You may be able to get the desired result by chaining multiple conversions, look closely to the source format you use."
-          ));
+          return new Err(
+            new MCPError(
+              `There was an error generating your file: ${normalizeError(e)}. ` +
+                "You may be able to get the desired result by chaining multiple conversions, look closely to the source format you use."
+            )
+          );
         }
       }
     )
@@ -267,11 +269,11 @@ const createServer = (
         const extension = extname(file_name).replace(/^\./, "");
         if (!isValidOutputType(extension)) {
           return new Ok([
-              {
-                type: "text",
-                text: `The format ${extension} is not supported.`,
-              },
-            ]);
+            {
+              type: "text",
+              text: `The format ${extension} is not supported.`,
+            },
+          ]);
         }
 
         // If the format requires conversion and we have plain text content,
@@ -387,42 +389,44 @@ ${file_content
               const base64 = Buffer.from(buffer).toString("base64");
 
               return new Ok([
-                  {
-                    type: "resource" as const,
-                    resource: {
-                      name: file_name,
-                      blob: base64,
-                      text: "Your file was generated successfully.",
-                      mimeType: getContentTypeFromOutputFormat(extension),
-                      uri: "",
-                    },
+                {
+                  type: "resource" as const,
+                  resource: {
+                    name: file_name,
+                    blob: base64,
+                    text: "Your file was generated successfully.",
+                    mimeType: getContentTypeFromOutputFormat(extension),
+                    uri: "",
                   },
-                ]);
+                },
+              ]);
             }
           } catch (e) {
-            return new Err(new MCPError(
-              `There was an error generating your ${extension} file: ${normalizeError(
-                e
-              )}. ` +
-                `For complex conversions, consider using the convert_file_format tool instead.`
-            ));
+            return new Err(
+              new MCPError(
+                `There was an error generating your ${extension} file: ${normalizeError(
+                  e
+                )}. ` +
+                  `For complex conversions, consider using the convert_file_format tool instead.`
+              )
+            );
           }
         }
 
         // Basic case: we have a text-based format and we can generate the file directly.
         return new Ok([
-            {
-              type: "resource" as const,
-              // We return a base64 blob, it will be uploaded in MCPConfigurationServerRunner.run.
-              resource: {
-                name: file_name,
-                blob: Buffer.from(file_content).toString("base64"),
-                text: "Your file was generated successfully.",
-                mimeType: getContentTypeFromOutputFormat(extension),
-                uri: "",
-              },
+          {
+            type: "resource" as const,
+            // We return a base64 blob, it will be uploaded in MCPConfigurationServerRunner.run.
+            resource: {
+              name: file_name,
+              blob: Buffer.from(file_content).toString("base64"),
+              text: "Your file was generated successfully.",
+              mimeType: getContentTypeFromOutputFormat(extension),
+              uri: "",
             },
-          ]);
+          },
+        ]);
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -107,7 +107,7 @@ const createServer = (
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: "get_supported_source_formats_for_output_format",
+        toolNameForMonitoring: "file_generation",
         agentLoopContext,
       },
       async ({ output_format }) => {
@@ -166,7 +166,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "convert_file_format", agentLoopContext },
+      { toolNameForMonitoring: "file_generation", agentLoopContext },
       async ({ file_name, file_id_or_url, source_format, output_format }) => {
         if (!process.env.CONVERTAPI_API_KEY) {
           return new Err(new MCPError("Missing environment variable."));
@@ -259,7 +259,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "generate_file", agentLoopContext },
+      { toolNameForMonitoring: "file_generation", agentLoopContext },
       async ({ file_name, file_content, source_format = "text" }) => {
         if (!process.env.CONVERTAPI_API_KEY) {
           return new Err(new MCPError("Missing environment variable."));

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -107,7 +107,7 @@ const createServer = (
     withToolLogging(
       auth,
       {
-        toolName: "get_supported_source_formats_for_output_format",
+        toolNameForMonitoring: "get_supported_source_formats_for_output_format",
         agentLoopContext,
       },
       async ({ output_format }) => {
@@ -166,7 +166,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "convert_file_format", agentLoopContext },
+      { toolNameForMonitoring: "convert_file_format", agentLoopContext },
       async ({ file_name, file_id_or_url, source_format, output_format }) => {
         if (!process.env.CONVERTAPI_API_KEY) {
           return new Err(new MCPError("Missing environment variable."));
@@ -259,7 +259,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "generate_file", agentLoopContext },
+      { toolNameForMonitoring: "generate_file", agentLoopContext },
       async ({ file_name, file_content, source_format = "text" }) => {
         if (!process.env.CONVERTAPI_API_KEY) {
           return new Err(new MCPError("Missing environment variable."));

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -74,7 +74,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_issue" },
+      { toolNameForMonitoring: "github" },
       async ({ owner, repo, title, body, assignees, labels }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -124,7 +124,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_pull_request" },
+      { toolNameForMonitoring: "github" },
       async ({ owner, repo, pullNumber }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -439,7 +439,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_pull_request_review" },
+      { toolNameForMonitoring: "github" },
       async (
         { owner, repo, pullNumber, body, event, comments = [] },
         { authInfo }
@@ -489,7 +489,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_organization_projects" },
+      { toolNameForMonitoring: "github" },
       async ({ owner }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -631,7 +631,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "add_issue_to_project" },
+      { toolNameForMonitoring: "github" },
       async ({ owner, repo, issueNumber, projectId, field }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -743,7 +743,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "comment_on_issue" },
+      { toolNameForMonitoring: "github" },
       async ({ owner, repo, issueNumber, body }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -790,7 +790,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_issue" },
+      { toolNameForMonitoring: "github" },
       async ({ owner, repo, issueNumber }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -946,7 +946,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_issues" },
+      { toolNameForMonitoring: "github" },
       async (
         {
           owner,
@@ -1106,7 +1106,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_pull_requests" },
+      { toolNameForMonitoring: "github" },
       async (
         {
           owner,

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -74,7 +74,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_issue" },
+      { toolNameForMonitoring: "create_issue" },
       async ({ owner, repo, title, body, assignees, labels }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -124,7 +124,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_pull_request" },
+      { toolNameForMonitoring: "get_pull_request" },
       async ({ owner, repo, pullNumber }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -439,7 +439,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_pull_request_review" },
+      { toolNameForMonitoring: "create_pull_request_review" },
       async (
         { owner, repo, pullNumber, body, event, comments = [] },
         { authInfo }
@@ -489,7 +489,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "list_organization_projects" },
+      { toolNameForMonitoring: "list_organization_projects" },
       async ({ owner }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -631,7 +631,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "add_issue_to_project" },
+      { toolNameForMonitoring: "add_issue_to_project" },
       async ({ owner, repo, issueNumber, projectId, field }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -743,7 +743,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "comment_on_issue" },
+      { toolNameForMonitoring: "comment_on_issue" },
       async ({ owner, repo, issueNumber, body }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -790,7 +790,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_issue" },
+      { toolNameForMonitoring: "get_issue" },
       async ({ owner, repo, issueNumber }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -946,7 +946,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "list_issues" },
+      { toolNameForMonitoring: "list_issues" },
       async (
         {
           owner,
@@ -1106,7 +1106,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "list_pull_requests" },
+      { toolNameForMonitoring: "list_pull_requests" },
       async (
         {
           owner,

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -7,14 +7,15 @@ import type {
 import { fetch as undiciFetch, ProxyAgent } from "undici";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
-  makeMCPToolTextError,
   makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { isWorkspaceUsingStaticIP } from "@app/lib/misc";
-import { EnvironmentConfig, normalizeError } from "@app/types";
+import { EnvironmentConfig, Err, normalizeError, Ok } from "@app/types";
 
 const GITHUB_GET_PULL_REQUEST_ACTION_MAX_COMMITS = 32;
 
@@ -71,33 +72,41 @@ const createServer = (auth: Authenticator): McpServer => {
         .optional()
         .describe("Labels to associate with this issue."),
     },
-    async ({ owner, repo, title, body, assignees, labels }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
-
-      try {
-        const { data: issue } = await octokit.request(
-          "POST /repos/{owner}/{repo}/issues",
-          {
-            owner,
-            repo,
-            title,
-            body,
-            assignees,
-            labels,
-          }
-        );
-
-        return makeMCPToolTextSuccess({
-          message: `Issue created: #${issue.number}`,
+    withToolLogging(
+      auth,
+      { toolName: "create_issue" },
+      async ({ owner, repo, title, body, assignees, labels }, { authInfo }) => {
+        const octokit = await createOctokit(auth, {
+          accessToken: authInfo?.token,
         });
-      } catch (e) {
-        return makeMCPToolTextError(
-          `Error creating GitHub issue: ${normalizeError(e).message}`
-        );
+
+        try {
+          const { data: issue } = await octokit.request(
+            "POST /repos/{owner}/{repo}/issues",
+            {
+              owner,
+              repo,
+              title,
+              body,
+              assignees,
+              labels,
+            }
+          );
+
+          return new Ok(
+            makeMCPToolTextSuccess({
+              message: `Issue created: #${issue.number}`,
+            }).content
+          );
+        } catch (e) {
+          return new Err(
+            new MCPError(
+              `Error creating GitHub issue: ${normalizeError(e).message}`
+            )
+          );
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -113,13 +122,16 @@ const createServer = (auth: Authenticator): McpServer => {
       repo: z.string().describe("The name of the repository."),
       pullNumber: z.number().describe("The pull request number."),
     },
-    async ({ owner, repo, pullNumber }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+    withToolLogging(
+      auth,
+      { toolName: "get_pull_request" },
+      async ({ owner, repo, pullNumber }, { authInfo }) => {
+        const octokit = await createOctokit(auth, {
+          accessToken: authInfo?.token,
+        });
 
-      try {
-        const query = `
+        try {
+          const query = `
           query($owner: String!, $repo: String!, $pullNumber: Int!) {
             repository(owner: $owner, name: $repo) {
               pullRequest(number: $pullNumber) {
@@ -168,214 +180,221 @@ const createServer = (auth: Authenticator): McpServer => {
             }
           }`;
 
-        // Get the PR description and base/head commit
-        const pull = (await octokit.graphql(query, {
-          owner,
-          repo,
-          pullNumber,
-        })) as {
-          repository: {
-            pullRequest: {
-              title: string;
-              body: string;
-              commits: {
-                nodes: {
-                  commit: {
-                    oid: string;
-                    message: string;
-                    author: {
-                      user: {
-                        login: string;
+          // Get the PR description and base/head commit
+          const pull = (await octokit.graphql(query, {
+            owner,
+            repo,
+            pullNumber,
+          })) as {
+            repository: {
+              pullRequest: {
+                title: string;
+                body: string;
+                commits: {
+                  nodes: {
+                    commit: {
+                      oid: string;
+                      message: string;
+                      author: {
+                        user: {
+                          login: string;
+                        };
                       };
                     };
-                  };
-                }[];
-              };
-              comments: {
-                nodes: {
-                  author: {
-                    login: string;
-                  };
-                  body: string;
-                  createdAt: string;
-                }[];
-              };
-              reviews: {
-                nodes: {
-                  author: {
-                    login: string;
-                  };
-                  body: string;
-                  state: string;
-                  createdAt: string;
-                  comments: {
-                    nodes: {
-                      body: string;
-                      path: string;
-                      line: number;
-                    }[];
-                  };
-                }[];
+                  }[];
+                };
+                comments: {
+                  nodes: {
+                    author: {
+                      login: string;
+                    };
+                    body: string;
+                    createdAt: string;
+                  }[];
+                };
+                reviews: {
+                  nodes: {
+                    author: {
+                      login: string;
+                    };
+                    body: string;
+                    state: string;
+                    createdAt: string;
+                    comments: {
+                      nodes: {
+                        body: string;
+                        path: string;
+                        line: number;
+                      }[];
+                    };
+                  }[];
+                };
               };
             };
           };
-        };
 
-        const pullTitle = pull.repository.pullRequest.title;
-        const pullBody = pull.repository.pullRequest.body;
-        const pullCommits = pull.repository.pullRequest.commits.nodes.map(
-          (n) => {
-            return {
-              sha: n.commit.oid,
-              message: n.commit.message,
-              author: n.commit.author.user?.login || "unknown",
-            };
-          }
-        );
-        const pullComments = pull.repository.pullRequest.comments.nodes.map(
-          (n) => {
-            return {
-              createdAt: new Date(n.createdAt).getTime(),
-              author: n.author?.login || "unknown",
-              body: n.body,
-            };
-          }
-        );
-        const pullReviews = pull.repository.pullRequest.reviews.nodes.map(
-          (n) => {
-            return {
-              createdAt: new Date(n.createdAt).getTime(),
-              author: n.author?.login || "unknown",
-              body: n.body,
-              state: n.state,
-              comments: n.comments.nodes.map((c) => {
-                return {
-                  body: c.body,
-                  path: c.path,
-                  line: c.line,
-                };
-              }),
-            };
-          }
-        );
-
-        // Transforms the diff to inject positions for each lines in the sense of the github pull
-        // request review comments definition.
-        const diffWithPositions = (diff: string) => {
-          const lines = diff.split("\n");
-
-          // First pass: calculate global max position
-          let currentFile = null;
-          let position = 0;
-          let globalMaxPosition = 0;
-
-          for (const line of lines) {
-            if (line.startsWith("diff --git")) {
-              currentFile = null;
-              position = 0;
-              continue;
+          const pullTitle = pull.repository.pullRequest.title;
+          const pullBody = pull.repository.pullRequest.body;
+          const pullCommits = pull.repository.pullRequest.commits.nodes.map(
+            (n) => {
+              return {
+                sha: n.commit.oid,
+                message: n.commit.message,
+                author: n.commit.author.user?.login || "unknown",
+              };
             }
-
-            if (line.startsWith("@@")) {
-              position = 0;
-              continue;
+          );
+          const pullComments = pull.repository.pullRequest.comments.nodes.map(
+            (n) => {
+              return {
+                createdAt: new Date(n.createdAt).getTime(),
+                author: n.author?.login || "unknown",
+                body: n.body,
+              };
             }
-
-            if (currentFile !== null) {
-              position++;
-              globalMaxPosition = Math.max(position, globalMaxPosition);
-            } else if (line.startsWith("+++")) {
-              currentFile = line.substring(4).trim();
+          );
+          const pullReviews = pull.repository.pullRequest.reviews.nodes.map(
+            (n) => {
+              return {
+                createdAt: new Date(n.createdAt).getTime(),
+                author: n.author?.login || "unknown",
+                body: n.body,
+                state: n.state,
+                comments: n.comments.nodes.map((c) => {
+                  return {
+                    body: c.body,
+                    path: c.path,
+                    line: c.line,
+                  };
+                }),
+              };
             }
-          }
+          );
 
-          // Second pass: add positions with consistent space padding
-          const result = [];
-          currentFile = null;
-          position = 0;
-          const digits = globalMaxPosition.toString().length;
+          // Transforms the diff to inject positions for each lines in the sense of the github pull
+          // request review comments definition.
+          const diffWithPositions = (diff: string) => {
+            const lines = diff.split("\n");
 
-          for (const line of lines) {
-            if (line.startsWith("diff --git")) {
-              currentFile = null;
-              position = 0;
-              result.push(line);
-              continue;
-            }
+            // First pass: calculate global max position
+            let currentFile = null;
+            let position = 0;
+            let globalMaxPosition = 0;
 
-            if (currentFile !== null) {
-              const paddedPosition = position.toString().padStart(digits, " ");
-              if (line.startsWith("@@")) {
-                result.push(line);
-              } else {
-                result.push(`[${paddedPosition}] ${line}`);
+            for (const line of lines) {
+              if (line.startsWith("diff --git")) {
+                currentFile = null;
+                position = 0;
+                continue;
               }
-              position++;
-            } else {
-              result.push(line);
-              if (line.startsWith("+++")) {
+
+              if (line.startsWith("@@")) {
+                position = 0;
+                continue;
+              }
+
+              if (currentFile !== null) {
+                position++;
+                globalMaxPosition = Math.max(position, globalMaxPosition);
+              } else if (line.startsWith("+++")) {
                 currentFile = line.substring(4).trim();
               }
             }
-          }
 
-          return result.join("\n");
-        };
+            // Second pass: add positions with consistent space padding
+            const result = [];
+            currentFile = null;
+            position = 0;
+            const digits = globalMaxPosition.toString().length;
 
-        // Get the actual diff using REST API (not available in GraphQL)
-        const diff = await octokit.request(
-          "GET /repos/{owner}/{repo}/pulls/{pull_number}",
-          {
-            owner,
-            repo,
-            pull_number: pullNumber,
-            headers: {
-              Accept: "application/vnd.github.v3.diff",
-            },
-          }
-        );
-        // @ts-expect-error - data is a string when mediatType.format is `diff` (wrongly typed as
-        // their defauilt response type)
-        const pullDiff = diffWithPositions(diff.data as string);
+            for (const line of lines) {
+              if (line.startsWith("diff --git")) {
+                currentFile = null;
+                position = 0;
+                result.push(line);
+                continue;
+              }
 
-        const content =
-          `TITLE: ${pullTitle}\n\n` +
-          `BODY:\n` +
-          `${pullBody}\n\n` +
-          `COMMITS:\n` +
-          `${(pullCommits || [])
-            .map((c) => `${c.sha} ${c.author}: ${c.message}`)
-            .join("\n")}\n\n` +
-          `DIFF (lines are prepended by diff file positions):\n` +
-          `${pullDiff}\n\n` +
-          `COMMENTS:\n` +
-          `${(pullComments || [])
-            .map((c) => {
-              return `${c.author} [${new Date(c.createdAt).toISOString()}]:\n${c.body}`;
-            })
-            .join("\n")}\n\n` +
-          `REVIEWS:\n` +
-          `${(pullReviews || [])
-            .map(
-              (r) =>
-                `${r.author} [${new Date(r.createdAt).toISOString()}]:\n(${r.state})\n${r.body}\n${(
-                  r.comments || []
-                )
-                  .map((c) => ` - ${c.path}:${c.line}:\n${c.body}`)
-                  .join("\n")}`
+              if (currentFile !== null) {
+                const paddedPosition = position
+                  .toString()
+                  .padStart(digits, " ");
+                if (line.startsWith("@@")) {
+                  result.push(line);
+                } else {
+                  result.push(`[${paddedPosition}] ${line}`);
+                }
+                position++;
+              } else {
+                result.push(line);
+                if (line.startsWith("+++")) {
+                  currentFile = line.substring(4).trim();
+                }
+              }
+            }
+
+            return result.join("\n");
+          };
+
+          // Get the actual diff using REST API (not available in GraphQL)
+          const diff = await octokit.request(
+            "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+            {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              headers: {
+                Accept: "application/vnd.github.v3.diff",
+              },
+            }
+          );
+          // @ts-expect-error - data is a string when mediatType.format is `diff` (wrongly typed as
+          // their defauilt response type)
+          const pullDiff = diffWithPositions(diff.data as string);
+
+          const content =
+            `TITLE: ${pullTitle}\n\n` +
+            `BODY:\n` +
+            `${pullBody}\n\n` +
+            `COMMITS:\n` +
+            `${(pullCommits || [])
+              .map((c) => `${c.sha} ${c.author}: ${c.message}`)
+              .join("\n")}\n\n` +
+            `DIFF (lines are prepended by diff file positions):\n` +
+            `${pullDiff}\n\n` +
+            `COMMENTS:\n` +
+            `${(pullComments || [])
+              .map((c) => {
+                return `${c.author} [${new Date(c.createdAt).toISOString()}]:\n${c.body}`;
+              })
+              .join("\n")}\n\n` +
+            `REVIEWS:\n` +
+            `${(pullReviews || [])
+              .map(
+                (r) =>
+                  `${r.author} [${new Date(r.createdAt).toISOString()}]:\n(${r.state})\n${r.body}\n${(
+                    r.comments || []
+                  )
+                    .map((c) => ` - ${c.path}:${c.line}:\n${c.body}`)
+                    .join("\n")}`
+              )
+              .join("\n")}`;
+
+          return new Ok(
+            makeMCPToolTextSuccess({
+              message: `Retrieved pull request #${pullNumber}`,
+              result: content,
+            }).content
+          );
+        } catch (e) {
+          return new Err(
+            new MCPError(
+              `Error retrieving GitHub pull request: ${normalizeError(e).message}`
             )
-            .join("\n")}`;
-
-        return makeMCPToolTextSuccess({
-          message: `Retrieved pull request #${pullNumber}`,
-          result: content,
-        });
-      } catch (e) {
-        return makeMCPToolTextError(
-          `Error retrieving GitHub pull request: ${normalizeError(e).message}`
-        );
+          );
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -418,36 +437,44 @@ const createServer = (auth: Authenticator): McpServer => {
         .describe("File comments to leave as part of the review.")
         .optional(),
     },
-    async (
-      { owner, repo, pullNumber, body, event, comments = [] },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
-
-      try {
-        const { data: review } = await octokit.request(
-          "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
-          {
-            owner,
-            repo,
-            pull_number: pullNumber,
-            body,
-            event,
-            comments,
-          }
-        );
-
-        return makeMCPToolTextSuccess({
-          message: `Review created with ID ${review.id}`,
+    withToolLogging(
+      auth,
+      { toolName: "create_pull_request_review" },
+      async (
+        { owner, repo, pullNumber, body, event, comments = [] },
+        { authInfo }
+      ) => {
+        const octokit = await createOctokit(auth, {
+          accessToken: authInfo?.token,
         });
-      } catch (e) {
-        return makeMCPToolTextError(
-          `Error reviewing GitHub pull request: ${normalizeError(e).message}`
-        );
+
+        try {
+          const { data: review } = await octokit.request(
+            "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+            {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              body,
+              event,
+              comments,
+            }
+          );
+
+          return new Ok(
+            makeMCPToolTextSuccess({
+              message: `Review created with ID ${review.id}`,
+            }).content
+          );
+        } catch (e) {
+          return new Err(
+            new MCPError(
+              `Error reviewing GitHub pull request: ${normalizeError(e).message}`
+            )
+          );
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -460,13 +487,16 @@ const createServer = (auth: Authenticator): McpServer => {
           "The owner of the repository (account or organization name)."
         ),
     },
-    async ({ owner }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+    withToolLogging(
+      auth,
+      { toolName: "list_organization_projects" },
+      async ({ owner }, { authInfo }) => {
+        const octokit = await createOctokit(auth, {
+          accessToken: authInfo?.token,
+        });
 
-      try {
-        const projectsQuery = `
+        try {
+          const projectsQuery = `
         query($owner: String!) {
           organization(login: $owner) {
             projectsV2(first: 100) {
@@ -493,71 +523,78 @@ const createServer = (auth: Authenticator): McpServer => {
           }
         }`;
 
-        const results = (await octokit.graphql(projectsQuery, {
-          owner,
-        })) as {
-          organization: {
-            projectsV2: {
-              nodes: {
-                id: string;
-                title: string;
-                shortDescription: string | null;
-                url: string;
-                closed: boolean;
-                fields: {
-                  nodes: {
-                    id: string;
-                    name: string;
-                    options: {
+          const results = (await octokit.graphql(projectsQuery, {
+            owner,
+          })) as {
+            organization: {
+              projectsV2: {
+                nodes: {
+                  id: string;
+                  title: string;
+                  shortDescription: string | null;
+                  url: string;
+                  closed: boolean;
+                  fields: {
+                    nodes: {
                       id: string;
                       name: string;
+                      options: {
+                        id: string;
+                        name: string;
+                      }[];
                     }[];
-                  }[];
-                };
-              }[];
+                  };
+                }[];
+              };
             };
           };
-        };
 
-        const projects = results.organization.projectsV2.nodes
-          .filter((project: any) => !project.closed)
-          .map((project) => ({
-            ...project,
-            fields: {
-              nodes: project.fields.nodes.filter((n) => n.id),
-            },
-          }));
+          const projects = results.organization.projectsV2.nodes
+            .filter((project: any) => !project.closed)
+            .map((project) => ({
+              ...project,
+              fields: {
+                nodes: project.fields.nodes.filter((n) => n.id),
+              },
+            }));
 
-        let content = "";
-        projects.forEach((project) => {
-          content +=
-            `project='${project.title}' node_id=${project.id} ` +
-            `description='${project.shortDescription}'\n`;
-          project.fields.nodes.forEach((field) => {
-            content += `  field='${field.name}' node_id=${field.id}\n`;
-            field.options.forEach((o) => {
-              content += `    option='${o.name}' node_id=${o.id}\n`;
+          let content = "";
+          projects.forEach((project) => {
+            content +=
+              `project='${project.title}' node_id=${project.id} ` +
+              `description='${project.shortDescription}'\n`;
+            project.fields.nodes.forEach((field) => {
+              content += `  field='${field.name}' node_id=${field.id}\n`;
+              field.options.forEach((o) => {
+                content += `    option='${o.name}' node_id=${o.id}\n`;
+              });
             });
+            content += "\n";
           });
-          content += "\n";
-        });
 
-        if (!content) {
-          return makeMCPToolTextSuccess({
-            message: "No open projects found",
-          });
+          if (!content) {
+            return new Ok(
+              makeMCPToolTextSuccess({
+                message: "No open projects found",
+              }).content
+            );
+          }
+
+          return new Ok(
+            makeMCPToolTextSuccess({
+              message: `Retrieved ${projects.length} open projects`,
+              result: content,
+            }).content
+          );
+        } catch (e) {
+          return new Err(
+            new MCPError(
+              `Error retrieving GitHub repository projects: ${normalizeError(e).message}`
+            )
+          );
         }
-
-        return makeMCPToolTextSuccess({
-          message: `Retrieved ${projects.length} open projects`,
-          result: content,
-        });
-      } catch (e) {
-        return makeMCPToolTextError(
-          `Error retrieving GitHub repository projects: ${normalizeError(e).message}`
-        );
       }
-    }
+    )
   );
 
   server.tool(
@@ -592,14 +629,17 @@ const createServer = (auth: Authenticator): McpServer => {
           "Optional field configuration with both fieldId and optionId required if provided."
         ),
     },
-    async ({ owner, repo, issueNumber, projectId, field }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+    withToolLogging(
+      auth,
+      { toolName: "add_issue_to_project" },
+      async ({ owner, repo, issueNumber, projectId, field }, { authInfo }) => {
+        const octokit = await createOctokit(auth, {
+          accessToken: authInfo?.token,
+        });
 
-      try {
-        // First, get the issue's node ID using GraphQL.
-        const issueQuery = `
+        try {
+          // First, get the issue's node ID using GraphQL.
+          const issueQuery = `
         query($owner: String!, $repo: String!, $issueNumber: Int!) {
           repository(owner: $owner, name: $repo) {
             issue(number: $issueNumber) {
@@ -608,20 +648,20 @@ const createServer = (auth: Authenticator): McpServer => {
           }
         }`;
 
-        const issue = (await octokit.graphql(issueQuery, {
-          owner,
-          repo,
-          issueNumber,
-        })) as {
-          repository: {
-            issue: {
-              id: string;
+          const issue = (await octokit.graphql(issueQuery, {
+            owner,
+            repo,
+            issueNumber,
+          })) as {
+            repository: {
+              issue: {
+                id: string;
+              };
             };
           };
-        };
 
-        // Add the issue to the project using GraphQL mutation.
-        const addToProjectMutation = `
+          // Add the issue to the project using GraphQL mutation.
+          const addToProjectMutation = `
           mutation($projectId: ID!, $contentId: ID!) {
             addProjectV2ItemById(input: {
               projectId: $projectId
@@ -633,20 +673,20 @@ const createServer = (auth: Authenticator): McpServer => {
             }
           }`;
 
-        const item = (await octokit.graphql(addToProjectMutation, {
-          projectId,
-          contentId: issue.repository.issue.id,
-        })) as {
-          addProjectV2ItemById: {
-            item: {
-              id: string;
+          const item = (await octokit.graphql(addToProjectMutation, {
+            projectId,
+            contentId: issue.repository.issue.id,
+          })) as {
+            addProjectV2ItemById: {
+              item: {
+                id: string;
+              };
             };
           };
-        };
 
-        if (field) {
-          // Mutation to update the field value to specified option.
-          const updateFieldMutation = `
+          if (field) {
+            // Mutation to update the field value to specified option.
+            const updateFieldMutation = `
           mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String) {
             updateProjectV2ItemFieldValue(input: {
               projectId: $projectId,
@@ -662,23 +702,28 @@ const createServer = (auth: Authenticator): McpServer => {
             }
           }`;
 
-          await octokit.graphql(updateFieldMutation, {
-            projectId,
-            itemId: item.addProjectV2ItemById.item.id,
-            fieldId: field.fieldId,
-            optionId: field.optionId,
-          });
-        }
+            await octokit.graphql(updateFieldMutation, {
+              projectId,
+              itemId: item.addProjectV2ItemById.item.id,
+              fieldId: field.fieldId,
+              optionId: field.optionId,
+            });
+          }
 
-        return makeMCPToolTextSuccess({
-          message: `Issue #${issueNumber} added to project`,
-        });
-      } catch (e) {
-        return makeMCPToolTextError(
-          `Error adding GitHub issue to project: ${normalizeError(e).message}`
-        );
+          return new Ok(
+            makeMCPToolTextSuccess({
+              message: `Issue #${issueNumber} added to project`,
+            }).content
+          );
+        } catch (e) {
+          return new Err(
+            new MCPError(
+              `Error adding GitHub issue to project: ${normalizeError(e).message}`
+            )
+          );
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -696,31 +741,39 @@ const createServer = (auth: Authenticator): McpServer => {
         .string()
         .describe("The contents of the comment (GitHub markdown)."),
     },
-    async ({ owner, repo, issueNumber, body }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
-
-      try {
-        const { data: comment } = await octokit.request(
-          "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-          {
-            owner,
-            repo,
-            issue_number: issueNumber,
-            body,
-          }
-        );
-
-        return makeMCPToolTextSuccess({
-          message: `Comment added to issue #${issueNumber} with ID ${comment.id}`,
+    withToolLogging(
+      auth,
+      { toolName: "comment_on_issue" },
+      async ({ owner, repo, issueNumber, body }, { authInfo }) => {
+        const octokit = await createOctokit(auth, {
+          accessToken: authInfo?.token,
         });
-      } catch (e) {
-        return makeMCPToolTextError(
-          `Error commenting on GitHub issue: ${normalizeError(e).message}`
-        );
+
+        try {
+          const { data: comment } = await octokit.request(
+            "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+            {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body,
+            }
+          );
+
+          return new Ok(
+            makeMCPToolTextSuccess({
+              message: `Comment added to issue #${issueNumber} with ID ${comment.id}`,
+            }).content
+          );
+        } catch (e) {
+          return new Err(
+            new MCPError(
+              `Error commenting on GitHub issue: ${normalizeError(e).message}`
+            )
+          );
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -735,13 +788,16 @@ const createServer = (auth: Authenticator): McpServer => {
       repo: z.string().describe("The name of the repository."),
       issueNumber: z.number().describe("The issue number."),
     },
-    async ({ owner, repo, issueNumber }, { authInfo }) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+    withToolLogging(
+      auth,
+      { toolName: "get_issue" },
+      async ({ owner, repo, issueNumber }, { authInfo }) => {
+        const octokit = await createOctokit(auth, {
+          accessToken: authInfo?.token,
+        });
 
-      try {
-        const query = `
+        try {
+          const query = `
           query($owner: String!, $repo: String!, $issueNumber: Int!) {
             repository(owner: $owner, name: $repo) {
               issue(number: $issueNumber) {
@@ -777,77 +833,82 @@ const createServer = (auth: Authenticator): McpServer => {
             }
           }`;
 
-        const issue = (await octokit.graphql(query, {
-          owner,
-          repo,
-          issueNumber,
-        })) as {
-          repository: {
-            issue: {
-              title: string;
-              body: string;
-              state: string;
-              createdAt: string;
-              updatedAt: string;
-              author: {
-                login: string;
-              };
-              labels: {
-                nodes: {
-                  name: string;
-                  color: string;
-                }[];
-              };
-              assignees: {
-                nodes: {
+          const issue = (await octokit.graphql(query, {
+            owner,
+            repo,
+            issueNumber,
+          })) as {
+            repository: {
+              issue: {
+                title: string;
+                body: string;
+                state: string;
+                createdAt: string;
+                updatedAt: string;
+                author: {
                   login: string;
-                }[];
-              };
-              comments: {
-                nodes: {
-                  author: {
+                };
+                labels: {
+                  nodes: {
+                    name: string;
+                    color: string;
+                  }[];
+                };
+                assignees: {
+                  nodes: {
                     login: string;
-                  };
-                  body: string;
-                  createdAt: string;
-                }[];
+                  }[];
+                };
+                comments: {
+                  nodes: {
+                    author: {
+                      login: string;
+                    };
+                    body: string;
+                    createdAt: string;
+                  }[];
+                };
               };
             };
           };
-        };
 
-        const issueData = issue.repository.issue;
-        const formattedIssue = {
-          title: issueData.title,
-          body: issueData.body,
-          state: issueData.state,
-          createdAt: issueData.createdAt,
-          updatedAt: issueData.updatedAt,
-          author: issueData.author.login,
-          labels: issueData.labels.nodes.map((label) => ({
-            name: label.name,
-            color: label.color,
-          })),
-          assignees: issueData.assignees.nodes.map(
-            (assignee) => assignee.login
-          ),
-          comments: issueData.comments.nodes.map((comment) => ({
-            author: comment.author.login,
-            body: comment.body,
-            createdAt: comment.createdAt,
-          })),
-        };
+          const issueData = issue.repository.issue;
+          const formattedIssue = {
+            title: issueData.title,
+            body: issueData.body,
+            state: issueData.state,
+            createdAt: issueData.createdAt,
+            updatedAt: issueData.updatedAt,
+            author: issueData.author.login,
+            labels: issueData.labels.nodes.map((label) => ({
+              name: label.name,
+              color: label.color,
+            })),
+            assignees: issueData.assignees.nodes.map(
+              (assignee) => assignee.login
+            ),
+            comments: issueData.comments.nodes.map((comment) => ({
+              author: comment.author.login,
+              body: comment.body,
+              createdAt: comment.createdAt,
+            })),
+          };
 
-        return makeMCPToolTextSuccess({
-          message: `Retrieved issue #${issueNumber}`,
-          result: JSON.stringify(formattedIssue, null, 2),
-        });
-      } catch (e) {
-        return makeMCPToolTextError(
-          `Error retrieving GitHub issue: ${normalizeError(e).message}`
-        );
+          return new Ok(
+            makeMCPToolTextSuccess({
+              message: `Retrieved issue #${issueNumber}`,
+              result: JSON.stringify(formattedIssue, null, 2),
+            }).content
+          );
+        } catch (e) {
+          return new Err(
+            new MCPError(
+              `Error retrieving GitHub issue: ${normalizeError(e).message}`
+            )
+          );
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -883,24 +944,27 @@ const createServer = (auth: Authenticator): McpServer => {
         .optional()
         .describe("Results per page. Defaults to 30, max 100."),
     },
-    async (
-      {
-        owner,
-        repo,
-        state = "OPEN",
-        labels,
-        sort = "CREATED_AT",
-        direction = "DESC",
-        perPage = 30,
-      },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+    withToolLogging(
+      auth,
+      { toolName: "list_issues" },
+      async (
+        {
+          owner,
+          repo,
+          state = "OPEN",
+          labels,
+          sort = "CREATED_AT",
+          direction = "DESC",
+          perPage = 30,
+        },
+        { authInfo }
+      ) => {
+        const octokit = await createOctokit(auth, {
+          accessToken: authInfo?.token,
+        });
 
-      try {
-        const query = `
+        try {
+          const query = `
           query($owner: String!, $repo: String!, $first: Int!, $orderBy: IssueOrder, $states: [IssueState!], $labels: [String!]) {
             repository(owner: $owner, name: $repo) {
               issues(first: $first, orderBy: $orderBy, states: $states, labels: $labels) {
@@ -932,72 +996,81 @@ const createServer = (auth: Authenticator): McpServer => {
             }
           }`;
 
-        const issues = (await octokit.graphql(query, {
-          owner,
-          repo,
-          first: perPage,
-          orderBy: {
-            field: sort,
-            direction: direction,
-          },
-          states: state === "ALL" ? undefined : [state],
-          labels: labels,
-        })) as {
-          repository: {
-            issues: {
-              nodes: {
-                number: number;
-                title: string;
-                state: string;
-                createdAt: string;
-                updatedAt: string;
-                author: {
-                  login: string;
-                };
-                labels: {
-                  nodes: {
-                    name: string;
-                    color: string;
-                  }[];
-                };
-                assignees: {
-                  nodes: {
+          const issues = (await octokit.graphql(query, {
+            owner,
+            repo,
+            first: perPage,
+            orderBy: {
+              field: sort,
+              direction: direction,
+            },
+            states: state === "ALL" ? undefined : [state],
+            labels: labels,
+          })) as {
+            repository: {
+              issues: {
+                nodes: {
+                  number: number;
+                  title: string;
+                  state: string;
+                  createdAt: string;
+                  updatedAt: string;
+                  author: {
                     login: string;
-                  }[];
-                };
-                comments: {
-                  totalCount: number;
-                };
-              }[];
+                  };
+                  labels: {
+                    nodes: {
+                      name: string;
+                      color: string;
+                    }[];
+                  };
+                  assignees: {
+                    nodes: {
+                      login: string;
+                    }[];
+                  };
+                  comments: {
+                    totalCount: number;
+                  };
+                }[];
+              };
             };
           };
-        };
 
-        const formattedIssues = issues.repository.issues.nodes.map((issue) => ({
-          number: issue.number,
-          title: issue.title,
-          state: issue.state,
-          createdAt: issue.createdAt,
-          updatedAt: issue.updatedAt,
-          author: issue.author.login,
-          labels: issue.labels.nodes.map((label) => ({
-            name: label.name,
-            color: label.color,
-          })),
-          assignees: issue.assignees.nodes.map((assignee) => assignee.login),
-          commentCount: issue.comments.totalCount,
-        }));
+          const formattedIssues = issues.repository.issues.nodes.map(
+            (issue) => ({
+              number: issue.number,
+              title: issue.title,
+              state: issue.state,
+              createdAt: issue.createdAt,
+              updatedAt: issue.updatedAt,
+              author: issue.author.login,
+              labels: issue.labels.nodes.map((label) => ({
+                name: label.name,
+                color: label.color,
+              })),
+              assignees: issue.assignees.nodes.map(
+                (assignee) => assignee.login
+              ),
+              commentCount: issue.comments.totalCount,
+            })
+          );
 
-        return makeMCPToolTextSuccess({
-          message: `Retrieved ${formattedIssues.length} issues`,
-          result: JSON.stringify(formattedIssues, null, 2),
-        });
-      } catch (e) {
-        return makeMCPToolTextError(
-          `Error listing GitHub issues: ${normalizeError(e).message}`
-        );
+          return new Ok(
+            makeMCPToolTextSuccess({
+              message: `Retrieved ${formattedIssues.length} issues`,
+              result: JSON.stringify(formattedIssues, null, 2),
+            }).content
+          );
+        } catch (e) {
+          return new Err(
+            new MCPError(
+              `Error listing GitHub issues: ${normalizeError(e).message}`
+            )
+          );
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -1031,25 +1104,28 @@ const createServer = (auth: Authenticator): McpServer => {
       after: z.string().optional().describe("The cursor to start after."),
       before: z.string().optional().describe("The cursor to start before."),
     },
-    async (
-      {
-        owner,
-        repo,
-        state = "OPEN",
-        sort = "CREATED_AT",
-        direction = "DESC",
-        perPage = 30,
-        after,
-        before,
-      },
-      { authInfo }
-    ) => {
-      const octokit = await createOctokit(auth, {
-        accessToken: authInfo?.token,
-      });
+    withToolLogging(
+      auth,
+      { toolName: "list_pull_requests" },
+      async (
+        {
+          owner,
+          repo,
+          state = "OPEN",
+          sort = "CREATED_AT",
+          direction = "DESC",
+          perPage = 30,
+          after,
+          before,
+        },
+        { authInfo }
+      ) => {
+        const octokit = await createOctokit(auth, {
+          accessToken: authInfo?.token,
+        });
 
-      try {
-        const query = `
+        try {
+          const query = `
           query($owner: String!, $repo: String!, $first: Int!, $orderBy: IssueOrder, $states: [PullRequestState!], $after: String, $before: String) {
             repository(owner: $owner, name: $repo) {
               pullRequests(first: $first, orderBy: $orderBy, states: $states, after: $after, before: $before) {
@@ -1106,127 +1182,132 @@ const createServer = (auth: Authenticator): McpServer => {
             }
           }`;
 
-        // Map our enum values to GitHub's GraphQL enum values
-        let graphqlStates;
-        if (state === "ALL") {
-          graphqlStates = undefined;
-        } else if (state === "OPEN") {
-          graphqlStates = ["OPEN"];
-        } else if (state === "CLOSED") {
-          graphqlStates = ["CLOSED"];
-        } else if (state === "MERGED") {
-          graphqlStates = ["MERGED"];
-        }
+          // Map our enum values to GitHub's GraphQL enum values
+          let graphqlStates;
+          if (state === "ALL") {
+            graphqlStates = undefined;
+          } else if (state === "OPEN") {
+            graphqlStates = ["OPEN"];
+          } else if (state === "CLOSED") {
+            graphqlStates = ["CLOSED"];
+          } else if (state === "MERGED") {
+            graphqlStates = ["MERGED"];
+          }
 
-        const pullRequests = (await octokit.graphql(query, {
-          owner,
-          repo,
-          before,
-          after,
-          first: perPage,
-          orderBy: {
-            field: sort,
-            direction: direction,
-          },
-          states: graphqlStates,
-        })) as {
-          repository: {
-            pullRequests: {
-              pageInfo: {
-                hasNextPage: boolean;
-                endCursor: string | null;
-                startCursor: string | null;
-                hasPreviousPage: boolean;
-              };
-              nodes: {
-                number: number;
-                title: string;
-                state: string;
-                createdAt: string;
-                updatedAt: string;
-                mergedAt: string | null;
-                closedAt: string | null;
-                author: {
-                  login: string;
+          const pullRequests = (await octokit.graphql(query, {
+            owner,
+            repo,
+            before,
+            after,
+            first: perPage,
+            orderBy: {
+              field: sort,
+              direction: direction,
+            },
+            states: graphqlStates,
+          })) as {
+            repository: {
+              pullRequests: {
+                pageInfo: {
+                  hasNextPage: boolean;
+                  endCursor: string | null;
+                  startCursor: string | null;
+                  hasPreviousPage: boolean;
                 };
-                baseRefName: string;
-                headRefName: string;
-                additions: number;
-                deletions: number;
-                changedFiles: number;
-                labels: {
-                  nodes: {
-                    name: string;
-                    color: string;
-                  }[];
-                };
-                assignees: {
-                  nodes: {
+                nodes: {
+                  number: number;
+                  title: string;
+                  state: string;
+                  createdAt: string;
+                  updatedAt: string;
+                  mergedAt: string | null;
+                  closedAt: string | null;
+                  author: {
                     login: string;
-                  }[];
-                };
-                reviewRequests: {
-                  nodes: {
-                    requestedReviewer: {
+                  };
+                  baseRefName: string;
+                  headRefName: string;
+                  additions: number;
+                  deletions: number;
+                  changedFiles: number;
+                  labels: {
+                    nodes: {
+                      name: string;
+                      color: string;
+                    }[];
+                  };
+                  assignees: {
+                    nodes: {
                       login: string;
-                    };
-                  }[];
-                };
-                comments: {
-                  totalCount: number;
-                };
-                reviews: {
-                  totalCount: number;
-                };
-              }[];
+                    }[];
+                  };
+                  reviewRequests: {
+                    nodes: {
+                      requestedReviewer: {
+                        login: string;
+                      };
+                    }[];
+                  };
+                  comments: {
+                    totalCount: number;
+                  };
+                  reviews: {
+                    totalCount: number;
+                  };
+                }[];
+              };
             };
           };
-        };
 
-        const formattedPullRequests =
-          pullRequests.repository.pullRequests.nodes.map((pr) => ({
-            number: pr.number,
-            title: pr.title,
-            state: pr.state,
-            createdAt: pr.createdAt,
-            updatedAt: pr.updatedAt,
-            mergedAt: pr.mergedAt,
-            closedAt: pr.closedAt,
-            author: pr.author.login,
-            baseRefName: pr.baseRefName,
-            headRefName: pr.headRefName,
-            additions: pr.additions,
-            deletions: pr.deletions,
-            changedFiles: pr.changedFiles,
-            labels: pr.labels.nodes.map((label) => ({
-              name: label.name,
-              color: label.color,
-            })),
-            assignees: pr.assignees.nodes.map((assignee) => assignee.login),
-            reviewRequests: pr.reviewRequests.nodes.map(
-              (request) => request.requestedReviewer.login
-            ),
-            commentCount: pr.comments.totalCount,
-            reviewCount: pr.reviews.totalCount,
-          }));
+          const formattedPullRequests =
+            pullRequests.repository.pullRequests.nodes.map((pr) => ({
+              number: pr.number,
+              title: pr.title,
+              state: pr.state,
+              createdAt: pr.createdAt,
+              updatedAt: pr.updatedAt,
+              mergedAt: pr.mergedAt,
+              closedAt: pr.closedAt,
+              author: pr.author.login,
+              baseRefName: pr.baseRefName,
+              headRefName: pr.headRefName,
+              additions: pr.additions,
+              deletions: pr.deletions,
+              changedFiles: pr.changedFiles,
+              labels: pr.labels.nodes.map((label) => ({
+                name: label.name,
+                color: label.color,
+              })),
+              assignees: pr.assignees.nodes.map((assignee) => assignee.login),
+              reviewRequests: pr.reviewRequests.nodes.map(
+                (request) => request.requestedReviewer.login
+              ),
+              commentCount: pr.comments.totalCount,
+              reviewCount: pr.reviews.totalCount,
+            }));
 
-        return makeMCPToolTextSuccess({
-          message: `Retrieved ${formattedPullRequests.length} pull requests`,
-          result: JSON.stringify(
-            {
-              pullRequests: formattedPullRequests,
-              pageInfo: pullRequests.repository.pullRequests.pageInfo,
-            },
-            null,
-            2
-          ),
-        });
-      } catch (e) {
-        return makeMCPToolTextError(
-          `Error listing GitHub pull requests: ${normalizeError(e).message}`
-        );
+          return new Ok(
+            makeMCPToolTextSuccess({
+              message: `Retrieved ${formattedPullRequests.length} pull requests`,
+              result: JSON.stringify(
+                {
+                  pullRequests: formattedPullRequests,
+                  pageInfo: pullRequests.repository.pullRequests.pageInfo,
+                },
+                null,
+                2
+              ),
+            }).content
+          );
+        } catch (e) {
+          return new Err(
+            new MCPError(
+              `Error listing GitHub pull requests: ${normalizeError(e).message}`
+            )
+          );
+        }
       }
-    }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -78,7 +78,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_drafts" },
+      { toolNameForMonitoring: "gmail" },
       async ({ q, pageToken }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -157,7 +157,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_draft" },
+      { toolNameForMonitoring: "gmail" },
       async ({ to, cc, bcc, subject, contentType, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -235,7 +235,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "delete_draft" },
+      { toolNameForMonitoring: "gmail" },
       async ({ draftId, subject, to }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -291,7 +291,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_messages" },
+      { toolNameForMonitoring: "gmail" },
       async ({ q, maxResults = 10, pageToken }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -422,7 +422,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_reply_draft" },
+      { toolNameForMonitoring: "gmail" },
       async (
         { messageId, body, contentType = "text/plain" as const, to, cc, bcc },
         { authInfo }

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -78,7 +78,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_drafts" },
+      { toolNameForMonitoring: "get_drafts" },
       async ({ q, pageToken }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -157,7 +157,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_draft" },
+      { toolNameForMonitoring: "create_draft" },
       async ({ to, cc, bcc, subject, contentType, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -235,7 +235,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "delete_draft" },
+      { toolNameForMonitoring: "delete_draft" },
       async ({ draftId, subject, to }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -291,7 +291,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_messages" },
+      { toolNameForMonitoring: "get_messages" },
       async ({ q, maxResults = 10, pageToken }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -422,7 +422,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_reply_draft" },
+      { toolNameForMonitoring: "create_reply_draft" },
       async (
         { messageId, body, contentType = "text/plain" as const, to, cc, bcc },
         { authInfo }

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -6,12 +6,11 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { Err, Ok } from "@app/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { Err, Ok } from "@app/types";
 
 interface GmailHeader {
   name: string;

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -580,25 +580,28 @@ const createServer = (
           });
 
           const calendarData = res.data.calendars?.[email];
-        for (const error of calendarData?.errors ?? []) {
-          if (error.reason === "notFound") {
-            return makeMCPToolTextError(
-              `Calendar not found for email: ${email}. The calendar may not exist or you may not have access to it.`
+          for (const error of calendarData?.errors ?? []) {
+            if (error.reason === "notFound") {
+              return new Err(
+                new MCPError(
+                  `Calendar not found for email: ${email}. The calendar may not exist or you may not have access to it.`
+                )
+              );
+            }
+            return new Err(
+              new MCPError(
+                `Error checking calendar availability for ${email}: ${error.reason}`
+              )
             );
           }
-          return makeMCPToolTextError(
-            `Error checking calendar availability for ${email}: ${error.reason}`
-          );
-        }
 
-        const busySlots = calendarData?.busy ?? [];
+          const busySlots = calendarData?.busy ?? [];
           const available = busySlots.length === 0;
           return new Ok(
             makeMCPToolJSONSuccess({
               result: {
                 available,
                 busySlots: busySlots.map((slot) => ({
-
                   start: slot.start ?? "",
 
                   end: slot.end ?? "",

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -4,12 +4,16 @@ import assert from "assert";
 import { google } from "googleapis";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 interface GoogleCalendarEventDateTime {
@@ -86,7 +90,10 @@ interface EnrichedGoogleCalendarEvent
   end?: EnrichedGoogleCalendarEventDateTime;
 }
 
-const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
+const createServer = (
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer => {
   const server = makeInternalMCPServer("google_calendar");
 
   async function getCalendarClient(authInfo?: AuthInfo) {
@@ -113,28 +120,32 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         .optional()
         .describe("Maximum number of calendars to return (max 250)."),
     },
-    async ({ pageToken, maxResults }, { authInfo }) => {
-      const calendar = await getCalendarClient(authInfo);
-      assert(
-        calendar,
-        "Calendar client could not be created - it should never happen"
-      );
-
-      try {
-        const res = await calendar.calendarList.list({
-          pageToken,
-          maxResults: maxResults ? Math.min(maxResults, 250) : undefined,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Calendars listed successfully",
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to list calendars"
+    withToolLogging(
+      auth,
+      { toolName: "list_calendars", agentLoopContext },
+      async ({ pageToken, maxResults }, { authInfo }) => {
+        const calendar = await getCalendarClient(authInfo);
+        assert(
+          calendar,
+          "Calendar client could not be created - it should never happen"
         );
+
+        try {
+          const res = await calendar.calendarList.list({
+            pageToken,
+            maxResults: maxResults ? Math.min(maxResults, 250) : undefined,
+          });
+          return new Ok(makeMCPToolJSONSuccess({
+            message: "Calendars listed successfully",
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to list calendars"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -163,66 +174,70 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         .describe("Maximum number of events to return (max 2500)."),
       pageToken: z.string().optional().describe("Page token for pagination."),
     },
-    async (
-      { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
-      { authInfo }
-    ) => {
-      const calendar = await getCalendarClient(authInfo);
-      assert(
-        calendar,
-        "Calendar client could not be created - it should never happen"
-      );
-
-      try {
-        const res = await calendar.events.list({
-          calendarId,
-          q,
-          timeMin,
-          timeMax,
-          maxResults: maxResults ? Math.min(maxResults, 2500) : undefined,
-          pageToken,
-          singleEvents: true,
-        });
-
-        const userTimezone = getUserTimezone();
-
-        // Return only essential event fields for context efficiency
-        const enrichedData = {
-          ...res.data,
-          items: res.data.items
-            ? res.data.items.map((event) => {
-                const enriched = isGoogleCalendarEvent(event)
-                  ? enrichEventWithDayOfWeek(event, userTimezone)
-                  : event;
-                return {
-                  id: enriched.id,
-                  summary: enriched.summary,
-                  description: enriched.description,
-                  location: enriched.location,
-                  start: enriched.start,
-                  end: enriched.end,
-                  attendees: enriched.attendees?.map((a) => ({
-                    email: a.email,
-                    displayName: a.displayName,
-                    responseStatus: a.responseStatus,
-                  })),
-                  htmlLink: enriched.htmlLink,
-                  status: enriched.status,
-                };
-              })
-            : undefined,
-        };
-
-        return makeMCPToolJSONSuccess({
-          message: "Events listed successfully",
-          result: enrichedData,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to list/search events"
+    withToolLogging(
+      auth,
+      { toolName: "list_events", agentLoopContext },
+      async (
+        { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
+        { authInfo }
+      ) => {
+        const calendar = await getCalendarClient(authInfo);
+        assert(
+          calendar,
+          "Calendar client could not be created - it should never happen"
         );
+
+        try {
+          const res = await calendar.events.list({
+            calendarId,
+            q,
+            timeMin,
+            timeMax,
+            maxResults: maxResults ? Math.min(maxResults, 2500) : undefined,
+            pageToken,
+            singleEvents: true,
+          });
+
+          const userTimezone = getUserTimezone();
+
+          // Return only essential event fields for context efficiency
+          const enrichedData = {
+            ...res.data,
+            items: res.data.items
+              ? res.data.items.map((event) => {
+                  const enriched = isGoogleCalendarEvent(event)
+                    ? enrichEventWithDayOfWeek(event, userTimezone)
+                    : event;
+                  return {
+                    id: enriched.id,
+                    summary: enriched.summary,
+                    description: enriched.description,
+                    location: enriched.location,
+                    start: enriched.start,
+                    end: enriched.end,
+                    attendees: enriched.attendees?.map((a) => ({
+                      email: a.email,
+                      displayName: a.displayName,
+                      responseStatus: a.responseStatus,
+                    })),
+                    htmlLink: enriched.htmlLink,
+                    status: enriched.status,
+                  };
+                })
+              : undefined,
+          };
+
+          return new Ok(makeMCPToolJSONSuccess({
+            message: "Events listed successfully",
+            result: enrichedData,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to list/search events"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -235,34 +250,38 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         .describe("The calendar ID (default: 'primary')."),
       eventId: z.string().describe("The ID of the event to retrieve."),
     },
-    async ({ calendarId = "primary", eventId }, { authInfo }) => {
-      const calendar = await getCalendarClient(authInfo);
-      assert(
-        calendar,
-        "Calendar client could not be created - it should never happen"
-      );
-
-      try {
-        const res = await calendar.events.get({
-          calendarId,
-          eventId,
-        });
-
-        const userTimezone = getUserTimezone();
-        const enrichedEvent = isGoogleCalendarEvent(res.data)
-          ? enrichEventWithDayOfWeek(res.data, userTimezone)
-          : res.data;
-
-        return makeMCPToolJSONSuccess({
-          message: "Event fetched successfully",
-          result: enrichedEvent,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to get event"
+    withToolLogging(
+      auth,
+      { toolName: "get_event", agentLoopContext },
+      async ({ calendarId = "primary", eventId }, { authInfo }) => {
+        const calendar = await getCalendarClient(authInfo);
+        assert(
+          calendar,
+          "Calendar client could not be created - it should never happen"
         );
+
+        try {
+          const res = await calendar.events.get({
+            calendarId,
+            eventId,
+          });
+
+          const userTimezone = getUserTimezone();
+          const enrichedEvent = isGoogleCalendarEvent(res.data)
+            ? enrichEventWithDayOfWeek(res.data, userTimezone)
+            : res.data;
+
+          return new Ok(makeMCPToolJSONSuccess({
+            message: "Event fetched successfully",
+            result: enrichedEvent,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to get event"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -288,69 +307,73 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
       location: z.string().optional().describe("Location of the event."),
       colorId: z.string().optional().describe("Color ID for the event."),
     },
-    async (
-      {
-        calendarId = "primary",
-        summary,
-        description,
-        start,
-        end,
-        attendees,
-        location,
-        colorId,
-      },
-      { authInfo }
-    ) => {
-      const calendar = await getCalendarClient(authInfo);
-      assert(
-        calendar,
-        "Calendar client could not be created - it should never happen"
-      );
-
-      try {
-        const event: {
-          summary: string;
-          description?: string;
-          start: { dateTime: string };
-          end: { dateTime: string };
-          attendees?: { email: string }[];
-          location?: string;
-          colorId?: string;
-        } = {
+    withToolLogging(
+      auth,
+      { toolName: "create_event", agentLoopContext },
+      async (
+        {
+          calendarId = "primary",
           summary,
           description,
           start,
           end,
-        };
-        if (attendees) {
-          event.attendees = attendees.map((email: string) => ({ email }));
-        }
-        if (location) {
-          event.location = location;
-        }
-        if (colorId) {
-          event.colorId = colorId;
-        }
-        const res = await calendar.events.insert({
-          calendarId,
-          requestBody: event,
-        });
-
-        const userTimezone = getUserTimezone();
-        const enrichedEvent = isGoogleCalendarEvent(res.data)
-          ? enrichEventWithDayOfWeek(res.data, userTimezone)
-          : res.data;
-
-        return makeMCPToolJSONSuccess({
-          message: "Event created successfully",
-          result: enrichedEvent,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to create event"
+          attendees,
+          location,
+          colorId,
+        },
+        { authInfo }
+      ) => {
+        const calendar = await getCalendarClient(authInfo);
+        assert(
+          calendar,
+          "Calendar client could not be created - it should never happen"
         );
+
+        try {
+          const event: {
+            summary: string;
+            description?: string;
+            start: { dateTime: string };
+            end: { dateTime: string };
+            attendees?: { email: string }[];
+            location?: string;
+            colorId?: string;
+          } = {
+            summary,
+            description,
+            start,
+            end,
+          };
+          if (attendees) {
+            event.attendees = attendees.map((email: string) => ({ email }));
+          }
+          if (location) {
+            event.location = location;
+          }
+          if (colorId) {
+            event.colorId = colorId;
+          }
+          const res = await calendar.events.insert({
+            calendarId,
+            requestBody: event,
+          });
+
+          const userTimezone = getUserTimezone();
+          const enrichedEvent = isGoogleCalendarEvent(res.data)
+            ? enrichEventWithDayOfWeek(res.data, userTimezone)
+            : res.data;
+
+          return new Ok(makeMCPToolJSONSuccess({
+            message: "Event created successfully",
+            result: enrichedEvent,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to create event"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -379,78 +402,82 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
       location: z.string().optional().describe("Location of the event."),
       colorId: z.string().optional().describe("Color ID for the event."),
     },
-    async (
-      {
-        calendarId = "primary",
-        eventId,
-        summary,
-        description,
-        start,
-        end,
-        attendees,
-        location,
-        colorId,
-      },
-      { authInfo }
-    ) => {
-      const calendar = await getCalendarClient(authInfo);
-      assert(
-        calendar,
-        "Calendar client could not be created - it should never happen"
-      );
-
-      try {
-        const event: {
-          summary?: string;
-          description?: string;
-          start?: { dateTime: string };
-          end?: { dateTime: string };
-          attendees?: { email: string }[];
-          location?: string;
-          colorId?: string;
-        } = {};
-        if (summary) {
-          event.summary = summary;
-        }
-        if (description) {
-          event.description = description;
-        }
-        if (start) {
-          event.start = start;
-        }
-        if (end) {
-          event.end = end;
-        }
-        if (attendees) {
-          event.attendees = attendees.map((email: string) => ({ email }));
-        }
-        if (location) {
-          event.location = location;
-        }
-        if (colorId) {
-          event.colorId = colorId;
-        }
-        const res = await calendar.events.patch({
-          calendarId,
+    withToolLogging(
+      auth,
+      { toolName: "update_event", agentLoopContext },
+      async (
+        {
+          calendarId = "primary",
           eventId,
-          requestBody: event,
-        });
-
-        const userTimezone = getUserTimezone();
-        const enrichedEvent = isGoogleCalendarEvent(res.data)
-          ? enrichEventWithDayOfWeek(res.data, userTimezone)
-          : res.data;
-
-        return makeMCPToolJSONSuccess({
-          message: "Event updated successfully",
-          result: enrichedEvent,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to update event"
+          summary,
+          description,
+          start,
+          end,
+          attendees,
+          location,
+          colorId,
+        },
+        { authInfo }
+      ) => {
+        const calendar = await getCalendarClient(authInfo);
+        assert(
+          calendar,
+          "Calendar client could not be created - it should never happen"
         );
+
+        try {
+          const event: {
+            summary?: string;
+            description?: string;
+            start?: { dateTime: string };
+            end?: { dateTime: string };
+            attendees?: { email: string }[];
+            location?: string;
+            colorId?: string;
+          } = {};
+          if (summary) {
+            event.summary = summary;
+          }
+          if (description) {
+            event.description = description;
+          }
+          if (start) {
+            event.start = start;
+          }
+          if (end) {
+            event.end = end;
+          }
+          if (attendees) {
+            event.attendees = attendees.map((email: string) => ({ email }));
+          }
+          if (location) {
+            event.location = location;
+          }
+          if (colorId) {
+            event.colorId = colorId;
+          }
+          const res = await calendar.events.patch({
+            calendarId,
+            eventId,
+            requestBody: event,
+          });
+
+          const userTimezone = getUserTimezone();
+          const enrichedEvent = isGoogleCalendarEvent(res.data)
+            ? enrichEventWithDayOfWeek(res.data, userTimezone)
+            : res.data;
+
+          return new Ok(makeMCPToolJSONSuccess({
+            message: "Event updated successfully",
+            result: enrichedEvent,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to update event"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -463,28 +490,32 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         .describe("The calendar ID (default: 'primary')."),
       eventId: z.string().describe("The ID of the event to delete."),
     },
-    async ({ calendarId = "primary", eventId }, { authInfo }) => {
-      const calendar = await getCalendarClient(authInfo);
-      assert(
-        calendar,
-        "Calendar client could not be created - it should never happen"
-      );
-
-      try {
-        await calendar.events.delete({
-          calendarId,
-          eventId,
-        });
-        return makeMCPToolJSONSuccess({
-          message: "Event deleted successfully",
-          result: "",
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to delete event"
+    withToolLogging(
+      auth,
+      { toolName: "delete_event", agentLoopContext },
+      async ({ calendarId = "primary", eventId }, { authInfo }) => {
+        const calendar = await getCalendarClient(authInfo);
+        assert(
+          calendar,
+          "Calendar client could not be created - it should never happen"
         );
+
+        try {
+          await calendar.events.delete({
+            calendarId,
+            eventId,
+          });
+          return new Ok(makeMCPToolJSONSuccess({
+            message: "Event deleted successfully",
+            result: "",
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to delete event"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -507,24 +538,27 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
           "Time zone used in the response. Optional. The default is UTC."
         ),
     },
-    async ({ email, startTime, endTime, timeZone }, { authInfo }) => {
-      const calendar = await getCalendarClient(authInfo);
-      assert(
-        calendar,
-        "Calendar client could not be created - it should never happen"
-      );
+    withToolLogging(
+      auth,
+      { toolName: "check_availability", agentLoopContext },
+      async ({ email, startTime, endTime, timeZone }, { authInfo }) => {
+        const calendar = await getCalendarClient(authInfo);
+        assert(
+          calendar,
+          "Calendar client could not be created - it should never happen"
+        );
 
-      try {
-        const res = await calendar.freebusy.query({
-          requestBody: {
-            timeMin: startTime,
-            timeMax: endTime,
-            timeZone,
-            items: [{ id: email }],
-          },
-        });
+        try {
+          const res = await calendar.freebusy.query({
+            requestBody: {
+              timeMin: startTime,
+              timeMax: endTime,
+              timeZone,
+              items: [{ id: email }],
+            },
+          });
 
-        const calendarData = res.data.calendars?.[email];
+          const calendarData = res.data.calendars?.[email];
         for (const error of calendarData?.errors ?? []) {
           if (error.reason === "notFound") {
             return makeMCPToolTextError(
@@ -537,22 +571,25 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         }
 
         const busySlots = calendarData?.busy ?? [];
-        const available = busySlots.length === 0;
-        return makeMCPToolJSONSuccess({
-          result: {
-            available,
-            busySlots: busySlots.map((slot) => ({
-              start: slot.start ?? "",
-              end: slot.end ?? "",
-            })),
-          },
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to check calendar availability"
-        );
+          const available = busySlots.length === 0;
+          return new Ok(makeMCPToolJSONSuccess({
+            result: {
+              available,
+              busySlots: busySlots.map((slot) => ({
+
+                start: slot.start ?? "",
+
+                end: slot.end ?? "",
+              })),
+            },
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to check calendar availability"
+          ));
+        }
       }
-    }
+    )
   );
 
   function getUserTimezone(): string | null {

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -121,7 +121,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_calendars", agentLoopContext },
+      { toolNameForMonitoring: "google_calendar", agentLoopContext },
       async ({ pageToken, maxResults }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -179,7 +179,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_events", agentLoopContext },
+      { toolNameForMonitoring: "google_calendar", agentLoopContext },
       async (
         { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
         { authInfo }
@@ -259,7 +259,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_event", agentLoopContext },
+      { toolNameForMonitoring: "google_calendar", agentLoopContext },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -318,7 +318,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_event", agentLoopContext },
+      { toolNameForMonitoring: "google_calendar", agentLoopContext },
       async (
         {
           calendarId = "primary",
@@ -417,7 +417,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "update_event", agentLoopContext },
+      { toolNameForMonitoring: "google_calendar", agentLoopContext },
       async (
         {
           calendarId = "primary",
@@ -509,7 +509,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "delete_event", agentLoopContext },
+      { toolNameForMonitoring: "google_calendar", agentLoopContext },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -561,7 +561,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "check_availability", agentLoopContext },
+      { toolNameForMonitoring: "google_calendar", agentLoopContext },
       async ({ email, startTime, endTime, timeZone }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -121,7 +121,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "list_calendars", agentLoopContext },
+      { toolNameForMonitoring: "list_calendars", agentLoopContext },
       async ({ pageToken, maxResults }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -179,7 +179,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "list_events", agentLoopContext },
+      { toolNameForMonitoring: "list_events", agentLoopContext },
       async (
         { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
         { authInfo }
@@ -259,7 +259,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_event", agentLoopContext },
+      { toolNameForMonitoring: "get_event", agentLoopContext },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -318,7 +318,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "create_event", agentLoopContext },
+      { toolNameForMonitoring: "create_event", agentLoopContext },
       async (
         {
           calendarId = "primary",
@@ -417,7 +417,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "update_event", agentLoopContext },
+      { toolNameForMonitoring: "update_event", agentLoopContext },
       async (
         {
           calendarId = "primary",
@@ -509,7 +509,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "delete_event", agentLoopContext },
+      { toolNameForMonitoring: "delete_event", agentLoopContext },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -561,7 +561,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "check_availability", agentLoopContext },
+      { toolNameForMonitoring: "check_availability", agentLoopContext },
       async ({ email, startTime, endTime, timeZone }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -8,7 +8,6 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -135,14 +134,18 @@ const createServer = (
             pageToken,
             maxResults: maxResults ? Math.min(maxResults, 250) : undefined,
           });
-          return new Ok(makeMCPToolJSONSuccess({
-            message: "Calendars listed successfully",
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              message: "Calendars listed successfully",
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to list calendars"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to list calendars"
+            )
+          );
         }
       }
     )
@@ -227,14 +230,18 @@ const createServer = (
               : undefined,
           };
 
-          return new Ok(makeMCPToolJSONSuccess({
-            message: "Events listed successfully",
-            result: enrichedData,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              message: "Events listed successfully",
+              result: enrichedData,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to list/search events"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to list/search events"
+            )
+          );
         }
       }
     )
@@ -271,14 +278,16 @@ const createServer = (
             ? enrichEventWithDayOfWeek(res.data, userTimezone)
             : res.data;
 
-          return new Ok(makeMCPToolJSONSuccess({
-            message: "Event fetched successfully",
-            result: enrichedEvent,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              message: "Event fetched successfully",
+              result: enrichedEvent,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to get event"
-          ));
+          return new Err(
+            new MCPError(normalizeError(err).message || "Failed to get event")
+          );
         }
       }
     )
@@ -363,14 +372,18 @@ const createServer = (
             ? enrichEventWithDayOfWeek(res.data, userTimezone)
             : res.data;
 
-          return new Ok(makeMCPToolJSONSuccess({
-            message: "Event created successfully",
-            result: enrichedEvent,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              message: "Event created successfully",
+              result: enrichedEvent,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to create event"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to create event"
+            )
+          );
         }
       }
     )
@@ -467,14 +480,18 @@ const createServer = (
             ? enrichEventWithDayOfWeek(res.data, userTimezone)
             : res.data;
 
-          return new Ok(makeMCPToolJSONSuccess({
-            message: "Event updated successfully",
-            result: enrichedEvent,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              message: "Event updated successfully",
+              result: enrichedEvent,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to update event"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to update event"
+            )
+          );
         }
       }
     )
@@ -505,14 +522,18 @@ const createServer = (
             calendarId,
             eventId,
           });
-          return new Ok(makeMCPToolJSONSuccess({
-            message: "Event deleted successfully",
-            result: "",
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              message: "Event deleted successfully",
+              result: "",
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to delete event"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to delete event"
+            )
+          );
         }
       }
     )
@@ -572,21 +593,26 @@ const createServer = (
 
         const busySlots = calendarData?.busy ?? [];
           const available = busySlots.length === 0;
-          return new Ok(makeMCPToolJSONSuccess({
-            result: {
-              available,
-              busySlots: busySlots.map((slot) => ({
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: {
+                available,
+                busySlots: busySlots.map((slot) => ({
 
-                start: slot.start ?? "",
+                  start: slot.start ?? "",
 
-                end: slot.end ?? "",
-              })),
-            },
-          }).content);
+                  end: slot.end ?? "",
+                })),
+              },
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to check calendar availability"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message ||
+                "Failed to check calendar availability"
+            )
+          );
         }
       }
     )

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -7,11 +7,10 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Err, Ok } from "@app/types";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const SUPPORTED_MIMETYPES = [
   "application/vnd.google-apps.document",

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -3,12 +3,15 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { google } from "googleapis";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextError,
+  makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { Err, Ok } from "@app/types";
 
 const SUPPORTED_MIMETYPES = [
   "application/vnd.google-apps.document",
@@ -21,7 +24,7 @@ const SUPPORTED_MIMETYPES = [
 const MAX_CONTENT_SIZE = 32000; // Max characters to return for file content
 const MAX_FILE_SIZE = 64 * 1024 * 1024; // 10 MB max original file size
 
-const createServer = (): McpServer => {
+const createServer = (auth: any): McpServer => {
   const server = makeInternalMCPServer("google_drive");
 
   async function getDriveClient(authInfo?: AuthInfo) {
@@ -44,28 +47,32 @@ const createServer = (): McpServer => {
     {
       pageToken: z.string().optional().describe("Page token for pagination."),
     },
-    async ({ pageToken }, { authInfo }) => {
-      const drive = await getDriveClient(authInfo);
-      if (!drive) {
-        return makeMCPToolTextError("Failed to authenticate with Google Drive");
-      }
+    withToolLogging(
+      auth,
+      { toolName: "list_drives" },
+      async ({ pageToken }, { authInfo }) => {
+        const drive = await getDriveClient(authInfo);
+        if (!drive) {
+          return new Err(new MCPError("Failed to authenticate with Google Drive"));
+        }
 
-      try {
-        const res = await drive.drives.list({
-          pageToken,
-          pageSize: 100,
-          fields: "nextPageToken, drives(id, name, createdTime)",
-        });
+        try {
+          const res = await drive.drives.list({
+            pageToken,
+            pageSize: 100,
+            fields: "nextPageToken, drives(id, name, createdTime)",
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to list drives"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to list drives"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -129,60 +136,64 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
         .describe("Maximum number of files to return (max 1000)."),
       pageToken: z.string().optional().describe("Page token for pagination."),
     },
-    async (
-      { q, pageToken, pageSize, driveId, includeSharedDrives, orderBy },
-      { authInfo }
-    ) => {
-      const drive = await getDriveClient(authInfo);
-      if (!drive) {
-        return makeMCPToolTextError("Failed to authenticate with Google Drive");
-      }
-
-      try {
-        const requestParams: {
-          q?: string;
-          pageToken?: string;
-          pageSize?: number;
-          fields: string;
-          orderBy?: string;
-          driveId?: string;
-          includeItemsFromAllDrives?: boolean;
-          supportsAllDrives?: boolean;
-          corpora?: string;
-        } = {
-          q,
-          pageToken,
-          pageSize: pageSize ? Math.min(pageSize, 1000) : undefined,
-          fields:
-            "nextPageToken, files(id, name, mimeType, size, createdTime, modifiedTime, owners, parents, webViewLink, shared)",
-          orderBy,
-        };
-
-        if (driveId) {
-          // Search in a specific shared drive
-          requestParams.driveId = driveId;
-          requestParams.includeItemsFromAllDrives = true;
-          requestParams.supportsAllDrives = true;
-          requestParams.corpora = "drive";
-        } else if (includeSharedDrives) {
-          // Search across all drives (personal + shared)
-          requestParams.includeItemsFromAllDrives = true;
-          requestParams.supportsAllDrives = true;
-          requestParams.corpora = "allDrives";
+    withToolLogging(
+      auth,
+      { toolName: "search_files" },
+      async (
+        { q, pageToken, pageSize, driveId, includeSharedDrives, orderBy },
+        { authInfo }
+      ) => {
+        const drive = await getDriveClient(authInfo);
+        if (!drive) {
+          return new Err(new MCPError("Failed to authenticate with Google Drive"));
         }
-        // If neither driveId nor includeSharedDrives, search only personal drive (default behavior)
 
-        const res = await drive.files.list(requestParams);
+        try {
+          const requestParams: {
+            q?: string;
+            pageToken?: string;
+            pageSize?: number;
+            fields: string;
+            orderBy?: string;
+            driveId?: string;
+            includeItemsFromAllDrives?: boolean;
+            supportsAllDrives?: boolean;
+            corpora?: string;
+          } = {
+            q,
+            pageToken,
+            pageSize: pageSize ? Math.min(pageSize, 1000) : undefined,
+            fields:
+              "nextPageToken, files(id, name, mimeType, size, createdTime, modifiedTime, owners, parents, webViewLink, shared)",
+            orderBy,
+          };
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to search files"
-        );
+          if (driveId) {
+            // Search in a specific shared drive
+            requestParams.driveId = driveId;
+            requestParams.includeItemsFromAllDrives = true;
+            requestParams.supportsAllDrives = true;
+            requestParams.corpora = "drive";
+          } else if (includeSharedDrives) {
+            // Search across all drives (personal + shared)
+            requestParams.includeItemsFromAllDrives = true;
+            requestParams.supportsAllDrives = true;
+            requestParams.corpora = "allDrives";
+          }
+          // If neither driveId nor includeSharedDrives, search only personal drive (default behavior)
+
+          const res = await drive.files.list(requestParams);
+
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to search files"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -206,101 +217,105 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
           `Maximum number of characters to return. Defaults to ${MAX_CONTENT_SIZE}.`
         ),
     },
-    async ({ fileId, offset, limit }, { authInfo }) => {
-      const drive = await getDriveClient(authInfo);
-      if (!drive) {
-        return makeMCPToolTextError("Failed to authenticate with Google Drive");
-      }
-
-      try {
-        // First, get file metadata to determine the mimetype
-        const fileMetadata = await drive.files.get({
-          fileId,
-          supportsAllDrives: true,
-          fields: "id, name, mimeType, size",
-        });
-        const file = fileMetadata.data;
-
-        if (!file.mimeType || !SUPPORTED_MIMETYPES.includes(file.mimeType)) {
-          return makeMCPToolTextError(
-            `Unsupported file type: ${file.mimeType}. Supported types: ${SUPPORTED_MIMETYPES.join(", ")}`
-          );
-        }
-        if (file.size && parseInt(file.size) > MAX_FILE_SIZE) {
-          return makeMCPToolTextError(
-            `File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)} MB.`
-          );
+    withToolLogging(
+      auth,
+      { toolName: "get_file_content" },
+      async ({ fileId, offset, limit }, { authInfo }) => {
+        const drive = await getDriveClient(authInfo);
+        if (!drive) {
+          return new Err(new MCPError("Failed to authenticate with Google Drive"));
         }
 
-        let content: string;
-
-        switch (file.mimeType) {
-          case "application/vnd.google-apps.document":
-          case "application/vnd.google-apps.presentation": {
-            // Export Google Docs and Presentations as plain text
-            const exportRes = await drive.files.export({
-              fileId,
-              mimeType: "text/plain",
-            });
-            if (typeof exportRes.data !== "string") {
-              return makeMCPToolTextError(
-                "Failed to export file content as text/plain"
-              );
-            }
-            content = exportRes.data;
-            break;
-          }
-          case "text/plain":
-          case "text/markdown":
-          case "text/csv": {
-            // Download regular text files
-            const downloadRes = await drive.files.get({
-              fileId,
-              alt: "media",
-            });
-
-            if (typeof downloadRes.data !== "string") {
-              return makeMCPToolTextError(
-                "Failed to download file content as text"
-              );
-            }
-            content = downloadRes.data;
-            break;
-          }
-          default:
-            return makeMCPToolTextError(
-              `Unsupported file type: ${file.mimeType}`
-            );
-        }
-
-        // Apply offset and limit
-        const totalContentLength = content.length;
-        const startIndex = Math.max(0, offset);
-        const endIndex = Math.min(content.length, startIndex + limit);
-        const truncatedContent = content.slice(startIndex, endIndex);
-
-        const hasMore = endIndex < content.length;
-        const nextOffset = hasMore ? endIndex : undefined;
-
-        return makeMCPToolJSONSuccess({
-          result: {
+        try {
+          // First, get file metadata to determine the mimetype
+          const fileMetadata = await drive.files.get({
             fileId,
-            fileName: file.name,
-            mimeType: file.mimeType,
-            content: truncatedContent,
-            returnedContentLength: truncatedContent.length,
-            totalContentLength,
-            offset: startIndex,
-            nextOffset,
-            hasMore,
-          },
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to get file content"
-        );
+            supportsAllDrives: true,
+            fields: "id, name, mimeType, size",
+          });
+          const file = fileMetadata.data;
+
+          if (!file.mimeType || !SUPPORTED_MIMETYPES.includes(file.mimeType)) {
+            return new Err(new MCPError(
+              `Unsupported file type: ${file.mimeType}. Supported types: ${SUPPORTED_MIMETYPES.join(", ")}`
+            ));
+          }
+          if (file.size && parseInt(file.size) > MAX_FILE_SIZE) {
+            return new Err(new MCPError(
+              `File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)} MB.`
+            ));
+          }
+
+          let content: string;
+
+          switch (file.mimeType) {
+            case "application/vnd.google-apps.document":
+            case "application/vnd.google-apps.presentation": {
+              // Export Google Docs and Presentations as plain text
+              const exportRes = await drive.files.export({
+                fileId,
+                mimeType: "text/plain",
+              });
+              if (typeof exportRes.data !== "string") {
+                return new Err(new MCPError(
+                  "Failed to export file content as text/plain"
+                ));
+              }
+              content = exportRes.data;
+              break;
+            }
+            case "text/plain":
+            case "text/markdown":
+            case "text/csv": {
+              // Download regular text files
+              const downloadRes = await drive.files.get({
+                fileId,
+                alt: "media",
+              });
+
+              if (typeof downloadRes.data !== "string") {
+                return new Err(new MCPError(
+                  "Failed to download file content as text"
+                ));
+              }
+              content = downloadRes.data;
+              break;
+            }
+            default:
+              return new Err(new MCPError(
+                `Unsupported file type: ${file.mimeType}`
+              ));
+          }
+
+          // Apply offset and limit
+          const totalContentLength = content.length;
+          const startIndex = Math.max(0, offset);
+          const endIndex = Math.min(content.length, startIndex + limit);
+          const truncatedContent = content.slice(startIndex, endIndex);
+
+          const hasMore = endIndex < content.length;
+          const nextOffset = hasMore ? endIndex : undefined;
+
+          return new Ok(makeMCPToolJSONSuccess({
+            result: {
+              fileId,
+              fileName: file.name,
+              mimeType: file.mimeType,
+              content: truncatedContent,
+              returnedContentLength: truncatedContent.length,
+              totalContentLength,
+              offset: startIndex,
+              nextOffset,
+              hasMore,
+            },
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to get file content"
+          ));
+        }
       }
-    }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -52,7 +52,9 @@ const createServer = (auth: any): McpServer => {
       async ({ pageToken }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
-          return new Err(new MCPError("Failed to authenticate with Google Drive"));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Drive")
+          );
         }
 
         try {
@@ -62,13 +64,15 @@ const createServer = (auth: any): McpServer => {
             fields: "nextPageToken, drives(id, name, createdTime)",
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to list drives"
-          ));
+          return new Err(
+            new MCPError(normalizeError(err).message || "Failed to list drives")
+          );
         }
       }
     )
@@ -144,7 +148,9 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       ) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
-          return new Err(new MCPError("Failed to authenticate with Google Drive"));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Drive")
+          );
         }
 
         try {
@@ -183,13 +189,17 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
 
           const res = await drive.files.list(requestParams);
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to search files"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to search files"
+            )
+          );
         }
       }
     )
@@ -222,7 +232,9 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       async ({ fileId, offset, limit }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
-          return new Err(new MCPError("Failed to authenticate with Google Drive"));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Drive")
+          );
         }
 
         try {
@@ -235,14 +247,18 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
           const file = fileMetadata.data;
 
           if (!file.mimeType || !SUPPORTED_MIMETYPES.includes(file.mimeType)) {
-            return new Err(new MCPError(
-              `Unsupported file type: ${file.mimeType}. Supported types: ${SUPPORTED_MIMETYPES.join(", ")}`
-            ));
+            return new Err(
+              new MCPError(
+                `Unsupported file type: ${file.mimeType}. Supported types: ${SUPPORTED_MIMETYPES.join(", ")}`
+              )
+            );
           }
           if (file.size && parseInt(file.size) > MAX_FILE_SIZE) {
-            return new Err(new MCPError(
-              `File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)} MB.`
-            ));
+            return new Err(
+              new MCPError(
+                `File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)} MB.`
+              )
+            );
           }
 
           let content: string;
@@ -256,9 +272,9 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
                 mimeType: "text/plain",
               });
               if (typeof exportRes.data !== "string") {
-                return new Err(new MCPError(
-                  "Failed to export file content as text/plain"
-                ));
+                return new Err(
+                  new MCPError("Failed to export file content as text/plain")
+                );
               }
               content = exportRes.data;
               break;
@@ -273,17 +289,17 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
               });
 
               if (typeof downloadRes.data !== "string") {
-                return new Err(new MCPError(
-                  "Failed to download file content as text"
-                ));
+                return new Err(
+                  new MCPError("Failed to download file content as text")
+                );
               }
               content = downloadRes.data;
               break;
             }
             default:
-              return new Err(new MCPError(
-                `Unsupported file type: ${file.mimeType}`
-              ));
+              return new Err(
+                new MCPError(`Unsupported file type: ${file.mimeType}`)
+              );
           }
 
           // Apply offset and limit
@@ -295,23 +311,27 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
           const hasMore = endIndex < content.length;
           const nextOffset = hasMore ? endIndex : undefined;
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: {
-              fileId,
-              fileName: file.name,
-              mimeType: file.mimeType,
-              content: truncatedContent,
-              returnedContentLength: truncatedContent.length,
-              totalContentLength,
-              offset: startIndex,
-              nextOffset,
-              hasMore,
-            },
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: {
+                fileId,
+                fileName: file.name,
+                mimeType: file.mimeType,
+                content: truncatedContent,
+                returnedContentLength: truncatedContent.length,
+                totalContentLength,
+                offset: startIndex,
+                nextOffset,
+                hasMore,
+              },
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to get file content"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to get file content"
+            )
+          );
         }
       }
     )

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -48,7 +48,7 @@ const createServer = (auth: any): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "list_drives" },
+      { toolNameForMonitoring: "list_drives" },
       async ({ pageToken }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
@@ -141,7 +141,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     withToolLogging(
       auth,
-      { toolName: "search_files" },
+      { toolNameForMonitoring: "search_files" },
       async (
         { q, pageToken, pageSize, driveId, includeSharedDrives, orderBy },
         { authInfo }
@@ -228,7 +228,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     withToolLogging(
       auth,
-      { toolName: "get_file_content" },
+      { toolNameForMonitoring: "get_file_content" },
       async ({ fileId, offset, limit }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -48,7 +48,7 @@ const createServer = (auth: any): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_drives" },
+      { toolNameForMonitoring: "google_drive" },
       async ({ pageToken }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
@@ -141,7 +141,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "search_files" },
+      { toolNameForMonitoring: "google_drive" },
       async (
         { q, pageToken, pageSize, driveId, includeSharedDrives, orderBy },
         { authInfo }
@@ -228,7 +228,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_file_content" },
+      { toolNameForMonitoring: "google_drive" },
       async ({ fileId, offset, limit }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -62,7 +62,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_spreadsheets" },
+      { toolNameForMonitoring: "google_sheets" },
       async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
@@ -117,7 +117,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_spreadsheet" },
+      { toolNameForMonitoring: "google_sheets" },
       async ({ spreadsheetId, includeGridData }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -169,7 +169,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_worksheet" },
+      { toolNameForMonitoring: "google_sheets" },
       async (
         { spreadsheetId, range, majorDimension, valueRenderOption },
         { authInfo }
@@ -229,7 +229,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "update_cells" },
+      { toolNameForMonitoring: "google_sheets" },
       async (
         { spreadsheetId, range, values, majorDimension, valueInputOption },
         { authInfo }
@@ -296,7 +296,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "append_data" },
+      { toolNameForMonitoring: "google_sheets" },
       async (
         {
           spreadsheetId,
@@ -354,7 +354,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "clear_range" },
+      { toolNameForMonitoring: "google_sheets" },
       async ({ spreadsheetId, range }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -397,7 +397,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_spreadsheet" },
+      { toolNameForMonitoring: "google_sheets" },
       async ({ title, sheetTitles }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -452,7 +452,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "add_worksheet" },
+      { toolNameForMonitoring: "google_sheets" },
       async ({ spreadsheetId, title, rowCount, columnCount }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -506,7 +506,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "delete_worksheet" },
+      { toolNameForMonitoring: "google_sheets" },
       async ({ spreadsheetId, sheetId }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -584,7 +584,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "format_cells" },
+      { toolNameForMonitoring: "google_sheets" },
       async (
         {
           spreadsheetId,
@@ -664,7 +664,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "copy_sheet" },
+      { toolNameForMonitoring: "google_sheets" },
       async (
         { sourceSpreadsheetId, sheetId, destinationSpreadsheetId },
         { authInfo }
@@ -709,7 +709,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "rename_worksheet" },
+      { toolNameForMonitoring: "google_sheets" },
       async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -767,7 +767,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "move_worksheet" },
+      { toolNameForMonitoring: "google_sheets" },
       async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -62,7 +62,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "list_spreadsheets" },
+      { toolNameForMonitoring: "list_spreadsheets" },
       async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
@@ -117,7 +117,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_spreadsheet" },
+      { toolNameForMonitoring: "get_spreadsheet" },
       async ({ spreadsheetId, includeGridData }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -169,7 +169,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_worksheet" },
+      { toolNameForMonitoring: "get_worksheet" },
       async (
         { spreadsheetId, range, majorDimension, valueRenderOption },
         { authInfo }
@@ -229,7 +229,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "update_cells" },
+      { toolNameForMonitoring: "update_cells" },
       async (
         { spreadsheetId, range, values, majorDimension, valueInputOption },
         { authInfo }
@@ -296,7 +296,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "append_data" },
+      { toolNameForMonitoring: "append_data" },
       async (
         {
           spreadsheetId,
@@ -354,7 +354,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "clear_range" },
+      { toolNameForMonitoring: "clear_range" },
       async ({ spreadsheetId, range }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -397,7 +397,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_spreadsheet" },
+      { toolNameForMonitoring: "create_spreadsheet" },
       async ({ title, sheetTitles }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -452,7 +452,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "add_worksheet" },
+      { toolNameForMonitoring: "add_worksheet" },
       async ({ spreadsheetId, title, rowCount, columnCount }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -506,7 +506,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "delete_worksheet" },
+      { toolNameForMonitoring: "delete_worksheet" },
       async ({ spreadsheetId, sheetId }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -584,7 +584,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "format_cells" },
+      { toolNameForMonitoring: "format_cells" },
       async (
         {
           spreadsheetId,
@@ -664,7 +664,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "copy_sheet" },
+      { toolNameForMonitoring: "copy_sheet" },
       async (
         { sourceSpreadsheetId, sheetId, destinationSpreadsheetId },
         { authInfo }
@@ -709,7 +709,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "rename_worksheet" },
+      { toolNameForMonitoring: "rename_worksheet" },
       async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -767,7 +767,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "move_worksheet" },
+      { toolNameForMonitoring: "move_worksheet" },
       async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -7,7 +7,6 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -13,6 +13,9 @@ import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+// We use a single tool name for monitoring given the high granularity (can be revisited).
+const GOOGLE_SHEET_TOOL_NAME = "google_sheets";
+
 const createServer = (auth: Authenticator): McpServer => {
   const server = makeInternalMCPServer("google_sheets");
 
@@ -62,7 +65,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
@@ -117,7 +120,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async ({ spreadsheetId, includeGridData }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -169,7 +172,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async (
         { spreadsheetId, range, majorDimension, valueRenderOption },
         { authInfo }
@@ -229,7 +232,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async (
         { spreadsheetId, range, values, majorDimension, valueInputOption },
         { authInfo }
@@ -296,7 +299,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async (
         {
           spreadsheetId,
@@ -354,7 +357,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async ({ spreadsheetId, range }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -397,7 +400,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async ({ title, sheetTitles }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -452,7 +455,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async ({ spreadsheetId, title, rowCount, columnCount }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -506,7 +509,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async ({ spreadsheetId, sheetId }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -584,7 +587,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async (
         {
           spreadsheetId,
@@ -664,7 +667,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async (
         { sourceSpreadsheetId, sheetId, destinationSpreadsheetId },
         { authInfo }
@@ -709,7 +712,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -767,7 +770,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_sheets" },
+      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
       async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -3,14 +3,18 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { google } from "googleapis";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextError,
+  makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-const createServer = (): McpServer => {
+const createServer = (auth: Authenticator): McpServer => {
   const server = makeInternalMCPServer("google_sheets");
 
   async function getSheetsClient(authInfo?: AuthInfo) {
@@ -57,37 +61,41 @@ const createServer = (): McpServer => {
         .optional()
         .describe("Maximum number of spreadsheets to return (max 1000)."),
     },
-    async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
-      const drive = await getDriveClient(authInfo);
-      if (!drive) {
-        return makeMCPToolTextError("Failed to authenticate with Google Drive");
+    withToolLogging(
+      auth,
+      { toolName: "list_spreadsheets" },
+      async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
+        const drive = await getDriveClient(authInfo);
+        if (!drive) {
+          return new Err(new MCPError("Failed to authenticate with Google Drive"));
+        }
+
+        try {
+          const query = nameFilter
+            ? `mimeType='application/vnd.google-apps.spreadsheet' and name contains '${nameFilter}'`
+            : "mimeType='application/vnd.google-apps.spreadsheet'";
+
+          const res = await drive.files.list({
+            q: query,
+            pageToken,
+            pageSize: pageSize ? Math.min(pageSize, 1000) : undefined,
+            fields:
+              "nextPageToken, files(id, name, createdTime, modifiedTime, owners, webViewLink)",
+            includeItemsFromAllDrives: true,
+            supportsAllDrives: true,
+            corpora: "allDrives",
+          });
+
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to list spreadsheets"
+          ));
+        }
       }
-
-      try {
-        const query = nameFilter
-          ? `mimeType='application/vnd.google-apps.spreadsheet' and name contains '${nameFilter}'`
-          : "mimeType='application/vnd.google-apps.spreadsheet'";
-
-        const res = await drive.files.list({
-          q: query,
-          pageToken,
-          pageSize: pageSize ? Math.min(pageSize, 1000) : undefined,
-          fields:
-            "nextPageToken, files(id, name, createdTime, modifiedTime, owners, webViewLink)",
-          includeItemsFromAllDrives: true,
-          supportsAllDrives: true,
-          corpora: "allDrives",
-        });
-
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to list spreadsheets"
-        );
-      }
-    }
+    )
   );
 
   server.tool(
@@ -102,29 +110,33 @@ const createServer = (): McpServer => {
         .default(false)
         .describe("Whether to include grid data in the response."),
     },
-    async ({ spreadsheetId, includeGridData }, { authInfo }) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
+    withToolLogging(
+      auth,
+      { toolName: "get_spreadsheet" },
+      async ({ spreadsheetId, includeGridData }, { authInfo }) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-      try {
-        const res = await sheets.spreadsheets.get({
-          spreadsheetId,
-          includeGridData,
-        });
+        try {
+          const res = await sheets.spreadsheets.get({
+            spreadsheetId,
+            includeGridData,
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to get spreadsheet"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to get spreadsheet"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -146,34 +158,38 @@ const createServer = (): McpServer => {
         .default("FORMATTED_VALUE")
         .describe("How values should be represented in the output."),
     },
-    async (
-      { spreadsheetId, range, majorDimension, valueRenderOption },
-      { authInfo }
-    ) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
+    withToolLogging(
+      auth,
+      { toolName: "get_worksheet" },
+      async (
+        { spreadsheetId, range, majorDimension, valueRenderOption },
+        { authInfo }
+      ) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-      try {
-        const res = await sheets.spreadsheets.values.get({
-          spreadsheetId,
-          range,
-          majorDimension,
-          valueRenderOption,
-        });
+        try {
+          const res = await sheets.spreadsheets.values.get({
+            spreadsheetId,
+            range,
+            majorDimension,
+            valueRenderOption,
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to get worksheet data"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to get worksheet data"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -198,37 +214,41 @@ const createServer = (): McpServer => {
         .default("USER_ENTERED")
         .describe("How the input data should be interpreted."),
     },
-    async (
-      { spreadsheetId, range, values, majorDimension, valueInputOption },
-      { authInfo }
-    ) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
+    withToolLogging(
+      auth,
+      { toolName: "update_cells" },
+      async (
+        { spreadsheetId, range, values, majorDimension, valueInputOption },
+        { authInfo }
+      ) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-      try {
-        const res = await sheets.spreadsheets.values.update({
-          spreadsheetId,
-          range,
-          valueInputOption,
-          requestBody: {
-            values,
-            majorDimension,
-          },
-        });
+        try {
+          const res = await sheets.spreadsheets.values.update({
+            spreadsheetId,
+            range,
+            valueInputOption,
+            requestBody: {
+              values,
+              majorDimension,
+            },
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to update cells"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to update cells"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -257,45 +277,49 @@ const createServer = (): McpServer => {
         .default("INSERT_ROWS")
         .describe("How the input data should be inserted."),
     },
-    async (
-      {
-        spreadsheetId,
-        range,
-        values,
-        majorDimension,
-        valueInputOption,
-        insertDataOption,
-      },
-      { authInfo }
-    ) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
-
-      try {
-        const res = await sheets.spreadsheets.values.append({
+    withToolLogging(
+      auth,
+      { toolName: "append_data" },
+      async (
+        {
           spreadsheetId,
           range,
+          values,
+          majorDimension,
           valueInputOption,
           insertDataOption,
-          requestBody: {
-            values,
-            majorDimension,
-          },
-        });
+        },
+        { authInfo }
+      ) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to append data"
-        );
+        try {
+          const res = await sheets.spreadsheets.values.append({
+            spreadsheetId,
+            range,
+            valueInputOption,
+            insertDataOption,
+            requestBody: {
+              values,
+              majorDimension,
+            },
+          });
+
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to append data"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -309,29 +333,33 @@ const createServer = (): McpServer => {
           "The A1 notation of the range to clear (e.g., 'Sheet1!A1:D10')."
         ),
     },
-    async ({ spreadsheetId, range }, { authInfo }) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
+    withToolLogging(
+      auth,
+      { toolName: "clear_range" },
+      async ({ spreadsheetId, range }, { authInfo }) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-      try {
-        const res = await sheets.spreadsheets.values.clear({
-          spreadsheetId,
-          range,
-        });
+        try {
+          const res = await sheets.spreadsheets.values.clear({
+            spreadsheetId,
+            range,
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to clear range"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to clear range"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -346,36 +374,40 @@ const createServer = (): McpServer => {
           "Titles for initial sheets. If not provided, creates one sheet with default title."
         ),
     },
-    async ({ title, sheetTitles }, { authInfo }) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
+    withToolLogging(
+      auth,
+      { toolName: "create_spreadsheet" },
+      async ({ title, sheetTitles }, { authInfo }) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
+
+        try {
+          const sheetsToCreate = sheetTitles?.map((sheetTitle) => ({
+            properties: { title: sheetTitle },
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          })) || [{ properties: { title: "Sheet1" } }];
+
+          const res = await sheets.spreadsheets.create({
+            requestBody: {
+              properties: { title },
+              sheets: sheetsToCreate,
+            },
+          });
+
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to create spreadsheet"
+          ));
+        }
       }
-
-      try {
-        const sheetsToCreate = sheetTitles?.map((sheetTitle) => ({
-          properties: { title: sheetTitle },
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        })) || [{ properties: { title: "Sheet1" } }];
-
-        const res = await sheets.spreadsheets.create({
-          requestBody: {
-            properties: { title },
-            sheets: sheetsToCreate,
-          },
-        });
-
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to create spreadsheet"
-        );
-      }
-    }
+    )
   );
 
   server.tool(
@@ -393,43 +425,47 @@ const createServer = (): McpServer => {
         .optional()
         .describe("Number of columns in the new worksheet."),
     },
-    async ({ spreadsheetId, title, rowCount, columnCount }, { authInfo }) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
+    withToolLogging(
+      auth,
+      { toolName: "add_worksheet" },
+      async ({ spreadsheetId, title, rowCount, columnCount }, { authInfo }) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-      try {
-        const res = await sheets.spreadsheets.batchUpdate({
-          spreadsheetId,
-          requestBody: {
-            requests: [
-              {
-                addSheet: {
-                  properties: {
-                    title,
-                    gridProperties: {
-                      rowCount,
-                      columnCount,
+        try {
+          const res = await sheets.spreadsheets.batchUpdate({
+            spreadsheetId,
+            requestBody: {
+              requests: [
+                {
+                  addSheet: {
+                    properties: {
+                      title,
+                      gridProperties: {
+                        rowCount,
+                        columnCount,
+                      },
                     },
                   },
                 },
-              },
-            ],
-          },
-        });
+              ],
+            },
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to add worksheet"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to add worksheet"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -439,37 +475,41 @@ const createServer = (): McpServer => {
       spreadsheetId: z.string().describe("The ID of the spreadsheet."),
       sheetId: z.number().describe("The ID of the worksheet to delete."),
     },
-    async ({ spreadsheetId, sheetId }, { authInfo }) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
+    withToolLogging(
+      auth,
+      { toolName: "delete_worksheet" },
+      async ({ spreadsheetId, sheetId }, { authInfo }) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-      try {
-        const res = await sheets.spreadsheets.batchUpdate({
-          spreadsheetId,
-          requestBody: {
-            requests: [
-              {
-                deleteSheet: {
-                  sheetId,
+        try {
+          const res = await sheets.spreadsheets.batchUpdate({
+            spreadsheetId,
+            requestBody: {
+              requests: [
+                {
+                  deleteSheet: {
+                    sheetId,
+                  },
                 },
-              },
-            ],
-          },
-        });
+              ],
+            },
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to delete worksheet"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to delete worksheet"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -509,58 +549,62 @@ const createServer = (): McpServer => {
         })
         .describe("Formatting options to apply."),
     },
-    async (
-      {
-        spreadsheetId,
-        sheetId,
-        startRowIndex,
-        endRowIndex,
-        startColumnIndex,
-        endColumnIndex,
-        format,
-      },
-      { authInfo }
-    ) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
-
-      try {
-        const res = await sheets.spreadsheets.batchUpdate({
+    withToolLogging(
+      auth,
+      { toolName: "format_cells" },
+      async (
+        {
           spreadsheetId,
-          requestBody: {
-            requests: [
-              {
-                repeatCell: {
-                  range: {
-                    sheetId,
-                    startRowIndex,
-                    endRowIndex,
-                    startColumnIndex,
-                    endColumnIndex,
-                  },
-                  cell: {
-                    userEnteredFormat: format,
-                  },
-                  fields: "userEnteredFormat",
-                },
-              },
-            ],
-          },
-        });
+          sheetId,
+          startRowIndex,
+          endRowIndex,
+          startColumnIndex,
+          endColumnIndex,
+          format,
+        },
+        { authInfo }
+      ) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to format cells"
-        );
+        try {
+          const res = await sheets.spreadsheets.batchUpdate({
+            spreadsheetId,
+            requestBody: {
+              requests: [
+                {
+                  repeatCell: {
+                    range: {
+                      sheetId,
+                      startRowIndex,
+                      endRowIndex,
+                      startColumnIndex,
+                      endColumnIndex,
+                    },
+                    cell: {
+                      userEnteredFormat: format,
+                    },
+                    fields: "userEnteredFormat",
+                  },
+                },
+              ],
+            },
+          });
+
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to format cells"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -581,35 +625,39 @@ const createServer = (): McpServer => {
           "The ID of the destination spreadsheet where the sheet will be copied."
         ),
     },
-    async (
-      { sourceSpreadsheetId, sheetId, destinationSpreadsheetId },
-      { authInfo }
-    ) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
+    withToolLogging(
+      auth,
+      { toolName: "copy_sheet" },
+      async (
+        { sourceSpreadsheetId, sheetId, destinationSpreadsheetId },
+        { authInfo }
+      ) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-      try {
-        const res = await sheets.spreadsheets.sheets.copyTo({
-          spreadsheetId: sourceSpreadsheetId,
-          sheetId: sheetId,
-          requestBody: {
-            destinationSpreadsheetId: destinationSpreadsheetId,
-          },
-        });
+        try {
+          const res = await sheets.spreadsheets.sheets.copyTo({
+            spreadsheetId: sourceSpreadsheetId,
+            sheetId: sheetId,
+            requestBody: {
+              destinationSpreadsheetId: destinationSpreadsheetId,
+            },
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to copy sheet"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to copy sheet"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -620,41 +668,45 @@ const createServer = (): McpServer => {
       sheetId: z.number().describe("The ID of the worksheet to rename."),
       newTitle: z.string().describe("The new title for the worksheet."),
     },
-    async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
+    withToolLogging(
+      auth,
+      { toolName: "rename_worksheet" },
+      async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-      try {
-        const res = await sheets.spreadsheets.batchUpdate({
-          spreadsheetId,
-          requestBody: {
-            requests: [
-              {
-                updateSheetProperties: {
-                  properties: {
-                    sheetId,
-                    title: newTitle,
+        try {
+          const res = await sheets.spreadsheets.batchUpdate({
+            spreadsheetId,
+            requestBody: {
+              requests: [
+                {
+                  updateSheetProperties: {
+                    properties: {
+                      sheetId,
+                      title: newTitle,
+                    },
+                    fields: "title",
                   },
-                  fields: "title",
                 },
-              },
-            ],
-          },
-        });
+              ],
+            },
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to rename worksheet"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to rename worksheet"
+          ));
+        }
       }
-    }
+    )
   );
 
   server.tool(
@@ -670,41 +722,45 @@ const createServer = (): McpServer => {
           "The new zero-based index position for the worksheet. 0 = first position, 1 = second position, etc."
         ),
     },
-    async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {
-      const sheets = await getSheetsClient(authInfo);
-      if (!sheets) {
-        return makeMCPToolTextError(
-          "Failed to authenticate with Google Sheets"
-        );
-      }
+    withToolLogging(
+      auth,
+      { toolName: "move_worksheet" },
+      async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(new MCPError(
+            "Failed to authenticate with Google Sheets"
+          ));
+        }
 
-      try {
-        const res = await sheets.spreadsheets.batchUpdate({
-          spreadsheetId,
-          requestBody: {
-            requests: [
-              {
-                updateSheetProperties: {
-                  properties: {
-                    sheetId,
-                    index: newIndex,
+        try {
+          const res = await sheets.spreadsheets.batchUpdate({
+            spreadsheetId,
+            requestBody: {
+              requests: [
+                {
+                  updateSheetProperties: {
+                    properties: {
+                      sheetId,
+                      index: newIndex,
+                    },
+                    fields: "index",
                   },
-                  fields: "index",
                 },
-              },
-            ],
-          },
-        });
+              ],
+            },
+          });
 
-        return makeMCPToolJSONSuccess({
-          result: res.data,
-        });
-      } catch (err) {
-        return makeMCPToolTextError(
-          normalizeError(err).message || "Failed to move worksheet"
-        );
+          return new Ok(makeMCPToolJSONSuccess({
+            result: res.data,
+          }).content);
+        } catch (err) {
+          return new Err(new MCPError(
+            normalizeError(err).message || "Failed to move worksheet"
+          ));
+        }
       }
-    }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -66,7 +66,9 @@ const createServer = (auth: Authenticator): McpServer => {
       async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
-          return new Err(new MCPError("Failed to authenticate with Google Drive"));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Drive")
+          );
         }
 
         try {
@@ -85,13 +87,17 @@ const createServer = (auth: Authenticator): McpServer => {
             corpora: "allDrives",
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to list spreadsheets"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to list spreadsheets"
+            )
+          );
         }
       }
     )
@@ -115,9 +121,9 @@ const createServer = (auth: Authenticator): McpServer => {
       async ({ spreadsheetId, includeGridData }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -126,13 +132,17 @@ const createServer = (auth: Authenticator): McpServer => {
             includeGridData,
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to get spreadsheet"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to get spreadsheet"
+            )
+          );
         }
       }
     )
@@ -166,9 +176,9 @@ const createServer = (auth: Authenticator): McpServer => {
       ) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -179,13 +189,17 @@ const createServer = (auth: Authenticator): McpServer => {
             valueRenderOption,
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to get worksheet data"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to get worksheet data"
+            )
+          );
         }
       }
     )
@@ -222,9 +236,9 @@ const createServer = (auth: Authenticator): McpServer => {
       ) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -238,13 +252,17 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to update cells"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to update cells"
+            )
+          );
         }
       }
     )
@@ -292,9 +310,9 @@ const createServer = (auth: Authenticator): McpServer => {
       ) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -309,13 +327,15 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to append data"
-          ));
+          return new Err(
+            new MCPError(normalizeError(err).message || "Failed to append data")
+          );
         }
       }
     )
@@ -338,9 +358,9 @@ const createServer = (auth: Authenticator): McpServer => {
       async ({ spreadsheetId, range }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -349,13 +369,15 @@ const createServer = (auth: Authenticator): McpServer => {
             range,
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to clear range"
-          ));
+          return new Err(
+            new MCPError(normalizeError(err).message || "Failed to clear range")
+          );
         }
       }
     )
@@ -379,9 +401,9 @@ const createServer = (auth: Authenticator): McpServer => {
       async ({ title, sheetTitles }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -397,13 +419,17 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to create spreadsheet"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to create spreadsheet"
+            )
+          );
         }
       }
     )
@@ -430,9 +456,9 @@ const createServer = (auth: Authenticator): McpServer => {
       async ({ spreadsheetId, title, rowCount, columnCount }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -455,13 +481,17 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to add worksheet"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to add worksheet"
+            )
+          );
         }
       }
     )
@@ -480,9 +510,9 @@ const createServer = (auth: Authenticator): McpServer => {
       async ({ spreadsheetId, sheetId }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -499,13 +529,17 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to delete worksheet"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to delete worksheet"
+            )
+          );
         }
       }
     )
@@ -565,9 +599,9 @@ const createServer = (auth: Authenticator): McpServer => {
       ) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -594,13 +628,17 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to format cells"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to format cells"
+            )
+          );
         }
       }
     )
@@ -633,9 +671,9 @@ const createServer = (auth: Authenticator): McpServer => {
       ) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -647,13 +685,15 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to copy sheet"
-          ));
+          return new Err(
+            new MCPError(normalizeError(err).message || "Failed to copy sheet")
+          );
         }
       }
     )
@@ -673,9 +713,9 @@ const createServer = (auth: Authenticator): McpServer => {
       async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -696,13 +736,17 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to rename worksheet"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to rename worksheet"
+            )
+          );
         }
       }
     )
@@ -727,9 +771,9 @@ const createServer = (auth: Authenticator): McpServer => {
       async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
-          return new Err(new MCPError(
-            "Failed to authenticate with Google Sheets"
-          ));
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
         }
 
         try {
@@ -750,13 +794,17 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(makeMCPToolJSONSuccess({
-            result: res.data,
-          }).content);
+          return new Ok(
+            makeMCPToolJSONSuccess({
+              result: res.data,
+            }).content
+          );
         } catch (err) {
-          return new Err(new MCPError(
-            normalizeError(err).message || "Failed to move worksheet"
-          ));
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to move worksheet"
+            )
+          );
         }
       }
     )

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -62,7 +62,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "generate_image", agentLoopContext },
+      { toolNameForMonitoring: "generate_image", agentLoopContext },
       async ({ prompt, name, quality, size }, { sendNotification, _meta }) => {
         const workspace = auth.getNonNullableWorkspace();
 

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -2,19 +2,16 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 import { z } from "zod";
 
-import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-  makeMCPToolTextError,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
-import { dustManagedCredentials } from "@app/types";
+import { dustManagedCredentials, Err, Ok } from "@app/types";
 
 const IMAGE_GENERATION_RATE_LIMITER_KEY = "image_generation";
 const IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS = 60 * 60 * 24 * 7; // 1 week.
@@ -67,112 +64,115 @@ const createServer = (
       auth,
       { toolName: "generate_image", agentLoopContext },
       async ({ prompt, name, quality, size }, { sendNotification, _meta }) => {
-      const workspace = auth.getNonNullableWorkspace();
+        const workspace = auth.getNonNullableWorkspace();
 
-      if (_meta?.progressToken) {
-        const notification: MCPProgressNotificationType = {
-          method: "notifications/progress",
-          params: {
-            progress: 0,
-            total: 1,
-            progressToken: _meta?.progressToken,
-            data: {
-              label: "Generating image...",
-              output: {
-                type: "image",
-                mimeType: DEFAULT_IMAGE_MIME_TYPE,
+        if (_meta?.progressToken) {
+          const notification: MCPProgressNotificationType = {
+            method: "notifications/progress",
+            params: {
+              progress: 0,
+              total: 1,
+              progressToken: _meta?.progressToken,
+              data: {
+                label: "Generating image...",
+                output: {
+                  type: "image",
+                  mimeType: DEFAULT_IMAGE_MIME_TYPE,
+                },
               },
             },
-          },
-        };
+          };
 
-        // Send a notification to the MCP Client, to display a placeholder for the image.
-        await sendNotification(notification);
-      }
-
-      const { limits } = auth.getNonNullablePlan();
-      const { maxImagesPerWeek } = limits.capabilities.images;
-
-      // Check current usage for the week.
-      const remaining = await rateLimiter({
-        key: `${IMAGE_GENERATION_RATE_LIMITER_KEY}_${workspace.sId}`,
-        maxPerTimeframe: maxImagesPerWeek,
-        timeframeSeconds: IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS,
-        logger,
-      });
-
-      const statsDClient = getStatsDClient();
-      statsDClient.increment("tools.image_generation.generated", 1, [
-        `quality:${quality}`,
-        `size:${size}`,
-      ]);
-
-      if (remaining <= 0) {
-        statsDClient.increment("tools.image_generation.rate_limit_hit", 1);
-
-        return makeMCPToolTextError(
-          `Rate limit of ${maxImagesPerWeek} requests per week exceeded. Contact your ` +
-            "administrator to increase the limit."
-        );
-      }
-
-      try {
-        const credentials = dustManagedCredentials();
-        const openai = new OpenAI({
-          apiKey: credentials.OPENAI_API_KEY,
-        });
-
-        const result = await openai.images.generate({
-          model: "gpt-image-1",
-          moderation: "low",
-          output_format: DEFAULT_IMAGE_OUTPUT_FORMAT,
-          prompt,
-          quality,
-          size,
-          user: `workspace-${workspace.sId}`,
-        });
-
-        statsDClient.increment(
-          "tools.image_generation.usage.input_tokens",
-          result.usage?.input_tokens ?? 0
-        );
-        statsDClient.increment(
-          "tools.image_generation.usage.output_tokens",
-          result.usage?.output_tokens ?? 0
-        );
-
-        if (!result.data) {
-          return makeMCPToolTextError("No image generated.");
+          // Send a notification to the MCP Client, to display a placeholder for the image.
+          await sendNotification(notification);
         }
 
-        const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
+        const { limits } = auth.getNonNullablePlan();
+        const { maxImagesPerWeek } = limits.capabilities.images;
 
-        return {
-          isError: false,
-          content: result.data.map((r) => ({
-            type: "image" as const,
-            mimeType: DEFAULT_IMAGE_MIME_TYPE,
-            data: r.b64_json!,
-            name: fileName,
-          })),
-        };
-      } catch (error) {
-        logger.error(
-          {
-            error,
-          },
-          "Error generating image."
-        );
+        // Check current usage for the week.
+        const remaining = await rateLimiter({
+          key: `${IMAGE_GENERATION_RATE_LIMITER_KEY}_${workspace.sId}`,
+          maxPerTimeframe: maxImagesPerWeek,
+          timeframeSeconds: IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS,
+          logger,
+        });
 
-        if (error instanceof OpenAI.APIError) {
-          return makeMCPToolTextError(
-            `Error generating image. Image generation service error: Status: ` +
-              `${error.status}, Code: ${error.code}, Message: ${error.message}`
+        const statsDClient = getStatsDClient();
+        statsDClient.increment("tools.image_generation.generated", 1, [
+          `quality:${quality}`,
+          `size:${size}`,
+        ]);
+
+        if (remaining <= 0) {
+          statsDClient.increment("tools.image_generation.rate_limit_hit", 1);
+
+          return new Err(
+            new MCPError(
+              `Rate limit of ${maxImagesPerWeek} requests per week exceeded. Contact your ` +
+                "administrator to increase the limit."
+            )
           );
         }
 
-        return makeMCPToolTextError("Error generating image.");
-      }
+        try {
+          const credentials = dustManagedCredentials();
+          const openai = new OpenAI({
+            apiKey: credentials.OPENAI_API_KEY,
+          });
+
+          const result = await openai.images.generate({
+            model: "gpt-image-1",
+            moderation: "low",
+            output_format: DEFAULT_IMAGE_OUTPUT_FORMAT,
+            prompt,
+            quality,
+            size,
+            user: `workspace-${workspace.sId}`,
+          });
+
+          statsDClient.increment(
+            "tools.image_generation.usage.input_tokens",
+            result.usage?.input_tokens ?? 0
+          );
+          statsDClient.increment(
+            "tools.image_generation.usage.output_tokens",
+            result.usage?.output_tokens ?? 0
+          );
+
+          if (!result.data) {
+            return new Err(new MCPError("No image generated."));
+          }
+
+          const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
+
+          return new Ok(
+            result.data.map((r) => ({
+              type: "image" as const,
+              mimeType: DEFAULT_IMAGE_MIME_TYPE,
+              data: r.b64_json!,
+              name: fileName,
+            }))
+          );
+        } catch (error) {
+          logger.error(
+            {
+              error,
+            },
+            "Error generating image."
+          );
+
+          if (error instanceof OpenAI.APIError) {
+            return new Err(
+              new MCPError(
+                `Error generating image. Image generation service error: Status: ` +
+                  `${error.status}, Code: ${error.code}, Message: ${error.message}`
+              )
+            );
+          }
+
+          return new Err(new MCPError("Error generating image."));
+        }
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -265,7 +265,7 @@ function createServer(
       commonInputsSchema,
       withToolLogging(
         auth,
-        { toolName: "include", agentLoopContext },
+        { toolNameForMonitoring: "include", agentLoopContext },
         includeFunction
       )
     );
@@ -279,7 +279,7 @@ function createServer(
       },
       withToolLogging(
         auth,
-        { toolName: "include", agentLoopContext },
+        { toolNameForMonitoring: "include", agentLoopContext },
         includeFunction
       )
     );

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -103,7 +103,7 @@ export async function getInternalMCPServer(
     case "primitive_types_debugger":
       return primitiveTypesDebuggerServer();
     case "jit_testing":
-      return jitTestingServer();
+      return jitTestingServer(auth);
     case "web_search_&_browse":
       return webtoolsServer(auth, agentLoopContext);
     case "search":
@@ -135,13 +135,13 @@ export async function getInternalMCPServer(
     case "salesforce":
       return salesforceServer();
     case "gmail":
-      return gmailServer();
+      return gmailServer(auth);
     case "google_calendar":
       return calendarServer(agentLoopContext);
     case "google_drive":
-      return driveServer();
+      return driveServer(auth);
     case "google_sheets":
-      return sheetsServer();
+      return sheetsServer(auth);
     case "data_sources_file_system":
       return dataSourcesFileSystemServer(auth, agentLoopContext);
     case "conversation_files":
@@ -157,7 +157,7 @@ export async function getInternalMCPServer(
     case AGENT_MEMORY_SERVER_NAME:
       return agentMemoryServer(auth, agentLoopContext);
     case "confluence":
-      return confluenceServer();
+      return confluenceServer(auth);
     case "outlook":
       return outlookServer();
     case "outlook_calendar":

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -101,7 +101,7 @@ export async function getInternalMCPServer(
     case "query_tables_v2":
       return tablesQueryServerV2(auth, agentLoopContext);
     case "primitive_types_debugger":
-      return primitiveTypesDebuggerServer();
+      return primitiveTypesDebuggerServer(auth);
     case "jit_testing":
       return jitTestingServer(auth);
     case "web_search_&_browse":
@@ -133,11 +133,11 @@ export async function getInternalMCPServer(
     case "extract_data":
       return extractDataServer(auth, agentLoopContext);
     case "salesforce":
-      return salesforceServer();
+      return salesforceServer(auth);
     case "gmail":
       return gmailServer(auth);
     case "google_calendar":
-      return calendarServer(agentLoopContext);
+      return calendarServer(auth, agentLoopContext);
     case "google_drive":
       return driveServer(auth);
     case "google_sheets":
@@ -149,7 +149,7 @@ export async function getInternalMCPServer(
     case "jira":
       return jiraServer(auth, agentLoopContext);
     case "monday":
-      return mondayServer();
+      return mondayServer(auth);
     case "slack":
       return slackServer(auth, mcpServerId, agentLoopContext);
     case "slack_bot":
@@ -157,9 +157,9 @@ export async function getInternalMCPServer(
     case AGENT_MEMORY_SERVER_NAME:
       return agentMemoryServer(auth, agentLoopContext);
     case "confluence":
-      return confluenceServer(auth);
+      return confluenceServer();
     case "outlook":
-      return outlookServer();
+      return outlookServer(auth);
     case "outlook_calendar":
       return outlookCalendarServer();
     case "agent_management":

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
@@ -113,7 +113,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+        agentLoopContext,
+      },
       async (
         { file_name, mime_type, content, description },
         { sendNotification, _meta }
@@ -226,7 +229,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+        agentLoopContext,
+      },
       async (
         { file_id, old_string, new_string, expected_replacements },
         { sendNotification, _meta }
@@ -290,7 +296,7 @@ const createServer = (
     withToolLogging(
       auth,
       {
-        toolName: REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+        toolNameForMonitoring: REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
         agentLoopContext,
       },
       async ({ file_id }, { sendNotification, _meta }) => {
@@ -360,7 +366,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+        agentLoopContext,
+      },
       async ({ file_id, new_file_name }, { sendNotification, _meta }) => {
         const { agentConfiguration } = agentLoopContext?.runContext ?? {};
 
@@ -419,7 +428,7 @@ const createServer = (
     withToolLogging(
       auth,
       {
-        toolName: RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+        toolNameForMonitoring: RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
         agentLoopContext,
       },
       async ({ file_id }) => {

--- a/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
@@ -61,7 +61,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_issue_read_fields" },
+      { toolNameForMonitoring: "jira" },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -98,7 +98,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_issue" },
+      { toolNameForMonitoring: "jira" },
       async ({ issueKey, fields }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -140,7 +140,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_projects" },
+      { toolNameForMonitoring: "jira" },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -171,7 +171,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_project" },
+      { toolNameForMonitoring: "jira" },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -209,7 +209,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_project_versions" },
+      { toolNameForMonitoring: "jira" },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -246,7 +246,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_transitions" },
+      { toolNameForMonitoring: "jira" },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -291,7 +291,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_comment" },
+      { toolNameForMonitoring: "jira" },
       async (
         { issueKey, comment, visibilityType, visibilityValue },
         { authInfo }
@@ -361,7 +361,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_issues" },
+      { toolNameForMonitoring: "jira" },
       async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -417,7 +417,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_issues_using_jql" },
+      { toolNameForMonitoring: "jira" },
       async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -462,7 +462,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_issue_types" },
+      { toolNameForMonitoring: "jira" },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -506,7 +506,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_issue_create_fields" },
+      { toolNameForMonitoring: "jira" },
       async ({ projectKey, issueTypeId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -546,7 +546,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_connection_info" },
+      { toolNameForMonitoring: "jira" },
       async (_, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -582,7 +582,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "transition_issue" },
+      { toolNameForMonitoring: "jira" },
       async ({ issueKey, transitionId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -640,7 +640,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_issue" },
+      { toolNameForMonitoring: "jira" },
       async ({ issueData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -680,7 +680,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "update_issue" },
+      { toolNameForMonitoring: "jira" },
       async ({ issueKey, updateData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -729,7 +729,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_issue_link" },
+      { toolNameForMonitoring: "jira" },
       async ({ linkData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -766,7 +766,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "delete_issue_link" },
+      { toolNameForMonitoring: "jira" },
       async ({ linkId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -794,7 +794,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_issue_link_types" },
+      { toolNameForMonitoring: "jira" },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -855,7 +855,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_users" },
+      { toolNameForMonitoring: "jira" },
       async (
         { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
         { authInfo }
@@ -961,7 +961,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "upload_attachment" },
+      { toolNameForMonitoring: "jira" },
       async ({ issueKey, attachment }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -1076,7 +1076,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_attachments" },
+      { toolNameForMonitoring: "jira" },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -1132,7 +1132,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "read_attachment" },
+      { toolNameForMonitoring: "jira" },
       async ({ issueKey, attachmentId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {

--- a/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   createComment,
   createIssue,
@@ -39,17 +40,17 @@ import {
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { normalizeError, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 const createServer = (
-  auth?: Authenticator,
+  auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
   const server = makeInternalMCPServer("jira");
@@ -58,23 +59,29 @@ const createServer = (
     "get_issue_read_fields",
     "Lists available Jira field keys/ids and names for use in the get_issue.fields parameter (read-time).",
     {},
-    async (_, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await listFieldSummaries(baseUrl, accessToken);
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error retrieving fields: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "get_issue_read_fields" },
+      async (_, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await listFieldSummaries(baseUrl, accessToken);
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error retrieving fields: ${result.error}`)
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Fields retrieved successfully",
+                result: result.value,
+              }).content
             );
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Fields retrieved successfully",
-            result: result.value,
-          });
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -89,57 +96,71 @@ const createServer = (
           "Optional list of fields to include. Defaults to a minimal set for performance."
         ),
     },
-    async ({ issueKey, fields }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const issue = await getIssue({
-            baseUrl,
-            accessToken,
-            issueKey,
-            fields,
-          });
-          if (issue.isOk() && issue.value === null) {
-            return makeMCPToolJSONSuccess({
-              message: "No issue found with the specified key",
-              result: { found: false, issueKey },
+    withToolLogging(
+      auth,
+      { toolName: "get_issue" },
+      async ({ issueKey, fields }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const issue = await getIssue({
+              baseUrl,
+              accessToken,
+              issueKey,
+              fields,
             });
-          }
-          if (issue.isErr()) {
-            return makeMCPToolTextError(
-              `Error retrieving issue: ${issue.error}`
+            if (issue.isOk() && issue.value === null) {
+              return new Ok(
+                makeMCPToolJSONSuccess({
+                  message: "No issue found with the specified key",
+                  result: { found: false, issueKey },
+                }).content
+              );
+            }
+            if (issue.isErr()) {
+              return new Err(
+                new MCPError(`Error retrieving issue: ${issue.error}`)
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Issue retrieved successfully",
+                result: { issue: issue.value },
+              }).content
             );
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Issue retrieved successfully",
-            result: { issue: issue.value },
-          });
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
     "get_projects",
     "Retrieves a list of JIRA projects.",
     {},
-    async (_, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await getProjects(baseUrl, accessToken);
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error retrieving projects: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "get_projects" },
+      async (_, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await getProjects(baseUrl, accessToken);
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error retrieving projects: ${result.error}`)
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Projects retrieved successfully",
+                result,
+              }).content
             );
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Projects retrieved successfully",
-            result,
-          });
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -148,28 +169,36 @@ const createServer = (
     {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
-    async ({ projectKey }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await getProject(baseUrl, accessToken, projectKey);
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error retrieving project: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "get_project" },
+      async ({ projectKey }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await getProject(baseUrl, accessToken, projectKey);
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error retrieving project: ${result.error}`)
+              );
+            }
+            if (result.value === null) {
+              return new Err(
+                new MCPError(
+                  `No project found with the specified key: ${projectKey}`
+                )
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Project retrieved successfully",
+                result: result.value,
+              }).content
             );
-          }
-          if (result.value === null) {
-            return makeMCPToolTextError(
-              `No project found with the specified key: ${projectKey}`
-            );
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Project retrieved successfully",
-            result: result.value,
-          });
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -178,27 +207,35 @@ const createServer = (
     {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
-    async ({ projectKey }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await getProjectVersions(
-            baseUrl,
-            accessToken,
-            projectKey
-          );
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error retrieving project versions: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "get_project_versions" },
+      async ({ projectKey }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await getProjectVersions(
+              baseUrl,
+              accessToken,
+              projectKey
             );
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Project versions retrieved successfully",
-            result: result.value,
-          });
-        },
-        authInfo,
-      });
-    }
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(
+                  `Error retrieving project versions: ${result.error}`
+                )
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Project versions retrieved successfully",
+                result: result.value,
+              }).content
+            );
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -207,23 +244,29 @@ const createServer = (
     {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
     },
-    async ({ issueKey }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await getTransitions(baseUrl, accessToken, issueKey);
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error retrieving transitions: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "get_transitions" },
+      async ({ issueKey }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await getTransitions(baseUrl, accessToken, issueKey);
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error retrieving transitions: ${result.error}`)
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Transitions retrieved successfully",
+                result,
+              }).content
             );
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Transitions retrieved successfully",
-            result,
-          });
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -245,48 +288,59 @@ const createServer = (
         .optional()
         .describe("Group or role name for visibility restriction"),
     },
-    async (
-      { issueKey, comment, visibilityType, visibilityValue },
-      { authInfo }
-    ) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const visibility =
-            visibilityType && visibilityValue
-              ? { type: visibilityType, value: visibilityValue }
-              : undefined;
 
-          const result = await createComment(
-            baseUrl,
-            accessToken,
-            issueKey,
-            comment,
-            visibility
-          );
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error adding comment: ${result.error}`
-            );
-          }
-          if (result.value === null) {
-            return makeMCPToolJSONSuccess({
-              message: "Issue not found or no permission to add comment",
-              result: { found: false, issueKey },
-            });
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Comment added successfully",
-            result: {
+    withToolLogging(
+      auth,
+      { toolName: "create_comment" },
+      async (
+        { issueKey, comment, visibilityType, visibilityValue },
+        { authInfo }
+      ) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const visibility =
+              visibilityType && visibilityValue
+                ? { type: visibilityType, value: visibilityValue }
+                : undefined;
+
+            const result = await createComment(
+              baseUrl,
+              accessToken,
               issueKey,
-              comment:
-                typeof comment === "string" ? comment : "[Rich ADF Content]",
-              commentId: result.value.id,
-            },
-          });
-        },
-        authInfo,
-      });
-    }
+              comment,
+              visibility
+            );
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error adding comment: ${result.error}`)
+              );
+            }
+            if (result.value === null) {
+              return new Ok(
+                makeMCPToolJSONSuccess({
+                  message: "Issue not found or no permission to add comment",
+                  result: { found: false, issueKey },
+                }).content
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Comment added successfully",
+                result: {
+                  issueKey,
+                  comment:
+                    typeof comment === "string"
+                      ? comment
+                      : "[Rich ADF Content]",
+                  commentId: result.value.id,
+                },
+              }).content
+            );
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -305,30 +359,36 @@ const createServer = (
         .optional()
         .describe("Token for next page of results (for pagination)"),
     },
-    async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await searchIssues(baseUrl, accessToken, filters, {
-            nextPageToken,
-            sortBy,
-          });
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error searching issues: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "get_issues" },
+      async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await searchIssues(baseUrl, accessToken, filters, {
+              nextPageToken,
+              sortBy,
+            });
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error searching issues: ${result.error}`)
+              );
+            }
+            const message =
+              result.value.issues.length === 0
+                ? "No issues found matching the search criteria"
+                : "Issues retrieved successfully";
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message,
+                result: result.value,
+              }).content
             );
-          }
-          const message =
-            result.value.issues.length === 0
-              ? "No issues found matching the search criteria"
-              : "Issues retrieved successfully";
-          return makeMCPToolJSONSuccess({
-            message,
-            result: result.value,
-          });
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -355,36 +415,42 @@ const createServer = (
         .optional()
         .describe("Token for next page of results (for pagination)"),
     },
-    async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await searchJiraIssuesUsingJql(
-            baseUrl,
-            accessToken,
-            jql,
-            {
-              maxResults,
-              fields,
-              nextPageToken,
-            }
-          );
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error executing JQL search: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "get_issues_using_jql" },
+      async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await searchJiraIssuesUsingJql(
+              baseUrl,
+              accessToken,
+              jql,
+              {
+                maxResults,
+                fields,
+                nextPageToken,
+              }
             );
-          }
-          const message =
-            result.value.issues.length === 0
-              ? "No issues found matching the JQL query"
-              : "Issues retrieved successfully using JQL";
-          return makeMCPToolJSONSuccess({
-            message,
-            result: result.value,
-          });
-        },
-        authInfo,
-      });
-    }
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error executing JQL search: ${result.error}`)
+              );
+            }
+            const message =
+              result.value.issues.length === 0
+                ? "No issues found matching the JQL query"
+                : "Issues retrieved successfully using JQL";
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message,
+                result: result.value,
+              }).content
+            );
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -393,33 +459,40 @@ const createServer = (
     {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
-    async ({ projectKey }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          try {
-            const result = await getIssueTypes(
-              baseUrl,
-              accessToken,
-              projectKey
-            );
-            if (result.isErr()) {
-              return makeMCPToolTextError(
-                `Error retrieving issue types: ${result.error}`
+
+    withToolLogging(
+      auth,
+      { toolName: "get_issue_types" },
+      async ({ projectKey }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            try {
+              const result = await getIssueTypes(
+                baseUrl,
+                accessToken,
+                projectKey
+              );
+              if (result.isErr()) {
+                return new Err(
+                  new MCPError(`Error retrieving issue types: ${result.error}`)
+                );
+              }
+              return new Ok(
+                makeMCPToolJSONSuccess({
+                  message: "Issue types retrieved successfully",
+                  result,
+                }).content
+              );
+            } catch (error) {
+              return new Err(
+                new MCPError(`Error retrieving issue types: ${error}`)
               );
             }
-            return makeMCPToolJSONSuccess({
-              message: "Issue types retrieved successfully",
-              result,
-            });
-          } catch (error) {
-            return makeMCPToolTextError(
-              `Error retrieving issue types: ${error}`
-            );
-          }
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -431,58 +504,72 @@ const createServer = (
         .string()
         .describe("The issue type ID to get fields for (required)"),
     },
-    async ({ projectKey, issueTypeId }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          try {
-            const result = await getIssueFields(
-              baseUrl,
-              accessToken,
-              projectKey,
-              issueTypeId
-            );
-            if (result.isErr()) {
-              return makeMCPToolTextError(
-                `Error retrieving issue fields: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "get_issue_create_fields" },
+      async ({ projectKey, issueTypeId }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            try {
+              const result = await getIssueFields(
+                baseUrl,
+                accessToken,
+                projectKey,
+                issueTypeId
+              );
+              if (result.isErr()) {
+                return new Err(
+                  new MCPError(`Error retrieving issue fields: ${result.error}`)
+                );
+              }
+              return new Ok(
+                makeMCPToolJSONSuccess({
+                  message: "Issue fields retrieved successfully",
+                  result,
+                }).content
+              );
+            } catch (error) {
+              return new Err(
+                new MCPError(`Error retrieving issue fields: ${error}`)
               );
             }
-            return makeMCPToolJSONSuccess({
-              message: "Issue fields retrieved successfully",
-              result,
-            });
-          } catch (error) {
-            return makeMCPToolTextError(
-              `Error retrieving issue fields: ${error}`
-            );
-          }
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
     "get_connection_info",
     "Gets comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves",
     {},
-    async (_, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return makeMCPToolTextError("No access token found");
-      }
+    withToolLogging(
+      auth,
+      { toolName: "get_connection_info" },
+      async (_, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("No access token found"));
+        }
 
-      const connectionInfo = await getConnectionInfo(accessToken);
-      if (connectionInfo.isErr()) {
-        return makeMCPToolTextError(
-          `Failed to retrieve connection information: ${connectionInfo.error}`
+        const connectionInfo = await getConnectionInfo(accessToken);
+        if (connectionInfo.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to retrieve connection information: ${connectionInfo.error}`
+            )
+          );
+        }
+
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Connection information retrieved successfully",
+            result: connectionInfo,
+          }).content
         );
       }
-
-      return makeMCPToolJSONSuccess({
-        message: "Connection information retrieved successfully",
-        result: connectionInfo,
-      });
-    }
+    )
   );
 
   server.tool(
@@ -492,46 +579,55 @@ const createServer = (
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       transitionId: z.string().describe("The ID of the transition to perform"),
     },
-    async ({ issueKey, transitionId }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await transitionIssue(
-            baseUrl,
-            accessToken,
-            issueKey,
-            transitionId
-          );
-          if (result.isErr()) {
-            // Provide more helpful error messages for transition issues
-            let errorMessage = `Error transitioning issue: ${result.error}`;
-            if (
-              result.error.includes("transition") &&
-              (result.error.includes("not valid") ||
-                result.error.includes("not allowed"))
-            ) {
-              errorMessage = `Transition failed: ${result.error}. This transition may not be available from the current status, or you may lack permission to perform it.`;
-            } else if (result.error.includes("workflow")) {
-              errorMessage = `Workflow error: ${result.error}. The issue's workflow may have conditions or validators preventing this transition.`;
-            }
-            return makeMCPToolTextError(errorMessage);
-          }
-          if (result.value === null) {
-            return makeMCPToolJSONSuccess({
-              message: "Issue not found or no permission to transition it",
-              result: { found: false, issueKey },
-            });
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Issue transitioned successfully",
-            result: {
+
+    withToolLogging(
+      auth,
+      { toolName: "transition_issue" },
+      async ({ issueKey, transitionId }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await transitionIssue(
+              baseUrl,
+              accessToken,
               issueKey,
-              transitionId,
-            },
-          });
-        },
-        authInfo,
-      });
-    }
+              transitionId
+            );
+            if (result.isErr()) {
+              // Provide more helpful error messages for transition issues
+              let errorMessage = `Error transitioning issue: ${result.error}`;
+              if (
+                result.error.includes("transition") &&
+                (result.error.includes("not valid") ||
+                  result.error.includes("not allowed"))
+              ) {
+                errorMessage = `Transition failed: ${result.error}. This transition may not be available from the current status, or you may lack permission to perform it.`;
+              } else if (result.error.includes("workflow")) {
+                errorMessage = `Workflow error: ${result.error}. The issue's workflow may have conditions or validators preventing this transition.`;
+              }
+              return new Err(new MCPError(errorMessage));
+            }
+            if (result.value === null) {
+              return new Ok(
+                makeMCPToolJSONSuccess({
+                  message: "Issue not found or no permission to transition it",
+                  result: { found: false, issueKey },
+                }).content
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Issue transitioned successfully",
+                result: {
+                  issueKey,
+                  transitionId,
+                },
+              }).content
+            );
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -542,28 +638,34 @@ const createServer = (
         "The description of the issue"
       ),
     },
-    async ({ issueData }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await createIssue(baseUrl, accessToken, issueData);
-          if (result.isErr()) {
-            let errorMessage = `Error creating issue: ${result.error}`;
-            if (
-              result.error.includes("cannot be set") ||
-              result.error.includes("not on the appropriate screen")
-            ) {
-              errorMessage = `Field configuration error: ${result.error}. Some fields are not available for this project/issue type. Use get_issue_create_fields to check which fields are required and available before creating issues.`;
+    withToolLogging(
+      auth,
+      { toolName: "create_issue" },
+      async ({ issueData }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await createIssue(baseUrl, accessToken, issueData);
+            if (result.isErr()) {
+              let errorMessage = `Error creating issue: ${result.error}`;
+              if (
+                result.error.includes("cannot be set") ||
+                result.error.includes("not on the appropriate screen")
+              ) {
+                errorMessage = `Field configuration error: ${result.error}. Some fields are not available for this project/issue type. Use get_issue_create_fields to check which fields are required and available before creating issues.`;
+              }
+              return new Err(new MCPError(errorMessage));
             }
-            return makeMCPToolTextError(errorMessage);
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Issue created successfully",
-            result: result.value,
-          });
-        },
-        authInfo,
-      });
-    }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Issue created successfully",
+                result: result.value,
+              }).content
+            );
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -575,37 +677,46 @@ const createServer = (
         "The partial data to update the issue with - description field supports both plain text and ADF format"
       ),
     },
-    async ({ issueKey, updateData }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await updateIssue(
-            baseUrl,
-            accessToken,
-            issueKey,
-            updateData
-          );
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error updating issue: ${result.error}`
+
+    withToolLogging(
+      auth,
+      { toolName: "update_issue" },
+      async ({ issueKey, updateData }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await updateIssue(
+              baseUrl,
+              accessToken,
+              issueKey,
+              updateData
             );
-          }
-          if (result.value === null) {
-            return makeMCPToolJSONSuccess({
-              message: "Issue not found or no permission to update it",
-              result: { found: false, issueKey },
-            });
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Issue updated successfully",
-            result: {
-              ...result.value,
-              updatedFields: Object.keys(updateData),
-            },
-          });
-        },
-        authInfo,
-      });
-    }
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error updating issue: ${result.error}`)
+              );
+            }
+            if (result.value === null) {
+              return new Ok(
+                makeMCPToolJSONSuccess({
+                  message: "Issue not found or no permission to update it",
+                  result: { found: false, issueKey },
+                }).content
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Issue updated successfully",
+                result: {
+                  ...result.value,
+                  updatedFields: Object.keys(updateData),
+                },
+              }).content
+            );
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -616,25 +727,35 @@ const createServer = (
         "Link configuration including type and issues to link"
       ),
     },
-    async ({ linkData }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await createIssueLink(baseUrl, accessToken, linkData);
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error creating issue link: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "create_issue_link" },
+      async ({ linkData }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await createIssueLink(
+              baseUrl,
+              accessToken,
+              linkData
             );
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Issue link created successfully",
-            result: {
-              ...linkData,
-            },
-          });
-        },
-        authInfo,
-      });
-    }
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error creating issue link: ${result.error}`)
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Issue link created successfully",
+                result: {
+                  ...linkData,
+                },
+              }).content
+            );
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -643,46 +764,59 @@ const createServer = (
     {
       linkId: z.string().describe("The ID of the issue link to delete"),
     },
-    async ({ linkId }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await deleteIssueLink(baseUrl, accessToken, linkId);
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error deleting issue link: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "delete_issue_link" },
+      async ({ linkId }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await deleteIssueLink(baseUrl, accessToken, linkId);
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(`Error deleting issue link: ${result.error}`)
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Issue link deleted successfully",
+                result: { linkId },
+              }).content
             );
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Issue link deleted successfully",
-            result: { linkId },
-          });
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
-
   server.tool(
     "get_issue_link_types",
     "Retrieves all available issue link types that can be used when creating issue links.",
     {},
-    async (_, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const result = await getIssueLinkTypes(baseUrl, accessToken);
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error retrieving issue link types: ${result.error}`
+    withToolLogging(
+      auth,
+      { toolName: "get_issue_link_types" },
+      async (_, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const result = await getIssueLinkTypes(baseUrl, accessToken);
+            if (result.isErr()) {
+              return new Err(
+                new MCPError(
+                  `Error retrieving issue link types: ${result.error}`
+                )
+              );
+            }
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: "Issue link types retrieved successfully",
+                result: result.value,
+              }).content
             );
-          }
-          return makeMCPToolJSONSuccess({
-            message: "Issue link types retrieved successfully",
-            result: result.value,
-          });
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -719,68 +853,76 @@ const createServer = (
           "Pagination offset. Pass the previous response's nextStartAt to fetch the next page."
         ),
     },
-    async (
-      { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
-      { authInfo }
-    ) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          if (emailAddress) {
-            const result = await searchUsersByEmailExact(
-              baseUrl,
-              accessToken,
-              emailAddress,
-              { maxResults, startAt }
-            );
+    withToolLogging(
+      auth,
+      { toolName: "get_users" },
+      async (
+        { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
+        { authInfo }
+      ) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            if (emailAddress) {
+              const result = await searchUsersByEmailExact(
+                baseUrl,
+                accessToken,
+                emailAddress,
+                { maxResults, startAt }
+              );
+              if (result.isErr()) {
+                return new Err(
+                  new MCPError(`Error searching users: ${result.error}`)
+                );
+              }
+
+              const message =
+                result.value.users.length === 0
+                  ? "No users found with the specified email address"
+                  : `Found ${result.value.users.length} exact match(es) for the specified email address`;
+              return new Ok(
+                makeMCPToolJSONSuccess({
+                  message,
+                  result: {
+                    users: result.value.users,
+                    nextStartAt: result.value.nextStartAt,
+                  },
+                }).content
+              );
+            }
+
+            const result = await listUsers(baseUrl, accessToken, {
+              name,
+              maxResults,
+              startAt,
+            });
             if (result.isErr()) {
-              return makeMCPToolTextError(
-                `Error searching users: ${result.error}`
+              return new Err(
+                new MCPError(`Error searching users: ${result.error}`)
               );
             }
 
             const message =
               result.value.users.length === 0
-                ? "No users found with the specified email address"
-                : `Found ${result.value.users.length} exact match(es) for the specified email address`;
-            return makeMCPToolJSONSuccess({
-              message,
-              result: {
-                users: result.value.users,
-                nextStartAt: result.value.nextStartAt,
-              },
-            });
-          }
-
-          const result = await listUsers(baseUrl, accessToken, {
-            name,
-            maxResults,
-            startAt,
-          });
-          if (result.isErr()) {
-            return makeMCPToolTextError(
-              `Error searching users: ${result.error}`
+                ? name
+                  ? "No users found matching the name"
+                  : "No users found"
+                : name
+                  ? `Found ${result.value.users.length} user(s) matching the name`
+                  : `Listed ${result.value.users.length} user(s)`;
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message,
+                result: {
+                  users: result.value.users,
+                  nextStartAt: result.value.nextStartAt,
+                },
+              }).content
             );
-          }
-
-          const message =
-            result.value.users.length === 0
-              ? name
-                ? "No users found matching the name"
-                : "No users found"
-              : name
-                ? `Found ${result.value.users.length} user(s) matching the name`
-                : `Listed ${result.value.users.length} user(s)`;
-          return makeMCPToolJSONSuccess({
-            message,
-            result: {
-              users: result.value.users,
-              nextStartAt: result.value.nextStartAt,
-            },
-          });
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -817,97 +959,113 @@ const createServer = (
         }),
       ]),
     },
-    async ({ issueKey, attachment }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          let fileToUpload: {
-            buffer: Buffer;
-            filename: string;
-            contentType: string;
-          };
+    withToolLogging(
+      auth,
+      { toolName: "upload_attachment" },
+      async ({ issueKey, attachment }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            let fileToUpload: {
+              buffer: Buffer;
+              filename: string;
+              contentType: string;
+            };
 
-          if (attachment.type === "conversation_file") {
-            if (!auth || !agentLoopContext) {
-              return makeMCPToolTextError(
-                "Authentication and conversation context required for conversation file attachments"
+            if (attachment.type === "conversation_file") {
+              if (!auth || !agentLoopContext) {
+                return new Err(
+                  new MCPError(
+                    "Authentication and conversation context required for conversation file attachments"
+                  )
+                );
+              }
+
+              const fileResult = await getFileFromConversationAttachment(
+                auth,
+                attachment.fileId,
+                agentLoopContext
               );
+
+              if (fileResult.isErr()) {
+                return new Err(
+                  new MCPError(
+                    `Failed to get conversation file ${attachment.fileId}: ${fileResult.error}`
+                  )
+                );
+              }
+
+              fileToUpload = fileResult.value;
+            } else if (attachment.type === "external_file") {
+              // Validate base64 data size to prevent memory exhaustion (100MB limit)
+              const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+              const estimatedSize = (attachment.base64Data.length * 3) / 4; // Base64 to bytes estimation
+
+              if (estimatedSize > MAX_FILE_SIZE_BYTES) {
+                return new Err(
+                  new MCPError(
+                    `File ${attachment.filename} is too large. Maximum size allowed is ${MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB`
+                  )
+                );
+              }
+
+              try {
+                const buffer = Buffer.from(attachment.base64Data, "base64");
+                fileToUpload = {
+                  buffer,
+                  filename: attachment.filename,
+                  contentType: attachment.contentType,
+                };
+              } catch (error) {
+                return new Err(
+                  new MCPError(
+                    `Failed to decode base64 data for ${attachment.filename}: ${normalizeError(error).message}`
+                  )
+                );
+              }
+            } else {
+              return new Err(new MCPError("Invalid attachment type"));
             }
 
-            const fileResult = await getFileFromConversationAttachment(
-              auth,
-              attachment.fileId,
-              agentLoopContext
-            );
-
-            if (fileResult.isErr()) {
-              return makeMCPToolTextError(
-                `Failed to get conversation file ${attachment.fileId}: ${fileResult.error}`
-              );
-            }
-
-            fileToUpload = fileResult.value;
-          } else if (attachment.type === "external_file") {
-            // Validate base64 data size to prevent memory exhaustion (100MB limit)
-            const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
-            const estimatedSize = (attachment.base64Data.length * 3) / 4; // Base64 to bytes estimation
-
-            if (estimatedSize > MAX_FILE_SIZE_BYTES) {
-              return makeMCPToolTextError(
-                `File ${attachment.filename} is too large. Maximum size allowed is ${MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB`
-              );
-            }
-
-            try {
-              const buffer = Buffer.from(attachment.base64Data, "base64");
-              fileToUpload = {
-                buffer,
-                filename: attachment.filename,
-                contentType: attachment.contentType,
-              };
-            } catch (error) {
-              return makeMCPToolTextError(
-                `Failed to decode base64 data for ${attachment.filename}: ${normalizeError(error).message}`
-              );
-            }
-          } else {
-            return makeMCPToolTextError("Invalid attachment type");
-          }
-
-          const uploadResult = await uploadAttachmentsToJira(
-            baseUrl,
-            accessToken,
-            issueKey,
-            [fileToUpload]
-          );
-
-          if (uploadResult.isErr()) {
-            return makeMCPToolTextError(
-              `Failed to upload attachment: ${uploadResult.error}`
-            );
-          }
-
-          const uploadedAttachment = uploadResult.value[0];
-
-          return makeMCPToolJSONSuccess({
-            message: `Successfully uploaded attachment to issue ${issueKey}`,
-            result: {
+            const uploadResult = await uploadAttachmentsToJira(
+              baseUrl,
+              accessToken,
               issueKey,
-              attachment: {
-                id: uploadedAttachment.id,
-                filename: uploadedAttachment.filename,
-                size: uploadedAttachment.size,
-                mimeType: uploadedAttachment.mimeType,
-                created: uploadedAttachment.created,
-                author:
-                  uploadedAttachment.author.displayName ??
-                  uploadedAttachment.author.accountId,
-              },
-            },
-          });
-        },
-        authInfo,
-      });
-    }
+              [fileToUpload]
+            );
+
+            if (uploadResult.isErr()) {
+              return new Err(
+                new MCPError(
+                  `Failed to upload attachment: ${uploadResult.error}`
+                )
+              );
+            }
+
+            const uploadedAttachment = uploadResult.value[0];
+
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: `Successfully uploaded attachment to issue ${issueKey}`,
+                result: {
+                  issueKey,
+                  attachment: {
+                    id: uploadedAttachment.id,
+                    filename: uploadedAttachment.filename,
+                    size: uploadedAttachment.size,
+                    mimeType: uploadedAttachment.mimeType,
+                    created: uploadedAttachment.created,
+                    author:
+                      uploadedAttachment.author.displayName ??
+                      uploadedAttachment.author.accountId,
+                  },
+                },
+              }).content
+            );
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -916,47 +1074,53 @@ const createServer = (
     {
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
     },
-    async ({ issueKey }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          const attachmentsResult = await getIssueAttachments({
-            baseUrl,
-            accessToken,
-            issueKey,
-          });
-
-          if (attachmentsResult.isErr()) {
-            return makeMCPToolTextError(attachmentsResult.error);
-          }
-
-          const attachments = attachmentsResult.value;
-          const attachmentSummary = attachments.map((att) => ({
-            id: att.id,
-            filename: att.filename,
-            size: att.size,
-            mimeType: att.mimeType,
-            created: att.created,
-            author: att.author?.displayName ?? att.author?.accountId,
-            content: att.content,
-            thumbnail: att.thumbnail,
-          }));
-
-          return makeMCPToolJSONSuccess({
-            message: `Found ${attachments.length} attachment(s) for issue ${issueKey}`,
-            result: {
+    withToolLogging(
+      auth,
+      { toolName: "get_attachments" },
+      async ({ issueKey }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            const attachmentsResult = await getIssueAttachments({
+              baseUrl,
+              accessToken,
               issueKey,
-              attachments: attachmentSummary,
-              totalAttachments: attachments.length,
-              totalSize: attachments.reduce(
-                (sum, att) => sum + (att.size || 0),
-                0
-              ),
-            },
-          });
-        },
-        authInfo,
-      });
-    }
+            });
+
+            if (attachmentsResult.isErr()) {
+              return new Err(new MCPError(attachmentsResult.error));
+            }
+
+            const attachments = attachmentsResult.value;
+            const attachmentSummary = attachments.map((att) => ({
+              id: att.id,
+              filename: att.filename,
+              size: att.size,
+              mimeType: att.mimeType,
+              created: att.created,
+              author: att.author?.displayName ?? att.author?.accountId,
+              content: att.content,
+              thumbnail: att.thumbnail,
+            }));
+
+            return new Ok(
+              makeMCPToolJSONSuccess({
+                message: `Found ${attachments.length} attachment(s) for issue ${issueKey}`,
+                result: {
+                  issueKey,
+                  attachments: attachmentSummary,
+                  totalAttachments: attachments.length,
+                  totalSize: attachments.reduce(
+                    (sum, att) => sum + (att.size || 0),
+                    0
+                  ),
+                },
+              }).content
+            );
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   server.tool(
@@ -966,66 +1130,74 @@ const createServer = (
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
       attachmentId: z.string().describe("The ID of the attachment to read"),
     },
-    async ({ issueKey, attachmentId }, { authInfo }) => {
-      return withAuth({
-        action: async (baseUrl, accessToken) => {
-          try {
-            const attachmentsResult = await getIssueAttachments({
-              baseUrl,
-              accessToken,
-              issueKey,
-            });
+    withToolLogging(
+      auth,
+      { toolName: "read_attachment" },
+      async ({ issueKey, attachmentId }, { authInfo }) => {
+        return withAuth({
+          action: async (baseUrl, accessToken) => {
+            try {
+              const attachmentsResult = await getIssueAttachments({
+                baseUrl,
+                accessToken,
+                issueKey,
+              });
 
-            if (attachmentsResult.isErr()) {
-              return makeMCPToolTextError(attachmentsResult.error);
-            }
+              if (attachmentsResult.isErr()) {
+                return new Err(new MCPError(attachmentsResult.error));
+              }
 
-            const attachments = attachmentsResult.value;
-            const targetAttachment = attachments.find(
-              (att) => att.id === attachmentId
-            );
-            if (!targetAttachment) {
-              return makeMCPToolTextError(
-                `Attachment with ID ${attachmentId} not found on issue ${issueKey}`
+              const attachments = attachmentsResult.value;
+              const targetAttachment = attachments.find(
+                (att) => att.id === attachmentId
+              );
+              if (!targetAttachment) {
+                return new Err(
+                  new MCPError(
+                    `Attachment with ID ${attachmentId} not found on issue ${issueKey}`
+                  )
+                );
+              }
+              return await processAttachment({
+                mimeType: targetAttachment.mimeType,
+                filename: targetAttachment.filename,
+                extractText: async () =>
+                  extractTextFromAttachment({
+                    baseUrl,
+                    accessToken,
+                    attachmentId,
+                    mimeType: targetAttachment.mimeType,
+                  }),
+                downloadContent: async () => {
+                  const result = await getAttachmentContent({
+                    baseUrl,
+                    accessToken,
+                    attachmentId,
+                    mimeType: targetAttachment.mimeType,
+                  });
+                  if (result.isErr()) {
+                    return result;
+                  }
+                  return new Ok(Buffer.from(result.value.content, "base64"));
+                },
+              });
+            } catch (error) {
+              logger.error(`Error in read_attachment:`, {
+                error: error,
+                issueKey,
+                attachmentId,
+              });
+              return new Err(
+                new MCPError(
+                  `Error in read_attachment: ${normalizeError(error).message}`
+                )
               );
             }
-            return await processAttachment({
-              mimeType: targetAttachment.mimeType,
-              filename: targetAttachment.filename,
-              extractText: async () =>
-                extractTextFromAttachment({
-                  baseUrl,
-                  accessToken,
-                  attachmentId,
-                  mimeType: targetAttachment.mimeType,
-                }),
-              downloadContent: async () => {
-                const result = await getAttachmentContent({
-                  baseUrl,
-                  accessToken,
-                  attachmentId,
-                  mimeType: targetAttachment.mimeType,
-                });
-                if (result.isErr()) {
-                  return result;
-                }
-                return new Ok(Buffer.from(result.value.content, "base64"));
-              },
-            });
-          } catch (error) {
-            logger.error(`Error in read_attachment:`, {
-              error: error,
-              issueKey,
-              attachmentId,
-            });
-            return makeMCPToolTextError(
-              `Error in read_attachment: ${normalizeError(error).message}`
-            );
-          }
-        },
-        authInfo,
-      });
-    }
+          },
+          authInfo,
+        });
+      }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   createComment,
   createIssue,
@@ -15,7 +14,6 @@ import {
   getIssueFields,
   getIssueLinkTypes,
   getIssueTypes,
-  getJiraBaseUrl,
   getProject,
   getProjects,
   getProjectVersions,
@@ -28,6 +26,7 @@ import {
   transitionIssue,
   updateIssue,
   uploadAttachmentsToJira,
+  withAuth,
 } from "@app/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper";
 import {
   ADFDocumentSchema,
@@ -40,17 +39,17 @@ import {
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
+  makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
-import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { Err, normalizeError, Ok } from "@app/types";
+import { normalizeError, Ok } from "@app/types";
 
 const createServer = (
-  auth: Authenticator,
+  auth?: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
   const server = makeInternalMCPServer("jira");
@@ -59,46 +58,23 @@ const createServer = (
     "get_issue_read_fields",
     "Lists available Jira field keys/ids and names for use in the get_issue.fields parameter (read-time).",
     {},
-    withToolLogging(
-      auth,
-      { toolName: "get_issue_read_fields" },
-      async (_, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async (_, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await listFieldSummaries(baseUrl, accessToken);
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error retrieving fields: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error retrieving fields: ${result.error}`
             );
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Fields retrieved successfully",
-              result: result.value,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Fields retrieved successfully",
+            result: result.value,
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -113,25 +89,9 @@ const createServer = (
           "Optional list of fields to include. Defaults to a minimal set for performance."
         ),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_issue" },
-      async ({ issueKey, fields }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ issueKey, fields }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const issue = await getIssue({
             baseUrl,
             accessToken,
@@ -139,79 +99,47 @@ const createServer = (
             fields,
           });
           if (issue.isOk() && issue.value === null) {
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "No issue found with the specified key",
-                result: { found: false, issueKey },
-              }).content
-            );
+            return makeMCPToolJSONSuccess({
+              message: "No issue found with the specified key",
+              result: { found: false, issueKey },
+            });
           }
           if (issue.isErr()) {
-            return new Err(
-              new MCPError(`Error retrieving issue: ${issue.error}`)
+            return makeMCPToolTextError(
+              `Error retrieving issue: ${issue.error}`
             );
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Issue retrieved successfully",
-              result: { issue: issue.value },
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Issue retrieved successfully",
+            result: { issue: issue.value },
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
     "get_projects",
     "Retrieves a list of JIRA projects.",
     {},
-    withToolLogging(
-      auth,
-      { toolName: "get_projects" },
-      async (_, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async (_, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await getProjects(baseUrl, accessToken);
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error retrieving projects: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error retrieving projects: ${result.error}`
             );
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Projects retrieved successfully",
-              result,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Projects retrieved successfully",
+            result,
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -220,53 +148,28 @@ const createServer = (
     {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_project" },
-      async ({ projectKey }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ projectKey }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await getProject(baseUrl, accessToken, projectKey);
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error retrieving project: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error retrieving project: ${result.error}`
             );
           }
           if (result.value === null) {
-            return new Err(
-              new MCPError(
-                `No project found with the specified key: ${projectKey}`
-              )
+            return makeMCPToolTextError(
+              `No project found with the specified key: ${projectKey}`
             );
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Project retrieved successfully",
-              result: result.value,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Project retrieved successfully",
+            result: result.value,
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -275,50 +178,27 @@ const createServer = (
     {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_project_versions" },
-      async ({ projectKey }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ projectKey }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await getProjectVersions(
             baseUrl,
             accessToken,
             projectKey
           );
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error retrieving project versions: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error retrieving project versions: ${result.error}`
             );
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Project versions retrieved successfully",
-              result: result.value,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Project versions retrieved successfully",
+            result: result.value,
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -327,46 +207,23 @@ const createServer = (
     {
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_transitions" },
-      async ({ issueKey }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ issueKey }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await getTransitions(baseUrl, accessToken, issueKey);
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error retrieving transitions: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error retrieving transitions: ${result.error}`
             );
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Transitions retrieved successfully",
-              result,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Transitions retrieved successfully",
+            result,
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -388,28 +245,12 @@ const createServer = (
         .optional()
         .describe("Group or role name for visibility restriction"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "create_comment" },
-      async (
-        { issueKey, comment, visibilityType, visibilityValue },
-        { authInfo }
-      ) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async (
+      { issueKey, comment, visibilityType, visibilityValue },
+      { authInfo }
+    ) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const visibility =
             visibilityType && visibilityValue
               ? { type: visibilityType, value: visibilityValue }
@@ -423,38 +264,29 @@ const createServer = (
             visibility
           );
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error adding comment: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error adding comment: ${result.error}`
             );
           }
           if (result.value === null) {
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue not found or no permission to add comment",
-                result: { found: false, issueKey },
-              }).content
-            );
+            return makeMCPToolJSONSuccess({
+              message: "Issue not found or no permission to add comment",
+              result: { found: false, issueKey },
+            });
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Comment added successfully",
-              result: {
-                issueKey,
-                comment:
-                  typeof comment === "string" ? comment : "[Rich ADF Content]",
-                commentId: result.value.id,
-              },
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Comment added successfully",
+            result: {
+              issueKey,
+              comment:
+                typeof comment === "string" ? comment : "[Rich ADF Content]",
+              commentId: result.value.id,
+            },
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -473,53 +305,30 @@ const createServer = (
         .optional()
         .describe("Token for next page of results (for pagination)"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_issues" },
-      async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await searchIssues(baseUrl, accessToken, filters, {
             nextPageToken,
             sortBy,
           });
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error searching issues: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error searching issues: ${result.error}`
             );
           }
           const message =
             result.value.issues.length === 0
               ? "No issues found matching the search criteria"
               : "Issues retrieved successfully";
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message,
-              result: result.value,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message,
+            result: result.value,
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -546,25 +355,9 @@ const createServer = (
         .optional()
         .describe("Token for next page of results (for pagination)"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_issues_using_jql" },
-      async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await searchJiraIssuesUsingJql(
             baseUrl,
             accessToken,
@@ -576,29 +369,22 @@ const createServer = (
             }
           );
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error executing JQL search: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error executing JQL search: ${result.error}`
             );
           }
           const message =
             result.value.issues.length === 0
               ? "No issues found matching the JQL query"
               : "Issues retrieved successfully using JQL";
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message,
-              result: result.value,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message,
+            result: result.value,
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -607,50 +393,33 @@ const createServer = (
     {
       projectKey: z.string().describe("The JIRA project key (e.g., 'PROJ')"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_issue_types" },
-      async ({ projectKey }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
+    async ({ projectKey }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          try {
+            const result = await getIssueTypes(
+              baseUrl,
+              accessToken,
+              projectKey
             );
-          }
-
-          const result = await getIssueTypes(
-            baseUrl,
-            accessToken,
-            projectKey
-          );
-          if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error retrieving issue types: ${result.error}`)
-            );
-          }
-          return new Ok(
-            makeMCPToolJSONSuccess({
+            if (result.isErr()) {
+              return makeMCPToolTextError(
+                `Error retrieving issue types: ${result.error}`
+              );
+            }
+            return makeMCPToolJSONSuccess({
               message: "Issue types retrieved successfully",
               result,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+            });
+          } catch (error) {
+            return makeMCPToolTextError(
+              `Error retrieving issue types: ${error}`
+            );
+          }
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -662,83 +431,58 @@ const createServer = (
         .string()
         .describe("The issue type ID to get fields for (required)"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_issue_create_fields" },
-      async ({ projectKey, issueTypeId }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
+    async ({ projectKey, issueTypeId }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          try {
+            const result = await getIssueFields(
+              baseUrl,
+              accessToken,
+              projectKey,
+              issueTypeId
             );
-          }
-
-          const result = await getIssueFields(
-            baseUrl,
-            accessToken,
-            projectKey,
-            issueTypeId
-          );
-          if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error retrieving issue fields: ${result.error}`)
-            );
-          }
-          return new Ok(
-            makeMCPToolJSONSuccess({
+            if (result.isErr()) {
+              return makeMCPToolTextError(
+                `Error retrieving issue fields: ${result.error}`
+              );
+            }
+            return makeMCPToolJSONSuccess({
               message: "Issue fields retrieved successfully",
               result,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+            });
+          } catch (error) {
+            return makeMCPToolTextError(
+              `Error retrieving issue fields: ${error}`
+            );
+          }
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
     "get_connection_info",
     "Gets comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves",
     {},
-    withToolLogging(
-      auth,
-      { toolName: "get_connection_info" },
-      async (_, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
+    async (_, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        return makeMCPToolTextError("No access token found");
+      }
 
-        const connectionInfo = await getConnectionInfo(accessToken);
-        if (connectionInfo.isErr()) {
-          return new Err(
-            new MCPError(
-              `Failed to retrieve connection information: ${connectionInfo.error}`
-            )
-          );
-        }
-
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Connection information retrieved successfully",
-            result: connectionInfo,
-          }).content
+      const connectionInfo = await getConnectionInfo(accessToken);
+      if (connectionInfo.isErr()) {
+        return makeMCPToolTextError(
+          `Failed to retrieve connection information: ${connectionInfo.error}`
         );
       }
-    )
+
+      return makeMCPToolJSONSuccess({
+        message: "Connection information retrieved successfully",
+        result: connectionInfo,
+      });
+    }
   );
 
   server.tool(
@@ -748,25 +492,9 @@ const createServer = (
       issueKey: z.string().describe("The JIRA issue key (e.g., 'PROJ-123')"),
       transitionId: z.string().describe("The ID of the transition to perform"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "transition_issue" },
-      async ({ issueKey, transitionId }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ issueKey, transitionId }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await transitionIssue(
             baseUrl,
             accessToken,
@@ -785,34 +513,25 @@ const createServer = (
             } else if (result.error.includes("workflow")) {
               errorMessage = `Workflow error: ${result.error}. The issue's workflow may have conditions or validators preventing this transition.`;
             }
-            return new Err(new MCPError(errorMessage));
+            return makeMCPToolTextError(errorMessage);
           }
           if (result.value === null) {
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue not found or no permission to transition it",
-                result: { found: false, issueKey },
-              }).content
-            );
+            return makeMCPToolJSONSuccess({
+              message: "Issue not found or no permission to transition it",
+              result: { found: false, issueKey },
+            });
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Issue transitioned successfully",
-              result: {
-                issueKey,
-                transitionId,
-              },
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Issue transitioned successfully",
+            result: {
+              issueKey,
+              transitionId,
+            },
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -823,25 +542,9 @@ const createServer = (
         "The description of the issue"
       ),
     },
-    withToolLogging(
-      auth,
-      { toolName: "create_issue" },
-      async ({ issueData }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ issueData }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await createIssue(baseUrl, accessToken, issueData);
           if (result.isErr()) {
             let errorMessage = `Error creating issue: ${result.error}`;
@@ -851,23 +554,16 @@ const createServer = (
             ) {
               errorMessage = `Field configuration error: ${result.error}. Some fields are not available for this project/issue type. Use get_issue_create_fields to check which fields are required and available before creating issues.`;
             }
-            return new Err(new MCPError(errorMessage));
+            return makeMCPToolTextError(errorMessage);
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Issue created successfully",
-              result: result.value,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Issue created successfully",
+            result: result.value,
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -879,25 +575,9 @@ const createServer = (
         "The partial data to update the issue with - description field supports both plain text and ADF format"
       ),
     },
-    withToolLogging(
-      auth,
-      { toolName: "update_issue" },
-      async ({ issueKey, updateData }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ issueKey, updateData }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await updateIssue(
             baseUrl,
             accessToken,
@@ -905,36 +585,27 @@ const createServer = (
             updateData
           );
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error updating issue: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error updating issue: ${result.error}`
             );
           }
           if (result.value === null) {
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue not found or no permission to update it",
-                result: { found: false, issueKey },
-              }).content
-            );
+            return makeMCPToolJSONSuccess({
+              message: "Issue not found or no permission to update it",
+              result: { found: false, issueKey },
+            });
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Issue updated successfully",
-              result: {
-                ...result.value,
-                updatedFields: Object.keys(updateData),
-              },
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Issue updated successfully",
+            result: {
+              ...result.value,
+              updatedFields: Object.keys(updateData),
+            },
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -945,52 +616,25 @@ const createServer = (
         "Link configuration including type and issues to link"
       ),
     },
-    withToolLogging(
-      auth,
-      { toolName: "create_issue_link" },
-      async ({ linkData }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
-          const result = await createIssueLink(
-            baseUrl,
-            accessToken,
-            linkData
-          );
+    async ({ linkData }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          const result = await createIssueLink(baseUrl, accessToken, linkData);
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error creating issue link: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error creating issue link: ${result.error}`
             );
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Issue link created successfully",
-              result: {
-                ...linkData,
-              },
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Issue link created successfully",
+            result: {
+              ...linkData,
+            },
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -999,94 +643,46 @@ const createServer = (
     {
       linkId: z.string().describe("The ID of the issue link to delete"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "delete_issue_link" },
-      async ({ linkId }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ linkId }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await deleteIssueLink(baseUrl, accessToken, linkId);
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error deleting issue link: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error deleting issue link: ${result.error}`
             );
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Issue link deleted successfully",
-              result: { linkId },
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Issue link deleted successfully",
+            result: { linkId },
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
     "get_issue_link_types",
     "Retrieves all available issue link types that can be used when creating issue links.",
     {},
-    withToolLogging(
-      auth,
-      { toolName: "get_issue_link_types" },
-      async (_, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async (_, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const result = await getIssueLinkTypes(baseUrl, accessToken);
           if (result.isErr()) {
-            return new Err(
-              new MCPError(
-                `Error retrieving issue link types: ${result.error}`
-              )
+            return makeMCPToolTextError(
+              `Error retrieving issue link types: ${result.error}`
             );
           }
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Issue link types retrieved successfully",
-              result: result.value,
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: "Issue link types retrieved successfully",
+            result: result.value,
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -1123,28 +719,12 @@ const createServer = (
           "Pagination offset. Pass the previous response's nextStartAt to fetch the next page."
         ),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_users" },
-      async (
-        { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
-        { authInfo }
-      ) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async (
+      { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
+      { authInfo }
+    ) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           if (emailAddress) {
             const result = await searchUsersByEmailExact(
               baseUrl,
@@ -1153,8 +733,8 @@ const createServer = (
               { maxResults, startAt }
             );
             if (result.isErr()) {
-              return new Err(
-                new MCPError(`Error searching users: ${result.error}`)
+              return makeMCPToolTextError(
+                `Error searching users: ${result.error}`
               );
             }
 
@@ -1162,15 +742,13 @@ const createServer = (
               result.value.users.length === 0
                 ? "No users found with the specified email address"
                 : `Found ${result.value.users.length} exact match(es) for the specified email address`;
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message,
-                result: {
-                  users: result.value.users,
-                  nextStartAt: result.value.nextStartAt,
-                },
-              }).content
-            );
+            return makeMCPToolJSONSuccess({
+              message,
+              result: {
+                users: result.value.users,
+                nextStartAt: result.value.nextStartAt,
+              },
+            });
           }
 
           const result = await listUsers(baseUrl, accessToken, {
@@ -1179,8 +757,8 @@ const createServer = (
             startAt,
           });
           if (result.isErr()) {
-            return new Err(
-              new MCPError(`Error searching users: ${result.error}`)
+            return makeMCPToolTextError(
+              `Error searching users: ${result.error}`
             );
           }
 
@@ -1192,24 +770,17 @@ const createServer = (
               : name
                 ? `Found ${result.value.users.length} user(s) matching the name`
                 : `Listed ${result.value.users.length} user(s)`;
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message,
-              result: {
-                users: result.value.users,
-                nextStartAt: result.value.nextStartAt,
-              },
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message,
+            result: {
+              users: result.value.users,
+              nextStartAt: result.value.nextStartAt,
+            },
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -1246,25 +817,9 @@ const createServer = (
         }),
       ]),
     },
-    withToolLogging(
-      auth,
-      { toolName: "upload_attachment" },
-      async ({ issueKey, attachment }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ issueKey, attachment }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           let fileToUpload: {
             buffer: Buffer;
             filename: string;
@@ -1272,11 +827,9 @@ const createServer = (
           };
 
           if (attachment.type === "conversation_file") {
-            if (!agentLoopContext) {
-              return new Err(
-                new MCPError(
-                  "Conversation context required for conversation file attachments"
-                )
+            if (!auth || !agentLoopContext) {
+              return makeMCPToolTextError(
+                "Authentication and conversation context required for conversation file attachments"
               );
             }
 
@@ -1287,10 +840,8 @@ const createServer = (
             );
 
             if (fileResult.isErr()) {
-              return new Err(
-                new MCPError(
-                  `Failed to get conversation file ${attachment.fileId}: ${fileResult.error}`
-                )
+              return makeMCPToolTextError(
+                `Failed to get conversation file ${attachment.fileId}: ${fileResult.error}`
               );
             }
 
@@ -1301,10 +852,8 @@ const createServer = (
             const estimatedSize = (attachment.base64Data.length * 3) / 4; // Base64 to bytes estimation
 
             if (estimatedSize > MAX_FILE_SIZE_BYTES) {
-              return new Err(
-                new MCPError(
-                  `File ${attachment.filename} is too large. Maximum size allowed is ${MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB`
-                )
+              return makeMCPToolTextError(
+                `File ${attachment.filename} is too large. Maximum size allowed is ${MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB`
               );
             }
 
@@ -1316,14 +865,12 @@ const createServer = (
                 contentType: attachment.contentType,
               };
             } catch (error) {
-              return new Err(
-                new MCPError(
-                  `Failed to decode base64 data for ${attachment.filename}: ${normalizeError(error).message}`
-                )
+              return makeMCPToolTextError(
+                `Failed to decode base64 data for ${attachment.filename}: ${normalizeError(error).message}`
               );
             }
           } else {
-            return new Err(new MCPError("Invalid attachment type"));
+            return makeMCPToolTextError("Invalid attachment type");
           }
 
           const uploadResult = await uploadAttachmentsToJira(
@@ -1334,42 +881,33 @@ const createServer = (
           );
 
           if (uploadResult.isErr()) {
-            return new Err(
-              new MCPError(
-                `Failed to upload attachment: ${uploadResult.error}`
-              )
+            return makeMCPToolTextError(
+              `Failed to upload attachment: ${uploadResult.error}`
             );
           }
 
           const uploadedAttachment = uploadResult.value[0];
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: `Successfully uploaded attachment to issue ${issueKey}`,
-              result: {
-                issueKey,
-                attachment: {
-                  id: uploadedAttachment.id,
-                  filename: uploadedAttachment.filename,
-                  size: uploadedAttachment.size,
-                  mimeType: uploadedAttachment.mimeType,
-                  created: uploadedAttachment.created,
-                  author:
-                    uploadedAttachment.author.displayName ??
-                    uploadedAttachment.author.accountId,
-                },
+          return makeMCPToolJSONSuccess({
+            message: `Successfully uploaded attachment to issue ${issueKey}`,
+            result: {
+              issueKey,
+              attachment: {
+                id: uploadedAttachment.id,
+                filename: uploadedAttachment.filename,
+                size: uploadedAttachment.size,
+                mimeType: uploadedAttachment.mimeType,
+                created: uploadedAttachment.created,
+                author:
+                  uploadedAttachment.author.displayName ??
+                  uploadedAttachment.author.accountId,
               },
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+            },
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -1378,25 +916,9 @@ const createServer = (
     {
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "get_attachments" },
-      async ({ issueKey }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
-
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
-            );
-          }
-
+    async ({ issueKey }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
           const attachmentsResult = await getIssueAttachments({
             baseUrl,
             accessToken,
@@ -1404,7 +926,7 @@ const createServer = (
           });
 
           if (attachmentsResult.isErr()) {
-            return new Err(new MCPError(attachmentsResult.error));
+            return makeMCPToolTextError(attachmentsResult.error);
           }
 
           const attachments = attachmentsResult.value;
@@ -1419,29 +941,22 @@ const createServer = (
             thumbnail: att.thumbnail,
           }));
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: `Found ${attachments.length} attachment(s) for issue ${issueKey}`,
-              result: {
-                issueKey,
-                attachments: attachmentSummary,
-                totalAttachments: attachments.length,
-                totalSize: attachments.reduce(
-                  (sum, att) => sum + (att.size || 0),
-                  0
-                ),
-              },
-            }).content
-          );
-        } catch (error) {
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+          return makeMCPToolJSONSuccess({
+            message: `Found ${attachments.length} attachment(s) for issue ${issueKey}`,
+            result: {
+              issueKey,
+              attachments: attachmentSummary,
+              totalAttachments: attachments.length,
+              totalSize: attachments.reduce(
+                (sum, att) => sum + (att.size || 0),
+                0
+              ),
+            },
+          });
+        },
+        authInfo,
+      });
+    }
   );
 
   server.tool(
@@ -1451,83 +966,66 @@ const createServer = (
       issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
       attachmentId: z.string().describe("The ID of the attachment to read"),
     },
-    withToolLogging(
-      auth,
-      { toolName: "read_attachment" },
-      async ({ issueKey, attachmentId }, { authInfo }) => {
-        const accessToken = authInfo?.token;
-        if (!accessToken) {
-          return new Err(new MCPError("No access token found"));
-        }
+    async ({ issueKey, attachmentId }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          try {
+            const attachmentsResult = await getIssueAttachments({
+              baseUrl,
+              accessToken,
+              issueKey,
+            });
 
-        try {
-          const baseUrl = await getJiraBaseUrl(accessToken);
-          if (!baseUrl) {
-            return new Err(
-              new MCPError(
-                "Failed to determine JIRA instance URL. Please check your connection."
-              )
+            if (attachmentsResult.isErr()) {
+              return makeMCPToolTextError(attachmentsResult.error);
+            }
+
+            const attachments = attachmentsResult.value;
+            const targetAttachment = attachments.find(
+              (att) => att.id === attachmentId
             );
-          }
-
-          const attachmentsResult = await getIssueAttachments({
-            baseUrl,
-            accessToken,
-            issueKey,
-          });
-
-          if (attachmentsResult.isErr()) {
-            return new Err(new MCPError(attachmentsResult.error));
-          }
-
-          const attachments = attachmentsResult.value;
-          const targetAttachment = attachments.find(
-            (att) => att.id === attachmentId
-          );
-          if (!targetAttachment) {
-            return new Err(
-              new MCPError(
+            if (!targetAttachment) {
+              return makeMCPToolTextError(
                 `Attachment with ID ${attachmentId} not found on issue ${issueKey}`
-              )
+              );
+            }
+            return await processAttachment({
+              mimeType: targetAttachment.mimeType,
+              filename: targetAttachment.filename,
+              extractText: async () =>
+                extractTextFromAttachment({
+                  baseUrl,
+                  accessToken,
+                  attachmentId,
+                  mimeType: targetAttachment.mimeType,
+                }),
+              downloadContent: async () => {
+                const result = await getAttachmentContent({
+                  baseUrl,
+                  accessToken,
+                  attachmentId,
+                  mimeType: targetAttachment.mimeType,
+                });
+                if (result.isErr()) {
+                  return result;
+                }
+                return new Ok(Buffer.from(result.value.content, "base64"));
+              },
+            });
+          } catch (error) {
+            logger.error(`Error in read_attachment:`, {
+              error: error,
+              issueKey,
+              attachmentId,
+            });
+            return makeMCPToolTextError(
+              `Error in read_attachment: ${normalizeError(error).message}`
             );
           }
-          return await processAttachment({
-            mimeType: targetAttachment.mimeType,
-            filename: targetAttachment.filename,
-            extractText: async () =>
-              extractTextFromAttachment({
-                baseUrl,
-                accessToken,
-                attachmentId,
-                mimeType: targetAttachment.mimeType,
-              }),
-            downloadContent: async () => {
-              const result = await getAttachmentContent({
-                baseUrl,
-                accessToken,
-                attachmentId,
-                mimeType: targetAttachment.mimeType,
-              });
-              if (result.isErr()) {
-                return result;
-              }
-              return new Ok(Buffer.from(result.value.content, "base64"));
-            },
-          });
-        } catch (error) {
-          logger.error(`Error in read_attachment:`, {
-            error: error,
-            issueKey,
-            attachmentId,
-          });
-          return new Err(
-            new MCPError(
-              `Authentication error: ${normalizeError(error).message}`
-            )
-          );
-        }
-      }
-    )
+        },
+        authInfo,
+      });
+    }
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
@@ -61,7 +61,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolName: "get_issue_read_fields" },
+      { toolNameForMonitoring: "get_issue_read_fields" },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -98,7 +98,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_issue" },
+      { toolNameForMonitoring: "get_issue" },
       async ({ issueKey, fields }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -140,7 +140,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolName: "get_projects" },
+      { toolNameForMonitoring: "get_projects" },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -171,7 +171,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_project" },
+      { toolNameForMonitoring: "get_project" },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -209,7 +209,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_project_versions" },
+      { toolNameForMonitoring: "get_project_versions" },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -246,7 +246,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_transitions" },
+      { toolNameForMonitoring: "get_transitions" },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -291,7 +291,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolName: "create_comment" },
+      { toolNameForMonitoring: "create_comment" },
       async (
         { issueKey, comment, visibilityType, visibilityValue },
         { authInfo }
@@ -361,7 +361,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_issues" },
+      { toolNameForMonitoring: "get_issues" },
       async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -417,7 +417,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_issues_using_jql" },
+      { toolNameForMonitoring: "get_issues_using_jql" },
       async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -462,7 +462,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolName: "get_issue_types" },
+      { toolNameForMonitoring: "get_issue_types" },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -506,7 +506,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_issue_create_fields" },
+      { toolNameForMonitoring: "get_issue_create_fields" },
       async ({ projectKey, issueTypeId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -546,7 +546,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolName: "get_connection_info" },
+      { toolNameForMonitoring: "get_connection_info" },
       async (_, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -582,7 +582,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolName: "transition_issue" },
+      { toolNameForMonitoring: "transition_issue" },
       async ({ issueKey, transitionId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -640,7 +640,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "create_issue" },
+      { toolNameForMonitoring: "create_issue" },
       async ({ issueData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -680,7 +680,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolName: "update_issue" },
+      { toolNameForMonitoring: "update_issue" },
       async ({ issueKey, updateData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -729,7 +729,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "create_issue_link" },
+      { toolNameForMonitoring: "create_issue_link" },
       async ({ linkData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -766,7 +766,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "delete_issue_link" },
+      { toolNameForMonitoring: "delete_issue_link" },
       async ({ linkId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -794,7 +794,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolName: "get_issue_link_types" },
+      { toolNameForMonitoring: "get_issue_link_types" },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -855,7 +855,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_users" },
+      { toolNameForMonitoring: "get_users" },
       async (
         { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
         { authInfo }
@@ -961,7 +961,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "upload_attachment" },
+      { toolNameForMonitoring: "upload_attachment" },
       async ({ issueKey, attachment }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -1076,7 +1076,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_attachments" },
+      { toolNameForMonitoring: "get_attachments" },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -1132,7 +1132,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "read_attachment" },
+      { toolNameForMonitoring: "read_attachment" },
       async ({ issueKey, attachmentId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {

--- a/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
@@ -49,6 +49,9 @@ import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { Err, normalizeError, Ok } from "@app/types";
 
+// We use a single tool name for monitoring given the high granularity (can be revisited).
+const JIRA_TOOL_NAME = "jira";
+
 const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
@@ -61,7 +64,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -98,7 +101,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ issueKey, fields }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -140,7 +143,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -171,7 +174,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -209,7 +212,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -246,7 +249,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -291,7 +294,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async (
         { issueKey, comment, visibilityType, visibilityValue },
         { authInfo }
@@ -361,7 +364,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -417,7 +420,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -462,7 +465,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -506,7 +509,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ projectKey, issueTypeId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -546,7 +549,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async (_, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -582,7 +585,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ issueKey, transitionId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -640,7 +643,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ issueData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -680,7 +683,7 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ issueKey, updateData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -729,7 +732,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ linkData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -766,7 +769,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ linkId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -794,7 +797,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -855,7 +858,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async (
         { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
         { authInfo }
@@ -961,7 +964,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ issueKey, attachment }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -1076,7 +1079,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -1132,7 +1135,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jira" },
+      { toolNameForMonitoring: JIRA_TOOL_NAME },
       async ({ issueKey, attachmentId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {

--- a/front/lib/actions/mcp_internal_actions/servers/jit_testing.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jit_testing.ts
@@ -68,7 +68,7 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolName: "jit_all_optionals_and_defaults" },
+      { toolNameForMonitoring: "jit_all_optionals_and_defaults" },
       async (params) => {
         return new Ok([
           {

--- a/front/lib/actions/mcp_internal_actions/servers/jit_testing.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jit_testing.ts
@@ -4,8 +4,11 @@ import { z } from "zod";
 
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { Ok } from "@app/types";
 
-function createServer(): McpServer {
+function createServer(auth: Authenticator): McpServer {
   const server = makeInternalMCPServer("jit_testing");
 
   server.tool(
@@ -63,17 +66,18 @@ function createServer(): McpServer {
 
       note: z.string().describe("Optional note for debugging").optional(),
     },
-    async (params) => {
-      return {
-        isError: false,
-        content: [
+    withToolLogging(
+      auth,
+      { toolName: "jit_all_optionals_and_defaults" },
+      async (params) => {
+        return new Ok([
           {
             type: "text",
             text: `JIT testing tool received: ${JSON.stringify(params)}`,
           },
-        ],
-      };
-    }
+        ]);
+      }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -1,9 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
@@ -49,15 +47,9 @@ const createServer = (
       "placeholder_tool",
       "This tool is a placeholder to catch missing actions.",
       {},
-      withToolLogging(
-        auth,
-        { toolName: "placeholder_tool" },
-        async () => {
-          return new Ok([
-            { type: "text", text: "No action name found" },
-          ]);
-        }
-      )
+      withToolLogging(auth, { toolName: "placeholder_tool" }, async () => {
+        return new Ok([{ type: "text", text: "No action name found" }]);
+      })
     );
   }
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -1,11 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
-  makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
+import { Err, Ok } from "@app/types";
 
 const createServer = (
   auth: Authenticator,
@@ -21,26 +23,41 @@ const createServer = (
       throw new Error("No action name found");
     }
 
-    server.tool(actionName, "", {}, async () => {
-      return makeMCPToolTextError(
-        `Tool "${actionName}" not found. ` +
-          "This answer to the function call is a catch-all. " +
-          "Please verify that the function name is correct : " +
-          "pay attention to case sensitivity and separators between words in the name. " +
-          "It's safe to retry automatically with another name."
-      );
-    });
+    server.tool(
+      actionName,
+      "",
+      {},
+      withToolLogging(
+        auth,
+        { toolName: actionName, agentLoopContext },
+        async () => {
+          return new Err(
+            new MCPError(
+              `Tool "${actionName}" not found. ` +
+                "This answer to the function call is a catch-all. " +
+                "Please verify that the function name is correct : " +
+                "pay attention to case sensitivity and separators between words in the name. " +
+                "It's safe to retry automatically with another name.",
+              { tracked: false }
+            )
+          );
+        }
+      )
+    );
   } else {
     server.tool(
       "placeholder_tool",
       "This tool is a placeholder to catch missing actions.",
       {},
-      async () => {
-        return {
-          isError: false,
-          content: [{ type: "text", text: "No action name found" }],
-        };
-      }
+      withToolLogging(
+        auth,
+        { toolName: "placeholder_tool" },
+        async () => {
+          return new Ok([
+            { type: "text", text: "No action name found" },
+          ]);
+        }
+      )
     );
   }
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -27,7 +27,7 @@ const createServer = (
       {},
       withToolLogging(
         auth,
-        { toolName: actionName, agentLoopContext },
+        { toolNameForMonitoring: actionName, agentLoopContext },
         async () => {
           return new Err(
             new MCPError(
@@ -47,9 +47,13 @@ const createServer = (
       "placeholder_tool",
       "This tool is a placeholder to catch missing actions.",
       {},
-      withToolLogging(auth, { toolName: "placeholder_tool" }, async () => {
-        return new Ok([{ type: "text", text: "No action name found" }]);
-      })
+      withToolLogging(
+        auth,
+        { toolNameForMonitoring: "placeholder_tool" },
+        async () => {
+          return new Ok([{ type: "text", text: "No action name found" }]);
+        }
+      )
     );
   }
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
@@ -52,7 +52,7 @@ const createServer = (auth: Authenticator): McpServer => {
     {},
     withToolLogging(
       auth,
-      { toolName: "get_boards" },
+      { toolNameForMonitoring: "get_boards" },
       async (_params, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -79,7 +79,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_board_items" },
+      { toolNameForMonitoring: "get_board_items" },
       async ({ boardId }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -106,7 +106,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_item_details" },
+      { toolNameForMonitoring: "get_item_details" },
       async ({ itemId }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -162,7 +162,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "search_items" },
+      { toolNameForMonitoring: "search_items" },
       async (
         {
           query,
@@ -231,7 +231,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_item" },
+      { toolNameForMonitoring: "create_item" },
       async ({ boardId, itemName, groupId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -269,7 +269,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "update_item" },
+      { toolNameForMonitoring: "update_item" },
       async ({ itemId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -300,7 +300,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_update" },
+      { toolNameForMonitoring: "create_update" },
       async ({ itemId, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
 

--- a/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
@@ -43,6 +43,9 @@ import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers"
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 
+// We use a single tool name for monitoring given the high granularity (can be revisited).
+const MONDAY_TOOL_NAME = "monday";
+
 const createServer = (auth: Authenticator): McpServer => {
   const server = makeInternalMCPServer("monday");
 
@@ -52,7 +55,7 @@ const createServer = (auth: Authenticator): McpServer => {
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "monday" },
+      { toolNameForMonitoring: MONDAY_TOOL_NAME },
       async (_params, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -79,7 +82,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "monday" },
+      { toolNameForMonitoring: MONDAY_TOOL_NAME },
       async ({ boardId }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -106,7 +109,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "monday" },
+      { toolNameForMonitoring: MONDAY_TOOL_NAME },
       async ({ itemId }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -162,7 +165,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "monday" },
+      { toolNameForMonitoring: MONDAY_TOOL_NAME },
       async (
         {
           query,
@@ -231,7 +234,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "monday" },
+      { toolNameForMonitoring: MONDAY_TOOL_NAME },
       async ({ boardId, itemName, groupId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -269,7 +272,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "monday" },
+      { toolNameForMonitoring: MONDAY_TOOL_NAME },
       async ({ itemId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -300,7 +303,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "monday" },
+      { toolNameForMonitoring: MONDAY_TOOL_NAME },
       async ({ itemId, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
 

--- a/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
@@ -40,9 +40,10 @@ import {
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 
-const createServer = (): McpServer => {
+const createServer = (auth: Authenticator): McpServer => {
   const server = makeInternalMCPServer("monday");
 
   server.tool(
@@ -50,7 +51,7 @@ const createServer = (): McpServer => {
     "Lists all accessible boards in Monday.com workspace. Returns up to 100 boards.",
     {},
     withToolLogging(
-      undefined,
+      auth,
       { toolName: "get_boards" },
       async (_params, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -60,10 +61,12 @@ const createServer = (): McpServer => {
         }
 
         const boards = await getBoards(accessToken);
-        return new Ok(makeMCPToolJSONSuccess({
-          message: "Boards retrieved successfully",
-          result: boards,
-        }).content);
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Boards retrieved successfully",
+            result: boards,
+          }).content
+        );
       }
     )
   );
@@ -75,7 +78,7 @@ const createServer = (): McpServer => {
       boardId: z.string().describe("The board ID to retrieve items from"),
     },
     withToolLogging(
-      undefined,
+      auth,
       { toolName: "get_board_items" },
       async ({ boardId }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -85,10 +88,12 @@ const createServer = (): McpServer => {
         }
 
         const items = await getBoardItems(accessToken, boardId);
-        return new Ok(makeMCPToolJSONSuccess({
-          message: "Board items retrieved successfully",
-          result: items,
-        }).content);
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Board items retrieved successfully",
+            result: items,
+          }).content
+        );
       }
     )
   );
@@ -100,7 +105,7 @@ const createServer = (): McpServer => {
       itemId: z.string().describe("The item ID to retrieve details for"),
     },
     withToolLogging(
-      undefined,
+      auth,
       { toolName: "get_item_details" },
       async ({ itemId }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -113,10 +118,12 @@ const createServer = (): McpServer => {
         if (!item) {
           return new Err(new MCPError("Item not found"));
         }
-        return new Ok(makeMCPToolJSONSuccess({
-          message: "Item details retrieved successfully",
-          result: item,
-        }).content);
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Item details retrieved successfully",
+            result: item,
+          }).content
+        );
       }
     )
   );
@@ -154,7 +161,7 @@ const createServer = (): McpServer => {
         .describe("Order direction (default: asc)"),
     },
     withToolLogging(
-      undefined,
+      auth,
       { toolName: "search_items" },
       async (
         {
@@ -195,10 +202,12 @@ const createServer = (): McpServer => {
         }
 
         const items = await searchItems(accessToken, filters);
-        return new Ok(makeMCPToolJSONSuccess({
-          message: `Found ${items.length} items (max 100 returned)`,
-          result: items,
-        }).content);
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: `Found ${items.length} items (max 100 returned)`,
+            result: items,
+          }).content
+        );
       }
     )
   );
@@ -221,7 +230,7 @@ const createServer = (): McpServer => {
         ),
     },
     withToolLogging(
-      undefined,
+      auth,
       { toolName: "create_item" },
       async ({ boardId, itemName, groupId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -237,10 +246,12 @@ const createServer = (): McpServer => {
           groupId,
           columnValues
         );
-        return new Ok(makeMCPToolJSONSuccess({
-          message: "Item created successfully",
-          result: item,
-        }).content);
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Item created successfully",
+            result: item,
+          }).content
+        );
       }
     )
   );
@@ -257,7 +268,7 @@ const createServer = (): McpServer => {
         ),
     },
     withToolLogging(
-      undefined,
+      auth,
       { toolName: "update_item" },
       async ({ itemId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -270,10 +281,12 @@ const createServer = (): McpServer => {
           return new Err(new MCPError("Invalid column values format"));
         }
         const item = await updateItem(accessToken, itemId, columnValues);
-        return new Ok(makeMCPToolJSONSuccess({
-          message: "Item updated successfully",
-          result: item,
-        }).content);
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Item updated successfully",
+            result: item,
+          }).content
+        );
       }
     )
   );
@@ -286,7 +299,7 @@ const createServer = (): McpServer => {
       body: z.string().describe("The content of the update/comment"),
     },
     withToolLogging(
-      undefined,
+      auth,
       { toolName: "create_update" },
       async ({ itemId, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -296,10 +309,12 @@ const createServer = (): McpServer => {
         }
 
         const update = await createUpdate(accessToken, itemId, body);
-        return new Ok(makeMCPToolJSONSuccess({
-          message: "Update added successfully",
-          result: update,
-        }).content);
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Update added successfully",
+            result: update,
+          }).content
+        );
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
@@ -52,7 +52,7 @@ const createServer = (auth: Authenticator): McpServer => {
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_boards" },
+      { toolNameForMonitoring: "monday" },
       async (_params, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -79,7 +79,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_board_items" },
+      { toolNameForMonitoring: "monday" },
       async ({ boardId }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -106,7 +106,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_item_details" },
+      { toolNameForMonitoring: "monday" },
       async ({ itemId }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -162,7 +162,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "search_items" },
+      { toolNameForMonitoring: "monday" },
       async (
         {
           query,
@@ -231,7 +231,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_item" },
+      { toolNameForMonitoring: "monday" },
       async ({ boardId, itemName, groupId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -269,7 +269,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "update_item" },
+      { toolNameForMonitoring: "monday" },
       async ({ itemId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -300,7 +300,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_update" },
+      { toolNameForMonitoring: "monday" },
       async ({ itemId, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
 

--- a/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { SearchItemsFilters } from "@app/lib/actions/mcp_internal_actions/servers/monday/monday_api_helper";
 import {
   createBoard,
@@ -38,6 +39,8 @@ import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import { Err, Ok } from "@app/types";
 
 const createServer = (): McpServer => {
   const server = makeInternalMCPServer("monday");
@@ -46,19 +49,23 @@ const createServer = (): McpServer => {
     "get_boards",
     "Lists all accessible boards in Monday.com workspace. Returns up to 100 boards.",
     {},
-    async (_params, { authInfo }) => {
-      const accessToken = authInfo?.token;
+    withToolLogging(
+      undefined,
+      { toolName: "get_boards" },
+      async (_params, { authInfo }) => {
+        const accessToken = authInfo?.token;
 
-      if (!accessToken) {
-        throw new Error("No Monday.com access token found");
+        if (!accessToken) {
+          return new Err(new MCPError("No Monday.com access token found"));
+        }
+
+        const boards = await getBoards(accessToken);
+        return new Ok(makeMCPToolJSONSuccess({
+          message: "Boards retrieved successfully",
+          result: boards,
+        }).content);
       }
-
-      const boards = await getBoards(accessToken);
-      return makeMCPToolJSONSuccess({
-        message: "Boards retrieved successfully",
-        result: boards,
-      });
-    }
+    )
   );
 
   server.tool(
@@ -67,19 +74,23 @@ const createServer = (): McpServer => {
     {
       boardId: z.string().describe("The board ID to retrieve items from"),
     },
-    async ({ boardId }, { authInfo }) => {
-      const accessToken = authInfo?.token;
+    withToolLogging(
+      undefined,
+      { toolName: "get_board_items" },
+      async ({ boardId }, { authInfo }) => {
+        const accessToken = authInfo?.token;
 
-      if (!accessToken) {
-        throw new Error("No Monday.com access token found");
+        if (!accessToken) {
+          return new Err(new MCPError("No Monday.com access token found"));
+        }
+
+        const items = await getBoardItems(accessToken, boardId);
+        return new Ok(makeMCPToolJSONSuccess({
+          message: "Board items retrieved successfully",
+          result: items,
+        }).content);
       }
-
-      const items = await getBoardItems(accessToken, boardId);
-      return makeMCPToolJSONSuccess({
-        message: "Board items retrieved successfully",
-        result: items,
-      });
-    }
+    )
   );
 
   server.tool(
@@ -88,22 +99,26 @@ const createServer = (): McpServer => {
     {
       itemId: z.string().describe("The item ID to retrieve details for"),
     },
-    async ({ itemId }, { authInfo }) => {
-      const accessToken = authInfo?.token;
+    withToolLogging(
+      undefined,
+      { toolName: "get_item_details" },
+      async ({ itemId }, { authInfo }) => {
+        const accessToken = authInfo?.token;
 
-      if (!accessToken) {
-        throw new Error("No Monday.com access token found");
-      }
+        if (!accessToken) {
+          return new Err(new MCPError("No Monday.com access token found"));
+        }
 
-      const item = await getItemDetails(accessToken, itemId);
-      if (!item) {
-        return makeMCPToolTextError("Item not found");
+        const item = await getItemDetails(accessToken, itemId);
+        if (!item) {
+          return new Err(new MCPError("Item not found"));
+        }
+        return new Ok(makeMCPToolJSONSuccess({
+          message: "Item details retrieved successfully",
+          result: item,
+        }).content);
       }
-      return makeMCPToolJSONSuccess({
-        message: "Item details retrieved successfully",
-        result: item,
-      });
-    }
+    )
   );
 
   server.tool(
@@ -138,50 +153,54 @@ const createServer = (): McpServer => {
         .optional()
         .describe("Order direction (default: asc)"),
     },
-    async (
-      {
-        query,
-        boardId,
-        status,
-        assigneeId,
-        groupId,
-        timeframeStart,
-        timeframeEnd,
-        orderBy,
-        orderDirection,
-      },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
+    withToolLogging(
+      undefined,
+      { toolName: "search_items" },
+      async (
+        {
+          query,
+          boardId,
+          status,
+          assigneeId,
+          groupId,
+          timeframeStart,
+          timeframeEnd,
+          orderBy,
+          orderDirection,
+        },
+        { authInfo }
+      ) => {
+        const accessToken = authInfo?.token;
 
-      if (!accessToken) {
-        throw new Error("No Monday.com access token found");
-      }
+        if (!accessToken) {
+          return new Err(new MCPError("No Monday.com access token found"));
+        }
 
-      const filters: SearchItemsFilters = {
-        query,
-        boardId,
-        status,
-        assigneeId,
-        groupId,
-        orderBy,
-        orderDirection,
-      };
-
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      if (timeframeStart || timeframeEnd) {
-        filters.timeframe = {
-          start: timeframeStart ? new Date(timeframeStart) : undefined,
-          end: timeframeEnd ? new Date(timeframeEnd) : undefined,
+        const filters: SearchItemsFilters = {
+          query,
+          boardId,
+          status,
+          assigneeId,
+          groupId,
+          orderBy,
+          orderDirection,
         };
-      }
 
-      const items = await searchItems(accessToken, filters);
-      return makeMCPToolJSONSuccess({
-        message: `Found ${items.length} items (max 100 returned)`,
-        result: items,
-      });
-    }
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        if (timeframeStart || timeframeEnd) {
+          filters.timeframe = {
+            start: timeframeStart ? new Date(timeframeStart) : undefined,
+            end: timeframeEnd ? new Date(timeframeEnd) : undefined,
+          };
+        }
+
+        const items = await searchItems(accessToken, filters);
+        return new Ok(makeMCPToolJSONSuccess({
+          message: `Found ${items.length} items (max 100 returned)`,
+          result: items,
+        }).content);
+      }
+    )
   );
 
   server.tool(
@@ -201,25 +220,29 @@ const createServer = (): McpServer => {
           'Optional column values as a JSON object (e.g., {"status": "Working on it", "date": "2024-01-25"})'
         ),
     },
-    async ({ boardId, itemName, groupId, columnValues }, { authInfo }) => {
-      const accessToken = authInfo?.token;
+    withToolLogging(
+      undefined,
+      { toolName: "create_item" },
+      async ({ boardId, itemName, groupId, columnValues }, { authInfo }) => {
+        const accessToken = authInfo?.token;
 
-      if (!accessToken) {
-        throw new Error("No Monday.com access token found");
+        if (!accessToken) {
+          return new Err(new MCPError("No Monday.com access token found"));
+        }
+
+        const item = await createItem(
+          accessToken,
+          boardId,
+          itemName,
+          groupId,
+          columnValues
+        );
+        return new Ok(makeMCPToolJSONSuccess({
+          message: "Item created successfully",
+          result: item,
+        }).content);
       }
-
-      const item = await createItem(
-        accessToken,
-        boardId,
-        itemName,
-        groupId,
-        columnValues
-      );
-      return makeMCPToolJSONSuccess({
-        message: "Item created successfully",
-        result: item,
-      });
-    }
+    )
   );
 
   server.tool(
@@ -233,22 +256,26 @@ const createServer = (): McpServer => {
           'Column values to update as a JSON object (e.g., {"status": "Done", "priority": "High"})'
         ),
     },
-    async ({ itemId, columnValues }, { authInfo }) => {
-      const accessToken = authInfo?.token;
+    withToolLogging(
+      undefined,
+      { toolName: "update_item" },
+      async ({ itemId, columnValues }, { authInfo }) => {
+        const accessToken = authInfo?.token;
 
-      if (!accessToken) {
-        throw new Error("No Monday.com access token found");
-      }
+        if (!accessToken) {
+          return new Err(new MCPError("No Monday.com access token found"));
+        }
 
-      if (!columnValues || Object.keys(columnValues).length === 0) {
-        return makeMCPToolTextError("Invalid column values format");
+        if (!columnValues || Object.keys(columnValues).length === 0) {
+          return new Err(new MCPError("Invalid column values format"));
+        }
+        const item = await updateItem(accessToken, itemId, columnValues);
+        return new Ok(makeMCPToolJSONSuccess({
+          message: "Item updated successfully",
+          result: item,
+        }).content);
       }
-      const item = await updateItem(accessToken, itemId, columnValues);
-      return makeMCPToolJSONSuccess({
-        message: "Item updated successfully",
-        result: item,
-      });
-    }
+    )
   );
 
   server.tool(
@@ -258,19 +285,23 @@ const createServer = (): McpServer => {
       itemId: z.string().describe("The item ID to add the update to"),
       body: z.string().describe("The content of the update/comment"),
     },
-    async ({ itemId, body }, { authInfo }) => {
-      const accessToken = authInfo?.token;
+    withToolLogging(
+      undefined,
+      { toolName: "create_update" },
+      async ({ itemId, body }, { authInfo }) => {
+        const accessToken = authInfo?.token;
 
-      if (!accessToken) {
-        throw new Error("No Monday.com access token found");
+        if (!accessToken) {
+          return new Err(new MCPError("No Monday.com access token found"));
+        }
+
+        const update = await createUpdate(accessToken, itemId, body);
+        return new Ok(makeMCPToolJSONSuccess({
+          message: "Update added successfully",
+          result: update,
+        }).content);
       }
-
-      const update = await createUpdate(accessToken, itemId, body);
-      return makeMCPToolJSONSuccess({
-        message: "Update added successfully",
-        result: update,
-      });
-    }
+    )
   );
 
   server.tool(

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -313,7 +313,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "search" },
+      { toolNameForMonitoring: "notion" },
       async ({ query, type, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(new MCPError("Agent loop run context is required"));
@@ -470,7 +470,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "retrieve_page" },
+      { toolNameForMonitoring: "notion" },
       async ({ pageId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.retrieve({ page_id: pageId }),
@@ -488,7 +488,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "retrieve_database_schema" },
+      { toolNameForMonitoring: "notion" },
       async ({ databaseId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.databases.retrieve({ database_id: databaseId }),
@@ -513,7 +513,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "retrieve_database_content" },
+      { toolNameForMonitoring: "notion" },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
         { authInfo }
@@ -548,7 +548,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "query_database" },
+      { toolNameForMonitoring: "notion" },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
         { authInfo }
@@ -581,7 +581,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_page" },
+      { toolNameForMonitoring: "notion" },
       async ({ parent, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.create({ parent, properties, icon, cover }),
@@ -602,7 +602,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "insert_row_into_database" },
+      { toolNameForMonitoring: "notion" },
       async ({ databaseId, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -636,7 +636,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_database" },
+      { toolNameForMonitoring: "notion" },
       async ({ parent, title, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -656,7 +656,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "update_page" },
+      { toolNameForMonitoring: "notion" },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.update({ page_id: pageId, properties }),
@@ -674,7 +674,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "retrieve_block" },
+      { toolNameForMonitoring: "notion" },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.blocks.retrieve({ block_id: blockId }),
@@ -697,7 +697,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "retrieve_block_children" },
+      { toolNameForMonitoring: "notion" },
       async ({ blockId, start_cursor, page_size }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -725,7 +725,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "add_page_content" },
+      { toolNameForMonitoring: "notion" },
       async ({ blockId, children }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -760,7 +760,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_comment" },
+      { toolNameForMonitoring: "notion" },
       async ({ parent_page_id, discussion_id, comment }, { authInfo }) => {
         return withNotionClient((notion) => {
           if (!parent_page_id && !discussion_id) {
@@ -796,7 +796,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "delete_block" },
+      { toolNameForMonitoring: "notion" },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -817,7 +817,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "fetch_comments" },
+      { toolNameForMonitoring: "notion" },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.comments.list({ block_id: blockId }),
@@ -836,7 +836,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "update_row_database" },
+      { toolNameForMonitoring: "notion" },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.update({ page_id: pageId, properties }),
@@ -855,7 +855,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "update_schema_database" },
+      { toolNameForMonitoring: "notion" },
       async ({ databaseId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -872,7 +872,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_users" },
+      { toolNameForMonitoring: "notion" },
       async (_, { authInfo }) => {
         return withNotionClient((notion) => notion.users.list({}), authInfo);
       }
@@ -887,7 +887,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_about_user" },
+      { toolNameForMonitoring: "notion" },
       async ({ userId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.users.retrieve({ user_id: userId }),

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -313,7 +313,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "search" },
+      { toolNameForMonitoring: "search" },
       async ({ query, type, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(new MCPError("Agent loop run context is required"));
@@ -470,7 +470,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "retrieve_page" },
+      { toolNameForMonitoring: "retrieve_page" },
       async ({ pageId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.retrieve({ page_id: pageId }),
@@ -488,7 +488,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "retrieve_database_schema" },
+      { toolNameForMonitoring: "retrieve_database_schema" },
       async ({ databaseId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.databases.retrieve({ database_id: databaseId }),
@@ -513,7 +513,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "retrieve_database_content" },
+      { toolNameForMonitoring: "retrieve_database_content" },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
         { authInfo }
@@ -548,7 +548,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "query_database" },
+      { toolNameForMonitoring: "query_database" },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
         { authInfo }
@@ -581,7 +581,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "create_page" },
+      { toolNameForMonitoring: "create_page" },
       async ({ parent, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.create({ parent, properties, icon, cover }),
@@ -602,7 +602,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "insert_row_into_database" },
+      { toolNameForMonitoring: "insert_row_into_database" },
       async ({ databaseId, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -636,7 +636,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "create_database" },
+      { toolNameForMonitoring: "create_database" },
       async ({ parent, title, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -656,7 +656,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "update_page" },
+      { toolNameForMonitoring: "update_page" },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.update({ page_id: pageId, properties }),
@@ -674,7 +674,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "retrieve_block" },
+      { toolNameForMonitoring: "retrieve_block" },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.blocks.retrieve({ block_id: blockId }),
@@ -697,7 +697,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "retrieve_block_children" },
+      { toolNameForMonitoring: "retrieve_block_children" },
       async ({ blockId, start_cursor, page_size }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -725,7 +725,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "add_page_content" },
+      { toolNameForMonitoring: "add_page_content" },
       async ({ blockId, children }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -760,7 +760,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "create_comment" },
+      { toolNameForMonitoring: "create_comment" },
       async ({ parent_page_id, discussion_id, comment }, { authInfo }) => {
         return withNotionClient((notion) => {
           if (!parent_page_id && !discussion_id) {
@@ -796,7 +796,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "delete_block" },
+      { toolNameForMonitoring: "delete_block" },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -817,7 +817,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "fetch_comments" },
+      { toolNameForMonitoring: "fetch_comments" },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.comments.list({ block_id: blockId }),
@@ -836,7 +836,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "update_row_database" },
+      { toolNameForMonitoring: "update_row_database" },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.update({ page_id: pageId, properties }),
@@ -855,7 +855,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "update_schema_database" },
+      { toolNameForMonitoring: "update_schema_database" },
       async ({ databaseId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -872,7 +872,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolName: "list_users" },
+      { toolNameForMonitoring: "list_users" },
       async (_, { authInfo }) => {
         return withNotionClient((notion) => notion.users.list({}), authInfo);
       }
@@ -887,7 +887,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_about_user" },
+      { toolNameForMonitoring: "get_about_user" },
       async ({ userId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.users.retrieve({ user_id: userId }),

--- a/front/lib/actions/mcp_internal_actions/servers/openai_usage.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/openai_usage.ts
@@ -128,7 +128,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_completions_usage", agentLoopContext },
+      { toolNameForMonitoring: "get_completions_usage", agentLoopContext },
       async (params) => {
         const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
         if (
@@ -277,7 +277,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: "get_organization_costs", agentLoopContext },
+      { toolNameForMonitoring: "get_organization_costs", agentLoopContext },
       async (params) => {
         const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
         if (

--- a/front/lib/actions/mcp_internal_actions/servers/openai_usage.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/openai_usage.ts
@@ -128,7 +128,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_completions_usage", agentLoopContext },
+      { toolNameForMonitoring: "openai_usage", agentLoopContext },
       async (params) => {
         const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
         if (
@@ -277,7 +277,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_organization_costs", agentLoopContext },
+      { toolNameForMonitoring: "openai_usage", agentLoopContext },
       async (params) => {
         const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
         if (

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
@@ -101,7 +101,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_messages" },
+      { toolNameForMonitoring: "outlook" },
       async ({ search, top = 10, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -178,7 +178,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_drafts" },
+      { toolNameForMonitoring: "outlook" },
       async ({ search, top = 10, skip = 0 }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -264,7 +264,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_draft" },
+      { toolNameForMonitoring: "outlook" },
       async (
         { to, cc, bcc, subject, contentType, body, importance = "normal" },
         { authInfo }
@@ -339,7 +339,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "delete_draft" },
+      { toolNameForMonitoring: "outlook" },
       async ({ messageId, subject, to }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -407,7 +407,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_reply_draft" },
+      { toolNameForMonitoring: "outlook" },
       async (
         {
           messageId,
@@ -522,7 +522,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "get_contacts" },
+      { toolNameForMonitoring: "outlook" },
       async ({ search, top = 20, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -607,7 +607,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "create_contact" },
+      { toolNameForMonitoring: "outlook" },
       async (
         {
           displayName,
@@ -726,7 +726,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "update_contact" },
+      { toolNameForMonitoring: "outlook" },
       async (
         {
           contactId,

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
@@ -1,12 +1,16 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextError,
+  makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { Err, Ok } from "@app/types";
 
 const OutlookEmailAddressSchema = z.object({
   address: z.string(),
@@ -68,7 +72,7 @@ const OutlookContactSchema = z.object({
 type OutlookMessage = z.infer<typeof OutlookMessageSchema>;
 type OutlookContact = z.infer<typeof OutlookContactSchema>;
 
-const createServer = (): McpServer => {
+const createServer = (auth: Authenticator): McpServer => {
   const server = makeInternalMCPServer("outlook");
 
   server.tool(
@@ -96,54 +100,62 @@ const createServer = (): McpServer => {
         .optional()
         .describe("Fields to include in the response."),
     },
-    async ({ search, top = 10, skip = 0, select }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return makeMCPToolTextError("Authentication required");
-      }
+    withToolLogging(
+      auth,
+      { toolName: "get_messages" },
+      async ({ search, top = 10, skip = 0, select }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Authentication required"));
+        }
 
-      const params = new URLSearchParams();
-      params.append("$top", Math.min(top, 100).toString());
+        const params = new URLSearchParams();
+        params.append("$top", Math.min(top, 100).toString());
 
-      if (search) {
-        params.append("$search", `"${search}"`);
-      } else {
-        params.append("$skip", skip.toString());
-      }
+        if (search) {
+          params.append("$search", `"${search}"`);
+        } else {
+          params.append("$skip", skip.toString());
+        }
 
-      if (select && select.length > 0) {
-        params.append("$select", select.join(","));
-      } else {
-        params.append(
-          "$select",
-          "id,conversationId,subject,bodyPreview,importance,receivedDateTime,sentDateTime,hasAttachments,isDraft,isRead,from,toRecipients,ccRecipients,parentFolderId"
+        if (select && select.length > 0) {
+          params.append("$select", select.join(","));
+        } else {
+          params.append(
+            "$select",
+            "id,conversationId,subject,bodyPreview,importance,receivedDateTime,sentDateTime,hasAttachments,isDraft,isRead,from,toRecipients,ccRecipients,parentFolderId"
+          );
+        }
+
+        const response = await fetchFromOutlook(
+          `/me/messages?${params.toString()}`,
+          accessToken,
+          { method: "GET" }
+        );
+
+        if (!response.ok) {
+          const errorText = await getErrorText(response);
+          return new Err(
+            new MCPError(
+              `Failed to get messages: ${response.status} ${response.statusText} - ${errorText}`
+            )
+          );
+        }
+
+        const result = await response.json();
+
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Messages fetched successfully",
+            result: {
+              messages: (result.value || []) as OutlookMessage[],
+              nextLink: result["@odata.nextLink"],
+              totalCount: result["@odata.count"],
+            },
+          }).content
         );
       }
-
-      const response = await fetchFromOutlook(
-        `/me/messages?${params.toString()}`,
-        accessToken,
-        { method: "GET" }
-      );
-
-      if (!response.ok) {
-        const errorText = await getErrorText(response);
-        return makeMCPToolTextError(
-          `Failed to get messages: ${response.status} ${response.statusText} - ${errorText}`
-        );
-      }
-
-      const result = await response.json();
-
-      return makeMCPToolJSONSuccess({
-        message: "Messages fetched successfully",
-        result: {
-          messages: (result.value || []) as OutlookMessage[],
-          nextLink: result["@odata.nextLink"],
-          totalCount: result["@odata.count"],
-        },
-      });
-    }
+    )
   );
 
   server.tool(
@@ -165,61 +177,67 @@ const createServer = (): McpServer => {
         .optional()
         .describe("Number of drafts to skip for pagination."),
     },
-    async ({ search, top = 10, skip = 0 }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return makeMCPToolTextError("Authentication required");
+    withToolLogging(
+      auth,
+      { toolName: "get_drafts" },
+      async ({ search, top = 10, skip = 0 }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Authentication required"));
+        }
+
+        const params = new URLSearchParams();
+        params.append("$filter", "isDraft eq true");
+        params.append("$top", Math.min(top, 100).toString());
+
+        if (search) {
+          params.append("$search", `"${search}"`);
+        } else {
+          params.append("$skip", skip.toString());
+        }
+
+        const response = await fetchFromOutlook(
+          `/me/messages?${params.toString()}`,
+          accessToken,
+          { method: "GET" }
+        );
+
+        if (!response.ok) {
+          return new Err(new MCPError("Failed to get drafts"));
+        }
+
+        const result = await response.json();
+
+        // Get detailed information for each draft
+        const draftDetails = await concurrentExecutor(
+          result.value || [],
+          async (draft: { id: string }): Promise<OutlookMessage | null> => {
+            const draftResponse = await fetchFromOutlook(
+              `/me/messages/${draft.id}`,
+              accessToken,
+              { method: "GET" }
+            );
+
+            if (!draftResponse.ok) {
+              return null;
+            }
+
+            return draftResponse.json();
+          },
+          { concurrency: 10 }
+        );
+
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Drafts fetched successfully",
+            result: {
+              drafts: draftDetails.filter(Boolean) as OutlookMessage[],
+              nextLink: result["@odata.nextLink"],
+            },
+          }).content
+        );
       }
-
-      const params = new URLSearchParams();
-      params.append("$filter", "isDraft eq true");
-      params.append("$top", Math.min(top, 100).toString());
-
-      if (search) {
-        params.append("$search", `"${search}"`);
-      } else {
-        params.append("$skip", skip.toString());
-      }
-
-      const response = await fetchFromOutlook(
-        `/me/messages?${params.toString()}`,
-        accessToken,
-        { method: "GET" }
-      );
-
-      if (!response.ok) {
-        return makeMCPToolTextError("Failed to get drafts");
-      }
-
-      const result = await response.json();
-
-      // Get detailed information for each draft
-      const draftDetails = await concurrentExecutor(
-        result.value || [],
-        async (draft: { id: string }): Promise<OutlookMessage | null> => {
-          const draftResponse = await fetchFromOutlook(
-            `/me/messages/${draft.id}`,
-            accessToken,
-            { method: "GET" }
-          );
-
-          if (!draftResponse.ok) {
-            return null;
-          }
-
-          return draftResponse.json();
-        },
-        { concurrency: 10 }
-      );
-
-      return makeMCPToolJSONSuccess({
-        message: "Drafts fetched successfully",
-        result: {
-          drafts: draftDetails.filter(Boolean) as OutlookMessage[],
-          nextLink: result["@odata.nextLink"],
-        },
-      });
-    }
+    )
   );
 
   server.tool(
@@ -245,65 +263,71 @@ const createServer = (): McpServer => {
         .optional()
         .describe("The importance level of the email"),
     },
-    async (
-      { to, cc, bcc, subject, contentType, body, importance = "normal" },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return makeMCPToolTextError("Authentication required");
+    withToolLogging(
+      auth,
+      { toolName: "create_draft" },
+      async (
+        { to, cc, bcc, subject, contentType, body, importance = "normal" },
+        { authInfo }
+      ) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Authentication required"));
+        }
+
+        // Create the email message object for Microsoft Graph API
+        const message: any = {
+          subject,
+          importance,
+          body: {
+            contentType,
+            content: body,
+          },
+          toRecipients: to.map((email) => ({
+            emailAddress: { address: email },
+          })),
+          isDraft: true,
+        };
+
+        if (cc && cc.length > 0) {
+          message.ccRecipients = cc.map((email) => ({
+            emailAddress: { address: email },
+          }));
+        }
+
+        if (bcc && bcc.length > 0) {
+          message.bccRecipients = bcc.map((email) => ({
+            emailAddress: { address: email },
+          }));
+        }
+
+        // Make the API call to create the draft in Outlook
+        const response = await fetchFromOutlook("/me/messages", accessToken, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(message),
+        });
+
+        if (!response.ok) {
+          const errorText = await getErrorText(response);
+          return new Err(new MCPError(`Failed to create draft: ${errorText}`));
+        }
+
+        const result = await response.json();
+
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Draft created successfully",
+            result: {
+              messageId: result.id,
+              conversationId: result.conversationId,
+            },
+          }).content
+        );
       }
-
-      // Create the email message object for Microsoft Graph API
-      const message: any = {
-        subject,
-        importance,
-        body: {
-          contentType,
-          content: body,
-        },
-        toRecipients: to.map((email) => ({
-          emailAddress: { address: email },
-        })),
-        isDraft: true,
-      };
-
-      if (cc && cc.length > 0) {
-        message.ccRecipients = cc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-
-      if (bcc && bcc.length > 0) {
-        message.bccRecipients = bcc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-
-      // Make the API call to create the draft in Outlook
-      const response = await fetchFromOutlook("/me/messages", accessToken, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(message),
-      });
-
-      if (!response.ok) {
-        const errorText = await getErrorText(response);
-        return makeMCPToolTextError(`Failed to create draft: ${errorText}`);
-      }
-
-      const result = await response.json();
-
-      return makeMCPToolJSONSuccess({
-        message: "Draft created successfully",
-        result: {
-          messageId: result.id,
-          conversationId: result.conversationId,
-        },
-      });
-    }
+    )
   );
 
   server.tool(
@@ -314,34 +338,42 @@ const createServer = (): McpServer => {
       subject: z.string().describe("The subject of the draft to delete"),
       to: z.array(z.string()).describe("The email addresses of the recipients"),
     },
-    async ({ messageId, subject, to }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return makeMCPToolTextError("Authentication required");
-      }
+    withToolLogging(
+      auth,
+      { toolName: "delete_draft" },
+      async ({ messageId, subject, to }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Authentication required"));
+        }
 
-      // Subject and to are required for user display/confirmation
-      if (!subject || to.length === 0) {
-        return makeMCPToolTextError(
-          "Subject and recipients are required for confirmation"
+        // Subject and to are required for user display/confirmation
+        if (!subject || to.length === 0) {
+          return new Err(
+            new MCPError(
+              "Subject and recipients are required for confirmation"
+            )
+          );
+        }
+
+        const response = await fetchFromOutlook(
+          `/me/messages/${messageId}`,
+          accessToken,
+          { method: "DELETE" }
+        );
+
+        if (!response.ok) {
+          return new Err(new MCPError("Failed to delete draft"));
+        }
+
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Draft deleted successfully",
+            result: "",
+          }).content
         );
       }
-
-      const response = await fetchFromOutlook(
-        `/me/messages/${messageId}`,
-        accessToken,
-        { method: "DELETE" }
-      );
-
-      if (!response.ok) {
-        return makeMCPToolTextError("Failed to delete draft");
-      }
-
-      return makeMCPToolJSONSuccess({
-        message: "Draft deleted successfully",
-        result: "",
-      });
-    }
+    )
   );
 
   server.tool(
@@ -376,78 +408,86 @@ const createServer = (): McpServer => {
         .optional()
         .describe("Override the BCC recipients for the reply."),
     },
-    async (
-      { messageId, body, contentType = "html", replyAll = false, to, cc, bcc },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return makeMCPToolTextError("Authentication required");
-      }
-
-      // Create the reply draft
-      const endpoint = replyAll
-        ? `/me/messages/${messageId}/createReplyAll`
-        : `/me/messages/${messageId}/createReply`;
-
-      const replyMessage: any = {
-        message: {
-          body: {
-            contentType,
-            content: body,
-          },
-        },
-      };
-
-      // Add recipients if overriding
-      if (to && to.length > 0) {
-        replyMessage.message.toRecipients = to.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-
-      if (cc && cc.length > 0) {
-        replyMessage.message.ccRecipients = cc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-
-      if (bcc && bcc.length > 0) {
-        replyMessage.message.bccRecipients = bcc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-
-      const response = await fetchFromOutlook(endpoint, accessToken, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(replyMessage),
-      });
-
-      if (!response.ok) {
-        const errorText = await getErrorText(response);
-        if (response.status === 404) {
-          return makeMCPToolTextError(`Message not found: ${messageId}`);
+    withToolLogging(
+      auth,
+      { toolName: "create_reply_draft" },
+      async (
+        { messageId, body, contentType = "html", replyAll = false, to, cc, bcc },
+        { authInfo }
+      ) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Authentication required"));
         }
-        return makeMCPToolTextError(
-          `Failed to create reply draft: ${response.status} ${response.statusText} - ${errorText}`
+
+        // Create the reply draft
+        const endpoint = replyAll
+          ? `/me/messages/${messageId}/createReplyAll`
+          : `/me/messages/${messageId}/createReply`;
+
+        const replyMessage: any = {
+          message: {
+            body: {
+              contentType,
+              content: body,
+            },
+          },
+        };
+
+        // Add recipients if overriding
+        if (to && to.length > 0) {
+          replyMessage.message.toRecipients = to.map((email) => ({
+            emailAddress: { address: email },
+          }));
+        }
+
+        if (cc && cc.length > 0) {
+          replyMessage.message.ccRecipients = cc.map((email) => ({
+            emailAddress: { address: email },
+          }));
+        }
+
+        if (bcc && bcc.length > 0) {
+          replyMessage.message.bccRecipients = bcc.map((email) => ({
+            emailAddress: { address: email },
+          }));
+        }
+
+        const response = await fetchFromOutlook(endpoint, accessToken, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(replyMessage),
+        });
+
+        if (!response.ok) {
+          const errorText = await getErrorText(response);
+          if (response.status === 404) {
+            return new Err(new MCPError(`Message not found: ${messageId}`));
+          }
+          return new Err(
+            new MCPError(
+              `Failed to create reply draft: ${response.status} ${response.statusText} - ${errorText}`
+            )
+          );
+        }
+
+        const result = await response.json();
+
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Reply draft created successfully",
+            result: {
+              messageId: result.id,
+              conversationId: result.conversationId,
+              originalMessageId: messageId,
+              subject: result.subject,
+            },
+          }).content
         );
       }
-
-      const result = await response.json();
-
-      return makeMCPToolJSONSuccess({
-        message: "Reply draft created successfully",
-        result: {
-          messageId: result.id,
-          conversationId: result.conversationId,
-          originalMessageId: messageId,
-          subject: result.subject,
-        },
-      });
-    }
+    )
   );
 
   server.tool(
@@ -475,54 +515,62 @@ const createServer = (): McpServer => {
         .optional()
         .describe("Fields to include in the response."),
     },
-    async ({ search, top = 20, skip = 0, select }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return makeMCPToolTextError("Authentication required");
-      }
+    withToolLogging(
+      auth,
+      { toolName: "get_contacts" },
+      async ({ search, top = 20, skip = 0, select }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Authentication required"));
+        }
 
-      const params = new URLSearchParams();
-      params.append("$top", Math.min(top, 100).toString());
+        const params = new URLSearchParams();
+        params.append("$top", Math.min(top, 100).toString());
 
-      if (search) {
-        params.append("$search", `"${search}"`);
-      } else {
-        params.append("$skip", skip.toString());
-      }
+        if (search) {
+          params.append("$search", `"${search}"`);
+        } else {
+          params.append("$skip", skip.toString());
+        }
 
-      if (select && select.length > 0) {
-        params.append("$select", select.join(","));
-      } else {
-        params.append(
-          "$select",
-          "id,displayName,givenName,surname,emailAddresses,businessPhones,homePhones,mobilePhone,jobTitle,companyName,department,officeLocation"
+        if (select && select.length > 0) {
+          params.append("$select", select.join(","));
+        } else {
+          params.append(
+            "$select",
+            "id,displayName,givenName,surname,emailAddresses,businessPhones,homePhones,mobilePhone,jobTitle,companyName,department,officeLocation"
+          );
+        }
+
+        const response = await fetchFromOutlook(
+          `/me/contacts?${params.toString()}`,
+          accessToken,
+          { method: "GET" }
+        );
+
+        if (!response.ok) {
+          const errorText = await getErrorText(response);
+          return new Err(
+            new MCPError(
+              `Failed to get contacts: ${response.status} ${response.statusText} - ${errorText}`
+            )
+          );
+        }
+
+        const result = await response.json();
+
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Contacts fetched successfully",
+            result: {
+              contacts: (result.value || []) as OutlookContact[],
+              nextLink: result["@odata.nextLink"],
+              totalCount: result["@odata.count"],
+            },
+          }).content
         );
       }
-
-      const response = await fetchFromOutlook(
-        `/me/contacts?${params.toString()}`,
-        accessToken,
-        { method: "GET" }
-      );
-
-      if (!response.ok) {
-        const errorText = await getErrorText(response);
-        return makeMCPToolTextError(
-          `Failed to get contacts: ${response.status} ${response.statusText} - ${errorText}`
-        );
-      }
-
-      const result = await response.json();
-
-      return makeMCPToolJSONSuccess({
-        message: "Contacts fetched successfully",
-        result: {
-          contacts: (result.value || []) as OutlookContact[],
-          nextLink: result["@odata.nextLink"],
-          totalCount: result["@odata.count"],
-        },
-      });
-    }
+    )
   );
 
   server.tool(
@@ -552,84 +600,92 @@ const createServer = (): McpServer => {
       department: z.string().optional().describe("Department"),
       officeLocation: z.string().optional().describe("Office location"),
     },
-    async (
-      {
-        displayName,
-        givenName,
-        surname,
-        emailAddresses,
-        businessPhones,
-        homePhones,
-        mobilePhone,
-        jobTitle,
-        companyName,
-        department,
-        officeLocation,
-      },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return makeMCPToolTextError("Authentication required");
-      }
-
-      const contact: any = {
-        displayName,
-      };
-
-      if (givenName) {
-        contact.givenName = givenName;
-      }
-      if (surname) {
-        contact.surname = surname;
-      }
-      if (emailAddresses) {
-        contact.emailAddresses = emailAddresses;
-      }
-      if (businessPhones) {
-        contact.businessPhones = businessPhones;
-      }
-      if (homePhones) {
-        contact.homePhones = homePhones;
-      }
-      if (mobilePhone) {
-        contact.mobilePhone = mobilePhone;
-      }
-      if (jobTitle) {
-        contact.jobTitle = jobTitle;
-      }
-      if (companyName) {
-        contact.companyName = companyName;
-      }
-      if (department) {
-        contact.department = department;
-      }
-      if (officeLocation) {
-        contact.officeLocation = officeLocation;
-      }
-
-      const response = await fetchFromOutlook("/me/contacts", accessToken, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+    withToolLogging(
+      auth,
+      { toolName: "create_contact" },
+      async (
+        {
+          displayName,
+          givenName,
+          surname,
+          emailAddresses,
+          businessPhones,
+          homePhones,
+          mobilePhone,
+          jobTitle,
+          companyName,
+          department,
+          officeLocation,
         },
-        body: JSON.stringify(contact),
-      });
+        { authInfo }
+      ) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Authentication required"));
+        }
 
-      if (!response.ok) {
-        const errorText = await getErrorText(response);
-        return makeMCPToolTextError(
-          `Failed to create contact: ${response.status} ${response.statusText} - ${errorText}`
+        const contact: any = {
+          displayName,
+        };
+
+        if (givenName) {
+          contact.givenName = givenName;
+        }
+        if (surname) {
+          contact.surname = surname;
+        }
+        if (emailAddresses) {
+          contact.emailAddresses = emailAddresses;
+        }
+        if (businessPhones) {
+          contact.businessPhones = businessPhones;
+        }
+        if (homePhones) {
+          contact.homePhones = homePhones;
+        }
+        if (mobilePhone) {
+          contact.mobilePhone = mobilePhone;
+        }
+        if (jobTitle) {
+          contact.jobTitle = jobTitle;
+        }
+        if (companyName) {
+          contact.companyName = companyName;
+        }
+        if (department) {
+          contact.department = department;
+        }
+        if (officeLocation) {
+          contact.officeLocation = officeLocation;
+        }
+
+        const response = await fetchFromOutlook("/me/contacts", accessToken, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(contact),
+        });
+
+        if (!response.ok) {
+          const errorText = await getErrorText(response);
+          return new Err(
+            new MCPError(
+              `Failed to create contact: ${response.status} ${response.statusText} - ${errorText}`
+            )
+          );
+        }
+
+        const result = await response.json();
+
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Contact created successfully",
+            result: result as OutlookContact,
+          }).content
         );
       }
-
-      const result = await response.json();
-
-      return makeMCPToolJSONSuccess({
-        message: "Contact created successfully",
-        result: result as OutlookContact,
-      });
-    }
+    )
   );
 
   server.tool(
@@ -663,93 +719,101 @@ const createServer = (): McpServer => {
       department: z.string().optional().describe("Department"),
       officeLocation: z.string().optional().describe("Office location"),
     },
-    async (
-      {
-        contactId,
-        displayName,
-        givenName,
-        surname,
-        emailAddresses,
-        businessPhones,
-        homePhones,
-        mobilePhone,
-        jobTitle,
-        companyName,
-        department,
-        officeLocation,
-      },
-      { authInfo }
-    ) => {
-      const accessToken = authInfo?.token;
-      if (!accessToken) {
-        return makeMCPToolTextError("Authentication required");
-      }
-
-      const contact: any = {};
-
-      if (displayName) {
-        contact.displayName = displayName;
-      }
-      if (givenName) {
-        contact.givenName = givenName;
-      }
-      if (surname) {
-        contact.surname = surname;
-      }
-      if (emailAddresses) {
-        contact.emailAddresses = emailAddresses;
-      }
-      if (businessPhones) {
-        contact.businessPhones = businessPhones;
-      }
-      if (homePhones) {
-        contact.homePhones = homePhones;
-      }
-      if (mobilePhone) {
-        contact.mobilePhone = mobilePhone;
-      }
-      if (jobTitle) {
-        contact.jobTitle = jobTitle;
-      }
-      if (companyName) {
-        contact.companyName = companyName;
-      }
-      if (department) {
-        contact.department = department;
-      }
-      if (officeLocation) {
-        contact.officeLocation = officeLocation;
-      }
-
-      const response = await fetchFromOutlook(
-        `/me/contacts/${contactId}`,
-        accessToken,
+    withToolLogging(
+      auth,
+      { toolName: "update_contact" },
+      async (
         {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(contact),
+          contactId,
+          displayName,
+          givenName,
+          surname,
+          emailAddresses,
+          businessPhones,
+          homePhones,
+          mobilePhone,
+          jobTitle,
+          companyName,
+          department,
+          officeLocation,
+        },
+        { authInfo }
+      ) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Authentication required"));
         }
-      );
 
-      if (!response.ok) {
-        const errorText = await getErrorText(response);
-        if (response.status === 404) {
-          return makeMCPToolTextError(`Contact not found: ${contactId}`);
+        const contact: any = {};
+
+        if (displayName) {
+          contact.displayName = displayName;
         }
-        return makeMCPToolTextError(
-          `Failed to update contact: ${response.status} ${response.statusText} - ${errorText}`
+        if (givenName) {
+          contact.givenName = givenName;
+        }
+        if (surname) {
+          contact.surname = surname;
+        }
+        if (emailAddresses) {
+          contact.emailAddresses = emailAddresses;
+        }
+        if (businessPhones) {
+          contact.businessPhones = businessPhones;
+        }
+        if (homePhones) {
+          contact.homePhones = homePhones;
+        }
+        if (mobilePhone) {
+          contact.mobilePhone = mobilePhone;
+        }
+        if (jobTitle) {
+          contact.jobTitle = jobTitle;
+        }
+        if (companyName) {
+          contact.companyName = companyName;
+        }
+        if (department) {
+          contact.department = department;
+        }
+        if (officeLocation) {
+          contact.officeLocation = officeLocation;
+        }
+
+        const response = await fetchFromOutlook(
+          `/me/contacts/${contactId}`,
+          accessToken,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(contact),
+          }
+        );
+
+        if (!response.ok) {
+          const errorText = await getErrorText(response);
+          if (response.status === 404) {
+            return new Err(new MCPError(`Contact not found: ${contactId}`));
+          }
+          return new Err(
+            new MCPError(
+              `Failed to update contact: ${response.status} ${response.statusText} - ${errorText}`
+            )
+          );
+        }
+
+        const result = await response.json();
+
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Contact updated successfully",
+            result: result as OutlookContact,
+          }).content
         );
       }
-
-      const result = await response.json();
-
-      return makeMCPToolJSONSuccess({
-        message: "Contact updated successfully",
-        result: result as OutlookContact,
-      });
-    }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
@@ -11,6 +11,9 @@ import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types";
 
+// We use a single tool name for monitoring given the high granularity (can be revisited).
+const OUTLOOK_TOOL_NAME = "outlook";
+
 const OutlookEmailAddressSchema = z.object({
   address: z.string(),
   name: z.string().optional(),
@@ -101,7 +104,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "outlook" },
+      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
       async ({ search, top = 10, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -178,7 +181,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "outlook" },
+      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
       async ({ search, top = 10, skip = 0 }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -264,7 +267,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "outlook" },
+      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
       async (
         { to, cc, bcc, subject, contentType, body, importance = "normal" },
         { authInfo }
@@ -339,7 +342,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "outlook" },
+      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
       async ({ messageId, subject, to }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -407,7 +410,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "outlook" },
+      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
       async (
         {
           messageId,
@@ -522,7 +525,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "outlook" },
+      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
       async ({ search, top = 20, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -607,7 +610,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "outlook" },
+      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
       async (
         {
           displayName,
@@ -726,7 +729,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "outlook" },
+      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
       async (
         {
           contactId,

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
@@ -101,7 +101,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_messages" },
+      { toolNameForMonitoring: "get_messages" },
       async ({ search, top = 10, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -178,7 +178,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_drafts" },
+      { toolNameForMonitoring: "get_drafts" },
       async ({ search, top = 10, skip = 0 }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -264,7 +264,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_draft" },
+      { toolNameForMonitoring: "create_draft" },
       async (
         { to, cc, bcc, subject, contentType, body, importance = "normal" },
         { authInfo }
@@ -339,7 +339,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "delete_draft" },
+      { toolNameForMonitoring: "delete_draft" },
       async ({ messageId, subject, to }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -407,7 +407,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_reply_draft" },
+      { toolNameForMonitoring: "create_reply_draft" },
       async (
         {
           messageId,
@@ -522,7 +522,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "get_contacts" },
+      { toolNameForMonitoring: "get_contacts" },
       async ({ search, top = 20, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -607,7 +607,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "create_contact" },
+      { toolNameForMonitoring: "create_contact" },
       async (
         {
           displayName,
@@ -726,7 +726,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "update_contact" },
+      { toolNameForMonitoring: "update_contact" },
       async (
         {
           contactId,

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
@@ -5,7 +5,6 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -350,9 +349,7 @@ const createServer = (auth: Authenticator): McpServer => {
         // Subject and to are required for user display/confirmation
         if (!subject || to.length === 0) {
           return new Err(
-            new MCPError(
-              "Subject and recipients are required for confirmation"
-            )
+            new MCPError("Subject and recipients are required for confirmation")
           );
         }
 
@@ -412,7 +409,15 @@ const createServer = (auth: Authenticator): McpServer => {
       auth,
       { toolName: "create_reply_draft" },
       async (
-        { messageId, body, contentType = "html", replyAll = false, to, cc, bcc },
+        {
+          messageId,
+          body,
+          contentType = "html",
+          replyAll = false,
+          to,
+          cc,
+          bcc,
+        },
         { authInfo }
       ) => {
         const accessToken = authInfo?.token;

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -23,7 +23,7 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolName: "tool_without_user_config", agentLoopContext },
+      { toolNameForMonitoring: "tool_without_user_config", agentLoopContext },
       async ({ query }) => {
         return new Ok([
           {
@@ -109,7 +109,7 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolName: "pass_through", agentLoopContext },
+      { toolNameForMonitoring: "pass_through", agentLoopContext },
       async (params) => {
         return new Ok([
           {

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -2,7 +2,6 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -87,7 +87,7 @@ function makeExtractInformationFromDocumentsTool(
 ) {
   return withToolLogging(
     auth,
-    { toolName: PROCESS_TOOL_NAME, agentLoopContext },
+    { toolNameForMonitoring: PROCESS_TOOL_NAME, agentLoopContext },
     async ({
       dataSources,
       objective,

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -66,7 +66,7 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolName: "advanced_reasoning", agentLoopContext },
+      { toolNameForMonitoring: "advanced_reasoning", agentLoopContext },
       async (
         { model: { modelId, providerId, temperature, reasoningEffort } },
         { sendNotification, _meta }

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -1,12 +1,11 @@
 import { assertNever, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import {
-  makeInternalMCPServer,
-  makeMCPToolTextError,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import { runActionStreamed } from "@app/lib/actions/server";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
@@ -29,10 +28,12 @@ import type {
 } from "@app/types";
 import {
   DEFAULT_REASONING_MODEL_ID,
+  Err,
   isModelId,
   isModelProviderId,
   isProviderWhitelisted,
   isReasoningEffortId,
+  Ok,
 } from "@app/types";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
@@ -63,88 +64,89 @@ function createServer(
         ...DEFAULT_REASONING_CONFIGURATION,
       }),
     },
-    async (
-      { model: { modelId, providerId, temperature, reasoningEffort } },
-      { sendNotification, _meta }
-    ) => {
-      if (!agentLoopContext?.runContext) {
-        throw new Error("Unreachable: missing agentLoopRunContext.");
-      }
+    withToolLogging(
+      auth,
+      { toolName: "advanced_reasoning", agentLoopContext },
+      async (
+        { model: { modelId, providerId, temperature, reasoningEffort } },
+        { sendNotification, _meta }
+      ) => {
+        if (!agentLoopContext?.runContext) {
+          throw new Error("Unreachable: missing agentLoopRunContext.");
+        }
 
-      const agentLoopRunContext = agentLoopContext.runContext;
+        const agentLoopRunContext = agentLoopContext.runContext;
 
-      if (
-        !isModelId(modelId) ||
-        !isModelProviderId(providerId) ||
-        (reasoningEffort !== null && !isReasoningEffortId(reasoningEffort))
-      ) {
-        return makeMCPToolTextError("Invalid model ID.");
-      }
+        if (
+          !isModelId(modelId) ||
+          !isModelProviderId(providerId) ||
+          (reasoningEffort !== null && !isReasoningEffortId(reasoningEffort))
+        ) {
+          return new Err(new MCPError("Invalid model ID."));
+        }
 
-      const actionOutput = {
-        content: "",
-        thinking: "",
-      };
+        const actionOutput = {
+          content: "",
+          thinking: "",
+        };
 
-      const { conversation, agentConfiguration, agentMessage } =
-        agentLoopRunContext;
+        const { conversation, agentConfiguration, agentMessage } =
+          agentLoopRunContext;
 
-      for await (const event of runReasoning(auth, {
-        reasoningModel: { modelId, providerId, temperature, reasoningEffort },
-        conversation,
-        agentConfiguration,
-        agentMessage,
-      })) {
-        switch (event.type) {
-          case "error": {
-            return makeMCPToolTextError(event.message);
-          }
-          case "token": {
-            const { classification, text } = event.token;
-            if (
-              classification === "opening_delimiter" ||
-              classification === "closing_delimiter"
-            ) {
-              continue;
+        for await (const event of runReasoning(auth, {
+          reasoningModel: { modelId, providerId, temperature, reasoningEffort },
+          conversation,
+          agentConfiguration,
+          agentMessage,
+        })) {
+          switch (event.type) {
+            case "error": {
+              return new Err(new MCPError(event.message));
             }
-            if (classification === "chain_of_thought") {
-              actionOutput.thinking += text;
-            } else {
-              actionOutput.content += text;
-            }
+            case "token": {
+              const { classification, text } = event.token;
+              if (
+                classification === "opening_delimiter" ||
+                classification === "closing_delimiter"
+              ) {
+                continue;
+              }
+              if (classification === "chain_of_thought") {
+                actionOutput.thinking += text;
+              } else {
+                actionOutput.content += text;
+              }
 
-            if (_meta?.progressToken) {
-              const notification: MCPProgressNotificationType = {
-                method: "notifications/progress",
-                params: {
-                  progress: 0,
-                  total: 1,
-                  progressToken: _meta?.progressToken,
-                  data: {
-                    label: "Thinking...",
-                    output: {
-                      type: "text",
-                      text,
+              if (_meta?.progressToken) {
+                const notification: MCPProgressNotificationType = {
+                  method: "notifications/progress",
+                  params: {
+                    progress: 0,
+                    total: 1,
+                    progressToken: _meta?.progressToken,
+                    data: {
+                      label: "Thinking...",
+                      output: {
+                        type: "text",
+                        text,
+                      },
                     },
                   },
-                },
-              };
+                };
 
-              await sendNotification(notification);
+                await sendNotification(notification);
+              }
+
+              break;
             }
-
-            break;
+            case "runId":
+              break;
+            default:
+              assertNever(event);
           }
-          case "runId":
-            break;
-          default:
-            assertNever(event);
         }
-      }
 
-      return {
-        isError: false,
-        content: [
+        return new Ok([
           {
             type: "resource",
             resource: {
@@ -161,9 +163,9 @@ function createServer(
               uri: "",
             },
           },
-        ],
-      };
-    }
+        ]);
+      }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -204,7 +204,7 @@ export default async function createServer(
       configurableProperties,
       withToolLogging(
         auth,
-        { toolName: RUN_AGENT_TOOL_LOG_NAME, agentLoopContext },
+        { toolNameForMonitoring: RUN_AGENT_TOOL_LOG_NAME, agentLoopContext },
         async () => new Err(new MCPError("No child agent configured"))
       )
     );
@@ -252,7 +252,7 @@ export default async function createServer(
     },
     withToolLogging(
       auth,
-      { toolName: RUN_AGENT_TOOL_LOG_NAME, agentLoopContext },
+      { toolNameForMonitoring: RUN_AGENT_TOOL_LOG_NAME, agentLoopContext },
       async (
         {
           query,

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -371,7 +371,7 @@ export default async function createServer(
       convertDatasetSchemaToZodRawShape(schema),
       withToolLogging(
         auth,
-        { toolName: app.name, agentLoopContext },
+        { toolNameForMonitoring: app.name, agentLoopContext },
         async () => {
           return new Ok([
             {
@@ -404,7 +404,7 @@ export default async function createServer(
       convertDatasetSchemaToZodRawShape(schema),
       withToolLogging(
         auth,
-        { toolName: app.name, agentLoopContext },
+        { toolNameForMonitoring: app.name, agentLoopContext },
         async (params) => {
           const content: (
             | TextContent
@@ -519,7 +519,7 @@ export default async function createServer(
       },
       withToolLogging(
         auth,
-        { toolName: "run_dust_app", agentLoopContext },
+        { toolNameForMonitoring: "run_dust_app", agentLoopContext },
         async () => {
           return new Ok([
             {

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -20,6 +20,9 @@ import { Err, Ok } from "@app/types";
 
 const SF_API_VERSION = "57.0";
 
+// We use a single tool name for monitoring given the high granularity (can be revisited).
+const SALESFORCE_TOOL_LOG_NAME = "salesforce";
+
 const createServer = (auth: Authenticator): McpServer => {
   const server = makeInternalMCPServer("salesforce");
 
@@ -31,7 +34,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "salesforce" },
+      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
       async ({ query }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -67,7 +70,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "salesforce" },
+      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
       async ({ filter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -109,7 +112,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "salesforce" },
+      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
       async ({ objectName }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -217,7 +220,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "salesforce" },
+      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
       async ({ recordId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -271,7 +274,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "salesforce" },
+      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
       async ({ recordId, attachmentId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -31,7 +31,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "execute_read_query" },
+      { toolNameForMonitoring: "salesforce" },
       async ({ query }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -67,7 +67,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_objects" },
+      { toolNameForMonitoring: "salesforce" },
       async ({ filter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -109,7 +109,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "describe_object" },
+      { toolNameForMonitoring: "salesforce" },
       async ({ objectName }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -217,7 +217,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list_attachments" },
+      { toolNameForMonitoring: "salesforce" },
       async ({ recordId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -271,7 +271,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "read_attachment" },
+      { toolNameForMonitoring: "salesforce" },
       async ({ recordId, attachmentId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -31,7 +31,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "execute_read_query" },
+      { toolNameForMonitoring: "execute_read_query" },
       async ({ query }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -67,7 +67,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "list_objects" },
+      { toolNameForMonitoring: "list_objects" },
       async ({ filter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -109,7 +109,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "describe_object" },
+      { toolNameForMonitoring: "describe_object" },
       async ({ objectName }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -217,7 +217,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "list_attachments" },
+      { toolNameForMonitoring: "list_attachments" },
       async ({ recordId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -271,7 +271,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolName: "read_attachment" },
+      { toolNameForMonitoring: "read_attachment" },
       async ({ recordId, attachmentId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -15,11 +15,12 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 
 const SF_API_VERSION = "57.0";
 
-const createServer = (): McpServer => {
+const createServer = (auth: Authenticator): McpServer => {
   const server = makeInternalMCPServer("salesforce");
 
   server.tool(
@@ -44,10 +45,12 @@ const createServer = (): McpServer => {
 
         const result = await conn.query(query);
 
-        return new Ok(makeMCPToolJSONSuccess({
-          message: "Operation completed successfully",
-          result: result,
-        }).content);
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: "Operation completed successfully",
+            result: result,
+          }).content
+        );
       }
     )
   );
@@ -88,10 +91,12 @@ const createServer = (): McpServer => {
           .map((object) => `${object.name} (display_name="${object.label}")`)
           .join("\n");
 
-        return new Ok(makeMCPToolTextSuccess({
-          message: "Operation completed successfully",
-          result: objects,
-        }).content);
+        return new Ok(
+          makeMCPToolTextSuccess({
+            message: "Operation completed successfully",
+            result: objects,
+          }).content
+        );
       }
     )
   );
@@ -179,7 +184,8 @@ const createServer = (): McpServer => {
           });
         }
 
-        summary += "\nChild Relationships (for Parent-to-Child SOQL queries):\n";
+        summary +=
+          "\nChild Relationships (for Parent-to-Child SOQL queries):\n";
         if (result.childRelationships && result.childRelationships.length > 0) {
           result.childRelationships.forEach((rel: any) => {
             summary += `- RelationshipName: ${rel.relationshipName || "(N/A - check API docs)"}`;
@@ -193,10 +199,12 @@ const createServer = (): McpServer => {
         summary +=
           "\nNote: For custom relationships in SOQL, names often end with '__r' (e.g., MyCustomChildren__r). Use the 'RelationshipName' listed above.\n";
 
-        return new Ok(makeMCPToolTextSuccess({
-          message: "Object described successfully. Summary provided.",
-          result: summary,
-        }).content);
+        return new Ok(
+          makeMCPToolTextSuccess({
+            message: "Object described successfully. Summary provided.",
+            result: summary,
+          }).content
+        );
       }
     )
   );
@@ -240,12 +248,14 @@ const createServer = (): McpServer => {
           author: att.author,
         }));
 
-        return new Ok(makeMCPToolJSONSuccess({
-          message: `Found ${attachments.length} attachment(s) for record ${recordId}`,
-          result: {
-            attachments: attachmentSummary,
-          },
-        }).content);
+        return new Ok(
+          makeMCPToolJSONSuccess({
+            message: `Found ${attachments.length} attachment(s) for record ${recordId}`,
+            result: {
+              attachments: attachmentSummary,
+            },
+          }).content
+        );
       }
     )
   );
@@ -279,9 +289,11 @@ const createServer = (): McpServer => {
         );
 
         if (attachmentsResult.isErr()) {
-          return new Err(new MCPError(
-            `Failed to get attachments: ${attachmentsResult.error}`
-          ));
+          return new Err(
+            new MCPError(
+              `Failed to get attachments: ${attachmentsResult.error}`
+            )
+          );
         }
 
         const attachments = attachmentsResult.value;
@@ -290,9 +302,11 @@ const createServer = (): McpServer => {
         );
 
         if (!targetAttachment) {
-          return new Err(new MCPError(
-            `Attachment with ID ${attachmentId} not found on record ${recordId}.`
-          ));
+          return new Err(
+            new MCPError(
+              `Attachment with ID ${attachmentId} not found on record ${recordId}.`
+            )
+          );
         }
 
         return processAttachment({

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import jsforce from "jsforce";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   downloadSalesforceContent,
   extractTextFromSalesforceAttachment,
@@ -10,10 +11,11 @@ import {
 import {
   makeInternalMCPServer,
   makeMCPToolJSONSuccess,
-  makeMCPToolTextError,
   makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import { Err, Ok } from "@app/types";
 
 const SF_API_VERSION = "57.0";
 
@@ -26,24 +28,28 @@ const createServer = (): McpServer => {
     {
       query: z.string().describe("The SOQL read query to execute"),
     },
-    async ({ query }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
+    withToolLogging(
+      auth,
+      { toolName: "execute_read_query" },
+      async ({ query }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
 
-      const conn = new jsforce.Connection({
-        instanceUrl,
-        accessToken,
-        version: SF_API_VERSION,
-      });
-      await conn.identity();
+        const conn = new jsforce.Connection({
+          instanceUrl,
+          accessToken,
+          version: SF_API_VERSION,
+        });
+        await conn.identity();
 
-      const result = await conn.query(query);
+        const result = await conn.query(query);
 
-      return makeMCPToolJSONSuccess({
-        message: "Operation completed successfully",
-        result: result,
-      });
-    }
+        return new Ok(makeMCPToolJSONSuccess({
+          message: "Operation completed successfully",
+          result: result,
+        }).content);
+      }
+    )
   );
 
   server.tool(
@@ -56,34 +62,38 @@ const createServer = (): McpServer => {
         .default("all")
         .describe("Filter objects by type: all, standard, or custom"),
     },
-    async ({ filter }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
+    withToolLogging(
+      auth,
+      { toolName: "list_objects" },
+      async ({ filter }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
 
-      const conn = new jsforce.Connection({
-        instanceUrl,
-        accessToken,
-        version: SF_API_VERSION,
-      });
-      await conn.identity();
+        const conn = new jsforce.Connection({
+          instanceUrl,
+          accessToken,
+          version: SF_API_VERSION,
+        });
+        await conn.identity();
 
-      const result = await conn.describeGlobal();
+        const result = await conn.describeGlobal();
 
-      const objects = result.sobjects
-        .filter((object) => {
-          if (filter === "all") {
-            return true;
-          }
-          return object.custom === (filter === "custom");
-        })
-        .map((object) => `${object.name} (display_name="${object.label}")`)
-        .join("\n");
+        const objects = result.sobjects
+          .filter((object) => {
+            if (filter === "all") {
+              return true;
+            }
+            return object.custom === (filter === "custom");
+          })
+          .map((object) => `${object.name} (display_name="${object.label}")`)
+          .join("\n");
 
-      return makeMCPToolTextSuccess({
-        message: "Operation completed successfully",
-        result: objects,
-      });
-    }
+        return new Ok(makeMCPToolTextSuccess({
+          message: "Operation completed successfully",
+          result: objects,
+        }).content);
+      }
+    )
   );
 
   server.tool(
@@ -92,99 +102,103 @@ const createServer = (): McpServer => {
     {
       objectName: z.string().describe("The name of the object to describe"),
     },
-    async ({ objectName }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
+    withToolLogging(
+      auth,
+      { toolName: "describe_object" },
+      async ({ objectName }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
 
-      const conn = new jsforce.Connection({
-        instanceUrl,
-        accessToken,
-        version: SF_API_VERSION,
-      });
-      await conn.identity();
+        const conn = new jsforce.Connection({
+          instanceUrl,
+          accessToken,
+          version: SF_API_VERSION,
+        });
+        await conn.identity();
 
-      const result = await conn.describe(objectName);
+        const result = await conn.describe(objectName);
 
-      let summary = `Object: ${result.name}\n`;
-      summary += `Label: ${result.label}\n`;
-      summary += `Plural Label: ${result.labelPlural}\n`;
-      if (result.keyPrefix) {
-        summary += `Key Prefix: ${result.keyPrefix}\n`;
-      }
-      summary += `Queryable: ${result.queryable}\n`;
-      summary += `Createable: ${result.createable}\n`;
-      summary += `Updateable: ${result.updateable}\n`;
-      summary += `Deletable: ${result.deletable}\n`;
-      summary += `Feed Enabled: ${result.feedEnabled}\n\n`;
-
-      summary += "Fields:\n";
-      const standardFields = result.fields.filter((f: any) => !f.custom);
-      const customFields = result.fields.filter((f: any) => f.custom);
-
-      const formatField = (field: any) => {
-        let fieldStr = `- ${field.name} (Label: "${field.label}", Type: ${field.type}`;
-        if (
-          field.type === "reference" &&
-          field.referenceTo &&
-          field.referenceTo.length > 0
-        ) {
-          fieldStr += ` -> References: ${field.referenceTo.join(", ")}`;
-          if (field.relationshipName) {
-            fieldStr += ` (Use '${field.relationshipName}' for parent fields)`;
-          }
+        let summary = `Object: ${result.name}\n`;
+        summary += `Label: ${result.label}\n`;
+        summary += `Plural Label: ${result.labelPlural}\n`;
+        if (result.keyPrefix) {
+          summary += `Key Prefix: ${result.keyPrefix}\n`;
         }
-        if (
-          field.type === "picklist" &&
-          field.picklistValues &&
-          field.picklistValues.length > 0
-        ) {
-          const activePicklistValues = field.picklistValues.filter(
-            (pv: any) => pv.active
-          );
-          const values = activePicklistValues
-            .map((pv: any) => pv.value)
-            .slice(0, 5);
-          if (values.length > 0) {
-            fieldStr += ` (Values: ${values.join(", ")}${activePicklistValues.length > 5 ? ", ..." : ""})`;
+        summary += `Queryable: ${result.queryable}\n`;
+        summary += `Createable: ${result.createable}\n`;
+        summary += `Updateable: ${result.updateable}\n`;
+        summary += `Deletable: ${result.deletable}\n`;
+        summary += `Feed Enabled: ${result.feedEnabled}\n\n`;
+
+        summary += "Fields:\n";
+        const standardFields = result.fields.filter((f: any) => !f.custom);
+        const customFields = result.fields.filter((f: any) => f.custom);
+
+        const formatField = (field: any) => {
+          let fieldStr = `- ${field.name} (Label: "${field.label}", Type: ${field.type}`;
+          if (
+            field.type === "reference" &&
+            field.referenceTo &&
+            field.referenceTo.length > 0
+          ) {
+            fieldStr += ` -> References: ${field.referenceTo.join(", ")}`;
+            if (field.relationshipName) {
+              fieldStr += ` (Use '${field.relationshipName}' for parent fields)`;
+            }
           }
+          if (
+            field.type === "picklist" &&
+            field.picklistValues &&
+            field.picklistValues.length > 0
+          ) {
+            const activePicklistValues = field.picklistValues.filter(
+              (pv: any) => pv.active
+            );
+            const values = activePicklistValues
+              .map((pv: any) => pv.value)
+              .slice(0, 5);
+            if (values.length > 0) {
+              fieldStr += ` (Values: ${values.join(", ")}${activePicklistValues.length > 5 ? ", ..." : ""})`;
+            }
+          }
+          fieldStr += `, Nillable: ${field.nillable}, Createable: ${field.createable}, Updateable: ${field.updateable})`;
+          return fieldStr;
+        };
+
+        if (standardFields.length > 0) {
+          summary += "\nStandard Fields:\n";
+          standardFields.forEach((field: any) => {
+            summary += `${formatField(field)}\n`;
+          });
         }
-        fieldStr += `, Nillable: ${field.nillable}, Createable: ${field.createable}, Updateable: ${field.updateable})`;
-        return fieldStr;
-      };
 
-      if (standardFields.length > 0) {
-        summary += "\nStandard Fields:\n";
-        standardFields.forEach((field: any) => {
-          summary += `${formatField(field)}\n`;
-        });
+        if (customFields.length > 0) {
+          summary += "\nCustom Fields (names end with '__c'):\n";
+          customFields.forEach((field: any) => {
+            summary += `${formatField(field)}\n`;
+          });
+        }
+
+        summary += "\nChild Relationships (for Parent-to-Child SOQL queries):\n";
+        if (result.childRelationships && result.childRelationships.length > 0) {
+          result.childRelationships.forEach((rel: any) => {
+            summary += `- RelationshipName: ${rel.relationshipName || "(N/A - check API docs)"}`;
+            summary += `, ChildObject: ${rel.childSObject}`;
+            summary += `, Field on Child: ${rel.field}\n`;
+          });
+        } else {
+          summary += "No child relationships found.\n";
+        }
+
+        summary +=
+          "\nNote: For custom relationships in SOQL, names often end with '__r' (e.g., MyCustomChildren__r). Use the 'RelationshipName' listed above.\n";
+
+        return new Ok(makeMCPToolTextSuccess({
+          message: "Object described successfully. Summary provided.",
+          result: summary,
+        }).content);
       }
-
-      if (customFields.length > 0) {
-        summary += "\nCustom Fields (names end with '__c'):\n";
-        customFields.forEach((field: any) => {
-          summary += `${formatField(field)}\n`;
-        });
-      }
-
-      summary += "\nChild Relationships (for Parent-to-Child SOQL queries):\n";
-      if (result.childRelationships && result.childRelationships.length > 0) {
-        result.childRelationships.forEach((rel: any) => {
-          summary += `- RelationshipName: ${rel.relationshipName || "(N/A - check API docs)"}`;
-          summary += `, ChildObject: ${rel.childSObject}`;
-          summary += `, Field on Child: ${rel.field}\n`;
-        });
-      } else {
-        summary += "No child relationships found.\n";
-      }
-
-      summary +=
-        "\nNote: For custom relationships in SOQL, names often end with '__r' (e.g., MyCustomChildren__r). Use the 'RelationshipName' listed above.\n";
-
-      return makeMCPToolTextSuccess({
-        message: "Object described successfully. Summary provided.",
-        result: summary,
-      });
-    }
+    )
   );
 
   server.tool(
@@ -193,43 +207,47 @@ const createServer = (): McpServer => {
     {
       recordId: z.string().describe("The Salesforce record ID"),
     },
-    async ({ recordId }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
+    withToolLogging(
+      auth,
+      { toolName: "list_attachments" },
+      async ({ recordId }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
 
-      const conn = new jsforce.Connection({
-        instanceUrl,
-        accessToken,
-        version: SF_API_VERSION,
-      });
-      await conn.identity();
+        const conn = new jsforce.Connection({
+          instanceUrl,
+          accessToken,
+          version: SF_API_VERSION,
+        });
+        await conn.identity();
 
-      const attachmentsResult = await getAllSalesforceAttachments(
-        conn,
-        recordId
-      );
+        const attachmentsResult = await getAllSalesforceAttachments(
+          conn,
+          recordId
+        );
 
-      if (attachmentsResult.isErr()) {
-        return makeMCPToolTextError(attachmentsResult.error);
+        if (attachmentsResult.isErr()) {
+          return new Err(new MCPError(attachmentsResult.error));
+        }
+
+        const attachments = attachmentsResult.value;
+        const attachmentSummary = attachments.map((att) => ({
+          id: att.id,
+          filename: att.filename,
+          mimeType: att.mimeType,
+          size: att.size,
+          created: att.created,
+          author: att.author,
+        }));
+
+        return new Ok(makeMCPToolJSONSuccess({
+          message: `Found ${attachments.length} attachment(s) for record ${recordId}`,
+          result: {
+            attachments: attachmentSummary,
+          },
+        }).content);
       }
-
-      const attachments = attachmentsResult.value;
-      const attachmentSummary = attachments.map((att) => ({
-        id: att.id,
-        filename: att.filename,
-        mimeType: att.mimeType,
-        size: att.size,
-        created: att.created,
-        author: att.author,
-      }));
-
-      return makeMCPToolJSONSuccess({
-        message: `Found ${attachments.length} attachment(s) for record ${recordId}`,
-        result: {
-          attachments: attachmentSummary,
-        },
-      });
-    }
+    )
   );
 
   server.tool(
@@ -241,52 +259,56 @@ const createServer = (): McpServer => {
         .string()
         .describe("The ID of the attachment or file to read"),
     },
-    async ({ recordId, attachmentId }, { authInfo }) => {
-      const accessToken = authInfo?.token;
-      const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
+    withToolLogging(
+      auth,
+      { toolName: "read_attachment" },
+      async ({ recordId, attachmentId }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
 
-      const conn = new jsforce.Connection({
-        instanceUrl,
-        accessToken,
-        version: SF_API_VERSION,
-      });
-      await conn.identity();
+        const conn = new jsforce.Connection({
+          instanceUrl,
+          accessToken,
+          version: SF_API_VERSION,
+        });
+        await conn.identity();
 
-      const attachmentsResult = await getAllSalesforceAttachments(
-        conn,
-        recordId
-      );
-
-      if (attachmentsResult.isErr()) {
-        return makeMCPToolTextError(
-          `Failed to get attachments: ${attachmentsResult.error}`
+        const attachmentsResult = await getAllSalesforceAttachments(
+          conn,
+          recordId
         );
-      }
 
-      const attachments = attachmentsResult.value;
-      const targetAttachment = attachments.find(
-        (att) => att.id === attachmentId
-      );
+        if (attachmentsResult.isErr()) {
+          return new Err(new MCPError(
+            `Failed to get attachments: ${attachmentsResult.error}`
+          ));
+        }
 
-      if (!targetAttachment) {
-        return makeMCPToolTextError(
-          `Attachment with ID ${attachmentId} not found on record ${recordId}.`
+        const attachments = attachmentsResult.value;
+        const targetAttachment = attachments.find(
+          (att) => att.id === attachmentId
         );
-      }
 
-      return processAttachment({
-        mimeType: targetAttachment.mimeType,
-        filename: targetAttachment.filename || `attachment-${attachmentId}`,
-        extractText: async () =>
-          extractTextFromSalesforceAttachment(
-            conn,
-            attachmentId,
-            targetAttachment.mimeType
-          ),
-        downloadContent: async () =>
-          downloadSalesforceContent(conn, attachmentId),
-      });
-    }
+        if (!targetAttachment) {
+          return new Err(new MCPError(
+            `Attachment with ID ${attachmentId} not found on record ${recordId}.`
+          ));
+        }
+
+        return processAttachment({
+          mimeType: targetAttachment.mimeType,
+          filename: targetAttachment.filename || `attachment-${attachmentId}`,
+          extractText: async () =>
+            extractTextFromSalesforceAttachment(
+              conn,
+              attachmentId,
+              targetAttachment.mimeType
+            ),
+          downloadContent: async () =>
+            downloadSalesforceContent(conn, attachmentId),
+        });
+      }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -270,7 +270,7 @@ function createServer(
       commonInputsSchema,
       withToolLogging(
         auth,
-        { toolName: SEARCH_TOOL_NAME, agentLoopContext },
+        { toolNameForMonitoring: SEARCH_TOOL_NAME, agentLoopContext },
         async (args) => searchFunction({ ...args, auth, agentLoopContext })
       )
     );
@@ -286,7 +286,7 @@ function createServer(
       },
       withToolLogging(
         auth,
-        { toolName: SEARCH_TOOL_NAME, agentLoopContext },
+        { toolNameForMonitoring: SEARCH_TOOL_NAME, agentLoopContext },
         async (args) => searchFunction({ ...args, auth, agentLoopContext })
       )
     );

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import uniqBy from "lodash/uniqBy";
 import { z } from "zod";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
@@ -28,6 +29,8 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_api_helper";
 import {
   makeInternalMCPServer,
+  makeMCPToolJSONSuccess,
+  makeMCPToolTextSuccess,
   makePersonalAuthenticationError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -39,9 +42,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { TimeFrame } from "@app/types";
-import {
-  Err,
-  Ok,
+import { Err, Ok,
   parseTimeFrame,
   stripNullBytes,
   timeFrameFromNow,

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -323,7 +323,7 @@ const createServer = async (
       },
       withToolLogging(
         auth,
-        { toolName: SLACK_SEARCH_MESSAGES, agentLoopContext },
+        { toolNameForMonitoring: SLACK_SEARCH_MESSAGES, agentLoopContext },
         async (
           {
             keywords,
@@ -477,7 +477,10 @@ const createServer = async (
       },
       withToolLogging(
         auth,
-        { toolName: SLACK_SEMANTIC_SEARCH_MESSAGES, agentLoopContext },
+        {
+          toolNameForMonitoring: SLACK_SEMANTIC_SEARCH_MESSAGES,
+          agentLoopContext,
+        },
         async (
           {
             query,
@@ -621,7 +624,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_LIST_THREADS, agentLoopContext },
+      { toolNameForMonitoring: SLACK_LIST_THREADS, agentLoopContext },
       async ({ channel, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(
@@ -762,7 +765,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_POST_MESSAGE, agentLoopContext },
+      { toolNameForMonitoring: SLACK_POST_MESSAGE, agentLoopContext },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -806,7 +809,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_LIST_USERS, agentLoopContext },
+      { toolNameForMonitoring: SLACK_LIST_USERS, agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -835,7 +838,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_GET_USER, agentLoopContext },
+      { toolNameForMonitoring: SLACK_GET_USER, agentLoopContext },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -865,7 +868,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_LIST_PUBLIC_CHANNELS, agentLoopContext },
+      { toolNameForMonitoring: SLACK_LIST_PUBLIC_CHANNELS, agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -323,7 +323,7 @@ const createServer = async (
       },
       withToolLogging(
         auth,
-        { toolNameForMonitoring: SLACK_SEARCH_MESSAGES, agentLoopContext },
+        { toolNameForMonitoring: "slack", agentLoopContext },
         async (
           {
             keywords,
@@ -624,7 +624,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_LIST_THREADS, agentLoopContext },
+      { toolNameForMonitoring: "slack", agentLoopContext },
       async ({ channel, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(
@@ -765,7 +765,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_POST_MESSAGE, agentLoopContext },
+      { toolNameForMonitoring: "slack", agentLoopContext },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -809,7 +809,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_LIST_USERS, agentLoopContext },
+      { toolNameForMonitoring: "slack", agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -838,7 +838,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_GET_USER, agentLoopContext },
+      { toolNameForMonitoring: "slack", agentLoopContext },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -868,7 +868,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_LIST_PUBLIC_CHANNELS, agentLoopContext },
+      { toolNameForMonitoring: "slack", agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -46,6 +46,9 @@ export type SlackSearchMatch = {
   permalink?: string;
 };
 
+// We use a single tool name for monitoring given the high granularity (can be revisited).
+const SLACK_TOOL_LOG_NAME = "slack";
+
 export const slackSearch = async (
   query: string,
   accessToken: string
@@ -314,7 +317,7 @@ const createServer = async (
       },
       withToolLogging(
         auth,
-        { toolNameForMonitoring: "slack", agentLoopContext },
+        { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
         async (
           {
             keywords,
@@ -469,7 +472,7 @@ const createServer = async (
       withToolLogging(
         auth,
         {
-          toolNameForMonitoring: "slack",
+          toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
           agentLoopContext,
         },
         async (
@@ -615,7 +618,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ channel, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(
@@ -756,7 +759,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -800,7 +803,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -829,7 +832,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -859,7 +862,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -11,15 +11,6 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { renderRelativeTimeFrameForToolOutput } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
-  SLACK_GET_USER,
-  SLACK_LIST_PUBLIC_CHANNELS,
-  SLACK_LIST_THREADS,
-  SLACK_LIST_USERS,
-  SLACK_POST_MESSAGE,
-  SLACK_SEARCH_MESSAGES,
-  SLACK_SEMANTIC_SEARCH_MESSAGES,
-} from "@app/lib/actions/mcp_internal_actions/servers/slack/constants";
-import {
   executeGetUser,
   executeListPublicChannels,
   executeListUsers,
@@ -478,7 +469,7 @@ const createServer = async (
       withToolLogging(
         auth,
         {
-          toolNameForMonitoring: SLACK_SEMANTIC_SEARCH_MESSAGES,
+          toolNameForMonitoring: "slack",
           agentLoopContext,
         },
         async (
@@ -881,7 +872,6 @@ const createServer = async (
             accessToken,
             mcpServerId
           );
-
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
             return new Err(new MCPError("slack"));

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -338,7 +338,7 @@ const createServer = async (
           if (!agentLoopContext?.runContext) {
             return new Err(
               new MCPError("Unreachable: missing agentLoopRunContext.")
-          );
+            );
           }
 
           if (keywords.length > 5) {
@@ -492,7 +492,7 @@ const createServer = async (
           if (!agentLoopContext?.runContext) {
             return new Err(
               new MCPError("Unreachable: missing agentLoopRunContext.")
-          );
+            );
           }
 
           const accessToken = authInfo?.token;
@@ -626,7 +626,7 @@ const createServer = async (
         if (!agentLoopContext?.runContext) {
           return new Err(
             new MCPError("Unreachable: missing agentLoopRunContext.")
-        );
+          );
         }
 
         const accessToken = authInfo?.token;
@@ -772,19 +772,19 @@ const createServer = async (
         if (!agentLoopContext?.runContext) {
           return new Err(
             new MCPError("Unreachable: missing agentLoopRunContext.")
-        );
+          );
         }
 
         try {
           return await executePostMessage(
             to,
             message,
-            threadTs,fileId,
+            threadTs,
+            fileId,
             accessToken,
             agentLoopContext,
             auth
           );
-
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
             return new Ok(makePersonalAuthenticationError("slack").content);
@@ -815,7 +815,6 @@ const createServer = async (
 
         try {
           return await executeListUsers(nameFilter, accessToken);
-
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
             return new Ok(makePersonalAuthenticationError("slack").content);
@@ -845,7 +844,6 @@ const createServer = async (
 
         try {
           return await executeGetUser(userId, accessToken);
-
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
             return new Ok(makePersonalAuthenticationError("slack").content);

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -3,7 +3,6 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import uniqBy from "lodash/uniqBy";
 import { z } from "zod";
 
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
@@ -29,8 +28,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_api_helper";
 import {
   makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-  makeMCPToolTextSuccess,
   makePersonalAuthenticationError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -42,7 +39,9 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { TimeFrame } from "@app/types";
-import { Err, Ok,
+import {
+  Err,
+  Ok,
   parseTimeFrame,
   stripNullBytes,
   timeFrameFromNow,
@@ -339,7 +338,7 @@ const createServer = async (
           if (!agentLoopContext?.runContext) {
             return new Err(
               new MCPError("Unreachable: missing agentLoopRunContext.")
-            );
+          );
           }
 
           if (keywords.length > 5) {
@@ -493,7 +492,7 @@ const createServer = async (
           if (!agentLoopContext?.runContext) {
             return new Err(
               new MCPError("Unreachable: missing agentLoopRunContext.")
-            );
+          );
           }
 
           const accessToken = authInfo?.token;
@@ -627,7 +626,7 @@ const createServer = async (
         if (!agentLoopContext?.runContext) {
           return new Err(
             new MCPError("Unreachable: missing agentLoopRunContext.")
-          );
+        );
         }
 
         const accessToken = authInfo?.token;
@@ -773,19 +772,19 @@ const createServer = async (
         if (!agentLoopContext?.runContext) {
           return new Err(
             new MCPError("Unreachable: missing agentLoopRunContext.")
-          );
+        );
         }
 
         try {
           return await executePostMessage(
             to,
             message,
-            threadTs,
-            fileId,
+            threadTs,fileId,
             accessToken,
             agentLoopContext,
             auth
           );
+
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
             return new Ok(makePersonalAuthenticationError("slack").content);
@@ -816,6 +815,7 @@ const createServer = async (
 
         try {
           return await executeListUsers(nameFilter, accessToken);
+
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
             return new Ok(makePersonalAuthenticationError("slack").content);
@@ -845,6 +845,7 @@ const createServer = async (
 
         try {
           return await executeGetUser(userId, accessToken);
+
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
             return new Ok(makePersonalAuthenticationError("slack").content);
@@ -879,6 +880,7 @@ const createServer = async (
             accessToken,
             mcpServerId
           );
+
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
             return new Err(new MCPError("slack"));

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -3,16 +3,6 @@ import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
-  SLACK_ADD_REACTION,
-  SLACK_GET_USER,
-  SLACK_LIST_PUBLIC_CHANNELS,
-  SLACK_LIST_USERS,
-  SLACK_POST_MESSAGE,
-  SLACK_READ_CHANNEL_HISTORY,
-  SLACK_READ_THREAD_MESSAGES,
-  SLACK_REMOVE_REACTION,
-} from "@app/lib/actions/mcp_internal_actions/servers/slack/constants";
-import {
   executeGetUser,
   executeListPublicChannels,
   executeListUsers,
@@ -27,6 +17,9 @@ import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers"
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, normalizeError, Ok } from "@app/types";
+
+// We use a single tool name for monitoring given the high granularity (can be revisited).
+const SLACK_TOOL_LOG_NAME = "slack_bot";
 
 const createServer = async (
   auth: Authenticator,
@@ -64,7 +57,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack_bot", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -105,7 +98,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack_bot", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -133,7 +126,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack_bot", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -162,7 +155,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack_bot", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -210,7 +203,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack_bot", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ channel, limit = 20, cursor, oldest, latest }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -284,7 +277,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack_bot", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async (
         { channel, threadTs, limit = 20, cursor, oldest, latest },
         { authInfo }
@@ -358,7 +351,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack_bot", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -411,7 +404,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "slack_bot", agentLoopContext },
+      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -64,7 +64,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_POST_MESSAGE, agentLoopContext },
+      { toolNameForMonitoring: "slack_bot", agentLoopContext },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -105,7 +105,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_LIST_USERS, agentLoopContext },
+      { toolNameForMonitoring: "slack_bot", agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -133,7 +133,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_GET_USER, agentLoopContext },
+      { toolNameForMonitoring: "slack_bot", agentLoopContext },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -162,7 +162,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_LIST_PUBLIC_CHANNELS, agentLoopContext },
+      { toolNameForMonitoring: "slack_bot", agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -210,7 +210,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_READ_CHANNEL_HISTORY, agentLoopContext },
+      { toolNameForMonitoring: "slack_bot", agentLoopContext },
       async ({ channel, limit = 20, cursor, oldest, latest }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -284,7 +284,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_READ_THREAD_MESSAGES, agentLoopContext },
+      { toolNameForMonitoring: "slack_bot", agentLoopContext },
       async (
         { channel, threadTs, limit = 20, cursor, oldest, latest },
         { authInfo }
@@ -358,7 +358,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_ADD_REACTION, agentLoopContext },
+      { toolNameForMonitoring: "slack_bot", agentLoopContext },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -411,7 +411,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_REMOVE_REACTION, agentLoopContext },
+      { toolNameForMonitoring: "slack_bot", agentLoopContext },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -64,7 +64,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_POST_MESSAGE, agentLoopContext },
+      { toolNameForMonitoring: SLACK_POST_MESSAGE, agentLoopContext },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -105,7 +105,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_LIST_USERS, agentLoopContext },
+      { toolNameForMonitoring: SLACK_LIST_USERS, agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -133,7 +133,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_GET_USER, agentLoopContext },
+      { toolNameForMonitoring: SLACK_GET_USER, agentLoopContext },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -162,7 +162,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_LIST_PUBLIC_CHANNELS, agentLoopContext },
+      { toolNameForMonitoring: SLACK_LIST_PUBLIC_CHANNELS, agentLoopContext },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -210,7 +210,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_READ_CHANNEL_HISTORY, agentLoopContext },
+      { toolNameForMonitoring: SLACK_READ_CHANNEL_HISTORY, agentLoopContext },
       async ({ channel, limit = 20, cursor, oldest, latest }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -284,7 +284,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_READ_THREAD_MESSAGES, agentLoopContext },
+      { toolNameForMonitoring: SLACK_READ_THREAD_MESSAGES, agentLoopContext },
       async (
         { channel, threadTs, limit = 20, cursor, oldest, latest },
         { authInfo }
@@ -358,7 +358,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_ADD_REACTION, agentLoopContext },
+      { toolNameForMonitoring: SLACK_ADD_REACTION, agentLoopContext },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -411,7 +411,7 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolName: SLACK_REMOVE_REACTION, agentLoopContext },
+      { toolNameForMonitoring: SLACK_REMOVE_REACTION, agentLoopContext },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {

--- a/front/lib/actions/mcp_internal_actions/servers/slideshow/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slideshow/index.ts
@@ -79,7 +79,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: CREATE_SLIDESHOW_FILE_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: CREATE_SLIDESHOW_FILE_TOOL_NAME,
+        agentLoopContext,
+      },
       async (
         { file_name, mime_type, content, description },
         { sendNotification, _meta }
@@ -204,7 +207,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: EDIT_SLIDESHOW_FILE_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: EDIT_SLIDESHOW_FILE_TOOL_NAME,
+        agentLoopContext,
+      },
       async (
         { file_id, old_string, new_string, expected_replacements },
         { sendNotification, _meta }
@@ -281,7 +287,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: RETRIEVE_SLIDESHOW_FILE_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: RETRIEVE_SLIDESHOW_FILE_TOOL_NAME,
+        agentLoopContext,
+      },
       async ({ file_id }) => {
         const result = await getClientExecutableFileContent(auth, file_id);
 

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -29,10 +29,7 @@ import {
   getSchemaContent,
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/schema";
 import { fetchTableDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import {
-  makeInternalMCPServer,
-  makeMCPToolTextError,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
@@ -107,9 +104,11 @@ function createServer(
           tables
         );
         if (tableConfigurationsRes.isErr()) {
-          return new Err(new MCPError(
-            `Error fetching table configurations: ${tableConfigurationsRes.error.message}`
-          ));
+          return new Err(
+            new MCPError(
+              `Error fetching table configurations: ${tableConfigurationsRes.error.message}`
+            )
+          );
         }
         const tableConfigurations = tableConfigurationsRes.value;
         if (tableConfigurations.length === 0) {
@@ -149,9 +148,11 @@ function createServer(
         });
 
         if (schemaResult.isErr()) {
-          return new Err(new MCPError(
-            `Error retrieving database schema: ${schemaResult.error.message}`
-          ));
+          return new Err(
+            new MCPError(
+              `Error retrieving database schema: ${schemaResult.error.message}`
+            )
+          );
         }
 
         return new Ok([

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -96,7 +96,10 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolName: GET_DATABASE_SCHEMA_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: GET_DATABASE_SCHEMA_TOOL_NAME,
+        agentLoopContext,
+      },
       async ({ tables }) => {
         // Fetch table configurations
         const tableConfigurationsRes = await fetchTableDataSourceConfigurations(
@@ -189,7 +192,10 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolName: EXECUTE_DATABASE_QUERY_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: EXECUTE_DATABASE_QUERY_TOOL_NAME,
+        agentLoopContext,
+      },
       async ({ tables, query, fileName }) => {
         // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
         if (!agentLoopContext?.runContext) {

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -29,7 +29,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "list", agentLoopContext },
+      { toolNameForMonitoring: "list_toolsets", agentLoopContext },
       async () => {
         const mcpServerViewIdsFromAgentConfiguration =
           agentLoopContext?.runContext?.agentConfiguration.actions

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -27,61 +27,67 @@ const createServer = (
     "list",
     "List the available toolsets with their names and descriptions. This is like using 'ls' in Unix.",
     {},
-    withToolLogging(auth, { toolName: "list", agentLoopContext }, async () => {
-      const mcpServerViewIdsFromAgentConfiguration =
-        agentLoopContext?.runContext?.agentConfiguration.actions
-          .filter(isServerSideMCPServerConfiguration)
-          .map((action) => action.mcpServerViewId) ?? [];
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "list", agentLoopContext },
+      async () => {
+        const mcpServerViewIdsFromAgentConfiguration =
+          agentLoopContext?.runContext?.agentConfiguration.actions
+            .filter(isServerSideMCPServerConfiguration)
+            .map((action) => action.mcpServerViewId) ?? [];
 
-      const owner = auth.getNonNullableWorkspace();
-      const requestedGroupIds = auth.groups().map((g) => g.sId);
-      const prodCredentials = await prodAPICredentialsForOwner(owner);
-      const config = apiConfig.getDustAPIConfig();
-      const api = new DustAPI(
-        config,
-        {
-          ...prodCredentials,
-          extraHeaders: {
-            ...getHeaderFromGroupIds(requestedGroupIds),
+        const owner = auth.getNonNullableWorkspace();
+        const requestedGroupIds = auth.groups().map((g) => g.sId);
+        const prodCredentials = await prodAPICredentialsForOwner(owner);
+        const config = apiConfig.getDustAPIConfig();
+        const api = new DustAPI(
+          config,
+          {
+            ...prodCredentials,
+            extraHeaders: {
+              ...getHeaderFromGroupIds(requestedGroupIds),
+            },
           },
-        },
-        logger,
-        config.nodeEnv === "development" ? "http://localhost:3000" : null
-      );
-      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-      const r = await api.getMCPServerViews(globalSpace.sId, true);
-      if (r.isErr()) {
-        throw new Error(r.error.message);
-      }
-
-      const mcpServerViews = r.value
-        .filter(
-          (mcpServerView) =>
-            !mcpServerViewIdsFromAgentConfiguration.includes(mcpServerView.sId)
-        )
-        .filter(
-          (mcpServerView) =>
-            getMCPServerToolsConfigurations(mcpServerView).configurable !==
-            "required"
-        )
-        .filter(
-          (mcpServerView) =>
-            mcpServerView.server.availability !== "auto_hidden_builder"
+          logger,
+          config.nodeEnv === "development" ? "http://localhost:3000" : null
         );
+        const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+        const r = await api.getMCPServerViews(globalSpace.sId, true);
+        if (r.isErr()) {
+          throw new Error(r.error.message);
+        }
 
-      return new Ok(
-        mcpServerViews.map((mcpServerView) => ({
-          type: "resource" as const,
-          resource: {
-            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.TOOLSET_LIST_RESULT,
-            uri: "",
-            id: mcpServerView.sId,
-            text: getMcpServerViewDisplayName(mcpServerView),
-            description: getMcpServerViewDescription(mcpServerView),
-          },
-        }))
-      );
-    })
+        const mcpServerViews = r.value
+          .filter(
+            (mcpServerView) =>
+              !mcpServerViewIdsFromAgentConfiguration.includes(
+                mcpServerView.sId
+              )
+          )
+          .filter(
+            (mcpServerView) =>
+              getMCPServerToolsConfigurations(mcpServerView).configurable !==
+              "required"
+          )
+          .filter(
+            (mcpServerView) =>
+              mcpServerView.server.availability !== "auto_hidden_builder"
+          );
+
+        return new Ok(
+          mcpServerViews.map((mcpServerView) => ({
+            type: "resource" as const,
+            resource: {
+              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.TOOLSET_LIST_RESULT,
+              uri: "",
+              id: mcpServerView.sId,
+              text: getMcpServerViewDisplayName(mcpServerView),
+              description: getMcpServerViewDescription(mcpServerView),
+            },
+          }))
+        );
+      }
+    )
   );
 
   return server;

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -64,7 +64,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: WEBSEARCH_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: WEBSEARCH_TOOL_NAME, agentLoopContext },
       async ({ query, page }) => {
         if (!agentLoopContext?.runContext) {
           throw new Error(
@@ -156,7 +156,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolName: WEBBROWSER_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: WEBBROWSER_TOOL_NAME, agentLoopContext },
       async ({
         urls,
         format = "markdown",

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -64,7 +64,7 @@ export function registerCatTool(
     catToolInputSchema,
     withToolLogging(
       auth,
-      { toolName: FILESYSTEM_CAT_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: FILESYSTEM_CAT_TOOL_NAME, agentLoopContext },
       async ({ dataSources, nodeId, offset, limit, grep }) => {
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -93,7 +93,7 @@ export function registerListTool(
     ListToolInputSchema,
     withToolLogging(
       auth,
-      { toolName: FILESYSTEM_LIST_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: FILESYSTEM_LIST_TOOL_NAME, agentLoopContext },
       async ({
         nodeId,
         dataSources,

--- a/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
@@ -54,7 +54,7 @@ export function registerFindTagsTool(
     findTagsSchema,
     withToolLogging(
       auth,
-      { toolName: FIND_TAGS_TOOL_NAME, agentLoopContext },
+      { toolNameForMonitoring: FIND_TAGS_TOOL_NAME, agentLoopContext },
       async ({
         query,
         dataSources,

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -17,14 +17,16 @@ import { errorToString } from "@app/types";
  * Wraps a tool callback with logging and monitoring.
  * The tool callback is expected to return a `Result<CallToolResult["content"], MCPError>`,
  * Errors are caught and logged unless not tracked, and the error is returned as a text content.
+ *
+ * The tool name is used as a tag in the DD metric, it's 1 tool name <=> 1 monitor.
  */
 export function withToolLogging<T>(
   auth: Authenticator,
   {
-    toolName,
+    toolNameForMonitoring,
     agentLoopContext,
   }: {
-    toolName: string;
+    toolNameForMonitoring: string;
     agentLoopContext?: AgentLoopContextType;
   },
   toolCallback: (
@@ -50,7 +52,7 @@ export function withToolLogging<T>(
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         plan_code: auth.plan()?.code || null,
       },
-      toolName,
+      toolName: toolNameForMonitoring,
     };
 
     // Adding agent loop context if available.
@@ -74,7 +76,7 @@ export function withToolLogging<T>(
     logger.info(loggerArgs, "Tool execution start");
 
     const tags = [
-      `tool:${toolName}`,
+      `tool:${toolNameForMonitoring}`,
       `workspace:${owner.sId}`,
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       `workspace_plan_code:${auth.plan()?.code || null}`,


### PR DESCRIPTION
## Description

First pass to wrap tools with `withToolLogging` to get more execution metrics / logs on all and get more consistent. Some tools are not yet done, require some more work ( some already have a withAuth wrapper )
Once all wrapped we can change the utils like makeMCPToolJSONSuccess to return content only to avoid useless objects creation.
All logic remains identical, no change expected outside of logging

## Tests


## Risk

Can break any tool

## Deploy Plan

deploy front
