### PR TITLE
Add tool output file support in frame

### DIFF
--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -63,8 +63,9 @@ export function WorkspaceInfoTable({
         return "primary";
     }
   };
+
   return (
-    <div className="flex justify-between gap-3">
+    <div className="mt-3 flex justify-between gap-3">
       <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4 pb-2">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-md flex-grow pb-4 font-bold">Workspace info</h2>

--- a/front/pages/api/v1/public/frames/[token]/files/[fileId].ts
+++ b/front/pages/api/v1/public/frames/[token]/files/[fileId].ts
@@ -134,11 +134,15 @@ async function handler(
     });
   }
 
-  // Verify the file belongs to the same conversation as the frame.
-  const sameConversation =
-    targetFile.useCase === "conversation" &&
-    targetFile.useCaseMetadata?.conversationId === frameConversationId;
-  if (!sameConversation) {
+  const { useCase, useCaseMetadata } = targetFile;
+  const isSupportedUsecase =
+    useCase === "tool_output" || useCase === "conversation";
+
+  // Verify the file has a supported usecase and belongs to the same conversation as the frame.
+  const canAccessFileThroughFrame =
+    isSupportedUsecase &&
+    useCaseMetadata?.conversationId === frameConversationId;
+  if (!canAccessFileThroughFrame) {
     return apiError(req, res, {
       status_code: 404,
       api_error: { type: "file_not_found", message: "File not found." },

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -215,7 +215,7 @@ const WorkspacePage = ({
 
       <div className="flex-col justify-center">
         <div className="flex flex-col space-y-8">
-          <div className="space-3 mt-4 flex flex-row items-stretch">
+          <div className="mt-4 flex flex-row items-stretch gap-3">
             <Tabs defaultValue="workspace" className="min-w-[512px]">
               <TabsList>
                 <TabsTrigger value="workspace" label="Workspace" />


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We want users to be able to leverage files resulting from a tool usage (e.g query table) within Frames. Today only files uploaded through the conversations were supported in Publicly accessible Frames. This PR lift this permissions to also support `tool_output` files.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
