### PR TITLE
Sparkle Avatar: treat visual empty string as no visual

### DIFF
--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -181,13 +181,15 @@ export function Avatar({
   icon,
   iconColor = "s-text-foreground",
 }: AvatarProps) {
+  const normalizedVisual = visual === "" ? null : visual;
   const emojiInfos =
-    typeof visual === "string" && getEmojiAndBackgroundFromUrl(visual);
+    typeof normalizedVisual === "string" &&
+    getEmojiAndBackgroundFromUrl(normalizedVisual);
   const backgroundColorToUse = emojiInfos
     ? emojiInfos.backgroundColor
     : backgroundColor;
   const emojiToUse = emojiInfos ? emojiInfos.skinEmoji : emoji;
-  const visualToUse = emojiInfos ? null : visual;
+  const visualToUse = emojiInfos ? null : normalizedVisual;
 
   const variant: AvatarVariantType = disabled
     ? "disabled"

--- a/sparkle/src/stories/Avatar.stories.tsx
+++ b/sparkle/src/stories/Avatar.stories.tsx
@@ -187,6 +187,10 @@ export const AvatarExample: Story = {
           visual="https://dust.tt/static/droidavatar/Droid_Lime_3.jpg"
         />
       </div>
+      <div>Visual as empty string should be treated as null</div>
+      <div className="s-flex s-gap-4">
+        <Avatar size="xs" name="Soupinou Meow" visual={""} />
+      </div>
       <div>With icon</div>
       <div className="s-flex s-gap-4">
         <Avatar size="xs" icon={SvgHome} />


### PR DESCRIPTION
## Description

I realized the Avatar component treats empty string as images and so displays broken images. 
Empty string should be treated as no visual, i.e our default behavior with the letter. 

## Tests

Locally on Storybook. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish Sparkle. 