### PR TITLE
[front] icon size for JIT tools 

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -160,7 +160,7 @@ export function ToolsPicker({
                 return (
                   <DropdownMenuItem
                     key={`tools-picker-${v.sId}`}
-                    icon={() => getAvatar(v.server, "xs")}
+                    icon={() => getAvatar(v.server)}
                     label={getMcpServerViewDisplayName(v)}
                     description={getMcpServerViewDescription(v)}
                     truncateText


### PR DESCRIPTION
## Description
Fixing the icon size of JIT tools 


before: 
<img width="894" height="818" alt="CleanShot 2025-10-13 at 11 29 32@2x" src="https://github.com/user-attachments/assets/b3d4b1b1-ff51-46d8-999c-087af6c33acc" />


after:
<img width="854" height="830" alt="CleanShot 2025-10-13 at 11 30 29@2x" src="https://github.com/user-attachments/assets/2769fa40-644e-4640-b74d-aa34a9749a9a" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
