### PR TITLE
[front] - fix(mcp): handle empty tables/data configurations

### DIFF
--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -167,10 +167,14 @@ export async function fetchMCPServerActionConfigurations(
         icon: serverIcon,
         mcpServerViewId: mcpServerView?.sId ?? "",
         internalMCPServerId: config.internalMCPServerId,
-        dataSources: dataSourceConfigurations.map(
-          renderDataSourceConfiguration
-        ),
-        tables: tablesConfigurations.map(renderTableConfiguration),
+        dataSources:
+          dataSourceConfigurations.length > 0
+            ? dataSourceConfigurations.map(renderDataSourceConfiguration)
+            : null,
+        tables:
+          tablesConfigurations.length > 0
+            ? tablesConfigurations.map(renderTableConfiguration)
+            : null,
         dustAppConfiguration: dustApp
           ? {
               id: dustApp.id,


### PR DESCRIPTION
## Description

This PR ensures to return `null` for `dataSources` and `tables` if the respective configurations arrays are empty by making sure  `fetchMCPServerActionConfigurations` function doesn't map over empty configuration arrays.

## Tests

Locally

## Risk

Low, worst case scenario doesn't have any harmful impact

## Deploy Plan

Deploy front