### PR TITLE
[front] - feat(ES): handler boilerplate

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -275,6 +275,22 @@ const config = {
       "UNTRUSTED_EGRESS_PROXY_PORT"
     );
   },
+  getElasticsearchConfig: (): {
+    url: string;
+    username: string;
+    password: string;
+    analyticsIndex: string;
+  } => {
+    return {
+      url: EnvironmentConfig.getEnvVariable("ELASTICSEARCH_URL"),
+      username: EnvironmentConfig.getEnvVariable("ELASTICSEARCH_USERNAME"),
+      password: EnvironmentConfig.getEnvVariable("ELASTICSEARCH_PASSWORD"),
+      analyticsIndex:
+        EnvironmentConfig.getOptionalEnvVariable(
+          "ELASTICSEARCH_ANALYTICS_INDEX"
+        ) ?? "front.agent_message_analytics_1",
+    };
+  },
 };
 
 export default config;

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -285,10 +285,9 @@ const config = {
       url: EnvironmentConfig.getEnvVariable("ELASTICSEARCH_URL"),
       username: EnvironmentConfig.getEnvVariable("ELASTICSEARCH_USERNAME"),
       password: EnvironmentConfig.getEnvVariable("ELASTICSEARCH_PASSWORD"),
-      analyticsIndex:
-        EnvironmentConfig.getOptionalEnvVariable(
-          "ELASTICSEARCH_ANALYTICS_INDEX"
-        ) ?? "front.agent_message_analytics_1",
+      analyticsIndex: EnvironmentConfig.getEnvVariable(
+        "ELASTICSEARCH_ANALYTICS_INDEX"
+      ),
     };
   },
 };

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -1,3 +1,5 @@
+import type { estypes } from "@elastic/elasticsearch";
+import { Client, errors as esErrors } from "@elastic/elasticsearch";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
@@ -8,47 +10,68 @@ export function getAnalyticsIndex(): string {
   return config.getElasticsearchConfig().analyticsIndex;
 }
 
