### PR TITLE
feat(front): add elevenlabs MCP server

### DIFF
--- a/front/components/resources/resources_icons.tsx
+++ b/front/components/resources/resources_icons.tsx
@@ -1,5 +1,4 @@
 import type { Avatar, Icon } from "@dust-tt/sparkle";
-import { ActionMegaphoneIcon } from "@dust-tt/sparkle";
 import {
   ActionAtomIcon,
   ActionBrainIcon,
@@ -13,6 +12,7 @@ import {
   ActionLightbulbIcon,
   ActionLockIcon,
   ActionMagnifyingGlassIcon,
+  ActionMegaphoneIcon,
   ActionPieChartIcon,
   ActionRobotIcon,
   ActionScanIcon,
@@ -84,8 +84,8 @@ export const InternalActionIcons = {
   ActionTableIcon,
   ActionPieChartIcon,
   ActionSlideshowIcon,
-  ActionTimeIcon,
   ActionMegaphoneIcon,
+  ActionTimeIcon,
   AsanaLogo,
   CommandLineIcon,
   ConfluenceLogo,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -85,6 +85,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "google_sheets",
   "hubspot",
   "image_generation",
+  "elevenlabs",
   "include_data",
   "interactive_content",
   "slideshow",
@@ -1034,6 +1035,30 @@ The directive should be used to display a clickable version of the agent name in
       instructions: null,
     },
   },
+  elevenlabs: {
+    id: 34,
+    availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("elevenlabs_tool");
+    },
+    isPreview: false,
+    tools_stakes: {
+      text_to_speech: "low",
+      generate_music: "low",
+    },
+    tools_retry_policies: { default: "retry_on_interrupt" },
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "elevenlabs",
+      version: "1.0.0",
+      description: "Generate speech audio and music with ElevenLabs.",
+      authorization: null,
+      icon: "ActionMegaphoneIcon",
+      documentationUrl: null,
+      instructions: null,
+    },
+  },
   [SEARCH_SERVER_NAME]: {
     id: 1006,
     availability: "auto",
@@ -1237,7 +1262,7 @@ The directive should be used to display a clickable version of the agent name in
       instructions: null,
     },
   },
