### PR TITLE
Remove use_openai_eu_key flag

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -26,7 +26,6 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -61,14 +60,7 @@ export async function searchFunction({
 }): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
-  // Fetch the feature flags for the owner of the run.
-  const keyWorkspaceFlags = await getFeatureFlags(
-    auth.getNonNullableWorkspace()
-  );
-
-  // Temporary flag to help test EU OpenAI in specific workspaces.
-  const useOpenAIEUKeyFlag = keyWorkspaceFlags.includes("use_openai_eu_key");
-  const credentials = dustManagedCredentials({ useOpenAIEUKeyFlag });
+  const credentials = dustManagedCredentials();
   const timeFrame = parseTimeFrame(relativeTimeFrame);
 
   if (!agentLoopContext?.runContext) {

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -17,7 +17,6 @@ import {
   getWorkspaceAdministrationVersionLock,
 } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes";
 import { DustError } from "@app/lib/error";
@@ -495,15 +494,8 @@ export async function upsertDocument({
     );
   }
 
-  // Fetch the feature flags for the owner of the run.
-  const keyWorkspaceFlags = await getFeatureFlags(
-    auth.getNonNullableWorkspace()
-  );
-
-  // Temporary flag to help test EU OpenAI in specific workspaces.
-  const useOpenAIEUKeyFlag = keyWorkspaceFlags.includes("use_openai_eu_key");
   // Data source operations are performed with our credentials.
-  const credentials = dustManagedCredentials({ useOpenAIEUKeyFlag });
+  const credentials = dustManagedCredentials();
 
   // Create document with the Dust internal API.
   const upsertRes = await coreAPI.upsertDataSourceDocument({
@@ -538,28 +530,18 @@ export async function handleDataSourceSearch({
   searchQuery,
   dataSource,
   dataSourceView,
-  auth,
 }: {
   searchQuery: DataSourceSearchQuery;
   dataSource: DataSourceResource;
   dataSourceView?: DataSourceViewResource;
-  auth: Authenticator;
 }): Promise<
   Result<
     DataSourceSearchResponseType,
     Omit<DustError, "code"> & { code: "data_source_error" }
   >
 > {
-  // Fetch the feature flags for the owner of the run.
-  const keyWorkspaceFlags = await getFeatureFlags(
-    auth.getNonNullableWorkspace()
-  );
-
-  // Temporary flag to help test EU OpenAI in specific workspaces.
-  const useOpenAIEUKeyFlag = keyWorkspaceFlags.includes("use_openai_eu_key");
-
   // Dust managed credentials: all data sources.
-  const credentials = dustManagedCredentials({ useOpenAIEUKeyFlag });
+  const credentials = dustManagedCredentials();
 
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const data = await coreAPI.searchDataSource(

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
@@ -78,7 +78,7 @@ async function handler(
         });
       }
       const searchQuery = r.data;
-      const s = await handleDataSourceSearch({ searchQuery, dataSource, auth });
+      const s = await handleDataSourceSearch({ searchQuery, dataSource });
       if (s.isErr()) {
         switch (s.error.code) {
           case "data_source_error":

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -273,14 +273,10 @@ async function handler(
         keyAuth.getNonNullableWorkspace()
       );
 
-      // Temporary flag to help test EU OpenAI in specific workspaces.
-      const useOpenAIEUKeyFlag =
-        keyWorkspaceFlags.includes("use_openai_eu_key");
-
       let credentials: CredentialsType | null = null;
       if (auth.isSystemKey() && !useWorkspaceCredentials) {
         // Dust managed credentials: system API key (packaged apps).
-        credentials = dustManagedCredentials({ useOpenAIEUKeyFlag });
+        credentials = dustManagedCredentials();
       } else {
         credentials = credentialsFromProviders(providers);
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
@@ -195,7 +195,6 @@ async function handler(
         searchQuery,
         dataSource: dataSourceView.dataSource,
         dataSourceView,
-        auth,
       });
       if (s.isErr()) {
         switch (s.error.code) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -12,7 +12,6 @@ import apiConfig from "@app/lib/api/config";
 import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import { computeWorkspaceOverallSizeCached } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes";
 import { runDocumentUpsertHooks } from "@app/lib/document_upsert_hooks/hooks";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
@@ -649,16 +648,8 @@ async function handler(
           },
         });
       } else {
-        // Fetch the feature flags for the owner of the run.
-        const keyWorkspaceFlags = await getFeatureFlags(
-          auth.getNonNullableWorkspace()
-        );
-
-        // Temporary flag to help test EU OpenAI in specific workspaces.
-        const useOpenAIEUKeyFlag =
-          keyWorkspaceFlags.includes("use_openai_eu_key");
         // Data source operations are performed with our credentials.
-        const credentials = dustManagedCredentials({ useOpenAIEUKeyFlag });
+        const credentials = dustManagedCredentials();
 
         // Create document with the Dust internal API.
         const upsertRes = await coreAPI.upsertDataSourceDocument({

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
@@ -231,7 +231,7 @@ async function handler(
         });
       }
       const searchQuery = r.data;
-      const s = await handleDataSourceSearch({ searchQuery, dataSource, auth });
+      const s = await handleDataSourceSearch({ searchQuery, dataSource });
       if (s.isErr()) {
         switch (s.error.code) {
           case "data_source_error":

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -565,7 +565,7 @@ export async function runModelActivity(
         } | null;
         const reasoningTokens = meta?.token_usage?.reasoning_tokens ?? 0;
 
-        // Determine the openai region
+        // Pass the current region, which helps decide whether encrypted blocks are usable
         const currentRegion = regionsConfig.getCurrentRegion();
         let region: "us" | "eu";
         switch (currentRegion) {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -35,7 +35,6 @@ import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -566,18 +565,18 @@ export async function runModelActivity(
         } | null;
         const reasoningTokens = meta?.token_usage?.reasoning_tokens ?? 0;
 
-        // Determine the region based on feature flag and current region
-        let region = "us";
-        const workspace = auth.getNonNullableWorkspace();
-        const featureFlags = await getFeatureFlags(workspace);
-
-        if (featureFlags.includes("use_openai_eu_key")) {
-          const currentRegion = regionsConfig.getCurrentRegion();
-          if (currentRegion === "europe-west1") {
+        // Determine the openai region
+        const currentRegion = regionsConfig.getCurrentRegion();
+        let region: "us" | "eu";
+        switch (currentRegion) {
+          case "europe-west1":
             region = "eu";
-          } else if (currentRegion === "us-central1") {
+            break;
+          case "us-central1":
             region = "us";
-          }
+            break;
+          default:
+            throw new Error(`Unexpected region: ${currentRegion}`);
         }
 
         const contents = (block.message.contents ?? []).map((content) => {

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -88,22 +88,19 @@ export const credentialsFromProviders = (
   return credentials;
 };
 
-export const dustManagedCredentials = (options?: {
-  useOpenAIEUKeyFlag?: boolean;
-}): CredentialsType => {
+export const dustManagedCredentials = (): CredentialsType => {
+  // Use the EU OpenAI key and endpoint if the Dust region is europe-west1.
   const isEuropeRegion = DUST_REGION === "europe-west1";
-
-  const useOpenAIEU = options?.useOpenAIEUKeyFlag && isEuropeRegion;
 
   return {
     ANTHROPIC_API_KEY: DUST_MANAGED_ANTHROPIC_API_KEY,
     AZURE_OPENAI_API_KEY: DUST_MANAGED_AZURE_OPENAI_API_KEY,
     AZURE_OPENAI_ENDPOINT: DUST_MANAGED_AZURE_OPENAI_ENDPOINT,
     MISTRAL_API_KEY: DUST_MANAGED_MISTRAL_API_KEY,
-    OPENAI_API_KEY: useOpenAIEU
+    OPENAI_API_KEY: isEuropeRegion
       ? DUST_MANAGED_OPENAI_API_KEY_EU
       : DUST_MANAGED_OPENAI_API_KEY,
-    OPENAI_USE_EU_ENDPOINT: useOpenAIEU ? "true" : "false",
+    OPENAI_USE_EU_ENDPOINT: isEuropeRegion ? "true" : "false",
     TEXTSYNTH_API_KEY: DUST_MANAGED_TEXTSYNTH_API_KEY,
     GOOGLE_AI_STUDIO_API_KEY: DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY,
     SERP_API_KEY: DUST_MANAGED_SERP_API_KEY,

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -89,7 +89,7 @@ export const credentialsFromProviders = (
 };
 
 export const dustManagedCredentials = (): CredentialsType => {
-  // Use the EU OpenAI key and endpoint if the Dust region is europe-west1.
+  // Based on the Dust region, we use different keys / endpoints for some providers.
   const isEuropeRegion = DUST_REGION === "europe-west1";
 
   return {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -181,10 +181,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Webhooks for Human Out Of The Loop (aka Triggers) / webhooks",
     stage: "dust_only",
   },
-  use_openai_eu_key: {
-    description: "Use OpenAI EU API key instead of the default OpenAI API key",
-    stage: "on_demand",
-  },
   slack_bot_mcp: {
     description: "Slack bot MCP server for workspace-level Slack integration",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -681,7 +681,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_message_splitting"
   | "slideshow"
   | "usage_data_api"
-  | "use_openai_eu_key"
   | "web_summarization"
   | "xai_feature"
   | "virtualized_conversations"


### PR DESCRIPTION
## Description

After this change, we will be using the OpenAI EU endpoint in all our openai scenarios for our EU Dust deployment.

## Tests

Manual

## Risk

Potential for openai EU issues that we didn't catch on more limited rollout.

## Deploy Plan

Front