### PR TITLE
refactor(front): rename MarkdownCitation to MCPReferenceCitation

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -26,8 +26,8 @@ import {
   CiteBlock,
   getCiteDirective,
 } from "@app/components/markdown/CiteBlock";
-import type { MarkdownCitation } from "@app/components/markdown/MarkdownCitation";
-import { getCitationIcon } from "@app/components/markdown/MarkdownCitation";
+import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
+import { getCitationIcon } from "@app/components/markdown/MCPReferenceCitation";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
@@ -92,7 +92,7 @@ export function MCPRunAgentActionDetails({
   >(null);
   const [streamedResponse, setStreamedResponse] = useState<string | null>(null);
   const [activeReferences, setActiveReferences] = useState<
-    { index: number; document: MarkdownCitation }[]
+    { index: number; document: MCPReferenceCitation }[]
   >([]);
 
   useEffect(() => {
@@ -160,7 +160,7 @@ export function MCPRunAgentActionDetails({
     if (!resultResource?.resource.refs) {
       return {};
     }
-    const markdownCitations: { [key: string]: MarkdownCitation } = {};
+    const mcpReferenceCitations: { [key: string]: MCPReferenceCitation } = {};
     Object.entries(resultResource.resource.refs).forEach(([key, citation]) => {
       const IconComponent = getCitationIcon(
         citation.provider,
@@ -168,7 +168,7 @@ export function MCPRunAgentActionDetails({
         undefined,
         citation.href
       );
-      markdownCitations[key] = {
+      mcpReferenceCitations[key] = {
         contentType: citation.mimeType as AllSupportedFileContentType,
         title: citation.title,
         href: citation.href,
@@ -177,10 +177,10 @@ export function MCPRunAgentActionDetails({
         fileId: key,
       };
     });
-    return markdownCitations;
+    return mcpReferenceCitations;
   }, [resultResource, isDark]);
 
-  const updateActiveReferences = (doc: MarkdownCitation, index: number) => {
+  const updateActiveReferences = (doc: MCPReferenceCitation, index: number) => {
     const existingIndex = activeReferences.find((r) => r.index === index);
     if (!existingIndex) {
       setActiveReferences([...activeReferences, { index, document: doc }]);

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -21,10 +21,9 @@ import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { AgentMessageActions } from "@app/components/assistant/conversation/actions/AgentMessageActions";
 import { AgentHandle } from "@app/components/assistant/conversation/AgentHandle";
 import { AgentMessageCompletionStatus } from "@app/components/assistant/conversation/AgentMessageCompletionStatus";
-import {
-  AgentMessageInteractiveContentGeneratedFiles,
-  DefaultAgentMessageGeneratedFiles,
-} from "@app/components/assistant/conversation/AgentMessageGeneratedFiles";
+import { AgentMessageInteractiveContentGeneratedFiles } from "@app/components/assistant/conversation/AgentMessageGeneratedFiles";
+import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
+import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import { useActionValidationContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
@@ -792,10 +791,11 @@ function getCitations({
   activeReferences.sort((a, b) => a.index - b.index);
 
   return activeReferences.map(({ document, index }) => {
+    const attachmentCitation = markdownCitationToAttachmentCitation(document);
     return (
-      <DefaultAgentMessageGeneratedFiles
+      <AttachmentCitation
         key={index}
-        document={document}
+        attachmentCitation={attachmentCitation}
         owner={owner}
         conversationId={conversationId}
       />

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -48,8 +48,8 @@ import {
   getCiteDirective,
 } from "@app/components/markdown/CiteBlock";
 import { getImgPlugin, imgDirective } from "@app/components/markdown/Image";
-import type { MarkdownCitation } from "@app/components/markdown/MarkdownCitation";
-import { getCitationIcon } from "@app/components/markdown/MarkdownCitation";
+import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
+import { getCitationIcon } from "@app/components/markdown/MCPReferenceCitation";
 import {
   getMentionPlugin,
   mentionDirective,
@@ -105,7 +105,7 @@ export function AgentMessage({
     React.useState<boolean>(false);
 
   const [activeReferences, setActiveReferences] = React.useState<
-    { index: number; document: MarkdownCitation }[]
+    { index: number; document: MCPReferenceCitation }[]
   >([]);
   const [isCopied, copy] = useCopyToClipboard();
 
@@ -176,7 +176,7 @@ export function AgentMessage({
   const references = useMemo(
     () =>
       Object.entries(agentMessageToRender.citations ?? {}).reduce<
-        Record<string, MarkdownCitation>
+        Record<string, MCPReferenceCitation>
       >((acc, [key, citation]) => {
         if (citation) {
           const IconComponent = getCitationIcon(
@@ -524,14 +524,14 @@ function AgentMessageContent({
     blockedOnly?: boolean;
   }) => Promise<void>;
   messageStreamState: MessageTemporaryState;
-  references: { [key: string]: MarkdownCitation };
+  references: { [key: string]: MCPReferenceCitation };
   streaming: boolean;
   lastTokenClassification: null | "tokens" | "chain_of_thought";
-  activeReferences: { index: number; document: MarkdownCitation }[];
+  activeReferences: { index: number; document: MCPReferenceCitation }[];
   setActiveReferences: (
     references: {
       index: number;
-      document: MarkdownCitation;
+      document: MCPReferenceCitation;
     }[]
   ) => void;
 }) {
@@ -578,7 +578,10 @@ function AgentMessageContent({
   );
 
   // References logic.
-  function updateActiveReferences(document: MarkdownCitation, index: number) {
+  function updateActiveReferences(
+    document: MCPReferenceCitation,
+    index: number
+  ) {
     const existingIndex = activeReferences.find((r) => r.index === index);
     if (!existingIndex) {
       setActiveReferences([...activeReferences, { index, document }]);
@@ -783,7 +786,7 @@ function getCitations({
 }: {
   activeReferences: {
     index: number;
-    document: MarkdownCitation;
+    document: MCPReferenceCitation;
   }[];
   owner: LightWorkspaceType;
   conversationId: string;

--- a/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
+++ b/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
@@ -7,35 +7,9 @@ import {
   SparklesIcon,
 } from "@dust-tt/sparkle";
 
-import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import type { MarkdownCitation } from "@app/components/markdown/MarkdownCitation";
-import type { LightAgentMessageType, LightWorkspaceType } from "@app/types";
+import type { LightAgentMessageType } from "@app/types";
 import { frameContentType } from "@app/types";
-
-import { AttachmentCitation } from "./attachment/AttachmentCitation";
-
-interface DefaultAgentMessageGeneratedFilesProps {
-  document: MarkdownCitation;
-  owner: LightWorkspaceType;
-  conversationId: string;
-}
-
-export const DefaultAgentMessageGeneratedFiles = ({
-  document,
-  owner,
-  conversationId,
-}: DefaultAgentMessageGeneratedFilesProps) => {
-  const attachmentCitation = markdownCitationToAttachmentCitation(document);
-
-  return (
-    <AttachmentCitation
-      attachmentCitation={attachmentCitation}
-      owner={owner}
-      conversationId={conversationId}
-    />
-  );
-};
 
 // Interactive content files.
 

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -12,10 +12,9 @@ import {
 } from "@dust-tt/sparkle";
 import React from "react";
 
-import {
-  AgentMessageInteractiveContentGeneratedFiles,
-  DefaultAgentMessageGeneratedFiles,
-} from "@app/components/assistant/conversation/AgentMessageGeneratedFiles";
+import { AgentMessageInteractiveContentGeneratedFiles } from "@app/components/assistant/conversation/AgentMessageGeneratedFiles";
+import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
+import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import { useConversationFiles } from "@app/lib/swr/conversations";
 import type {
@@ -98,26 +97,28 @@ interface FileRendererProps {
   conversationId: string;
 }
 
-function FileRenderer({ files, owner, conversationId }: FileRendererProps) {
-  return (
-    <CitationGrid variant="grid" className="md:grid-cols-3">
-      {files.map((file, index) => (
-        <DefaultAgentMessageGeneratedFiles
+const FileRenderer = ({ files, owner, conversationId }: FileRendererProps) => (
+  <CitationGrid variant="grid" className="md:grid-cols-3">
+    {files.map((file, index) => {
+      const attachmentCitation = markdownCitationToAttachmentCitation({
+        href: `/api/w/${owner.sId}/files/${file.fileId}`,
+        icon: <DocumentIcon />,
+        title: file.title,
+        contentType: file.contentType,
+        fileId: file.fileId,
+      });
+
+      return (
+        <AttachmentCitation
           key={index}
-          document={{
-            href: `/api/w/${owner.sId}/files/${file.fileId}`,
-            icon: <DocumentIcon />,
-            title: file.title,
-            contentType: file.contentType,
-            fileId: file.fileId,
-          }}
+          attachmentCitation={attachmentCitation}
           owner={owner}
           conversationId={conversationId}
         />
-      ))}
-    </CitationGrid>
-  );
-}
+      );
+    })}
+  </CitationGrid>
+);
 
 interface FileGroupSectionProps {
   group: FileGroup;
@@ -126,12 +127,12 @@ interface FileGroupSectionProps {
   conversationId: string;
 }
 
-function FileGroupSection({
+const FileGroupSection = ({
   group,
   onFileClick,
   owner,
   conversationId,
-}: FileGroupSectionProps) {
+}: FileGroupSectionProps) => {
   const isInteractiveContent = isInteractiveContentContentType(
     group.contentType
   );
@@ -158,7 +159,7 @@ function FileGroupSection({
       </div>
     </div>
   );
-}
+};
 
 function EmptyFilesState() {
   return (
@@ -178,10 +179,10 @@ interface ConversationFilesPopoverProps {
   owner: LightWorkspaceType;
 }
 
-export function ConversationFilesPopover({
+export const ConversationFilesPopover = ({
   conversationId,
   owner,
-}: ConversationFilesPopoverProps) {
+}: ConversationFilesPopoverProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [shouldDisableConversationFiles, setShouldDisableConversationFiles] =
     React.useState(true);
@@ -264,4 +265,4 @@ export function ConversationFilesPopover({
       </PopoverContent>
     </PopoverRoot>
   );
-}
+};

--- a/front/components/assistant/conversation/attachment/utils.tsx
+++ b/front/components/assistant/conversation/attachment/utils.tsx
@@ -19,7 +19,7 @@ import {
   getDisplayNameFromPastedFileId,
   isPastedFile,
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
-import type { MarkdownCitation } from "@app/components/markdown/MarkdownCitation";
+import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import type { ContentFragmentType } from "@app/types";
 import {
@@ -180,7 +180,7 @@ export function attachmentToAttachmentCitation(
 }
 
 export function markdownCitationToAttachmentCitation(
-  citation: MarkdownCitation
+  citation: MCPReferenceCitation
 ): AttachmentCitation {
   return {
     id: citation.fileId,

--- a/front/components/markdown/CiteBlock.tsx
+++ b/front/components/markdown/CiteBlock.tsx
@@ -2,13 +2,13 @@ import React, { useEffect } from "react";
 import type { ReactMarkdownProps } from "react-markdown/lib/complex-types";
 import { visit } from "unist-util-visit";
 
-import type { MarkdownCitation } from "./MarkdownCitation";
+import type { MCPReferenceCitation } from "./MCPReferenceCitation";
 
 export type CitationsContextType = {
   references: {
-    [key: string]: MarkdownCitation;
+    [key: string]: MCPReferenceCitation;
   };
-  updateActiveReferences: (doc: MarkdownCitation, index: number) => void;
+  updateActiveReferences: (doc: MCPReferenceCitation, index: number) => void;
 };
 
 export const CitationsContext = React.createContext<CitationsContextType>({

--- a/front/components/markdown/MCPReferenceCitation.tsx
+++ b/front/components/markdown/MCPReferenceCitation.tsx
@@ -42,7 +42,7 @@ export function getCitationIcon(
 }
 
 // TODO(interactive_content 2025-08-27): Use proper and distinct types for Interactive Content.
-export interface MarkdownCitation {
+export interface MCPReferenceCitation {
   description?: string;
   href?: string;
   icon: React.JSX.Element;


### PR DESCRIPTION
## Description

Rename `MarkdownCitation` to `MCPReferenceCitation`, as it's not a markdown anymore, and it's output of a MCP server so let's me specific 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
