### PR TITLE
Poke UI to make Notion requests

### DIFF
--- a/connectors/src/api/admin.ts
+++ b/connectors/src/api/admin.ts
@@ -38,6 +38,10 @@ const whitelistedCommands = [
     command: "update-orphaned-resources-parents",
   },
   {
+    majorCommand: "notion",
+    command: "api-request",
+  },
+  {
     majorCommand: "slack",
     command: "whitelist-bot",
   },

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -426,6 +426,7 @@ export const NotionCommandSchema = t.type({
     t.literal("update-parents-fields"),
     t.literal("clear-parents-last-updated-at"),
     t.literal("update-orphaned-resources-parents"),
+    t.literal("api-request"),
   ]),
   args: t.record(
     t.string,
@@ -486,6 +487,14 @@ export const NotionMeResponseSchema = t.type({
   botOwner: t.UnknownRecord, // notion type, can't be iots'd
 });
 export type NotionMeResponseType = t.TypeOf<typeof NotionMeResponseSchema>;
+
+export const NotionApiRequestResponseSchema = t.type({
+  status: t.number,
+  data: t.unknown, // notion API response type, can't be iots'd
+});
+export type NotionApiRequestResponseType = t.TypeOf<
+  typeof NotionApiRequestResponseSchema
+>;
 /**
  * </Notion>
  */
@@ -845,6 +854,7 @@ export const AdminResponseSchema = t.union([
   IntercomFetchConversationResponseSchema,
   IntercomForceResyncArticlesResponseSchema,
   IntercomSearchConversationsResponseSchema,
+  NotionApiRequestResponseSchema,
   NotionCheckUrlResponseSchema,
   NotionDeleteUrlResponseSchema,
   NotionMeResponseSchema,

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -633,7 +633,25 @@ const DataSourcePage = ({
               />
             ) : null}
             {dataSource.connectorProvider === "notion" && (
-              <NotionUrlCheckOrFind owner={owner} dsId={dataSource.sId} />
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    if (
+                      window.confirm(
+                        "Are you sure you want to access this sensitive user data? (Access will be logged)"
+                      )
+                    ) {
+                      void router.push(
+                        `/poke/${owner.sId}/data_sources/${dataSource.sId}/notion-requests`
+                      );
+                    }
+                  }}
+                  label="Notion Requests"
+                  icon={LockIcon}
+                />
+                <NotionUrlCheckOrFind owner={owner} dsId={dataSource.sId} />
+              </>
             )}
             {dataSource.connectorProvider === "zendesk" && (
               <ZendeskTicketCheck owner={owner} dsId={dataSource.sId} />

--- a/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
@@ -49,9 +49,6 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
 type HttpMethod = "GET" | "POST";
 
-export default function NotionRequestsPage({
-  owner,
-  dataSource,
 interface NotionRequestsPageProps {
   owner: WorkspaceType;
   dataSource: DataSourceType;

--- a/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
@@ -1,0 +1,260 @@
+import { Button, Input, Spinner, TextArea } from "@dust-tt/sparkle";
+import { JsonViewer } from "@textea/json-viewer";
+import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react";
+import { useState } from "react";
+
+import PokeLayout from "@app/components/poke/PokeLayout";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import type { DataSourceType, WorkspaceType } from "@app/types";
+
+export const getServerSideProps = withSuperUserAuthRequirements<{
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+}>(async (context, auth) => {
+  const owner = auth.getNonNullableWorkspace();
+
+  const { dsId } = context.params || {};
+  if (typeof dsId !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
+    includeEditedBy: true,
+  });
+  if (!dataSource) {
+    return {
+      notFound: true,
+    };
+  }
+
+  // Only allow for Notion datasources
+  if (dataSource.connectorProvider !== "notion") {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+      dataSource: dataSource.toJSON(),
+    },
+  };
+});
+
+type HttpMethod = "GET" | "POST";
+
+export default function NotionRequestsPage({
+  owner,
+  dataSource,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { isDark } = useTheme();
+  const [url, setUrl] = useState("");
+  const [method, setMethod] = useState<HttpMethod>("GET");
+  const [body, setBody] = useState("");
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [response, setResponse] = useState<{
+    status: number;
+    data: unknown;
+  } | null>(null);
+
+  const handleExecuteRequest = async () => {
+    if (!url.trim()) {
+      setError("Please enter a URL");
+      return;
+    }
+
+    // Validate body for POST requests
+    if (method === "POST" && body.trim()) {
+      try {
+        JSON.parse(body);
+      } catch (e) {
+        setError("Invalid JSON in request body");
+        return;
+      }
+    }
+
+    setIsExecuting(true);
+    setError(null);
+    setResponse(null);
+
+    try {
+      const res = await fetch(`/api/poke/admin`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          majorCommand: "notion",
+          command: "api-request",
+          args: {
+            wId: owner.sId,
+            dsId: dataSource.sId,
+            url,
+            method,
+            body: method === "POST" && body.trim() ? body : undefined,
+          },
+        }),
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw new Error(
+          errorData.error?.connectors_error?.message ||
+            errorData.error?.message ||
+            "Failed to execute request"
+        );
+      }
+
+      const result = await res.json();
+      setResponse(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setIsExecuting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-6xl">
+      <h3 className="text-xl font-bold">
+        Notion API Requests for {dataSource.name} in workspace{" "}
+        <a href={`/poke/${owner.sId}`} className="text-highlight-500">
+          {owner.name}
+        </a>
+      </h3>
+
+      <div className="mt-2 text-sm text-gray-600">
+        Make HTTP requests to the Notion API using the stored token. The
+        Notion-Version header (2022-06-28) and authentication are automatically
+        included.
+      </div>
+
+      <div className="mt-6 flex flex-col gap-6">
+        {/* Request Configuration */}
+        <div className="border-material-200 rounded-lg border p-4">
+          <h4 className="mb-3 text-lg font-semibold">Request</h4>
+
+          {/* Method Selector */}
+          <div className="mb-4 flex items-center gap-3">
+            <label className="w-20 text-sm font-medium">Method:</label>
+            <div className="flex gap-2">
+              <Button
+                variant={method === "GET" ? "primary" : "outline"}
+                label="GET"
+                size="sm"
+                onClick={() => {
+                  setMethod("GET");
+                  setBody("");
+                }}
+              />
+              <Button
+                variant={method === "POST" ? "primary" : "outline"}
+                label="POST"
+                size="sm"
+                onClick={() => setMethod("POST")}
+              />
+            </div>
+          </div>
+
+          {/* URL Input */}
+          <div className="mb-4">
+            <label className="mb-2 block text-sm font-medium">
+              URL (relative to https://api.notion.com/v1/):
+            </label>
+            <Input
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="e.g., search, users/me, databases/{database_id}/query"
+              name="url"
+            />
+            <div className="mt-1 text-xs text-gray-500">
+              Enter the path without the base URL. Example: "search" for
+              https://api.notion.com/v1/search
+            </div>
+          </div>
+
+          {/* Body Input (only for POST) */}
+          {method === "POST" && (
+            <div>
+              <label className="mb-2 block text-sm font-medium">
+                Request Body (JSON):
+              </label>
+              <TextArea
+                value={body}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setBody(e.target.value)
+                }
+                placeholder='{"query": "test"}'
+                className="min-h-32 w-full font-mono text-sm"
+              />
+            </div>
+          )}
+
+          <div className="mt-4 flex items-center gap-3">
+            <Button
+              variant="primary"
+              onClick={handleExecuteRequest}
+              disabled={isExecuting}
+              label={isExecuting ? "Executing..." : "Execute Request"}
+              icon={isExecuting ? Spinner : undefined}
+            />
+          </div>
+        </div>
+
+        {/* Error Display */}
+        {error && (
+          <div className="rounded-lg border border-red-300 bg-red-50 p-4">
+            <p className="text-sm font-semibold text-red-800">Error</p>
+            <p className="mt-1 text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        {/* Response Display */}
+        {response && (
+          <div className="border-material-200 rounded-lg border p-4">
+            <h4 className="mb-3 text-lg font-semibold">Response</h4>
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-sm font-medium">Status:</span>
+              <span
+                className={`rounded px-2 py-1 text-sm font-semibold ${
+                  response.status >= 200 && response.status < 300
+                    ? "bg-green-100 text-green-800"
+                    : response.status >= 400
+                      ? "bg-red-100 text-red-800"
+                      : "bg-yellow-100 text-yellow-800"
+                }`}
+              >
+                {response.status}
+              </span>
+            </div>
+            <div className="rounded-md bg-gray-50 p-4">
+              <JsonViewer
+                theme={isDark ? "dark" : "light"}
+                value={response.data}
+                rootName={false}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+NotionRequestsPage.getLayout = (
+  page: ReactElement,
+  { owner, dataSource }: { owner: WorkspaceType; dataSource: DataSourceType }
+) => {
+  return (
+    <PokeLayout title={`${owner.name} - Notion Requests - ${dataSource.name}`}>
+      {page}
+    </PokeLayout>
+  );
+};

--- a/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
@@ -52,7 +52,15 @@ type HttpMethod = "GET" | "POST";
 export default function NotionRequestsPage({
   owner,
   dataSource,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+interface NotionRequestsPageProps {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+}
+
+export default function NotionRequestsPage({
+  owner,
+  dataSource,
+}: NotionRequestsPageProps) {
   const { isDark } = useTheme();
   const [url, setUrl] = useState("");
   const [method, setMethod] = useState<HttpMethod>("GET");

--- a/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
@@ -1,6 +1,5 @@
 import { Button, Input, Spinner, TextArea } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
-import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 import { useState } from "react";
 

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -400,6 +400,7 @@ export const NotionCommandSchema = t.type({
     t.literal("update-parents-fields"),
     t.literal("clear-parents-last-updated-at"),
     t.literal("update-orphaned-resources-parents"),
+    t.literal("api-request"),
   ]),
   args: t.record(
     t.string,
@@ -460,6 +461,14 @@ export const NotionMeResponseSchema = t.type({
   botOwner: t.UnknownRecord, // notion type, can't be iots'd
 });
 export type NotionMeResponseType = t.TypeOf<typeof NotionMeResponseSchema>;
+
+export const NotionApiRequestResponseSchema = t.type({
+  status: t.number,
+  data: t.unknown, // notion API response type, can't be iots'd
+});
+export type NotionApiRequestResponseType = t.TypeOf<
+  typeof NotionApiRequestResponseSchema
+>;
 /**
  * </Notion>
  */
@@ -817,6 +826,7 @@ export const AdminResponseSchema = t.union([
   IntercomFetchArticlesResponseSchema,
   IntercomFetchConversationResponseSchema,
   IntercomForceResyncArticlesResponseSchema,
+  NotionApiRequestResponseSchema,
   NotionCheckUrlResponseSchema,
   NotionDeleteUrlResponseSchema,
   NotionMeResponseSchema,


### PR DESCRIPTION
## Description

Adds a Notion Request UI to Poke to make Notion API requests. Useful for debugging various issues. e.g. "does the search API find a certain page", ...

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Same caveat as for other similar Poke UI, which do give a lot of power.

## Deploy Plan

Front and Connector