### PR TITLE
[front] update tool display name

### DIFF
--- a/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
+++ b/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
@@ -17,7 +17,7 @@ function getDescriptionForContentType(
   file: LightAgentMessageType["generatedFiles"][number]
 ) {
   if (file.contentType === frameContentType) {
-    return "Frame";
+    return "Frames";
   }
 
   return null;

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -32,7 +32,7 @@ interface FileGroup {
 
 // Configuration for content types that get their own groups.
 const GROUPED_CONTENT_TYPES = {
-  [frameContentType]: "Frame",
+  [frameContentType]: "Frames",
   "application/json": "JSON",
   "text/csv": "Tables",
   "text/plain": "Text",

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -25,7 +25,7 @@ import type {
   MultiActionPreset,
   TemplateActionPreset,
 } from "@app/types";
-import { asDisplayName } from "@app/types";
+import { asDisplayName, asDisplayToolName } from "@app/types";
 
 export const getServerTypeAndIdFromSId = (
   mcpServerId: string
@@ -151,7 +151,7 @@ export function getMcpServerDisplayName(
 ) {
   // Unreleased internal servers are displayed with a suffix in the UI.
   const res = getInternalMCPServerNameAndWorkspaceId(server.sId);
-  let displayName = asDisplayName(server.name);
+  let displayName = asDisplayToolName(server.name);
 
   if (res.isOk()) {
     const isCustomName = action?.name && action.name !== server.name;

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -136,11 +136,7 @@ const SPECIAL_CASES_PATTERN = new RegExp(
   "g"
 );
 
-export function asDisplayName(name?: string | null) {
-  if (!name) {
-    return "";
-  }
-
+function formatAsDisplayName(name: string): string {
   return slugify(name)
     .replace(/_/g, " ")
     .replace(
@@ -148,4 +144,36 @@ export function asDisplayName(name?: string | null) {
       (match) => SPECIAL_CASES[match as keyof typeof SPECIAL_CASES]
     )
     .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function asDisplayToolName(name?: string | null) {
+  if (!name) {
+    return "";
+  }
+
+  if (name === "interactive_content") {
+    return "Create Frames";
+  }
+
+  if (name === "image_generation") {
+    return "Create Images";
+  }
+
+  if (name === "file_generation") {
+    return "Create Files";
+  }
+
+  if (name === "slideshow") {
+    return "Create Slideshows";
+  }
+
+  return formatAsDisplayName(name);
+}
+
+export function asDisplayName(name?: string | null) {
+  if (!name) {
+    return "";
+  }
+
+  return formatAsDisplayName(name);
 }


### PR DESCRIPTION
## Description

This PR is to rename creation tool names to "Create ..." pattern in frontend.

<img width="1540" height="838" alt="CleanShot 2025-10-14 at 12 11 26@2x" src="https://github.com/user-attachments/assets/78b6267d-1db0-4880-9af1-c7d9570f568b" />

<img width="778" height="336" alt="CleanShot 2025-10-14 at 12 10 23@2x" src="https://github.com/user-attachments/assets/fc2bcc17-77ec-4b3f-b321-868609cd2743" />



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
