### PR TITLE
[front] chore(JIT): remove include file tool

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -27,7 +27,7 @@ export const DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION =
 
 export const DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME = "list_files";
 
-export const DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME = "include_file";
+export const DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME = "cat";
 
 export const DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME =
   "query_conversation_tables";

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -97,7 +97,7 @@ export function withToolLogging<T>(
 
         logger.error(
           {
-            error: result.error.message,
+            error: result.error,
             ...loggerArgs,
           },
           "Tool execution error"

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -97,7 +97,7 @@ export function withToolLogging<T>(
 
         logger.error(
           {
-            error: result.error,
+            error: result.error.message,
             ...loggerArgs,
           },
           "Tool execution error"

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,7 +1,7 @@
 import moment from "moment-timezone";
 
 import {
-  DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
+  DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME,
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
   DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
@@ -152,7 +152,7 @@ export async function constructPromptMultiActions(
     "Attachments may originate from the user directly or from tool outputs. " +
     "These tags indicate when the file was attached but do not always contain the full contents (it may contain a small snippet or description of the file).\n" +
     "Each file attachment has a specific content type and status (includable, queryable, searchable):\n\n" +
-    `// includable: full content can be retrieved using \`${DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME}\`\n` +
+    `// includable: content can be retrieved using \`${DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME}\`\n` +
     `// queryable: represents tabular data that can be queried alongside other queryable files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`\n` +
     `// searchable: content can be searched alongside other searchable files' content using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`\n` +
     "Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files mime types to decide which tool to use on which file.\n";


### PR DESCRIPTION
## Description

- This PR removes the JIT `conversation_files__include_file` tool.
- The meta prompt is updated to refer to the `cat` tool instead, the property in the attachments was not renamed.
- Follow up work: rename `list_files` into `list` (will soft break existing conversations but the naming is currently not really consistent).

## Tests

- Checked locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
