### PR TITLE
Rework Deep Dive tool output

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -25,12 +25,12 @@ const createServer = (
   const owner = auth.getNonNullableWorkspace();
 
   server.tool(
-    "dive",
+    "handoff",
     `Handoff the query to the ${DEEP_DIVE_NAME} agent`,
     {},
     withToolLogging(
       auth,
-      { toolName: "run_dust_deep", agentLoopContext },
+      { toolName: "handoff", agentLoopContext },
       async () => {
         if (!agentLoopContext?.runContext) {
           return new Err(new MCPError("No conversation context available"));
@@ -54,9 +54,9 @@ const createServer = (
         );
 
         const runContext = agentLoopContext.runContext;
-        const { agentConfiguration, conversation } = runContext;
+        const { agentConfiguration, conversation, agentMessage } = runContext;
         const instructions = agentConfiguration.instructions;
-        const query = `You have been summoned by @${agentConfiguration.name}. Its instructions are: <main_agent_instructions>${instructions ?? ""}</main_agent_instructions>`;
+        const query = `You have been summoned by @${agentConfiguration.name}. Its instructions are: <caller_agent_instructions>${instructions ?? ""}</caller_agent_instructions>`;
 
         const convRes = await getOrCreateConversation(api, runContext, {
           childAgentBlob: {
@@ -65,7 +65,7 @@ const createServer = (
           },
           childAgentId: GLOBAL_AGENTS_SID.DEEP_DIVE,
           mainAgent: agentConfiguration,
-          originMessage: agentLoopContext.runContext.agentMessage,
+          originMessage: agentMessage,
           mainConversation: conversation,
           query,
           toolsetsToAdd: null,
@@ -77,8 +77,18 @@ const createServer = (
           return new Err(convRes.error);
         }
 
+        // Determine what to display before the Deep Dive agent mention:
+        // - If agent already has content: display nothing (content is already shown)
+        // - If no content but has chain of thought: display the chain of thought
+        // - Otherwise: display nothing
+        const prefixContent = agentMessage.content
+          ? ""
+          : agentMessage.chainOfThought ?? "";
+        const mentionString = `\n:mention[${DEEP_DIVE_NAME}]{sId=${GLOBAL_AGENTS_SID.DEEP_DIVE}}`;
+        const responseText = prefixContent + mentionString;
+
         const response = makeMCPToolExit({
-          message: `Deep diving by forwarding this request to @${DEEP_DIVE_NAME}.`,
+          message: responseText,
           isError: false,
         });
 

--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -56,7 +56,7 @@ const createServer = (
         const runContext = agentLoopContext.runContext;
         const { agentConfiguration, conversation, agentMessage } = runContext;
         const instructions = agentConfiguration.instructions;
-        const query = `You have been summoned by @${agentConfiguration.name}. Its instructions are: <caller_agent_instructions>${instructions ?? ""}</caller_agent_instructions>`;
+        const query = `The user's query is being handed off to you from @${agentConfiguration.name} within the same conversation. The calling agent's instructions are: <caller_agent_instructions>${instructions ?? ""}</caller_agent_instructions>`;
 
         const convRes = await getOrCreateConversation(api, runContext, {
           childAgentBlob: {


### PR DESCRIPTION
## Description

Rename the tool from "dive" to "handoff" because it was displaying:
<img width="950" height="525" alt="Screenshot 2025-10-10 at 11 44 48" src="https://github.com/user-attachments/assets/3f997932-fd1c-4297-8a2d-bde7e3877a94" />

And change the output. 
Instead of the hardcoded sentence, we display either the generation or the chain of though, and then a mention to clarify the handoff. 

Ex here where there is not content so we display the thinking and then the mention: 
<img width="881" height="732" alt="Screenshot 2025-10-10 at 11 58 12" src="https://github.com/user-attachments/assets/61aab7c3-4a30-4cc5-98e5-2e031f7b088d" />


## Tests

Locally

## Risk

Can be rolled back. 

## Deploy Plan

deploy front. 