### PR TITLE
Members list don't show the correct amount of users

### DIFF
--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -455,6 +455,11 @@ export class UserResource extends BaseResource<UserModel> {
         {
           model: MembershipModel,
           as: "memberships",
+          where: {
+            id: {
+              [Op.in]: memberships.map((m) => m.id),
+            },
+          },
         },
       ],
       order: [[paginationParams.orderColumn, paginationParams.orderDirection]],


### PR DESCRIPTION
## Description

In the Dust workspace we show a total of 293 items when there's actually less than 80 members in the workspace.
It means we show a total of 12 pages for the pagination when there's only 4 needed.
Could be generalized issue or isolated to Dust workspace need to investigate why there's this bug difference.
https://github.com/dust-tt/tasks/issues/4485

This bug occurs because we count users multiple times when they belong to several workspaces.

## Tests

Here are the steps I followed locally:
- Created a new workspace and add myself as a member.
- Went back to my workspace and managed to reproduce the bug ("2 items" while there is only one)
<img width="856" height="299" alt="image" src="https://github.com/user-attachments/assets/512c7323-dff8-4ea9-ac29-4591c3f1eac2" />


## Risk

Low

## Deploy Plan

Deploy front
