### PR TITLE
[front] add in app ad for frames

### DIFF
--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -3,7 +3,7 @@ import { cn } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 const localStorageKey = "frame-announcement-dismissed";
-const docLink = "https://docs.dust.tt/";
+const docLink = "https://docs.dust.tt/docs/frames";
 
 export const InAppBanner = () => {
   const [showInAppBanner, setShowInAppBanner] = useState(

--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -5,19 +5,19 @@ import { useState } from "react";
 const localStorageKey = "frame-announcement-dismissed";
 const docLink = "https://docs.dust.tt/docs/frames";
 
-export const InAppBanner = () => {
+export function InAppBanner() {
   const [showInAppBanner, setShowInAppBanner] = useState(
     localStorage.getItem(localStorageKey) !== "true"
   );
 
-  function onDismiss() {
+  const onDismiss = () => {
     localStorage.setItem(localStorageKey, "true");
     setShowInAppBanner(false);
-  }
+  };
 
-  function onLearnMore() {
+  const onLearnMore = () => {
     window.open(docLink, "_blank", "noopener,noreferrer");
-  }
+  };
 
   if (!showInAppBanner) {
     return null;
@@ -33,12 +33,12 @@ export const InAppBanner = () => {
         "mx-2 mb-2"
       )}
     >
-      <div className="relative px-4 py-3">
-        <div className="mb-2 text-sm font-medium text-primary dark:text-primary-night">
-          What’s new
-        </div>
-        <h4 className="text-md mb-4 font-medium leading-tight text-foreground dark:text-foreground-night">
+      <div className="relative p-4">
+        <div className="text-md mb-2 font-medium text-foreground dark:text-foreground-night">
           Introducing Frames ✨
+        </div>
+        <h4 className="mb-4 text-sm font-medium leading-tight text-primary dark:text-primary-night">
+          Turn AI outputs into interactive content
         </h4>
         <Button
           variant="highlight"
@@ -55,4 +55,4 @@ export const InAppBanner = () => {
       </div>
     </div>
   );
-};
+}

--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -38,7 +38,7 @@ export function InAppBanner() {
           Introducing Frames ✨
         </div>
         <h4 className="mb-4 text-sm font-medium leading-tight text-primary dark:text-primary-night">
-          Turn AI outputs into interactive content
+          Turn agent outputs into interactive content
         </h4>
         <Button
           variant="highlight"

--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -2,6 +2,8 @@ import { Button, XMarkIcon } from "@dust-tt/sparkle";
 import { cn } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+
 const localStorageKey = "frame-announcement-dismissed";
 const docLink = "https://docs.dust.tt/docs/frames";
 
@@ -16,6 +18,7 @@ export function InAppBanner() {
   };
 
   const onLearnMore = () => {
+    withTracking(TRACKING_AREAS.FRAME, "cta_frame_banner");
     window.open(docLink, "_blank", "noopener,noreferrer");
   };
 
@@ -38,7 +41,7 @@ export function InAppBanner() {
           Introducing Frames ✨
         </div>
         <h4 className="mb-4 text-sm font-medium leading-tight text-primary dark:text-primary-night">
-          Turn agent outputs into interactive content
+          Turn conversations into interactive visuals
         </h4>
         <Button
           variant="highlight"

--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -1,0 +1,58 @@
+import { Button, XMarkIcon } from "@dust-tt/sparkle";
+import { cn } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const localStorageKey = "frame-announcement-dismissed";
+const docLink = "https://docs.dust.tt/";
+
+export const InAppBanner = () => {
+  const [showInAppBanner, setShowInAppBanner] = useState(
+    localStorage.getItem(localStorageKey) !== "true"
+  );
+
+  function onDismiss() {
+    localStorage.setItem(localStorageKey, "true");
+    setShowInAppBanner(false);
+  }
+
+  function onLearnMore() {
+    window.open(docLink, "_blank", "noopener,noreferrer");
+  }
+
+  if (!showInAppBanner) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "hidden flex-col sm:flex",
+        "bg-background dark:bg-background-night",
+        "rounded-2xl shadow-sm",
+        "border border-border/0 dark:border-border-night/0",
+        "mx-2 mb-2"
+      )}
+    >
+      <div className="relative px-4 py-3">
+        <div className="mb-2 text-sm font-medium text-primary dark:text-primary-night">
+          What’s new
+        </div>
+        <h4 className="text-md mb-4 font-medium leading-tight text-foreground dark:text-foreground-night">
+          Introducing Frames ✨
+        </h4>
+        <Button
+          variant="highlight"
+          size="xs"
+          onClick={onLearnMore}
+          label="Learn more"
+        />
+        <Button
+          variant="ghost"
+          icon={XMarkIcon}
+          className="absolute right-1 top-1 opacity-50"
+          onClick={onDismiss}
+        />
+      </div>
+    </div>
+  );
+};

--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -18,7 +18,6 @@ export function InAppBanner() {
   };
 
   const onLearnMore = () => {
-    withTracking(TRACKING_AREAS.FRAME, "cta_frame_banner");
     window.open(docLink, "_blank", "noopener,noreferrer");
   };
 
@@ -46,7 +45,11 @@ export function InAppBanner() {
         <Button
           variant="highlight"
           size="xs"
-          onClick={onLearnMore}
+          onClick={withTracking(
+            TRACKING_AREAS.FRAME,
+            "cta_frame_banner",
+            onLearnMore
+          )}
           label="Learn more"
         />
         <Button

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -72,6 +72,8 @@ import {
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
 import { isBuilder } from "@app/types";
 
+import { InAppBanner } from "./InAppBanner";
+
 type AssistantSidebarMenuProps = {
   owner: WorkspaceType;
 };
@@ -541,6 +543,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                 </>
               )}
             </NavigationList>
+            <InAppBanner />
           </div>
         </div>
       </div>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -53,6 +53,7 @@ import {
 } from "@app/components/assistant/conversation/ConversationMenu";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
+import { InAppBanner } from "@app/components/assistant/conversation/InAppBanner";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -71,8 +72,6 @@ import {
 } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
 import { isBuilder } from "@app/types";
-
-import { InAppBanner } from "./InAppBanner";
 
 type AssistantSidebarMenuProps = {
   owner: WorkspaceType;


### PR DESCRIPTION
## Description
The MessageCard from Sparkle doesn't really work well inside the sidebar (it's too big). Since Alex is out and Frame will be out today I temporary created a new component in front, I will work with Alex to improve it on sparkle side

<img width="622" height="262" alt="CleanShot 2025-10-14 at 16 24 05@2x" src="https://github.com/user-attachments/assets/ea110612-80cb-4fca-9d1c-3942aec44a84" />
<img width="636" height="294" alt="CleanShot 2025-10-14 at 16 24 13@2x" src="https://github.com/user-attachments/assets/72d5d48e-4b1d-49d3-8357-7a77490cd0d9" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
