### PR TITLE
[front] refactor: fix type+naming for MCP server requirements

### DIFF
--- a/front/components/agent_builder/MCPServerViewsContext.tsx
+++ b/front/components/agent_builder/MCPServerViewsContext.tsx
@@ -7,7 +7,7 @@ import {
   getMcpServerViewDisplayName,
   mcpServerViewSortingFn,
 } from "@app/lib/actions/mcp_helper";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
@@ -98,7 +98,11 @@ function getGroupedMCPServerViews({
 
   const { mcpServerViewsWithKnowledge, mcpServerViewsWithoutKnowledge } =
     groupBy(mcpServerViewsWithLabel, (view) => {
-      const toolsConfigurations = getMCPServerToolsConfigurations(view);
+      const {
+        requiresDataSourceConfiguration,
+        requiresDataWarehouseConfiguration,
+        requiresTableConfiguration,
+      } = getMCPServerRequirements(view);
 
       // Special handling for interactive_content server:
       // The interactive_content server includes list and cat tools for convenience, but its primary purpose is
@@ -108,10 +112,9 @@ function getGroupedMCPServerViews({
 
       const isWithKnowledge =
         !isInteractiveContentServer &&
-        (toolsConfigurations.dataSourceConfiguration ??
-          toolsConfigurations.dataWarehouseConfiguration ??
-          toolsConfigurations.tableConfiguration ??
-          false);
+        (requiresDataSourceConfiguration ||
+          requiresDataWarehouseConfiguration ||
+          requiresTableConfiguration);
 
       return isWithKnowledge
         ? "mcpServerViewsWithKnowledge"

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -61,7 +61,7 @@ import {
   ADVANCED_SEARCH_SWITCH,
   SEARCH_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { TemplateActionPreset } from "@app/types";
@@ -155,7 +155,10 @@ function KnowledgeConfigurationSheetForm({
 
   const handleSave = (formData: CapabilityFormData) => {
     const { description, configuration, mcpServerView } = formData;
-    const toolsConfigurations = getMCPServerToolsConfigurations(mcpServerView);
+    const {
+      requiresDataSourceConfiguration,
+      requiresDataWarehouseConfiguration,
+    } = getMCPServerRequirements(mcpServerView);
 
     // Transform the tree structure to selection configurations
     const dataSourceConfigurations = transformTreeToSelectionConfigurations(
@@ -164,9 +167,7 @@ function KnowledgeConfigurationSheetForm({
     );
 
     const datasource =
-      toolsConfigurations.dataSourceConfiguration ??
-      toolsConfigurations.dataWarehouseConfiguration ??
-      false
+      requiresDataSourceConfiguration || requiresDataWarehouseConfiguration
         ? { dataSourceConfigurations: dataSourceConfigurations }
         : { tablesConfigurations: dataSourceConfigurations };
 
@@ -283,8 +284,8 @@ function KnowledgeConfigurationSheetContent({
     return null;
   }, [mcpServerView]);
 
-  const toolsConfigurations = useMemo(() => {
-    return getMCPServerToolsConfigurations(mcpServerView);
+  const requirements = useMemo(() => {
+    return getMCPServerRequirements(mcpServerView);
   }, [mcpServerView]);
 
   // Focus NameSection input when navigating to CONFIGURATION page
@@ -361,10 +362,10 @@ function KnowledgeConfigurationSheetContent({
   const pages: MultiPageSheetPage[] = [
     {
       id: CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION,
-      title: toolsConfigurations.tableConfiguration
+      title: requirements.requiresTableConfiguration
         ? "Select Tables"
         : "Select Data Sources",
-      description: toolsConfigurations.tableConfiguration
+      description: requirements.requiresTableConfiguration
         ? "Choose the tables to query for your processing method"
         : "Choose the data sources to include in your knowledge base",
       icon: undefined,
@@ -393,11 +394,11 @@ function KnowledgeConfigurationSheetContent({
             triggerValidationOnChange={true}
           />
 
-          {toolsConfigurations.mayRequireTimeFrameConfiguration && (
+          {requirements.mayRequireTimeFrameConfiguration && (
             <TimeFrameSection actionType="extract" />
           )}
 
-          {toolsConfigurations.mayRequireJsonSchemaConfiguration && (
+          {requirements.mayRequireJsonSchemaConfiguration && (
             <JsonSchemaSection getAgentInstructions={getAgentInstructions} />
           )}
 

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -14,7 +14,7 @@ import {
   isCustomResourceIconType,
 } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { WhitelistableFeature } from "@app/types";
 
 interface DataVisualizationCardProps {
@@ -56,8 +56,8 @@ function MCPServerCard({
   onToolInfoClick,
   featureFlags,
 }: MCPServerCardProps) {
-  const requirement = getMCPServerToolsConfigurations(view, featureFlags);
-  const canAdd = requirement.configurable !== "no" ? true : !isSelected;
+  const requirements = getMCPServerRequirements(view, featureFlags);
+  const canAdd = requirements.noRequirement ? !isSelected : true;
 
   const icon = isCustomResourceIconType(view.server.icon)
     ? ActionIcons[view.server.icon]

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -9,11 +9,9 @@ vi.mock("@app/lib/actions/mcp_internal_actions/input_configuration", () => ({
   getMCPServerToolsConfigurations: vi.fn(),
 }));
 
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 
-const mockGetMCPServerToolsConfigurations = vi.mocked(
-  getMCPServerToolsConfigurations
-);
+const mockGetMCPServerToolsConfigurations = vi.mocked(getMCPServerRequirements);
 
 describe("getDefaultConfiguration", () => {
   beforeEach(() => {

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -4,9 +4,8 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 
 import { getDefaultConfiguration } from "./formDefaults";
 
-// Mock the input configuration module
 vi.mock("@app/lib/actions/mcp_internal_actions/input_configuration", () => ({
-  getMCPServerToolsConfigurations: vi.fn(),
+  getMCPServerRequirements: vi.fn(),
 }));
 
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -11,7 +11,7 @@ vi.mock("@app/lib/actions/mcp_internal_actions/input_configuration", () => ({
 
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 
-const mockGetMCPServerToolsConfigurations = vi.mocked(getMCPServerRequirements);
+const mockGetMCPServerRequirements = vi.mocked(getMCPServerRequirements);
 
 describe("getDefaultConfiguration", () => {
   beforeEach(() => {
@@ -83,33 +83,19 @@ describe("getDefaultConfiguration", () => {
       toolsMetadata: [],
     };
 
-    it("should use mcpServerView sId as mcpServerViewId", () => {
-      mockGetMCPServerToolsConfigurations.mockReturnValue({
-        mayRequireTimeFrameConfiguration: false,
-        mayRequireJsonSchemaConfiguration: false,
-        stringConfigurations: [],
-        numberConfigurations: [],
-        booleanConfigurations: [],
-        enumConfigurations: {},
-        listConfigurations: {},
-        mayRequireDustAppConfiguration: false,
-        mayRequireSecretConfiguration: false,
-        configurable: "optional",
-      });
-
-      const result = getDefaultConfiguration(mockMCPServerView);
-
-      expect(result.mcpServerViewId).toBe("test-server-123");
-    });
-
     describe("boolean configurations", () => {
       it("should set boolean configurations to false by default", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [],
-          numberConfigurations: [],
-          booleanConfigurations: [
+          requiredStrings: [],
+          requiredNumbers: [],
+          requiredBooleans: [
             {
               key: "is_enabled",
               description: "Whether the feature is enabled",
@@ -117,11 +103,11 @@ describe("getDefaultConfiguration", () => {
             { key: "admin_mode", description: "Admin mode setting" },
             { key: "nested.deep.flag", description: "A deeply nested boolean" },
           ],
-          enumConfigurations: {},
-          listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiredEnums: {},
+          requiredLists: {},
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -138,12 +124,17 @@ describe("getDefaultConfiguration", () => {
       });
 
       it("should use explicit boolean defaults when available", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [],
-          numberConfigurations: [],
-          booleanConfigurations: [
+          requiredStrings: [],
+          requiredNumbers: [],
+          requiredBooleans: [
             {
               key: "feature_enabled",
               description: "Feature enabled",
@@ -152,11 +143,11 @@ describe("getDefaultConfiguration", () => {
             { key: "debug_mode", description: "Debug mode", default: false },
             { key: "auto_save", description: "Auto save" }, // no explicit default
           ],
-          enumConfigurations: {},
-          listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiredEnums: {},
+          requiredLists: {},
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -169,17 +160,22 @@ describe("getDefaultConfiguration", () => {
       });
 
       it("should handle empty boolean configurations", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [],
-          numberConfigurations: [],
-          booleanConfigurations: [],
-          enumConfigurations: {},
-          listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiredStrings: [],
+          requiredNumbers: [],
+          requiredBooleans: [],
+          requiredEnums: {},
+          requiredLists: {},
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -189,14 +185,19 @@ describe("getDefaultConfiguration", () => {
     });
 
     describe("enum configurations", () => {
-      it("should set enum configurations to first option", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+      it("should set enum configurations to the first option", () => {
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [],
-          numberConfigurations: [],
-          booleanConfigurations: [],
-          enumConfigurations: {
+          requiredStrings: [],
+          requiredNumbers: [],
+          requiredBooleans: [],
+          requiredEnums: {
             priority: {
               options: [
                 { value: "low", label: "Low" },
@@ -221,10 +222,10 @@ describe("getDefaultConfiguration", () => {
               description: "Nested enum",
             },
           },
-          listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiredLists: {},
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -239,13 +240,18 @@ describe("getDefaultConfiguration", () => {
       });
 
       it("should skip enum configurations with empty options", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [],
-          numberConfigurations: [],
-          booleanConfigurations: [],
-          enumConfigurations: {
+          requiredStrings: [],
+          requiredNumbers: [],
+          requiredBooleans: [],
+          requiredEnums: {
             valid_enum: {
               options: [
                 { value: "option1", label: "Option 1" },
@@ -258,10 +264,10 @@ describe("getDefaultConfiguration", () => {
               description: "Empty enum",
             },
           },
-          listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiredLists: {},
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -273,13 +279,18 @@ describe("getDefaultConfiguration", () => {
       });
 
       it("should use explicit enum defaults when available", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [],
-          numberConfigurations: [],
-          booleanConfigurations: [],
-          enumConfigurations: {
+          requiredStrings: [],
+          requiredNumbers: [],
+          requiredBooleans: [],
+          requiredEnums: {
             priority: {
               options: [
                 { value: "low", label: "Low" },
@@ -298,10 +309,10 @@ describe("getDefaultConfiguration", () => {
               description: "Status", // no explicit default, should use first
             },
           },
-          listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiredLists: {},
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -315,14 +326,19 @@ describe("getDefaultConfiguration", () => {
 
     describe("list configurations", () => {
       it("should set list configurations to empty arrays", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [],
-          numberConfigurations: [],
-          booleanConfigurations: [],
-          enumConfigurations: {},
-          listConfigurations: {
+          requiredStrings: [],
+          requiredNumbers: [],
+          requiredBooleans: [],
+          requiredEnums: {},
+          requiredLists: {
             tags: {
               options: [
                 { value: "tag1", label: "Tag 1" },
@@ -342,9 +358,9 @@ describe("getDefaultConfiguration", () => {
               description: "Nested list",
             },
           },
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -361,10 +377,15 @@ describe("getDefaultConfiguration", () => {
 
     describe("string configurations", () => {
       it("should set defaults for string configurations when available", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [
+          requiredStrings: [
             {
               key: "api_key",
               description: "API Key",
@@ -377,13 +398,13 @@ describe("getDefaultConfiguration", () => {
             },
             { key: "user_name", description: "User Name" }, // no default
           ],
-          numberConfigurations: [],
-          booleanConfigurations: [],
-          enumConfigurations: {},
-          listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiredNumbers: [],
+          requiredBooleans: [],
+          requiredEnums: {},
+          requiredLists: {},
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -399,21 +420,26 @@ describe("getDefaultConfiguration", () => {
 
     describe("number configurations", () => {
       it("should set defaults for number configurations when available", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [],
-          numberConfigurations: [
+          requiredStrings: [],
+          requiredNumbers: [
             { key: "timeout", description: "Timeout in seconds", default: 30 },
             { key: "max_retries", description: "Maximum retries", default: 3 },
             { key: "port", description: "Port number" }, // no default
           ],
-          booleanConfigurations: [],
-          enumConfigurations: {},
-          listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiredBooleans: [],
+          requiredEnums: {},
+          requiredLists: {},
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -429,19 +455,22 @@ describe("getDefaultConfiguration", () => {
 
     describe("mixed configurations", () => {
       it("should handle all configuration types together", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [
+          requiredStrings: [
             { key: "api_key", description: "API Key", default: "secret-key" },
           ],
-          numberConfigurations: [
+          requiredNumbers: [
             { key: "timeout", description: "Timeout", default: 30 },
           ],
-          booleanConfigurations: [
-            { key: "is_enabled", description: "Enabled" },
-          ],
-          enumConfigurations: {
+          requiredBooleans: [{ key: "is_enabled", description: "Enabled" }],
+          requiredEnums: {
             priority: {
               options: [
                 { value: "low", label: "Low" },
@@ -451,15 +480,15 @@ describe("getDefaultConfiguration", () => {
               description: "Priority",
             },
           },
-          listConfigurations: {
+          requiredLists: {
             tags: {
               options: [{ value: "tag1", label: "Tag 1" }],
               description: "Tags",
             },
           },
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -477,10 +506,15 @@ describe("getDefaultConfiguration", () => {
 
     describe("comprehensive default handling", () => {
       it("should handle mixed types with nested paths and explicit defaults", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [
+          requiredStrings: [
             { key: "api.key", description: "API Key", default: "dev-key-123" },
             { key: "api.endpoint", description: "API Endpoint" }, // no default
             {
@@ -489,12 +523,12 @@ describe("getDefaultConfiguration", () => {
               default: "mongodb://localhost:27017",
             },
           ],
-          numberConfigurations: [
+          requiredNumbers: [
             { key: "api.timeout", description: "API Timeout", default: 5000 },
             { key: "database.pool.max", description: "Max Pool Size" }, // no default
             { key: "server.port", description: "Server Port", default: 3000 },
           ],
-          booleanConfigurations: [
+          requiredBooleans: [
             {
               key: "features.auth.enabled",
               description: "Auth enabled",
@@ -502,7 +536,7 @@ describe("getDefaultConfiguration", () => {
             },
             { key: "features.logging.debug", description: "Debug logging" }, // no default (will use false)
           ],
-          enumConfigurations: {
+          requiredEnums: {
             "logging.level": {
               options: [
                 { value: "debug", label: "Debug" },
@@ -522,7 +556,7 @@ describe("getDefaultConfiguration", () => {
               description: "Environment", // no default (will use first)
             },
           },
-          listConfigurations: {
+          requiredLists: {
             "features.experimental": {
               options: [
                 { value: "feature1", label: "Feature 1" },
@@ -539,9 +573,9 @@ describe("getDefaultConfiguration", () => {
               description: "Allowed origins", // no default (will use empty array)
             },
           },
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -583,15 +617,20 @@ describe("getDefaultConfiguration", () => {
 
     describe("nested path handling", () => {
       it("should handle deeply nested configuration paths", () => {
-        mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mockGetMCPServerRequirements.mockReturnValue({
+          requiresDataSourceConfiguration: false,
+          requiresDataWarehouseConfiguration: false,
+          requiresTableConfiguration: false,
+          requiresChildAgentConfiguration: false,
+          requiresReasoningConfiguration: false,
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
-          stringConfigurations: [],
-          numberConfigurations: [],
-          booleanConfigurations: [
+          requiredStrings: [],
+          requiredNumbers: [],
+          requiredBooleans: [
             { key: "level1.level2.level3.deep_flag", description: "Deep flag" },
           ],
-          enumConfigurations: {
+          requiredEnums: {
             "a.b.c.d.enum": {
               options: [
                 { value: "x", label: "X" },
@@ -600,15 +639,15 @@ describe("getDefaultConfiguration", () => {
               description: "Deeply nested enum",
             },
           },
-          listConfigurations: {
+          requiredLists: {
             "config.advanced.options": {
               options: [{ value: "opt1", label: "Option 1" }],
               description: "Advanced options",
             },
           },
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
-          configurable: "optional",
+          requiresDustAppConfiguration: false,
+          requiresSecretConfiguration: false,
+          noRequirement: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -637,147 +676,6 @@ describe("getDefaultConfiguration", () => {
           },
         });
       });
-    });
-  });
-
-  describe("when toolsConfigurations is null", () => {
-    it("should return base defaults when getMCPServerToolsConfigurations returns null", () => {
-      const mockMCPServerView: MCPServerViewType = {
-        id: 1,
-        sId: "test-server-123",
-        name: "Test Server",
-        description: "Test server description",
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-        spaceId: "test-space-123",
-        serverType: "internal",
-        server: {
-          sId: "test",
-          name: "test",
-          version: "1.0.0",
-          description: "Test",
-          tools: [],
-          icon: "ActionEmotionLaughIcon",
-          authorization: null,
-          availability: "manual",
-          allowMultipleInstances: false,
-          documentationUrl: null,
-        },
-        oAuthUseCase: null,
-        editedByUser: null,
-        toolsMetadata: [],
-      };
-
-      // Simulate getMCPServerToolsConfigurations returning null somehow
-      mockGetMCPServerToolsConfigurations.mockReturnValue(null as any);
-
-      const result = getDefaultConfiguration(mockMCPServerView);
-
-      expect(result).toEqual({
-        mcpServerViewId: "test-server-123",
-        dataSourceConfigurations: null,
-        tablesConfigurations: null,
-        childAgentId: null,
-        reasoningModel: null,
-        timeFrame: null,
-        additionalConfiguration: {},
-        dustAppConfiguration: null,
-        jsonSchema: null,
-        _jsonSchemaString: null,
-        secretName: null,
-      });
-    });
-  });
-});
-
-describe("Analysis: Why strings and numbers don't get defaults", () => {
-  describe("Historical reasoning investigation - RESOLVED", () => {
-    it("should demonstrate that the fix provides better UX while maintaining validation", () => {
-      // This test shows how the fix improves UX while keeping validation intact
-
-      const mockMCPServerView: MCPServerViewType = {
-        id: 1,
-        sId: "test-server",
-        name: "Test Server",
-        description: "Test server description",
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-        spaceId: "test-space-123",
-        serverType: "internal",
-        server: {
-          sId: "test",
-          name: "test",
-          version: "1.0.0",
-          description: "Test",
-          tools: [],
-          icon: "ActionEmotionLaughIcon",
-          authorization: null,
-          availability: "manual",
-          allowMultipleInstances: false,
-          documentationUrl: null,
-        },
-        oAuthUseCase: null,
-        editedByUser: null,
-        toolsMetadata: [],
-      };
-
-      mockGetMCPServerToolsConfigurations.mockReturnValue({
-        mayRequireTimeFrameConfiguration: false,
-        mayRequireJsonSchemaConfiguration: false,
-        stringConfigurations: [
-          { key: "required_field", description: "Required field" }, // no default
-          {
-            key: "optional_field",
-            description: "Optional field",
-            default: "default_value",
-          },
-        ],
-        numberConfigurations: [
-          { key: "required_number", description: "Required number" }, // no default
-          {
-            key: "optional_number",
-            description: "Optional number",
-            default: 42,
-          },
-        ],
-        booleanConfigurations: [],
-        enumConfigurations: {},
-        listConfigurations: {},
-        mayRequireDustAppConfiguration: false,
-        mayRequireSecretConfiguration: false,
-        configurable: "optional",
-      });
-
-      const result = getDefaultConfiguration(mockMCPServerView);
-
-      // Fixed behavior: fields with defaults are pre-filled, fields without defaults remain empty
-      expect(result.additionalConfiguration).toEqual({
-        optional_field: "default_value", // ✅ Default applied - better UX
-        optional_number: 42, // ✅ Default applied - better UX
-        // required_field: missing - will trigger validation if required ✅
-        // required_number: missing - will trigger validation if required ✅
-      });
-
-      // The fix provides:
-      // ✅ Better UX: Users see helpful defaults immediately
-      // ✅ Validation still works: Required fields without defaults trigger validation
-      // ✅ User choice: Defaults can be overridden if needed
-      // ✅ Modern behavior: Forms pre-populate sensible defaults
-    });
-  });
-
-  describe("Current validation behavior", () => {
-    it("should show that validation still works with defaults present", () => {
-      // This test would verify that having defaults doesn't prevent validation
-      // from working properly. Validation should still catch:
-      // - Invalid values (wrong type, out of range, etc.)
-      // - Missing required fields that don't have defaults
-      // - Schema violations
-
-      // The presence of a default value doesn't break validation,
-      // it just provides a starting point for the user
-
-      expect(true).toBe(true); // Placeholder - would need actual validation tests
     });
   });
 });

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -4,7 +4,7 @@ import type {
   AdditionalConfigurationInBuilderType,
   MCPServerConfigurationType,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
 /**
@@ -15,10 +15,6 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 export function getDefaultConfiguration(
   mcpServerView?: MCPServerViewType | null
 ): MCPServerConfigurationType {
-  const toolsConfigurations = mcpServerView
-    ? getMCPServerToolsConfigurations(mcpServerView)
-    : null;
-
   const defaults: MCPServerConfigurationType = {
     mcpServerViewId: mcpServerView?.sId ?? "not-a-valid-sId",
     dataSourceConfigurations: null,
@@ -33,9 +29,17 @@ export function getDefaultConfiguration(
     secretName: null,
   };
 
-  if (!toolsConfigurations) {
+  if (!mcpServerView) {
     return defaults;
   }
+
+  const {
+    requiredLists,
+    requiredEnums,
+    requiredBooleans,
+    requiredStrings,
+    requiredNumbers,
+  } = getMCPServerRequirements(mcpServerView);
 
   const additionalConfig: AdditionalConfigurationInBuilderType = {};
 
@@ -44,10 +48,7 @@ export function getDefaultConfiguration(
   // validation to catch truly missing required fields
 
   // Boolean configurations: use explicit default or fallback to false
-  for (const {
-    key,
-    default: defaultValue,
-  } of toolsConfigurations.booleanConfigurations) {
+  for (const { key, default: defaultValue } of requiredBooleans) {
     set(
       additionalConfig,
       key,
@@ -56,21 +57,18 @@ export function getDefaultConfiguration(
     );
   }
 
-  // Enum configurations: use explicit default or fallback to first option
-  for (const [
-    key,
-    { options: enumOptions, default: defaultValue },
-  ] of Object.entries(toolsConfigurations.enumConfigurations)) {
+  for (const [key, { options, default: defaultValue }] of Object.entries(
+    requiredEnums
+  )) {
     if (defaultValue !== undefined) {
       set(additionalConfig, key, defaultValue);
-    } else if (enumOptions.length > 0) {
-      set(additionalConfig, key, enumOptions[0].value);
+    } else if (options.length > 0) {
+      set(additionalConfig, key, options[0].value);
     }
   }
 
-  // List configurations: use explicit default or fallback to empty array
   for (const [key, { default: defaultValue }] of Object.entries(
-    toolsConfigurations.listConfigurations
+    requiredLists
   )) {
     set(
       additionalConfig,
@@ -79,21 +77,13 @@ export function getDefaultConfiguration(
     );
   }
 
-  // String configurations: set defaults when available
-  for (const {
-    key,
-    default: defaultValue,
-  } of toolsConfigurations.stringConfigurations) {
+  for (const { key, default: defaultValue } of requiredStrings) {
     if (defaultValue !== undefined) {
       set(additionalConfig, key, defaultValue);
     }
   }
 
-  // Number configurations: set defaults when available
-  for (const {
-    key,
-    default: defaultValue,
-  } of toolsConfigurations.numberConfigurations) {
+  for (const { key, default: defaultValue } of requiredNumbers) {
     if (defaultValue !== undefined) {
       set(additionalConfig, key, defaultValue);
     }
@@ -110,12 +100,9 @@ export function getDefaultConfiguration(
  * @returns Default form data object
  */
 export function getDefaultFormValues(mcpServerView: MCPServerViewType | null) {
-  const config = getDefaultConfiguration(mcpServerView);
-  const result = {
+  return {
     name: "",
     description: "",
-    configuration: config,
+    configuration: getDefaultConfiguration(mcpServerView),
   };
-
-  return result;
 }

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -43,18 +43,8 @@ export function getDefaultConfiguration(
 
   const additionalConfig: AdditionalConfigurationInBuilderType = {};
 
-  // Set default values for all configuration types when available
-  // This provides better UX by pre-filling known defaults while still allowing
-  // validation to catch truly missing required fields
-
-  // Boolean configurations: use explicit default or fallback to false
   for (const { key, default: defaultValue } of requiredBooleans) {
-    set(
-      additionalConfig,
-      key,
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      defaultValue !== undefined ? defaultValue : false
-    );
+    set(additionalConfig, key, defaultValue ?? false);
   }
 
   for (const [key, { options, default: defaultValue }] of Object.entries(

--- a/front/components/agent_builder/capabilities/mcp/utils/formValidation.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formValidation.ts
@@ -1,6 +1,6 @@
 import { createMCPFormSchema } from "@app/components/agent_builder/capabilities/mcp/validation/schemaBuilders";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
 /**
@@ -13,11 +13,11 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 export function getMCPConfigurationFormSchema(
   mcpServerView: MCPServerViewType | null | undefined
 ) {
-  const toolsConfigurations = mcpServerView
-    ? getMCPServerToolsConfigurations(mcpServerView)
+  const requirements = mcpServerView
+    ? getMCPServerRequirements(mcpServerView)
     : null;
 
-  return createMCPFormSchema(toolsConfigurations);
+  return createMCPFormSchema(requirements);
 }
 
 /**
@@ -31,9 +31,9 @@ export function validateMCPActionConfiguration(
   serverView: MCPServerViewType
 ): { isValid: boolean; errorMessage?: string } {
   try {
-    const toolsConfigurations = getMCPServerToolsConfigurations(serverView);
+    const { noRequirement } = getMCPServerRequirements(serverView);
 
-    if (toolsConfigurations.configurable === "no") {
+    if (noRequirement) {
       return { isValid: true };
     }
 

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -9,7 +9,7 @@ import { getDefaultConfiguration } from "@app/components/agent_builder/capabilit
 import { dataSourceBuilderTreeType } from "@app/components/data_source_view/context/types";
 import { DEFAULT_MCP_ACTION_NAME } from "@app/lib/actions/constants";
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { WhitelistableFeature } from "@app/types";
@@ -125,16 +125,13 @@ export const capabilityFormSchema = z
     configuration: mcpServerConfigurationSchema,
   })
   .superRefine((val, ctx) => {
-    const toolsConfigurations = getMCPServerToolsConfigurations(
-      val.mcpServerView
-    );
+    const {
+      mayRequireTimeFrameConfiguration,
+      mayRequireJsonSchemaConfiguration,
+    } = getMCPServerRequirements(val.mcpServerView);
     const configuration = val.configuration;
 
-    if (!toolsConfigurations) {
-      return true;
-    }
-
-    if (toolsConfigurations.mayRequireTimeFrameConfiguration) {
+    if (mayRequireTimeFrameConfiguration) {
       if (
         configuration.timeFrame !== null &&
         (configuration.timeFrame.duration === null ||
@@ -150,7 +147,7 @@ export const capabilityFormSchema = z
     }
 
     if (
-      toolsConfigurations.mayRequireJsonSchemaConfiguration &&
+      mayRequireJsonSchemaConfiguration &&
       configuration._jsonSchemaString !== null
     ) {
       const parsedSchema = validateConfiguredJsonSchema(
@@ -172,7 +169,12 @@ export const capabilityFormSchema = z
 export function getDefaultMCPAction(
   mcpServerView?: MCPServerViewType
 ): AgentBuilderAction {
-  const toolsConfigurations = getMCPServerToolsConfigurations(mcpServerView);
+  const {
+    requiresDataSourceConfiguration,
+    requiresDataWarehouseConfiguration,
+    requiresTableConfiguration,
+    noRequirement,
+  } = getMCPServerRequirements(mcpServerView);
   const configuration = getDefaultConfiguration(mcpServerView);
   const rawName = mcpServerView?.name ?? mcpServerView?.server.name ?? "";
   const sanitizedName = rawName ? nameToStorageFormat(rawName) : "";
@@ -184,15 +186,15 @@ export function getDefaultMCPAction(
     // Ensure default name always matches validation regex (^[a-z0-9_]+$)
     name: sanitizedName,
     description:
-      toolsConfigurations.dataSourceConfiguration ??
-      toolsConfigurations.dataWarehouseConfiguration ??
-      toolsConfigurations.tableConfiguration ??
-      false
+      requiresDataSourceConfiguration ||
+      requiresDataWarehouseConfiguration ||
+      requiresTableConfiguration
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    configurable: toolsConfigurations.configurable !== "no",
+    // TODO(2025-10-10 aubin): rename back to noConfigurationRequired.
+    configurable: noRequirement,
   };
 }
 

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -194,7 +194,7 @@ export function getDefaultMCPAction(
           ? getMcpServerViewDescription(mcpServerView)
           : "",
     // TODO(2025-10-10 aubin): rename back to noConfigurationRequired.
-    configurable: noRequirement,
+    configurable: !noRequirement,
   };
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -9,7 +9,7 @@ import {
   DEFAULT_DATA_VISUALIZATION_NAME,
 } from "@app/lib/actions/constants";
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { AdditionalConfigurationType } from "@app/lib/models/assistant/actions/mcp";
 import type {
@@ -112,7 +112,7 @@ export function getDataVisualizationConfiguration(): AssistantBuilderDataVisuali
 export function getDefaultMCPServerActionConfiguration(
   mcpServerView?: MCPServerViewType
 ): AssistantBuilderMCPConfiguration {
-  const toolsConfigurations = getMCPServerToolsConfigurations(mcpServerView);
+  const requirements = getMCPServerRequirements(mcpServerView);
 
   return {
     type: "MCP",
@@ -131,15 +131,15 @@ export function getDefaultMCPServerActionConfiguration(
     },
     name: mcpServerView?.name ?? mcpServerView?.server.name ?? "",
     description:
-      toolsConfigurations.dataSourceConfiguration ??
-      toolsConfigurations.dataWarehouseConfiguration ??
-      toolsConfigurations.tableConfiguration ??
-      false
+      requirements.requiresDataSourceConfiguration ||
+      requirements.requiresDataWarehouseConfiguration ||
+      requirements.requiresTableConfiguration
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    configurable: toolsConfigurations.configurable !== "no",
+    // TODO(2025-10-10 aubin): rename back to noConfigurationRequired.
+    configurable: !requirements.noRequirement,
   };
 }
 

--- a/front/hooks/useAgentBuilderTools.ts
+++ b/front/hooks/useAgentBuilderTools.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
 function getGroupedMCPServerViews({
@@ -54,7 +54,7 @@ function getGroupedMCPServerViews({
 
   const { mcpServerViewsWithKnowledge, mcpServerViewsWithoutKnowledge } =
     groupBy(mcpServerViewsWithLabel, (view) => {
-      const toolsConfigurations = getMCPServerToolsConfigurations(view);
+      const toolsConfigurations = getMCPServerRequirements(view);
 
       const isWithKnowledge =
         toolsConfigurations.dataSourceConfiguration ??

--- a/front/hooks/useAgentBuilderTools.ts
+++ b/front/hooks/useAgentBuilderTools.ts
@@ -54,12 +54,16 @@ function getGroupedMCPServerViews({
 
   const { mcpServerViewsWithKnowledge, mcpServerViewsWithoutKnowledge } =
     groupBy(mcpServerViewsWithLabel, (view) => {
-      const toolsConfigurations = getMCPServerRequirements(view);
+      const {
+        requiresDataSourceConfiguration,
+        requiresDataWarehouseConfiguration,
+        requiresTableConfiguration,
+      } = getMCPServerRequirements(view);
 
       const isWithKnowledge =
-        toolsConfigurations.dataSourceConfiguration ??
-        toolsConfigurations.dataWarehouseConfiguration ??
-        toolsConfigurations.tableConfiguration ??
+        requiresDataSourceConfiguration ??
+        requiresDataWarehouseConfiguration ??
+        requiresTableConfiguration ??
         false;
 
       return isWithKnowledge

--- a/front/hooks/useAgentBuilderTools.ts
+++ b/front/hooks/useAgentBuilderTools.ts
@@ -61,10 +61,9 @@ function getGroupedMCPServerViews({
       } = getMCPServerRequirements(view);
 
       const isWithKnowledge =
-        requiresDataSourceConfiguration ??
-        requiresDataWarehouseConfiguration ??
-        requiresTableConfiguration ??
-        false;
+        requiresDataSourceConfiguration ||
+        requiresDataWarehouseConfiguration ||
+        requiresTableConfiguration;
 
       return isWithKnowledge
         ? "mcpServerViewsWithKnowledge"

--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -159,8 +159,8 @@ describe("augmentInputsWithConfiguration", () => {
         dataSources: [
           {
             workspaceId: mockWorkspace.sId,
-            sId: "ds-123",
-            dataSourceViewId: "view-123",
+            sId: "dsc_123",
+            dataSourceViewId: "view_123",
             filter: {
               tags: { in: ["test"], not: [], mode: "auto" },
               parents: { in: [], not: [] },
@@ -188,7 +188,7 @@ describe("augmentInputsWithConfiguration", () => {
       expect(result).toEqual({
         dataSource: [
           {
-            uri: `data_source_configuration://dust/w/${mockWorkspace.sId}/data_source_configurations/ds-123`,
+            uri: `data_source_configuration://dust/w/${mockWorkspace.sId}/data_source_configurations/dsc_123`,
             mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
           },
         ],
@@ -202,7 +202,7 @@ describe("augmentInputsWithConfiguration", () => {
           {
             workspaceId: mockWorkspace.sId,
             sId: undefined,
-            dataSourceViewId: "view-123",
+            dataSourceViewId: "view_123",
             filter: {
               tags: { in: ["test"], not: [], mode: "auto" },
               parents: { in: [], not: [] },
@@ -236,7 +236,7 @@ describe("augmentInputsWithConfiguration", () => {
       expect(result).toEqual({
         dataSource: [
           {
-            uri: `data_source_configuration://dust/w/${mockWorkspace.sId}/data_source_views/view-123/filter/${expectedFilter}`,
+            uri: `data_source_configuration://dust/w/${mockWorkspace.sId}/data_source_views/view_123/filter/${expectedFilter}`,
             mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
           },
         ],
@@ -252,7 +252,7 @@ describe("augmentInputsWithConfiguration", () => {
           {
             workspaceId: mockWorkspace.sId,
             sId: "table-123",
-            dataSourceViewId: "view-123",
+            dataSourceViewId: "view_123",
             tableId: "table-id-123",
           },
         ],
@@ -1370,8 +1370,8 @@ describe("nested objects and complex schemas", () => {
       dataSources: [
         {
           workspaceId: mockWorkspace.sId,
-          sId: "ds-123",
-          dataSourceViewId: "view-123",
+          sId: "dsc_123",
+          dataSourceViewId: "view_123",
           filter: {
             tags: { in: ["test"], not: [], mode: "auto" },
             parents: { in: [], not: [] },
@@ -1415,7 +1415,7 @@ describe("nested objects and complex schemas", () => {
       },
       dataSource: [
         {
-          uri: `data_source_configuration://dust/w/${mockWorkspace.sId}/data_source_configurations/ds-123`,
+          uri: `data_source_configuration://dust/w/${mockWorkspace.sId}/data_source_configurations/dsc_123`,
           mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
         },
       ],

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -469,6 +469,23 @@ export function augmentInputsWithConfiguration({
   return inputs;
 }
 
+function extractSchemaDefault<T>(
+  schema: JSONSchema,
+  typeGuard: (value: unknown) => value is T
+): T | undefined {
+  // Try object-level default first: { value: T, mimeType: "..." }
+  if (
+    schema.default &&
+    typeof schema.default === "object" &&
+    "value" in schema.default &&
+    typeGuard(schema.default.value)
+  ) {
+    return schema.default.value;
+  }
+
+  return undefined;
+}
+
 export interface MCPServerRequirements {
   requiresDataSourceConfiguration: boolean;
   requiresDataWarehouseConfiguration: boolean;
@@ -539,23 +556,6 @@ export function getMCPServerRequirements(
     };
   }
   const { server } = mcpServerView;
-
-  function extractSchemaDefault<T>(
-    schema: JSONSchema,
-    typeGuard: (value: unknown) => value is T
-  ): T | undefined {
-    // Try object-level default first: { value: T, mimeType: "..." }
-    if (
-      schema.default &&
-      typeof schema.default === "object" &&
-      "value" in schema.default &&
-      typeGuard(schema.default.value)
-    ) {
-      return schema.default.value;
-    }
-
-    return undefined;
-  }
 
   const requiresDataSourceConfiguration =
     Object.keys(

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -820,13 +820,15 @@ export function getMCPServerRequirements(
       !requiresTableConfiguration &&
       !requiresChildAgentConfiguration &&
       !requiresReasoningConfiguration &&
-      !requiresDustAppConfiguration &&
       !mayRequireTimeFrameConfiguration &&
+      !mayRequireJsonSchemaConfiguration &&
       !requiredStrings.some((c) => c.default === undefined) &&
       !requiredNumbers.some((c) => c.default === undefined) &&
       !requiredBooleans.some((c) => c.default === undefined) &&
       !Object.values(requiredEnums).some((c) => c.default === undefined) &&
-      !Object.values(requiredLists).some((c) => c.default === undefined),
+      !Object.values(requiredLists).some((c) => c.default === undefined) &&
+      !requiresDustAppConfiguration &&
+      !requiresSecretConfiguration,
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -1047,11 +1047,7 @@ function recursiveInlineAllRefs(
   return outputSchema;
 }
 
-/**
- * Inlines all references in a schema.
- * @param schema The schema to inline references in.
- * @returns The schema with all references inlined.
- */
-export function inlineAllRefs(schema: JSONSchema): JSONSchema {
+// TODO(2025-10-10 aubin): remove this.
+function inlineAllRefs(schema: JSONSchema): JSONSchema {
   return recursiveInlineAllRefs(schema, schema);
 }

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -273,7 +273,7 @@ function generateConfiguredInput({
           }
         }
       }
-      if (!Array.isArray(values) || values.some((v) => isString(v))) {
+      if (!Array.isArray(values) || values.some((v) => !isString(v))) {
         throw new Error(
           `Expected array of string values for key ${keyPath}, got ${typeof values}`
         );

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -5,7 +5,7 @@ import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
 } from "@app/lib/actions/mcp_helper";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -66,8 +66,7 @@ const createServer = (
           )
           .filter(
             (mcpServerView) =>
-              getMCPServerToolsConfigurations(mcpServerView).configurable !==
-              "required"
+              getMCPServerRequirements(mcpServerView).noRequirement
           )
           .filter(
             (mcpServerView) =>

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -20,7 +20,7 @@ import type {
   ToolEarlyExitEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { AgentMCPActionOutputItem } from "@app/lib/models/assistant/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -238,6 +238,6 @@ export function isJITMCPServerView(view: MCPServerViewType): boolean {
   return (
     !isInternalMCPServerOfName(view.server.sId, AGENT_MEMORY_SERVER_NAME) &&
     // Only tools that do not require any configuration can be enabled directly in a conversation.
-    getMCPServerToolsConfigurations(view).configurable !== "required"
+    getMCPServerRequirements(view).noRequirement
   );
 }


### PR DESCRIPTION
## Description

- We used to describe MCP server configuration requirements with booleans: `requiresDataSourceConfiguration`, `requiresTablesConfiguration`, ...
- This type was changed into a much more complex type in https://github.com/dust-tt/dust/pull/15826 and https://github.com/dust-tt/dust/pull/16032 for a use case we don't have anymore.
- This PR brings back the previous name and type.
- Some tests are also removed: `when toolsConfigurations is null` (cannot be null as per the type, the test actually relies on a typecast as any to pass the typecheck) and `Analysis: Why strings and numbers don't get defaults`, which clearly brings no value and clutters the tests.

## Tests

- Checked locally.
- Somewhat good test coverage here.

## Risk

- Medium

## Deploy Plan

- Deploy front.
