### PR TITLE
refactor(front): pass conversationId to the attachment

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -18,7 +18,6 @@ import {
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
-import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { classNames } from "@app/lib/utils";
@@ -36,12 +35,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
     { data, context, prevData, nextData }: MessageItemProps,
     ref
   ) {
-    const fileUploaderService = useFileUploaderService({
-      owner: context.owner,
-      useCase: "conversation",
-      useCaseMetadata: { conversationId: context.conversationId },
-    });
-
     const sId = getMessageSId(data);
 
     const sendNotification = useSendNotification();
@@ -114,7 +107,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                 owner={context.owner}
                 key={attachmentCitation.id}
                 attachmentCitation={attachmentCitation}
-                fileUploaderService={fileUploaderService}
+                conversationId={context.conversationId}
               />
             );
           })

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -16,20 +16,19 @@ import {
   isAudioContentType,
   isTextualContentType,
 } from "@app/components/assistant/conversation/attachment/utils";
-import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { LightWorkspaceType } from "@app/types";
 import { isSupportedImageContentType } from "@app/types";
 
 interface AttachmentCitationProps {
   owner: LightWorkspaceType;
   attachmentCitation: AttachmentCitation;
-  fileUploaderService: FileUploaderService;
+  conversationId: string | null;
 }
 
 export function AttachmentCitation({
   owner,
   attachmentCitation,
-  fileUploaderService,
+  conversationId,
 }: AttachmentCitationProps) {
   const [viewerOpen, setViewerOpen] = useState(false);
 
@@ -120,7 +119,7 @@ export function AttachmentCitation({
           setViewerOpen={setViewerOpen}
           viewerOpen={viewerOpen}
           attachmentCitation={attachmentCitation}
-          fileUploaderService={fileUploaderService}
+          conversationId={conversationId}
           owner={owner}
         />
       )}

--- a/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
@@ -13,7 +13,7 @@ import React, { useEffect, useMemo, useState } from "react";
 
 import type { FileAttachmentCitation } from "@app/components/assistant/conversation/attachment/types";
 import { isAudioContentType } from "@app/components/assistant/conversation/attachment/utils";
-import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
+import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import {
   getFileDownloadUrl,
   getFileViewUrl,
@@ -26,15 +26,22 @@ export const AttachmentViewer = ({
   viewerOpen,
   setViewerOpen,
   attachmentCitation,
-  fileUploaderService,
+  conversationId,
   owner,
 }: {
   viewerOpen: boolean;
   setViewerOpen: (open: boolean) => void;
   attachmentCitation: FileAttachmentCitation;
-  fileUploaderService: FileUploaderService;
+  conversationId: string | null;
   owner: LightWorkspaceType;
 }) => {
+  const fileUploaderService = useFileUploaderService({
+    owner: owner,
+    useCase: "conversation",
+    useCaseMetadata: {
+      conversationId: conversationId ?? undefined,
+    },
+  });
   const [text, setText] = useState<string | undefined>();
 
   const isAudio = isAudioContentType(attachmentCitation);

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -315,6 +315,7 @@ export const InputBar = React.memo(function InputBar({
               items: attachedNodes,
               onRemove: handleNodesAttachmentRemove,
             }}
+            conversationId={conversationId}
           />
           <InputBarContainer
             actions={actions}

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -40,12 +40,14 @@ interface InputBarAttachmentsProps {
   owner: LightWorkspaceType;
   files: FileAttachmentsProps;
   nodes?: NodeAttachmentsProps;
+  conversationId: string | null;
 }
 
 export function InputBarAttachments({
   owner,
   files,
   nodes,
+  conversationId,
 }: InputBarAttachmentsProps) {
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
@@ -87,8 +89,7 @@ export function InputBarAttachments({
           fileId: blob.id,
           onRemove: () => files.service.removeFile(blob.id),
         };
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      }) || []
+      }) ?? []
     );
   }, [files?.service]);
 
@@ -126,8 +127,7 @@ export function InputBarAttachments({
           visual,
           onRemove: () => nodes.onRemove(node),
         };
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      }) || []
+      }) ?? []
     );
   }, [nodes, spacesMap]);
 
@@ -147,7 +147,7 @@ export function InputBarAttachments({
               key={attachmentCitation.id}
               owner={owner}
               attachmentCitation={attachmentCitation}
-              fileUploaderService={files.service}
+              conversationId={conversationId}
             />
           );
         })}


### PR DESCRIPTION
## Description

Small refactoring that'll be useful in the next PR. 

As an attachment is always part of a conversation it makes more sense to pass it rather than the fileuploadservice

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
