### PR TITLE
Rename dust-deep agent

### DIFF
--- a/extension/shared/lib/global_agents.ts
+++ b/extension/shared/lib/global_agents.ts
@@ -2,7 +2,7 @@
 export const GLOBAL_AGENTS_SID = {
   HELPER: "helper",
   DUST: "dust",
-  DUST_DEEP: "dust-deep",
+  DEEP_DIVE: "deep-dive",
   CLAUDE_4_SONNET: "claude-4-sonnet",
   GPT4: "gpt-4",
   GPT5: "gpt-5",

--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -200,10 +200,10 @@ export function compareAgentsForSort(
     return 1;
   }
 
-  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+  if (a.sId === GLOBAL_AGENTS_SID.DEEP_DIVE) {
     return -1;
   }
-  if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+  if (b.sId === GLOBAL_AGENTS_SID.DEEP_DIVE) {
     return 1;
   }
 

--- a/extension/ui/components/conversation/AgentSuggestion.tsx
+++ b/extension/ui/components/conversation/AgentSuggestion.tsx
@@ -142,9 +142,9 @@ function sortAgents(
     return 1;
   }
 
-  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+  if (a.sId === GLOBAL_AGENTS_SID.DEEP_DIVE) {
     return -1;
-  } else if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+  } else if (b.sId === GLOBAL_AGENTS_SID.DEEP_DIVE) {
     return 1;
   }
 

