### PR TITLE
[front] enh(`run_agent`): discourage sub agent self-call

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -211,8 +211,10 @@ export default async function createServer(
     return server;
   }
 
+  const toolName = `run_${childAgentBlob.name}`;
+
   server.tool(
-    `run_${childAgentBlob.name}`,
+    toolName,
     `Run agent ${childAgentBlob.name} (${childAgentBlob.description})`,
     {
       query: z
@@ -354,6 +356,7 @@ export default async function createServer(
 You have been summoned by @${mainAgent.name}. Its instructions are: <main_agent_instructions>
 ${instructions ?? ""}
 </main_agent_instructions>
+The ${toolName} tool is not available to you, do not attempt to use it.
 ${query}`
               : query,
             toolsetsToAdd: toolsetsToAdd ?? null,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -353,10 +353,13 @@ export default async function createServer(
             mainConversation,
             query: isHandoff
               ? `
-You have been summoned by @${mainAgent.name}. Its instructions are: <main_agent_instructions>
+You are now handling this conversation and have been summoned by @${mainAgent.name}.
+The instructions of @${mainAgent.name} are:
+<main_agent_instructions>
 ${instructions ?? ""}
 </main_agent_instructions>
 The ${toolName} tool is not available to you, do not attempt to use it.
+Your goal is to answer the following query:
 ${query}`
               : query,
             toolsetsToAdd: toolsetsToAdd ?? null,


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/4570.
- We have an occurrence of a sub agent attempting to call itself, most likely because it's in handoff mode and was able to get the function call name from the conversation (see [here](https://eu.dust.tt/poke/2WJ4Akk9tx/conversations/jLcXz3X4Xa)).
- The sub agent is generally very confused as to what its responsibilities are.
- This PR attempts to improve the message sent to the sub agent.

## Tests

- Checked locally, actually fairly easy to reenact: if the sub agent's instructions are too generic and encourage using it too much it almost always attempt to call itself.

## Risk

- Low.

## Deploy Plan

- Deploy front.
