### PR TITLE
Hide retry button for agent message handing off

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -89,6 +89,7 @@ interface AgentMessageProps {
   messageFeedback: FeedbackSelectorProps;
   owner: WorkspaceType;
   user: UserType;
+  hideRetryButton: boolean;
 }
 
 export function AgentMessage({
@@ -97,6 +98,7 @@ export function AgentMessage({
   messageStreamState,
   messageFeedback,
   owner,
+  hideRetryButton = false,
 }: AgentMessageProps) {
   const sId = getMessageSId(messageStreamState);
   const { isDark } = useTheme();
@@ -348,7 +350,8 @@ export function AgentMessage({
   if (
     agentMessageToRender.status !== "created" &&
     agentMessageToRender.status !== "failed" &&
-    !shouldStream
+    !shouldStream &&
+    !hideRetryButton
   ) {
     buttons.push(
       <Button

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -153,7 +153,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               messageStreamState={data}
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}
-              hideRetryButton={hackyIsAgentHandingOver(data, nextData)}
             />
           )}
         </div>
@@ -161,30 +160,3 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
     );
   }
 );
-
-/*
- * Hacky way to check if an agent message is performing a handover to another agent:
- * A handover agent message will be followed by a handover user message that points to this message.
- *
- * Since we don't have branching in the conversation, we don't want to retry a message that has generated another agent response.
- *
- * This is not very robust and should be removed once we have branching in the conversation.
- * (ex: if there's another agent message in between, this will return false and we will display the buttons of the agent message handing off).
- */
-const hackyIsAgentHandingOver = (
-  currentMessage: VirtuosoMessage | null,
-  nextMessage: VirtuosoMessage | null
-): boolean => {
-  // Early return if current message is not an agent message.
-  if (!currentMessage || !isMessageTemporayState(currentMessage)) {
-    return false;
-  }
-
-  // Early return if next message is not a handover user message.
-  if (!nextMessage || !isHandoverUserMessage(nextMessage)) {
-    return false;
-  }
-
-  // Check if the current message is the same as the origin message of the handover user message.
-  return currentMessage.message.sId === nextMessage.context.originMessageId;
-};

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -153,6 +153,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               messageStreamState={data}
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}
+              hideRetryButton={hackyIsAgentHandingOver(data, nextData)}
             />
           )}
         </div>
@@ -160,3 +161,30 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
     );
   }
 );
+
+/*
+ * Hacky way to check if an agent message is performing a handover to another agent:
+ * A handover agent message will be followed by a handover user message that points to this message.
+ *
+ * Since we don't have branching in the conversation, we don't want to retry a message that has generated another agent response.
+ *
+ * This is not very robust and should be removed once we have branching in the conversation.
+ * (ex: if there's another agent message in between, this will return false and we will display the buttons of the agent message handing off).
+ */
+const hackyIsAgentHandingOver = (
+  currentMessage: VirtuosoMessage | null,
+  nextMessage: VirtuosoMessage | null
+): boolean => {
+  // Early return if current message is not an agent message.
+  if (!currentMessage || !isMessageTemporayState(currentMessage)) {
+    return false;
+  }
+
+  // Early return if next message is not a handover user message.
+  if (!nextMessage || !isHandoverUserMessage(nextMessage)) {
+    return false;
+  }
+
+  // Check if the current message is the same as the origin message of the handover user message.
+  return currentMessage.message.sId === nextMessage.context.originMessageId;
+};


### PR DESCRIPTION
## Description

Goal of this PR: Hide the retry button of the agent message handing off. 
I had the choice between doing something "clean" in the backend or hacky in the UI.

I picked the hacky way in the UI for several reasons: 
- I expect we will want branching soon with Collaboration. 
- I think it's okay if this is not super robust since worst case scenario we let a user retry and they just have the not so great xp of having the new message handed off at the bottom of the convo. 
- This was much quicker to implement and will be quicker to remove, and I'm not sure it would have been super clean in the backend. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 