### PR TITLE
fix(front): download and display of attachments and generated files

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -98,14 +98,14 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
 
     const citations =
       isUserMessage(data) && data.contentFragments.length > 0
-        ? data.contentFragments.map((contentFragment) => {
+        ? data.contentFragments.map((contentFragment, index) => {
             const attachmentCitation =
               contentFragmentToAttachmentCitation(contentFragment);
 
             return (
               <AttachmentCitation
                 owner={context.owner}
-                key={attachmentCitation.id}
+                key={index}
                 attachmentCitation={attachmentCitation}
                 conversationId={context.conversationId}
               />

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -17,6 +17,7 @@ import {
   isTextualContentType,
 } from "@app/components/assistant/conversation/attachment/utils";
 import type { LightWorkspaceType } from "@app/types";
+import { getFileFormat } from "@app/types";
 import { isSupportedImageContentType } from "@app/types";
 
 interface AttachmentCitationProps {
@@ -59,6 +60,7 @@ export function AttachmentCitation({
 
   const canOpenInDialog =
     attachmentCitation.type === "file" &&
+    getFileFormat(attachmentCitation.contentType)?.isSafeToDisplay &&
     (isTextualContentType(attachmentCitation) ||
       isAudioContentType(attachmentCitation));
 
@@ -114,7 +116,7 @@ export function AttachmentCitation({
         }
         label={tooltipContent}
       />
-      {attachmentCitation.type === "file" && (
+      {canOpenInDialog && (
         <AttachmentViewer
           setViewerOpen={setViewerOpen}
           viewerOpen={viewerOpen}

--- a/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
@@ -104,7 +104,10 @@ export const AttachmentViewer = ({
         return;
       }
 
-      if (attachmentCitation.attachmentCitationType === "fragment") {
+      if (
+        attachmentCitation.attachmentCitationType === "fragment" ||
+        attachmentCitation.attachmentCitationType === "mcp"
+      ) {
         if (isFileContentLoading) {
           return;
         }
@@ -142,9 +145,11 @@ export const AttachmentViewer = ({
     </>
   );
 
+  const canDownload = !!fileId;
   const onClickDownload = () => {
-    const downloadUrl =
-      isAudio && fileId ? getFileDownloadUrl(owner, fileId) : undefined;
+    const downloadUrl = canDownload
+      ? getFileDownloadUrl(owner, fileId)
+      : undefined;
 
     if (downloadUrl) {
       window.open(downloadUrl, "_blank");
@@ -156,7 +161,7 @@ export const AttachmentViewer = ({
       <DialogContent size="xl" height="lg">
         <DialogHeader>
           <DialogTitle>
-            {isAudio && (
+            {canDownload && (
               <Button
                 onClick={onClickDownload}
                 icon={ArrowDownOnSquareIcon}

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -140,11 +140,11 @@ export function InputBarAttachments({
   return (
     <>
       <CitationGrid className="border-b border-separator px-3 pb-3 pt-3 dark:border-separator-night">
-        {allAttachments.map((attachment) => {
+        {allAttachments.map((attachment, index) => {
           const attachmentCitation = attachmentToAttachmentCitation(attachment);
           return (
             <AttachmentCitation
-              key={attachmentCitation.id}
+              key={index}
               owner={owner}
               attachmentCitation={attachmentCitation}
               conversationId={conversationId}

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -493,7 +493,7 @@ export function getFileFormatCategory(
   return null;
 }
 
-function getFileFormat(contentType: string): FileFormat | null {
+export function getFileFormat(contentType: string): FileFormat | null {
   if (isSupportedFileContentType(contentType)) {
     const format = FILE_FORMATS[contentType];
     if (format) {


### PR DESCRIPTION
## Description

Fix, and I hope, once and for good display and download of attachments. 

It should be:
* you can only download (without seeing it) the file if it's unsafe to display and not a pure text/audio file
* you can see the file if it's safe to display and a pure text/audio. And you can download it in the popover

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
