### PR TITLE
Add discord list agents command

### DIFF
--- a/connectors/src/api/webhooks/discord/startup.ts
+++ b/connectors/src/api/webhooks/discord/startup.ts
@@ -1,0 +1,125 @@
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+
+import { apiConfig } from "@connectors/lib/api/config";
+import mainLogger from "@connectors/logger/logger";
+
+const logger = mainLogger.child(
+  {
+    provider: "discord",
+  },
+  {
+    msgPrefix: "[Discord Initialization] ",
+  }
+);
+
+interface DiscordSlashCommand {
+  name: string;
+  description: string;
+  type?: number;
+}
+
+async function registerSlashCommand(
+  command: DiscordSlashCommand
+): Promise<Result<void, Error>> {
+  const botToken = apiConfig.getDiscordBotToken();
+  const applicationId = apiConfig.getDiscordApplicationId();
+
+  if (!botToken || !applicationId) {
+    const error = new Error(
+      "Discord API credentials not configured. Set DISCORD_BOT_TOKEN and DISCORD_APPLICATION_ID environment variables."
+    );
+    logger.warn(
+      { command: command.name },
+      "Discord API credentials not configured, skipping command registration"
+    );
+    return new Err(error);
+  }
+
+  try {
+    const url = `https://discord.com/api/v10/applications/${applicationId}/commands`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bot ${botToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: command.name,
+        description: command.description,
+        type: command.type || 1, // 1 is default for slash command
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.error(
+        {
+          status: response.status,
+          statusText: response.statusText,
+          error: errorText,
+          command: command.name,
+        },
+        "Failed to register Discord slash command"
+      );
+      return new Err(
+        new Error(
+          `Failed to register Discord slash command: ${response.status} ${errorText}`
+        )
+      );
+    }
+
+    logger.info(
+      { command: command.name },
+      "Successfully registered Discord slash command"
+    );
+
+    return new Ok(undefined);
+  } catch (error) {
+    logger.error(
+      { error, command: command.name },
+      "Error registering Discord slash command"
+    );
+    return new Err(
+      error instanceof Error
+        ? error
+        : new Error(`Failed to register command: ${error}`)
+    );
+  }
+}
+
+/**
+ * Register the agents command as a Discord slash command
+ */
+async function registerAgentsCommand(): Promise<Result<void, Error>> {
+  const agentsCommand: DiscordSlashCommand = {
+    name: "list-dust-agents",
+    description: "List available agents for this workspace",
+  };
+
+  return registerSlashCommand(agentsCommand);
+}
+
+/**
+ * Initialize Discord commands during service startup
+ * This registers the slash commands with Discord
+ */
+export async function initializeDiscordCommands(): Promise<void> {
+  logger.info("Registering agents command with Discord");
+
+  try {
+    const result = await registerAgentsCommand();
+
+    if (result.isOk()) {
+      logger.info("Discord agents command successfully registered");
+    } else {
+      logger.error(
+        { error: result.error },
+        "Failed to register Discord agents command"
+      );
+    }
+  } catch (error) {
+    logger.error({ error }, "Error during Discord command initialization");
+  }
+}

