### PR TITLE
feat(front): add a browser notification when an agent is running for a long time and it finishes

### DIFF
--- a/front/hooks/useAgentMessageStreamVirtuoso.ts
+++ b/front/hooks/useAgentMessageStreamVirtuoso.ts
@@ -13,9 +13,11 @@ import {
   getMessageSId,
   isMessageTemporayState,
 } from "@app/components/assistant/conversation/types";
+import { useBrowserNotification } from "@app/hooks/useBrowserNotification";
 import { useEventSource } from "@app/hooks/useEventSource";
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
+import { TERMINAL_AGENT_MESSAGE_EVENT_TYPES } from "@app/lib/api/assistant/streaming/types";
 import type {
   LightAgentMessageWithActionsType,
   LightWorkspaceType,
@@ -125,6 +127,10 @@ export function useAgentMessageStreamVirtuoso({
         !!messageStreamState.message.chainOfThought)
   );
 
+  // Track the start time of the streaming run to compute duration on completion.
+  const { notify } = useBrowserNotification();
+  const runStartedAt = shouldStream ? Date.now() : null;
+
   const chainOfThought = useRef(
     messageStreamState.message.chainOfThought ?? ""
   );
@@ -142,9 +148,8 @@ export function useAgentMessageStreamVirtuoso({
         // We have a lastEventId, so this is not a fresh mount
         isFreshMountWithContent.current = false;
       }
-      const url = esURL + "?lastEventId=" + lastEventId;
 
-      return url;
+      return esURL + "?lastEventId=" + lastEventId;
     },
     [conversationId, sId, owner.sId]
   );
@@ -301,6 +306,23 @@ export function useAgentMessageStreamVirtuoso({
         customOnEventCallback(eventPayload);
       }
 
+      // Notify if the run took a long time and just finished.
+      if (TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(eventType)) {
+        if (runStartedAt !== null) {
+          const elapsedMs = Date.now() - runStartedAt;
+          const LONG_RUN_THRESHOLD_MS = 120; // 2 minutes
+          if (elapsedMs >= LONG_RUN_THRESHOLD_MS) {
+            notify(
+              `${messageStreamState.message.configuration.name} finished`,
+              {
+                body: "The agent run has completed.",
+                tag: `agent-finished-${sId}`,
+              }
+            );
+          }
+        }
+      }
+
       const shouldRefresh = [
         "agent_action_success",
         "agent_error",
@@ -312,7 +334,15 @@ export function useAgentMessageStreamVirtuoso({
         void mutateMessage();
       }
     },
-    [customOnEventCallback, methods, mutateMessage, sId]
+    [
+      customOnEventCallback,
+      messageStreamState.message.configuration.name,
+      methods,
+      mutateMessage,
+      notify,
+      runStartedAt,
+      sId,
+    ]
   );
 
   useEventSource(buildEventSourceURL, onEventCallback, streamId, {

--- a/front/hooks/useBrowserNotification.ts
+++ b/front/hooks/useBrowserNotification.ts
@@ -1,0 +1,74 @@
+import { useCallback } from "react";
+
+interface BrowserNotificationOptions {
+  body?: string;
+  icon?: string;
+  tag?: string;
+}
+
+interface UseBrowserNotificationApi {
+  notify: (title: string, options?: BrowserNotificationOptions) => void;
+}
+
+// This hook provides a thin wrapper around the Web Notifications API. It handles permission
+// requests and ensures that notifications are only attempted in supported environments.
+export function useBrowserNotification(): UseBrowserNotificationApi {
+  const notify = useCallback(
+    (title: string, options?: BrowserNotificationOptions) => {
+      // Guard against non-browser environments or unsupported APIs.
+      if (
+        typeof window === "undefined" ||
+        typeof Notification === "undefined"
+      ) {
+        return;
+      }
+
+      // Do not send a system notification if the page is currently visible and focused. As an example, this implies
+      // that the conversation is on screen and the user can already see the outcome.
+      if (typeof document !== "undefined") {
+        const hasFocus =
+          typeof document.hasFocus === "function" ? document.hasFocus() : true;
+        if (document.visibilityState === "visible" && hasFocus) {
+          return;
+        }
+      }
+
+      const show = () => {
+        try {
+          const n = new Notification(title, {
+            body: options?.body,
+            icon: options?.icon,
+            tag: options?.tag,
+          });
+
+          // Focus the window when the notification is clicked.
+          n.onclick = () => {
+            window.focus();
+            n.close();
+          };
+        } catch (_) {
+          // Silently ignore errors to avoid noisy logs as per logging policy.
+        }
+      };
+
+      // If permission is already granted, show the notification immediately.
+      if (Notification.permission === "granted") {
+        show();
+        return;
+      }
+
+      // If the permission is not denied, request it once and show if granted.
+      if (Notification.permission !== "denied") {
+        void Notification.requestPermission().then((permission) => {
+          if (permission === "granted") {
+            show();
+          }
+        });
+      }
+      // If denied, do nothing.
+    },
+    []
+  );
+
+  return { notify };
+}

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -26,3 +26,11 @@ export type ConversationEvents =
   | AgentMessageNewEvent
   | UserMessageNewEvent
   | AgentMessageDoneEvent;
+
+export const TERMINAL_AGENT_MESSAGE_EVENT_TYPES: AgentMessageEvents["type"][] =
+  [
+    "agent_message_success",
+    "agent_generation_cancelled",
+    "agent_error",
+    "tool_error",
+  ] as const;

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -7,6 +7,7 @@ import {
 import { fetchMessageInConversation } from "@app/lib/api/assistant/messages";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import { TERMINAL_AGENT_MESSAGE_EVENT_TYPES } from "@app/lib/api/assistant/streaming/types";
 import { maybeTrackTokenUsageCost } from "@app/lib/api/public_api_limits";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { Authenticator as AuthenticatorClass } from "@app/lib/auth";
@@ -90,14 +91,8 @@ async function processEventForUnreadState(
     conversation,
   }: { event: AgentMessageEvents; conversation: ConversationWithoutContentType }
 ) {
-  const agentMessageDoneEventTypes: AgentMessageEvents["type"][] = [
-    "agent_message_success",
-    "agent_generation_cancelled",
-    "agent_error",
-    "tool_error",
-  ];
   // If the event is a done event, we want to mark the conversation as unread for all participants.
-  if (agentMessageDoneEventTypes.includes(event.type)) {
+  if (TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)) {
     // No excluded user because the message is created by the agent.
     await ConversationResource.markAsUnreadForOtherParticipants(auth, {
       conversation,


### PR DESCRIPTION
## Description

For long running agents, it's interesting to know when it's done working. 

This PR adds a small browser notification if an agent finished with more than 2 minutes of runtime. 
It also doesn't send the notification if the conversation is on focus

<img width="365" height="117" alt="image" src="https://github.com/user-attachments/assets/004b5f82-5620-42e8-b2fd-90bf0ab5e8ee" />
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
