### PR TITLE
add front-get-past-conversations tool

### DIFF
--- a/extension/platforms/front/tools/getPastConversationsTool.ts
+++ b/extension/platforms/front/tools/getPastConversationsTool.ts
@@ -1,0 +1,167 @@
+import { normalizeError } from "@app/shared/lib/utils";
+import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+// Schema for the get past conversations tool arguments.
+export const GetPastConversationsToolArgsSchema = z.object({
+  limit: z
+    .number()
+    .optional()
+    .describe("Maximum number of past conversations to return (default 5)."),
+});
+
+/**
+ * Registers the get past conversations tool with the MCP server
+ * @param server The MCP server to register the tool with
+ * @param frontContext The Front context for searching conversations
+ */
+export function registerGetPastConversationsTool(
+  server: McpServer,
+  frontContext: WebViewContext | null
+): void {
+  server.tool(
+    "front-get-past-conversations",
+    "Retrieves past conversations with the current conversation's customer. SECURITY: Only searches\n" +
+      "for conversations from the customer email in the current conversation - cannot search arbitrary\n" +
+      "email addresses. Returns conversation IDs, subjects, dates, and status. Useful for understanding\n" +
+      "conversation history with the current customer.",
+    {
+      searchParams: GetPastConversationsToolArgsSchema,
+    },
+    async ({ searchParams }) => {
+      if (!frontContext || frontContext.type !== "singleConversation") {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "Front context not available or no conversation is currently selected",
+            },
+          ],
+        };
+      }
+
+      try {
+        const { limit = 5 } = searchParams;
+
+        // Get the current conversation's messages to extract the customer email
+        const messages = await frontContext.listMessages();
+
+        if (!messages.results || messages.results.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: "No messages found in current conversation",
+              },
+            ],
+          };
+        }
+
+        // Find the first inbound message to get the customer's email
+        const inboundMessage = messages.results.find(
+          (msg) => msg.status === "inbound"
+        );
+
+        if (!inboundMessage || !inboundMessage.from) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: "Could not identify customer email from current conversation",
+              },
+            ],
+          };
+        }
+
+        // Extract the customer's email (handle property contains the email)
+        const customerEmail =
+          "handle" in inboundMessage.from
+            ? inboundMessage.from.handle
+            : null;
+
+        if (!customerEmail) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: "Could not extract customer email from current conversation",
+              },
+            ],
+          };
+        }
+
+        // SECURITY: Only search for conversations from the current customer
+        const results = await frontContext.search(`from:${customerEmail}`);
+
+        if (!results.conversations || results.conversations.length === 0) {
+          return {
+            isError: false,
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    customerEmail,
+                    totalResults: 0,
+                    conversations: [],
+                    message: "No past conversations found with this customer.",
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        // Filter out the current conversation and format results
+        const currentConversationId = frontContext.conversation.id;
+        const pastConversations = results.conversations
+          .filter((conv) => conv.id !== currentConversationId)
+          .slice(0, limit)
+          .map((conv, idx) => ({
+            index: idx + 1,
+            id: conv.id,
+            subject: conv.subject || "(No subject)",
+            date: conv.createdAt.toISOString(),
+            status: conv.status,
+          }));
+
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  customerEmail,
+                  totalResults: results.conversations.length - 1, // Exclude current
+                  showing: pastConversations.length,
+                  conversations: pastConversations,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        console.error("Error getting past conversations from Front:", error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Error getting past conversations: ${normalizeError(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+}

--- a/extension/platforms/front/tools/getPastConversationsTool.ts
+++ b/extension/platforms/front/tools/getPastConversationsTool.ts
@@ -79,9 +79,7 @@ export function registerGetPastConversationsTool(
 
         // Extract the customer's email (handle property contains the email)
         const customerEmail =
-          "handle" in inboundMessage.from
-            ? inboundMessage.from.handle
-            : null;
+          "handle" in inboundMessage.from ? inboundMessage.from.handle : null;
 
         if (!customerEmail) {
           return {

--- a/extension/platforms/front/tools/getPastConversationsTool.ts
+++ b/extension/platforms/front/tools/getPastConversationsTool.ts
@@ -93,8 +93,27 @@ export function registerGetPastConversationsTool(
           };
         }
 
+        // Validate email format to prevent injection
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(customerEmail)) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: "Invalid customer email format",
+              },
+            ],
+          };
+        }
+
+        // SECURITY: Sanitize email and wrap in quotes to prevent search injection
+        // Escape quotes and backslashes in the email address
+        const sanitizedEmail = customerEmail.replace(/["\\']/g, "\\$&");
+
         // SECURITY: Only search for conversations from the current customer
-        const results = await frontContext.search(`from:${customerEmail}`);
+        // Wrapping in quotes treats the email as a literal string
+        const results = await frontContext.search(`from:"${sanitizedEmail}"`);
 
         if (!results.conversations || results.conversations.length === 0) {
           return {

--- a/extension/platforms/front/tools/getPastConversationsTool.ts
+++ b/extension/platforms/front/tools/getPastConversationsTool.ts
@@ -139,7 +139,7 @@ export function registerGetPastConversationsTool(
           ],
         };
       } catch (error) {
-        console.error("Error getting past conversations from Front:", error);
+        logger.error({ err: normalizeError(error) }, "Error getting past conversations from Front");
         return {
           isError: true,
           content: [

--- a/extension/platforms/front/tools/index.ts
+++ b/extension/platforms/front/tools/index.ts
@@ -1,5 +1,6 @@
 import { registerEmailDraftTool } from "@app/platforms/front/tools/emailDraftTool";
 import { registerGetCurrentConversationTool } from "@app/platforms/front/tools/getCurrentConversationTool";
+import { registerGetPastConversationsTool } from "@app/platforms/front/tools/getPastConversationsTool";
 import { registerNewConversationDraftTool } from "@app/platforms/front/tools/newConversationDraftTool";
 import { registerUpdateDraftTool } from "@app/platforms/front/tools/updateDraftTool";
 import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
@@ -25,4 +26,7 @@ export function registerAllTools(
 
   // Register get current conversation id tool.
   registerGetCurrentConversationTool(server, frontContext);
+
+  // Register get past conversations tool.
+  registerGetPastConversationsTool(server, frontContext);
 }

--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -286,3 +286,15 @@ export function normalizeError(error: unknown): Error {
 
   return new Error(errorToString(error));
 }
+
+// Email validation from front/lib/utils.ts
+// from http://emailregex.com/
+const EMAIL_REGEX =
+  /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+export const isEmailValid = (email: string | null): boolean => {
+  if (!email) {
+    return false;
+  }
+  return EMAIL_REGEX.test(email);
+};


### PR DESCRIPTION
## Description

- Add tool to retrieve past conversations with the current customer
- Security: automatically extracts customer email from current conversation (cannot search arbitrary emails)

## Tests

Locally

## Deploy Plan

extension only