### PR TITLE
Remove makeMCPToolJSONSuccess from microsoft MCP

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
@@ -7,7 +7,6 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import { Err, Ok } from "@app/types";
@@ -70,11 +69,9 @@ const createServer = (auth: any): McpServer => {
             .api(endpoint)
             .version("beta")
             .post(requestBody);
-          return new Ok(
-            makeMCPToolJSONSuccess({
-              result: response.retrievalHits,
-            }).content
-          );
+          return new Ok([
+            {type: "text" as const, text: JSON.stringify(response.retrievalHits, null, 2)}
+          ]);
         } catch (err) {
           return new Err(
             new MCPError(

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
@@ -5,9 +5,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  makeInternalMCPServer,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -70,7 +68,10 @@ const createServer = (auth: any): McpServer => {
             .version("beta")
             .post(requestBody);
           return new Ok([
-            {type: "text" as const, text: JSON.stringify(response.retrievalHits, null, 2)}
+            {
+              type: "text" as const,
+              text: JSON.stringify(response.retrievalHits, null, 2),
+            },
           ]);
         } catch (err) {
           return new Err(


### PR DESCRIPTION
## Description

Remove the makeMCPToolJSONSuccess helper from the new Microsoft Drive server

## Tests


## Risk

Low

## Deploy Plan

Deploy front
