### PR TITLE
MCP OAuth: fix the finalize flow when the window.opener is null

### DIFF
--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -38,6 +38,8 @@ export default function Finalize({
   // Finalize the connection on component mount.
   useEffect(() => {
     async function finalizeOAuth() {
+      // You can end up here when you directly edit the configuration
+      // (e.g. go to GitHub and configure repositories from Dust App in Settings, hence no opener).
       const res = await doFinalize(provider, queryParams);
 
       // Prepare message data
@@ -76,21 +78,6 @@ export default function Finalize({
             "[OAuth Finalize] BroadcastChannel failed",
             e
           );
-        }
-
-        // Method 3: localStorage (fallback for all browsers)
-        try {
-          const storageKey = `oauth_finalize_${provider}`;
-          const dataWithExpiration = {
-            ...messageData,
-            expiresAt: Date.now() + 30000, // 30 seconds expiration
-          };
-          localStorage.setItem(
-            storageKey,
-            JSON.stringify(dataWithExpiration)
-          );
-        } catch (e) {
-          logger.error({ err: e }, "[OAuth Finalize] localStorage failed", e);
         }
       }
 

--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -81,7 +81,14 @@ export default function Finalize({
         // Method 3: localStorage (fallback for all browsers)
         try {
           const storageKey = `oauth_finalize_${provider}`;
-          localStorage.setItem(storageKey, JSON.stringify(messageData));
+          const dataWithExpiration = {
+            ...messageData,
+            expiresAt: Date.now() + 30000, // 30 seconds expiration
+          };
+          localStorage.setItem(
+            storageKey,
+            JSON.stringify(dataWithExpiration)
+          );
         } catch (e) {
           logger.error({ err: e }, "[OAuth Finalize] localStorage failed", e);
         }

--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { useFinalize } from "@app/lib/swr/oauth";
+import logger from "@app/logger/logger";
 import type { OAuthProvider } from "@app/types";
 import { isOAuthProvider } from "@app/types";
 
@@ -57,7 +58,11 @@ export default function Finalize({
         try {
           window.opener.postMessage(messageData, window.location.origin);
         } catch (e) {
-          console.error("[OAuth Finalize] window.opener.postMessage failed", e);
+          logger.error(
+            { err: e },
+            "[OAuth Finalize] window.opener.postMessage failed",
+            e
+          );
         }
       } else {
         // Method 2: BroadcastChannel (fallback for modern browsers)
@@ -66,7 +71,11 @@ export default function Finalize({
           channel.postMessage(messageData);
           setTimeout(() => channel.close(), 100);
         } catch (e) {
-          console.error("[OAuth Finalize] BroadcastChannel failed", e);
+          logger.error(
+            { err: e },
+            "[OAuth Finalize] BroadcastChannel failed",
+            e
+          );
         }
 
         // Method 3: localStorage (fallback for all browsers)
@@ -74,7 +83,7 @@ export default function Finalize({
           const storageKey = `oauth_finalize_${provider}`;
           localStorage.setItem(storageKey, JSON.stringify(messageData));
         } catch (e) {
-          console.error("[OAuth Finalize] localStorage failed", e);
+          logger.error({ err: e }, "[OAuth Finalize] localStorage failed", e);
         }
       }
 

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -95,6 +95,15 @@ export async function setupOAuthConnection({
         const stored = localStorage.getItem(storageKey);
         if (stored) {
           const data = JSON.parse(stored);
+
+          // Check if data has expired (30 second window)
+          if (data.expiresAt && Date.now() > data.expiresAt) {
+            // Data expired, remove it and ignore
+            localStorage.removeItem(storageKey);
+            return;
+          }
+
+          // Clean up immediately after reading
           localStorage.removeItem(storageKey);
           handleFinalization(data);
         }

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -78,7 +78,7 @@ export async function setupOAuthConnection({
 
     window.addEventListener("message", handleWindowMessage);
 
-    // Method 2: BroadcastChannel (fallback for modern browsers)
+    // Method 2: BroadcastChannel (fallback)
     let channel: BroadcastChannel | null = null;
     try {
       channel = new BroadcastChannel("oauth_finalize");
@@ -89,38 +89,11 @@ export async function setupOAuthConnection({
       // BroadcastChannel not supported, will use localStorage
     }
 
-    // Method 3: localStorage polling (fallback for all browsers)
-    const checkLocalStorage = () => {
-      try {
-        const stored = localStorage.getItem(storageKey);
-        if (stored) {
-          const data = JSON.parse(stored);
-
-          // Check if data has expired (30 second window)
-          if (data.expiresAt && Date.now() > data.expiresAt) {
-            // Data expired, remove it and ignore
-            localStorage.removeItem(storageKey);
-            return;
-          }
-
-          // Clean up immediately after reading
-          localStorage.removeItem(storageKey);
-          handleFinalization(data);
-        }
-      } catch (e) {
-        // Ignore localStorage errors
-      }
-    };
-
-    // Poll localStorage every 100ms
-    const storageCheckInterval = setInterval(checkLocalStorage, 100);
-
     const cleanup = () => {
       window.removeEventListener("message", handleWindowMessage);
       if (channel) {
         channel.close();
       }
-      clearInterval(storageCheckInterval);
     };
   });
 }

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -23,6 +23,14 @@ export async function setupOAuthConnection({
   extraConfig: OAuthCredentials;
 }): Promise<Result<OAuthConnectionType, Error>> {
   return new Promise((resolve) => {
+    // Clear any stale OAuth data from previous attempts
+    const storageKey = `oauth_finalize_${provider}`;
+    try {
+      localStorage.removeItem(storageKey);
+    } catch (e) {
+      // Ignore localStorage errors
+    }
+
     let url = `${dustClientFacingUrl}/w/${owner.sId}/oauth/${provider}/setup?useCase=${useCase}`;
     if (extraConfig) {
       url += `&extraConfig=${encodeURIComponent(JSON.stringify(extraConfig))}`;
@@ -30,14 +38,18 @@ export async function setupOAuthConnection({
     const oauthPopup = window.open(url);
     let authComplete = false;
 
-    const popupMessageEventListener = (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) {
-        return;
+    const handleFinalization = (data: any) => {
+      if (authComplete) {
+        return; // Already processed
       }
 
-      if (event.data.type === "connection_finalized") {
+      if (data.type === "connection_finalized" && data.provider === provider) {
         authComplete = true;
-        const { error, connection } = event.data;
+        const { error, connection } = data;
+
+        cleanup();
+        oauthPopup?.close();
+
         if (error) {
           resolve(new Err(new Error(error)));
         } else if (
@@ -53,25 +65,53 @@ export async function setupOAuthConnection({
             )
           );
         }
-        window.removeEventListener("message", popupMessageEventListener);
-        oauthPopup?.close();
       }
     };
 
-    window.addEventListener("message", popupMessageEventListener);
-
-    const checkPopupStatus = setInterval(() => {
-      if (oauthPopup && oauthPopup.closed) {
-        window.removeEventListener("message", popupMessageEventListener);
-        clearInterval(checkPopupStatus);
-        setTimeout(() => {
-          if (!authComplete) {
-            resolve(
-              new Err(new Error("User closed the window before auth completed"))
-            );
-          }
-        }, 100);
+    // Method 1: window.postMessage (preferred, direct communication)
+    const handleWindowMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) {
+        return;
       }
-    }, 100);
+      handleFinalization(event.data);
+    };
+
+    window.addEventListener("message", handleWindowMessage);
+
+    // Method 2: BroadcastChannel (fallback for modern browsers)
+    let channel: BroadcastChannel | null = null;
+    try {
+      channel = new BroadcastChannel("oauth_finalize");
+      channel.addEventListener("message", (event: MessageEvent) => {
+        handleFinalization(event.data);
+      });
+    } catch (e) {
+      // BroadcastChannel not supported, will use localStorage
+    }
+
+    // Method 3: localStorage polling (fallback for all browsers)
+    const checkLocalStorage = () => {
+      try {
+        const stored = localStorage.getItem(storageKey);
+        if (stored) {
+          const data = JSON.parse(stored);
+          localStorage.removeItem(storageKey);
+          handleFinalization(data);
+        }
+      } catch (e) {
+        // Ignore localStorage errors
+      }
+    };
+
+    // Poll localStorage every 100ms
+    const storageCheckInterval = setInterval(checkLocalStorage, 100);
+
+    const cleanup = () => {
+      window.removeEventListener("message", handleWindowMessage);
+      if (channel) {
+        channel.close();
+      }
+      clearInterval(storageCheckInterval);
+    };
   });
 }


### PR DESCRIPTION
## Description

The issue is that after opening back dust after login, the window.opener is null so the finalize step fails.

Here is the explanation by claude:
The fundamental issue is that window.opener will ALWAYS be null after cross-origin navigation due to browser security. This is by design and cannot be bypassed. The flow is:
 1. Parent opens popup to localhost:3000/setup → window.opener exists
 2. Setup page redirects to mcp.zapier.com/authorize → window.opener becomes null (cross-origin)
 3. Zapier redirects back to localhost:3000/finalize → window.opener stays null

The alternative solution here is to broadcast back a message to the window creating the MCP when we come back to the finalize step.
Per Claude, the broadcast might not be supported on all brother and it. has added a fallback on local storage. I'm not sure we want to keep it as or not 🤷 

https://github.com/user-attachments/assets/2eebb233-fc6f-4395-956b-037c8fcc1e38

related to https://github.com/dust-tt/tasks/issues/4564 and https://github.com/dust-tt/tasks/issues/4517


## Tests
Manual test with mcp.zapier.com

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
deploy oauth ?