### PR TITLE
Run_agent handoff: prompt the agent to generate something about doing a handoff

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -134,7 +134,7 @@ export async function runToolActivity(
                 messageId: agentMessage.sId,
                 message: {
                   ...agentMessage,
-                  content: agentMessage.content ?? event.text,
+                  content: agentMessage.content,
                   completedTs: event.created,
                 },
                 runIds: runIds ?? [],


### PR DESCRIPTION
## Description

- Update the tool description when the tool is configured for a handoff to tell the main agent it should let the user know it's going to handoff. 
- Remove the hack in `runToolActivity` to put the tool output as agent generation content. 

On the example this text is generated by lovely Soupinou
<kbd>
<img width="978" height="608" alt="Screenshot 2025-10-13 at 16 04 45" src="https://github.com/user-attachments/assets/d11a0144-bc04-49a1-9c73-9e8e40dcee46" />
</kbd>

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 