### PR TITLE
chore(GH actions): update claude actions from beta to GA version

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,10 +47,10 @@ jobs:
       - name: Run Code Review with Claude
         if: steps.should-run.outputs.result == 'true'
         id: code-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           # Define the review focus areas
-          direct_prompt: >-
+          prompt: >-
             Code Review Agent
 
             ## Primary Objective:
@@ -114,6 +114,8 @@ jobs:
             - When our guidelines conflict with general best practices, our guidelines take precedence
 
           # Limited tools for safer review operations
-          allowed_tools: '["Bash(git diff --name-only HEAD~1)", "Bash(git diff HEAD~1)", "View", "GlobTool", "GrepTool"]'
+          claude_args: |
+            --model claude-4.5-sonnet-20251022
+            --allowed-tools Bash(git diff --name-only HEAD~1),Bash(git diff HEAD~1),View,GlobTool,GrepTool
 
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -72,7 +72,6 @@ jobs:
             - Add comments **only** for complex, non-obvious logic; wrap at ~100 characters.
             - Write code that fails fast and explicitly; assume valid inputs.
             - Write high quality, general purpose solutions. Implement solutions that works correctly for all valid inputs, not just the test cases.
-            - Provide principled implementations that follows best practices and software design principles.
             - After receiving tool results, carefully reflect on their quality and determine optimal next steps before proceeding. Use your thinking to plan and iterate based on this new information, and then take the best next action.
             - Follow the codebase's best practices and aim for consistency.
             - In TypeScript, never use `any`. Properly type your code.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,39 +53,15 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Specify model (defaults to Claude Sonnet 4, using Claude Opus 4)
-          model: "claude-opus-4-20250514"
-
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-
-          # Allow Claude to use all available tools
-          allowed_tools: |
-            Agent,
-            Bash,
-            Edit,
-            Glob,
-            Grep,
-            LS,
-            MultiEdit,
-            NotebookEdit,
-            NotebookRead,
-            Read,
-            TodoRead,
-            TodoWrite,
-            WebFetch,
-            WebSearch,
-            Write
-
-          # Custom instructions based on CLAUDE.md
-          custom_instructions: |
+          claude_args: |
+            --model claude-4.5-sonnet-20251022
+            --max-turns 12
+            --allowed-tools Agent,Bash,Edit,Glob,Grep,LS,MultiEdit,NotebookEdit,NotebookRead,Read,TodoRead,TodoWrite,WebFetch,WebSearch,Write
+            --system-prompt "
             ### 1. General Principles
 
             - Never make changes to the codebase that the user did not ask for.
@@ -154,8 +130,15 @@ jobs:
             - Follow all CODING_RULES.md files in each project directory
             - Let exceptions propagate, avoid defensive patterns
             - Make minimal changes required
-            - Use normalizeError() instead of `err as Error`
+            - Use normalizeError() instead of `err as Error`"
+
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
 
           # Environment variables for Claude
-          claude_env: |
-            NODE_ENV: test
+          settings: |
+            {
+              "env": {
+                "NODE_ENV": "test"
+              }
+            }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -102,12 +102,16 @@ jobs:
 
             - When renaming a function, **do not** keep the old name for backward compatibility.
 
-            ### 6. Internet Access
+            ### 6. Planning Requests
+
+            - If asked to create a plan, propose actions only—**no code changes** until approval.
+
+            ### 7. Internet Access
 
             - Use your WebSearch tools to search the internet.
             - This is required to find documentation for libraries, latest package versions, etc.
 
-            ### 7. Import Rules
+            ### 8. Import Rules
 
             - For TypeScript, place all imports at the top of the file; never use async imports.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -71,6 +71,11 @@ jobs:
             - Avoid "defensive" patterns (default values, removing tests, non-null assertions).
             - Add comments **only** for complex, non-obvious logic; wrap at ~100 characters.
             - Write code that fails fast and explicitly; assume valid inputs.
+            - Write high quality, general purpose solutions. Implement solutions that works correctly for all valid inputs, not just the test cases.
+            - Provide principled implementations that follows best practices and software design principles.
+            - After receiving tool results, carefully reflect on their quality and determine optimal next steps before proceeding. Use your thinking to plan and iterate based on this new information, and then take the best next action.
+            - Follow the codebase's best practices and aim for consistency.
+            - In TypeScript, never use `any`. Properly type your code.
 
             ### 2. Code Modification & Compilation
 
@@ -97,16 +102,12 @@ jobs:
 
             - When renaming a function, **do not** keep the old name for backward compatibility.
 
-            ### 6. Planning Requests
-
-            - If asked to create a plan, propose actions only—**no code changes** until approval.
-
-            ### 8. Internet Access
+            ### 6. Internet Access
 
             - Use your WebSearch tools to search the internet.
             - This is required to find documentation for libraries, latest package versions, etc.
 
-            ### 9. Import Rules
+            ### 7. Import Rules
 
             - For TypeScript, place all imports at the top of the file; never use async imports.
 


### PR DESCRIPTION
## Description

- This PR updates the GitHub actions for claude code and claude review from the beta to the GA version (v1).
- Documentation [here](https://docs.claude.com/en/docs/claude-code/github-actions) and [here](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md).
- Will try out with a much lighter prompt as well, not convinced we need this many instructions with 4.5.

## Tests

## Risk

- Low.

## Deploy Plan

- No deploy.
