### PR TITLE
Rename Deep Dive tool

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -86,7 +86,7 @@ const TOP_MCP_SERVER_VIEWS = [
   "web_search_&_browse",
   "image_generation",
   AGENT_MEMORY_SERVER_NAME,
-  "deep_research",
+  "deep_dive",
   "interactive_content",
   "slack",
   "gmail",

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -47,7 +47,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "agent_memory", id: 21 },
       { name: "interactive_content", id: 23 },
       { name: "slideshow", id: 28 },
-      { name: "deep_research", id: 29 },
+      { name: "deep_dive", id: 29 },
       { name: "search", id: 1006 },
       { name: "run_agent", id: 1008 },
       { name: "reasoning", id: 1007 },

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -14,7 +14,10 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/instructions";
 import { INTERACTIVE_CONTENT_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content/instructions";
 import { SLIDESHOW_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/slideshow/instructions";
-import { DUST_DEEP_DESCRIPTION } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
+import {
+  DUST_DEEP_DESCRIPTION,
+  DUST_DEEP_NAME,
+} from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import type {
   InternalMCPServerDefinitionType,
   MCPToolRetryPolicyType,
@@ -71,7 +74,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "conversation_files",
   "data_sources_file_system",
   DATA_WAREHOUSE_SERVER_NAME,
-  "deep_research",
+  "deep_dive",
   "extract_data",
   "file_generation",
   "freshservice",
@@ -916,7 +919,7 @@ The directive should be used to display a clickable version of the agent name in
       instructions: SLIDESHOW_INSTRUCTIONS,
     },
   },
-  deep_research: {
+  deep_dive: {
     id: 29,
     availability: "auto",
     isRestricted: ({ featureFlags, isDustDeepDisabled }) => {
@@ -930,13 +933,13 @@ The directive should be used to display a clickable version of the agent name in
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
-      name: "deep_research",
+      name: "deep_dive",
       version: "0.1.0",
-      description: "Handoff the query to the deep research agent.",
+      description: `Handoff the query to the @${DUST_DEEP_NAME} agent.`,
       authorization: null,
       icon: "ActionAtomIcon",
       documentationUrl: null,
-      instructions: `This tool performs a complete handoff to the dust-deep research agent: ${DUST_DEEP_DESCRIPTION}`,
+      instructions: `This tool performs a complete handoff to the @${DUST_DEEP_NAME} agent: ${DUST_DEEP_DESCRIPTION}`,
     },
   },
   slack_bot: {

--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -20,13 +20,13 @@ const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
-  const server = makeInternalMCPServer("deep_research");
+  const server = makeInternalMCPServer("deep_dive");
 
   const owner = auth.getNonNullableWorkspace();
 
   server.tool(
-    "run_dust_deep",
-    "Handoff the query to the generic deep research agent",
+    "dive",
+    `Handoff the query to the ${DUST_DEEP_NAME} agent`,
     {},
     withToolLogging(
       auth,
@@ -78,7 +78,7 @@ const createServer = (
         }
 
         const response = makeMCPToolExit({
-          message: `Forwarding this request to @${DUST_DEEP_NAME} for Deep Research.`,
+          message: `Deep diving by forwarding this request to @${DUST_DEEP_NAME}.`,
           isError: false,
         });
 

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -12,7 +12,7 @@ import { default as confluenceServer } from "@app/lib/actions/mcp_internal_actio
 import { default as conversationFilesServer } from "@app/lib/actions/mcp_internal_actions/servers/conversation_files";
 import { default as dataSourcesFileSystemServer } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system";
 import { default as dataWarehousesServer } from "@app/lib/actions/mcp_internal_actions/servers/data_warehouses/server";
-import { default as deepResearchServer } from "@app/lib/actions/mcp_internal_actions/servers/deep_research";
+import { default as deepDiveServer } from "@app/lib/actions/mcp_internal_actions/servers/deep_dive";
 import { default as generateFileServer } from "@app/lib/actions/mcp_internal_actions/servers/file_generation";
 import { default as freshserviceServer } from "@app/lib/actions/mcp_internal_actions/servers/freshservice/server";
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
@@ -170,8 +170,8 @@ export async function getInternalMCPServer(
       return dataWarehousesServer(auth, agentLoopContext);
     case "toolsets":
       return toolsetsServer(auth, agentLoopContext);
-    case "deep_research":
-      return deepResearchServer(auth, agentLoopContext);
+    case "deep_dive":
+      return deepDiveServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -4,6 +4,7 @@ import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { SUGGEST_AGENTS_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
+import { DUST_DEEP_NAME } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
 import {
@@ -36,7 +37,7 @@ export function _getDustGlobalAgent(
     agentRouterMCPServerView,
     webSearchBrowseMCPServerView,
     searchMCPServerView,
-    deepResearchMCPServerView,
+    deepDiveMCPServerView,
     interactiveContentMCPServerView,
   }: {
     settings: GlobalAgentSettings | null;
@@ -44,7 +45,7 @@ export function _getDustGlobalAgent(
     agentRouterMCPServerView: MCPServerViewResource | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
     searchMCPServerView: MCPServerViewResource | null;
-    deepResearchMCPServerView: MCPServerViewResource | null;
+    deepDiveMCPServerView: MCPServerViewResource | null;
     interactiveContentMCPServerView: MCPServerViewResource | null;
   }
 ): AgentConfigurationType | null {
@@ -129,7 +130,7 @@ export function _getDustGlobalAgent(
   </general_guidelines>
   `;
 
-  if (deepResearchMCPServerView) {
+  if (deepDiveMCPServerView) {
     instructions += requestComplexityPrompt;
   } else {
     instructions += `<instructions>
@@ -276,15 +277,15 @@ export function _getDustGlobalAgent(
     )
   );
 
-  if (deepResearchMCPServerView) {
+  if (deepDiveMCPServerView) {
     actions.push({
       id: -1,
-      sId: GLOBAL_AGENTS_SID.DUST + "-deep-research",
+      sId: GLOBAL_AGENTS_SID.DUST + "-deep-dive",
       type: "mcp_server_configuration",
-      name: "deep_research" satisfies InternalMCPServerNameType,
-      description: "Deep research agent",
-      mcpServerViewId: deepResearchMCPServerView.sId,
-      internalMCPServerId: deepResearchMCPServerView.internalMCPServerId,
+      name: "deep_dive" satisfies InternalMCPServerNameType,
+      description: `Handoff the query to the @${DUST_DEEP_NAME} agent`,
+      mcpServerViewId: deepDiveMCPServerView.sId,
+      internalMCPServerId: deepDiveMCPServerView.internalMCPServerId,
       dataSources: null,
       tables: null,
       childAgentId: null,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -80,7 +80,7 @@ function getGlobalAgent({
   toolsetsMCPServerView,
   dataWarehousesMCPServerView,
   slideshowMCPServerView,
-  deepResearchMCPServerView,
+  deepDiveMCPServerView,
 }: {
   auth: Authenticator;
   sId: string | number;
@@ -96,7 +96,7 @@ function getGlobalAgent({
   toolsetsMCPServerView: MCPServerViewResource | null;
   dataWarehousesMCPServerView: MCPServerViewResource | null;
   slideshowMCPServerView: MCPServerViewResource | null;
-  deepResearchMCPServerView: MCPServerViewResource | null;
+  deepDiveMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType | null {
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
@@ -335,7 +335,7 @@ function getGlobalAgent({
         agentRouterMCPServerView,
         webSearchBrowseMCPServerView,
         searchMCPServerView,
-        deepResearchMCPServerView,
+        deepDiveMCPServerView,
         interactiveContentMCPServerView,
       });
       break;
@@ -442,7 +442,7 @@ export async function getGlobalAgents(
     toolsetsMCPServerView,
     dataWarehousesMCPServerView,
     slideshowMCPServerView,
-    deepResearchMCPServerView,
+    deepDiveMCPServerView,
   ] = await Promise.all([
     variant === "full"
       ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
@@ -508,7 +508,7 @@ export async function getGlobalAgents(
     variant === "full"
       ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
           auth,
-          "deep_research"
+          "deep_dive"
         )
       : null,
   ]);
@@ -567,7 +567,7 @@ export async function getGlobalAgents(
       toolsetsMCPServerView,
       dataWarehousesMCPServerView,
       slideshowMCPServerView,
-      deepResearchMCPServerView,
+      deepDiveMCPServerView,
     })
   );
 


### PR DESCRIPTION
## Description

Renaming the tool. 
Will then rename the agent. 

## Tests

Locally. 

## Risk

Tool is currently only used internally. 
Can be rolled back. 

## Deploy Plan

Deploy front. 