### PR TITLE
Fix getConversationRoute params: Broken urls

### DIFF
--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -262,7 +262,7 @@ async function handler(
             agentConfiguration: answer.agentConfiguration,
             htmlContent: `<div><div>${
               answer.html
-            }</div><br/><a href="${getConversationRoute(auth.workspace()?.sId ?? "", conversation.sId, DUST_CLIENT_FACING_URL)}">Open in Dust</a></div>`,
+            }</div><br/><a href="${getConversationRoute(workspace.sId, conversation.sId, undefined, DUST_CLIENT_FACING_URL)}">Open in Dust</a></div>`,
           });
         });
       }

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -702,7 +702,7 @@ export async function processTranscriptActivity(
       },
       subject: `[DUST] Transcripts - ${transcriptTitle.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")}`,
       body: `${htmlAnswer}<div style="text-align: center; margin-top: 20px;">
-    <a href="${getConversationRoute(owner.sId, conversation.sId, config.getClientFacingUrl())}"
+    <a href="${getConversationRoute(owner.sId, conversation.sId, undefined, config.getClientFacingUrl())}"
       style="display: inline-block;
               padding: 10px 20px;
               background-color: #000000;


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/4626

Ideally we refactor `getConversationRoute` to use an object as param but I went with the fast fix

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 