### PR TITLE
[front] fix: fix `run_dust_app` tool name used for monitoring

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -15,6 +15,9 @@ import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+// We use a single tool name for monitoring given the high granularity (can be revisited).
+const GOOGLE_CALENDAR_TOOL_NAME = "google_calendar";
+
 interface GoogleCalendarEventDateTime {
   date?: string;
   dateTime?: string;
@@ -121,7 +124,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_calendar", agentLoopContext },
+      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
       async ({ pageToken, maxResults }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -179,7 +182,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_calendar", agentLoopContext },
+      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
       async (
         { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
         { authInfo }
@@ -259,7 +262,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_calendar", agentLoopContext },
+      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -318,7 +321,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_calendar", agentLoopContext },
+      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
       async (
         {
           calendarId = "primary",
@@ -417,7 +420,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_calendar", agentLoopContext },
+      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
       async (
         {
           calendarId = "primary",
@@ -509,7 +512,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_calendar", agentLoopContext },
+      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -561,7 +564,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_calendar", agentLoopContext },
+      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
       async ({ email, startTime, endTime, timeZone }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -27,7 +27,7 @@ const createServer = (
       {},
       withToolLogging(
         auth,
-        { toolNameForMonitoring: actionName, agentLoopContext },
+        { toolNameForMonitoring: "tool_not_found", agentLoopContext },
         async () => {
           return new Err(
             new MCPError(

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -71,6 +71,9 @@ const allowedColors = [
   "red_background",
 ] as const;
 
+// We use a single tool name for monitoring given the high granularity (can be revisited).
+const NOTION_TOOL_NAME = "notion";
+
 const titleRichTextSchema = z
   .object({
     type: z.literal("text"),
@@ -313,7 +316,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ query, type, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(new MCPError("Agent loop run context is required"));
@@ -470,7 +473,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ pageId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.retrieve({ page_id: pageId }),
@@ -488,7 +491,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ databaseId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.databases.retrieve({ database_id: databaseId }),
@@ -513,7 +516,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
         { authInfo }
@@ -548,7 +551,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
         { authInfo }
@@ -581,7 +584,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ parent, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.create({ parent, properties, icon, cover }),
@@ -602,7 +605,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ databaseId, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -636,7 +639,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ parent, title, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -656,7 +659,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.update({ page_id: pageId, properties }),
@@ -674,7 +677,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.blocks.retrieve({ block_id: blockId }),
@@ -697,7 +700,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ blockId, start_cursor, page_size }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -725,7 +728,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ blockId, children }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -760,7 +763,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ parent_page_id, discussion_id, comment }, { authInfo }) => {
         return withNotionClient((notion) => {
           if (!parent_page_id && !discussion_id) {
@@ -796,7 +799,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -817,7 +820,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.comments.list({ block_id: blockId }),
@@ -836,7 +839,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.update({ page_id: pageId, properties }),
@@ -855,7 +858,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ databaseId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -872,7 +875,7 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async (_, { authInfo }) => {
         return withNotionClient((notion) => notion.users.list({}), authInfo);
       }
@@ -887,7 +890,7 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "notion" },
+      { toolNameForMonitoring: NOTION_TOOL_NAME },
       async ({ userId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.users.retrieve({ user_id: userId }),

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -371,7 +371,7 @@ export default async function createServer(
       convertDatasetSchemaToZodRawShape(schema),
       withToolLogging(
         auth,
-        { toolNameForMonitoring: app.name, agentLoopContext },
+        { toolNameForMonitoring: "run_dust_app", agentLoopContext },
         async () => {
           return new Ok([
             {
@@ -404,7 +404,7 @@ export default async function createServer(
       convertDatasetSchemaToZodRawShape(schema),
       withToolLogging(
         auth,
-        { toolNameForMonitoring: app.name, agentLoopContext },
+        { toolNameForMonitoring: "run_dust_app", agentLoopContext },
         async (params) => {
           const content: (
             | TextContent


### PR DESCRIPTION
## Description

- This PR also fixes the name used for logging when running a Dust app (currently it's the Dust app name so changes with the dust app).
- This PR centralizes certain tool names used for logging in `withToolLogging`.

## Tests

## Risk

## Deploy Plan

- Deploy front.
