### PR TITLE
[front] chore(run_agent): remove `conversationId` parameter

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -239,15 +239,6 @@ export default async function createServer(
         )
         .optional()
         .nullable(),
-      conversationId: z
-        .string()
-        .describe(
-          "The conversation id where the sub-agent will run. " +
-            "Can be used to continue an existing conversation of the sub-agent. " +
-            "Cannot be the same as the main conversation."
-        )
-        .optional()
-        .nullable(),
       ...configurableProperties,
     },
     withToolLogging(
@@ -260,7 +251,6 @@ export default async function createServer(
           executionMode,
           toolsetsToAdd,
           fileOrContentFragmentIds,
-          conversationId,
         },
         { sendNotification, _meta }
       ) => {
@@ -275,14 +265,6 @@ export default async function createServer(
           agentConfiguration: mainAgent,
           conversation: mainConversation,
         } = agentLoopContext.runContext;
-
-        if (conversationId === mainConversation.sId) {
-          return new Err(
-            new MCPError(
-              "Conversation id cannot be the same as the main conversation."
-            )
-          );
-        }
 
         const childAgentIdRes = parseAgentConfigurationUri(uri);
         if (childAgentIdRes.isErr()) {
@@ -358,9 +340,7 @@ ${query}`
               : query,
             toolsetsToAdd: toolsetsToAdd ?? null,
             fileOrContentFragmentIds: fileOrContentFragmentIds ?? null,
-            conversationId: isHandoff
-              ? mainConversation.sId
-              : conversationId ?? null,
+            conversationId: isHandoff ? mainConversation.sId : null,
             originMessage: agentLoopContext.runContext.agentMessage,
           }
         );


### PR DESCRIPTION
## Description

- This PR removes the `conversationId` parameter for the `run_agent` tool.
- This parameter was introduced on the demand of one customer before we had the handoff.
- Confirmed with this customer that the handoff superseded this parameter cf https://dust4ai.slack.com/archives/C07EEJQT0RX/p1760021615139279.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
