### PR TITLE
[front] Keep default group, even in provisioned mode

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -795,7 +795,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const groupFilter =
       this.managementMode === "manual"
         ? (group: GroupResource) => !group.isProvisioned()
-        : (group: GroupResource) => group.isProvisioned();
+        : () => true;
 
     // Open space.
     // Currently only using global group for simplicity.


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/4579


## Description

Keep default group, even in provisioned mode. Needed as keys aare linked to this default group .
We should clean the groups as members will still have access to the group, which is not what the user could expect.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
