### PR TITLE
Cleaner way to identify an agentmessage is from a handover + update UI

### DIFF
--- a/front/components/assistant/conversation/MessageItemVirtuoso.tsx
+++ b/front/components/assistant/conversation/MessageItemVirtuoso.tsx
@@ -125,12 +125,11 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
       getMessageDate(prevData).toDateString() ===
         getMessageDate(data).toDateString();
 
-    const shouldHideUserMessage = isHandoverUserMessage(data);
-    const isAgentMessageHandover =
-      prevData &&
-      isHandoverUserMessage(prevData) &&
-      isMessageTemporayState(data) &&
-      data.message.parentMessageId === prevData.sId;
+    if (isHandoverUserMessage(data)) {
+      // This is hacky but in case of handover we generate a user message from the agent and we want to hide it in the conversation
+      // because it has no value to display.
+      return null;
+    }
 
     return (
       <>
@@ -144,7 +143,7 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
             "max-w-3xl"
           )}
         >
-          {isUserMessage(data) && !shouldHideUserMessage && (
+          {isUserMessage(data) && (
             <UserMessage
               citations={citations}
               conversationId={context.conversationId}
@@ -158,7 +157,6 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
               user={context.user}
               conversationId={context.conversationId}
               isLastMessage={!nextData}
-              isAgentMessageHandover={isAgentMessageHandover ?? false}
               messageStreamState={data}
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -158,6 +158,7 @@ export function createPlaceholderAgentMessage({
       created: createdAt,
       completedTs: null,
       parentMessageId: null,
+      parentAgentMessageId: null,
       status: "created",
       content: null,
       chainOfThought: null,

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -133,6 +133,7 @@ export function getLightAgentMessageFromAgentMessage(
     version: agentMessage.version,
     rank: agentMessage.rank,
     parentMessageId: agentMessage.parentMessageId,
+    parentAgentMessageId: agentMessage.parentAgentMessageId,
     content: agentMessage.content,
     chainOfThought: agentMessage.chainOfThought,
     error: agentMessage.error,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -631,6 +631,11 @@ export async function postUserMessage(
                 }
               );
 
+              const parentAgentMessageId =
+                userMessage.context.origin === "agent_handover"
+                  ? userMessage.context.originMessageId ?? null
+                  : null;
+
               return {
                 row: agentMessageRow,
                 m: {
@@ -643,6 +648,7 @@ export async function postUserMessage(
                   visibility: "visible",
                   version: 0,
                   parentMessageId: userMessage.sId,
+                  parentAgentMessageId,
                   status: "created",
                   actions: [],
                   content: null,
@@ -1084,6 +1090,11 @@ export async function editUserMessage(
               }
             );
 
+            const parentAgentMessageId =
+              userMessage.context.origin === "agent_handover"
+                ? userMessage.context.originMessageId ?? null
+                : null;
+
             return {
               row: agentMessageRow,
               m: {
@@ -1096,6 +1107,7 @@ export async function editUserMessage(
                 visibility: "visible",
                 version: 0,
                 parentMessageId: userMessage.sId,
+                parentAgentMessageId,
                 status: "created",
                 actions: [],
                 content: null,
@@ -1329,6 +1341,7 @@ export async function retryAgentMessage(
         visibility: m.visibility,
         version: m.version,
         parentMessageId: message.parentMessageId,
+        parentAgentMessageId: message.parentAgentMessageId,
         status: "created",
         actions: [],
         content: null,

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -177,6 +177,7 @@ async function handler(
         created: Date.now(),
         completedTs: null,
         parentMessageId: null,
+        parentAgentMessageId: null,
         status: "created",
         content: null,
         chainOfThought: null,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -146,6 +146,7 @@ export type BaseAgentMessageType = {
   created: number;
   completedTs: number | null;
   parentMessageId: string | null;
+  parentAgentMessageId: string | null; // If handover, this is the agent message that summoned this agent.
   status: AgentMessageStatus;
   content: string | null;
   chainOfThought: string | null;


### PR DESCRIPTION
## Description

This is an attempt to make it a little less hacky how to know that an agent message is from a handover. 
I updated  `BaseAgentMessageType` that already has a  `parentMessageId` pointing to the user message, a new `parentAgentMessageId` that point to the parent Agent message in case of handover. 

I then use this on the UI which is cleaner than relying on the "previous message". 

## Tests

Locally no issue on conversations. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 