### PR TITLE
Support using a UUID as an alternative to the Notion URL

### DIFF
--- a/connectors/src/connectors/notion/lib/utils.ts
+++ b/connectors/src/connectors/notion/lib/utils.ts
@@ -148,7 +148,18 @@ export async function buildNotionBreadcrumbs(
  * @throws Error if URL is invalid
  */
 export function pageOrDbIdFromUrl(url: string): string {
-  const u = new URL(url);
+  // If it is already a UUID, return it directly. This allows users to enter
+  // either a full URL or just the ID (e.g. in the Check URL Poke UI).
+  const trimmed = url.trim();
+  if (
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
+      trimmed
+    )
+  ) {
+    return trimmed;
+  }
+
+  const u = new URL(trimmed);
   const last = u.pathname.split("/").pop();
   if (!last) {
     throw new Error(`Unhandled URL (could not get "last"): ${url}`);


### PR DESCRIPTION
## Description

Just a small convenience to be able to use the UUID instead of the URL. e.g. this is useful when walking parent chain in Poke, where the parent is given as just the UUID.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Connectors.