### PR TITLE
[front] - fix: handle missing parent messages in usage data query

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -626,7 +626,8 @@ export async function getAssistantsUsageData(
              LEFT JOIN "users" u ON um."userId" = u."id"
              JOIN "agent_configurations" ac ON a."agentConfigurationId" = ac."sId"
              JOIN "users" aut ON ac."authorId" = aut."id"
-      WHERE a."createdAt" BETWEEN :startDate AND :endDate
+      WHERE a."status" = 'succeeded'
+        AND a."createdAt" BETWEEN :startDate AND :endDate
         AND ac."workspaceId" = :wId
         AND ac."status" = 'active'
         AND ac."scope" != 'hidden'

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -621,9 +621,9 @@ export async function getAssistantsUsageData(
              MAX(CAST(ac."createdAt" AS DATE))  AS "lastEdit"
       FROM "agent_messages" a
              JOIN "messages" m ON a."id" = m."agentMessageId"
-             JOIN "messages" parent ON m."parentId" = parent."id"
-             JOIN "user_messages" um ON um."id" = parent."userMessageId"
-             JOIN "users" u ON um."userId" = u."id"
+             LEFT JOIN "messages" parent ON m."parentId" = parent."id"
+             LEFT JOIN "user_messages" um ON um."id" = parent."userMessageId"
+             LEFT JOIN "users" u ON um."userId" = u."id"
              JOIN "agent_configurations" ac ON a."agentConfigurationId" = ac."sId"
              JOIN "users" aut ON ac."authorId" = aut."id"
       WHERE a."createdAt" BETWEEN :startDate AND :endDate


### PR DESCRIPTION
## Description

This PR fixes workspace-usage API discrepancy between `assistants` and `assistant_messages` tables.

The problem was that `assistants` and `assistant_messages` tables in the workspace-usage API returned significantly different message counts for the same time period, particularly for workspaces using API-triggered conversations (e.g., via Zendesk or other integrations).

The `getAssistantsUsageData` query used INNER JOINs that require every agent message to have a complete parent chain:

```sql
FROM "agent_messages" a
JOIN "messages" m ON a."id" = m."agentMessageId"
JOIN "messages" parent ON m."parentId" = parent."id"              -- requires parent message exists
JOIN "user_messages" um ON um."id" = parent."userMessageId"      -- requires user message exists  
```

Changed `getAssistantsUsageData` to match assistant_messages behavior:
1. Replace INNER JOINs with LEFT JOINs for parent/user message relationships
2. Add `WHERE a."status" = 'succeeded'` filter

This ensures both tables count all succeeded agent messages, regardless of parent chain completeness.

**References:**
- https://github.com/dust-tt/tasks/issues/4593

## Tests

Metabase

## Risk

Touches user facing data

## Deploy Plan

- [ ] Deploy front-edge
- [ ] Deploy front