-export async function esSearch<TResponse = unknown>(
-  body: unknown,
-  index?: string
-): Promise<TResponse> {
-  const { url, username, password } = config.getElasticsearchConfig();
-  const idx = index ?? getAnalyticsIndex();
+let esClient: Client | null = null;
 
-  const resp = await fetch(`${url}/${encodeURIComponent(idx)}/_search`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString(
-        "base64"
-      )}`,
-    },
-    body: JSON.stringify(body),
-  });
+function hasProp<K extends string>(
+  obj: unknown,
+  key: K
+): obj is Record<K, unknown> {
+  return typeof obj === "object" && obj !== null && key in obj;
+}
 
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`Elasticsearch query failed (${resp.status}): ${text}`);
+function extractErrorReason(err: esErrors.ResponseError): string {
+  const body = err.meta?.body;
+  if (hasProp(body, "error") && typeof body.error === "object" && body.error) {
+    const e = body.error as unknown;
+    if (hasProp(e, "reason") && typeof e.reason !== "undefined") {
+      return String(e.reason);
+    }
   }
-  return (await resp.json()) as TResponse;
+  return err.message;
 }
 
-export function formatUTCDateFromMillis(ms: number): string {
-  const d = new Date(ms);
-  const y = d.getUTCFullYear();
-  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(d.getUTCDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
+function getClient(): Client {
+  if (esClient) {
+    return esClient;
+  }
+  const { url, username, password } = config.getElasticsearchConfig();
+  esClient = new Client({
+    node: url,
+    auth: { username, password },
+  });
+  return esClient;
 }
 
-export async function safeEsSearch<TResponse = unknown>(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<TResponse>>,
-  body: unknown,
-  index?: string
-): Promise<TResponse | null> {
+export type SearchParams = estypes.SearchRequest;
+
+export async function esSearch<TDocument = unknown, TAggregations = unknown>(
+  params: SearchParams
+): Promise<estypes.SearchResponse<TDocument, TAggregations>> {
+  const client = getClient();
   try {
-    return await esSearch<TResponse>(body, index);
+    return await client.search<TDocument, TAggregations>({
+      ...params,
+    });
+  } catch (err) {
+    if (err instanceof esErrors.ResponseError) {
+      const status = err.statusCode ?? "unknown";
+      const reason = extractErrorReason(err);
+      throw new Error(`Elasticsearch query failed (${status}): ${reason}`);
+    }
+    throw err;
+  }
+}
+
+export async function safeEsSearch<
+  TDocument = unknown,
+  TAggregations = unknown,
+>(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<any>>,
+  params: SearchParams
+): Promise<estypes.SearchResponse<TDocument, TAggregations> | null> {
+  try {
+    return await esSearch<TDocument, TAggregations>(params);
   } catch (err) {
     apiError(req, res, {
       status_code: 502,
@@ -59,4 +82,21 @@ export async function safeEsSearch<TResponse = unknown>(
     });
     return null;
   }
+}
+
+export function bucketsToArray<TBucket>(
+  buckets?: estypes.AggregationsMultiBucketAggregateBase<TBucket>["buckets"]
+): TBucket[] {
+  if (!buckets) {
+    return [];
+  }
+  return Array.isArray(buckets) ? buckets : Object.values(buckets);
+}
+
+export function formatUTCDateFromMillis(ms: number): string {
+  const d = new Date(ms);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -49,12 +49,12 @@ export async function safeEsSearch<TResponse = unknown>(
 ): Promise<TResponse | null> {
   try {
     return await esSearch<TResponse>(body, index);
-  } catch (e: any) {
+  } catch (err) {
     apiError(req, res, {
       status_code: 502,
       api_error: {
         type: "elasticsearch_error",
-        message: String(e?.message || e),
+        message: String(err),
       },
     });
     return null;

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -1,14 +1,9 @@
 import type { estypes } from "@elastic/elasticsearch";
 import { Client, errors as esErrors } from "@elastic/elasticsearch";
-import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
-import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types";
-
-export function getAnalyticsIndex(): string {
-  return config.getElasticsearchConfig().analyticsIndex;
-}
+import { Err, Ok } from "@app/types/shared/result";
+import type { Result } from "@app/types/shared/result";
 
 let esClient: Client | null = null;
 
@@ -42,45 +37,45 @@ function getClient(): Client {
   return esClient;
 }
 
-export type SearchParams = estypes.SearchRequest;
+export type ElasticsearchError = {
+  type: "connection_error" | "query_error" | "unknown_error";
+  message: string;
+  statusCode?: number;
+};
 
-export async function esSearch<TDocument = unknown, TAggregations = unknown>(
+type SearchParams = estypes.SearchRequest;
+
+async function esSearch<TDocument = unknown, TAggregations = unknown>(
   params: SearchParams
-): Promise<estypes.SearchResponse<TDocument, TAggregations>> {
+): Promise<
+  Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
+> {
   const client = getClient();
   try {
-    return await client.search<TDocument, TAggregations>({
+    const result = await client.search<TDocument, TAggregations>({
       ...params,
     });
+    return new Ok(result);
   } catch (err) {
     if (err instanceof esErrors.ResponseError) {
-      const status = err.statusCode ?? "unknown";
+      const statusCode = err.statusCode ?? undefined;
       const reason = extractErrorReason(err);
-      throw new Error(`Elasticsearch query failed (${status}): ${reason}`);
+      return new Err({
+        type: "query_error",
+        message: reason,
+        statusCode,
+      });
     }
-    throw err;
-  }
-}
-
-export async function safeEsSearch<
-  TDocument = unknown,
-  TAggregations = unknown,
->(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<any>>,
-  params: SearchParams
-): Promise<estypes.SearchResponse<TDocument, TAggregations> | null> {
-  try {
-    return await esSearch<TDocument, TAggregations>(params);
-  } catch (err) {
-    apiError(req, res, {
-      status_code: 502,
-      api_error: {
-        type: "elasticsearch_error",
-        message: String(err),
-      },
+    if (err instanceof esErrors.ConnectionError) {
+      return new Err({
+        type: "connection_error",
+        message: "Failed to connect to Elasticsearch",
+      });
+    }
+    return new Err({
+      type: "unknown_error",
+      message: err instanceof Error ? err.message : String(err),
     });
-    return null;
   }
 }
 

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import config from "@app/lib/api/config";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export function getAnalyticsIndex(): string {
+  return config.getElasticsearchConfig().analyticsIndex;
+}
+
+export async function esSearch<TResponse = unknown>(
+  body: unknown,
+  index?: string
+): Promise<TResponse> {
+  const { url, username, password } = config.getElasticsearchConfig();
+  const idx = index ?? getAnalyticsIndex();
+
+  const resp = await fetch(`${url}/${encodeURIComponent(idx)}/_search`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString(
+        "base64"
+      )}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Elasticsearch query failed (${resp.status}): ${text}`);
+  }
+  return (await resp.json()) as TResponse;
+}
+
+export function formatUTCDateFromMillis(ms: number): string {
+  const d = new Date(ms);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export async function safeEsSearch<TResponse = unknown>(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<TResponse>>,
+  body: unknown,
+  index?: string
+): Promise<TResponse | null> {
+  try {
+    return await esSearch<TResponse>(body, index);
+  } catch (e: any) {
+    apiError(req, res, {
+      status_code: 502,
+      api_error: {
+        type: "elasticsearch_error",
+        message: String(e?.message || e),
+      },
+    });
+    return null;
+  }
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,6 +8,7 @@
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.3.9",
+        "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -1586,11 +1587,91 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@elastic/elasticsearch": {
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.19.1.tgz",
+      "integrity": "sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==",
+      "dependencies": {
+        "@elastic/transport": "^8.9.6",
+        "apache-arrow": "18.x - 21.x",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@elastic/transport": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.10.0.tgz",
+      "integrity": "sha512-Xd62ZtgdrJuaunTLk0LqYtkUtJ3D2/NQ4QyLWPYj0c2h97SNUaNkrQH9lzb6r2P0Bdjx/HwKtW3X8kO5LJ7qEQ==",
+      "dependencies": {
+        "@opentelemetry/api": "1.x",
+        "@opentelemetry/core": "2.x",
+        "debug": "^4.4.1",
+        "hpagent": "^1.2.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^3.0.1",
+        "tslib": "^2.8.1",
+        "undici": "^6.21.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@elastic/transport/node_modules/@opentelemetry/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@elastic/transport/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
+      "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@elastic/transport/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/@elastic/transport/node_modules/secure-json-parse": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
+      "integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/@elastic/transport/node_modules/undici": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
+      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@elevenlabs/elevenlabs-js": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.17.0.tgz",
-      "integrity": "sha512-PFQGlW089nzdeiOIyD4BZWDFruLVOq36JYbkXRwsFTKupXmhxGRDHA9I8lPBmeL6gFHV0W2s+YV9kMGKM767ow==",
-      "license": "MIT",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.19.0.tgz",
+      "integrity": "sha512-3hKO469/dNDn+5tRadUUHC/LYNkoIdHRMEBsI/TOsdJrSlbN1wofYuRIEbTSOdjM2Ykfm2kTXCL0WGYloiRY9g==",
       "dependencies": {
         "command-exists": "^1.2.9",
         "node-fetch": "^2.7.0"
@@ -9745,6 +9826,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw=="
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -11356,6 +11447,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
+      "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
+      "dependencies": {
+        "undici-types": "~7.14.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="
+    },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -11424,6 +11555,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -12280,6 +12419,20 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/character-entities": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
@@ -12723,8 +12876,43 @@
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
-      "license": "MIT"
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+      "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
+      "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/commander": {
       "version": "9.5.0",
@@ -16278,6 +16466,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/find-root": {
       "version": "1.1.0",
       "license": "MIT",
@@ -16312,6 +16516,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="
     },
     "node_modules/flatted": {
       "version": "3.2.9",
@@ -18283,6 +18492,14 @@
         "unix-dgram": "2.x"
       }
     },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -18513,6 +18730,17 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
+    },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -19563,6 +19791,14 @@
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/json-buffer": {
@@ -27826,6 +28062,18 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.3.tgz",
@@ -28760,6 +29008,14 @@
       "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
       "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==",
       "license": "MIT"
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/uc.micro": {
       "version": "2.0.0",
@@ -30080,6 +30336,14 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -26,6 +26,7 @@
     "analyze": "NODE_OPTIONS=--max-old-space-size=8192 ANALYZE=true npm run build"
   },
   "dependencies": {
+    "@elastic/elasticsearch": "^8.15.0",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.3.9",

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -139,6 +139,8 @@ const API_ERROR_TYPES = [
   "workos_multiple_directories_not_supported",
   "user_authentication_required",
   "agent_memory_not_found",
+  // ES
+  "elasticsearch_error",
 ] as const;
 
 export type APIErrorType = (typeof API_ERROR_TYPES)[number];


### PR DESCRIPTION
## Description

Adds foundational Elasticsearch configuration and API utilities to support analytics data indexing. This introduces configuration settings for Elasticsearch connection details and provides helper functions for executing queries, building on the team's plan to create analytics indexes in ES for heavy queries that would be slow on the read replica.

This will be used as part of the observability initiative to fetch analytics from ES.

## Risk

Introduces new Elasticsearch dependency with authentication credentials that need to be properly configured in environment variables.

## Deploy Plan

Environment variables need to be set:
- `ELASTICSEARCH_URL`
- `ELASTICSEARCH_USERNAME`
- `ELASTICSEARCH_PASSWORD`
- `ELASTICSEARCH_ANALYTICS_INDEX` (optional, defaults to `front.agent_message_analytics_1`)
