### PR TITLE
Fix message status completed in icon

### DIFF
--- a/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
+++ b/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
@@ -1,4 +1,4 @@
-import { ChevronRightIcon, cn } from "@dust-tt/sparkle";
+import { ChevronRightIcon, cn, Icon } from "@dust-tt/sparkle";
 import React from "react";
 
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -55,7 +55,7 @@ export const AgentMessageCompletionStatus = ({
       onClick={onClick}
     >
       <span>{displayText}</span>
-      <ChevronRightIcon className="h-3 w-3" />
+      <Icon visual={ChevronRightIcon} size="xs" />
     </div>
   );
 };


### PR DESCRIPTION
## Description

Fixing this icon : 
<img width="871" height="351" alt="Screenshot 2025-10-13 at 18 38 58" src="https://github.com/user-attachments/assets/f079d82d-ce14-44ab-bb06-23ba2fdf8c09" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 