### PR TITLE
Add: agent placeholder messages

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -17,6 +17,7 @@ import {
   GenerationContext,
   GenerationContextProvider,
 } from "@app/components/assistant/conversation/GenerationContextProvider";
+import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import type { DustError } from "@app/lib/error";
 import { useUser } from "@app/lib/swr/user";
@@ -25,7 +26,6 @@ import type {
   ContentFragmentsType,
   ConversationWithoutContentType,
   LightAgentConfigurationType,
-  MentionType,
   Result,
   UserType,
   WorkspaceType,
@@ -73,7 +73,7 @@ interface PreviewContentProps {
   resetConversation: () => void;
   handleSubmit: (
     input: string,
-    mentions: MentionType[],
+    mentions: EditorMention[],
     contentFragments: ContentFragmentsType
   ) => Promise<Result<undefined, DustError>>;
   setStickyMentions: (mentions: AgentMention[]) => void;

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -5,6 +5,7 @@ import { useFormContext } from "react-hook-form";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
+import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import {
   createConversationWithMessage,
   submitMessage,
@@ -18,7 +19,6 @@ import type {
   ContentFragmentsType,
   ConversationType,
   LightAgentConfigurationType,
-  MentionType,
   Result,
 } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -136,7 +136,7 @@ export function useDraftConversation({
 
   const handleSubmit = async (
     input: string,
-    mentions: MentionType[],
+    mentions: EditorMention[],
     contentFragments: ContentFragmentsType
   ): Promise<Result<undefined, DustError>> => {
     if (!user) {
@@ -160,7 +160,7 @@ export function useDraftConversation({
 
       // Update mentions in the message data to use the current draft agent
       mentions = mentions.map((mention) =>
-        mention.configurationId === draftAgent?.sId && currentAgent?.sId
+        mention.id === draftAgent?.sId && currentAgent?.sId
           ? { ...mention, configurationId: currentAgent.sId }
           : mention
       );
@@ -172,7 +172,13 @@ export function useDraftConversation({
       });
     }
 
-    const messageData = { input, mentions, contentFragments };
+    const messageData = {
+      input,
+      mentions: mentions.map((mention) => ({
+        configurationId: mention.id,
+      })),
+      contentFragments,
+    };
 
     if (!conversation) {
       const result = await createConversationWithMessage({

--- a/front/components/assistant/HelpDrawer.tsx
+++ b/front/components/assistant/HelpDrawer.tsx
@@ -13,19 +13,13 @@ import { useRouter } from "next/router";
 import type { ComponentType } from "react";
 import { useCallback, useState } from "react";
 
+import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { DustError } from "@app/lib/error";
 import { getAgentRoute } from "@app/lib/utils/router";
-import type {
-  AgentMention,
-  MentionType,
-  Result,
-  RoleType,
-  UserType,
-  WorkspaceType,
-} from "@app/types";
+import type { Result, RoleType, UserType, WorkspaceType } from "@app/types";
 import { Err, GLOBAL_AGENTS_SID, Ok } from "@app/types";
 
 // describe the type of userContent where the
@@ -115,7 +109,7 @@ export function HelpDrawer({
   const handleHelpSubmit = useCallback(
     async (
       input: string,
-      mentions: MentionType[]
+      mentions: EditorMention[]
     ): Promise<Result<undefined, DustError>> => {
       if (isSubmitting) {
         return new Err({
@@ -131,19 +125,18 @@ export function HelpDrawer({
         ? input
         : `@help ${input.trimStart()}`;
       const mentionsWithHelp = mentions.some(
-        (mention) => mention.configurationId === GLOBAL_AGENTS_SID.HELPER
+        (mention) => mention.id === GLOBAL_AGENTS_SID.HELPER
       )
         ? mentions
-        : [
-            ...mentions,
-            { configurationId: GLOBAL_AGENTS_SID.HELPER } as AgentMention,
-          ];
+        : [...mentions, { id: GLOBAL_AGENTS_SID.HELPER } as EditorMention];
       const conversationRes = await createConversationWithMessage({
         owner,
         user,
         messageData: {
           input: inputWithHelp.replace("@help", ":mention[help]{sId=helper}"),
-          mentions: mentionsWithHelp,
+          mentions: mentionsWithHelp.map((mention) => ({
+            configurationId: mention.id,
+          })),
           contentFragments: {
             uploaded: [],
             contentNodes: [],
@@ -217,7 +210,7 @@ export function HelpDrawer({
                           size="sm"
                           onClick={() => {
                             void handleHelpSubmit(`@help ${iceBreaker}`, [
-                              { configurationId: GLOBAL_AGENTS_SID.HELPER },
+                              { id: GLOBAL_AGENTS_SID.HELPER, label: "Help" },
                             ]);
                           }}
                           key={index}

--- a/front/components/assistant/conversation/AgentMessageVirtuoso.tsx
+++ b/front/components/assistant/conversation/AgentMessageVirtuoso.tsx
@@ -206,17 +206,17 @@ export function AgentMessageVirtuoso({
     const isInArray = generationContext.generatingMessages.some(
       (m) => m.messageId === sId
     );
-    if (agentMessageToRender.status === "created" && !isInArray) {
+    if (shouldStream && !isInArray) {
       generationContext.setGeneratingMessages((s) => [
         ...s,
         { messageId: sId, conversationId },
       ]);
-    } else if (agentMessageToRender.status !== "created" && isInArray) {
+    } else if (!shouldStream && isInArray) {
       generationContext.setGeneratingMessages((s) =>
         s.filter((m) => m.messageId !== sId)
       );
     }
-  }, [agentMessageToRender.status, generationContext, sId, conversationId]);
+  }, [shouldStream, generationContext, sId, conversationId]);
 
   const PopoverContent = useCallback(
     () => (
@@ -302,7 +302,7 @@ export function AgentMessageVirtuoso({
   // Show stop agent button only when streaming with multiple agents
   // (it feels distractive to show buttons while streaming so we would like to avoid as much as possible.
   // However, when there are multiple agents there is no other way to stop only single agent so we need to show it here).
-  if (hasMultiAgents && agentMessageToRender.status === "created") {
+  if (hasMultiAgents && shouldStream) {
     buttons.push(
       <Button
         key="stop-msg-button"
@@ -337,7 +337,7 @@ export function AgentMessageVirtuoso({
   }
 
   // Show retry button as long as it's not streaming
-  if (agentMessageToRender.status !== "created") {
+  if (agentMessageToRender.status !== "created" && !shouldStream) {
     buttons.push(
       <Button
         key="retry-msg-button"
@@ -449,9 +449,11 @@ export function AgentMessageVirtuoso({
       isDisabled={isArchived}
       renderName={renderName}
       timestamp={
-        agentMessageToRender.completedTs && !isDeepDive
-          ? formatTimestring(agentMessageToRender.completedTs)
-          : undefined
+        isDeepDive
+          ? undefined
+          : formatTimestring(
+              agentMessageToRender.completedTs ?? agentMessageToRender.created
+            )
       }
       completionStatus={
         <AgentMessageCompletionStatus agentMessage={agentMessageToRender} />

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -13,6 +13,7 @@ import { useActionValidationContext } from "@app/components/assistant/conversati
 import { useCoEditionContext } from "@app/components/assistant/conversation/co_edition/context";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
+import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import {
@@ -34,7 +35,6 @@ import { getAgentRoute } from "@app/lib/utils/router";
 import type {
   AgentMention,
   ContentFragmentsType,
-  MentionType,
   Result,
   SubscriptionType,
   UserType,
@@ -85,7 +85,7 @@ export function ConversationContainer({
 
   const handleSubmit = async (
     input: string,
-    mentions: MentionType[],
+    mentions: EditorMention[],
     contentFragments: ContentFragmentsType
   ): Promise<Result<undefined, DustError>> => {
     if (!activeConversationId) {
@@ -98,7 +98,7 @@ export function ConversationContainer({
 
     const messageData = {
       input,
-      mentions,
+      mentions: mentions.map((mention) => ({ configurationId: mention.id })),
       contentFragments,
       clientSideMCPServerIds: removeNulls([serverId]),
     };
@@ -148,7 +148,7 @@ export function ConversationContainer({
               input,
               mentions,
               user,
-              lastMessageRank,
+              rank: lastMessageRank + 1,
             });
             return updateMessagePagesWithOptimisticData(
               currentMessagePages,
@@ -181,7 +181,7 @@ export function ConversationContainer({
   const handleConversationCreation = useCallback(
     async (
       input: string,
-      mentions: MentionType[],
+      mentions: EditorMention[],
       contentFragments: ContentFragmentsType,
       selectedMCPServerViewIds?: string[]
     ): Promise<Result<undefined, DustError>> => {
@@ -200,7 +200,9 @@ export function ConversationContainer({
         user,
         messageData: {
           input,
-          mentions,
+          mentions: mentions.map((mention) => ({
+            configurationId: mention.id,
+          })),
           contentFragments,
           clientSideMCPServerIds: removeNulls([serverId]),
           selectedMCPServerViewIds,

--- a/front/components/assistant/conversation/ConversationContainerVirtuoso.tsx
+++ b/front/components/assistant/conversation/ConversationContainerVirtuoso.tsx
@@ -13,6 +13,7 @@ import { useActionValidationContext } from "@app/components/assistant/conversati
 import { useCoEditionContext } from "@app/components/assistant/conversation/co_edition/context";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import ConversationViewerVirtuoso from "@app/components/assistant/conversation/ConversationViewerVirtuoso";
+import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
@@ -28,7 +29,6 @@ import {
 import { getAgentRoute } from "@app/lib/utils/router";
 import type {
   ContentFragmentsType,
-  MentionType,
   Result,
   SubscriptionType,
   UserType,
@@ -80,7 +80,7 @@ export function ConversationContainerVirtuoso({
   const handleConversationCreation = useCallback(
     async (
       input: string,
-      mentions: MentionType[],
+      mentions: EditorMention[],
       contentFragments: ContentFragmentsType,
       selectedMCPServerViewIds?: string[]
     ): Promise<Result<undefined, DustError>> => {
@@ -99,7 +99,9 @@ export function ConversationContainerVirtuoso({
         user,
         messageData: {
           input,
-          mentions,
+          mentions: mentions.map((mention) => ({
+            configurationId: mention.id,
+          })),
           contentFragments,
           clientSideMCPServerIds: removeNulls([serverId]),
           selectedMCPServerViewIds,
@@ -127,11 +129,7 @@ export function ConversationContainerVirtuoso({
       } else {
         // We start the push before creating the message to optimize for instantaneity as well.
         await router.push(
-          getAgentRoute(
-            owner.sId,
-            conversationRes.value.sId,
-            "justCreated=true"
-          ),
+          getAgentRoute(owner.sId, conversationRes.value.sId),
           undefined,
           { shallow: true }
         );

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -1,8 +1,10 @@
 import { Button, cn, StopIcon } from "@dust-tt/sparkle";
+import _ from "lodash";
 import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import { useFileDrop } from "@app/components/assistant/conversation/FileUploaderContext";
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import { InputBarAttachments } from "@app/components/assistant/conversation/input_bar/InputBarAttachments";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import InputBarContainer, {
@@ -26,7 +28,6 @@ import type {
   ContentFragmentsType,
   DataSourceViewContentNode,
   LightAgentConfigurationType,
-  MentionType,
   Result,
   WorkspaceType,
 } from "@app/types";
@@ -38,7 +39,7 @@ interface AssistantInputBarProps {
   owner: WorkspaceType;
   onSubmit: (
     input: string,
-    mentions: MentionType[],
+    mentions: EditorMention[],
     contentFragments: ContentFragmentsType,
     selectedMCPServerViewIds?: string[]
   ) => Promise<Result<undefined, DustError>>;
@@ -203,13 +204,11 @@ export const AssistantInputBar = React.memo(function AssistantInputBar({
     }
 
     const { mentions: rawMentions, markdown } = markdownAndMentions;
-    const mentions: MentionType[] = [
-      ...new Set(rawMentions.map((mention) => mention.id)),
-    ].map((id) => ({ configurationId: id }));
+    const mentions: EditorMention[] = _.uniqBy(rawMentions, "id");
 
     const uploadedFiles = fileUploaderService.getFileBlobs();
     const mentionedAgents = agentConfigurations.filter((a) =>
-      mentions.some((m) => m.configurationId === a.sId)
+      mentions.some((m) => m.id === a.sId)
     );
 
     trackEvent({
@@ -426,7 +425,7 @@ export function FixedAssistantInputBar({
   owner: WorkspaceType;
   onSubmit: (
     input: string,
-    mentions: MentionType[],
+    mentions: EditorMention[],
     contentFragments: ContentFragmentsType,
     selectedMCPServerViewIds?: string[]
   ) => Promise<Result<undefined, DustError>>;

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -1,6 +1,8 @@
 import type { NotificationType } from "@dust-tt/sparkle";
 import type * as t from "io-ts";
 
+import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
+import type { MessageTemporaryState } from "@app/components/assistant/conversation/types";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type { PostMessagesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";
@@ -32,13 +34,13 @@ export function createPlaceholderUserMessage({
   input,
   mentions,
   user,
-  lastMessageRank,
+  rank,
   contentFragments,
 }: {
   input: string;
-  mentions: MentionType[];
+  mentions: EditorMention[];
   user: UserType;
-  lastMessageRank: number;
+  rank: number;
   contentFragments?: ContentFragmentsType;
 }): UserMessageType & { contentFragments: ContentFragmentType[] } {
   const createdAt = new Date().getTime();
@@ -48,13 +50,13 @@ export function createPlaceholderUserMessage({
     id: -1,
     content: input,
     created: createdAt,
-    mentions,
+    mentions: mentions.map((mention) => ({ configurationId: mention.id })),
     user,
     visibility: "visible",
     type: "user_message",
-    sId: `placeholder-${createdAt.toString()}`,
+    sId: `placeholder-user-message-${createdAt.toString()}`,
     version: 0,
-    rank: lastMessageRank + 1,
+    rank: rank,
     context: {
       email,
       fullName,
@@ -80,7 +82,7 @@ export function createPlaceholderUserMessage({
             created: Date.now(),
             visibility: "visible" as const,
             version: 0,
-            rank: lastMessageRank,
+            rank,
             sourceUrl: null,
             contentType: cf.contentType,
             context: {
@@ -121,7 +123,7 @@ export function createPlaceholderUserMessage({
             created: Date.now(),
             visibility: "visible" as const,
             version: 0,
-            rank: lastMessageRank,
+            rank,
             sourceUrl: null,
 
             context: {
@@ -136,6 +138,47 @@ export function createPlaceholderUserMessage({
           }) satisfies ContentFragmentType
       ),
     ],
+  };
+}
+
+export function createPlaceholderAgentMessage({
+  mention,
+  rank,
+}: {
+  mention: EditorMention;
+  rank: number;
+}): MessageTemporaryState {
+  const createdAt = new Date().getTime();
+  return {
+    message: {
+      sId: `placeholder-agent-message-${createdAt.toString()}`,
+      rank: rank,
+      type: "agent_message",
+      version: 0,
+      created: createdAt,
+      completedTs: null,
+      parentMessageId: null,
+      status: "created",
+      content: null,
+      chainOfThought: null,
+      error: null,
+      configuration: {
+        sId: mention.id,
+        name: mention.label,
+        pictureUrl: "",
+        status: "active",
+        canRead: true,
+        requestedGroupIds: [],
+      },
+      citations: {},
+      generatedFiles: [],
+      actions: [],
+    },
+    agentState: "placeholder",
+    isRetrying: false,
+    lastUpdated: new Date(),
+    actionProgress: new Map(),
+    useFullChainOfThought: false,
   };
 }
 

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -1,3 +1,4 @@
+import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
@@ -9,7 +10,6 @@ import type {
   LightAgentMessageType,
   LightAgentMessageWithActionsType,
   LightWorkspaceType,
-  MentionType,
   ModelId,
   Result,
   UserMessageType,
@@ -18,7 +18,12 @@ import type {
 import { isLightAgentMessageWithActionsType } from "@app/types";
 import type { AgentMCPActionType } from "@app/types/actions";
 
-type AgentStateClassification = "thinking" | "acting" | "writing" | "done";
+type AgentStateClassification =
+  | "placeholder"
+  | "thinking"
+  | "acting"
+  | "writing"
+  | "done";
 
 type ActionProgressState = Map<
   ModelId,
@@ -57,7 +62,7 @@ export type VirtuosoMessageListContext = {
   user: UserType;
   handleSubmit: (
     input: string,
-    mentions: MentionType[],
+    mentions: EditorMention[],
     contentFragments: ContentFragmentsType
   ) => Promise<Result<undefined, DustError>>;
   conversationId: string;
@@ -89,6 +94,9 @@ export const getMessageDate = (msg: VirtuosoMessage): Date =>
     ? new Date(msg.message.created)
     : new Date(msg.created);
 
+export const getMessageRank = (msg: VirtuosoMessage): number =>
+  isMessageTemporayState(msg) ? msg.message.rank : msg.rank;
+
 export const makeInitialMessageStreamState = (
   message: LightAgentMessageType | LightAgentMessageWithActionsType
 ): MessageTemporaryState => {
@@ -105,4 +113,11 @@ export const makeInitialMessageStreamState = (
     },
     useFullChainOfThought: false,
   };
+};
+
+export const areSameRank = (
+  messageA: VirtuosoMessage,
+  messageB: VirtuosoMessage
+) => {
+  return getMessageRank(messageA) === getMessageRank(messageB);
 };

--- a/front/hooks/useAgentMessageStreamVirtuoso.ts
+++ b/front/hooks/useAgentMessageStreamVirtuoso.ts
@@ -112,15 +112,17 @@ export function useAgentMessageStreamVirtuoso({
     VirtuosoMessageListContext
   >();
 
-  const isFreshMountWithContent = useRef(
-    messageStreamState.message.status === "created" &&
-      (!!messageStreamState.message.content ||
-        !!messageStreamState.message.chainOfThought)
+  const shouldStream = useMemo(
+    () =>
+      messageStreamState.message.status === "created" &&
+      messageStreamState.agentState !== "placeholder",
+    [messageStreamState.message.status, messageStreamState.agentState]
   );
 
-  const shouldStream = useMemo(
-    () => messageStreamState.message.status === "created",
-    [messageStreamState.message.status]
+  const isFreshMountWithContent = useRef(
+    shouldStream &&
+      (!!messageStreamState.message.content ||
+        !!messageStreamState.message.chainOfThought)
   );
 
   const chainOfThought = useRef(

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -10,6 +10,7 @@ import type {
 } from "@app/types/actions";
 
 export type AgentStateClassification =
+  | "placeholder"
   | "thinking"
   | "acting"
   | "writing"


### PR DESCRIPTION
## Description

Add agent message placeholder when sending a message (one per mention).
We used to only get the configurationId of the agent mentionned and I wanted to avoid fetching all agents configurations.
So I refactored to get the name of the agent mentionned as well (we had it but we stripped it early).
Also, added a "placeholder" state to the agent message stream state.
I lack the pictureUrl but I think it's okay for now (it's usually very briefly seen)

## Tests

Local

<img width="1034" height="596" alt="image" src="https://github.com/user-attachments/assets/07f0459d-f11c-4c5c-aea9-a7218d054c1d" />


## Risk

Low because behind FF and limited to rendering during stream.

## Deploy Plan

Deploy front
