### PR TITLE
Keep mobile font size normal

### DIFF
--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -150,10 +150,7 @@ export const ConversationMessageContent = React.forwardRef<
       {...props}
     >
       <div
-        className={cn(
-          "s-text-base",
-          "s-text-foreground dark:s-text-foreground-night"
-        )}
+        className="s-text-base s-text-foreground dark:s-text-foreground-night"
       >
         {children}
       </div>
@@ -230,11 +227,7 @@ export const ConversationMessageHeader = React.forwardRef<
         )}
         <div className="s-flex s-w-full s-flex-row s-justify-between s-gap-0.5">
           <div
-            className={cn(
-              "s-heading-sm",
-              "s-text-foreground dark:s-text-foreground-night",
-              "s-flex s-flex-row s-items-center s-gap-2"
-            )}
+            className="s-heading-sm s-text-foreground dark:s-text-foreground-night s-flex s-flex-row s-items-center s-gap-2"
           >
             {renderName(name)}
             {infoChip}

--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -151,7 +151,7 @@ export const ConversationMessageContent = React.forwardRef<
     >
       <div
         className={cn(
-          "s-text-sm @sm:s-text-base",
+          "s-text-base",
           "s-text-foreground dark:s-text-foreground-night"
         )}
       >
@@ -231,7 +231,7 @@ export const ConversationMessageHeader = React.forwardRef<
         <div className="s-flex s-w-full s-flex-row s-justify-between s-gap-0.5">
           <div
             className={cn(
-              "s-heading-xs @sm:s-heading-sm",
+              "s-heading-sm",
               "s-text-foreground dark:s-text-foreground-night",
               "s-flex s-flex-row s-items-center s-gap-2"
             )}

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -37,7 +37,7 @@ export const markdownHeaderClasses = {
 };
 
 const sizes = {
-  p: "s-copy-sm @sm:s-text-base @sm:s-leading-7",
+  p: "s-text-base s-leading-7",
   ...markdownHeaderClasses,
 };
 


### PR DESCRIPTION
## Description

Match the size of chatgpt.
Note: we lost the shrinking of text on desktop too, couldn't make both work.

| GPT | DST |
| --- | --- |
| <img  width="100%" alt="IMG_4604" src="https://github.com/user-attachments/assets/44e05ea2-f50a-4d80-90e1-f8e697d4485a" /> | <img width="100%" alt="IMG_4603" src="https://github.com/user-attachments/assets/17aeda13-4b41-4010-b0c8-f840e0e36a0c" /> |

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy sparkle, update front & extension.