### PR TITLE
[front] enh(JIRA): improve reserved chars escaping

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_utils.ts
@@ -14,7 +14,7 @@ export const escapeJQLValue = (value: string): string => {
 
   // JQL reserved words that need quoting
   const isReservedWord =
-    /^(and|or|not|in|is|was|from|to|on|by|during|before|after|empty|null|order|asc|desc|changed|was|in|not|to|from|by|before|after|on|during)$/i.test(
+    /^(and|or|not|in|is|was|from|to|on|by|during|before|after|empty|null|order|asc|desc|changed)$/i.test(
       value
     );
 

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_utils.ts
@@ -9,8 +9,8 @@ import { FIELD_MAPPINGS } from "@app/lib/actions/mcp_internal_actions/servers/ji
 
 // Helper function to escape JQL values that contain spaces or special characters
 export const escapeJQLValue = (value: string): string => {
-  // JQL special characters that need quoting: space, quotes, backslash, forward slash,
-  const hasSpecialChars = /[\s"'\\/]/.test(value);
+  // JQL reserved characters per official Atlassian docs: space, +, ., ,, ;, ?, |, *, /, %, ^, $, #, @, [, ]
+  const hasSpecialChars = /[\s"'\\/@+.,;?|*%^$#[\]]/.test(value);
 
   // JQL reserved words that need quoting
   const isReservedWord =


### PR DESCRIPTION
## Description

- Some reserved JQL characters are not correctly escaped ([logs](https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40toolName%3Ajira%20%22Tool%20execution%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZncDOEvrQvlQAAAABhBWm5jRE94UUFBQURxdFBxT0Q3YjJnQUYAAAAkMDE5OWRjMGYtMDNiNi00ZmNlLWIwODgtZGRiYzkyYzg5MDY5AAXs3w&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760330054000&to_ts=1760333954000&live=false)).
- This PR updates the list of reserved characters with the one found in the [official documentation](https://confluence.atlassian.com/jirasoftwareserver/advanced-searching-939938733.html).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