--- a/connectors/src/api/webhooks/discord/startup.ts
+++ b/connectors/src/api/webhooks/discord/startup.ts
@@ -90,7 +90,7 @@ async function registerSlashCommand(
 }
 
 /**
- * Register the agents command as a Discord slash command
+ * Register the agents command as a Discord slash command.
  */
 async function registerAgentsCommand(): Promise<Result<void, Error>> {
   const agentsCommand: DiscordSlashCommand = {
@@ -102,8 +102,8 @@ async function registerAgentsCommand(): Promise<Result<void, Error>> {
 }
 
 /**
- * Initialize Discord commands during service startup
- * This registers the slash commands with Discord
+ * Initialize Discord commands during service startup. This registers the slash commands with
+ * Discord.
  */
 export async function initializeDiscordCommands(): Promise<void> {
   logger.info("Registering agents command with Discord");

--- a/connectors/src/api/webhooks/discord/utils.ts
+++ b/connectors/src/api/webhooks/discord/utils.ts
@@ -67,7 +67,7 @@ export async function getAvailableAgents(
 }
 
 /**
- * Format agents list for Discord response
+ * Format agents list for Discord response.
  */
 export function formatAgentsList(
   agents: LightAgentConfigurationType[]
@@ -87,8 +87,8 @@ export function formatAgentsList(
 }
 
 /**
- * Get connector from Discord guild ID
- * Looks up the Discord configuration for the guild and returns the associated connector
+ * Get connector from Discord guild ID. Looks up the Discord configuration for the guild and
+ * returns the associated connector.
  *
  * @param guildId - Discord guild (server) ID
  * @param logger - Logger instance

--- a/connectors/src/api/webhooks/discord/utils.ts
+++ b/connectors/src/api/webhooks/discord/utils.ts
@@ -1,0 +1,135 @@
+import type { LightAgentConfigurationType, Result } from "@dust-tt/client";
+import { DustAPI, Err, Ok } from "@dust-tt/client";
+
+import { apiConfig } from "@connectors/lib/api/config";
+import type { Logger } from "@connectors/logger/logger";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import { ConnectorResource as ConnectorResourceClass } from "@connectors/resources/connector_resource";
+import { DiscordConfigurationResource } from "@connectors/resources/discord_configuration_resource";
+import { getHeaderFromUserEmail } from "@connectors/types/shared/headers";
+
+/**
+ * Get available agents for a Discord user.
+ *
+ * @param connector - The connector resource for the workspace
+ * @param userEmail - Optional user email for permission filtering
+ * @param logger - Logger instance
+ */
+export async function getAvailableAgents(
+  connector: ConnectorResource,
+  logger: Logger,
+  userEmail?: string
+): Promise<Result<LightAgentConfigurationType[], Error>> {
+  try {
+    const dustAPI = new DustAPI(
+      { url: apiConfig.getDustFrontAPIUrl() },
+      {
+        workspaceId: connector.workspaceId,
+        apiKey: connector.workspaceAPIKey,
+        extraHeaders: {
+          ...getHeaderFromUserEmail(userEmail),
+        },
+      },
+      logger
+    );
+
+    const agentConfigurationsRes = await dustAPI.getAgentConfigurations({});
+    if (agentConfigurationsRes.isErr()) {
+      logger.error(
+        { error: agentConfigurationsRes.error },
+        "Failed to get agent configurations"
+      );
+      return new Err(new Error(agentConfigurationsRes.error.message));
+    }
+
+    const activeAgents = agentConfigurationsRes.value.filter(
+      (ac) => ac.status === "active"
+    );
+
+    logger.info(
+      {
+        workspaceId: connector.workspaceId,
+        totalAgents: agentConfigurationsRes.value.length,
+        activeAgents: activeAgents.length,
+        userEmail: userEmail,
+      },
+      "Retrieved available agents for Discord user"
+    );
+
+    return new Ok(activeAgents);
+  } catch (error) {
+    logger.error(
+      { error, workspaceId: connector.workspaceId },
+      "Error getting available agents for Discord user"
+    );
+    return new Err(new Error(`Failed to get agents: ${error}`));
+  }
+}
+
+/**
+ * Format agents list for Discord response
+ */
+export function formatAgentsList(
+  agents: LightAgentConfigurationType[]
+): string {
+  if (agents.length === 0) {
+    return "No active agents found in this workspace.";
+  }
+
+  const agentsList = agents
+    .map((agent, index) => {
+      const description = agent.description ? ` - ${agent.description}` : "";
+      return `${index + 1}. **${agent.name}**${description}`;
+    })
+    .join("\n");
+
+  return `**Published Agents (${agents.length}):**\n\n${agentsList}`;
+}
+
+/**
+ * Get connector from Discord guild ID
+ * Looks up the Discord configuration for the guild and returns the associated connector
+ *
+ * @param guildId - Discord guild (server) ID
+ * @param logger - Logger instance
+ */
+export async function getConnectorFromGuildId(
+  guildId: string,
+  logger: Logger
+): Promise<Result<ConnectorResource, Error>> {
+  try {
+    const discordConfigs =
+      await DiscordConfigurationResource.listForGuildId(guildId);
+
+    if (discordConfigs.length === 0) {
+      return new Err(
+        new Error("No Dust workspace is connected to this Discord server.")
+      );
+    }
+
+    const enabledConfig = discordConfigs.find((config) => config.botEnabled);
+
+    if (!enabledConfig) {
+      return new Err(
+        new Error("The Dust bot is not enabled for this Discord server.")
+      );
+    }
+
+    const connector = await ConnectorResourceClass.fetchById(
+      enabledConfig.connectorId
+    );
+
+    if (!connector) {
+      logger.error(
+        { connectorId: enabledConfig.connectorId, guildId },
+        "Connector not found for Discord configuration"
+      );
+      return new Err(new Error("Connector not found."));
+    }
+
+    return new Ok(connector);
+  } catch (error) {
+    logger.error({ error, guildId }, "Error getting connector from guild ID");
+    return new Err(new Error(`Failed to get connector: ${error}`));
+  }
+}

--- a/connectors/src/api/webhooks/webhook_discord_app.ts
+++ b/connectors/src/api/webhooks/webhook_discord_app.ts
@@ -145,13 +145,9 @@ async function handleListAgentsCommand(
 
   const connector = connectorResult.value;
 
-  const agentsResult = await getAvailableAgents(
-    connector,
-    logger
-    // Discord doesn't provide email directly in slash commands.
-    // You would need to implement a separate user mapping system if you want
-    // to filter agents based on user permissions.
-  );
+  // Discord doesn't provide email directly in slash commands. You would need to implement a
+  // separate user mapping system if you want to filter agents based on user permissions.
+  const agentsResult = await getAvailableAgents(connector, logger);
 
   if (agentsResult.isErr()) {
     logger.error(
@@ -231,7 +227,7 @@ const _webhookDiscordAppHandler = async (
     });
   }
 
-  // Handle application commands (slash commands)
+  // Handle application commands (slash commands).
   if (interactionBody.type === DiscordInteraction.APPLICATION_COMMAND) {
     const commandName = interactionBody.data?.name;
     const guildId = interactionBody.guild_id;
@@ -247,12 +243,12 @@ const _webhookDiscordAppHandler = async (
     }
 
     if (commandName === "list-dust-agents") {
-      // Send deferred response immediately to avoid timeout
+      // Send deferred response immediately to avoid timeout.
       const deferredResponse = res.status(200).json({
         type: DiscordInteractionResponse.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
       });
 
-      // Process the command asynchronously
+      // Process the command asynchronously.
       setImmediate(async () => {
         await handleListAgentsCommand(interactionBody, guildId, userId);
       });
@@ -287,7 +283,7 @@ async function parseExpressRequestRawBody(req: Request): Promise<string> {
 }
 
 /**
- * Send a follow-up message to Discord after a deferred response
+ * Send a follow-up message to Discord after a deferred response.
  */
 async function sendDiscordFollowUp(
   interactionBody: DiscordWebhookReqBody,

--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -40,4 +40,10 @@ export const apiConfig = {
   getDiscordAppPublicKey: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("DISCORD_APP_PUBLIC_KEY");
   },
+  getDiscordBotToken: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("DISCORD_BOT_TOKEN");
+  },
+  getDiscordApplicationId: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("DISCORD_APP_ID");
+  },
 };

--- a/connectors/src/start.ts
+++ b/connectors/src/start.ts
@@ -8,6 +8,7 @@ import { runMicrosoftWorker } from "@connectors/connectors/microsoft/temporal/wo
 import { runSalesforceWorker } from "@connectors/connectors/salesforce/temporal/worker";
 import { runSnowflakeWorker } from "@connectors/connectors/snowflake/temporal/worker";
 
+import { initializeDiscordCommands } from "./api/webhooks/discord/startup";
 import { runGithubWorker } from "./connectors/github/temporal/worker";
 import { runGoogleWorkers } from "./connectors/google_drive/temporal/worker";
 import { runIntercomWorker } from "./connectors/intercom/temporal/worker";
@@ -68,4 +69,8 @@ runSalesforceWorker().catch((err) =>
 );
 runGongWorker().catch((err) =>
   logger.error(errorFromAny(err), "Error running gong worker")
+);
+
+initializeDiscordCommands().catch((err) =>
+  logger.error(errorFromAny(err), "Error initializing Discord commands")
 );

--- a/connectors/src/start.ts
+++ b/connectors/src/start.ts
@@ -71,6 +71,4 @@ runGongWorker().catch((err) =>
   logger.error(errorFromAny(err), "Error running gong worker")
 );
 
-initializeDiscordCommands().catch((err) =>
-  logger.error(errorFromAny(err), "Error initializing Discord commands")
-);
+initializeDiscordCommands();


### PR DESCRIPTION
## Description

* Adding ability to automatically update slash command registration upon connector start up
* Adding ability to list Dust agents in discord. Note, we currently have no way of acquiring the calling user email. As a result, only agents that are published associated with company space will be shown

## Tests

<img width="778" height="491" alt="Screenshot 2025-10-13 at 3 30 36 PM" src="https://github.com/user-attachments/assets/793266ed-c956-41f2-b833-932687f10938" />


## Risk

* Not public facing yet

## Deploy Plan

1. Add environment variables - DISCORD_BOT_TOKEN and DISCORD_APP_ID to connector
2. Deploy connectors