### PR TITLE
Migration is complete, remove dust-deep global agent sId

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -495,7 +495,6 @@ export function _getDeepDiveGlobalAgent(
   auth: Authenticator,
   {
     settings,
-    sId,
     preFetchedDataSources,
     webSearchBrowseMCPServerView,
     dataSourcesFileSystemMCPServerView,
@@ -506,7 +505,6 @@ export function _getDeepDiveGlobalAgent(
     slideshowMCPServerView,
   }: {
     settings: GlobalAgentSettings | null;
-    sId: string;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
     dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
@@ -526,7 +524,7 @@ export function _getDeepDiveGlobalAgent(
     "status" | "maxStepsPerRun" | "actions"
   > = {
     id: -1,
-    sId: sId,
+    sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
     version: 0,
     versionCreatedAt: null,
     versionAuthorId: null,

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -263,13 +263,6 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "An agent with context on your company data.",
         pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
       };
-    case GLOBAL_AGENTS_SID.DUST_DEEP:
-      return {
-        sId: GLOBAL_AGENTS_SID.DUST_DEEP,
-        name: DEEP_DIVE_NAME,
-        description: DEEP_DIVE_DESC,
-        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
-      };
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
       return {
         sId: GLOBAL_AGENTS_SID.DEEP_DIVE,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -340,12 +340,7 @@ function getGlobalAgent({
       });
       break;
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
-    case GLOBAL_AGENTS_SID.DUST_DEEP:
       agentConfiguration = _getDeepDiveGlobalAgent(auth, {
-        sId:
-          sId === GLOBAL_AGENTS_SID.DUST_DEEP
-            ? GLOBAL_AGENTS_SID.DUST_DEEP
-            : GLOBAL_AGENTS_SID.DEEP_DIVE,
         settings,
         preFetchedDataSources,
         webSearchBrowseMCPServerView,
@@ -408,7 +403,6 @@ const RETIRED_GLOBAL_AGENTS_SID = [
   GLOBAL_AGENTS_SID.NOTION,
   GLOBAL_AGENTS_SID.O1_MINI,
   GLOBAL_AGENTS_SID.SLACK,
-  GLOBAL_AGENTS_SID.DUST_DEEP,
   // Hidden helper sub-agent, only invoked via run_agent by deep-dive
   GLOBAL_AGENTS_SID.DUST_TASK,
   GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY,

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1713,7 +1713,6 @@ export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
   DEEP_DIVE = "deep-dive",
-  DUST_DEEP = "dust-deep",
   DUST_TASK = "dust-task",
   DUST_BROWSER_SUMMARY = "dust-browser-summary",
   DUST_PLANNING = "dust-planning",


### PR DESCRIPTION
## Description

Now that this one is merged and migration ran: https://github.com/dust-tt/dust/pull/16712
-> We can remove the sId that I kept for the past conversations. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 