### PR TITLE
[front] enh(run_agent): refine handoff/spawn behavior descriptions

### DIFF
--- a/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
@@ -302,7 +302,7 @@ function EnumConfigurationInput({
         </div>
       </div>
       {currentDescription && (
-        <div className="mt-1 text-sm text-gray-600 dark:text-gray-600-night">
+        <div className="mt-1 whitespace-pre-line text-sm text-gray-600 dark:text-gray-600-night">
           {currentDescription}
         </div>
       )}

--- a/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
@@ -72,7 +72,7 @@ function BooleanConfigurationInput({
               <Icon
                 visual={InformationCircleIcon}
                 size="xs"
-                className="cursor-help text-gray-400 hover:text-gray-600"
+                className="cursor-help text-gray-400 hover:text-gray-600 dark:text-gray-400-night dark:hover:text-gray-600-night"
               />
             }
             label={description}
@@ -129,7 +129,7 @@ function NumberConfigurationInput({
               <Icon
                 visual={InformationCircleIcon}
                 size="xs"
-                className="cursor-help text-gray-400 hover:text-gray-600"
+                className="cursor-help text-gray-400 hover:text-gray-600 dark:text-gray-400-night dark:hover:text-gray-600-night"
               />
             }
             label={description}
@@ -192,7 +192,7 @@ function StringConfigurationInput({
               <Icon
                 visual={InformationCircleIcon}
                 size="xs"
-                className="cursor-help text-gray-400 hover:text-gray-600"
+                className="cursor-help text-gray-400 hover:text-gray-600 dark:text-gray-400-night dark:hover:text-gray-600-night"
               />
             }
             label={description}
@@ -266,7 +266,7 @@ function EnumConfigurationInput({
                 <Icon
                   visual={InformationCircleIcon}
                   size="xs"
-                  className="cursor-help text-gray-400 hover:text-gray-600"
+                  className="cursor-help text-gray-400 hover:text-gray-600 dark:text-gray-400-night dark:hover:text-gray-600-night"
                 />
               }
               label={description}
@@ -302,7 +302,9 @@ function EnumConfigurationInput({
         </div>
       </div>
       {currentDescription && (
-        <div className="mt-1 text-sm text-gray-600">{currentDescription}</div>
+        <div className="mt-1 text-sm text-gray-600 dark:text-gray-600-night">
+          {currentDescription}
+        </div>
       )}
     </div>
   );
@@ -657,23 +659,21 @@ export function AdditionalConfigurationSection({
   }
 
   return (
-    <>
-      <ConfigurationSectionContainer
-        title="Additional configuration"
-        description="Configure additional parameters required by this action."
-      >
-        {allPrefixes.map((prefix) => (
-          <GroupedConfigurationSection
-            key={prefix || "general"}
-            prefix={prefix}
-            stringConfigurations={groupedStrings[prefix] || []}
-            numberConfigurations={groupedNumbers[prefix] || []}
-            booleanConfigurations={groupedBooleans[prefix] || []}
-            enumConfigurations={groupedEnums[prefix] || {}}
-            listConfigurations={groupedLists[prefix] || {}}
-          />
-        ))}
-      </ConfigurationSectionContainer>
-    </>
+    <ConfigurationSectionContainer
+      title="Additional configuration"
+      description="Configure additional parameters required by this action."
+    >
+      {allPrefixes.map((prefix) => (
+        <GroupedConfigurationSection
+          key={prefix || "general"}
+          prefix={prefix}
+          stringConfigurations={groupedStrings[prefix] || []}
+          numberConfigurations={groupedNumbers[prefix] || []}
+          booleanConfigurations={groupedBooleans[prefix] || []}
+          enumConfigurations={groupedEnums[prefix] || {}}
+          listConfigurations={groupedLists[prefix] || {}}
+        />
+      ))}
+    </ConfigurationSectionContainer>
   );
 }

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -132,8 +132,8 @@ const configurableProperties = {
             })
             .describe(
               "The selected agent runs in a background conversation and passes results back to " +
-                "the main agent.\n This is the default behavior, well suited for delegating " +
-                "specialized tasks such as researching data from company data or the web."
+                "the main agent.\n This is the default behavior, well suited for " +
+                "specialized tasks such as researching from company data or the web."
             ),
           z
             .object({

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -132,8 +132,9 @@ const configurableProperties = {
             })
             .describe(
               "The selected agent runs in a background conversation and passes results back to " +
-                "the main agent.\n This is the default behavior, well suited for " +
-                "specialized tasks such as researching from company data or the web."
+                "the main agent.\nThis is the default behavior, well suited for breaking down " +
+                "complex work by delegating specific research/analysis subtasks while " +
+                "maintaining control of the overall response."
             ),
           z
             .object({
@@ -142,7 +143,7 @@ const configurableProperties = {
             })
             .describe(
               "The selected agent takes over and responds directly in the conversation." +
-                "\n Well suited for a routing use case where the sub-agent should handle " +
+                "\nWell suited for a routing use case where the sub-agent should handle " +
                 "the entire interaction going forward."
             ),
         ])

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -128,10 +128,12 @@ const configurableProperties = {
           z
             .object({
               value: z.literal("run-agent"),
-              label: z.literal("Agent runs in background"),
+              label: z.literal("Agent runs in the background"),
             })
             .describe(
-              "The selected agent runs silently in a background conversation and passes results to the main agent."
+              "The selected agent runs in a background conversation and passes results back to " +
+                "the main agent.\n This is the default behavior, well suited for delegating " +
+                "specialized tasks such as researching data from company data or the web."
             ),
           z
             .object({
@@ -139,7 +141,9 @@ const configurableProperties = {
               label: z.literal("Agent responds in conversation"),
             })
             .describe(
-              "The selected agent takes over and responds directly in the conversation."
+              "The selected agent takes over and responds directly in the conversation." +
+                "\n Well suited for a routing use case where the sub-agent should handle " +
+                "the entire interaction going forward."
             ),
         ])
         .optional(),
@@ -164,8 +168,7 @@ export default async function createServer(
   let childAgentId: string | null = null;
 
   if (
-    agentLoopContext &&
-    agentLoopContext.listToolsContext &&
+    agentLoopContext?.listToolsContext &&
     isServerSideMCPServerConfiguration(
       agentLoopContext.listToolsContext.agentActionConfiguration
     ) &&
@@ -176,8 +179,7 @@ export default async function createServer(
   }
 
   if (
-    agentLoopContext &&
-    agentLoopContext.runContext &&
+    agentLoopContext?.runContext &&
     isLightServerSideMCPToolConfiguration(
       agentLoopContext.runContext.toolConfiguration
     ) &&


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/tasks/issues/4570.
- This PR is an attempt to make it easier to choose between the "handoff" and the "spawn" mode as we've seen examples where the handoff mode was selected even though it did not fit the use case.
- The bottom line is still that the default should be kept unless you know what you're doing but not sure how to phrase this.
- Somewhat unrelated but the text was also not very readable in dark mode and line breaks were not preserved.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