-  // Using satisfies here instead of : type to avoid typescript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
+  // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {
   [K in InternalMCPServerNameType]: {
     id: number;

--- a/front/lib/actions/mcp_internal_actions/servers/elevenlabs.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/elevenlabs.ts
@@ -1,0 +1,176 @@
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { ElevenLabsEnvironment } from "@elevenlabs/elevenlabs-js/environments";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import {
+  makeInternalMCPServer,
+  makeMCPToolTextError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
+import { config as regionsConfig } from "@app/lib/api/regions/config";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { dustManagedCredentials, normalizeError } from "@app/types";
+
+function getElevenLabsClient() {
+  const credentials = dustManagedCredentials();
+  const environment =
+    regionsConfig.getCurrentRegion() === "europe-west1"
+      ? ElevenLabsEnvironment.ProductionEu
+      : ElevenLabsEnvironment.ProductionUs;
+
+  return new ElevenLabsClient({
+    apiKey: credentials.ELEVENLABS_API_KEY,
+    environment,
+  });
+}
+
+async function streamToBase64(
+  stream: ReadableStream<Uint8Array>
+): Promise<string> {
+  // Convert a web ReadableStream to a base64 string.
+  const arrayBuffer = await new Response(stream).arrayBuffer();
+  return Buffer.from(arrayBuffer).toString("base64");
+}
+
+const VOICE_TO_VOICE_ID = {
+  female: "cgSgspJ2msm6clMCkdW9",
+  male: "bIHbv24MWmeRgasZH58o",
+};
+
+const createServer = (_auth: Authenticator): McpServer => {
+  const server = makeInternalMCPServer("elevenlabs");
+
+  server.tool(
+    "text_to_speech",
+    "Generate speech audio from a text prompt using ElevenLabs. Provide the desired voice.",
+    {
+      text: z
+        .string()
+        .min(1)
+        .max(10_000)
+        .describe("The text to convert to speech."),
+      voice: z
+        .enum(["female", "male"])
+        .default("female")
+        .describe(
+          "The ElevenLabs voice to use. Possible options are female, or male."
+        ),
+      name: z
+        .string()
+        .max(128)
+        .optional()
+        .default("speech")
+        .describe("Base filename (without extension) for the generated audio."),
+    },
+    async ({ text, voice = "female", name = "speech" }) => {
+      try {
+        const client = getElevenLabsClient();
+        const voiceId = VOICE_TO_VOICE_ID[voice];
+
+        const stream = await client.textToSpeech.convert(voiceId, {
+          text,
+          modelId: "eleven_multilingual_v2",
+          outputFormat: "mp3_44100_128",
+        });
+
+        const base64 = await streamToBase64(stream);
+        const fileName = `${name}.mp3`;
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "resource" as const,
+              resource: {
+                name: fileName,
+                blob: base64,
+                text: "Your audio file was generated successfully.",
+                mimeType: "audio/mpeg",
+                uri: "",
+              },
+            },
+          ],
+        };
+      } catch (e) {
+        logger.error(
+          { err: normalizeError(e) },
+          "Error generating text-to-speech with ElevenLabs."
+        );
+        return makeMCPToolTextError(
+          `Error generating speech audio with ElevenLabs: ${normalizeError(e).message}`
+        );
+      }
+    }
+  );
+
+  server.tool(
+    "generate_music",
+    "Generate a short music track from a prompt using ElevenLabs Music.",
+    {
+      prompt: z
+        .string()
+        .min(1)
+        .max(2000)
+        .describe(
+          "Describe the style and mood of the music to generate (eg: 'energetic electronic beat with ambient pads')."
+        ),
+      duration_ms: z
+        .number()
+        .int()
+        .min(3000)
+        .max(120000)
+        .optional()
+        .default(20000)
+        .describe(
+          "Target duration of the generated music in milliseconds (3s to 120s)."
+        ),
+      name: z
+        .string()
+        .max(128)
+        .optional()
+        .default("music")
+        .describe("Base filename (without extension) for the generated audio."),
+    },
+    async ({ prompt, duration_ms = 20000, name = "music" }) => {
+      try {
+        const client = getElevenLabsClient();
+
+        const stream = await client.music.compose({
+          prompt,
+          musicLengthMs: duration_ms,
+        });
+
+        const base64 = await streamToBase64(stream);
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "resource" as const,
+              resource: {
+                name: `${name}.mp3`,
+                blob: base64,
+                text: "Your music track was generated successfully.",
+                mimeType: "audio/mpeg",
+                uri: "",
+              },
+            },
+          ],
+        };
+      } catch (e) {
+        logger.error(
+          { err: normalizeError(e) },
+          "Error generating music with ElevenLabs."
+        );
+        return makeMCPToolTextError(
+          `Error generating music with ElevenLabs: ${normalizeError(e).message}`
+        );
+      }
+    }
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -13,6 +13,7 @@ import { default as conversationFilesServer } from "@app/lib/actions/mcp_interna
 import { default as dataSourcesFileSystemServer } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system";
 import { default as dataWarehousesServer } from "@app/lib/actions/mcp_internal_actions/servers/data_warehouses/server";
 import { default as deepDiveServer } from "@app/lib/actions/mcp_internal_actions/servers/deep_dive";
+import { default as elevenlabsServer } from "@app/lib/actions/mcp_internal_actions/servers/elevenlabs";
 import { default as generateFileServer } from "@app/lib/actions/mcp_internal_actions/servers/file_generation";
 import { default as freshserviceServer } from "@app/lib/actions/mcp_internal_actions/servers/freshservice/server";
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
@@ -94,6 +95,8 @@ export async function getInternalMCPServer(
       return hubspotServer();
     case "image_generation":
       return imageGenerationDallEServer(auth);
+    case "elevenlabs":
+      return elevenlabsServer(auth);
     case "file_generation":
       return generateFileServer(auth);
     case "interactive_content":

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -188,6 +188,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "AI-powered web page summarization in the web browser tool",
     stage: "on_demand",
   },
+  elevenlabs_tool: {
+    description: "Elevenlabs MCP tool for voice synthesis",
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -685,6 +685,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "web_summarization"
   | "xai_feature"
   | "noop_model_feature"
+  | "elevenlabs_tool"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Add ElevenLabs as an internal MCP server. It only contains 2 tools for now:
* Text to speech
* Generate music

The idea is to release it internally and see if some use cases arise

## Tests

locally

## Risk

None it's behind a feature flag
## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
