### PR TITLE
[front] enh: prevent duplicate retry button from showing for failed messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessageVirtuoso.tsx
+++ b/front/components/assistant/conversation/AgentMessageVirtuoso.tsx
@@ -342,8 +342,13 @@ export function AgentMessageVirtuoso({
     );
   }
 
-  // Show retry button as long as it's not streaming
-  if (agentMessageToRender.status !== "created" && !shouldStream) {
+  // Show the retry button as long as it's not streaming nor failed,
+  // since failed messages have their own retry button in ErrorMessage.
+  if (
+    agentMessageToRender.status !== "created" &&
+    agentMessageToRender.status !== "failed" &&
+    !shouldStream
+  ) {
     buttons.push(
       <Button
         key="retry-msg-button"


### PR DESCRIPTION
## Description

As it stands we see two retry buttons for failed messages: one in the `ContentMessage` and one underneath it.
The goal of this PR is to remove one of the two (the one below).
Argument for removing the one below: looked weird to have the details button at one place and the retry at another place.
Argument for removing the one in the `ContentMessage`: nice to have the same button always at the same location.

Before
<img width="715" height="372" alt="Screenshot 2025-10-10 at 10 41 19 AM" src="https://github.com/user-attachments/assets/95d74938-ff71-4b1b-8455-6475c2641911" />

After
<img width="715" height="372" alt="Screenshot 2025-10-10 at 10 40 23 AM" src="https://github.com/user-attachments/assets/a56c42ea-726f-400b-ae83-3b5b081a7f1c" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
