### PR TITLE
queryParam /assistant=... redirect to /agent=...

### DIFF
--- a/front/pages/w/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/[cId]/index.tsx
@@ -22,6 +22,20 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   const subscription = auth.subscription();
   const isAdmin = auth.isAdmin();
 
+  // Redirect old ?assistant= query param to ?agent=
+  if (context.query.assistant && !context.query.agent) {
+    const { assistant, wId, cId, ...restQuery } = context.query;
+    const params = new URLSearchParams(restQuery as Record<string, string>);
+    params.set("agent", assistant as string);
+
+    return {
+      redirect: {
+        destination: `/w/${wId}/conversation/${cId}?${params.toString()}`,
+        permanent: true,
+      },
+    };
+  }
+
   if (!owner || !user || !auth.isUser() || !subscription) {
     const { cId } = context.query;
 


### PR DESCRIPTION
## Description

This PR follow this one : https://github.com/dust-tt/dust/pull/16280, modifying the query param ?assistant to ?agent broke previously shared link with ?assistant=... in the URL. To solve this issue, I added a redirection in /Users/leandrelebizec/Desktop/dust/front/pages/w/[wId]/conversation/[cId]/index.tsx, not in /Users/leandrelebizec/Desktop/dust/front/next.config.js because query params aren't handled here.

## Tests

Locally

## Risk

Limited

## Deploy Plan

Run front
