### PR TITLE
[front] webhooks: payload filter grammar

### DIFF
--- a/front/lib/webhooks/matcher.test.ts
+++ b/front/lib/webhooks/matcher.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from "vitest";
+
+import { matchPayload } from "./matcher";
+import { parseMatcherExpression } from "./parser";
+
+describe("matchPayload", () => {
+  const samplePayload = {
+    user: {
+      name: "Alice",
+      email: "alice@example.com",
+      age: 30,
+      active: true,
+    },
+    tags: ["urgent", "bug", "frontend"],
+    priority: 1,
+    count: 42,
+    metadata: {
+      created_at: "2024-01-01",
+      source: "webhook",
+    },
+  };
+
+  describe("equality operator", () => {
+    it("should match string equality", () => {
+      const matcher = parseMatcherExpression('(eq "user.name" "Alice")');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match incorrect string", () => {
+      const matcher = parseMatcherExpression('(eq "user.name" "Bob")');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should match number equality", () => {
+      const matcher = parseMatcherExpression('(eq "count" 42)');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should match boolean equality", () => {
+      const matcher = parseMatcherExpression('(eq "user.active" true)');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match wrong boolean", () => {
+      const matcher = parseMatcherExpression('(eq "user.active" false)');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should not match non-existent field", () => {
+      const matcher = parseMatcherExpression('(eq "nonexistent" "value")');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+  });
+
+  describe("string operators", () => {
+    it("should match starts-with", () => {
+      const matcher = parseMatcherExpression(
+        '(starts-with "user.email" "alice@")'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match incorrect prefix", () => {
+      const matcher = parseMatcherExpression(
+        '(starts-with "user.email" "bob@")'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should not match starts-with on non-string", () => {
+      const matcher = parseMatcherExpression('(starts-with "count" "42")');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+  });
+
+  describe("array operators", () => {
+    it("should match has single value", () => {
+      const matcher = parseMatcherExpression('(has "tags" "urgent")');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match absent value", () => {
+      const matcher = parseMatcherExpression('(has "tags" "backend")');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should match has-all when all values present", () => {
+      const matcher = parseMatcherExpression(
+        '(has-all "tags" ("urgent" "bug"))'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match has-all when one value missing", () => {
+      const matcher = parseMatcherExpression(
+        '(has-all "tags" ("urgent" "missing"))'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should match has-any when at least one value present", () => {
+      const matcher = parseMatcherExpression(
+        '(has-any "tags" ("missing" "urgent"))'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match has-any when no values present", () => {
+      const matcher = parseMatcherExpression(
+        '(has-any "tags" ("missing1" "missing2"))'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should not match array operators on non-array", () => {
+      const matcher = parseMatcherExpression('(has "user.name" "Alice")');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+  });
+
+  describe("numeric operators", () => {
+    it("should match gt", () => {
+      const matcher = parseMatcherExpression('(gt "user.age" 25)');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match gt when equal", () => {
+      const matcher = parseMatcherExpression('(gt "user.age" 30)');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should match gte when equal", () => {
+      const matcher = parseMatcherExpression('(gte "user.age" 30)');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should match gte when greater", () => {
+      const matcher = parseMatcherExpression('(gte "user.age" 25)');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should match lt", () => {
+      const matcher = parseMatcherExpression('(lt "user.age" 35)');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match lt when equal", () => {
+      const matcher = parseMatcherExpression('(lt "user.age" 30)');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should match lte when equal", () => {
+      const matcher = parseMatcherExpression('(lte "user.age" 30)');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should match lte when less", () => {
+      const matcher = parseMatcherExpression('(lte "user.age" 35)');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match numeric operators on non-numbers", () => {
+      const matcher = parseMatcherExpression('(gt "user.name" 10)');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+  });
+
+  describe("existence operator", () => {
+    it("should match exists for present field", () => {
+      const matcher = parseMatcherExpression('(exists "user.name")');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should match exists for nested field", () => {
+      const matcher = parseMatcherExpression('(exists "metadata.source")');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match exists for absent field", () => {
+      const matcher = parseMatcherExpression('(exists "nonexistent")');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should not match exists for nested absent field", () => {
+      const matcher = parseMatcherExpression('(exists "user.missing.field")');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+  });
+
+  describe("logical operators", () => {
+    it("should match AND when all conditions true", () => {
+      const matcher = parseMatcherExpression(
+        '(and (eq "user.name" "Alice") (eq "user.age" 30))'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match AND when one condition false", () => {
+      const matcher = parseMatcherExpression(
+        '(and (eq "user.name" "Alice") (eq "user.age" 25))'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should match OR when at least one condition true", () => {
+      const matcher = parseMatcherExpression(
+        '(or (eq "user.name" "Bob") (eq "user.age" 30))'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match OR when all conditions false", () => {
+      const matcher = parseMatcherExpression(
+        '(or (eq "user.name" "Bob") (eq "user.age" 25))'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should match NOT when condition false", () => {
+      const matcher = parseMatcherExpression('(not (eq "user.name" "Bob"))');
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+
+    it("should not match NOT when condition true", () => {
+      const matcher = parseMatcherExpression('(not (eq "user.name" "Alice"))');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should handle nested logical operators", () => {
+      const matcher = parseMatcherExpression(
+        '(and (or (eq "priority" 1) (eq "priority" 2)) (has "tags" "urgent"))'
+      );
+      expect(matchPayload(samplePayload, matcher)).toBe(true);
+    });
+  });
+
+  describe("wildcard array access", () => {
+    const payloadWithArrayOfObjects = {
+      items: [
+        { id: 1, name: "Item 1", status: "active" },
+        { id: 2, name: "Item 2", status: "inactive" },
+        { id: 3, name: "Item 3", status: "active" },
+      ],
+      tags: [
+        { label: "urgent", color: "red" },
+        { label: "bug", color: "orange" },
+      ],
+    };
+
+    it("should match wildcard path with has", () => {
+      const matcher = parseMatcherExpression('(has "items.*.name" "Item 2")');
+      expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(true);
+    });
+
+    it("should not match wildcard path when value absent", () => {
+      const matcher = parseMatcherExpression('(has "items.*.name" "Item 999")');
+      expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(false);
+    });
+
+    it("should match wildcard with has-all", () => {
+      const matcher = parseMatcherExpression(
+        '(has-all "items.*.status" ("active" "inactive"))'
+      );
+      expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(true);
+    });
+
+    it("should match wildcard with has-any", () => {
+      const matcher = parseMatcherExpression(
+        '(has-any "tags.*.label" ("urgent" "missing"))'
+      );
+      expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(true);
+    });
+
+    it("should not match wildcard on non-array", () => {
+      const matcher = parseMatcherExpression('(has "user.*.name" "value")');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+
+    it("should handle wildcard with nested fields", () => {
+      const matcher = parseMatcherExpression('(eq "tags.*.color" "red")');
+      expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(false);
+      // eq doesn't work on arrays, but has would
+      const matcher2 = parseMatcherExpression('(has "tags.*.color" "red")');
+      expect(matchPayload(payloadWithArrayOfObjects, matcher2)).toBe(true);
+    });
+
+    it("should return undefined for missing array in wildcard path", () => {
+      const matcher = parseMatcherExpression('(has "missing.*.field" "value")');
+      expect(matchPayload(samplePayload, matcher)).toBe(false);
+    });
+  });
+
+  describe("real-world scenarios", () => {
+    const githubPRPayload = {
+      action: "opened",
+      pull_request: {
+        number: 123,
+        title: "[Feature] Add new webhook support",
+        state: "open",
+        user: {
+          login: "alice",
+          type: "User",
+        },
+        labels: [
+          { name: "feature", color: "blue" },
+          { name: "high-priority", color: "red" },
+        ],
+        requested_reviewers: [{ login: "bob" }, { login: "charlie" }],
+        base: {
+          ref: "main",
+        },
+      },
+      repository: {
+        name: "dust",
+        owner: {
+          login: "dust-tt",
+        },
+      },
+    };
+
+    it("should match GitHub PR opened to main", () => {
+      const matcher = parseMatcherExpression(
+        '(and (eq "action" "opened") (eq "pull_request.base.ref" "main"))'
+      );
+      expect(matchPayload(githubPRPayload, matcher)).toBe(true);
+    });
+
+    it("should match PR with specific label", () => {
+      const matcher = parseMatcherExpression(
+        '(has "pull_request.labels.*.name" "feature")'
+      );
+      expect(matchPayload(githubPRPayload, matcher)).toBe(true);
+    });
+
+    it("should match PR with multiple required labels", () => {
+      const matcher = parseMatcherExpression(
+        '(has-all "pull_request.labels.*.name" ("feature" "high-priority"))'
+      );
+      expect(matchPayload(githubPRPayload, matcher)).toBe(true);
+    });
+
+    it("should match complex PR filter", () => {
+      const matcher = parseMatcherExpression(
+        '(and (eq "action" "opened") (eq "pull_request.base.ref" "main") (has "pull_request.labels.*.name" "high-priority"))'
+      );
+      expect(matchPayload(githubPRPayload, matcher)).toBe(true);
+    });
+
+    it("should match PR author and title pattern", () => {
+      const matcher = parseMatcherExpression(
+        '(and (eq "pull_request.user.login" "alice") (starts-with "pull_request.title" "[Feature]"))'
+      );
+      expect(matchPayload(githubPRPayload, matcher)).toBe(true);
+    });
+
+    it("should not match when conditions fail", () => {
+      const matcher = parseMatcherExpression(
+        '(and (eq "action" "opened") (has "pull_request.labels.*.name" "bug"))'
+      );
+      expect(matchPayload(githubPRPayload, matcher)).toBe(false);
+    });
+  });
+});

--- a/front/lib/webhooks/matcher.ts
+++ b/front/lib/webhooks/matcher.ts
@@ -1,0 +1,125 @@
+import get from "lodash/get";
+
+import { eq } from "./operators/equality";
+import { exists } from "./operators/existence";
+import { gt, gte, lt, lte } from "./operators/numeric";
+import { startsWith } from "./operators/string";
+import { has, hasAll, hasAny } from "./operators/array";
+import type { MatcherExpression } from "./types";
+import { isLogicalExpression, isOperationExpression } from "./types";
+
+/**
+ * Gets a field value from a payload, supporting wildcard array paths.
+ *
+ * Examples:
+ * - "user.email" -> get(payload, "user.email")
+ * - "tags.*.name" -> maps over tags array and extracts name from each
+ *
+ * @param payload - The payload object
+ * @param fieldPath - The field path, potentially with wildcards
+ * @returns The field value or array of values if wildcard used
+ */
+function getFieldValue(
+  payload: Record<string, unknown>,
+  fieldPath: string
+): unknown {
+  // Check if path contains wildcard for array access.
+  if (fieldPath.includes(".*")) {
+    const parts = fieldPath.split(".*");
+    if (parts.length !== 2) {
+      // Support one wildcard level.
+      return undefined;
+    }
+
+    const [arrayPath, subField] = parts;
+    const arrayValue = get(payload, arrayPath);
+
+    if (!Array.isArray(arrayValue)) {
+      return undefined;
+    }
+
+    // Map over array and extract subField from each element.
+    // Remove leading dot from subField if present.
+    const cleanSubField = subField.startsWith(".")
+      ? subField.slice(1)
+      : subField;
+    return arrayValue
+      .map((item) => get(item, cleanSubField))
+      .filter((v) => v !== undefined);
+  }
+
+  // Standard path access.
+  return get(payload, fieldPath);
+}
+
+/**
+ * Recursively matches a payload against a matcher expression.
+ *
+ * @param payload - The JSON payload to match against
+ * @param matcher - The matcher expression (typed structure)
+ * @returns true if the payload matches the expression, false otherwise
+ */
+export function matchPayload(
+  payload: Record<string, unknown>,
+  matcher: MatcherExpression
+): boolean {
+  // Handle logical operators (and, or, not).
+  if (isLogicalExpression(matcher)) {
+    if (matcher.op === "and") {
+      return matcher.expressions.every((expr) => matchPayload(payload, expr));
+    } else if (matcher.op === "or") {
+      return matcher.expressions.some((expr) => matchPayload(payload, expr));
+    } else if (matcher.op === "not") {
+      // NOT negates the single expression.
+      if (matcher.expressions.length !== 1) {
+        return false;
+      }
+      return !matchPayload(payload, matcher.expressions[0]);
+    }
+  }
+
+  // Handle comparison operators.
+  if (isOperationExpression(matcher)) {
+    const fieldValue = getFieldValue(payload, matcher.field);
+
+    switch (matcher.op) {
+      case "eq":
+        return eq(fieldValue, matcher.value);
+
+      case "starts-with":
+        return startsWith(fieldValue, matcher.value);
+
+      case "has":
+        return has(fieldValue, matcher.value);
+
+      case "has-all":
+        if (!matcher.values) {
+          return false;
+        }
+        return hasAll(fieldValue, matcher.values);
+
+      case "has-any":
+        if (!matcher.values) {
+          return false;
+        }
+        return hasAny(fieldValue, matcher.values);
+
+      case "gt":
+        return gt(fieldValue, matcher.value);
+
+      case "gte":
+        return gte(fieldValue, matcher.value);
+
+      case "lt":
+        return lt(fieldValue, matcher.value);
+
+      case "lte":
+        return lte(fieldValue, matcher.value);
+
+      case "exists":
+        return exists(fieldValue);
+    }
+  }
+
+  return false;
+}

--- a/front/lib/webhooks/matcher.ts
+++ b/front/lib/webhooks/matcher.ts
@@ -1,10 +1,10 @@
 import get from "lodash/get";
 
+import { has, hasAll, hasAny } from "./operators/array";
 import { eq } from "./operators/equality";
 import { exists } from "./operators/existence";
 import { gt, gte, lt, lte } from "./operators/numeric";
 import { startsWith } from "./operators/string";
-import { has, hasAll, hasAny } from "./operators/array";
 import type { MatcherExpression } from "./types";
 import { isLogicalExpression, isOperationExpression } from "./types";
 

--- a/front/lib/webhooks/operators/array.ts
+++ b/front/lib/webhooks/operators/array.ts
@@ -1,0 +1,41 @@
+/**
+ * Array has operator: checks if array contains a specific value.
+ *
+ * @param fieldValue - The array from the payload
+ * @param value - The value to check for
+ * @returns true if fieldValue array contains value
+ */
+export function has(fieldValue: unknown, value: unknown): boolean {
+  if (!Array.isArray(fieldValue)) {
+    return false;
+  }
+  return fieldValue.includes(value);
+}
+
+/**
+ * Array has-all operator: checks if array contains all specified values.
+ *
+ * @param fieldValue - The array from the payload
+ * @param values - The values that must all be present
+ * @returns true if fieldValue array contains all values
+ */
+export function hasAll(fieldValue: unknown, values: unknown[]): boolean {
+  if (!Array.isArray(fieldValue)) {
+    return false;
+  }
+  return values.every((value) => fieldValue.includes(value));
+}
+
+/**
+ * Array has-any operator: checks if array contains at least one of the specified values.
+ *
+ * @param fieldValue - The array from the payload
+ * @param values - The values to check for
+ * @returns true if fieldValue array contains at least one value
+ */
+export function hasAny(fieldValue: unknown, values: unknown[]): boolean {
+  if (!Array.isArray(fieldValue)) {
+    return false;
+  }
+  return values.some((value) => fieldValue.includes(value));
+}

--- a/front/lib/webhooks/operators/equality.ts
+++ b/front/lib/webhooks/operators/equality.ts
@@ -1,0 +1,10 @@
+/**
+ * Equality operator: checks if field exactly equals value.
+ *
+ * @param fieldValue - The value from the payload
+ * @param value - The expected value
+ * @returns true if fieldValue === value
+ */
+export function eq(fieldValue: unknown, value: unknown): boolean {
+  return fieldValue === value;
+}

--- a/front/lib/webhooks/operators/existence.ts
+++ b/front/lib/webhooks/operators/existence.ts
@@ -1,0 +1,9 @@
+/**
+ * Exists operator: checks if field exists and is not null/undefined.
+ *
+ * @param fieldValue - The value from the payload
+ * @returns true if fieldValue is not null and not undefined
+ */
+export function exists(fieldValue: unknown): boolean {
+  return fieldValue !== null && fieldValue !== undefined;
+}

--- a/front/lib/webhooks/operators/numeric.ts
+++ b/front/lib/webhooks/operators/numeric.ts
@@ -1,0 +1,55 @@
+/**
+ * Greater than operator: checks if field > value.
+ *
+ * @param fieldValue - The value from the payload
+ * @param value - The value to compare against
+ * @returns true if fieldValue > value
+ */
+export function gt(fieldValue: unknown, value: unknown): boolean {
+  if (typeof fieldValue !== "number" || typeof value !== "number") {
+    return false;
+  }
+  return fieldValue > value;
+}
+
+/**
+ * Greater than or equal operator: checks if field >= value.
+ *
+ * @param fieldValue - The value from the payload
+ * @param value - The value to compare against
+ * @returns true if fieldValue >= value
+ */
+export function gte(fieldValue: unknown, value: unknown): boolean {
+  if (typeof fieldValue !== "number" || typeof value !== "number") {
+    return false;
+  }
+  return fieldValue >= value;
+}
+
+/**
+ * Less than operator: checks if field < value.
+ *
+ * @param fieldValue - The value from the payload
+ * @param value - The value to compare against
+ * @returns true if fieldValue < value
+ */
+export function lt(fieldValue: unknown, value: unknown): boolean {
+  if (typeof fieldValue !== "number" || typeof value !== "number") {
+    return false;
+  }
+  return fieldValue < value;
+}
+
+/**
+ * Less than or equal operator: checks if field <= value.
+ *
+ * @param fieldValue - The value from the payload
+ * @param value - The value to compare against
+ * @returns true if fieldValue <= value
+ */
+export function lte(fieldValue: unknown, value: unknown): boolean {
+  if (typeof fieldValue !== "number" || typeof value !== "number") {
+    return false;
+  }
+  return fieldValue <= value;
+}

--- a/front/lib/webhooks/operators/string.ts
+++ b/front/lib/webhooks/operators/string.ts
@@ -1,0 +1,13 @@
+/**
+ * String starts-with operator: checks if string starts with prefix.
+ *
+ * @param fieldValue - The value from the payload
+ * @param prefix - The expected prefix
+ * @returns true if fieldValue starts with prefix
+ */
+export function startsWith(fieldValue: unknown, prefix: unknown): boolean {
+  if (typeof fieldValue !== "string" || typeof prefix !== "string") {
+    return false;
+  }
+  return fieldValue.startsWith(prefix);
+}

--- a/front/lib/webhooks/parser.test.ts
+++ b/front/lib/webhooks/parser.test.ts
@@ -239,7 +239,7 @@ describe("parseMatcherExpression", () => {
 
     it("should throw on exists with wrong arity", () => {
       expect(() => parseMatcherExpression('(exists "field" "extra")')).toThrow(
-        "exists requires exactly one field"
+        "exists requires exactly one expression"
       );
     });
   });

--- a/front/lib/webhooks/parser.test.ts
+++ b/front/lib/webhooks/parser.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+
+import { parseMatcherExpression } from "./parser";
+import type { LogicalExpression, OperationExpression } from "./types";
+import { isLogicalExpression, isOperationExpression } from "./types";
+
+describe("parseMatcherExpression", () => {
+  describe("logical operators", () => {
+    it("should parse AND expression", () => {
+      const result = parseMatcherExpression(
+        '(and (eq "field1" "value1") (eq "field2" "value2"))'
+      );
+      expect(isLogicalExpression(result)).toBe(true);
+      const logical = result as LogicalExpression;
+      expect(logical.op).toBe("and");
+      expect(logical.expressions).toHaveLength(2);
+    });
+
+    it("should parse OR expression", () => {
+      const result = parseMatcherExpression(
+        '(or (eq "field1" "value1") (eq "field2" "value2"))'
+      );
+      expect(isLogicalExpression(result)).toBe(true);
+      const logical = result as LogicalExpression;
+      expect(logical.op).toBe("or");
+      expect(logical.expressions).toHaveLength(2);
+    });
+
+    it("should parse NOT expression", () => {
+      const result = parseMatcherExpression('(not (eq "field" "value"))');
+      expect(isLogicalExpression(result)).toBe(true);
+      const logical = result as LogicalExpression;
+      expect(logical.op).toBe("not");
+      expect(logical.expressions).toHaveLength(1);
+    });
+
+    it("should parse nested logical expressions", () => {
+      const result = parseMatcherExpression(
+        '(and (or (eq "a" "1") (eq "b" "2")) (eq "c" "3"))'
+      );
+      expect(isLogicalExpression(result)).toBe(true);
+      const logical = result as LogicalExpression;
+      expect(logical.op).toBe("and");
+      expect(logical.expressions).toHaveLength(2);
+      expect(isLogicalExpression(logical.expressions[0])).toBe(true);
+    });
+  });
+
+  describe("equality operators", () => {
+    it("should parse eq with string value", () => {
+      const result = parseMatcherExpression('(eq "user.name" "Alice")');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("eq");
+      expect(op.field).toBe("user.name");
+      expect(op.value).toBe("Alice");
+    });
+
+    it("should parse eq with number value", () => {
+      const result = parseMatcherExpression('(eq "count" 42)');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("eq");
+      expect(op.field).toBe("count");
+      expect(op.value).toBe(42);
+    });
+
+    it("should parse eq with boolean value", () => {
+      const result = parseMatcherExpression('(eq "active" true)');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("eq");
+      expect(op.field).toBe("active");
+      expect(op.value).toBe(true);
+    });
+  });
+
+  describe("string operators", () => {
+    it("should parse starts-with", () => {
+      const result = parseMatcherExpression('(starts-with "email" "admin@")');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("starts-with");
+      expect(op.field).toBe("email");
+      expect(op.value).toBe("admin@");
+    });
+  });
+
+  describe("array operators", () => {
+    it("should parse has", () => {
+      const result = parseMatcherExpression('(has "tags" "urgent")');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("has");
+      expect(op.field).toBe("tags");
+      expect(op.value).toBe("urgent");
+    });
+
+    it("should parse has-all with array", () => {
+      const result = parseMatcherExpression(
+        '(has-all "tags" ("bug" "urgent"))'
+      );
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("has-all");
+      expect(op.field).toBe("tags");
+      expect(op.values).toEqual(["bug", "urgent"]);
+    });
+
+    it("should parse has-any with array", () => {
+      const result = parseMatcherExpression('(has-any "labels" ("p0" "p1"))');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("has-any");
+      expect(op.field).toBe("labels");
+      expect(op.values).toEqual(["p0", "p1"]);
+    });
+  });
+
+  describe("numeric operators", () => {
+    it("should parse gt", () => {
+      const result = parseMatcherExpression('(gt "age" 18)');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("gt");
+      expect(op.field).toBe("age");
+      expect(op.value).toBe(18);
+    });
+
+    it("should parse gte", () => {
+      const result = parseMatcherExpression('(gte "score" 90)');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("gte");
+      expect(op.value).toBe(90);
+    });
+
+    it("should parse lt", () => {
+      const result = parseMatcherExpression('(lt "temperature" 100)');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("lt");
+      expect(op.value).toBe(100);
+    });
+
+    it("should parse lte", () => {
+      const result = parseMatcherExpression('(lte "price" 50.99)');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("lte");
+      expect(op.value).toBe(50.99);
+    });
+  });
+
+  describe("existence operator", () => {
+    it("should parse exists", () => {
+      const result = parseMatcherExpression('(exists "optional_field")');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("exists");
+      expect(op.field).toBe("optional_field");
+      expect(op.value).toBeUndefined();
+    });
+  });
+
+  describe("special characters and escaping", () => {
+    it("should parse escaped quotes in strings", () => {
+      const result = parseMatcherExpression(
+        '(eq "message" "He said \\"hello\\"")'
+      );
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.value).toBe('He said "hello"');
+    });
+
+    it("should parse field paths with dots", () => {
+      const result = parseMatcherExpression(
+        '(eq "user.profile.email" "test@example.com")'
+      );
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.field).toBe("user.profile.email");
+    });
+
+    it("should parse wildcard paths", () => {
+      const result = parseMatcherExpression('(has "tags.*.name" "urgent")');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.field).toBe("tags.*.name");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw on empty expression", () => {
+      expect(() => parseMatcherExpression("()")).toThrow("Empty expression");
+    });
+
+    it("should throw on missing opening paren", () => {
+      expect(() => parseMatcherExpression('eq "field" "value")')).toThrow(
+        "Expression must start with '('"
+      );
+    });
+
+    it("should throw on unknown operator", () => {
+      expect(() => parseMatcherExpression('(unknown "field" "value")')).toThrow(
+        "Unknown operator: unknown"
+      );
+    });
+
+    it("should throw on not with wrong arity", () => {
+      expect(() =>
+        parseMatcherExpression('(not (eq "a" "1") (eq "b" "2"))')
+      ).toThrow("not requires exactly one expression");
+    });
+
+    it("should throw on missing field for eq", () => {
+      expect(() => parseMatcherExpression("(eq)")).toThrow(
+        "eq requires field and value(s)"
+      );
+    });
+
+    it("should throw on non-string field", () => {
+      expect(() => parseMatcherExpression("(eq 123 456)")).toThrow(
+        "Field must be a string"
+      );
+    });
+
+    it("should throw on has-all without array", () => {
+      expect(() =>
+        parseMatcherExpression('(has-all "field" "single")')
+      ).toThrow("has-all requires a list of values");
+    });
+
+    it("should throw on unclosed string", () => {
+      expect(() => parseMatcherExpression('(eq "field" "unclosed)')).toThrow(
+        "Expected closing '\"'"
+      );
+    });
+
+    it("should throw on exists with wrong arity", () => {
+      expect(() => parseMatcherExpression('(exists "field" "extra")')).toThrow(
+        "exists requires exactly one field"
+      );
+    });
+  });
+
+  describe("whitespace handling", () => {
+    it("should handle extra whitespace", () => {
+      const result = parseMatcherExpression('  (  eq   "field"   "value"  )  ');
+      expect(isOperationExpression(result)).toBe(true);
+      const op = result as OperationExpression;
+      expect(op.op).toBe("eq");
+      expect(op.field).toBe("field");
+      expect(op.value).toBe("value");
+    });
+
+    it("should handle newlines and tabs", () => {
+      const result = parseMatcherExpression(
+        '(\n\tand\n\t\t(eq "a" "1")\n\t\t(eq "b" "2")\n)'
+      );
+      expect(isLogicalExpression(result)).toBe(true);
+      const logical = result as LogicalExpression;
+      expect(logical.op).toBe("and");
+      expect(logical.expressions).toHaveLength(2);
+    });
+  });
+});

--- a/front/lib/webhooks/parser.ts
+++ b/front/lib/webhooks/parser.ts
@@ -1,14 +1,11 @@
 import { assertNever } from "@app/types";
+
+import type { LogicalOp, MatcherExpression, Operation } from "./types";
 import {
   isDyadicOperation,
-  isLogicalExpression,
-  isOperationExpression,
-  isOperator,
   isMonadicOperation,
+  isOperator,
   isVariadicOperation,
-  type LogicalOp,
-  type MatcherExpression,
-  type Operation,
 } from "./types";
 
 /**

--- a/front/lib/webhooks/parser.ts
+++ b/front/lib/webhooks/parser.ts
@@ -1,0 +1,196 @@
+import { assertNever } from "@app/types";
+import {
+  isDyadicOperation,
+  isLogicalExpression,
+  isOperationExpression,
+  isOperator,
+  isMonadicOperation,
+  isVariadicOperation,
+  type LogicalOp,
+  type MatcherExpression,
+  type Operation,
+} from "./types";
+
+/**
+ * Parses a Lisp-inspired matcher expression string into a structured format.
+ *
+ * @param expression - The Lisp-inspired expression string, e.g.:
+ *   '(or (and (eq "pr.author" "adrien@dust.tt") (has "pr.labels" "bug")))'
+ * @returns Parsed matcher expression as typed structure
+ * @throws Error if the expression is invalid
+ */
+export function parseMatcherExpression(expression: string): MatcherExpression {
+  let index = 0;
+
+  function skipWhitespace() {
+    while (index < expression.length && /\s/.test(expression[index])) {
+      index++;
+    }
+  }
+
+  function parseString(): string {
+    if (expression[index] !== '"') {
+      throw new Error(`Expected '"' at position ${index}`);
+    }
+    index++; // Skip opening quote.
+    let str = "";
+    while (index < expression.length && expression[index] !== '"') {
+      if (expression[index] === "\\") {
+        index++;
+        if (index >= expression.length) {
+          throw new Error("Unexpected end of string");
+        }
+      }
+      str += expression[index];
+      index++;
+    }
+    if (expression[index] !== '"') {
+      throw new Error(`Expected closing '"' at position ${index}`);
+    }
+    index++; // Skip closing quote.
+    return str;
+  }
+
+  function parseAtom(): string | number | boolean | null {
+    skipWhitespace();
+    if (expression[index] === '"') {
+      return parseString();
+    }
+    // Parse symbol, number, or boolean.
+    let atom = "";
+    while (index < expression.length && !/[\s()]/.test(expression[index])) {
+      atom += expression[index];
+      index++;
+    }
+    // Try to parse as boolean.
+    if (atom === "true") {
+      return true;
+    }
+    if (atom === "false") {
+      return false;
+    }
+    // Try to parse as null.
+    if (atom === "null") {
+      return null;
+    }
+    // Try to parse as number.
+    const num = Number(atom);
+    if (!isNaN(num) && atom !== "") {
+      return num;
+    }
+    return atom;
+  }
+
+  function parseList(): unknown[] {
+    const result: unknown[] = [];
+    skipWhitespace();
+    while (expression[index] !== ")") {
+      if (expression[index] === "(") {
+        index++; // Skip opening paren.
+        const list = parseList();
+        result.push(list);
+      } else {
+        result.push(parseAtom());
+      }
+      skipWhitespace();
+    }
+    index++; // Skip closing paren.
+    return result;
+  }
+
+  function convertToTypedExpression(list: unknown[]): MatcherExpression {
+    if (list.length === 0) {
+      throw new Error("Empty expression");
+    }
+
+    const op = list[0];
+
+    if (!isOperator(op)) {
+      throw new Error(`Unknown operator: ${op}`);
+    }
+
+    // Handle logical operators (and, or, not).
+    if (isVariadicOperation(op)) {
+      const expressions = list.slice(1).map((item) => {
+        if (!Array.isArray(item)) {
+          throw new Error(`Expected list for ${op} operand`);
+        }
+        return convertToTypedExpression(item);
+      });
+      return {
+        op: op as LogicalOp,
+        expressions,
+      };
+    }
+
+    if (isMonadicOperation(op)) {
+      if (list.length !== 2) {
+        throw new Error(`${op} requires exactly one expression`);
+      }
+      const expr = list[1];
+      switch (op) {
+        case "not":
+          if (!Array.isArray(expr)) {
+            throw new Error("Expected list for not operand");
+          }
+          return {
+            op: "not" as LogicalOp,
+            expressions: [convertToTypedExpression(expr)],
+          };
+        case "exists":
+          if (typeof expr !== "string") {
+            throw new Error("Field must be a string for exists");
+          }
+          return {
+            op: "exists" as Operation,
+            field: expr,
+          };
+        default:
+          assertNever(op);
+      }
+    }
+
+    if (isDyadicOperation(op)) {
+      // Binary operators: (op field value) or (op field (values...))
+      if (list.length !== 3) {
+        throw new Error(`${op} requires field and value(s)`);
+      }
+      const field = list[1];
+      const valueOrValues = list[2];
+
+      if (typeof field !== "string") {
+        throw new Error(`Field must be a string for ${op}`);
+      }
+
+      // For array operators (has-all, has-any), expect an array of values.
+      if (op === "has-all" || op === "has-any") {
+        if (!Array.isArray(valueOrValues)) {
+          throw new Error(`${op} requires a list of values`);
+        }
+        return {
+          op: op as Operation,
+          field,
+          values: valueOrValues,
+        };
+      }
+
+      // For single-value operators, accept either value or single-element array.
+      return {
+        op: op as Operation,
+        field,
+        value: valueOrValues,
+      };
+    }
+
+    throw new Error(`Unknown operator: ${op}`);
+  }
+
+  skipWhitespace();
+  if (expression[index] !== "(") {
+    throw new Error("Expression must start with '('");
+  }
+  index++; // Skip opening paren.
+  const list = parseList();
+
+  return convertToTypedExpression(list);
+}

--- a/front/lib/webhooks/payload_matcher.ts
+++ b/front/lib/webhooks/payload_matcher.ts
@@ -1,0 +1,19 @@
+// Main exports for payload matching functionality.
+
+// Export types.
+export type {
+  MatcherExpression,
+  Operation,
+  LogicalOp,
+  OperationExpression,
+  LogicalExpression,
+} from "./types";
+
+// Export type guards.
+export { isLogicalExpression, isOperationExpression } from "./types";
+
+// Export parser.
+export { parseMatcherExpression } from "./parser";
+
+// Export matcher.
+export { matchPayload } from "./matcher";

--- a/front/lib/webhooks/payload_matcher.ts
+++ b/front/lib/webhooks/payload_matcher.ts
@@ -2,11 +2,11 @@
 
 // Export types.
 export type {
+  LogicalExpression,
+  LogicalOp,
   MatcherExpression,
   Operation,
-  LogicalOp,
   OperationExpression,
-  LogicalExpression,
 } from "./types";
 
 // Export type guards.

--- a/front/lib/webhooks/types.ts
+++ b/front/lib/webhooks/types.ts
@@ -1,0 +1,78 @@
+// Type definitions for matcher expressions.
+
+const Operations = [
+  "eq",
+  "starts-with",
+  "has",
+  "has-all",
+  "has-any",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "exists",
+] as const;
+export type Operation = (typeof Operations)[number];
+
+export const LogicalOps = ["and", "or", "not"] as const;
+export type LogicalOp = (typeof LogicalOps)[number];
+
+export type OperationExpression = {
+  op: Operation;
+  field: string;
+  value?: unknown;
+  values?: unknown[];
+};
+
+export type LogicalExpression = {
+  op: LogicalOp;
+  expressions: MatcherExpression[];
+};
+
+export type MatcherExpression = OperationExpression | LogicalExpression;
+
+// Type guard functions.
+export function isLogicalExpression(
+  expr: MatcherExpression
+): expr is LogicalExpression {
+  return "expressions" in expr;
+}
+
+export function isOperationExpression(
+  expr: MatcherExpression
+): expr is OperationExpression {
+  return "field" in expr;
+}
+
+export function isMonadicOperation(
+  op: Operation | LogicalOp
+): op is "exists" | "not" {
+  return op === "exists" || op === "not";
+}
+
+export function isDyadicOperation(op: Operation | LogicalOp): boolean {
+  return (
+    op === "eq" ||
+    op === "starts-with" ||
+    op === "has" ||
+    op === "gt" ||
+    op === "gte" ||
+    op === "lt" ||
+    op === "lte" ||
+    op === "has-all" ||
+    op === "has-any"
+  );
+}
+
+export function isVariadicOperation(
+  op: Operation | LogicalOp
+): op is "and" | "or" {
+  return op === "and" || op === "or";
+}
+
+export function isOperator(op: unknown): op is Operation | LogicalOp {
+  return (
+    typeof op === "string" &&
+    ([...Operations, ...LogicalOps] as readonly string[]).includes(op)
+  );
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

See https://www.notion.so/dust-tt/Design-Doc-Human-Out-Of-The-Loop-21828599d94180dda12cf43dde916ad1?source=copy_link#28728599d941805abcbfea3537197db8 for details on the grammar.

This PR adds a payload matcher lib to allow filtering the webhook payloads.
60% of the PR are tests ^^

NOTE : this has already been approved in an earlier version here : https://github.com/dust-tt/dust/pull/16744/ by @fabiencelier 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested with unit tests + by hand, in the product (with followup PRs)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, unused

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.