### PR TITLE
feat(front): stop workflow scrubbing if workspace already deleted

### DIFF
--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -30,6 +30,7 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -91,6 +92,15 @@ export async function scrubWorkspaceData({
 }: {
   workspaceId: string;
 }) {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.info(
+      { workspaceId },
+      "Workspace not found, it was probably already deleted"
+    );
+    return true;
+  }
+
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
     dangerouslyRequestAllGroups: true,
   });

--- a/front/temporal/scrub_workspace/workflows.ts
+++ b/front/temporal/scrub_workspace/workflows.ts
@@ -61,6 +61,10 @@ export async function scheduleWorkspaceScrubWorkflowV2({
 }: {
   workspaceId: string;
 }): Promise<boolean> {
+  if (!(await shouldStillScrubData({ workspaceId }))) {
+    return false;
+  }
+
   await pauseAllConnectors({ workspaceId });
   await pauseAllTriggers({ workspaceId });
   await sendDataDeletionEmail({


### PR DESCRIPTION
## Description

It seems workspaces can be delete before we run the scrubbing, and it [generates errors](https://app.datadoghq.eu/dashboard/zms-vrt-9zr/stuck-front-worker?fromUser=false&refresh_mode=sliding&from_ts=1760427048568&to_ts=1760430648568&live=true). 

Let's properly return in this case

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
