### PR TITLE
Ungate file system tool - display checkbox, not activated by default

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -17,7 +17,6 @@ import {
   useWatch,
 } from "react-hook-form";
 
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { DataSourceBuilderSelector } from "@app/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector";
 import { transformTreeToSelectionConfigurations } from "@app/components/agent_builder/capabilities/knowledge/transformations";
 import {
@@ -63,7 +62,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { TemplateActionPreset } from "@app/types";
 
 import { KnowledgeFooter } from "./KnowledgeFooter";
@@ -255,12 +253,10 @@ function KnowledgeConfigurationSheetContent({
   getAgentInstructions,
   isEditing,
 }: KnowledgeConfigurationSheetContentProps) {
-  const { owner } = useAgentBuilderContext();
   const { currentPageId, setSheetPageId } = useKnowledgePageContext();
   const { setValue, getValues, setFocus } =
     useFormContext<CapabilityFormData>();
   const [isAdvancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",
@@ -411,8 +407,7 @@ function KnowledgeConfigurationSheetContent({
 
           {/* Advanced Settings collapsible section */}
           {mcpServerView?.serverType === "internal" &&
-            mcpServerView.server.name === SEARCH_SERVER_NAME &&
-            hasFeature("advanced_search") && (
+            mcpServerView.server.name === SEARCH_SERVER_NAME && (
               <Collapsible
                 open={isAdvancedSettingsOpen}
                 onOpenChange={setAdvancedSettingsOpen}
@@ -424,8 +419,8 @@ function KnowledgeConfigurationSheetContent({
                 </CollapsibleTrigger>
                 <CollapsibleContent className="m-1">
                   <CustomCheckboxSection
-                    title="Advanced Search Mode"
-                    description="Enable advanced search capabilities with enhanced discovery and filtering options for more precise results."
+                    title="Enable exploratory search mode"
+                    description="Allows agents to navigate your data like a filesystem (list folders, browse files, explore hierarchies). Best for complex tasks with large datasets where thoroughness matters more than speed."
                     targetMCPServerName={SEARCH_SERVER_NAME}
                     selectedMCPServerView={mcpServerView ?? undefined}
                     configurationKey={ADVANCED_SEARCH_SWITCH}

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -420,7 +420,7 @@ function KnowledgeConfigurationSheetContent({
                 <CollapsibleContent className="m-1">
                   <CustomCheckboxSection
                     title="Enable exploratory search mode"
-                    description="Allows agents to navigate your data like a filesystem (list folders, browse files, explore hierarchies). Best for complex tasks with large datasets where thoroughness matters more than speed."
+                    description="Allow the agent to navigate the selected Data Sources like a filesystem (list folders, browse files, explore hierarchies). Best for complex tasks with large datasets where thoroughness matters more than speed."
                     targetMCPServerName={SEARCH_SERVER_NAME}
                     selectedMCPServerView={mcpServerView ?? undefined}
                     configurationKey={ADVANCED_SEARCH_SWITCH}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -12,11 +12,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Setup Notion private integration tokens",
     stage: "on_demand",
   },
-  advanced_search: {
-    description:
-      "Activates the advanced search option: browse selected data like a file system",
-    stage: "on_demand",
-  },
   agent_to_yaml: {
     description: "Export and Import agents to/from YAML format",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -643,7 +643,6 @@ export type RetrievalDocumentPublicType = z.infer<
 
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
-  | "advanced_search"
   | "agent_builder_instructions_autocomplete"
   | "agent_management_tool"
   | "agent_to_yaml"


### PR DESCRIPTION
## Description

Un-gate file-system: 
- We display the toggle "Advanced Settings" to all workspaces and not if feature flag activated. 
- At the moment it is still not ticked by default. 

Change the wording to clarify:
- what the feature does
- when to use it
- its drawbacks (slower)


| Before  | After |
| ------------- | ------------- |
| <img width="760" height="795" alt="Screenshot 2025-10-14 at 11 55 29" src="https://github.com/user-attachments/assets/1ca3edb4-d39d-4129-bb71-e2e8300e7178" /> | <img width="761" height="822" alt="Screenshot 2025-10-14 at 11 55 46" src="https://github.com/user-attachments/assets/a1d6ed8a-9181-4f21-942d-8e9f7bdd4452" />  | 


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
