### PR TITLE
Restrict POST to only the search endpoint, to prevent data modification

### DIFF
--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -680,6 +680,13 @@ export const notion = async ({
         throw new Error("Invalid --method argument (must be GET or POST)");
       }
 
+      // Restrict POST to only the search endpoint, to prevent data modification
+      if (method === "POST" && url !== "search") {
+        throw new Error(
+          "POST method is only allowed for the 'search' endpoint"
+        );
+      }
+
       logger.info(
         { url, method, connectorId: connector.id },
         "[Admin] Making Notion API request"


### PR DESCRIPTION
## Description

In Notion request UI, Restrict POST to only the search endpoint, to prevent data modification

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Connectors