### PR TITLE
[front] fix(AgentBuilder): fix data source selection

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -142,7 +142,7 @@ export function transformSelectionConfigurationsToTree(
         dataSourceView,
         tagsFilter: config.tagsFilter,
       });
-      continue;
+      // No early return: we still need to append exclusions below.
     }
 
     // UI reconstruction guard:

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -100,7 +100,8 @@ export function transformTreeToSelectionConfigurations(
         dataSourceView,
         selectedResources: [],
         excludedResources: [],
-        isSelectAll: false,
+        // By default, we consider the data source to be selected when we start by excluding nodes.
+        isSelectAll: true,
         tagsFilter: null,
       };
     }

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -53,7 +53,8 @@ export function transformTreeToSelectionConfigurations(
     // Check if this is a full data source selection or specific nodes
     const isFullDataSource =
       item.type === "data_source" &&
-      isNodeSelected(tree, item.path.split("/")) === true;
+      (isNodeSelected(tree, item.path.split("/")) === true ||
+        isNodeSelected(tree, item.path.split("/")) === "partial");
 
     // Initialize configuration if not exists
     if (!configurations[dataSourceView.sId]) {

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -53,8 +53,7 @@ export function transformTreeToSelectionConfigurations(
     // Check if this is a full data source selection or specific nodes
     const isFullDataSource =
       item.type === "data_source" &&
-      (isNodeSelected(tree, item.path.split("/")) === true ||
-        isNodeSelected(tree, item.path.split("/")) === "partial");
+      isNodeSelected(tree, item.path.split("/")) === true;
 
     // Initialize configuration if not exists
     if (!configurations[dataSourceView.sId]) {
@@ -101,8 +100,7 @@ export function transformTreeToSelectionConfigurations(
         dataSourceView,
         selectedResources: [],
         excludedResources: [],
-        // By default, we consider the data source to be selected when we start by excluding nodes.
-        isSelectAll: true,
+        isSelectAll: false,
         tagsFilter: null,
       };
     }

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -43,7 +43,14 @@ function processDataSourceConfigurations(
     workspaceId: owner.sId,
     filter: {
       parents: config.isSelectAll
-        ? null
+        ? config.excludedResources.length > 0
+          ? {
+              in: null,
+              not: config.excludedResources.map(
+                (resource) => resource.internalId
+              ),
+            }
+          : null
         : {
             in: config.selectedResources.map((resource) => resource.internalId),
             not: config.excludedResources.map(

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -42,21 +42,12 @@ function processDataSourceConfigurations(
     dataSourceViewId: config.dataSourceView.sId,
     workspaceId: owner.sId,
     filter: {
-      parents: config.isSelectAll
-        ? config.excludedResources.length > 0
-          ? {
-              in: null,
-              not: config.excludedResources.map(
-                (resource) => resource.internalId
-              ),
-            }
-          : null
-        : {
-            in: config.selectedResources.map((resource) => resource.internalId),
-            not: config.excludedResources.map(
-              (resource) => resource.internalId
-            ),
-          },
+      parents: {
+        in: config.isSelectAll
+          ? null
+          : config.selectedResources.map((resource) => resource.internalId),
+        not: config.excludedResources.map((resource) => resource.internalId),
+      },
       tags: config.tagsFilter
         ? {
             in: config.tagsFilter.in,

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -114,6 +114,9 @@ export function AssistantKnowledgeSection({
                   existingFilter.not.concat(ds.filter.parents.not)
                 );
               }
+              // We need to remove duplicates
+              existingFilter.in = _.uniq(existingFilter.in);
+              existingFilter.not = _.uniq(existingFilter.not);
             }
           } else {
             // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
@@ -156,6 +159,9 @@ export function AssistantKnowledgeSection({
                   existingFilter.not.concat(ds.filter.parents.not)
                 );
               }
+              // We need to remove duplicates
+              existingFilter.in = _.uniq(existingFilter.in);
+              existingFilter.not = _.uniq(existingFilter.not);
             }
           } else {
             // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -100,16 +100,18 @@ export function AssistantKnowledgeSection({
               const existingFilter = acc[ds.dataSourceViewId].filter.parents;
               // Merge the filters if they are not null
               if (existingFilter) {
-                existingFilter.in = existingFilter.in.concat(
-                  ds.filter.parents.in
+                // Handle case where in or not could be null
+                if (existingFilter.in !== null && ds.filter.parents.in !== null) {
+                  existingFilter.in = _.uniq(
+                    existingFilter.in.concat(ds.filter.parents.in)
+                  );
+                } else if (ds.filter.parents.in === null) {
+                  // If the new filter has in: null, it means "all", so we keep null
+                  existingFilter.in = null;
+                }
+                existingFilter.not = _.uniq(
+                  existingFilter.not.concat(ds.filter.parents.not)
                 );
-                existingFilter.not = existingFilter.not.concat(
-                  ds.filter.parents.not
-                );
-
-                // We need to remove duplicates
-                existingFilter.in = _.uniq(existingFilter.in);
-                existingFilter.not = _.uniq(existingFilter.not);
               }
             } else {
               // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
@@ -139,16 +141,18 @@ export function AssistantKnowledgeSection({
               const existingFilter = acc[ds.dataSourceViewId].filter.parents;
               // Merge the filters if they are not null
               if (existingFilter) {
-                existingFilter.in = existingFilter.in.concat(
-                  ds.filter.parents.in
+                // Handle case where in or not could be null
+                if (existingFilter.in !== null && ds.filter.parents.in !== null) {
+                  existingFilter.in = _.uniq(
+                    existingFilter.in.concat(ds.filter.parents.in)
+                  );
+                } else if (ds.filter.parents.in === null) {
+                  // If the new filter has in: null, it means "all", so we keep null
+                  existingFilter.in = null;
+                }
+                existingFilter.not = _.uniq(
+                  existingFilter.not.concat(ds.filter.parents.not)
                 );
-                existingFilter.not = existingFilter.not.concat(
-                  ds.filter.parents.not
-                );
-
-                // We need to remove duplicates
-                existingFilter.in = _.uniq(existingFilter.in);
-                existingFilter.not = _.uniq(existingFilter.not);
               }
             } else {
               // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
@@ -246,9 +250,12 @@ function getDataSourceConfigurationsForTableAction(
         }
 
         if (dataSourceView) {
-          dsConfigs[table.dataSourceViewId].filter.parents?.in.push(
-            getContentNodeInternalIdFromTableId(dataSourceView, table.tableId)
-          );
+          const parents = dsConfigs[table.dataSourceViewId].filter.parents;
+          if (parents && parents.in) {
+            parents.in.push(
+              getContentNodeInternalIdFromTableId(dataSourceView, table.tableId)
+            );
+          }
         }
 
         return dsConfigs;

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -486,63 +486,57 @@ function DataSourceViewSelectedNodes({
     viewType,
   });
 
-  return (
-    <>
-      {nodes.map((node) => (
-        <Tree.Item
-          key={node.internalId}
-          label={node.title}
-          type={node.expandable && viewType !== "table" ? "node" : "leaf"}
-          visual={getVisualForDataSourceViewContentNode(node)}
-          className="whitespace-nowrap"
-          actions={
-            <div className="mr-8 flex flex-row gap-2">
-              <IconButton
-                size="xs"
-                icon={ExternalLinkIcon}
-                onClick={() => {
-                  if (node.sourceUrl) {
-                    window.open(node.sourceUrl, "_blank");
-                  }
-                }}
-                className={classNames(
-                  node.sourceUrl ? "" : "pointer-events-none opacity-0"
-                )}
-                disabled={!node.sourceUrl}
-                variant="ghost"
-              />
-              <IconButton
-                size="xs"
-                icon={BracesIcon}
-                onClick={() => {
-                  if (node.type === "document") {
-                    setDataSourceViewToDisplay(dataSourceView);
-                    setDocumentToDisplay(node.internalId);
-                  }
-                }}
-                className={classNames(
-                  node.type === "document"
-                    ? ""
-                    : "pointer-events-none opacity-0"
-                )}
-                disabled={node.type !== "document"}
-                variant="outline"
-              />
-            </div>
-          }
-        >
-          <DataSourceViewPermissionTree
-            owner={owner}
-            dataSourceView={dataSourceView}
-            parentId={node.internalId}
-            onDocumentViewClick={(documentId: string) => {
-              setDataSourceViewToDisplay(dataSourceView);
-              setDocumentToDisplay(documentId);
+  return nodes.map((node) => (
+    <Tree.Item
+      key={node.internalId}
+      label={node.title}
+      type={node.expandable && viewType !== "table" ? "node" : "leaf"}
+      visual={getVisualForDataSourceViewContentNode(node)}
+      className="whitespace-nowrap"
+      actions={
+        <div className="mr-8 flex flex-row gap-2">
+          <IconButton
+            size="xs"
+            icon={ExternalLinkIcon}
+            onClick={() => {
+              if (node.sourceUrl) {
+                window.open(node.sourceUrl, "_blank");
+              }
             }}
-            viewType="all"
+            className={classNames(
+              node.sourceUrl ? "" : "pointer-events-none opacity-0"
+            )}
+            disabled={!node.sourceUrl}
+            variant="ghost"
           />
-        </Tree.Item>
-      ))}
-    </>
-  );
+          <IconButton
+            size="xs"
+            icon={BracesIcon}
+            onClick={() => {
+              if (node.type === "document") {
+                setDataSourceViewToDisplay(dataSourceView);
+                setDocumentToDisplay(node.internalId);
+              }
+            }}
+            className={classNames(
+              node.type === "document" ? "" : "pointer-events-none opacity-0"
+            )}
+            disabled={node.type !== "document"}
+            variant="outline"
+          />
+        </div>
+      }
+    >
+      <DataSourceViewPermissionTree
+        owner={owner}
+        dataSourceView={dataSourceView}
+        parentId={node.internalId}
+        onDocumentViewClick={(documentId: string) => {
+          setDataSourceViewToDisplay(dataSourceView);
+          setDocumentToDisplay(documentId);
+        }}
+        viewType="all"
+      />
+    </Tree.Item>
+  ));
 }

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -258,12 +258,9 @@ function getDataSourceConfigurationsForTableAction(
         }
 
         if (dataSourceView) {
-          const parents = dsConfigs[table.dataSourceViewId].filter.parents;
-          if (parents && parents.in) {
-            parents.in.push(
-              getContentNodeInternalIdFromTableId(dataSourceView, table.tableId)
-            );
-          }
+          dsConfigs[table.dataSourceViewId].filter.parents?.in?.push(
+            getContentNodeInternalIdFromTableId(dataSourceView, table.tableId)
+          );
         }
 
         return dsConfigs;

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -99,19 +99,17 @@ export function AssistantKnowledgeSection({
             const existingFilter = acc[ds.dataSourceViewId].filter.parents;
             // Merge the filters if they are not null
             if (existingFilter) {
-              if (ds.filter.parents.in === null) {
-                // If the new filter has in: null, it means "all", so we keep null.
-                existingFilter.in = null;
-              } else if (existingFilter.in !== null) {
-                existingFilter.in = _.uniq(
-                  existingFilter.in.concat(ds.filter.parents.in)
+              if (existingFilter.in !== null || ds.filter.parents.in !== null) {
+                existingFilter.in = (existingFilter.in ?? []).concat(
+                  ds.filter.parents.in ?? []
                 );
               }
-              if (ds.filter.parents.not === null) {
-                existingFilter.not = null;
-              } else if (existingFilter.not !== null) {
-                existingFilter.not = _.uniq(
-                  existingFilter.not.concat(ds.filter.parents.not)
+              if (
+                existingFilter.not !== null ||
+                ds.filter.parents.not !== null
+              ) {
+                existingFilter.not = (existingFilter.not ?? []).concat(
+                  ds.filter.parents.not ?? []
                 );
               }
               // We need to remove duplicates
@@ -144,19 +142,17 @@ export function AssistantKnowledgeSection({
             const existingFilter = acc[ds.dataSourceViewId].filter.parents;
             // Merge the filters if they are not null
             if (existingFilter) {
-              if (ds.filter.parents.in === null) {
-                // If the new filter has in: null, it means "all", so we keep null.
-                existingFilter.in = null;
-              } else if (existingFilter.in !== null) {
-                existingFilter.in = _.uniq(
-                  existingFilter.in.concat(ds.filter.parents.in)
+              if (existingFilter.in !== null || ds.filter.parents.in !== null) {
+                existingFilter.in = (existingFilter.in ?? []).concat(
+                  ds.filter.parents.in ?? []
                 );
               }
-              if (ds.filter.parents.not === null) {
-                existingFilter.not = null;
-              } else if (existingFilter.not !== null) {
-                existingFilter.not = _.uniq(
-                  existingFilter.not.concat(ds.filter.parents.not)
+              if (
+                existingFilter.not !== null ||
+                ds.filter.parents.not !== null
+              ) {
+                existingFilter.not = (existingFilter.not ?? []).concat(
+                  ds.filter.parents.not ?? []
                 );
               }
               // We need to remove duplicates

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -95,28 +95,29 @@ export function AssistantKnowledgeSection({
           if (!acc[ds.dataSourceViewId]) {
             // First one sets the filter
             acc[ds.dataSourceViewId] = ds;
-          } else {
-            if (ds.filter.parents) {
-              const existingFilter = acc[ds.dataSourceViewId].filter.parents;
-              // Merge the filters if they are not null
-              if (existingFilter) {
-                // Handle case where in or not could be null
-                if (existingFilter.in !== null && ds.filter.parents.in !== null) {
-                  existingFilter.in = _.uniq(
-                    existingFilter.in.concat(ds.filter.parents.in)
-                  );
-                } else if (ds.filter.parents.in === null) {
-                  // If the new filter has in: null, it means "all", so we keep null
-                  existingFilter.in = null;
-                }
+          } else if (ds.filter.parents) {
+            const existingFilter = acc[ds.dataSourceViewId].filter.parents;
+            // Merge the filters if they are not null
+            if (existingFilter) {
+              if (ds.filter.parents.in === null) {
+                // If the new filter has in: null, it means "all", so we keep null.
+                existingFilter.in = null;
+              } else if (existingFilter.in !== null) {
+                existingFilter.in = _.uniq(
+                  existingFilter.in.concat(ds.filter.parents.in)
+                );
+              }
+              if (ds.filter.parents.not === null) {
+                existingFilter.not = null;
+              } else if (existingFilter.not !== null) {
                 existingFilter.not = _.uniq(
                   existingFilter.not.concat(ds.filter.parents.not)
                 );
               }
-            } else {
-              // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
-              acc[ds.dataSourceViewId].filter.parents = null;
             }
+          } else {
+            // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
+            acc[ds.dataSourceViewId].filter.parents = null;
           }
         });
       }
@@ -136,28 +137,29 @@ export function AssistantKnowledgeSection({
           if (!acc[ds.dataSourceViewId]) {
             // First one sets the filter
             acc[ds.dataSourceViewId] = ds;
-          } else {
-            if (ds.filter.parents) {
-              const existingFilter = acc[ds.dataSourceViewId].filter.parents;
-              // Merge the filters if they are not null
-              if (existingFilter) {
-                // Handle case where in or not could be null
-                if (existingFilter.in !== null && ds.filter.parents.in !== null) {
-                  existingFilter.in = _.uniq(
-                    existingFilter.in.concat(ds.filter.parents.in)
-                  );
-                } else if (ds.filter.parents.in === null) {
-                  // If the new filter has in: null, it means "all", so we keep null
-                  existingFilter.in = null;
-                }
+          } else if (ds.filter.parents) {
+            const existingFilter = acc[ds.dataSourceViewId].filter.parents;
+            // Merge the filters if they are not null
+            if (existingFilter) {
+              if (ds.filter.parents.in === null) {
+                // If the new filter has in: null, it means "all", so we keep null.
+                existingFilter.in = null;
+              } else if (existingFilter.in !== null) {
+                existingFilter.in = _.uniq(
+                  existingFilter.in.concat(ds.filter.parents.in)
+                );
+              }
+              if (ds.filter.parents.not === null) {
+                existingFilter.not = null;
+              } else if (existingFilter.not !== null) {
                 existingFilter.not = _.uniq(
                   existingFilter.not.concat(ds.filter.parents.not)
                 );
               }
-            } else {
-              // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
-              acc[ds.dataSourceViewId].filter.parents = null;
             }
+          } else {
+            // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
+            acc[ds.dataSourceViewId].filter.parents = null;
           }
         });
       }

--- a/front/lib/actions/configuration/helpers.ts
+++ b/front/lib/actions/configuration/helpers.ts
@@ -43,7 +43,8 @@ export function renderDataSourceConfiguration(
     }),
     filter: {
       parents:
-        dataSourceConfig.parentsIn && dataSourceConfig.parentsNotIn
+        dataSourceConfig.parentsIn !== null ||
+        dataSourceConfig.parentsNotIn !== null
           ? {
               in: dataSourceConfig.parentsIn,
               not: dataSourceConfig.parentsNotIn,

--- a/front/lib/api/assistant/configuration/types.ts
+++ b/front/lib/api/assistant/configuration/types.ts
@@ -3,7 +3,7 @@ import type { Order } from "sequelize";
 import type { AgentConfigurationType, TagsFilter } from "@app/types";
 
 export type DataSourceFilter = {
-  parents: { in: string[]; not: string[] } | null;
+  parents: { in: string[] | null; not: string[] } | null;
   tags?: TagsFilter;
 };
 

--- a/front/lib/api/assistant/configuration/types.ts
+++ b/front/lib/api/assistant/configuration/types.ts
@@ -3,7 +3,7 @@ import type { Order } from "sequelize";
 import type { AgentConfigurationType, TagsFilter } from "@app/types";
 
 export type DataSourceFilter = {
-  parents: { in: string[] | null; not: string[] } | null;
+  parents: { in: string[] | null; not: string[] | null } | null;
   tags?: TagsFilter;
 };
 

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -154,6 +154,7 @@ export async function getContentNodesForDataSourceView(
 
   // There's an early return possible on !dataSourceView.dataSource.connectorId && internalIds?.length === 0,
   // won't include it for now as we are shadow-reading.
+  // TODO(2025-10-15 aubin): implement this early return.
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   // We use searchNodes to fetch the content nodes from core:

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -47,8 +47,8 @@ export const GetAgentConfigurationsHistoryQuerySchema = t.type({
 
 const DataSourceFilterParentsCodec = t.union([
   t.type({
-    in: t.array(t.string),
-    not: t.array(t.string),
+    in: t.union([t.array(t.string), t.null]),
+    not: t.union([t.array(t.string), t.null]),
   }),
   t.null,
 ]);


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/4550.
- This PR aims at fixing one specific flow in the data source node selection in Agent Builder:
  - Select the entire data source.
  - Navigate down in the tree and unselect one node.
  - The resulting data source configuration has an empty array in `parentsIn`, causing every search to return empty results.
- The change spans across a few places: in `transformTreeToSelectionConfigurations`, set the `isFullDataSource` property correctly in this case, allow the case `parentsIn` `null` and `parentsNot` not `null` when submitting the AB form.

## Tests

- Tested locally.

## Risk

- Quite high as it affects Knowledge selection in Agent Builder.

## Deploy Plan

- Deploy front.
