### PR TITLE
[connectors] fix(github): Handle case with 'Issues are disabled for this repo' error

### DIFF
--- a/connectors/src/connectors/github/lib/errors.ts
+++ b/connectors/src/connectors/github/lib/errors.ts
@@ -45,6 +45,16 @@ export function isGithubIssueWasDeletedError(
   );
 }
 
+export function isGithubIssueWasDisabledError(
+  error: unknown
+): error is RequestError {
+  return (
+    error instanceof RequestError &&
+    error.status === 410 &&
+    error.message.includes("Issues are disabled for this repo")
+  );
+}
+
 export function isGraphQLNotFound(error: unknown): error is Error {
   return (
     error instanceof Error &&

--- a/connectors/src/connectors/github/lib/github_api.ts
+++ b/connectors/src/connectors/github/lib/github_api.ts
@@ -13,6 +13,7 @@ import { fetch as undiciFetch, ProxyAgent } from "undici";
 import {
   isBadCredentials,
   isGithubIssueWasDeletedError,
+  isGithubIssueWasDisabledError,
   isGithubRequestErrorNotFound,
   isGithubRequestRedirectCountExceededError,
 } from "@connectors/connectors/github/lib/errors";
@@ -296,7 +297,8 @@ export async function getIssue(
     if (
       isGithubRequestRedirectCountExceededError(err) ||
       isGithubRequestErrorNotFound(err) ||
-      isGithubIssueWasDeletedError(err)
+      isGithubIssueWasDeletedError(err) ||
+      isGithubIssueWasDisabledError(err)
     ) {
       logger.info({ err: err.message }, "Failed to get issue.");
       return null;


### PR DESCRIPTION
## Description

Skip issue when we get "RequestError: Issues are disabled for this repo - https://docs.github.com/v3/issues/"

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

deploy connectors
