### PR TITLE
Clear the cache in process-database-upsert-queue workflow

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows/upsert_database_queue.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/upsert_database_queue.ts
@@ -34,8 +34,6 @@ export async function processDatabaseUpsertQueueWorkflow({
 }: {
   connectorId: ModelId;
 }) {
-  const topLevelWorkflowId = workflowInfo().workflowId;
-
   const res = await isFullSyncPendingOrOngoing({
     connectorId,
   });
@@ -57,14 +55,17 @@ export async function processDatabaseUpsertQueueWorkflow({
 
   if (notionDatabaseId) {
     // Clear the workflow cache before processing
-    await clearWorkflowCache({ connectorId, topLevelWorkflowId });
+    await clearWorkflowCache({
+      connectorId,
+      topLevelWorkflowId: workflowInfo().workflowId,
+    });
 
     // We either haven't processed the DB recently, or we have no trace of ever processing it.
     await upsertDatabaseInCore({
       connectorId,
       databaseId: notionDatabaseId,
       runTimestamp: Date.now(),
-      topLevelWorkflowId,
+      topLevelWorkflowId: workflowInfo().workflowId,
       queue: new PQueue({
         concurrency: MAX_CONCURRENT_CHILD_WORKFLOWS,
       }),


### PR DESCRIPTION
## Description

We were clearing the `workflow-notion` cache, but not the process-database-upsert-queue, so it was accumulating entries forever across run, leading to bad corruption.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Connector