### PR TITLE
[front] chore(alerting): make alerting opt-in in `withToolLogging`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
@@ -28,7 +28,10 @@ const createServer = (auth: Authenticator): McpServer => {
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: CONFLUENCE_TOOL_NAME },
+      {
+        toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -71,7 +74,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: CONFLUENCE_TOOL_NAME },
+      {
+        toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (params, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -128,7 +134,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: CONFLUENCE_TOOL_NAME },
+      {
+        toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (params, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -196,7 +205,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: CONFLUENCE_TOOL_NAME },
+      {
+        toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (params, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {

--- a/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
@@ -203,7 +203,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ filter, fields, page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -275,7 +278,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ ticket_id, fields, include }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -331,7 +337,10 @@ function createServer(auth: Authenticator): McpServer {
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (_, { authInfo }) => {
         return withAuth({
           action: async () => {
@@ -374,7 +383,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           email,
@@ -485,7 +497,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           ticket_id,
@@ -558,7 +573,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ ticket_id, body, private: isPrivate }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -597,7 +615,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ ticket_id, body }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -634,7 +655,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ ticket_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -666,7 +690,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ ticket_id, task_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -716,7 +743,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           ticket_id,
@@ -809,7 +839,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           ticket_id,
@@ -884,7 +917,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ ticket_id, task_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -920,7 +956,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -958,7 +997,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -996,7 +1038,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1034,7 +1079,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1077,7 +1125,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ category_id, page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1136,7 +1187,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { search_term, workspace_id, user_email, page, per_page },
         { authInfo }
@@ -1185,7 +1239,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ display_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1218,7 +1275,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ display_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1275,7 +1335,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { display_id, email, quantity, requested_for, fields },
         { authInfo }
@@ -1368,7 +1431,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1406,7 +1472,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ category_id, page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1456,7 +1525,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ folder_id, category_id, page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1511,7 +1583,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ article_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1553,7 +1628,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ title, description, folder_id, status, tags }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1606,7 +1684,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ email, mobile, phone, page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1652,7 +1733,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ requester_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1685,7 +1769,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1720,7 +1807,10 @@ function createServer(auth: Authenticator): McpServer {
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1754,7 +1844,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ search }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1812,7 +1905,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { search, category_id, folder_id, is_public, page, per_page },
         { authInfo }
@@ -1864,7 +1960,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ response_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1896,7 +1995,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ ticket_id, approval_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1927,7 +2029,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ ticket_id }, { authInfo }) => {
         return withAuth({
           action: async (accessToken, freshserviceDomain) => {
@@ -1975,7 +2080,10 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FRESHSERVICE_TOOL_NAME },
+      {
+        toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { ticket_id, approver_id, approval_type, email_content },
         { authInfo }

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -78,7 +78,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "gmail" },
+      {
+        toolNameForMonitoring: "gmail",
+        skipAlerting: true,
+      },
       async ({ q, pageToken }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -157,7 +160,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "gmail" },
+      {
+        toolNameForMonitoring: "gmail",
+        skipAlerting: true,
+      },
       async ({ to, cc, bcc, subject, contentType, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -235,7 +241,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "gmail" },
+      {
+        toolNameForMonitoring: "gmail",
+        skipAlerting: true,
+      },
       async ({ draftId, subject, to }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -291,7 +300,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "gmail" },
+      {
+        toolNameForMonitoring: "gmail",
+        skipAlerting: true,
+      },
       async ({ q, maxResults = 10, pageToken }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -422,7 +434,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "gmail" },
+      {
+        toolNameForMonitoring: "gmail",
+        skipAlerting: true,
+      },
       async (
         { messageId, body, contentType = "text/plain" as const, to, cc, bcc },
         { authInfo }

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -124,7 +124,11 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ pageToken, maxResults }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -182,7 +186,11 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async (
         { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
         { authInfo }
@@ -262,7 +270,11 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -321,7 +333,11 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async (
         {
           calendarId = "primary",
@@ -420,7 +436,11 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async (
         {
           calendarId = "primary",
@@ -512,7 +532,11 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
@@ -564,7 +588,11 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ email, startTime, endTime, timeZone }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
         assert(

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -48,7 +48,10 @@ const createServer = (auth: any): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_drive" },
+      {
+        toolNameForMonitoring: "google_drive",
+        skipAlerting: true,
+      },
       async ({ pageToken }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
@@ -141,7 +144,10 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_drive" },
+      {
+        toolNameForMonitoring: "google_drive",
+        skipAlerting: true,
+      },
       async (
         { q, pageToken, pageSize, driveId, includeSharedDrives, orderBy },
         { authInfo }
@@ -229,7 +235,10 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "google_drive" },
+      {
+        toolNameForMonitoring: "google_drive",
+        skipAlerting: true,
+      },
       async ({ fileId, offset, limit }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -65,7 +65,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
         if (!drive) {
@@ -120,7 +123,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ spreadsheetId, includeGridData }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -172,7 +178,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { spreadsheetId, range, majorDimension, valueRenderOption },
         { authInfo }
@@ -232,7 +241,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { spreadsheetId, range, values, majorDimension, valueInputOption },
         { authInfo }
@@ -299,7 +311,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           spreadsheetId,
@@ -357,7 +372,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ spreadsheetId, range }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -400,7 +418,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ title, sheetTitles }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -455,7 +476,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ spreadsheetId, title, rowCount, columnCount }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -509,7 +533,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ spreadsheetId, sheetId }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -587,7 +614,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           spreadsheetId,
@@ -667,7 +697,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { sourceSpreadsheetId, sheetId, destinationSpreadsheetId },
         { authInfo }
@@ -712,7 +745,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
@@ -770,7 +806,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME },
+      {
+        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {

--- a/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
@@ -64,7 +64,10 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -101,7 +104,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ issueKey, fields }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -143,7 +149,10 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -174,7 +183,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -212,7 +224,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -249,7 +264,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -294,7 +312,10 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { issueKey, comment, visibilityType, visibilityValue },
         { authInfo }
@@ -364,7 +385,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -420,7 +444,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -465,7 +492,10 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -509,7 +539,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ projectKey, issueTypeId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -549,7 +582,10 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (_, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -585,7 +621,10 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ issueKey, transitionId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -643,7 +682,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ issueData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -683,7 +725,10 @@ const createServer = (
 
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ issueKey, updateData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -732,7 +777,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ linkData }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -769,7 +817,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ linkId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -797,7 +848,10 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (_, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -858,7 +912,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
         { authInfo }
@@ -964,7 +1021,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ issueKey, attachment }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -1079,7 +1139,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {
@@ -1135,7 +1198,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: JIRA_TOOL_NAME },
+      {
+        toolNameForMonitoring: JIRA_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ issueKey, attachmentId }, { authInfo }) => {
         return withAuth({
           action: async (baseUrl, accessToken) => {

--- a/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
@@ -55,7 +55,10 @@ const createServer = (auth: Authenticator): McpServer => {
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: MONDAY_TOOL_NAME },
+      {
+        toolNameForMonitoring: MONDAY_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (_params, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -82,7 +85,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: MONDAY_TOOL_NAME },
+      {
+        toolNameForMonitoring: MONDAY_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ boardId }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -109,7 +115,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: MONDAY_TOOL_NAME },
+      {
+        toolNameForMonitoring: MONDAY_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ itemId }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -165,7 +174,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: MONDAY_TOOL_NAME },
+      {
+        toolNameForMonitoring: MONDAY_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           query,
@@ -234,7 +246,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: MONDAY_TOOL_NAME },
+      {
+        toolNameForMonitoring: MONDAY_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ boardId, itemName, groupId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -272,7 +287,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: MONDAY_TOOL_NAME },
+      {
+        toolNameForMonitoring: MONDAY_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ itemId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
 
@@ -305,7 +323,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: MONDAY_TOOL_NAME },
+      {
+        toolNameForMonitoring: MONDAY_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ itemId, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
 

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -331,7 +331,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ query, type, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(new MCPError("Agent loop run context is required"));
@@ -488,7 +491,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ pageId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.retrieve({ page_id: pageId }),
@@ -506,7 +512,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ databaseId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.databases.retrieve({ database_id: databaseId }),
@@ -531,7 +540,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
         { authInfo }
@@ -566,7 +578,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
         { authInfo }
@@ -599,7 +614,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ parent, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.create({ parent, properties, icon, cover }),
@@ -620,7 +638,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ databaseId, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -654,7 +675,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ parent, title, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -674,7 +698,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.update({ page_id: pageId, properties }),
@@ -692,7 +719,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.blocks.retrieve({ block_id: blockId }),
@@ -715,7 +745,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ blockId, start_cursor, page_size }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -743,7 +776,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ blockId, children }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -778,7 +814,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ parent_page_id, discussion_id, comment }, { authInfo }) => {
         return withNotionClient((notion) => {
           if (!parent_page_id && !discussion_id) {
@@ -814,7 +853,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -835,7 +877,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.comments.list({ block_id: blockId }),
@@ -854,7 +899,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.pages.update({ page_id: pageId, properties }),
@@ -873,7 +921,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ databaseId, properties }, { authInfo }) => {
         return withNotionClient(
           (notion) =>
@@ -890,7 +941,10 @@ const createServer = (
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (_, { authInfo }) => {
         return withNotionClient((notion) => notion.users.list({}), authInfo);
       }
@@ -905,7 +959,10 @@ const createServer = (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: NOTION_TOOL_NAME },
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ userId }, { authInfo }) => {
         return withNotionClient(
           (notion) => notion.users.retrieve({ user_id: userId }),

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
@@ -104,7 +104,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
+      {
+        toolNameForMonitoring: OUTLOOK_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ search, top = 10, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -181,7 +184,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
+      {
+        toolNameForMonitoring: OUTLOOK_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ search, top = 10, skip = 0 }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -267,7 +273,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
+      {
+        toolNameForMonitoring: OUTLOOK_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         { to, cc, bcc, subject, contentType, body, importance = "normal" },
         { authInfo }
@@ -342,7 +351,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
+      {
+        toolNameForMonitoring: OUTLOOK_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ messageId, subject, to }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -410,7 +422,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
+      {
+        toolNameForMonitoring: OUTLOOK_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           messageId,
@@ -529,7 +544,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
+      {
+        toolNameForMonitoring: OUTLOOK_TOOL_NAME,
+        skipAlerting: true,
+      },
       async ({ search, top = 20, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -614,7 +632,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
+      {
+        toolNameForMonitoring: OUTLOOK_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           displayName,
@@ -733,7 +754,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: OUTLOOK_TOOL_NAME },
+      {
+        toolNameForMonitoring: OUTLOOK_TOOL_NAME,
+        skipAlerting: true,
+      },
       async (
         {
           contactId,

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -34,7 +34,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
+      {
+        toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
+        skipAlerting: true,
+      },
       async ({ query }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -70,7 +73,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
+      {
+        toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
+        skipAlerting: true,
+      },
       async ({ filter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -112,7 +118,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
+      {
+        toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
+        skipAlerting: true,
+      },
       async ({ objectName }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -220,7 +229,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
+      {
+        toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
+        skipAlerting: true,
+      },
       async ({ recordId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;
@@ -274,7 +286,10 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME },
+      {
+        toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
+        skipAlerting: true,
+      },
       async ({ recordId, attachmentId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         const instanceUrl = authInfo?.extra?.instance_url as string | undefined;

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -317,7 +317,11 @@ const createServer = async (
       },
       withToolLogging(
         auth,
-        { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+        {
+          toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+          agentLoopContext,
+          skipAlerting: true,
+        },
         async (
           {
             keywords,
@@ -618,7 +622,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ channel, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(
@@ -759,7 +767,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -801,7 +813,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -830,7 +846,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -860,7 +880,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {

--- a/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
@@ -57,7 +57,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -96,7 +100,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -124,7 +132,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -153,7 +165,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -201,7 +217,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ channel, limit = 20, cursor, oldest, latest }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -275,7 +295,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async (
         { channel, threadTs, limit = 20, cursor, oldest, latest },
         { authInfo }
@@ -349,7 +373,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {
@@ -402,7 +430,11 @@ const createServer = async (
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: SLACK_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+        skipAlerting: true,
+      },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;
         if (!accessToken) {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -51,8 +51,7 @@ export function withToolLogging<T>(
     > = {
       workspace: {
         sId: owner.sId,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        plan_code: auth.plan()?.code || null,
+        plan_code: auth.plan()?.code ?? null,
       },
       toolName: toolNameForMonitoring,
     };
@@ -80,8 +79,7 @@ export function withToolLogging<T>(
     const tags = [
       `tool:${toolNameForMonitoring}`,
       `workspace:${owner.sId}`,
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      `workspace_plan_code:${auth.plan()?.code || null}`,
+      `workspace_plan_code:${auth.plan()?.code ?? null}`,
     ];
 
     if (!skipAlerting) {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -128,6 +128,14 @@ export function withToolLogging<T>(
       );
     }
 
+    logger.info(
+      {
+        ...loggerArgs,
+        duration: elapsed,
+      },
+      "Tool execution success"
+    );
+
     return { isError: false, content: result.value };
   };
 }

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -94,15 +94,15 @@ export function withToolLogging<T>(
           "error_type:run_error",
           ...tags,
         ]);
-
-        logger.error(
-          {
-            error: result.error,
-            ...loggerArgs,
-          },
-          "Tool execution error"
-        );
       }
+
+      logger.error(
+        {
+          error: result.error,
+          ...loggerArgs,
+        },
+        "Tool execution error"
+      );
 
       return {
         isError: true,


### PR DESCRIPTION
## Description

- The monitor is too spammy currently and not reasonably actionable.
- To smooth out the transition this PR makes the alerting part (datadog metric) optional when using `withToolLogging` and disables it for some MCP servers.
- It also unformizes the logging: the success is also logged so that we see in the logs the start + the error or success.
- The goal is to eventually filter errors correctly and untrack those that don't need to be tracked and remove the parameter `skipAlerting`.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
