### PR TITLE
Sparkle: Fix alignment in ConversationMessage + remove type agentAsTool

### DIFF
--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -43,15 +43,13 @@ interface ConversationMessageProps
   type: ConversationMessageType;
 }
 
-export type ConversationMessageType = "user" | "agent" | "agentAsTool";
+export type ConversationMessageType = "user" | "agent";
 
 const messageVariants = cva("s-flex s-w-full s-flex-col s-rounded-2xl", {
   variants: {
     type: {
       user: "s-bg-muted-background dark:s-bg-muted-background-night s-px-5 s-py-4 s-gap-2",
       agent: "s-w-full s-gap-3",
-      agentAsTool:
-        "s-w-full s-gap-5 s-border s-border-border dark:s-border-border-night s-rounded-2xl s-px-5 s-py-5",
     },
   },
   defaultVariants: {
@@ -64,7 +62,6 @@ const buttonsVariants = cva("s-flex s-justify-start s-gap-2 s-pt-2", {
     type: {
       user: "s-justify-end",
       agent: "s-justify-start",
-      agentAsTool: "s-justify-start",
     },
   },
   defaultVariants: {
@@ -110,7 +107,6 @@ export const ConversationMessage = React.forwardRef<
             isDisabled={isDisabled}
             renderName={renderName}
             infoChip={infoChip}
-            type={type}
           />
 
           <ConversationMessageContent citations={citations} type={type}>
@@ -149,9 +145,7 @@ export const ConversationMessageContent = React.forwardRef<
       )}
       {...props}
     >
-      <div
-        className="s-text-base s-text-foreground dark:s-text-foreground-night"
-      >
+      <div className="s-text-base s-text-foreground dark:s-text-foreground-night">
         {children}
       </div>
       {citations && citations.length > 0 && (
@@ -173,7 +167,6 @@ interface ConversationMessageHeaderProps
   completionStatus?: React.ReactNode;
   infoChip?: React.ReactNode;
   renderName: (name: string | null) => React.ReactNode;
-  type: ConversationMessageType;
 }
 
 export const ConversationMessageHeader = React.forwardRef<
@@ -188,7 +181,6 @@ export const ConversationMessageHeader = React.forwardRef<
       name = "",
       timestamp,
       infoChip,
-      type,
       completionStatus,
       renderName,
       className,
@@ -205,33 +197,27 @@ export const ConversationMessageHeader = React.forwardRef<
         )}
         {...props}
       >
-        {type !== "agentAsTool" && (
-          <>
-            <Avatar
-              className="@sm:s-hidden"
-              name={name}
-              visual={avatarUrl}
-              busy={isBusy}
-              disabled={isDisabled}
-              size="xs"
-            />
-            <Avatar
-              className="s-hidden @sm:s-flex"
-              name={name}
-              visual={avatarUrl}
-              busy={isBusy}
-              disabled={isDisabled}
-              size="sm"
-            />
-          </>
-        )}
-        <div className="s-flex s-w-full s-flex-row s-justify-between s-gap-0.5">
-          <div
-            className="s-heading-sm s-text-foreground dark:s-text-foreground-night s-flex s-flex-row s-items-center s-gap-2"
-          >
-            {renderName(name)}
-            {infoChip}
-            <span className="s-text-xs s-text-muted-foreground dark:s-text-muted-foreground-night">
+        <Avatar
+          className="@sm:s-hidden"
+          name={name}
+          visual={avatarUrl}
+          busy={isBusy}
+          disabled={isDisabled}
+          size="xs"
+        />
+        <Avatar
+          className="s-hidden @sm:s-flex"
+          name={name}
+          visual={avatarUrl}
+          busy={isBusy}
+          disabled={isDisabled}
+          size="sm"
+        />
+        <div className="s-inline-flex s-w-full s-justify-between s-gap-0.5">
+          <div className="s-inline-flex s-items-baseline s-gap-2 s-text-foreground dark:s-text-foreground-night">
+            <span className="s-heading-sm">{renderName(name)}</span>
+            {infoChip && infoChip}
+            <span className="s-heading-xs s-text-muted-foreground dark:s-text-muted-foreground-night">
               {timestamp}
             </span>
           </div>

--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -216,10 +216,10 @@ export const ConversationMessageHeader = React.forwardRef<
         <div className="s-inline-flex s-w-full s-justify-between s-gap-0.5">
           <div className="s-inline-flex s-items-baseline s-gap-2 s-text-foreground dark:s-text-foreground-night">
             <span className="s-heading-sm">{renderName(name)}</span>
-            {infoChip && infoChip}
             <span className="s-heading-xs s-text-muted-foreground dark:s-text-muted-foreground-night">
               {timestamp}
             </span>
+            {infoChip && infoChip}
           </div>
           {completionStatus ?? null}
         </div>

--- a/sparkle/src/stories/ConversationMessage.stories.tsx
+++ b/sparkle/src/stories/ConversationMessage.stories.tsx
@@ -3,15 +3,14 @@ import React from "react";
 
 import {
   ArrowPathIcon,
-  AtomIcon,
   Avatar,
   Button,
+  ChevronRightIcon,
   Citation,
   CitationIcons,
   CitationTitle,
   ClipboardIcon,
   ClockIcon,
-  CommandLineIcon,
   ConversationContainer,
   ConversationMessage,
   GithubIcon,
@@ -227,24 +226,13 @@ export const ConversationHandoffExample = () => {
             />
           </ConversationMessage>
           <ConversationMessage
-            type="agentAsTool"
-            name="Deep Dive"
-            renderName={(name) => (
-              <span className="s-inline-flex s-items-center s-text-muted-foreground dark:s-text-muted-foreground-night">
-                <Icon visual={AtomIcon} size="sm" />
-                <span className="s-ml-1">{name}</span>
-              </span>
-            )}
+            name="@deep-dive"
+            type="agent"
             completionStatus={
-              <Button
-                icon={CommandLineIcon}
-                onClick={() => {
-                  console.log("soupinou");
-                }}
-                label="Completed in 9 min 30 sec"
-                size="xs"
-                variant={"outline"}
-              />
+              <span className="s-flex s-cursor-pointer s-items-center s-gap-1 s-text-xs">
+                <span>Completed in 9 min 30 sec</span>
+                <Icon visual={ChevronRightIcon} size="xs" />
+              </span>
             }
             citations={[
               <Citation href="https://www.google.com">

--- a/sparkle/src/stories/ConversationMessage.stories.tsx
+++ b/sparkle/src/stories/ConversationMessage.stories.tsx
@@ -3,14 +3,13 @@ import React from "react";
 
 import {
   ArrowPathIcon,
-  Avatar,
+  BoltIcon,
   Button,
   ChevronRightIcon,
   Citation,
   CitationIcons,
   CitationTitle,
   ClipboardIcon,
-  ClockIcon,
   ConversationContainer,
   ConversationMessage,
   GithubIcon,
@@ -47,7 +46,9 @@ export const ConversationExample = () => {
               </Citation>,
             ]}
             infoChip={
-              <Avatar size="xs" visual={<ClockIcon className="h-4 w-4" />} />
+              <span className="s-translate-y-1 s-text-muted-foreground dark:s-text-muted-foreground-night">
+                <Icon size="xs" visual={BoltIcon} />
+              </span>
             }
           >
             I only want to show citations if a citations reactnode has been


### PR DESCRIPTION
## Description

ConversationMessage component: 
- Remove styling for type = "agentAsTool" that we won't use (explo for deep dive). 
- Fix alignment using baseline. 

<kbd>
<img width="408" height="298" alt="Screenshot 2025-10-13 at 22 18 35" src="https://github.com/user-attachments/assets/4efabe19-365b-448b-933a-45994c95e338" />
</kbd>


<kbd>
<img width="460" height="236" alt="Screenshot 2025-10-13 at 22 18 41" src="https://github.com/user-attachments/assets/032d70f0-04d3-4d26-a394-b3b39b0aca82" />
</kbd>


## Tests

Locally on storybook. 

## Risk

type "agentAsTool" is unused. 

## Deploy Plan

Publish Sparkle. 