### PR TITLE
[front] chore(MCP): wrap existing tools with `withToolLogging`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
@@ -14,7 +14,6 @@ import {
   makeMCPToolJSONSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 

--- a/front/lib/actions/mcp_internal_actions/servers/confluence/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/types.ts
@@ -2,10 +2,16 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
+import type { MCPError } from "@app/lib/actions/mcp_errors";
+import type { Result } from "@app/types";
+
 export type ConfluenceErrorResult = string;
 export type WithAuthParams = {
   authInfo?: AuthInfo;
-  action: (baseUrl: string, accessToken: string) => Promise<CallToolResult>;
+  action: (
+    baseUrl: string,
+    accessToken: string
+  ) => Promise<Result<CallToolResult["content"], MCPError>>;
 };
 
 // Schema for Atlassian resource information

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -92,7 +92,7 @@ export async function getInternalMCPServer(
     case "github":
       return githubServer(auth);
     case "hubspot":
-      return hubspotServer();
+      return hubspotServer(auth, agentLoopContext);
     case "image_generation":
       return imageGenerationDallEServer(auth);
     case "elevenlabs":
@@ -160,15 +160,15 @@ export async function getInternalMCPServer(
     case AGENT_MEMORY_SERVER_NAME:
       return agentMemoryServer(auth, agentLoopContext);
     case "confluence":
-      return confluenceServer();
+      return confluenceServer(auth);
     case "outlook":
       return outlookServer(auth);
     case "outlook_calendar":
-      return outlookCalendarServer();
+      return outlookCalendarServer(auth);
     case "agent_management":
       return agentManagementServer(auth, agentLoopContext);
     case "freshservice":
-      return freshserviceServer();
+      return freshserviceServer(auth);
     case "data_warehouses":
       return dataWarehousesServer(auth, agentLoopContext);
     case "toolsets":

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -92,7 +92,7 @@ export async function getInternalMCPServer(
     case "github":
       return githubServer(auth);
     case "hubspot":
-      return hubspotServer(auth, agentLoopContext);
+      return hubspotServer();
     case "image_generation":
       return imageGenerationDallEServer(auth);
     case "elevenlabs":


### PR DESCRIPTION
## Description

- This PR adds the wrapper `withToolLogging` on the Confluence, Freshservice and Outlook MCP servers.
- Next step is to add a mode to still log but not trigger a monitor for MCP servers managed by the acceleration team.

## Tests

- Checked locally.

## Risk

- Non negligible cost.
- Will add a lot of noise in monitors at the beginning + require some attending to filter out certain errors.

## Deploy Plan

- Deploy front.
