### PR TITLE
Throw nonretriable errors

### DIFF
--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -42,6 +42,8 @@ import {
 import { Err } from "@app/types";
 import { CoreAPI } from "@app/types";
 
+class TranscriptNonRetryableError extends Error {}
+
 export async function retrieveNewTranscriptsActivity(
   transcriptsConfigurationId: string
 ): Promise<string[]> {
@@ -71,7 +73,7 @@ export async function retrieveNewTranscriptsActivity(
 
   if (!workspace) {
     await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-    throw new Error(
+    throw new TranscriptNonRetryableError(
       `Could not find workspace for user (workspaceId: ${transcriptsConfiguration.workspaceId}).`
     );
   }
@@ -81,8 +83,9 @@ export async function retrieveNewTranscriptsActivity(
   );
   if (!user) {
     await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-    localLogger.error({}, "[retrieveNewTranscripts] User not found. Stopping.");
-    return [];
+    throw new TranscriptNonRetryableError(
+      `Could not find user for id ${transcriptsConfiguration.userId}.`
+    );
   }
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
     user.sId,
@@ -91,11 +94,9 @@ export async function retrieveNewTranscriptsActivity(
 
   if (!auth.workspace()) {
     await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-    localLogger.error(
-      {},
-      "[retrieveNewTranscripts] Workspace not found. Stopping."
+    throw new TranscriptNonRetryableError(
+      `Workspace not found for user (workspaceId: ${transcriptsConfiguration.workspaceId}).`
     );
-    return [];
   }
 
   const transcriptsIdsToProcess: string[] = [];
@@ -109,8 +110,9 @@ export async function retrieveNewTranscriptsActivity(
       );
       if (googleTranscriptsRes.isErr()) {
         await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-        await transcriptsConfiguration.setIsActive(false);
-        throw googleTranscriptsRes.error;
+        throw new TranscriptNonRetryableError(
+          `Error retrieving Google transcripts: ${googleTranscriptsRes.error.message}`
+        );
       }
       const googleTranscriptsIds = googleTranscriptsRes.value;
       transcriptsIdsToProcess.push(...googleTranscriptsIds);
@@ -216,7 +218,7 @@ export async function processTranscriptActivity(
 
   if (!workspace) {
     await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-    throw new Error(
+    throw new TranscriptNonRetryableError(
       `Could not find workspace for user (workspaceId: ${transcriptsConfiguration.workspaceId}).`
     );
   }
@@ -227,7 +229,7 @@ export async function processTranscriptActivity(
 
   if (!user) {
     await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-    throw new Error(
+    throw new TranscriptNonRetryableError(
       `Could not find user for id ${transcriptsConfiguration.userId}.`
     );
   }
@@ -239,14 +241,14 @@ export async function processTranscriptActivity(
   const owner = auth.workspace();
   if (!owner) {
     await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-    throw new Error(
+    throw new TranscriptNonRetryableError(
       `Could not find workspace for user (workspaceId: ${transcriptsConfiguration.workspaceId}).`
     );
   }
 
   if (!auth.user() || !auth.isUser()) {
     await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-    throw new Error(
+    throw new TranscriptNonRetryableError(
       `Could not find user for id ${transcriptsConfiguration.userId}.`
     );
   }

--- a/front/temporal/labs/transcripts/workflows.ts
+++ b/front/temporal/labs/transcripts/workflows.ts
@@ -14,6 +14,9 @@ const TEMPORAL_WORKFLOW_MAX_HISTORY_SIZE_MB = 10;
 const { retrieveNewTranscriptsActivity, processTranscriptActivity } =
   proxyActivities<typeof activities>({
     startToCloseTimeout: "20 minutes",
+    retry: {
+      nonRetryableErrorTypes: ["TranscriptNonRetryableError"],
+    },
   });
 
 export async function retrieveNewTranscriptsWorkflow({


### PR DESCRIPTION









## Description

This change introduces proper error handling for transcript processing workflows by creating a `TranscriptNonRetryableError` class and configuring Temporal activities to not retry when these specific errors occur. Previously, activities would throw generic errors and continue retrying indefinitely for cases like missing workspaces or users, which are permanent failures that won't succeed on retry.

## Risk

Low risk change that improves workflow reliability by preventing infinite retries on permanent failures. The workflow will fail faster and more clearly when encountering configuration issues.

## Deploy Plan

No special deployment steps required - this is a code-only change that will take effect immediately upon deployment.
