### PR TITLE
[front] enh(MCP): improve logging

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
@@ -13,10 +13,10 @@ import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   void agentLoopContext;
 
   const server = makeInternalMCPServer("agent_management");
@@ -186,6 +186,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
@@ -13,10 +13,10 @@ import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import type { Result } from "@app/types";
 import { Ok } from "@app/types";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer(AGENT_MEMORY_SERVER_NAME);
 
   const isUserScopedMemory = true;
@@ -227,6 +227,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -20,10 +20,10 @@ const MAX_INSTRUCTIONS_LENGTH = 1000;
 const LIST_ALL_AGENTS_TOOL_NAME = "list_all_published_agents";
 export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer(DEFAULT_AGENT_ROUTER_ACTION_NAME);
 
   server.tool(
@@ -168,6 +168,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
@@ -11,12 +11,16 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/confluence/confluence_api_helper";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 
 const CONFLUENCE_TOOL_NAME = "confluence";
 
-const createServer = (auth: Authenticator): McpServer => {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("confluence");
 
   server.tool(
@@ -28,6 +32,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (_, { authInfo }) => {
         return withAuth({
@@ -78,6 +83,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (params, { authInfo }) => {
         return withAuth({
@@ -142,6 +148,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (params, { authInfo }) => {
         return withAuth({
@@ -214,6 +221,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (params, { authInfo }) => {
         return withAuth({
@@ -239,6 +247,6 @@ const createServer = (auth: Authenticator): McpServer => {
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -333,10 +333,10 @@ async function searchCallback(
   ]);
 }
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("data_sources_file_system");
 
   registerCatTool(auth, server, agentLoopContext, {
@@ -729,6 +729,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
@@ -37,10 +37,10 @@ const TABLES_FILESYSTEM_TOOL_NAME = "tables_filesystem_navigation";
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("data_warehouses");
 
   server.tool(
@@ -419,6 +419,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -16,10 +16,10 @@ import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { Err, getHeaderFromUserEmail, GLOBAL_AGENTS_SID, Ok } from "@app/types";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("deep_dive");
 
   const owner = auth.getNonNullableWorkspace();
@@ -88,6 +88,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -94,10 +94,10 @@ function getContentTypeFromOutputFormat(
   }
 }
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("file_generation");
   server.tool(
     "get_supported_source_formats_for_output_format",
@@ -441,6 +441,6 @@ ${file_content
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -18,7 +19,10 @@ import { FreshserviceTicketSchema } from "./freshservice_api_helper";
 
 const FRESHSERVICE_TOOL_NAME = "freshservice";
 
-function createServer(auth: Authenticator): McpServer {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("freshservice");
 
   // Helper function to make authenticated API calls
@@ -203,6 +207,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ filter, fields, page, per_page }, { authInfo }) => {
         return withAuth({
@@ -282,6 +287,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ ticket_id, fields, include }, { authInfo }) => {
         return withAuth({
@@ -342,6 +348,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (_, { authInfo }) => {
         return withAuth({
@@ -396,6 +403,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -514,6 +522,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -591,6 +600,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ ticket_id, body, private: isPrivate }, { authInfo }) => {
         return withAuth({
@@ -634,6 +644,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ ticket_id, body }, { authInfo }) => {
         return withAuth({
@@ -675,6 +686,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ ticket_id }, { authInfo }) => {
         return withAuth({
@@ -714,6 +726,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ ticket_id, task_id }, { authInfo }) => {
         return withAuth({
@@ -768,6 +781,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -865,6 +879,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -944,6 +959,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ ticket_id, task_id }, { authInfo }) => {
         return withAuth({
@@ -984,6 +1000,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1029,6 +1046,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1074,6 +1092,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1119,6 +1138,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1169,6 +1189,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ category_id, page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1235,6 +1256,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { search_term, workspace_id, user_email, page, per_page },
@@ -1291,6 +1313,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ display_id }, { authInfo }) => {
         return withAuth({
@@ -1331,6 +1354,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ display_id }, { authInfo }) => {
         return withAuth({
@@ -1399,6 +1423,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { display_id, email, quantity, requested_for, fields },
@@ -1503,6 +1528,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1548,6 +1574,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ category_id, page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1605,6 +1632,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ folder_id, category_id, page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1667,6 +1695,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ article_id }, { authInfo }) => {
         return withAuth({
@@ -1716,6 +1745,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ title, description, folder_id, status, tags }, { authInfo }) => {
         return withAuth({
@@ -1776,6 +1806,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ email, mobile, phone, page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1829,6 +1860,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ requester_id }, { authInfo }) => {
         return withAuth({
@@ -1869,6 +1901,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
         return withAuth({
@@ -1911,6 +1944,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (_, { authInfo }) => {
         return withAuth({
@@ -1952,6 +1986,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ search }, { authInfo }) => {
         return withAuth({
@@ -2021,6 +2056,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { search, category_id, folder_id, is_public, page, per_page },
@@ -2080,6 +2116,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ response_id }, { authInfo }) => {
         return withAuth({
@@ -2119,6 +2156,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ ticket_id, approval_id }, { authInfo }) => {
         return withAuth({
@@ -2157,6 +2195,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ ticket_id }, { authInfo }) => {
         return withAuth({
@@ -2216,6 +2255,7 @@ function createServer(auth: Authenticator): McpServer {
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { ticket_id, approver_id, approval_type, email_content },

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { isWorkspaceUsingStaticIP } from "@app/lib/misc";
 import { EnvironmentConfig, Err, normalizeError, Ok } from "@app/types";
@@ -45,7 +46,10 @@ const createOctokit = async (
   });
 };
 
-const createServer = (auth: Authenticator): McpServer => {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("github");
 
   server.tool(
@@ -71,7 +75,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "github" },
+      { toolNameForMonitoring: "github", agentLoopContext },
       async ({ owner, repo, title, body, assignees, labels }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -119,7 +123,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "github" },
+      { toolNameForMonitoring: "github", agentLoopContext },
       async ({ owner, repo, pullNumber }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -435,7 +439,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "github" },
+      { toolNameForMonitoring: "github", agentLoopContext },
       async (
         { owner, repo, pullNumber, body, event, comments = [] },
         { authInfo }
@@ -486,7 +490,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "github" },
+      { toolNameForMonitoring: "github", agentLoopContext },
       async ({ owner }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -627,7 +631,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "github" },
+      { toolNameForMonitoring: "github", agentLoopContext },
       async ({ owner, repo, issueNumber, projectId, field }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -740,7 +744,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "github" },
+      { toolNameForMonitoring: "github", agentLoopContext },
       async ({ owner, repo, issueNumber, body }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -788,7 +792,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "github" },
+      { toolNameForMonitoring: "github", agentLoopContext },
       async ({ owner, repo, issueNumber }, { authInfo }) => {
         const octokit = await createOctokit(auth, {
           accessToken: authInfo?.token,
@@ -945,7 +949,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "github" },
+      { toolNameForMonitoring: "github", agentLoopContext },
       async (
         {
           owner,
@@ -1109,7 +1113,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "github" },
+      { toolNameForMonitoring: "github", agentLoopContext },
       async (
         {
           owner,
@@ -1318,6 +1322,6 @@ const createServer = (auth: Authenticator): McpServer => {
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types";
@@ -55,7 +56,10 @@ interface MessageDetail {
   error?: string;
 }
 
-const createServer = (auth: Authenticator): McpServer => {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("gmail");
 
   server.tool(
@@ -78,6 +82,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: "gmail",
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ q, pageToken }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -165,6 +170,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: "gmail",
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ to, cc, bcc, subject, contentType, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -251,6 +257,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: "gmail",
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ draftId, subject, to }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -307,6 +314,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: "gmail",
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ q, maxResults = 10, pageToken }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -446,6 +454,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: "gmail",
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { messageId, body, contentType = "text/plain" as const, to, cc, bcc },
@@ -600,7 +609,7 @@ const createServer = (auth: Authenticator): McpServer => {
   );
 
   return server;
-};
+}
 
 const decodeMessageBody = (
   payload: GmailMessagePayload | undefined

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -89,10 +89,10 @@ interface EnrichedGoogleCalendarEvent
   end?: EnrichedGoogleCalendarEventDateTime;
 }
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("google_calendar");
 
   async function getCalendarClient(authInfo?: AuthInfo) {
@@ -685,7 +685,7 @@ const createServer = (
   }
 
   return server;
-};
+}
 
 // Type guard to safely convert googleapis event to our interface
 function isGoogleCalendarEvent(event: any): event is GoogleCalendarEvent {

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -20,7 +22,10 @@ const SUPPORTED_MIMETYPES = [
 const MAX_CONTENT_SIZE = 32000; // Max characters to return for file content
 const MAX_FILE_SIZE = 64 * 1024 * 1024; // 10 MB max original file size
 
-const createServer = (auth: any): McpServer => {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("google_drive");
 
   async function getDriveClient(authInfo?: AuthInfo) {
@@ -48,6 +53,7 @@ const createServer = (auth: any): McpServer => {
       {
         toolNameForMonitoring: "google_drive",
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ pageToken }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
@@ -142,6 +148,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       {
         toolNameForMonitoring: "google_drive",
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { q, pageToken, pageSize, driveId, includeSharedDrives, orderBy },
@@ -231,6 +238,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       {
         toolNameForMonitoring: "google_drive",
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ fileId, offset, limit }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
@@ -354,6 +362,6 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -13,7 +14,10 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 // We use a single tool name for monitoring given the high granularity (can be revisited).
 const GOOGLE_SHEET_TOOL_NAME = "google_sheets";
 
-const createServer = (auth: Authenticator): McpServer => {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("google_sheets");
 
   async function getSheetsClient(authInfo?: AuthInfo) {
@@ -65,6 +69,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
         const drive = await getDriveClient(authInfo);
@@ -121,6 +126,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ spreadsheetId, includeGridData }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
@@ -174,6 +180,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { spreadsheetId, range, majorDimension, valueRenderOption },
@@ -235,6 +242,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { spreadsheetId, range, values, majorDimension, valueInputOption },
@@ -303,6 +311,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -362,6 +371,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ spreadsheetId, range }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
@@ -406,6 +416,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ title, sheetTitles }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
@@ -462,6 +473,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ spreadsheetId, title, rowCount, columnCount }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
@@ -517,6 +529,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ spreadsheetId, sheetId }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
@@ -596,6 +609,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -677,6 +691,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { sourceSpreadsheetId, sheetId, destinationSpreadsheetId },
@@ -723,6 +738,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
@@ -782,6 +798,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
@@ -824,6 +841,6 @@ const createServer = (auth: Authenticator): McpServer => {
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/index.ts
@@ -55,7 +55,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 
-const createServer = (): McpServer => {
+function createServer(): McpServer {
   const server = makeInternalMCPServer("hubspot");
 
   server.tool(
@@ -1495,6 +1495,6 @@ const createServer = (): McpServer => {
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -20,10 +20,10 @@ const IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS = 60 * 60 * 24 * 7; // 1 w
 const DEFAULT_IMAGE_OUTPUT_FORMAT = "png";
 const DEFAULT_IMAGE_MIME_TYPE = "image/png";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("image_generation");
 
   server.tool(
@@ -184,6 +184,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -22,7 +22,7 @@ import { default as calendarServer } from "@app/lib/actions/mcp_internal_actions
 import { default as driveServer } from "@app/lib/actions/mcp_internal_actions/servers/google_drive";
 import { default as sheetsServer } from "@app/lib/actions/mcp_internal_actions/servers/google_sheets";
 import { default as hubspotServer } from "@app/lib/actions/mcp_internal_actions/servers/hubspot";
-import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation";
+import { default as imageGenerationServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation";
 import { default as includeDataServer } from "@app/lib/actions/mcp_internal_actions/servers/include";
 import { default as interactiveContentServer } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content";
 import { default as jiraServer } from "@app/lib/actions/mcp_internal_actions/servers/jira";
@@ -94,7 +94,7 @@ export async function getInternalMCPServer(
     case "hubspot":
       return hubspotServer();
     case "image_generation":
-      return imageGenerationDallEServer(auth);
+      return imageGenerationServer(auth);
     case "elevenlabs":
       return elevenlabsServer(auth, agentLoopContext);
     case "file_generation":

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -90,23 +90,23 @@ export async function getInternalMCPServer(
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":
-      return githubServer(auth);
+      return githubServer(auth, agentLoopContext);
     case "hubspot":
       return hubspotServer();
     case "image_generation":
-      return imageGenerationServer(auth);
+      return imageGenerationServer(auth, agentLoopContext);
     case "elevenlabs":
       return elevenlabsServer(auth, agentLoopContext);
     case "file_generation":
-      return generateFileServer(auth);
+      return generateFileServer(auth, agentLoopContext);
     case "interactive_content":
       return interactiveContentServer(auth, agentLoopContext);
     case "query_tables_v2":
       return tablesQueryServerV2(auth, agentLoopContext);
     case "primitive_types_debugger":
-      return primitiveTypesDebuggerServer(auth);
+      return primitiveTypesDebuggerServer(auth, agentLoopContext);
     case "jit_testing":
-      return jitTestingServer(auth);
+      return jitTestingServer(auth, agentLoopContext);
     case "web_search_&_browse":
       return webtoolsServer(auth, agentLoopContext);
     case "search":
@@ -132,19 +132,19 @@ export async function getInternalMCPServer(
     case "run_dust_app":
       return dustAppServer(auth, agentLoopContext);
     case "agent_router":
-      return agentRouterServer(auth);
+      return agentRouterServer(auth, agentLoopContext);
     case "extract_data":
       return extractDataServer(auth, agentLoopContext);
     case "salesforce":
-      return salesforceServer(auth);
+      return salesforceServer(auth, agentLoopContext);
     case "gmail":
-      return gmailServer(auth);
+      return gmailServer(auth, agentLoopContext);
     case "google_calendar":
       return calendarServer(auth, agentLoopContext);
     case "google_drive":
-      return driveServer(auth);
+      return driveServer(auth, agentLoopContext);
     case "google_sheets":
-      return sheetsServer(auth);
+      return sheetsServer(auth, agentLoopContext);
     case "data_sources_file_system":
       return dataSourcesFileSystemServer(auth, agentLoopContext);
     case "conversation_files":
@@ -152,7 +152,7 @@ export async function getInternalMCPServer(
     case "jira":
       return jiraServer(auth, agentLoopContext);
     case "monday":
-      return mondayServer(auth);
+      return mondayServer(auth, agentLoopContext);
     case "slack":
       return slackServer(auth, mcpServerId, agentLoopContext);
     case "slack_bot":
@@ -160,15 +160,15 @@ export async function getInternalMCPServer(
     case AGENT_MEMORY_SERVER_NAME:
       return agentMemoryServer(auth, agentLoopContext);
     case "confluence":
-      return confluenceServer(auth);
+      return confluenceServer(auth, agentLoopContext);
     case "outlook":
-      return outlookServer(auth);
+      return outlookServer(auth, agentLoopContext);
     case "outlook_calendar":
-      return outlookCalendarServer(auth);
+      return outlookCalendarServer(auth, agentLoopContext);
     case "agent_management":
       return agentManagementServer(auth, agentLoopContext);
     case "freshservice":
-      return freshserviceServer(auth);
+      return freshserviceServer(auth, agentLoopContext);
     case "data_warehouses":
       return dataWarehousesServer(auth, agentLoopContext);
     case "toolsets":

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
@@ -68,10 +68,10 @@ function buildInteractiveContentFileNotification(
  * Files are rendered in a viewer where users can execute and interact with them.
  * We return the file resource only on file creation, as edit updates the existing file.
  */
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("interactive_content");
 
   server.tool(
@@ -473,6 +473,6 @@ const createServer = (
   // });
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
@@ -49,10 +49,10 @@ import { Err, normalizeError, Ok } from "@app/types";
 // We use a single tool name for monitoring given the high granularity (can be revisited).
 const JIRA_TOOL_NAME = "jira";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("jira");
 
   server.tool(
@@ -1367,6 +1367,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/jit_testing.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jit_testing.ts
@@ -5,10 +5,14 @@ import { z } from "zod";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Ok } from "@app/types";
 
-function createServer(auth: Authenticator): McpServer {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("jit_testing");
 
   server.tool(
@@ -68,7 +72,7 @@ function createServer(auth: Authenticator): McpServer {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jit_all_optionals_and_defaults" },
+      { toolNameForMonitoring: "jit_all_optionals_and_defaults", agentLoopContext },
       async (params) => {
         return new Ok([
           {

--- a/front/lib/actions/mcp_internal_actions/servers/jit_testing.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jit_testing.ts
@@ -72,7 +72,10 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "jit_all_optionals_and_defaults", agentLoopContext },
+      {
+        toolNameForMonitoring: "jit_all_optionals_and_defaults",
+        agentLoopContext,
+      },
       async (params) => {
         return new Ok([
           {

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -7,10 +7,10 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("missing_action_catcher");
   if (agentLoopContext) {
     const actionName = agentLoopContext.runContext
@@ -57,6 +57,6 @@ const createServer = (
     );
   }
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
@@ -36,13 +36,17 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/monday/monday_api_helper";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 
 // We use a single tool name for monitoring given the high granularity (can be revisited).
 const MONDAY_TOOL_NAME = "monday";
 
-const createServer = (auth: Authenticator): McpServer => {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("monday");
 
   server.tool(
@@ -54,6 +58,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (_params, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -82,6 +87,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ boardId }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -110,6 +116,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ itemId }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -170,6 +177,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -243,6 +251,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ boardId, itemName, groupId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -282,6 +291,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ itemId, columnValues }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -316,6 +326,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ itemId, body }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -1055,6 +1066,6 @@ const createServer = (auth: Authenticator): McpServer => {
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -302,10 +302,10 @@ async function withNotionClient<T>(
   }
 }
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("notion");
 
   server.tool(
@@ -970,6 +970,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/openai_usage.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/openai_usage.ts
@@ -10,10 +10,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustAppSecret } from "@app/lib/models/dust_app_secret";
 import { decrypt, Err, Ok } from "@app/types";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("openai_usage");
 
   const makeOpenAIRequest = async (
@@ -393,6 +393,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -5,12 +5,16 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import * as OutlookApi from "@app/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 
 const OUTLOOK_CALENDAR_TOOL_NAME = "outlook_calendar";
 
-const createServer = (auth: Authenticator): McpServer => {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("outlook_calendar");
 
   server.tool(
@@ -22,6 +26,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (_, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -81,6 +86,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ top = 250, skip = 0, userTimezone }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -150,6 +156,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -213,6 +220,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ calendarId, eventId, userTimezone }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -295,6 +303,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -396,6 +405,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -473,6 +483,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ calendarId, eventId, userTimezone }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -530,6 +541,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { emails, startTime, endTime, intervalInMinutes = 60, userTimezone },
@@ -561,6 +573,6 @@ const createServer = (auth: Authenticator): McpServer => {
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
@@ -72,10 +72,10 @@ const OutlookContactSchema = z.object({
 type OutlookMessage = z.infer<typeof OutlookMessageSchema>;
 type OutlookContact = z.infer<typeof OutlookContactSchema>;
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("outlook");
 
   server.tool(
@@ -890,7 +890,7 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 const fetchFromOutlook = async (
   endpoint: string,

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types";
@@ -71,7 +72,10 @@ const OutlookContactSchema = z.object({
 type OutlookMessage = z.infer<typeof OutlookMessageSchema>;
 type OutlookContact = z.infer<typeof OutlookContactSchema>;
 
-const createServer = (auth: Authenticator): McpServer => {
+const createServer = (
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer => {
   const server = makeInternalMCPServer("outlook");
 
   server.tool(
@@ -104,6 +108,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ search, top = 10, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -189,6 +194,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ search, top = 10, skip = 0 }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -283,6 +289,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         { to, cc, bcc, subject, contentType, body, importance = "normal" },
@@ -366,6 +373,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ messageId, subject, to }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -434,6 +442,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -561,6 +570,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ search, top = 20, skip = 0, select }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -654,6 +664,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {
@@ -777,6 +788,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async (
         {

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -11,6 +11,7 @@ import {
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 
@@ -19,7 +20,10 @@ const SF_API_VERSION = "57.0";
 // We use a single tool name for monitoring given the high granularity (can be revisited).
 const SALESFORCE_TOOL_LOG_NAME = "salesforce";
 
-const createServer = (auth: Authenticator): McpServer => {
+const createServer = (
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer => {
   const server = makeInternalMCPServer("salesforce");
 
   server.tool(
@@ -33,6 +37,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ query }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -70,6 +75,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ filter }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -113,6 +119,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ objectName }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -225,6 +232,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ recordId }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -290,6 +298,7 @@ const createServer = (auth: Authenticator): McpServer => {
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
         skipAlerting: true,
+        agentLoopContext,
       },
       async ({ recordId, attachmentId }, { authInfo }) => {
         const accessToken = authInfo?.token;

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -20,10 +20,10 @@ const SF_API_VERSION = "57.0";
 // We use a single tool name for monitoring given the high granularity (can be revisited).
 const SALESFORCE_TOOL_LOG_NAME = "salesforce";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("salesforce");
 
   server.tool(
@@ -354,6 +354,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -279,11 +279,11 @@ const getCachedSlackAIEnablementStatus = cacheWithRedis(
   }
 );
 
-const createServer = async (
+async function createServer(
   auth: Authenticator,
   mcpServerId: string,
   agentLoopContext?: AgentLoopContextType
-): Promise<McpServer> => {
+): Promise<McpServer> {
   const server = makeInternalMCPServer("slack");
 
   const c = await getConnectionForMCPServer(auth, {
@@ -908,6 +908,6 @@ const createServer = async (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
@@ -18,11 +18,11 @@ import { Err, normalizeError, Ok } from "@app/types";
 // We use a single tool name for monitoring given the high granularity (can be revisited).
 const SLACK_TOOL_LOG_NAME = "slack_bot";
 
-const createServer = async (
+async function createServer(
   auth: Authenticator,
   mcpServerId: string,
   agentLoopContext?: AgentLoopContextType
-): Promise<McpServer> => {
+): Promise<McpServer> {
   const server = makeInternalMCPServer("slack_bot");
 
   server.tool(
@@ -484,6 +484,6 @@ const createServer = async (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/slideshow/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slideshow/index.ts
@@ -34,10 +34,10 @@ const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
  * Files are rendered in a interactive content viewer where users can interact with them.
  * We return the file resource only on file creation, as edit updates the existing file.
  */
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("slideshow");
 
   server.tool(
@@ -313,6 +313,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -17,10 +17,10 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { getHeaderFromGroupIds, Ok } from "@app/types";
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer("toolsets");
 
   server.tool(
@@ -90,6 +90,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -36,10 +36,10 @@ import { Err, GLOBAL_AGENTS_SID, Ok } from "@app/types";
 
 const BROWSE_MAX_TOKENS_LIMIT = 32_000;
 
-const createServer = (
+function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): McpServer {
   const server = makeInternalMCPServer(DEFAULT_WEBSEARCH_ACTION_NAME);
 
   server.tool(
@@ -450,6 +450,6 @@ const createServer = (
   );
 
   return server;
-};
+}
 
 export default createServer;


### PR DESCRIPTION
## Description

- This PR improves logging across several internal MCP servers by passing the `agentLoopContext` in the `withToolLogging` wrapper, which adds useful fields to the logs (action ID, agent ID, conversation ID, etc..).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
