### PR TITLE
[front] refactor(MCP): cleanup util functions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
@@ -9,10 +9,7 @@ import {
   updatePage,
   withAuth,
 } from "@app/lib/actions/mcp_internal_actions/servers/confluence/confluence_api_helper";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
@@ -38,12 +35,10 @@ const createServer = (auth: Authenticator): McpServer => {
                 new MCPError(`Error getting current user: ${result.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Current user information retrieved successfully",
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Current user information retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -81,15 +76,16 @@ const createServer = (auth: Authenticator): McpServer => {
                 new MCPError(`Error listing pages: ${result.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message:
+            return new Ok([
+              {
+                type: "text" as const,
+                text:
                   result.value.results.length === 0
                     ? "No pages found"
                     : `Found ${result.value.results.length} page(s)`,
-                result: result.value,
-              }).content
-            );
+              },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -138,12 +134,10 @@ const createServer = (auth: Authenticator): McpServer => {
                 new MCPError(`Error creating page: ${result.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Page created successfully",
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Page created successfully" },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -206,12 +200,10 @@ const createServer = (auth: Authenticator): McpServer => {
                 new MCPError(`Error updating page: ${result.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Page updated successfully",
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Page updated successfully" },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });

--- a/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
@@ -36,8 +36,14 @@ const createServer = (auth: Authenticator): McpServer => {
               );
             }
             return new Ok([
-              { type: "text" as const, text: "Current user information retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: "Current user information retrieved successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -84,7 +90,10 @@ const createServer = (auth: Authenticator): McpServer => {
                     ? "No pages found"
                     : `Found ${result.value.results.length} page(s)`,
               },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -136,7 +145,10 @@ const createServer = (auth: Authenticator): McpServer => {
             }
             return new Ok([
               { type: "text" as const, text: "Page created successfully" },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -202,7 +214,10 @@ const createServer = (auth: Authenticator): McpServer => {
             }
             return new Ok([
               { type: "text" as const, text: "Page updated successfully" },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,

--- a/front/lib/actions/mcp_internal_actions/servers/elevenlabs.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/elevenlabs.ts
@@ -3,10 +3,7 @@ import { ElevenLabsEnvironment } from "@elevenlabs/elevenlabs-js/environments";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import {
-  makeInternalMCPServer,
-  makeMCPToolTextError,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -98,9 +95,15 @@ const createServer = (_auth: Authenticator): McpServer => {
           { err: normalizeError(e) },
           "Error generating text-to-speech with ElevenLabs."
         );
-        return makeMCPToolTextError(
-          `Error generating speech audio with ElevenLabs: ${normalizeError(e).message}`
-        );
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Error generating speech audio with ElevenLabs: ${normalizeError(e).message}`,
+            },
+          ],
+        };
       }
     }
   );
@@ -164,9 +167,15 @@ const createServer = (_auth: Authenticator): McpServer => {
           { err: normalizeError(e) },
           "Error generating music with ElevenLabs."
         );
-        return makeMCPToolTextError(
-          `Error generating music with ElevenLabs: ${normalizeError(e).message}`
-        );
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `Error generating music with ElevenLabs: ${normalizeError(e).message}`,
+            },
+          ],
+        };
       }
     }
   );

--- a/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
@@ -240,8 +240,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${filteredTickets.length} tickets` },
-              { type: "text" as const, text: JSON.stringify(filteredTickets, null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${filteredTickets.length} tickets`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(filteredTickets, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -309,7 +315,10 @@ function createServer(auth: Authenticator): McpServer {
 
             return new Ok([
               { type: "text" as const, text: "Ticket retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(filteredTicket, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(filteredTicket, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -331,8 +340,18 @@ function createServer(auth: Authenticator): McpServer {
             // Currently static based on documentation. In the future, we can get this from the Freshservice API.
             // This will require additional authentication scopes, so avoiding in the short term.
             return new Ok([
-              { type: "text" as const, text: "Base ticket field ids (without includes)" },
-              { type: "text" as const, text: JSON.stringify(FreshserviceTicketSchema.keyof().options, null, 2) },
+              {
+                type: "text" as const,
+                text: "Base ticket field ids (without includes)",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  FreshserviceTicketSchema.keyof().options,
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -441,8 +460,14 @@ function createServer(auth: Authenticator): McpServer {
             const ticketUrl = `https://${apiDomain}/support/tickets/${ticket.id}`;
 
             return new Ok([
-              { type: "text" as const, text: `Ticket created successfully. View ticket at: ${ticketUrl}` },
-              { type: "text" as const, text: JSON.stringify(ticketUrl, null, 2) },
+              {
+                type: "text" as const,
+                text: `Ticket created successfully. View ticket at: ${ticketUrl}`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(ticketUrl, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -522,7 +547,10 @@ function createServer(auth: Authenticator): McpServer {
 
             return new Ok([
               { type: "text" as const, text: "Ticket updated successfully" },
-              { type: "text" as const, text: JSON.stringify(result.ticket, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.ticket, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -564,7 +592,10 @@ function createServer(auth: Authenticator): McpServer {
 
             return new Ok([
               { type: "text" as const, text: "Note added successfully" },
-              { type: "text" as const, text: JSON.stringify(result.conversation, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.conversation, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -600,7 +631,10 @@ function createServer(auth: Authenticator): McpServer {
 
             return new Ok([
               { type: "text" as const, text: "Reply added successfully" },
-              { type: "text" as const, text: JSON.stringify(result.conversation, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.conversation, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -628,8 +662,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.tasks?.length || 0} tasks for ticket ${ticket_id}` },
-              { type: "text" as const, text: JSON.stringify(result.tasks || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.tasks?.length || 0} tasks for ticket ${ticket_id}`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.tasks || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -659,7 +699,10 @@ function createServer(auth: Authenticator): McpServer {
 
             return new Ok([
               { type: "text" as const, text: "Task retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.task, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.task, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -746,7 +789,10 @@ function createServer(auth: Authenticator): McpServer {
 
             return new Ok([
               { type: "text" as const, text: "Task created successfully" },
-              { type: "text" as const, text: JSON.stringify(result.task, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.task, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -841,7 +887,10 @@ function createServer(auth: Authenticator): McpServer {
 
             return new Ok([
               { type: "text" as const, text: "Task updated successfully" },
-              { type: "text" as const, text: JSON.stringify(result.task, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.task, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -874,7 +923,10 @@ function createServer(auth: Authenticator): McpServer {
 
             return new Ok([
               { type: "text" as const, text: "Task deleted successfully" },
-              { type: "text" as const, text: JSON.stringify({ deleted_task_id: task_id }, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify({ deleted_task_id: task_id }, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -909,8 +961,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.departments?.length || 0} departments` },
-              { type: "text" as const, text: JSON.stringify(result.departments || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.departments?.length || 0} departments`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.departments || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -945,8 +1003,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.products?.length || 0} products` },
-              { type: "text" as const, text: JSON.stringify(result.products || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.products?.length || 0} products`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.products || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -981,8 +1045,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.oncall_schedules?.length || 0} on-call schedules` },
-              { type: "text" as const, text: JSON.stringify(result.oncall_schedules || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.oncall_schedules?.length || 0} on-call schedules`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.oncall_schedules || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1017,8 +1087,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.service_categories?.length || 0} service categories` },
-              { type: "text" as const, text: JSON.stringify(result.service_categories || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.service_categories?.length || 0} service categories`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.service_categories || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1062,8 +1138,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.service_items?.length || 0} service items` },
-              { type: "text" as const, text: JSON.stringify(result.service_items || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.service_items?.length || 0} service items`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.service_items || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1126,8 +1208,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Found ${result.service_items?.length || 0} service items matching '${search_term}'` },
-              { type: "text" as const, text: JSON.stringify(result.service_items || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Found ${result.service_items?.length || 0} service items matching '${search_term}'`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.service_items || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1157,8 +1245,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: "Service item retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.service_item, null, 2) },
+              {
+                type: "text" as const,
+                text: "Service item retrieved successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.service_item, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1194,10 +1288,20 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${requiredFields.length} service item required fields for item ${display_id}` },
-              { type: "text" as const, text: JSON.stringify({
-                fields,
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${requiredFields.length} service item required fields for item ${display_id}`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    fields,
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -1298,13 +1402,23 @@ function createServer(auth: Authenticator): McpServer {
             const ticketUrl = `https://${apiDomain}/support/tickets/${serviceRequest.id}`;
 
             return new Ok([
-              { type: "text" as const, text: `Service request created successfully. View ticket at: ${ticketUrl}` },
-              { type: "text" as const, text: JSON.stringify({
-                service_request: serviceRequest,
-                ticket_id: serviceRequest.id,
-                ticket_url: ticketUrl,
-                service_item_name: serviceItem.name,
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: `Service request created successfully. View ticket at: ${ticketUrl}`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    service_request: serviceRequest,
+                    ticket_id: serviceRequest.id,
+                    ticket_url: ticketUrl,
+                    service_item_name: serviceItem.name,
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -1339,8 +1453,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.categories?.length || 0} solution categories` },
-              { type: "text" as const, text: JSON.stringify(result.categories || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.categories?.length || 0} solution categories`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.categories || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1379,8 +1499,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.folders?.length || 0} solution folders` },
-              { type: "text" as const, text: JSON.stringify(result.folders || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.folders?.length || 0} solution folders`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.folders || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1442,8 +1568,14 @@ function createServer(auth: Authenticator): McpServer {
             }));
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${articlesMetadata.length} solution articles (metadata only)` },
-              { type: "text" as const, text: JSON.stringify(articlesMetadata, null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${articlesMetadata.length} solution articles (metadata only)`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(articlesMetadata, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1471,8 +1603,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: "Solution article retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.article, null, 2) },
+              {
+                type: "text" as const,
+                text: "Solution article retrieved successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.article, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1528,8 +1666,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: "Solution article created successfully" },
-              { type: "text" as const, text: JSON.stringify(result.article, null, 2) },
+              {
+                type: "text" as const,
+                text: "Solution article created successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.article, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1577,8 +1721,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.requesters?.length || 0} requesters` },
-              { type: "text" as const, text: JSON.stringify(result.requesters || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.requesters?.length || 0} requesters`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.requesters || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1606,8 +1756,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: "Requester retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.requester, null, 2) },
+              {
+                type: "text" as const,
+                text: "Requester retrieved successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.requester, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1642,8 +1798,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.purchase_orders?.length || 0} purchase orders` },
-              { type: "text" as const, text: JSON.stringify(result.purchase_orders || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.purchase_orders?.length || 0} purchase orders`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.purchase_orders || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1670,8 +1832,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.sla_policies?.length || 0} SLA policies` },
-              { type: "text" as const, text: JSON.stringify(result.sla_policies || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.sla_policies?.length || 0} SLA policies`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.sla_policies || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1715,11 +1883,21 @@ function createServer(auth: Authenticator): McpServer {
             }
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${filteredFields.length} ticket fields${search ? ` matching "${search}"` : ""}` },
-              { type: "text" as const, text: JSON.stringify({
-                ticket_fields: filteredFields,
-                total_ticket_fields: filteredFields.length,
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${filteredFields.length} ticket fields${search ? ` matching "${search}"` : ""}`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    ticket_fields: filteredFields,
+                    total_ticket_fields: filteredFields.length,
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -1779,8 +1957,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.canned_responses?.length || 0} canned responses` },
-              { type: "text" as const, text: JSON.stringify(result.canned_responses || [], null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.canned_responses?.length || 0} canned responses`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.canned_responses || [], null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1808,8 +1992,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: "Canned response retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.canned_response, null, 2) },
+              {
+                type: "text" as const,
+                text: "Canned response retrieved successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.canned_response, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1838,8 +2028,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: "Ticket approval retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.approval, null, 2) },
+              {
+                type: "text" as const,
+                text: "Ticket approval retrieved successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.approval, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -1867,11 +2063,21 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: `Retrieved ${result.approvals?.length || 0} approval(s) for ticket ${ticket_id}` },
-              { type: "text" as const, text: JSON.stringify({
-                approvals: result.approvals || [],
-                total_approvals: result.approvals?.length || 0,
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: `Retrieved ${result.approvals?.length || 0} approval(s) for ticket ${ticket_id}`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    approvals: result.approvals || [],
+                    total_approvals: result.approvals?.length || 0,
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -1956,8 +2162,14 @@ function createServer(auth: Authenticator): McpServer {
             );
 
             return new Ok([
-              { type: "text" as const, text: "Service request approval created successfully" },
-              { type: "text" as const, text: JSON.stringify(result.approval || result, null, 2) },
+              {
+                type: "text" as const,
+                text: "Service request approval created successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.approval || result, null, 2),
+              },
             ]);
           },
           authInfo,

--- a/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
@@ -3,10 +3,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
@@ -242,12 +239,10 @@ function createServer(auth: Authenticator): McpServer {
               pickFields(ticket, selectedFields)
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${filteredTickets.length} tickets`,
-                result: filteredTickets,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${filteredTickets.length} tickets` },
+              { type: "text" as const, text: JSON.stringify(filteredTickets, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -312,12 +307,10 @@ function createServer(auth: Authenticator): McpServer {
             );
             const filteredTicket = pickFields(ticket, unionSelected);
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Ticket retrieved successfully",
-                result: filteredTicket,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Ticket retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(filteredTicket, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -337,12 +330,10 @@ function createServer(auth: Authenticator): McpServer {
           action: async () => {
             // Currently static based on documentation. In the future, we can get this from the Freshservice API.
             // This will require additional authentication scopes, so avoiding in the short term.
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Base ticket field ids (without includes)",
-                result: FreshserviceTicketSchema.keyof().options,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Base ticket field ids (without includes)" },
+              { type: "text" as const, text: JSON.stringify(FreshserviceTicketSchema.keyof().options, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -449,12 +440,10 @@ function createServer(auth: Authenticator): McpServer {
             const apiDomain = normalizeApiDomain(freshserviceDomain);
             const ticketUrl = `https://${apiDomain}/support/tickets/${ticket.id}`;
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Ticket created successfully. View ticket at: ${ticketUrl}`,
-                result: ticketUrl,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Ticket created successfully. View ticket at: ${ticketUrl}` },
+              { type: "text" as const, text: JSON.stringify(ticketUrl, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -531,12 +520,10 @@ function createServer(auth: Authenticator): McpServer {
               }
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Ticket updated successfully",
-                result: result.ticket,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Ticket updated successfully" },
+              { type: "text" as const, text: JSON.stringify(result.ticket, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -575,12 +562,10 @@ function createServer(auth: Authenticator): McpServer {
               }
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Note added successfully",
-                result: result.conversation,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Note added successfully" },
+              { type: "text" as const, text: JSON.stringify(result.conversation, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -613,12 +598,10 @@ function createServer(auth: Authenticator): McpServer {
               }
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Reply added successfully",
-                result: result.conversation,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Reply added successfully" },
+              { type: "text" as const, text: JSON.stringify(result.conversation, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -644,12 +627,10 @@ function createServer(auth: Authenticator): McpServer {
               `tickets/${ticket_id}/tasks`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.tasks?.length || 0} tasks for ticket ${ticket_id}`,
-                result: result.tasks || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.tasks?.length || 0} tasks for ticket ${ticket_id}` },
+              { type: "text" as const, text: JSON.stringify(result.tasks || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -676,12 +657,10 @@ function createServer(auth: Authenticator): McpServer {
               `tickets/${ticket_id}/tasks/${task_id}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Task retrieved successfully",
-                result: result.task,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Task retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.task, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -765,12 +744,10 @@ function createServer(auth: Authenticator): McpServer {
               }
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Task created successfully",
-                result: result.task,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Task created successfully" },
+              { type: "text" as const, text: JSON.stringify(result.task, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -862,12 +839,10 @@ function createServer(auth: Authenticator): McpServer {
               }
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Task updated successfully",
-                result: result.task,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Task updated successfully" },
+              { type: "text" as const, text: JSON.stringify(result.task, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -897,12 +872,10 @@ function createServer(auth: Authenticator): McpServer {
               }
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Task deleted successfully",
-                result: { deleted_task_id: task_id },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Task deleted successfully" },
+              { type: "text" as const, text: JSON.stringify({ deleted_task_id: task_id }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -935,12 +908,10 @@ function createServer(auth: Authenticator): McpServer {
               `departments?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.departments?.length || 0} departments`,
-                result: result.departments || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.departments?.length || 0} departments` },
+              { type: "text" as const, text: JSON.stringify(result.departments || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -973,12 +944,10 @@ function createServer(auth: Authenticator): McpServer {
               `products?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.products?.length || 0} products`,
-                result: result.products || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.products?.length || 0} products` },
+              { type: "text" as const, text: JSON.stringify(result.products || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1011,12 +980,10 @@ function createServer(auth: Authenticator): McpServer {
               `oncall_schedules?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.oncall_schedules?.length || 0} on-call schedules`,
-                result: result.oncall_schedules || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.oncall_schedules?.length || 0} on-call schedules` },
+              { type: "text" as const, text: JSON.stringify(result.oncall_schedules || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1049,12 +1016,10 @@ function createServer(auth: Authenticator): McpServer {
               `service_catalog/categories?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.service_categories?.length || 0} service categories`,
-                result: result.service_categories || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.service_categories?.length || 0} service categories` },
+              { type: "text" as const, text: JSON.stringify(result.service_categories || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1096,12 +1061,10 @@ function createServer(auth: Authenticator): McpServer {
               `service_catalog/items?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.service_items?.length || 0} service items`,
-                result: result.service_items || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.service_items?.length || 0} service items` },
+              { type: "text" as const, text: JSON.stringify(result.service_items || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1162,12 +1125,10 @@ function createServer(auth: Authenticator): McpServer {
               `service_catalog/items/search?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Found ${result.service_items?.length || 0} service items matching '${search_term}'`,
-                result: result.service_items || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Found ${result.service_items?.length || 0} service items matching '${search_term}'` },
+              { type: "text" as const, text: JSON.stringify(result.service_items || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1195,12 +1156,10 @@ function createServer(auth: Authenticator): McpServer {
               `service_catalog/items/${display_id}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Service item retrieved successfully",
-                result: result.service_item,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Service item retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.service_item, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1234,14 +1193,12 @@ function createServer(auth: Authenticator): McpServer {
               (field: FreshserviceServiceItemField) => field.required
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${requiredFields.length} service item required fields for item ${display_id}`,
-                result: {
-                  fields,
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${requiredFields.length} service item required fields for item ${display_id}` },
+              { type: "text" as const, text: JSON.stringify({
+                fields,
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1340,17 +1297,15 @@ function createServer(auth: Authenticator): McpServer {
             const apiDomain = normalizeApiDomain(freshserviceDomain);
             const ticketUrl = `https://${apiDomain}/support/tickets/${serviceRequest.id}`;
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Service request created successfully. View ticket at: ${ticketUrl}`,
-                result: {
-                  service_request: serviceRequest,
-                  ticket_id: serviceRequest.id,
-                  ticket_url: ticketUrl,
-                  service_item_name: serviceItem.name,
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Service request created successfully. View ticket at: ${ticketUrl}` },
+              { type: "text" as const, text: JSON.stringify({
+                service_request: serviceRequest,
+                ticket_id: serviceRequest.id,
+                ticket_url: ticketUrl,
+                service_item_name: serviceItem.name,
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1383,12 +1338,10 @@ function createServer(auth: Authenticator): McpServer {
               `solutions/categories?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.categories?.length || 0} solution categories`,
-                result: result.categories || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.categories?.length || 0} solution categories` },
+              { type: "text" as const, text: JSON.stringify(result.categories || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1425,12 +1378,10 @@ function createServer(auth: Authenticator): McpServer {
               `solutions/folders?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.folders?.length || 0} solution folders`,
-                result: result.folders || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.folders?.length || 0} solution folders` },
+              { type: "text" as const, text: JSON.stringify(result.folders || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1490,12 +1441,10 @@ function createServer(auth: Authenticator): McpServer {
               // Exclude description/description_text to reduce payload
             }));
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${articlesMetadata.length} solution articles (metadata only)`,
-                result: articlesMetadata,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${articlesMetadata.length} solution articles (metadata only)` },
+              { type: "text" as const, text: JSON.stringify(articlesMetadata, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1521,12 +1470,10 @@ function createServer(auth: Authenticator): McpServer {
               `solutions/articles/${article_id}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Solution article retrieved successfully",
-                result: result.article,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Solution article retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.article, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1580,12 +1527,10 @@ function createServer(auth: Authenticator): McpServer {
               }
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Solution article created successfully",
-                result: result.article,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Solution article created successfully" },
+              { type: "text" as const, text: JSON.stringify(result.article, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1631,12 +1576,10 @@ function createServer(auth: Authenticator): McpServer {
               `requesters?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.requesters?.length || 0} requesters`,
-                result: result.requesters || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.requesters?.length || 0} requesters` },
+              { type: "text" as const, text: JSON.stringify(result.requesters || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1662,12 +1605,10 @@ function createServer(auth: Authenticator): McpServer {
               `requesters/${requester_id}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Requester retrieved successfully",
-                result: result.requester,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Requester retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.requester, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1700,12 +1641,10 @@ function createServer(auth: Authenticator): McpServer {
               `purchase_orders?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.purchase_orders?.length || 0} purchase orders`,
-                result: result.purchase_orders || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.purchase_orders?.length || 0} purchase orders` },
+              { type: "text" as const, text: JSON.stringify(result.purchase_orders || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1730,12 +1669,10 @@ function createServer(auth: Authenticator): McpServer {
               "sla_policies"
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.sla_policies?.length || 0} SLA policies`,
-                result: result.sla_policies || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.sla_policies?.length || 0} SLA policies` },
+              { type: "text" as const, text: JSON.stringify(result.sla_policies || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1777,15 +1714,13 @@ function createServer(auth: Authenticator): McpServer {
               );
             }
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${filteredFields.length} ticket fields${search ? ` matching "${search}"` : ""}`,
-                result: {
-                  ticket_fields: filteredFields,
-                  total_ticket_fields: filteredFields.length,
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${filteredFields.length} ticket fields${search ? ` matching "${search}"` : ""}` },
+              { type: "text" as const, text: JSON.stringify({
+                ticket_fields: filteredFields,
+                total_ticket_fields: filteredFields.length,
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1843,12 +1778,10 @@ function createServer(auth: Authenticator): McpServer {
               `canned_responses?${params.toString()}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.canned_responses?.length || 0} canned responses`,
-                result: result.canned_responses || [],
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.canned_responses?.length || 0} canned responses` },
+              { type: "text" as const, text: JSON.stringify(result.canned_responses || [], null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1874,12 +1807,10 @@ function createServer(auth: Authenticator): McpServer {
               `canned_responses/${response_id}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Canned response retrieved successfully",
-                result: result.canned_response,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Canned response retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.canned_response, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1906,12 +1837,10 @@ function createServer(auth: Authenticator): McpServer {
               `tickets/${ticket_id}/approvals/${approval_id}`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Ticket approval retrieved successfully",
-                result: result.approval,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Ticket approval retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.approval, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1937,15 +1866,13 @@ function createServer(auth: Authenticator): McpServer {
               `tickets/${ticket_id}/approvals`
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Retrieved ${result.approvals?.length || 0} approval(s) for ticket ${ticket_id}`,
-                result: {
-                  approvals: result.approvals || [],
-                  total_approvals: result.approvals?.length || 0,
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Retrieved ${result.approvals?.length || 0} approval(s) for ticket ${ticket_id}` },
+              { type: "text" as const, text: JSON.stringify({
+                approvals: result.approvals || [],
+                total_approvals: result.approvals?.length || 0,
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -2028,12 +1955,10 @@ function createServer(auth: Authenticator): McpServer {
               }
             );
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Service request approval created successfully",
-                result: result.approval || result,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Service request approval created successfully" },
+              { type: "text" as const, text: JSON.stringify(result.approval || result, null, 2) },
+            ]);
           },
           authInfo,
         });

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -8,10 +8,7 @@ import { fetch as undiciFetch, ProxyAgent } from "undici";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-  makeMCPToolTextSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { isWorkspaceUsingStaticIP } from "@app/lib/misc";
@@ -93,11 +90,9 @@ const createServer = (auth: Authenticator): McpServer => {
             }
           );
 
-          return new Ok(
-            makeMCPToolTextSuccess({
-              message: `Issue created: #${issue.number}`,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Issue created: #${issue.number}` },
+          ]);
         } catch (e) {
           return new Err(
             new MCPError(
@@ -380,12 +375,10 @@ const createServer = (auth: Authenticator): McpServer => {
               )
               .join("\n")}`;
 
-          return new Ok(
-            makeMCPToolTextSuccess({
-              message: `Retrieved pull request #${pullNumber}`,
-              result: content,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Retrieved pull request #${pullNumber}` },
+            { type: "text" as const, text: JSON.stringify(content, null, 2) },
+          ]);
         } catch (e) {
           return new Err(
             new MCPError(
@@ -461,11 +454,9 @@ const createServer = (auth: Authenticator): McpServer => {
             }
           );
 
-          return new Ok(
-            makeMCPToolTextSuccess({
-              message: `Review created with ID ${review.id}`,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Review created with ID ${review.id}` },
+          ]);
         } catch (e) {
           return new Err(
             new MCPError(
@@ -573,19 +564,15 @@ const createServer = (auth: Authenticator): McpServer => {
           });
 
           if (!content) {
-            return new Ok(
-              makeMCPToolTextSuccess({
-                message: "No open projects found",
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "No open projects found" },
+            ]);
           }
 
-          return new Ok(
-            makeMCPToolTextSuccess({
-              message: `Retrieved ${projects.length} open projects`,
-              result: content,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Retrieved ${projects.length} open projects` },
+            { type: "text" as const, text: JSON.stringify(content, null, 2) },
+          ]);
         } catch (e) {
           return new Err(
             new MCPError(
@@ -710,11 +697,9 @@ const createServer = (auth: Authenticator): McpServer => {
             });
           }
 
-          return new Ok(
-            makeMCPToolTextSuccess({
-              message: `Issue #${issueNumber} added to project`,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Issue #${issueNumber} added to project` },
+          ]);
         } catch (e) {
           return new Err(
             new MCPError(
@@ -760,11 +745,9 @@ const createServer = (auth: Authenticator): McpServer => {
             }
           );
 
-          return new Ok(
-            makeMCPToolTextSuccess({
-              message: `Comment added to issue #${issueNumber} with ID ${comment.id}`,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Comment added to issue #${issueNumber} with ID ${comment.id}` },
+          ]);
         } catch (e) {
           return new Err(
             new MCPError(
@@ -894,12 +877,10 @@ const createServer = (auth: Authenticator): McpServer => {
             })),
           };
 
-          return new Ok(
-            makeMCPToolTextSuccess({
-              message: `Retrieved issue #${issueNumber}`,
-              result: JSON.stringify(formattedIssue, null, 2),
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Retrieved issue #${issueNumber}` },
+            { type: "text" as const, text: JSON.stringify(formattedIssue, null, 2) },
+          ]);
         } catch (e) {
           return new Err(
             new MCPError(
@@ -1056,12 +1037,10 @@ const createServer = (auth: Authenticator): McpServer => {
             })
           );
 
-          return new Ok(
-            makeMCPToolTextSuccess({
-              message: `Retrieved ${formattedIssues.length} issues`,
-              result: JSON.stringify(formattedIssues, null, 2),
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Retrieved ${formattedIssues.length} issues` },
+            { type: "text" as const, text: JSON.stringify(formattedIssues, null, 2) },
+          ]);
         } catch (e) {
           return new Err(
             new MCPError(
@@ -1286,19 +1265,17 @@ const createServer = (auth: Authenticator): McpServer => {
               reviewCount: pr.reviews.totalCount,
             }));
 
-          return new Ok(
-            makeMCPToolTextSuccess({
-              message: `Retrieved ${formattedPullRequests.length} pull requests`,
-              result: JSON.stringify(
-                {
-                  pullRequests: formattedPullRequests,
-                  pageInfo: pullRequests.repository.pullRequests.pageInfo,
-                },
-                null,
-                2
-              ),
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Retrieved ${formattedPullRequests.length} pull requests` },
+            { type: "text" as const, text: JSON.stringify(
+              {
+                pullRequests: formattedPullRequests,
+                pageInfo: pullRequests.repository.pullRequests.pageInfo,
+              },
+              null,
+              2
+            ) },
+          ]);
         } catch (e) {
           return new Err(
             new MCPError(

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -376,7 +376,10 @@ const createServer = (auth: Authenticator): McpServer => {
               .join("\n")}`;
 
           return new Ok([
-            { type: "text" as const, text: `Retrieved pull request #${pullNumber}` },
+            {
+              type: "text" as const,
+              text: `Retrieved pull request #${pullNumber}`,
+            },
             { type: "text" as const, text: JSON.stringify(content, null, 2) },
           ]);
         } catch (e) {
@@ -455,7 +458,10 @@ const createServer = (auth: Authenticator): McpServer => {
           );
 
           return new Ok([
-            { type: "text" as const, text: `Review created with ID ${review.id}` },
+            {
+              type: "text" as const,
+              text: `Review created with ID ${review.id}`,
+            },
           ]);
         } catch (e) {
           return new Err(
@@ -570,7 +576,10 @@ const createServer = (auth: Authenticator): McpServer => {
           }
 
           return new Ok([
-            { type: "text" as const, text: `Retrieved ${projects.length} open projects` },
+            {
+              type: "text" as const,
+              text: `Retrieved ${projects.length} open projects`,
+            },
             { type: "text" as const, text: JSON.stringify(content, null, 2) },
           ]);
         } catch (e) {
@@ -698,7 +707,10 @@ const createServer = (auth: Authenticator): McpServer => {
           }
 
           return new Ok([
-            { type: "text" as const, text: `Issue #${issueNumber} added to project` },
+            {
+              type: "text" as const,
+              text: `Issue #${issueNumber} added to project`,
+            },
           ]);
         } catch (e) {
           return new Err(
@@ -746,7 +758,10 @@ const createServer = (auth: Authenticator): McpServer => {
           );
 
           return new Ok([
-            { type: "text" as const, text: `Comment added to issue #${issueNumber} with ID ${comment.id}` },
+            {
+              type: "text" as const,
+              text: `Comment added to issue #${issueNumber} with ID ${comment.id}`,
+            },
           ]);
         } catch (e) {
           return new Err(
@@ -879,7 +894,10 @@ const createServer = (auth: Authenticator): McpServer => {
 
           return new Ok([
             { type: "text" as const, text: `Retrieved issue #${issueNumber}` },
-            { type: "text" as const, text: JSON.stringify(formattedIssue, null, 2) },
+            {
+              type: "text" as const,
+              text: JSON.stringify(formattedIssue, null, 2),
+            },
           ]);
         } catch (e) {
           return new Err(
@@ -1038,8 +1056,14 @@ const createServer = (auth: Authenticator): McpServer => {
           );
 
           return new Ok([
-            { type: "text" as const, text: `Retrieved ${formattedIssues.length} issues` },
-            { type: "text" as const, text: JSON.stringify(formattedIssues, null, 2) },
+            {
+              type: "text" as const,
+              text: `Retrieved ${formattedIssues.length} issues`,
+            },
+            {
+              type: "text" as const,
+              text: JSON.stringify(formattedIssues, null, 2),
+            },
           ]);
         } catch (e) {
           return new Err(
@@ -1266,15 +1290,21 @@ const createServer = (auth: Authenticator): McpServer => {
             }));
 
           return new Ok([
-            { type: "text" as const, text: `Retrieved ${formattedPullRequests.length} pull requests` },
-            { type: "text" as const, text: JSON.stringify(
-              {
-                pullRequests: formattedPullRequests,
-                pageInfo: pullRequests.repository.pullRequests.pageInfo,
-              },
-              null,
-              2
-            ) },
+            {
+              type: "text" as const,
+              text: `Retrieved ${formattedPullRequests.length} pull requests`,
+            },
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  pullRequests: formattedPullRequests,
+                  pageInfo: pullRequests.repository.pullRequests.pageInfo,
+                },
+                null,
+                2
+              ),
+            },
           ]);
         } catch (e) {
           return new Err(

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -3,10 +3,7 @@ import assert from "assert";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -123,15 +120,20 @@ const createServer = (auth: Authenticator): McpServer => {
           { concurrency: 10 }
         );
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Drafts fetched successfully",
-            result: {
-              drafts,
-              nextPageToken: result.nextPageToken,
-            },
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Drafts fetched successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                drafts,
+                nextPageToken: result.nextPageToken,
+              },
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );
@@ -212,15 +214,20 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const result = await response.json();
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Draft created successfully",
-            result: {
-              draftId: result.id,
-              messageId: result.message.id,
-            },
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Draft created successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                draftId: result.id,
+                messageId: result.message.id,
+              },
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );
@@ -258,12 +265,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError("Failed to delete draft"));
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Draft deleted successfully",
-            result: "",
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Draft deleted successfully" },
+          { type: "text" as const, text: JSON.stringify("", null, 2) },
+        ]);
       }
     )
   );
@@ -373,21 +378,26 @@ const createServer = (auth: Authenticator): McpServer => {
           message = `Messages fetched with ${totalFailed} failures out of ${totalRequested} total messages`;
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message,
-            result: {
-              messages: successfulMessages,
-              failedMessages,
-              summary: {
-                totalRequested,
-                totalSuccessful,
-                totalFailed,
+        return new Ok([
+          { type: "text" as const, text: message },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                messages: successfulMessages,
+                failedMessages,
+                summary: {
+                  totalRequested,
+                  totalSuccessful,
+                  totalFailed,
+                },
+                nextPageToken: result.nextPageToken,
               },
-              nextPageToken: result.nextPageToken,
-            },
-          }).content
-        );
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );
@@ -554,18 +564,23 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const result = await response.json();
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Reply draft created successfully",
-            result: {
-              draftId: result.id,
-              messageId: result.message.id,
-              originalMessageId: messageId,
-              replyTo,
-              subject: replySubject,
-            },
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Reply draft created successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                draftId: result.id,
+                messageId: result.message.id,
+                originalMessageId: messageId,
+                replyTo,
+                subject: replySubject,
+              },
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -267,7 +267,6 @@ const createServer = (auth: Authenticator): McpServer => {
 
         return new Ok([
           { type: "text" as const, text: "Draft deleted successfully" },
-          { type: "text" as const, text: JSON.stringify("", null, 2) },
         ]);
       }
     )

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -526,7 +526,6 @@ const createServer = (
           });
           return new Ok([
             { type: "text" as const, text: "Event deleted successfully" },
-            { type: "text" as const, text: JSON.stringify("", null, 2) },
           ]);
         } catch (err) {
           return new Err(

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -5,10 +5,7 @@ import { google } from "googleapis";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
@@ -137,12 +134,10 @@ const createServer = (
             pageToken,
             maxResults: maxResults ? Math.min(maxResults, 250) : undefined,
           });
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Calendars listed successfully",
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: "Calendars listed successfully" },
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -233,12 +228,13 @@ const createServer = (
               : undefined,
           };
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Events listed successfully",
-              result: enrichedData,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: "Events listed successfully" },
+            {
+              type: "text" as const,
+              text: JSON.stringify(enrichedData, null, 2),
+            },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -281,12 +277,13 @@ const createServer = (
             ? enrichEventWithDayOfWeek(res.data, userTimezone)
             : res.data;
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Event fetched successfully",
-              result: enrichedEvent,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: "Event fetched successfully" },
+            {
+              type: "text" as const,
+              text: JSON.stringify(enrichedEvent, null, 2),
+            },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(normalizeError(err).message || "Failed to get event")
@@ -375,12 +372,13 @@ const createServer = (
             ? enrichEventWithDayOfWeek(res.data, userTimezone)
             : res.data;
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Event created successfully",
-              result: enrichedEvent,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: "Event created successfully" },
+            {
+              type: "text" as const,
+              text: JSON.stringify(enrichedEvent, null, 2),
+            },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -483,12 +481,13 @@ const createServer = (
             ? enrichEventWithDayOfWeek(res.data, userTimezone)
             : res.data;
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Event updated successfully",
-              result: enrichedEvent,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: "Event updated successfully" },
+            {
+              type: "text" as const,
+              text: JSON.stringify(enrichedEvent, null, 2),
+            },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -525,12 +524,10 @@ const createServer = (
             calendarId,
             eventId,
           });
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "Event deleted successfully",
-              result: "",
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: "Event deleted successfully" },
+            { type: "text" as const, text: JSON.stringify("", null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -600,18 +597,23 @@ const createServer = (
 
           const busySlots = calendarData?.busy ?? [];
           const available = busySlots.length === 0;
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: {
-                available,
-                busySlots: busySlots.map((slot) => ({
-                  start: slot.start ?? "",
+          return new Ok([
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  available,
+                  busySlots: busySlots.map((slot) => ({
+                    start: slot.start ?? "",
 
-                  end: slot.end ?? "",
-                })),
-              },
-            }).content
-          );
+                    end: slot.end ?? "",
+                  })),
+                },
+                null,
+                2
+              ),
+            },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -4,10 +4,7 @@ import { google } from "googleapis";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -64,11 +61,9 @@ const createServer = (auth: any): McpServer => {
             fields: "nextPageToken, drives(id, name, createdTime)",
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(normalizeError(err).message || "Failed to list drives")
@@ -189,11 +184,9 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
 
           const res = await drive.files.list(requestParams);
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           const error = normalizeError(err);
           return new Err(
@@ -320,21 +313,26 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
           const hasMore = endIndex < content.length;
           const nextOffset = hasMore ? endIndex : undefined;
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: {
-                fileId,
-                fileName: file.name,
-                mimeType: file.mimeType,
-                content: truncatedContent,
-                returnedContentLength: truncatedContent.length,
-                totalContentLength,
-                offset: startIndex,
-                nextOffset,
-                hasMore,
-              },
-            }).content
-          );
+          return new Ok([
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  fileId,
+                  fileName: file.name,
+                  mimeType: file.mimeType,
+                  content: truncatedContent,
+                  returnedContentLength: truncatedContent.length,
+                  totalContentLength,
+                  offset: startIndex,
+                  nextOffset,
+                  hasMore,
+                },
+                null,
+                2
+              ),
+            },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -4,10 +4,7 @@ import { google } from "googleapis";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
@@ -90,11 +87,9 @@ const createServer = (auth: Authenticator): McpServer => {
             corpora: "allDrives",
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -135,11 +130,9 @@ const createServer = (auth: Authenticator): McpServer => {
             includeGridData,
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -192,11 +185,9 @@ const createServer = (auth: Authenticator): McpServer => {
             valueRenderOption,
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -255,11 +246,9 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -330,11 +319,9 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(normalizeError(err).message || "Failed to append data")
@@ -372,11 +359,9 @@ const createServer = (auth: Authenticator): McpServer => {
             range,
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(normalizeError(err).message || "Failed to clear range")
@@ -422,11 +407,9 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -484,11 +467,9 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -532,11 +513,9 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -631,11 +610,9 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -688,11 +665,9 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(normalizeError(err).message || "Failed to copy sheet")
@@ -739,11 +714,9 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -797,11 +770,9 @@ const createServer = (auth: Authenticator): McpServer => {
             },
           });
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: res.data,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_utils.ts
@@ -105,7 +105,12 @@ export const logAndReturnError = ({
   );
   return {
     isError: true,
-    content: [{ type: "text", text: error.response?.body?.message ?? error.message ?? message }],
+    content: [
+      {
+        type: "text",
+        text: error.response?.body?.message ?? error.message ?? message,
+      },
+    ],
   };
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_utils.ts
@@ -2,7 +2,6 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
-import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import logger from "@app/logger/logger";
 
 export const ERROR_MESSAGES = {
@@ -76,7 +75,10 @@ export const withAuth = async ({
 }): Promise<CallToolResult> => {
   const accessToken = authInfo?.token;
   if (!accessToken) {
-    return makeMCPToolTextError(ERROR_MESSAGES.NO_ACCESS_TOKEN);
+    return {
+      isError: true,
+      content: [{ type: "text", text: ERROR_MESSAGES.NO_ACCESS_TOKEN }],
+    };
   }
   try {
     return await action(accessToken);
@@ -101,9 +103,10 @@ export const logAndReturnError = ({
     },
     `[Hubspot MCP Server] ${message}`
   );
-  return makeMCPToolTextError(
-    error.response?.body?.message ?? error.message ?? message
-  );
+  return {
+    isError: true,
+    content: [{ type: "text", text: error.response?.body?.message ?? error.message ?? message }],
+  };
 };
 
 // HubSpot link generation tool

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/index.ts
@@ -144,7 +144,9 @@ const createServer = (): McpServer => {
           if (!object) {
             return {
               isError: true,
-              content: [{ type: "text", text: ERROR_MESSAGES.OBJECT_NOT_FOUND }],
+              content: [
+                { type: "text", text: ERROR_MESSAGES.OBJECT_NOT_FOUND },
+              ],
             };
           }
           // Handle different object types properly
@@ -158,7 +160,10 @@ const createServer = (): McpServer => {
               isError: false,
               content: [
                 { type: "text", text: formatted.message },
-                { type: "text", text: JSON.stringify(formatted.result, null, 2) },
+                {
+                  type: "text",
+                  text: JSON.stringify(formatted.result, null, 2),
+                },
               ],
             };
           } else {
@@ -167,13 +172,23 @@ const createServer = (): McpServer => {
             return {
               isError: false,
               content: [
-                { type: "text", text: `${objectType.slice(0, -1)} retrieved successfully` },
-                { type: "text", text: JSON.stringify({
-                  id: owner.id,
-                  email: owner.email,
-                  firstName: owner.firstName,
-                  lastName: owner.lastName,
-                }, null, 2) },
+                {
+                  type: "text",
+                  text: `${objectType.slice(0, -1)} retrieved successfully`,
+                },
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      id: owner.id,
+                      email: owner.email,
+                      firstName: owner.firstName,
+                      lastName: owner.lastName,
+                    },
+                    null,
+                    2
+                  ),
+                },
               ],
             };
           }
@@ -231,13 +246,21 @@ const createServer = (): McpServer => {
           if (!owners.length) {
             return {
               isError: true,
-              content: [{ type: "text", text: `No owners found matching "${searchQuery}".` }],
+              content: [
+                {
+                  type: "text",
+                  text: `No owners found matching "${searchQuery}".`,
+                },
+              ],
             };
           }
           return {
             isError: false,
             content: [
-              { type: "text", text: `Found ${owners.length} owner(s) matching "${searchQuery}".` },
+              {
+                type: "text",
+                text: `Found ${owners.length} owner(s) matching "${searchQuery}".`,
+              },
               { type: "text", text: JSON.stringify(owners, null, 2) },
             ],
           };
@@ -286,14 +309,19 @@ const createServer = (): McpServer => {
           if (!count) {
             return {
               isError: true,
-              content: [{ type: "text", text: ERROR_MESSAGES.NO_OBJECTS_FOUND }],
+              content: [
+                { type: "text", text: ERROR_MESSAGES.NO_OBJECTS_FOUND },
+              ],
             };
           }
           if (count >= MAX_COUNT_LIMIT) {
             return {
               isError: false,
               content: [
-                { type: "text", text: `Found ${MAX_COUNT_LIMIT}+ ${objectType} matching the filters (exact count unavailable due to API limits)` },
+                {
+                  type: "text",
+                  text: `Found ${MAX_COUNT_LIMIT}+ ${objectType} matching the filters (exact count unavailable due to API limits)`,
+                },
                 { type: "text", text: `${MAX_COUNT_LIMIT}+` },
               ],
             };
@@ -301,7 +329,10 @@ const createServer = (): McpServer => {
           return {
             isError: false,
             content: [
-              { type: "text", text: `Found ${count} ${objectType} matching the specified filters` },
+              {
+                type: "text",
+                text: `Found ${count} ${objectType} matching the specified filters`,
+              },
               { type: "text", text: count.toString() },
             ],
           };
@@ -329,7 +360,9 @@ const createServer = (): McpServer => {
           if (!objects.length) {
             return {
               isError: true,
-              content: [{ type: "text", text: ERROR_MESSAGES.NO_OBJECTS_FOUND }],
+              content: [
+                { type: "text", text: ERROR_MESSAGES.NO_OBJECTS_FOUND },
+              ],
             };
           }
           const formattedText = formatHubSpotObjectsAsText(objects, objectType);
@@ -580,7 +613,10 @@ const createServer = (): McpServer => {
           return {
             isError: false,
             content: [
-              { type: "text", text: `Communication (channel: ${properties.hs_communication_channel_type || "unknown"}) created successfully.` },
+              {
+                type: "text",
+                text: `Communication (channel: ${properties.hs_communication_channel_type || "unknown"}) created successfully.`,
+              },
               { type: "text", text: JSON.stringify(result, null, 2) },
             ],
           };
@@ -643,7 +679,9 @@ const createServer = (): McpServer => {
           if (!result) {
             return {
               isError: true,
-              content: [{ type: "text", text: ERROR_MESSAGES.OBJECT_NOT_FOUND }],
+              content: [
+                { type: "text", text: ERROR_MESSAGES.OBJECT_NOT_FOUND },
+              ],
             };
           }
           const formatted = formatHubSpotGetSuccess(result, "contacts");
@@ -674,7 +712,9 @@ const createServer = (): McpServer => {
           if (!result) {
             return {
               isError: true,
-              content: [{ type: "text", text: ERROR_MESSAGES.OBJECT_NOT_FOUND }],
+              content: [
+                { type: "text", text: ERROR_MESSAGES.OBJECT_NOT_FOUND },
+              ],
             };
           }
           const formatted = formatHubSpotGetSuccess(result, "companies");
@@ -705,7 +745,9 @@ const createServer = (): McpServer => {
           if (!result) {
             return {
               isError: true,
-              content: [{ type: "text", text: ERROR_MESSAGES.OBJECT_NOT_FOUND }],
+              content: [
+                { type: "text", text: ERROR_MESSAGES.OBJECT_NOT_FOUND },
+              ],
             };
           }
           return {
@@ -737,7 +779,14 @@ const createServer = (): McpServer => {
           if (!result) {
             return {
               isError: true,
-              content: [{ type: "text", text: ERROR_MESSAGES.OBJECT_NOT_FOUND + " Or it was not a meeting." }],
+              content: [
+                {
+                  type: "text",
+                  text:
+                    ERROR_MESSAGES.OBJECT_NOT_FOUND +
+                    " Or it was not a meeting.",
+                },
+              ],
             };
           }
           return {
@@ -767,7 +816,12 @@ const createServer = (): McpServer => {
           if (!result) {
             return {
               isError: true,
-              content: [{ type: "text", text: "File not found or public URL not available." }],
+              content: [
+                {
+                  type: "text",
+                  text: "File not found or public URL not available.",
+                },
+              ],
             };
           }
           return {
@@ -804,13 +858,18 @@ const createServer = (): McpServer => {
           if (result === null) {
             return {
               isError: true,
-              content: [{ type: "text", text: "Error retrieving associated meetings." }],
+              content: [
+                { type: "text", text: "Error retrieving associated meetings." },
+              ],
             };
           }
           return {
             isError: false,
             content: [
-              { type: "text", text: "Associated meetings retrieved successfully." },
+              {
+                type: "text",
+                text: "Associated meetings retrieved successfully.",
+              },
               { type: "text", text: JSON.stringify(result, null, 2) },
             ],
           };
@@ -890,9 +949,7 @@ const createServer = (): McpServer => {
           });
           return {
             isError: false,
-            content: [
-              { type: "text", text: JSON.stringify(result, null, 2) },
-            ],
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
           };
         },
         authInfo,
@@ -921,9 +978,7 @@ const createServer = (): McpServer => {
           });
           return {
             isError: false,
-            content: [
-              { type: "text", text: JSON.stringify(result, null, 2) },
-            ],
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
           };
         },
         authInfo,
@@ -974,7 +1029,9 @@ const createServer = (): McpServer => {
           if (!result || result.results.length === 0) {
             return {
               isError: true,
-              content: [{ type: "text", text: "Search failed or returned no results." }],
+              content: [
+                { type: "text", text: "Search failed or returned no results." },
+              ],
             };
           }
 
@@ -1061,7 +1118,12 @@ const createServer = (): McpServer => {
       } catch (err) {
         return {
           isError: true,
-          content: [{ type: "text", text: `Failed to fetch objects from HubSpot: ${err instanceof Error ? err.message : String(err)}` }],
+          content: [
+            {
+              type: "text",
+              text: `Failed to fetch objects from HubSpot: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
         };
       }
       if (!allResults.length) {
@@ -1100,7 +1162,10 @@ const createServer = (): McpServer => {
       return {
         isError: false,
         content: [
-          { type: "text", text: `Exported ${csvRows.length} ${input.objectType} to CSV` },
+          {
+            type: "text",
+            text: `Exported ${csvRows.length} ${input.objectType} to CSV`,
+          },
           { type: "text", text: fullCsv },
         ],
       };
@@ -1149,7 +1214,9 @@ const createServer = (): McpServer => {
 
         return {
           isError: true,
-          content: [{ type: "text", text: JSON.stringify(errorResponse, null, 2) }],
+          content: [
+            { type: "text", text: JSON.stringify(errorResponse, null, 2) },
+          ],
         };
       }
       const urlResults = generateUrls(portalId, uiDomain, pageRequests);
@@ -1175,8 +1242,14 @@ const createServer = (): McpServer => {
           return {
             isError: false,
             content: [
-              { type: "text", text: "Portal information retrieved successfully" },
-              { type: "text", text: `Portal ID: ${result.hub_id}\nUI Domain: app.hubspot.com` },
+              {
+                type: "text",
+                text: "Portal information retrieved successfully",
+              },
+              {
+                type: "text",
+                text: `Portal ID: ${result.hub_id}\nUI Domain: app.hubspot.com`,
+              },
             ],
           };
         },
@@ -1214,7 +1287,10 @@ const createServer = (): McpServer => {
           return {
             isError: false,
             content: [
-              { type: "text", text: `Association created successfully between ${fromObjectType}:${fromObjectId} and ${toObjectType}:${toObjectId}` },
+              {
+                type: "text",
+                text: `Association created successfully between ${fromObjectType}:${fromObjectId} and ${toObjectType}:${toObjectId}`,
+              },
               { type: "text", text: JSON.stringify(result, null, 2) },
             ],
           };
@@ -1249,7 +1325,10 @@ const createServer = (): McpServer => {
           return {
             isError: false,
             content: [
-              { type: "text", text: `Associations retrieved successfully for ${objectType}:${objectId}` },
+              {
+                type: "text",
+                text: `Associations retrieved successfully for ${objectType}:${objectId}`,
+              },
               { type: "text", text: JSON.stringify(result, null, 2) },
             ],
           };
@@ -1288,8 +1367,14 @@ const createServer = (): McpServer => {
           return {
             isError: false,
             content: [
-              { type: "text", text: `Association removed successfully between ${fromObjectType}:${fromObjectId} and ${toObjectType}:${toObjectId}` },
-              { type: "text", text: JSON.stringify({ success: true }, null, 2) },
+              {
+                type: "text",
+                text: `Association removed successfully between ${fromObjectType}:${fromObjectId} and ${toObjectType}:${toObjectId}`,
+              },
+              {
+                type: "text",
+                text: JSON.stringify({ success: true }, null, 2),
+              },
             ],
           };
         },
@@ -1311,7 +1396,10 @@ const createServer = (): McpServer => {
           return {
             isError: false,
             content: [
-              { type: "text", text: "Current user information retrieved successfully" },
+              {
+                type: "text",
+                text: "Current user information retrieved successfully",
+              },
               { type: "text", text: JSON.stringify(result, null, 2) },
             ],
           };
@@ -1368,8 +1456,14 @@ const createServer = (): McpServer => {
             return {
               isError: false,
               content: [
-                { type: "text", text: `No activities found for owner ${ownerId} between ${startDate} and ${endDate}` },
-                { type: "text", text: `No activities found for the specified period. Summary: ${JSON.stringify(result.summary, null, 2)}` },
+                {
+                  type: "text",
+                  text: `No activities found for owner ${ownerId} between ${startDate} and ${endDate}`,
+                },
+                {
+                  type: "text",
+                  text: `No activities found for the specified period. Summary: ${JSON.stringify(result.summary, null, 2)}`,
+                },
               ],
             };
           }
@@ -1377,11 +1471,21 @@ const createServer = (): McpServer => {
           return {
             isError: false,
             content: [
-              { type: "text", text: `Found ${result.results.length} activities for owner ${ownerId} between ${startDate} and ${endDate}` },
-              { type: "text", text: JSON.stringify({
-                activities: result.results,
-                summary: result.summary,
-              }, null, 2) },
+              {
+                type: "text",
+                text: `Found ${result.results.length} activities for owner ${ownerId} between ${startDate} and ${endDate}`,
+              },
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    activities: result.results,
+                    summary: result.summary,
+                  },
+                  null,
+                  2
+                ),
+              },
             ],
           };
         },

--- a/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
@@ -73,7 +73,10 @@ const createServer = (
             }
             return new Ok([
               { type: "text" as const, text: "Fields retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -108,8 +111,14 @@ const createServer = (
             });
             if (issue.isOk() && issue.value === null) {
               return new Ok([
-                { type: "text" as const, text: "No issue found with the specified key" },
-                { type: "text" as const, text: JSON.stringify({ found: false, issueKey }, null, 2) },
+                {
+                  type: "text" as const,
+                  text: "No issue found with the specified key",
+                },
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ found: false, issueKey }, null, 2),
+                },
               ]);
             }
             if (issue.isErr()) {
@@ -119,7 +128,10 @@ const createServer = (
             }
             return new Ok([
               { type: "text" as const, text: "Issue retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify({ issue: issue.value }, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify({ issue: issue.value }, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -145,7 +157,10 @@ const createServer = (
               );
             }
             return new Ok([
-              { type: "text" as const, text: "Projects retrieved successfully" },
+              {
+                type: "text" as const,
+                text: "Projects retrieved successfully",
+              },
               { type: "text" as const, text: JSON.stringify(result, null, 2) },
             ]);
           },
@@ -182,7 +197,10 @@ const createServer = (
             }
             return new Ok([
               { type: "text" as const, text: "Project retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -216,8 +234,14 @@ const createServer = (
               );
             }
             return new Ok([
-              { type: "text" as const, text: "Project versions retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: "Project versions retrieved successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -245,7 +269,10 @@ const createServer = (
               );
             }
             return new Ok([
-              { type: "text" as const, text: "Transitions retrieved successfully" },
+              {
+                type: "text" as const,
+                text: "Transitions retrieved successfully",
+              },
               { type: "text" as const, text: JSON.stringify(result, null, 2) },
             ]);
           },
@@ -303,20 +330,33 @@ const createServer = (
             }
             if (result.value === null) {
               return new Ok([
-                { type: "text" as const, text: "Issue not found or no permission to add comment" },
-                { type: "text" as const, text: JSON.stringify({ found: false, issueKey }, null, 2) },
+                {
+                  type: "text" as const,
+                  text: "Issue not found or no permission to add comment",
+                },
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ found: false, issueKey }, null, 2),
+                },
               ]);
             }
             return new Ok([
               { type: "text" as const, text: "Comment added successfully" },
-              { type: "text" as const, text: JSON.stringify({
-                issueKey,
-                comment:
-                  typeof comment === "string"
-                    ? comment
-                    : "[Rich ADF Content]",
-                commentId: result.value.id,
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    issueKey,
+                    comment:
+                      typeof comment === "string"
+                        ? comment
+                        : "[Rich ADF Content]",
+                    commentId: result.value.id,
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -362,7 +402,10 @@ const createServer = (
                 : "Issues retrieved successfully";
             return new Ok([
               { type: "text" as const, text: message },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -422,7 +465,10 @@ const createServer = (
                 : "Issues retrieved successfully using JQL";
             return new Ok([
               { type: "text" as const, text: message },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -456,8 +502,14 @@ const createServer = (
                 );
               }
               return new Ok([
-                { type: "text" as const, text: "Issue types retrieved successfully" },
-                { type: "text" as const, text: JSON.stringify(result, null, 2) },
+                {
+                  type: "text" as const,
+                  text: "Issue types retrieved successfully",
+                },
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(result, null, 2),
+                },
               ]);
             } catch (error) {
               return new Err(
@@ -499,8 +551,14 @@ const createServer = (
                 );
               }
               return new Ok([
-                { type: "text" as const, text: "Issue fields retrieved successfully" },
-                { type: "text" as const, text: JSON.stringify(result, null, 2) },
+                {
+                  type: "text" as const,
+                  text: "Issue fields retrieved successfully",
+                },
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(result, null, 2),
+                },
               ]);
             } catch (error) {
               return new Err(
@@ -537,8 +595,14 @@ const createServer = (
         }
 
         return new Ok([
-          { type: "text" as const, text: "Connection information retrieved successfully" },
-          { type: "text" as const, text: JSON.stringify(connectionInfo, null, 2) },
+          {
+            type: "text" as const,
+            text: "Connection information retrieved successfully",
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(connectionInfo, null, 2),
+          },
         ]);
       }
     )
@@ -580,16 +644,32 @@ const createServer = (
             }
             if (result.value === null) {
               return new Ok([
-                { type: "text" as const, text: "Issue not found or no permission to transition it" },
-                { type: "text" as const, text: JSON.stringify({ found: false, issueKey }, null, 2) },
+                {
+                  type: "text" as const,
+                  text: "Issue not found or no permission to transition it",
+                },
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ found: false, issueKey }, null, 2),
+                },
               ]);
             }
             return new Ok([
-              { type: "text" as const, text: "Issue transitioned successfully" },
-              { type: "text" as const, text: JSON.stringify({
-                issueKey,
-                transitionId,
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: "Issue transitioned successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    issueKey,
+                    transitionId,
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -625,7 +705,10 @@ const createServer = (
             }
             return new Ok([
               { type: "text" as const, text: "Issue created successfully" },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -663,16 +746,29 @@ const createServer = (
             }
             if (result.value === null) {
               return new Ok([
-                { type: "text" as const, text: "Issue not found or no permission to update it" },
-                { type: "text" as const, text: JSON.stringify({ found: false, issueKey }, null, 2) },
+                {
+                  type: "text" as const,
+                  text: "Issue not found or no permission to update it",
+                },
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ found: false, issueKey }, null, 2),
+                },
               ]);
             }
             return new Ok([
               { type: "text" as const, text: "Issue updated successfully" },
-              { type: "text" as const, text: JSON.stringify({
-                ...result.value,
-                updatedFields: Object.keys(updateData),
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    ...result.value,
+                    updatedFields: Object.keys(updateData),
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -706,10 +802,20 @@ const createServer = (
               );
             }
             return new Ok([
-              { type: "text" as const, text: "Issue link created successfully" },
-              { type: "text" as const, text: JSON.stringify({
-                ...linkData,
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: "Issue link created successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    ...linkData,
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -737,8 +843,14 @@ const createServer = (
               );
             }
             return new Ok([
-              { type: "text" as const, text: "Issue link deleted successfully" },
-              { type: "text" as const, text: JSON.stringify({ linkId }, null, 2) },
+              {
+                type: "text" as const,
+                text: "Issue link deleted successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify({ linkId }, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -765,8 +877,14 @@ const createServer = (
               );
             }
             return new Ok([
-              { type: "text" as const, text: "Issue link types retrieved successfully" },
-              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+              {
+                type: "text" as const,
+                text: "Issue link types retrieved successfully",
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(result.value, null, 2),
+              },
             ]);
           },
           authInfo,
@@ -837,10 +955,17 @@ const createServer = (
                   : `Found ${result.value.users.length} exact match(es) for the specified email address`;
               return new Ok([
                 { type: "text" as const, text: message },
-                { type: "text" as const, text: JSON.stringify({
-                  users: result.value.users,
-                  nextStartAt: result.value.nextStartAt,
-                }, null, 2) },
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(
+                    {
+                      users: result.value.users,
+                      nextStartAt: result.value.nextStartAt,
+                    },
+                    null,
+                    2
+                  ),
+                },
               ]);
             }
 
@@ -865,10 +990,17 @@ const createServer = (
                   : `Listed ${result.value.users.length} user(s)`;
             return new Ok([
               { type: "text" as const, text: message },
-              { type: "text" as const, text: JSON.stringify({
-                users: result.value.users,
-                nextStartAt: result.value.nextStartAt,
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    users: result.value.users,
+                    nextStartAt: result.value.nextStartAt,
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -996,20 +1128,30 @@ const createServer = (
             const uploadedAttachment = uploadResult.value[0];
 
             return new Ok([
-              { type: "text" as const, text: `Successfully uploaded attachment to issue ${issueKey}` },
-              { type: "text" as const, text: JSON.stringify({
-                issueKey,
-                attachment: {
-                  id: uploadedAttachment.id,
-                  filename: uploadedAttachment.filename,
-                  size: uploadedAttachment.size,
-                  mimeType: uploadedAttachment.mimeType,
-                  created: uploadedAttachment.created,
-                  author:
-                    uploadedAttachment.author.displayName ??
-                    uploadedAttachment.author.accountId,
-                },
-              }, null, 2) },
+              {
+                type: "text" as const,
+                text: `Successfully uploaded attachment to issue ${issueKey}`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    issueKey,
+                    attachment: {
+                      id: uploadedAttachment.id,
+                      filename: uploadedAttachment.filename,
+                      size: uploadedAttachment.size,
+                      mimeType: uploadedAttachment.mimeType,
+                      created: uploadedAttachment.created,
+                      author:
+                        uploadedAttachment.author.displayName ??
+                        uploadedAttachment.author.accountId,
+                    },
+                  },
+                  null,
+                  2
+                ),
+              },
             ]);
           },
           authInfo,
@@ -1053,16 +1195,26 @@ const createServer = (
             }));
 
             return new Ok([
-              { type: "text" as const, text: `Found ${attachments.length} attachment(s) for issue ${issueKey}` },
-              { type: "text" as const, text: JSON.stringify({
-                issueKey,
-                attachments: attachmentSummary,
-                totalAttachments: attachments.length,
-                totalSize: attachments.reduce(
-                  (sum, att) => sum + (att.size || 0),
-                  0
+              {
+                type: "text" as const,
+                text: `Found ${attachments.length} attachment(s) for issue ${issueKey}`,
+              },
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    issueKey,
+                    attachments: attachmentSummary,
+                    totalAttachments: attachments.length,
+                    totalSize: attachments.reduce(
+                      (sum, att) => sum + (att.size || 0),
+                      0
+                    ),
+                  },
+                  null,
+                  2
                 ),
-              }, null, 2) },
+              },
             ]);
           },
           authInfo,

--- a/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
@@ -37,10 +37,7 @@ import {
   JiraSortSchema,
   SEARCH_USERS_MAX_RESULTS,
 } from "@app/lib/actions/mcp_internal_actions/servers/jira/types";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -74,12 +71,10 @@ const createServer = (
                 new MCPError(`Error retrieving fields: ${result.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Fields retrieved successfully",
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Fields retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -112,24 +107,20 @@ const createServer = (
               fields,
             });
             if (issue.isOk() && issue.value === null) {
-              return new Ok(
-                makeMCPToolJSONSuccess({
-                  message: "No issue found with the specified key",
-                  result: { found: false, issueKey },
-                }).content
-              );
+              return new Ok([
+                { type: "text" as const, text: "No issue found with the specified key" },
+                { type: "text" as const, text: JSON.stringify({ found: false, issueKey }, null, 2) },
+              ]);
             }
             if (issue.isErr()) {
               return new Err(
                 new MCPError(`Error retrieving issue: ${issue.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue retrieved successfully",
-                result: { issue: issue.value },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Issue retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify({ issue: issue.value }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -153,12 +144,10 @@ const createServer = (
                 new MCPError(`Error retrieving projects: ${result.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Projects retrieved successfully",
-                result,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Projects retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -191,12 +180,10 @@ const createServer = (
                 )
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Project retrieved successfully",
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Project retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -228,12 +215,10 @@ const createServer = (
                 )
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Project versions retrieved successfully",
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Project versions retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -259,12 +244,10 @@ const createServer = (
                 new MCPError(`Error retrieving transitions: ${result.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Transitions retrieved successfully",
-                result,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Transitions retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -319,26 +302,22 @@ const createServer = (
               );
             }
             if (result.value === null) {
-              return new Ok(
-                makeMCPToolJSONSuccess({
-                  message: "Issue not found or no permission to add comment",
-                  result: { found: false, issueKey },
-                }).content
-              );
+              return new Ok([
+                { type: "text" as const, text: "Issue not found or no permission to add comment" },
+                { type: "text" as const, text: JSON.stringify({ found: false, issueKey }, null, 2) },
+              ]);
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Comment added successfully",
-                result: {
-                  issueKey,
-                  comment:
-                    typeof comment === "string"
-                      ? comment
-                      : "[Rich ADF Content]",
-                  commentId: result.value.id,
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Comment added successfully" },
+              { type: "text" as const, text: JSON.stringify({
+                issueKey,
+                comment:
+                  typeof comment === "string"
+                    ? comment
+                    : "[Rich ADF Content]",
+                commentId: result.value.id,
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -381,12 +360,10 @@ const createServer = (
               result.value.issues.length === 0
                 ? "No issues found matching the search criteria"
                 : "Issues retrieved successfully";
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message,
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: message },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -443,12 +420,10 @@ const createServer = (
               result.value.issues.length === 0
                 ? "No issues found matching the JQL query"
                 : "Issues retrieved successfully using JQL";
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message,
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: message },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -480,12 +455,10 @@ const createServer = (
                   new MCPError(`Error retrieving issue types: ${result.error}`)
                 );
               }
-              return new Ok(
-                makeMCPToolJSONSuccess({
-                  message: "Issue types retrieved successfully",
-                  result,
-                }).content
-              );
+              return new Ok([
+                { type: "text" as const, text: "Issue types retrieved successfully" },
+                { type: "text" as const, text: JSON.stringify(result, null, 2) },
+              ]);
             } catch (error) {
               return new Err(
                 new MCPError(`Error retrieving issue types: ${error}`)
@@ -525,12 +498,10 @@ const createServer = (
                   new MCPError(`Error retrieving issue fields: ${result.error}`)
                 );
               }
-              return new Ok(
-                makeMCPToolJSONSuccess({
-                  message: "Issue fields retrieved successfully",
-                  result,
-                }).content
-              );
+              return new Ok([
+                { type: "text" as const, text: "Issue fields retrieved successfully" },
+                { type: "text" as const, text: JSON.stringify(result, null, 2) },
+              ]);
             } catch (error) {
               return new Err(
                 new MCPError(`Error retrieving issue fields: ${error}`)
@@ -565,12 +536,10 @@ const createServer = (
           );
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Connection information retrieved successfully",
-            result: connectionInfo,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Connection information retrieved successfully" },
+          { type: "text" as const, text: JSON.stringify(connectionInfo, null, 2) },
+        ]);
       }
     )
   );
@@ -610,22 +579,18 @@ const createServer = (
               return new Err(new MCPError(errorMessage));
             }
             if (result.value === null) {
-              return new Ok(
-                makeMCPToolJSONSuccess({
-                  message: "Issue not found or no permission to transition it",
-                  result: { found: false, issueKey },
-                }).content
-              );
+              return new Ok([
+                { type: "text" as const, text: "Issue not found or no permission to transition it" },
+                { type: "text" as const, text: JSON.stringify({ found: false, issueKey }, null, 2) },
+              ]);
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue transitioned successfully",
-                result: {
-                  issueKey,
-                  transitionId,
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Issue transitioned successfully" },
+              { type: "text" as const, text: JSON.stringify({
+                issueKey,
+                transitionId,
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -658,12 +623,10 @@ const createServer = (
               }
               return new Err(new MCPError(errorMessage));
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue created successfully",
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Issue created successfully" },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -699,22 +662,18 @@ const createServer = (
               );
             }
             if (result.value === null) {
-              return new Ok(
-                makeMCPToolJSONSuccess({
-                  message: "Issue not found or no permission to update it",
-                  result: { found: false, issueKey },
-                }).content
-              );
+              return new Ok([
+                { type: "text" as const, text: "Issue not found or no permission to update it" },
+                { type: "text" as const, text: JSON.stringify({ found: false, issueKey }, null, 2) },
+              ]);
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue updated successfully",
-                result: {
-                  ...result.value,
-                  updatedFields: Object.keys(updateData),
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Issue updated successfully" },
+              { type: "text" as const, text: JSON.stringify({
+                ...result.value,
+                updatedFields: Object.keys(updateData),
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -746,14 +705,12 @@ const createServer = (
                 new MCPError(`Error creating issue link: ${result.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue link created successfully",
-                result: {
-                  ...linkData,
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Issue link created successfully" },
+              { type: "text" as const, text: JSON.stringify({
+                ...linkData,
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -779,12 +736,10 @@ const createServer = (
                 new MCPError(`Error deleting issue link: ${result.error}`)
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue link deleted successfully",
-                result: { linkId },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Issue link deleted successfully" },
+              { type: "text" as const, text: JSON.stringify({ linkId }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -809,12 +764,10 @@ const createServer = (
                 )
               );
             }
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: "Issue link types retrieved successfully",
-                result: result.value,
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: "Issue link types retrieved successfully" },
+              { type: "text" as const, text: JSON.stringify(result.value, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -882,15 +835,13 @@ const createServer = (
                 result.value.users.length === 0
                   ? "No users found with the specified email address"
                   : `Found ${result.value.users.length} exact match(es) for the specified email address`;
-              return new Ok(
-                makeMCPToolJSONSuccess({
-                  message,
-                  result: {
-                    users: result.value.users,
-                    nextStartAt: result.value.nextStartAt,
-                  },
-                }).content
-              );
+              return new Ok([
+                { type: "text" as const, text: message },
+                { type: "text" as const, text: JSON.stringify({
+                  users: result.value.users,
+                  nextStartAt: result.value.nextStartAt,
+                }, null, 2) },
+              ]);
             }
 
             const result = await listUsers(baseUrl, accessToken, {
@@ -912,15 +863,13 @@ const createServer = (
                 : name
                   ? `Found ${result.value.users.length} user(s) matching the name`
                   : `Listed ${result.value.users.length} user(s)`;
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message,
-                result: {
-                  users: result.value.users,
-                  nextStartAt: result.value.nextStartAt,
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: message },
+              { type: "text" as const, text: JSON.stringify({
+                users: result.value.users,
+                nextStartAt: result.value.nextStartAt,
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1046,24 +995,22 @@ const createServer = (
 
             const uploadedAttachment = uploadResult.value[0];
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Successfully uploaded attachment to issue ${issueKey}`,
-                result: {
-                  issueKey,
-                  attachment: {
-                    id: uploadedAttachment.id,
-                    filename: uploadedAttachment.filename,
-                    size: uploadedAttachment.size,
-                    mimeType: uploadedAttachment.mimeType,
-                    created: uploadedAttachment.created,
-                    author:
-                      uploadedAttachment.author.displayName ??
-                      uploadedAttachment.author.accountId,
-                  },
+            return new Ok([
+              { type: "text" as const, text: `Successfully uploaded attachment to issue ${issueKey}` },
+              { type: "text" as const, text: JSON.stringify({
+                issueKey,
+                attachment: {
+                  id: uploadedAttachment.id,
+                  filename: uploadedAttachment.filename,
+                  size: uploadedAttachment.size,
+                  mimeType: uploadedAttachment.mimeType,
+                  created: uploadedAttachment.created,
+                  author:
+                    uploadedAttachment.author.displayName ??
+                    uploadedAttachment.author.accountId,
                 },
-              }).content
-            );
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });
@@ -1105,20 +1052,18 @@ const createServer = (
               thumbnail: att.thumbnail,
             }));
 
-            return new Ok(
-              makeMCPToolJSONSuccess({
-                message: `Found ${attachments.length} attachment(s) for issue ${issueKey}`,
-                result: {
-                  issueKey,
-                  attachments: attachmentSummary,
-                  totalAttachments: attachments.length,
-                  totalSize: attachments.reduce(
-                    (sum, att) => sum + (att.size || 0),
-                    0
-                  ),
-                },
-              }).content
-            );
+            return new Ok([
+              { type: "text" as const, text: `Found ${attachments.length} attachment(s) for issue ${issueKey}` },
+              { type: "text" as const, text: JSON.stringify({
+                issueKey,
+                attachments: attachmentSummary,
+                totalAttachments: attachments.length,
+                totalSize: attachments.reduce(
+                  (sum, att) => sum + (att.size || 0),
+                  0
+                ),
+              }, null, 2) },
+            ]);
           },
           authInfo,
         });

--- a/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
@@ -36,8 +36,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/monday/monday_api_helper";
 import {
   makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-  makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -64,12 +62,10 @@ const createServer = (auth: Authenticator): McpServer => {
         }
 
         const boards = await getBoards(accessToken);
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Boards retrieved successfully",
-            result: boards,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Boards retrieved successfully" },
+          { type: "text" as const, text: JSON.stringify(boards, null, 2) },
+        ]);
       }
     )
   );
@@ -91,12 +87,10 @@ const createServer = (auth: Authenticator): McpServer => {
         }
 
         const items = await getBoardItems(accessToken, boardId);
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Board items retrieved successfully",
-            result: items,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Board items retrieved successfully" },
+          { type: "text" as const, text: JSON.stringify(items, null, 2) },
+        ]);
       }
     )
   );
@@ -121,12 +115,10 @@ const createServer = (auth: Authenticator): McpServer => {
         if (!item) {
           return new Err(new MCPError("Item not found", { tracked: false }));
         }
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Item details retrieved successfully",
-            result: item,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Item details retrieved successfully" },
+          { type: "text" as const, text: JSON.stringify(item, null, 2) },
+        ]);
       }
     )
   );
@@ -205,12 +197,10 @@ const createServer = (auth: Authenticator): McpServer => {
         }
 
         const items = await searchItems(accessToken, filters);
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: `Found ${items.length} items (max 100 returned)`,
-            result: items,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: `Found ${items.length} items (max 100 returned)` },
+          { type: "text" as const, text: JSON.stringify(items, null, 2) },
+        ]);
       }
     )
   );
@@ -249,12 +239,10 @@ const createServer = (auth: Authenticator): McpServer => {
           groupId,
           columnValues
         );
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Item created successfully",
-            result: item,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Item created successfully" },
+          { type: "text" as const, text: JSON.stringify(item, null, 2) },
+        ]);
       }
     )
   );
@@ -286,12 +274,10 @@ const createServer = (auth: Authenticator): McpServer => {
           );
         }
         const item = await updateItem(accessToken, itemId, columnValues);
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Item updated successfully",
-            result: item,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Item updated successfully" },
+          { type: "text" as const, text: JSON.stringify(item, null, 2) },
+        ]);
       }
     )
   );
@@ -314,12 +300,10 @@ const createServer = (auth: Authenticator): McpServer => {
         }
 
         const update = await createUpdate(accessToken, itemId, body);
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Update added successfully",
-            result: update,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Update added successfully" },
+          { type: "text" as const, text: JSON.stringify(update, null, 2) },
+        ]);
       }
     )
   );
@@ -338,10 +322,13 @@ const createServer = (auth: Authenticator): McpServer => {
       }
 
       const result = await deleteItem(accessToken, itemId);
-      return makeMCPToolJSONSuccess({
-        message: "Item deleted successfully",
-        result,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Item deleted successfully" },
+          { type: "text", text: JSON.stringify(result, null, 2) },
+        ],
+      };
     }
   );
 
@@ -360,10 +347,13 @@ const createServer = (auth: Authenticator): McpServer => {
       }
 
       const item = await updateItemName(accessToken, itemId, name);
-      return makeMCPToolJSONSuccess({
-        message: "Item name updated successfully",
-        result: item,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Item name updated successfully" },
+          { type: "text", text: JSON.stringify(item, null, 2) },
+        ],
+      };
     }
   );
 
@@ -403,10 +393,13 @@ const createServer = (auth: Authenticator): McpServer => {
         workspaceId,
         description
       );
-      return makeMCPToolJSONSuccess({
-        message: "Board created successfully",
-        result: board,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Board created successfully" },
+          { type: "text", text: JSON.stringify(board, null, 2) },
+        ],
+      };
     }
   );
 
@@ -438,10 +431,13 @@ const createServer = (auth: Authenticator): McpServer => {
         columnType,
         description
       );
-      return makeMCPToolJSONSuccess({
-        message: "Column created successfully",
-        result: column,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Column created successfully" },
+          { type: "text", text: JSON.stringify(column, null, 2) },
+        ],
+      };
     }
   );
 
@@ -469,10 +465,13 @@ const createServer = (auth: Authenticator): McpServer => {
         groupName,
         position
       );
-      return makeMCPToolJSONSuccess({
-        message: "Group created successfully",
-        result: group,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Group created successfully" },
+          { type: "text", text: JSON.stringify(group, null, 2) },
+        ],
+      };
     }
   );
 
@@ -500,10 +499,13 @@ const createServer = (auth: Authenticator): McpServer => {
         itemName,
         columnValues
       );
-      return makeMCPToolJSONSuccess({
-        message: "Subitem created successfully",
-        result: subitem,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Subitem created successfully" },
+          { type: "text", text: JSON.stringify(subitem, null, 2) },
+        ],
+      };
     }
   );
 
@@ -522,10 +524,13 @@ const createServer = (auth: Authenticator): McpServer => {
       }
 
       const result = await deleteGroup(accessToken, boardId, groupId);
-      return makeMCPToolJSONSuccess({
-        message: "Group deleted successfully",
-        result,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Group deleted successfully" },
+          { type: "text", text: JSON.stringify(result, null, 2) },
+        ],
+      };
     }
   );
 
@@ -558,10 +563,13 @@ const createServer = (auth: Authenticator): McpServer => {
         addToTop,
         groupTitle
       );
-      return makeMCPToolJSONSuccess({
-        message: "Group duplicated successfully",
-        result: group,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Group duplicated successfully" },
+          { type: "text", text: JSON.stringify(group, null, 2) },
+        ],
+      };
     }
   );
 
@@ -582,10 +590,13 @@ const createServer = (auth: Authenticator): McpServer => {
       }
 
       const subitem = await updateSubitem(accessToken, subitemId, columnValues);
-      return makeMCPToolJSONSuccess({
-        message: "Subitem updated successfully",
-        result: subitem,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Subitem updated successfully" },
+          { type: "text", text: JSON.stringify(subitem, null, 2) },
+        ],
+      };
     }
   );
 
@@ -610,10 +621,13 @@ const createServer = (auth: Authenticator): McpServer => {
         columnId,
         file
       );
-      return makeMCPToolJSONSuccess({
-        message: "File uploaded successfully",
-        result,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "File uploaded successfully" },
+          { type: "text", text: JSON.stringify(result, null, 2) },
+        ],
+      };
     }
   );
 
@@ -638,10 +652,13 @@ const createServer = (auth: Authenticator): McpServer => {
         columnId,
         columnValue
       );
-      return makeMCPToolJSONSuccess({
-        message: "Items retrieved successfully",
-        result: items,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Items retrieved successfully" },
+          { type: "text", text: JSON.stringify(items, null, 2) },
+        ],
+      };
     }
   );
 
@@ -660,12 +677,18 @@ const createServer = (auth: Authenticator): McpServer => {
 
       const user = await findUserByName(accessToken, name);
       if (!user) {
-        return makeMCPToolTextError("User not found");
+        return {
+          isError: true,
+          content: [{ type: "text", text: "User not found" }],
+        };
       }
-      return makeMCPToolJSONSuccess({
-        message: "User found successfully",
-        result: user,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "User found successfully" },
+          { type: "text", text: JSON.stringify(user, null, 2) },
+        ],
+      };
     }
   );
 
@@ -683,10 +706,13 @@ const createServer = (auth: Authenticator): McpServer => {
       }
 
       const board = await getBoardValues(accessToken, boardId);
-      return makeMCPToolJSONSuccess({
-        message: "Board details retrieved successfully",
-        result: board,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Board details retrieved successfully" },
+          { type: "text", text: JSON.stringify(board, null, 2) },
+        ],
+      };
     }
   );
 
@@ -712,12 +738,18 @@ const createServer = (auth: Authenticator): McpServer => {
         columnId
       );
       if (!columnValue) {
-        return makeMCPToolTextError("Column value not found");
+        return {
+          isError: true,
+          content: [{ type: "text", text: "Column value not found" }],
+        };
       }
-      return makeMCPToolJSONSuccess({
-        message: "Column values retrieved successfully",
-        result: columnValue,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Column values retrieved successfully" },
+          { type: "text", text: JSON.stringify(columnValue, null, 2) },
+        ],
+      };
     }
   );
 
@@ -742,10 +774,13 @@ const createServer = (auth: Authenticator): McpServer => {
         itemId,
         columnId
       );
-      return makeMCPToolJSONSuccess({
-        message: "File column values retrieved successfully",
-        result: fileColumnValue,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "File column values retrieved successfully" },
+          { type: "text", text: JSON.stringify(fileColumnValue, null, 2) },
+        ],
+      };
     }
   );
 
@@ -765,12 +800,18 @@ const createServer = (auth: Authenticator): McpServer => {
 
       const group = await getGroupDetails(accessToken, boardId, groupId);
       if (!group) {
-        return makeMCPToolTextError("Group not found");
+        return {
+          isError: true,
+          content: [{ type: "text", text: "Group not found" }],
+        };
       }
-      return makeMCPToolJSONSuccess({
-        message: "Group details retrieved successfully",
-        result: group,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Group details retrieved successfully" },
+          { type: "text", text: JSON.stringify(group, null, 2) },
+        ],
+      };
     }
   );
 
@@ -788,10 +829,13 @@ const createServer = (auth: Authenticator): McpServer => {
       }
 
       const subitems = await getSubitemValues(accessToken, itemId);
-      return makeMCPToolJSONSuccess({
-        message: "Subitems retrieved successfully",
-        result: subitems,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Subitems retrieved successfully" },
+          { type: "text", text: JSON.stringify(subitems, null, 2) },
+        ],
+      };
     }
   );
 
@@ -810,12 +854,18 @@ const createServer = (auth: Authenticator): McpServer => {
 
       const user = await getUserDetails(accessToken, userId);
       if (!user) {
-        return makeMCPToolTextError("User not found");
+        return {
+          isError: true,
+          content: [{ type: "text", text: "User not found" }],
+        };
       }
-      return makeMCPToolJSONSuccess({
-        message: "User details retrieved successfully",
-        result: user,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "User details retrieved successfully" },
+          { type: "text", text: JSON.stringify(user, null, 2) },
+        ],
+      };
     }
   );
 
@@ -859,10 +909,13 @@ const createServer = (auth: Authenticator): McpServer => {
         targetGroupId,
         columnsMapping
       );
-      return makeMCPToolJSONSuccess({
-        message: "Item moved to board successfully",
-        result: item,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Item moved to board successfully" },
+          { type: "text", text: JSON.stringify(item, null, 2) },
+        ],
+      };
     }
   );
 
@@ -895,10 +948,13 @@ const createServer = (auth: Authenticator): McpServer => {
       }
 
       const createdItems = await createMultipleItems(accessToken, items);
-      return makeMCPToolJSONSuccess({
-        message: `Created ${createdItems.length} items successfully`,
-        result: createdItems,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: `Created ${createdItems.length} items successfully` },
+          { type: "text", text: JSON.stringify(createdItems, null, 2) },
+        ],
+      };
     }
   );
 
@@ -936,10 +992,13 @@ const createServer = (auth: Authenticator): McpServer => {
         to ? new Date(to) : undefined,
         limit
       );
-      return makeMCPToolJSONSuccess({
-        message: "Activity logs retrieved successfully",
-        result: logs,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Activity logs retrieved successfully" },
+          { type: "text", text: JSON.stringify(logs, null, 2) },
+        ],
+      };
     }
   );
 
@@ -957,10 +1016,13 @@ const createServer = (auth: Authenticator): McpServer => {
       }
 
       const analytics = await getBoardAnalytics(accessToken, boardId);
-      return makeMCPToolJSONSuccess({
-        message: "Board analytics retrieved successfully",
-        result: analytics,
-      });
+      return {
+        isError: false,
+        content: [
+          { type: "text", text: "Board analytics retrieved successfully" },
+          { type: "text", text: JSON.stringify(analytics, null, 2) },
+        ],
+      };
     }
   );
 

--- a/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
@@ -34,9 +34,7 @@ import {
   updateSubitem,
   uploadFileToColumn,
 } from "@app/lib/actions/mcp_internal_actions/servers/monday/monday_api_helper";
-import {
-  makeInternalMCPServer,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
@@ -116,7 +114,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError("Item not found", { tracked: false }));
         }
         return new Ok([
-          { type: "text" as const, text: "Item details retrieved successfully" },
+          {
+            type: "text" as const,
+            text: "Item details retrieved successfully",
+          },
           { type: "text" as const, text: JSON.stringify(item, null, 2) },
         ]);
       }
@@ -198,7 +199,10 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const items = await searchItems(accessToken, filters);
         return new Ok([
-          { type: "text" as const, text: `Found ${items.length} items (max 100 returned)` },
+          {
+            type: "text" as const,
+            text: `Found ${items.length} items (max 100 returned)`,
+          },
           { type: "text" as const, text: JSON.stringify(items, null, 2) },
         ]);
       }
@@ -951,7 +955,10 @@ const createServer = (auth: Authenticator): McpServer => {
       return {
         isError: false,
         content: [
-          { type: "text", text: `Created ${createdItems.length} items successfully` },
+          {
+            type: "text",
+            text: `Created ${createdItems.length} items successfully`,
+          },
           { type: "text", text: JSON.stringify(createdItems, null, 2) },
         ],
       };

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -22,7 +22,6 @@ import type {
 import { renderRelativeTimeFrameForToolOutput } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
   makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
   makePersonalAuthenticationError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -280,12 +279,10 @@ async function withNotionClient<T>(
     const notion = new Client({ auth: accessToken });
 
     const result = await fn(notion);
-    return new Ok(
-      makeMCPToolJSONSuccess({
-        message: "Success",
-        result: JSON.stringify(result),
-      }).content
-    );
+    return new Ok([
+      { type: "text" as const, text: "Success" },
+      { type: "text" as const, text: JSON.stringify(result, null, 2) },
+    ]);
   } catch (e) {
     const tracked =
       APIResponseError.isAPIResponseError(e) &&

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -471,7 +471,6 @@ const createServer = (auth: Authenticator): McpServer => {
 
         return new Ok([
           { type: "text" as const, text: "Event deleted successfully" },
-          { type: "text" as const, text: JSON.stringify("", null, 2) },
         ]);
       }
     )

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -3,10 +3,7 @@ import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import * as OutlookApi from "@app/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
@@ -32,16 +29,24 @@ const createServer = (auth: Authenticator): McpServer => {
         const result = await OutlookApi.getUserTimezone(accessToken);
 
         if (typeof result === "string") {
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: "User timezone retrieved successfully",
-              result: {
-                timezone: result,
-                description:
-                  "Use this timezone value when creating, updating, or searching for calendar events to ensure times are displayed correctly.",
-              },
-            }).content
-          );
+          return new Ok([
+            {
+              type: "text" as const,
+              text: "User timezone retrieved successfully",
+            },
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  timezone: result,
+                  description:
+                    "Use this timezone value when creating, updating, or searching for calendar events to ensure times are displayed correctly.",
+                },
+                null,
+                2
+              ),
+            },
+          ]);
         } else {
           return new Err(new MCPError(result.error));
         }
@@ -87,12 +92,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError(result.error));
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Calendars listed successfully",
-            result,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Calendars listed successfully" },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
       }
     )
   );
@@ -170,12 +173,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError(result.error));
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Events searched successfully",
-            result,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Events searched successfully" },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
       }
     )
   );
@@ -217,12 +218,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError(result.error));
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Event fetched successfully",
-            result,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Event fetched successfully" },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
       }
     )
   );
@@ -325,12 +324,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError(result.error));
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Event created successfully",
-            result,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Event created successfully" },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
       }
     )
   );
@@ -427,12 +424,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError(result.error));
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Event updated successfully",
-            result,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Event updated successfully" },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
       }
     )
   );
@@ -474,12 +469,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError(result.error));
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Event deleted successfully",
-            result: "",
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Event deleted successfully" },
+          { type: "text" as const, text: JSON.stringify("", null, 2) },
+        ]);
       }
     )
   );
@@ -536,12 +529,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError(result.error));
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Availability checked successfully",
-            result,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Availability checked successfully" },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
@@ -380,7 +380,6 @@ const createServer = (auth: Authenticator): McpServer => {
 
         return new Ok([
           { type: "text" as const, text: "Draft deleted successfully" },
-          { type: "text" as const, text: JSON.stringify("", null, 2) },
         ]);
       }
     )

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
@@ -2,10 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -146,16 +143,21 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const result = await response.json();
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Messages fetched successfully",
-            result: {
-              messages: (result.value || []) as OutlookMessage[],
-              nextLink: result["@odata.nextLink"],
-              totalCount: result["@odata.count"],
-            },
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Messages fetched successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                messages: (result.value || []) as OutlookMessage[],
+                nextLink: result["@odata.nextLink"],
+                totalCount: result["@odata.count"],
+              },
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );
@@ -229,15 +231,20 @@ const createServer = (auth: Authenticator): McpServer => {
           { concurrency: 10 }
         );
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Drafts fetched successfully",
-            result: {
-              drafts: draftDetails.filter(Boolean) as OutlookMessage[],
-              nextLink: result["@odata.nextLink"],
-            },
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Drafts fetched successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                drafts: draftDetails.filter(Boolean) as OutlookMessage[],
+                nextLink: result["@odata.nextLink"],
+              },
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );
@@ -319,15 +326,20 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const result = await response.json();
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Draft created successfully",
-            result: {
-              messageId: result.id,
-              conversationId: result.conversationId,
-            },
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Draft created successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                messageId: result.id,
+                conversationId: result.conversationId,
+              },
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );
@@ -366,12 +378,10 @@ const createServer = (auth: Authenticator): McpServer => {
           return new Err(new MCPError("Failed to delete draft"));
         }
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Draft deleted successfully",
-            result: "",
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Draft deleted successfully" },
+          { type: "text" as const, text: JSON.stringify("", null, 2) },
+        ]);
       }
     )
   );
@@ -487,17 +497,22 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const result = await response.json();
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Reply draft created successfully",
-            result: {
-              messageId: result.id,
-              conversationId: result.conversationId,
-              originalMessageId: messageId,
-              subject: result.subject,
-            },
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Reply draft created successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                messageId: result.id,
+                conversationId: result.conversationId,
+                originalMessageId: messageId,
+                subject: result.subject,
+              },
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );
@@ -571,16 +586,21 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const result = await response.json();
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Contacts fetched successfully",
-            result: {
-              contacts: (result.value || []) as OutlookContact[],
-              nextLink: result["@odata.nextLink"],
-              totalCount: result["@odata.count"],
-            },
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Contacts fetched successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                contacts: (result.value || []) as OutlookContact[],
+                nextLink: result["@odata.nextLink"],
+                totalCount: result["@odata.count"],
+              },
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );
@@ -690,12 +710,13 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const result = await response.json();
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Contact created successfully",
-            result: result as OutlookContact,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Contact created successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(result as OutlookContact, null, 2),
+          },
+        ]);
       }
     )
   );
@@ -822,12 +843,13 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const result = await response.json();
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Contact updated successfully",
-            result: result as OutlookContact,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Contact updated successfully" },
+          {
+            type: "text" as const,
+            text: JSON.stringify(result as OutlookContact, null, 2),
+          },
+        ]);
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -8,11 +8,7 @@ import {
   extractTextFromSalesforceAttachment,
   getAllSalesforceAttachments,
 } from "@app/lib/actions/mcp_internal_actions/servers/salesforce/salesforce_api_helper";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-  makeMCPToolTextSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -48,12 +44,10 @@ const createServer = (auth: Authenticator): McpServer => {
 
         const result = await conn.query(query);
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: "Operation completed successfully",
-            result: result,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: "Operation completed successfully" },
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ]);
       }
     )
   );
@@ -94,12 +88,10 @@ const createServer = (auth: Authenticator): McpServer => {
           .map((object) => `${object.name} (display_name="${object.label}")`)
           .join("\n");
 
-        return new Ok(
-          makeMCPToolTextSuccess({
-            message: "Operation completed successfully",
-            result: objects,
-          }).content
-        );
+        return new Ok([
+          { type: "text", text: "Operation completed successfully" },
+          { type: "text", text: objects },
+        ]);
       }
     )
   );
@@ -202,12 +194,10 @@ const createServer = (auth: Authenticator): McpServer => {
         summary +=
           "\nNote: For custom relationships in SOQL, names often end with '__r' (e.g., MyCustomChildren__r). Use the 'RelationshipName' listed above.\n";
 
-        return new Ok(
-          makeMCPToolTextSuccess({
-            message: "Object described successfully. Summary provided.",
-            result: summary,
-          }).content
-        );
+        return new Ok([
+          { type: "text", text: "Object described successfully. Summary provided." },
+          { type: "text", text: summary },
+        ]);
       }
     )
   );
@@ -251,14 +241,22 @@ const createServer = (auth: Authenticator): McpServer => {
           author: att.author,
         }));
 
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: `Found ${attachments.length} attachment(s) for record ${recordId}`,
-            result: {
-              attachments: attachmentSummary,
-            },
-          }).content
-        );
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Found ${attachments.length} attachment(s) for record ${recordId}`,
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              {
+                attachments: attachmentSummary,
+              },
+              null,
+              2
+            ),
+          },
+        ]);
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -195,7 +195,10 @@ const createServer = (auth: Authenticator): McpServer => {
           "\nNote: For custom relationships in SOQL, names often end with '__r' (e.g., MyCustomChildren__r). Use the 'RelationshipName' listed above.\n";
 
         return new Ok([
-          { type: "text", text: "Object described successfully. Summary provided." },
+          {
+            type: "text",
+            text: "Object described successfully. Summary provided.",
+          },
           { type: "text", text: summary },
         ]);
       }

--- a/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
@@ -9,10 +9,7 @@ import {
   executePostMessage,
   getSlackClient,
 } from "@app/lib/actions/mcp_internal_actions/servers/slack_bot/slack_api_helper";
-import {
-  makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
@@ -221,20 +218,18 @@ const createServer = async (
           const hasMore = !!response.has_more;
           const nextCursor = response.response_metadata?.next_cursor;
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: {
-                messages: response.messages,
-                has_more: hasMore,
-                next_cursor: nextCursor,
-                pagination_info: {
-                  current_page_size: response.messages?.length ?? 0,
-                  has_more_pages: hasMore,
-                  next_cursor_for_pagination: nextCursor,
-                },
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify({
+              messages: response.messages,
+              has_more: hasMore,
+              next_cursor: nextCursor,
+              pagination_info: {
+                current_page_size: response.messages?.length ?? 0,
+                has_more_pages: hasMore,
+                next_cursor_for_pagination: nextCursor,
               },
-            }).content
-          );
+            }, null, 2) },
+          ]);
         } catch (error) {
           return new Err(
             new MCPError(
@@ -304,24 +299,22 @@ const createServer = async (
           const parentMessage = response.messages?.[0];
           const threadReplies = response.messages?.slice(1) ?? [];
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: `Retrieved thread with ${response.messages?.length} total messages (1 parent + ${threadReplies.length} replies)${hasMore ? ". More replies available." : ""}`,
-              result: {
-                parent_message: parentMessage,
-                thread_replies: threadReplies,
-                total_messages: response.messages?.length ?? 0,
-                has_more: hasMore,
-                next_cursor: nextCursor,
-                pagination_info: {
-                  current_page_size: response.messages?.length ?? 0,
-                  replies_in_this_page: threadReplies.length,
-                  has_more_pages: hasMore,
-                  next_cursor_for_pagination: nextCursor,
-                },
+          return new Ok([
+            { type: "text" as const, text: `Retrieved thread with ${response.messages?.length} total messages (1 parent + ${threadReplies.length} replies)${hasMore ? ". More replies available." : ""}` },
+            { type: "text" as const, text: JSON.stringify({
+              parent_message: parentMessage,
+              thread_replies: threadReplies,
+              total_messages: response.messages?.length ?? 0,
+              has_more: hasMore,
+              next_cursor: nextCursor,
+              pagination_info: {
+                current_page_size: response.messages?.length ?? 0,
+                replies_in_this_page: threadReplies.length,
+                has_more_pages: hasMore,
+                next_cursor_for_pagination: nextCursor,
               },
-            }).content
-          );
+            }, null, 2) },
+          ]);
         } catch (error) {
           return new Err(
             new MCPError(
@@ -371,12 +364,10 @@ const createServer = async (
             );
           }
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: `Successfully added ${name} reaction to message`,
-              result: response,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Successfully added ${name} reaction to message` },
+            { type: "text" as const, text: JSON.stringify(response, null, 2) },
+          ]);
         } catch (error) {
           return new Err(
             new MCPError(`Error adding reaction: ${normalizeError(error)}`)
@@ -424,12 +415,10 @@ const createServer = async (
             );
           }
 
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              message: `Successfully removed ${name} reaction from message`,
-              result: response,
-            }).content
-          );
+          return new Ok([
+            { type: "text" as const, text: `Successfully removed ${name} reaction from message` },
+            { type: "text" as const, text: JSON.stringify(response, null, 2) },
+          ]);
         } catch (error) {
           return new Err(
             new MCPError(`Error removing reaction: ${normalizeError(error)}`)

--- a/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
@@ -219,16 +219,23 @@ const createServer = async (
           const nextCursor = response.response_metadata?.next_cursor;
 
           return new Ok([
-            { type: "text" as const, text: JSON.stringify({
-              messages: response.messages,
-              has_more: hasMore,
-              next_cursor: nextCursor,
-              pagination_info: {
-                current_page_size: response.messages?.length ?? 0,
-                has_more_pages: hasMore,
-                next_cursor_for_pagination: nextCursor,
-              },
-            }, null, 2) },
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  messages: response.messages,
+                  has_more: hasMore,
+                  next_cursor: nextCursor,
+                  pagination_info: {
+                    current_page_size: response.messages?.length ?? 0,
+                    has_more_pages: hasMore,
+                    next_cursor_for_pagination: nextCursor,
+                  },
+                },
+                null,
+                2
+              ),
+            },
           ]);
         } catch (error) {
           return new Err(
@@ -300,20 +307,30 @@ const createServer = async (
           const threadReplies = response.messages?.slice(1) ?? [];
 
           return new Ok([
-            { type: "text" as const, text: `Retrieved thread with ${response.messages?.length} total messages (1 parent + ${threadReplies.length} replies)${hasMore ? ". More replies available." : ""}` },
-            { type: "text" as const, text: JSON.stringify({
-              parent_message: parentMessage,
-              thread_replies: threadReplies,
-              total_messages: response.messages?.length ?? 0,
-              has_more: hasMore,
-              next_cursor: nextCursor,
-              pagination_info: {
-                current_page_size: response.messages?.length ?? 0,
-                replies_in_this_page: threadReplies.length,
-                has_more_pages: hasMore,
-                next_cursor_for_pagination: nextCursor,
-              },
-            }, null, 2) },
+            {
+              type: "text" as const,
+              text: `Retrieved thread with ${response.messages?.length} total messages (1 parent + ${threadReplies.length} replies)${hasMore ? ". More replies available." : ""}`,
+            },
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  parent_message: parentMessage,
+                  thread_replies: threadReplies,
+                  total_messages: response.messages?.length ?? 0,
+                  has_more: hasMore,
+                  next_cursor: nextCursor,
+                  pagination_info: {
+                    current_page_size: response.messages?.length ?? 0,
+                    replies_in_this_page: threadReplies.length,
+                    has_more_pages: hasMore,
+                    next_cursor_for_pagination: nextCursor,
+                  },
+                },
+                null,
+                2
+              ),
+            },
           ]);
         } catch (error) {
           return new Err(
@@ -365,7 +382,10 @@ const createServer = async (
           }
 
           return new Ok([
-            { type: "text" as const, text: `Successfully added ${name} reaction to message` },
+            {
+              type: "text" as const,
+              text: `Successfully added ${name} reaction to message`,
+            },
             { type: "text" as const, text: JSON.stringify(response, null, 2) },
           ]);
         } catch (error) {
@@ -416,7 +436,10 @@ const createServer = async (
           }
 
           return new Ok([
-            { type: "text" as const, text: `Successfully removed ${name} reaction from message` },
+            {
+              type: "text" as const,
+              text: `Successfully removed ${name} reaction from message`,
+            },
             { type: "text" as const, text: JSON.stringify(response, null, 2) },
           ]);
         } catch (error) {

--- a/front/lib/actions/mcp_internal_actions/servers/slack_bot/slack_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack_bot/slack_api_helper.ts
@@ -4,7 +4,6 @@ import type { Member } from "@slack/web-api/dist/response/UsersListResponse";
 import slackifyMarkdown from "slackify-markdown";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { makeMCPToolJSONSuccess } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -177,12 +176,10 @@ export async function executePostMessage(
       return new Err(new MCPError(uploadResp.error ?? "Unknown error"));
     }
 
-    return new Ok(
-      makeMCPToolJSONSuccess({
-        message: `Message with file uploaded to ${channelId}`,
-        result: uploadResp,
-      }).content
-    );
+    return new Ok([
+      { type: "text" as const, text: `Message with file uploaded to ${channelId}` },
+      { type: "text" as const, text: JSON.stringify(uploadResp, null, 2) },
+    ]);
   }
 
   // No file provided: regular message
@@ -197,12 +194,10 @@ export async function executePostMessage(
     return new Err(new MCPError(response.error ?? "Unknown error"));
   }
 
-  return new Ok(
-    makeMCPToolJSONSuccess({
-      message: `Message posted to ${to}`,
-      result: response,
-    }).content
-  );
+  return new Ok([
+    { type: "text" as const, text: `Message posted to ${to}` },
+    { type: "text" as const, text: JSON.stringify(response, null, 2) },
+  ]);
 }
 
 export async function executeListUsers(
@@ -238,31 +233,25 @@ export async function executeListUsers(
 
       // Early return if we found a user
       if (filteredUsers.length > 0) {
-        return new Ok(
-          makeMCPToolJSONSuccess({
-            message: `The workspace has ${filteredUsers.length} users containing "${nameFilter}"`,
-            result: filteredUsers,
-          }).content
-        );
+        return new Ok([
+          { type: "text" as const, text: `The workspace has ${filteredUsers.length} users containing "${nameFilter}"` },
+          { type: "text" as const, text: JSON.stringify(filteredUsers, null, 2) },
+        ]);
       }
     }
   } while (cursor);
 
   if (nameFilter) {
-    return new Ok(
-      makeMCPToolJSONSuccess({
-        message: `The workspace has ${users.length} users but none containing "${nameFilter}"`,
-        result: users,
-      }).content
-    );
+    return new Ok([
+      { type: "text" as const, text: `The workspace has ${users.length} users but none containing "${nameFilter}"` },
+      { type: "text" as const, text: JSON.stringify(users, null, 2) },
+    ]);
   }
 
-  return new Ok(
-    makeMCPToolJSONSuccess({
-      message: `The workspace has ${users.length} users`,
-      result: users,
-    }).content
-  );
+  return new Ok([
+    { type: "text" as const, text: `The workspace has ${users.length} users` },
+    { type: "text" as const, text: JSON.stringify(users, null, 2) },
+  ]);
 }
 
 export async function executeGetUser(userId: string, accessToken: string) {
@@ -272,12 +261,10 @@ export async function executeGetUser(userId: string, accessToken: string) {
   if (!response.ok || !response.user) {
     return new Err(new MCPError(response.error ?? "Unknown error"));
   }
-  return new Ok(
-    makeMCPToolJSONSuccess({
-      message: `Retrieved user information for ${userId}`,
-      result: response.user,
-    }).content
-  );
+  return new Ok([
+    { type: "text" as const, text: `Retrieved user information for ${userId}` },
+    { type: "text" as const, text: JSON.stringify(response.user, null, 2) },
+  ]);
 }
 
 export async function executeListPublicChannels(
@@ -305,27 +292,21 @@ export async function executeListPublicChannels(
 
     // Early return if we found a channel
     if (filteredChannels.length > 0) {
-      return new Ok(
-        makeMCPToolJSONSuccess({
-          message: `The workspace has ${filteredChannels.length} channels containing "${nameFilter}"`,
-          result: filteredChannels,
-        }).content
-      );
+      return new Ok([
+        { type: "text" as const, text: `The workspace has ${filteredChannels.length} channels containing "${nameFilter}"` },
+        { type: "text" as const, text: JSON.stringify(filteredChannels, null, 2) },
+      ]);
     }
   }
   if (nameFilter) {
-    return new Ok(
-      makeMCPToolJSONSuccess({
-        message: `The workspace has ${channels.length} channels but none containing "${nameFilter}"`,
-        result: channels,
-      }).content
-    );
+    return new Ok([
+      { type: "text" as const, text: `The workspace has ${channels.length} channels but none containing "${nameFilter}"` },
+      { type: "text" as const, text: JSON.stringify(channels, null, 2) },
+    ]);
   }
 
-  return new Ok(
-    makeMCPToolJSONSuccess({
-      message: `The workspace has ${channels.length} channels`,
-      result: channels,
-    }).content
-  );
+  return new Ok([
+    { type: "text" as const, text: `The workspace has ${channels.length} channels` },
+    { type: "text" as const, text: JSON.stringify(channels, null, 2) },
+  ]);
 }

--- a/front/lib/actions/mcp_internal_actions/servers/slack_bot/slack_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack_bot/slack_api_helper.ts
@@ -177,7 +177,10 @@ export async function executePostMessage(
     }
 
     return new Ok([
-      { type: "text" as const, text: `Message with file uploaded to ${channelId}` },
+      {
+        type: "text" as const,
+        text: `Message with file uploaded to ${channelId}`,
+      },
       { type: "text" as const, text: JSON.stringify(uploadResp, null, 2) },
     ]);
   }
@@ -234,8 +237,14 @@ export async function executeListUsers(
       // Early return if we found a user
       if (filteredUsers.length > 0) {
         return new Ok([
-          { type: "text" as const, text: `The workspace has ${filteredUsers.length} users containing "${nameFilter}"` },
-          { type: "text" as const, text: JSON.stringify(filteredUsers, null, 2) },
+          {
+            type: "text" as const,
+            text: `The workspace has ${filteredUsers.length} users containing "${nameFilter}"`,
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(filteredUsers, null, 2),
+          },
         ]);
       }
     }
@@ -243,7 +252,10 @@ export async function executeListUsers(
 
   if (nameFilter) {
     return new Ok([
-      { type: "text" as const, text: `The workspace has ${users.length} users but none containing "${nameFilter}"` },
+      {
+        type: "text" as const,
+        text: `The workspace has ${users.length} users but none containing "${nameFilter}"`,
+      },
       { type: "text" as const, text: JSON.stringify(users, null, 2) },
     ]);
   }
@@ -293,20 +305,32 @@ export async function executeListPublicChannels(
     // Early return if we found a channel
     if (filteredChannels.length > 0) {
       return new Ok([
-        { type: "text" as const, text: `The workspace has ${filteredChannels.length} channels containing "${nameFilter}"` },
-        { type: "text" as const, text: JSON.stringify(filteredChannels, null, 2) },
+        {
+          type: "text" as const,
+          text: `The workspace has ${filteredChannels.length} channels containing "${nameFilter}"`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(filteredChannels, null, 2),
+        },
       ]);
     }
   }
   if (nameFilter) {
     return new Ok([
-      { type: "text" as const, text: `The workspace has ${channels.length} channels but none containing "${nameFilter}"` },
+      {
+        type: "text" as const,
+        text: `The workspace has ${channels.length} channels but none containing "${nameFilter}"`,
+      },
       { type: "text" as const, text: JSON.stringify(channels, null, 2) },
     ]);
   }
 
   return new Ok([
-    { type: "text" as const, text: `The workspace has ${channels.length} channels` },
+    {
+      type: "text" as const,
+      text: `The workspace has ${channels.length} channels`,
+    },
     { type: "text" as const, text: JSON.stringify(channels, null, 2) },
   ]);
 }

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -46,20 +46,6 @@ export function makeInternalMCPServer(
   });
 }
 
-export function makeMCPToolTextError(text: string): {
-  isError: true;
-  content: [TextContent];
-} {
-  return {
-    isError: true,
-    content: [
-      {
-        type: "text",
-        text,
-      },
-    ],
-  };
-}
 
 export function makePersonalAuthenticationError(
   provider: OAuthProvider,
@@ -105,43 +91,7 @@ export function makeMCPToolExit({
   };
 }
 
-export function makeMCPToolTextSuccess({
-  message,
-  result,
-}: {
-  message: string;
-  result?: string;
-}): CallToolResult {
-  if (!result) {
-    return {
-      isError: false,
-      content: [{ type: "text", text: message }],
-    };
-  }
-  return {
-    isError: false,
-    content: [
-      { type: "text", text: message },
-      { type: "text", text: result },
-    ],
-  };
-}
 
-export const makeMCPToolJSONSuccess = ({
-  message,
-  result,
-}: {
-  message?: string;
-  result: object | string;
-}): CallToolResult => {
-  return {
-    isError: false,
-    content: [
-      ...(message ? [{ type: "text" as const, text: message }] : []),
-      { type: "text" as const, text: JSON.stringify(result, null, 2) },
-    ],
-  };
-};
 
 export async function getExitOrPauseEvents({
   outputItems,

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -5,10 +5,6 @@ import {
   isAgentPauseOutputResourceType,
 } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type {
-  CallToolResult,
-  TextContent,
-} from "@modelcontextprotocol/sdk/types.js";
 
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
@@ -45,7 +41,6 @@ export function makeInternalMCPServer(
     instructions,
   });
 }
-
 
 export function makePersonalAuthenticationError(
   provider: OAuthProvider,
@@ -90,8 +85,6 @@ export function makeMCPToolExit({
     ],
   };
 }
-
-
 
 export async function getExitOrPauseEvents({
   outputItems,


### PR DESCRIPTION
## Description

- This PR inlines the util functions `makeMCPToolJSONSuccess`, `makeMCPToolTextSuccess`, `makeMCPToolTextError`.
- Now that we are wrapping tool callbacks with `withToolLogging` these utils don't really return the correct type (we hack it by taking the `.content` only).
- Note that in every example here we should not be returning a stringified JSON but should instead expose a well formatted string (can be a Markdown), but not the topic of this PR.

## Tests

## Risk

- Low, purely a refactoring.

## Deploy Plan

- Deploy front.
