### PR TITLE
Enable slack bot to attach files

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -299,7 +299,7 @@ async function streamAgentAnswerToSlack(
         );
         const files = actions.flatMap((action) => action.generatedFiles);
         const filesUploaded = await getFilesFromDust(files, dustAPI);
-        
+
         const slackContent = slackifyMarkdown(
           normalizeContentForSlack(formattedContent)
         );
@@ -315,7 +315,7 @@ async function streamAgentAnswerToSlack(
           const splitMessages = splitContentForSlack(slackContent);
 
           debouncedPostSlackMessageUpdate.cancel();
-          
+
           // If we have files, we need to delete and repost the message
           if (filesUploaded.length > 0) {
             await deleteAndRepostMessageWithFiles({
@@ -495,7 +495,7 @@ async function deleteAndRepostMessageWithFiles({
   connector: ConnectorResource;
   conversation: ConversationPublicType;
   mainMessage: ChatPostMessageResponse;
-  uploadedFiles: {file: Buffer, filename: string}[];
+  uploadedFiles: { file: Buffer; filename: string }[];
 }): Promise<void> {
   const { slackChannelId, slackClient } = slack;
   const conversationUrl = makeConversationUrl(
@@ -752,7 +752,6 @@ async function getMessageSplittingFromFeatureFlag(
   }
 }
 
-
 async function getFilesFromDust(
   files: Array<{
     fileId: string;
@@ -761,8 +760,8 @@ async function getFilesFromDust(
     snippet: string | null;
     hidden?: boolean;
   }>,
-  dustAPI: DustAPI,
-): Promise<{file: Buffer, filename: string}[]> {
+  dustAPI: DustAPI
+): Promise<{ file: Buffer; filename: string }[]> {
   const uploadPromises = files
     .filter((file) => !file.hidden) // Skip hidden files
     .map(async (file) => {
@@ -777,10 +776,10 @@ async function getFilesFromDust(
         };
       } catch (error) {
         logger.error(
-          { 
-            fileId: file.fileId, 
+          {
+            fileId: file.fileId,
             title: file.title,
-            error: error instanceof Error ? error.message : String(error)
+            error: error instanceof Error ? error.message : String(error),
           },
           "Error downloading file from Dust"
         );
@@ -789,5 +788,8 @@ async function getFilesFromDust(
     });
 
   const uploadResults = await Promise.all(uploadPromises);
-  return uploadResults.filter(result => result !== null) as {file: Buffer, filename: string}[];
+  return uploadResults.filter((result) => result !== null) as {
+    file: Buffer;
+    filename: string;
+  }[];
 }

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1225,6 +1225,41 @@ export class DustAPI {
     return new Ok(r.value);
   }
 
+  async downloadFile({ fileID }: { fileID: string }) {
+    const res = await this.request({
+      method: "GET",
+      path: `files/${fileID}?action=download`,
+    });
+    
+    if (res.isErr()) {
+      return res;
+    }
+
+    // Handle redirect response (the API redirects to a signed URL)
+    if (res.value.response.status >= 200 && res.value.response.status < 400) {
+      const redirectUrl = res.value.response.url;
+      
+      // Fetch the actual file content from the signed URL
+      try {
+        const fileResponse = await fetch(redirectUrl);
+        if (!fileResponse.ok) {
+          return new Err({
+            type: "unexpected_network_error",
+            message: `Failed to download file from signed URL: ${fileResponse.status}`,
+          });
+        }
+        
+        const buffer = Buffer.from(await fileResponse.arrayBuffer());
+        return new Ok(buffer);
+      } catch (error) {
+        return new Err({
+          type: "unexpected_network_error",
+          message: `Failed to download file: ${error}`,
+        });
+      }
+    }
+  }
+
   async uploadFile({
     contentType,
     fileName,


### PR DESCRIPTION
## Description

The Slack bot wasn't able to attach files to its messages.
Thus, even if the response on Dust has a file attached, this file doesn't end up on Slack.
Issue [here](https://github.com/dust-tt/tasks/issues/4583)

## Tests

- Created an agent that generates a file and sends it (needs to have the tools "File generation")
- Called this agent through Slack

## Risk

Low

## Deploy Plan

Deploy connectors and sdks
