### PR TITLE
feat(front): improve finding intent in voice interactions

### DIFF
--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -341,7 +341,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "F15zoc9d8a",
       appHash:
-        "b8e00639db1b38ccb0eca33781858fd2adf00f37ad81940451e257c17ce8dd27",
+        "ce806cd503d298c64ae97a8f786a60be62d81aa000fca02c363efec51356926f",
     },
     config: {
       GET_AUGMENTED_MESSAGE: {


### PR DESCRIPTION
## Description

The previous version was buggy as we didn't always find the agent ID. 

This changes:
* the dust app: we now ask the LLM to only find the agent based on their name
* after we find the sID backend side based on the name of the agent

Trust me it works better

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
