### PR TITLE
Use virtuoso for agent builder

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,5 +1,5 @@
-import { ArrowPathIcon, Button, Spinner } from "@dust-tt/sparkle";
-import { useContext, useEffect, useMemo, useRef } from "react";
+import { Spinner } from "@dust-tt/sparkle";
+import { useEffect, useMemo, useRef } from "react";
 import { useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -12,17 +12,13 @@ import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPan
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
-import {
-  GenerationContext,
-  GenerationContextProvider,
-} from "@app/components/assistant/conversation/GenerationContextProvider";
+import ConversationViewerVirtuoso from "@app/components/assistant/conversation/ConversationViewerVirtuoso";
+import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import type { DustError } from "@app/lib/error";
 import { useUser } from "@app/lib/swr/user";
 import type {
-  AgentMention,
   ContentFragmentsType,
   ConversationWithoutContentType,
   LightAgentConfigurationType,
@@ -71,13 +67,11 @@ interface PreviewContentProps {
   owner: WorkspaceType;
   currentPanel: ConversationSidePanelType;
   resetConversation: () => void;
-  handleSubmit: (
+  createConversation: (
     input: string,
     mentions: EditorMention[],
     contentFragments: ContentFragmentsType
   ) => Promise<Result<undefined, DustError>>;
-  setStickyMentions: (mentions: AgentMention[]) => void;
-  stickyMentions: AgentMention[];
   draftAgent: LightAgentConfigurationType | null;
   isSavingDraftAgent: boolean;
 }
@@ -88,53 +82,47 @@ function PreviewContent({
   owner,
   currentPanel,
   resetConversation,
-  handleSubmit,
-  setStickyMentions,
-  stickyMentions,
+  createConversation,
   draftAgent,
   isSavingDraftAgent,
 }: PreviewContentProps) {
-  const generationContext = useContext(GenerationContext);
-  const isGenerating = !!generationContext?.generatingMessages.length;
-
   return (
     <>
       <div className={currentPanel ? "hidden" : "flex h-full flex-col"}>
         <div className="flex-1 overflow-y-auto">
           {conversation && user && (
-            <ConversationViewer
+            <ConversationViewerVirtuoso
               owner={owner}
               user={user}
               conversationId={conversation.sId}
-              onStickyMentionsChange={setStickyMentions}
-              isInModal
+              agentBuilderContext={{
+                draftAgent: draftAgent ?? undefined,
+                isSavingDraftAgent,
+                resetConversation,
+                actionsToShow: ["attachment"],
+              }}
               key={conversation.sId}
             />
           )}
         </div>
-        {conversation && !isGenerating && (
-          <div className="flex justify-center px-4">
-            <Button
-              variant="outline"
-              icon={ArrowPathIcon}
-              onClick={resetConversation}
-              label="Clear conversation"
+
+        {!conversation && (
+          <div className="mx-4 flex-shrink-0 py-4">
+            <AssistantInputBar
+              disable={isSavingDraftAgent}
+              owner={owner}
+              onSubmit={createConversation}
+              stickyMentions={
+                draftAgent ? [{ configurationId: draftAgent.sId }] : []
+              }
+              conversationId={null}
+              additionalAgentConfiguration={draftAgent ?? undefined}
+              actions={["attachment"]}
+              disableAutoFocus
+              isFloating={false}
             />
           </div>
         )}
-        <div className="flex-shrink-0 py-4">
-          <AssistantInputBar
-            disable={isSavingDraftAgent}
-            owner={owner}
-            onSubmit={handleSubmit}
-            stickyMentions={stickyMentions}
-            conversationId={conversation?.sId ?? null}
-            additionalAgentConfiguration={draftAgent ?? undefined}
-            actions={["attachment"]}
-            disableAutoFocus
-            isFloating={false}
-          />
-        </div>
       </div>
 
       {conversation && (
@@ -173,11 +161,9 @@ export function AgentBuilderPreview() {
     getDraftAgent,
     isSavingDraftAgent,
     draftCreationFailed,
-    stickyMentions,
-    setStickyMentions,
   } = useDraftAgent();
 
-  const { conversation, handleSubmit, resetConversation } =
+  const { conversation, createConversation, resetConversation } =
     useDraftConversation({
       draftAgent,
       getDraftAgent,
@@ -223,7 +209,6 @@ export function AgentBuilderPreview() {
           const newDraft = await createDraftAgent();
           if (newDraft) {
             setDraftAgent(newDraft);
-            setStickyMentions([{ configurationId: newDraft.sId }]);
           }
           isUpdatingDraftRef.current = false;
         }, 500);
@@ -245,7 +230,6 @@ export function AgentBuilderPreview() {
     agentName,
     createDraftAgent,
     setDraftAgent,
-    setStickyMentions,
   ]);
 
   // Show loading spinner only when the first time we create a draft agent. After that the spinner is shown
@@ -283,9 +267,7 @@ export function AgentBuilderPreview() {
         owner={owner}
         currentPanel={currentPanel}
         resetConversation={resetConversation}
-        handleSubmit={handleSubmit}
-        setStickyMentions={setStickyMentions}
-        stickyMentions={stickyMentions}
+        createConversation={createConversation}
         draftAgent={draftAgent}
         isSavingDraftAgent={isSavingDraftAgent}
       />

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -143,7 +143,7 @@ function ExpandedContent({
         />
       )}
       {selectedTab === "testing" && (
-        <div className="min-h-0 flex-1 px-1">
+        <div className="min-h-0 flex-1">
           <AgentBuilderPreview />
         </div>
       )}
@@ -189,14 +189,16 @@ export function AgentBuilderRightPanel({
   };
 
   return (
-    <div className="mx-4 flex h-full flex-col">
-      <PanelHeader
-        isPreviewPanelOpen={isPreviewPanelOpen}
-        selectedTab={selectedTab}
-        onTogglePanel={handleTogglePanel}
-        onTabChange={handleTabChange}
-        hasTemplate={hasTemplate}
-      />
+    <div className="flex h-full flex-col">
+      <div className="mx-4">
+        <PanelHeader
+          isPreviewPanelOpen={isPreviewPanelOpen}
+          selectedTab={selectedTab}
+          onTogglePanel={handleTogglePanel}
+          onTabChange={handleTabChange}
+          hasTemplate={hasTemplate}
+        />
+      </div>
       {isPreviewPanelOpen ? (
         <ExpandedContent
           selectedTab={selectedTab}

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -6,16 +6,11 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
 import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
-import {
-  createConversationWithMessage,
-  submitMessage,
-} from "@app/components/assistant/conversation/lib";
+import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { DustError } from "@app/lib/error";
-import { useConversation } from "@app/lib/swr/conversations";
 import { useUser } from "@app/lib/swr/user";
 import type {
-  AgentMention,
   ContentFragmentsType,
   ConversationType,
   LightAgentConfigurationType,
@@ -34,7 +29,6 @@ export function useDraftAgent() {
     useState<LightAgentConfigurationType | null>(null);
   const [isSavingDraftAgent, setIsSavingDraftAgent] = useState(false);
   const [draftCreationFailed, setDraftCreationFailed] = useState(false);
-  const [stickyMentions, setStickyMentions] = useState<AgentMention[]>([]);
 
   const createDraftAgent =
     useCallback(async (): Promise<LightAgentConfigurationType | null> => {
@@ -81,7 +75,6 @@ export function useDraftAgent() {
       const newDraft = aRes.value;
 
       setDraftAgent(newDraft);
-      setStickyMentions([{ configurationId: newDraft.sId }]);
       setIsSavingDraftAgent(false);
       return newDraft;
     }, [owner, user, sendNotification, getValues]);
@@ -107,8 +100,6 @@ export function useDraftAgent() {
     isSavingDraftAgent,
     draftCreationFailed,
     getDraftAgent,
-    stickyMentions,
-    setStickyMentions,
   };
 }
 
@@ -122,35 +113,42 @@ export function useDraftConversation({
   const { owner } = useAgentBuilderContext();
   const { user } = useUser();
   const sendNotification = useSendNotification();
+  const [conversation, setConversation] = useState<ConversationType | null>(
+    null
+  );
 
-  const [conversationId, setConversationId] = useState<string | null>(null);
+  const createConversation = useCallback(
+    async (
+      input: string,
+      mentions: EditorMention[],
+      contentFragments: ContentFragmentsType
+    ): Promise<Result<undefined, DustError>> => {
+      if (!user) {
+        return new Err({
+          code: "internal_error",
+          name: "No user",
+          message: "No user found",
+        });
+      }
 
-  const { conversation } = useConversation({
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    conversationId: conversationId || "",
-    workspaceId: owner.sId,
-    options: {
-      disabled: !conversationId,
-    },
-  });
+      try {
+        // Ensure we have a current draft agent before submitting
+        const currentAgent = await getDraftAgent();
+        if (!currentAgent) {
+          return new Err({
+            code: "internal_error",
+            name: "Draft Agent Creation Failed",
+            message: "Failed to create draft agent before submitting message",
+          });
+        }
 
-  const handleSubmit = async (
-    input: string,
-    mentions: EditorMention[],
-    contentFragments: ContentFragmentsType
-  ): Promise<Result<undefined, DustError>> => {
-    if (!user) {
-      return new Err({
-        code: "internal_error",
-        name: "No user",
-        message: "No user found",
-      });
-    }
-
-    try {
-      // Ensure we have a current draft agent before submitting
-      const currentAgent = await getDraftAgent();
-      if (!currentAgent) {
+        // Update mentions in the message data to use the current draft agent
+        mentions = mentions.map((mention) =>
+          mention.id === draftAgent?.sId && currentAgent?.sId
+            ? { ...mention, configurationId: currentAgent.sId }
+            : mention
+        );
+      } catch (error) {
         return new Err({
           code: "internal_error",
           name: "Draft Agent Creation Failed",
@@ -158,29 +156,14 @@ export function useDraftConversation({
         });
       }
 
-      // Update mentions in the message data to use the current draft agent
-      mentions = mentions.map((mention) =>
-        mention.id === draftAgent?.sId && currentAgent?.sId
-          ? { ...mention, configurationId: currentAgent.sId }
-          : mention
-      );
-    } catch (error) {
-      return new Err({
-        code: "internal_error",
-        name: "Draft Agent Creation Failed",
-        message: "Failed to create draft agent before submitting message",
-      });
-    }
+      const messageData = {
+        input,
+        mentions: mentions.map((mention) => ({
+          configurationId: mention.id,
+        })),
+        contentFragments,
+      };
 
-    const messageData = {
-      input,
-      mentions: mentions.map((mention) => ({
-        configurationId: mention.id,
-      })),
-      contentFragments,
-    };
-
-    if (!conversation) {
       const result = await createConversationWithMessage({
         owner,
         user,
@@ -189,7 +172,7 @@ export function useDraftConversation({
       });
 
       if (result.isOk()) {
-        setConversationId(result.value.sId);
+        setConversation(result.value);
         return new Ok(undefined);
       }
 
@@ -204,45 +187,17 @@ export function useDraftConversation({
         name: result.error.title,
         message: result.error.message,
       });
-    } else {
-      const result = await submitMessage({
-        owner,
-        user,
-        conversationId: conversation.sId as string,
-        messageData,
-      });
-
-      if (result.isOk()) {
-        return new Ok(undefined);
-      }
-
-      sendNotification({
-        title: result.error.title,
-        description: result.error.message,
-        type: "error",
-      });
-
-      return new Err({
-        code: "internal_error",
-        name: result.error.title,
-        message: result.error.message,
-      });
-    }
-  };
+    },
+    [draftAgent?.sId, getDraftAgent, owner, sendNotification, user]
+  );
 
   const resetConversation = useCallback(() => {
     setConversation(null);
-  }, []);
-
-  const setConversation = (newConversation: ConversationType | null) => {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    setConversationId(newConversation?.sId || null);
-  };
+  }, [setConversation]);
 
   return {
     conversation,
-    setConversation,
-    handleSubmit,
+    createConversation,
     resetConversation,
   };
 }

--- a/front/components/assistant/ConversationViewerEmptyState.tsx
+++ b/front/components/assistant/ConversationViewerEmptyState.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from "@dust-tt/sparkle";
+
+export function ConversationViewerEmptyState() {
+  return (
+    <div className="flex h-full w-full flex-1 flex-col items-center justify-center">
+      <Spinner variant="color" size="xl" />
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/MessageItemVirtuoso.tsx
+++ b/front/components/assistant/conversation/MessageItemVirtuoso.tsx
@@ -141,7 +141,7 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
           className={classNames(
             "mx-auto min-w-60",
             "pt-6 md:pt-10",
-            context.isInModal ? "max-w-full" : "max-w-3xl"
+            "max-w-3xl"
           )}
         >
           {isUserMessage(data) && !shouldHideUserMessage && (

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -1,4 +1,5 @@
 import type { EditorMention } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
+import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
@@ -7,6 +8,7 @@ import type { DustError } from "@app/lib/error";
 import type {
   ContentFragmentsType,
   ContentFragmentType,
+  LightAgentConfigurationType,
   LightAgentMessageType,
   LightAgentMessageWithActionsType,
   LightWorkspaceType,
@@ -66,7 +68,12 @@ export type VirtuosoMessageListContext = {
     contentFragments: ContentFragmentsType
   ) => Promise<Result<undefined, DustError>>;
   conversationId: string;
-  isInModal: boolean;
+  agentBuilderContext?: {
+    draftAgent?: LightAgentConfigurationType;
+    isSavingDraftAgent: boolean;
+    actionsToShow: InputBarContainerProps["actions"];
+    resetConversation: () => void;
+  };
   feedbacksByMessageId: Record<string, AgentMessageFeedbackType>;
 };
 


### PR DESCRIPTION
## Description

Use virtuoso conversation viewer in agent builder preview.
Main "issue" was that ConversationViewerVirtuoso owns an input bar. I refactored so Agentbuilder preview is like the "/new" page, there is an input bar alone to create the conversation and then we pass it to ConversationViewerVirtuoso.
I took the opportunity to fix an issue where the scrollbar of the conversation preview would have a padding to their right.

## Tests

Local

https://github.com/user-attachments/assets/d3b288bb-a145-450e-ab9b-3e36a0d6d3cb

## Risk

Medium, part of critical path.

## Deploy Plan

Deploy front