### PR TITLE
Revert "Add files:write scope on Slack"

### DIFF
--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -75,7 +75,6 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
             "channels:read",
             "chat:write",
             "files:read",
-            "files:write",
             "groups:history",
             "groups:read",
             "im:history",


### PR DESCRIPTION
Reverts dust-tt/dust#16819

@Chrisjow temporary reverting as Slack does not let you use a scope that has not been approved. Even on your own workspace.