--- a/extension/ui/components/input_bar/editor/suggestion.ts
+++ b/extension/ui/components/input_bar/editor/suggestion.ts
@@ -19,7 +19,7 @@ const SUGGESTION_DISPLAY_LIMIT = 7;
 
 const SUGGESTION_PRIORITY: Record<string, number> = {
   [GLOBAL_AGENTS_SID.DUST]: 1,
-  [GLOBAL_AGENTS_SID.DUST_DEEP]: 2,
+  [GLOBAL_AGENTS_SID.DEEP_DIVE]: 2,
 };
 
 function filterAndSortSuggestions(

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -454,7 +454,7 @@ export function AgentMessage({
   const isArchived = agentConfiguration.status === "archived";
 
   // Determine if this should be displayed as "agentAsTool" type.
-  const isDustDeep = agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST_DEEP;
+  const isDustDeep = agentConfiguration.sId === GLOBAL_AGENTS_SID.DEEP_DIVE;
   const isDeepDive = isHandoverGroup && isDustDeep;
 
   return (

--- a/front/components/assistant/conversation/AgentMessageVirtuoso.tsx
+++ b/front/components/assistant/conversation/AgentMessageVirtuoso.tsx
@@ -411,7 +411,7 @@ export function AgentMessageVirtuoso({
   const isArchived = agentConfiguration.status === "archived";
 
   // Determine if this should be displayed as "agentAsTool" type.
-  const isDustDeep = agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST_DEEP;
+  const isDustDeep = agentConfiguration.sId === GLOBAL_AGENTS_SID.DEEP_DIVE;
   const isDeepDive = isAgentMessageHandover && isDustDeep;
 
   const renderName = useCallback(

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -205,10 +205,10 @@ function sortAgents(
   } else if (b.sId === GLOBAL_AGENTS_SID.DUST) {
     return 1;
   }
-  // Dust-deep always second
-  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+  // Deep dive always second
+  if (a.sId === GLOBAL_AGENTS_SID.DEEP_DIVE) {
     return -1;
-  } else if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+  } else if (b.sId === GLOBAL_AGENTS_SID.DEEP_DIVE) {
     return 1;
   }
 

--- a/front/components/assistant/conversation/input_bar/editor/suggestion.ts
+++ b/front/components/assistant/conversation/input_bar/editor/suggestion.ts
@@ -19,7 +19,7 @@ const SUGGESTION_DISPLAY_LIMIT = 7;
 
 const SUGGESTION_PRIORITY: Record<string, number> = {
   [GLOBAL_AGENTS_SID.DUST]: 1,
-  [GLOBAL_AGENTS_SID.DUST_DEEP]: 2,
+  [GLOBAL_AGENTS_SID.DEEP_DIVE]: 2,
 };
 
 function filterAndSortSuggestions(

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -15,8 +15,8 @@ import {
 import { INTERACTIVE_CONTENT_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content/instructions";
 import { SLIDESHOW_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/slideshow/instructions";
 import {
-  DUST_DEEP_DESCRIPTION,
-  DUST_DEEP_NAME,
+  DEEP_DIVE_DESC,
+  DEEP_DIVE_NAME,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import type {
   InternalMCPServerDefinitionType,
@@ -933,11 +933,11 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "deep_dive",
       version: "0.1.0",
-      description: `Handoff the query to the @${DUST_DEEP_NAME} agent.`,
+      description: `Handoff the query to the @${DEEP_DIVE_NAME} agent.`,
       authorization: null,
       icon: "ActionAtomIcon",
       documentationUrl: null,
-      instructions: `This tool performs a complete handoff to the @${DUST_DEEP_NAME} agent: ${DUST_DEEP_DESCRIPTION}`,
+      instructions: `This tool performs a complete handoff to the @${DEEP_DIVE_NAME} agent: ${DEEP_DIVE_DESC}`,
     },
   },
   slack_bot: {

--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -9,7 +9,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { DUST_DEEP_NAME } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
+import { DEEP_DIVE_NAME } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
@@ -26,7 +26,7 @@ const createServer = (
 
   server.tool(
     "dive",
-    `Handoff the query to the ${DUST_DEEP_NAME} agent`,
+    `Handoff the query to the ${DEEP_DIVE_NAME} agent`,
     {},
     withToolLogging(
       auth,
@@ -60,10 +60,10 @@ const createServer = (
 
         const convRes = await getOrCreateConversation(api, runContext, {
           childAgentBlob: {
-            name: DUST_DEEP_NAME,
-            description: "Deep research agent",
+            name: DEEP_DIVE_NAME,
+            description: "Deep dive agent",
           },
-          childAgentId: GLOBAL_AGENTS_SID.DUST_DEEP,
+          childAgentId: GLOBAL_AGENTS_SID.DEEP_DIVE,
           mainAgent: agentConfiguration,
           originMessage: agentLoopContext.runContext.agentMessage,
           mainConversation: conversation,
@@ -78,7 +78,7 @@ const createServer = (
         }
 
         const response = makeMCPToolExit({
-          message: `Deep diving by forwarding this request to @${DUST_DEEP_NAME}.`,
+          message: `Deep diving by forwarding this request to @${DEEP_DIVE_NAME}.`,
           isError: false,
         });
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/consts.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/consts.ts
@@ -1,4 +1,3 @@
-export const DUST_DEEP_NAME = "dust-deep";
-
-export const DUST_DEEP_DESCRIPTION =
-  "Deep research with company data, web search/browse, Interactive Content, slideshow presentations, and data warehouses.";
+export const DEEP_DIVE_NAME = "deepDive";
+export const DEEP_DIVE_DESC =
+  "Deep dive within your company data and data warehouses, web search/browse, Interactive Content.";

--- a/front/lib/api/assistant/global_agents/configurations/dust/consts.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/consts.ts
@@ -1,3 +1,3 @@
-export const DEEP_DIVE_NAME = "deepDive";
+export const DEEP_DIVE_NAME = "deep-dive";
 export const DEEP_DIVE_DESC =
-  "Deep dive within your company data and data warehouses, web search/browse, Interactive Content.";
+  "Deep dive within the full company data and data warehouses, web search/browse.";

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -2,8 +2,8 @@ import { DEFAULT_WEBSEARCH_ACTION_DESCRIPTION } from "@app/lib/actions/constants
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
-  DUST_DEEP_DESCRIPTION,
-  DUST_DEEP_NAME,
+  DEEP_DIVE_DESC,
+  DEEP_DIVE_NAME,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
 import {
@@ -142,7 +142,7 @@ These tasks can be for web browsing, company data exploration, data warehouse qu
 
 <clarifying_questions>
 - Ask clarifying questions only when they are truly necessary to proceed or to prevent likely rework (e.g., missing scope, timeframe, audience, definitions, or constraints).
-- Reserve clarifying questions for very complex, deep research tasks. For routine or moderately complex tasks, proceed without asking.
+- Reserve clarifying questions for very complex, deep dive tasks. For routine or moderately complex tasks, proceed without asking.
 - Do not ask performative or obvious questions. If the information can be reasonably inferred, proceed.
 - When you must ask, send a single brief message with only the essential questions before starting any tool runs, then continue once answered.
 
@@ -239,7 +239,7 @@ DO NOT comment on your research or reasoning process. DO NOT tell the user about
 The user's UI already lets them inspect the output of the planning agent and your own reasoning process.
 
 Exception for clarifications (very complex tasks only):
-- If critical information is missing and you cannot proceed without it, and the task is very complex/deep research, you may send one brief clarifying message before using tools.
+- If critical information is missing and you cannot proceed without it, and the task is very complex/deep dive, you may send one brief clarifying message before using tools.
 - Keep that message to only essential questions. You may include key assumptions that require user confirmation; avoid any other commentary. Outside of this case, do not message the user until the final answer.
 
  Formatting rules (adapt to the task):
@@ -429,7 +429,7 @@ function getCompanyDataAction(
 
   return {
     id: -1,
-    sId: GLOBAL_AGENTS_SID.DUST_DEEP + "-company-data-action",
+    sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-company-data-action",
     type: "mcp_server_configuration",
     name: "company_data",
     description: "The user's internal company data.",
@@ -469,7 +469,7 @@ function getCompanyDataWarehousesAction(
 
   return {
     id: -1,
-    sId: GLOBAL_AGENTS_SID.DUST_DEEP + "-data-warehouses-action",
+    sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-data-warehouses-action",
     type: "mcp_server_configuration",
     name: "data_warehouses",
     description: "The user's data warehouses.",
@@ -491,10 +491,11 @@ function getCompanyDataWarehousesAction(
   };
 }
 
-export function _getDustDeepGlobalAgent(
+export function _getDeepDiveGlobalAgent(
   auth: Authenticator,
   {
     settings,
+    sId,
     preFetchedDataSources,
     webSearchBrowseMCPServerView,
     dataSourcesFileSystemMCPServerView,
@@ -505,6 +506,7 @@ export function _getDustDeepGlobalAgent(
     slideshowMCPServerView,
   }: {
     settings: GlobalAgentSettings | null;
+    sId: string;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
     dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
@@ -524,12 +526,12 @@ export function _getDustDeepGlobalAgent(
     "status" | "maxStepsPerRun" | "actions"
   > = {
     id: -1,
-    sId: GLOBAL_AGENTS_SID.DUST_DEEP,
+    sId: sId,
     version: 0,
     versionCreatedAt: null,
     versionAuthorId: null,
-    name: DUST_DEEP_NAME,
-    description: DUST_DEEP_DESCRIPTION,
+    name: DEEP_DIVE_NAME,
+    description: DEEP_DIVE_DESC,
     instructions: dustDeepInstructions,
     pictureUrl,
     scope: "global" as const,
@@ -574,7 +576,7 @@ export function _getDustDeepGlobalAgent(
 
   actions.push(
     ..._getDefaultWebActionsForGlobalAgent({
-      agentId: GLOBAL_AGENTS_SID.DUST_DEEP,
+      agentId: GLOBAL_AGENTS_SID.DEEP_DIVE,
       webSearchBrowseMCPServerView,
     }),
     ..._getToolsetsToolsConfiguration({
@@ -596,7 +598,7 @@ export function _getDustDeepGlobalAgent(
   if (interactiveContentMCPServerView) {
     actions.push({
       id: -1,
-      sId: GLOBAL_AGENTS_SID.DUST_DEEP + "-interactive-content",
+      sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-interactive-content",
       type: "mcp_server_configuration",
       name: "interactive_content" satisfies InternalMCPServerNameType,
       description: "Create & update Interactive Content files.",
@@ -618,7 +620,7 @@ export function _getDustDeepGlobalAgent(
   if (runAgentMCPServerView) {
     actions.push({
       id: -1,
-      sId: GLOBAL_AGENTS_SID.DUST_DEEP + "-run-agent-dust-task",
+      sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-run-agent-dust-task",
       type: "mcp_server_configuration",
       name: "sub_agent",
       description: "Run the dust-task sub-agent for focused tasks.",
@@ -636,7 +638,7 @@ export function _getDustDeepGlobalAgent(
     });
     actions.push({
       id: -1,
-      sId: GLOBAL_AGENTS_SID.DUST_DEEP + "-run-agent-dust-planning",
+      sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-run-agent-dust-planning",
       type: "mcp_server_configuration",
       name: "planning_agent",
       description:
@@ -659,7 +661,7 @@ export function _getDustDeepGlobalAgent(
   if (slideshowMCPServerView) {
     actions.push({
       id: -1,
-      sId: GLOBAL_AGENTS_SID.DUST_DEEP + "-slideshow",
+      sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-slideshow",
       type: "mcp_server_configuration",
       name: "slideshow" satisfies InternalMCPServerNameType,
       description: "Create & update interactive slideshow presentations.",
@@ -709,8 +711,7 @@ export function _getDustTaskGlobalAgent(
   const owner = auth.getNonNullableWorkspace();
 
   const name = "dust-task";
-  const description =
-    "Focused research sub-agent. Same data/web tools as dust-deep, without Interactive Content or spawning sub-agents.";
+  const description = `Focused research sub-agent. Same data/web tools as ${DEEP_DIVE_NAME}, without Interactive Content or spawning sub-agents.`;
 
   const pictureUrl =
     "https://dust.tt/static/systemavatar/dust-task_avatar_full.png";

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -106,7 +106,7 @@ export function _getDustGlobalAgent(
   - It requires doing several web searches, or browsing 3+ web pages
   - It requires running SQL queries
   - It requires 3+ steps of tool uses
-  - The user specifically asks for a "deep dive", a "deep research", a "comprehensive analysis" or other terms that indicate a deep dive task
+  - The user specifically asks for a "deep dive", a "deep research", a "comprehensive analysis" or other terms that indicate a deep research task
 
   Any other request is considered "simple".
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -4,7 +4,7 @@ import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { SUGGEST_AGENTS_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
-import { DUST_DEEP_NAME } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
+import { DEEP_DIVE_NAME } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
 import {
@@ -106,13 +106,13 @@ export function _getDustGlobalAgent(
   - It requires doing several web searches, or browsing 3+ web pages
   - It requires running SQL queries
   - It requires 3+ steps of tool uses
-  - The user specifically asks for a "deep dive", a "deep research", a "comprehensive analysis" or other terms that indicate a deep research task
+  - The user specifically asks for a "deep dive", a "deep research", a "comprehensive analysis" or other terms that indicate a deep dive task
 
   Any other request is considered "simple".
 
   <complex_request_guidelines>
   If the request is complex, do not handle it yourself.
-  Immediately delegate the request to the deep research agent by using the \`deep_research\` tool.
+  Immediately delegate the request to the deep dive agent by using the \`deep_dive\` tool.
   </complex_request_guidelines>
 
   <simple_request_guidelines>
@@ -283,7 +283,7 @@ export function _getDustGlobalAgent(
       sId: GLOBAL_AGENTS_SID.DUST + "-deep-dive",
       type: "mcp_server_configuration",
       name: "deep_dive" satisfies InternalMCPServerNameType,
-      description: `Handoff the query to the @${DUST_DEEP_NAME} agent`,
+      description: `Handoff the query to the @${DEEP_DIVE_NAME} agent`,
       mcpServerViewId: deepDiveMCPServerView.sId,
       internalMCPServerId: deepDiveMCPServerView.internalMCPServerId,
       dataSources: null,

--- a/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
@@ -11,7 +11,7 @@ export const isDustDeepDisabledByAdmin = memoizer.sync({
     const settings = await GlobalAgentSettings.findOne({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        agentId: GLOBAL_AGENTS_SID.DUST_DEEP,
+        agentId: GLOBAL_AGENTS_SID.DEEP_DIVE,
       },
     });
     return settings?.status === "disabled_by_admin";

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -1,4 +1,8 @@
 import {
+  DEEP_DIVE_DESC,
+  DEEP_DIVE_NAME,
+} from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
+import {
   assertNever,
   CLAUDE_2_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
@@ -262,11 +266,16 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
     case GLOBAL_AGENTS_SID.DUST_DEEP:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_DEEP,
-        name: "dust-deep",
-        description:
-          "Deep research agent with company data, web search, browsing, Interactive Content, and data warehouses.",
-        pictureUrl:
-          "https://dust.tt/static/systemavatar/dust-deep_avatar_full.png",
+        name: DEEP_DIVE_NAME,
+        description: DEEP_DIVE_DESC,
+        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+      };
+    case GLOBAL_AGENTS_SID.DEEP_DIVE:
+      return {
+        sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
+        name: DEEP_DIVE_NAME,
+        description: DEEP_DIVE_DESC,
+        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
       };
     case GLOBAL_AGENTS_SID.DUST_TASK:
       return {

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -9,13 +9,13 @@ import {
   _getClaudeInstantGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/anthropic";
 import { _getDeepSeekR1GlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/deepseek";
-import { _getDustGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import {
   _getBrowserSummaryAgent,
-  _getDustDeepGlobalAgent,
+  _getDeepDiveGlobalAgent,
   _getDustTaskGlobalAgent,
   _getPlanningAgent,
-} from "@app/lib/api/assistant/global_agents/configurations/dust/dust-deep";
+} from "@app/lib/api/assistant/global_agents/configurations/dust/deep-dive";
+import { _getDustGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import { _getNoopAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/noop";
 import { _getGeminiProGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/google";
 import {
@@ -103,9 +103,9 @@ function getGlobalAgent({
 
   let agentConfiguration: AgentConfigurationType | null = null;
 
-  // We use only default selected global datasources for all global agents except `@dust-deep` and
+  // We use only default selected global datasources for all global agents except `@deepDive` and
   // `@dust-task`
-  // We use all global datasources for `@dust-deep` and `@dust-task`
+  // We use all global datasources for `@deepDive` and `@dust-task`
   const defaultSelectedPrefetchedDataSources: PrefetchedDataSourcesType | null =
     !preFetchedDataSources
       ? null
@@ -339,8 +339,13 @@ function getGlobalAgent({
         interactiveContentMCPServerView,
       });
       break;
+    case GLOBAL_AGENTS_SID.DEEP_DIVE:
     case GLOBAL_AGENTS_SID.DUST_DEEP:
-      agentConfiguration = _getDustDeepGlobalAgent(auth, {
+      agentConfiguration = _getDeepDiveGlobalAgent(auth, {
+        sId:
+          sId === GLOBAL_AGENTS_SID.DUST_DEEP
+            ? GLOBAL_AGENTS_SID.DUST_DEEP
+            : GLOBAL_AGENTS_SID.DEEP_DIVE,
         settings,
         preFetchedDataSources,
         webSearchBrowseMCPServerView,
@@ -403,7 +408,8 @@ const RETIRED_GLOBAL_AGENTS_SID = [
   GLOBAL_AGENTS_SID.NOTION,
   GLOBAL_AGENTS_SID.O1_MINI,
   GLOBAL_AGENTS_SID.SLACK,
-  // Hidden helper sub-agent, only invoked via run_agent by dust-deep
+  GLOBAL_AGENTS_SID.DUST_DEEP,
+  // Hidden helper sub-agent, only invoked via run_agent by deep-dive
   GLOBAL_AGENTS_SID.DUST_TASK,
   GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY,
   GLOBAL_AGENTS_SID.DUST_PLANNING,
@@ -545,7 +551,7 @@ export async function getGlobalAgents(
 
   if (!flags.includes("research_agent")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.DUST_DEEP
+      (sId) => sId !== GLOBAL_AGENTS_SID.DEEP_DIVE
     );
   }
 

--- a/front/migrations/db/migration_376.sql
+++ b/front/migrations/db/migration_376.sql
@@ -1,0 +1,2 @@
+update agent_messages set "agentConfigurationId"='deep-dive' where "agentConfigurationId"='dust-deep';
+update mentions set "agentConfigurationId"='deep-dive' where "agentConfigurationId"='dust-deep';

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1712,6 +1712,7 @@ export type ReasoningModelConfigurationType = {
 export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
+  DEEP_DIVE = "deep-dive",
   DUST_DEEP = "dust-deep",
   DUST_TASK = "dust-task",
   DUST_BROWSER_SUMMARY = "dust-browser-summary",
@@ -1793,7 +1794,7 @@ export function getGlobalAgentAuthorName(agentId: string): string {
 
 const CUSTOM_ORDER: string[] = [
   GLOBAL_AGENTS_SID.DUST,
-  GLOBAL_AGENTS_SID.DUST_DEEP,
+  GLOBAL_AGENTS_SID.DEEP_DIVE,
   GLOBAL_AGENTS_SID.CLAUDE_4_SONNET,
   GLOBAL_AGENTS_SID.GPT4,
   GLOBAL_AGENTS_SID.O3_MINI,
@@ -1837,10 +1838,10 @@ export function compareAgentsForSort(
     return 1;
   }
 
-  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+  if (a.sId === GLOBAL_AGENTS_SID.DEEP_DIVE) {
     return -1;
   }
-  if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+  if (b.sId === GLOBAL_AGENTS_SID.DEEP_DIVE) {
     return 1;
   }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -143,11 +143,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
   },
   research_agent: {
-    description: "Activate @research agent.",
-    stage: "dust_only",
+    description: "Activate @deepDive agent.",
+    stage: "rolling_out",
   },
   deep_research_as_a_tool: {
-    description: "Activate deep research as a tool",
+    description: "Activate Deep Dive tool",
     stage: "dust_only",
   },
   hootl_subscriptions: {


### PR DESCRIPTION
## Description

After the tool https://github.com/dust-tt/dust/pull/16711, renaming the agent. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Merge. 
Run migration. 
