### PR TITLE
[front] fix(logging): log error causes in tool execution errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -97,7 +97,7 @@ export function withToolLogging<T>(
 
         logger.error(
           {
-            error: result.error.message,
+            error: result.error,
             ...loggerArgs,
           },
           "Tool execution error"


### PR DESCRIPTION
## Description

- We have some logs where a cause is used but not logged (e.g. [here](https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40toolName%3Arun_agent%20%22Tool%20execution%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZncMQ3NaiQKqwAAABhBWm5jTVI5VEFBRFA1ZlBVSmZORGRBQUYAAAAkMDE5OWRjNGUtMTcxYy00MDAyLWI4MTUtZDY0OTg5YWY2NzdiAAoeTg&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760331625929&to_ts=1760346025929&live=true)).
- Causes are surfaced at a few places, to make sure we leverage them, this PR updates the `withToolLogging` wrapper to log the full error instead of only the message.

## Tests

- Checked locally, we do get the cause and the stack trace.

## Risk

- Low.

## Deploy Plan

- Deploy front.
