### PR TITLE
Fix never ending loading avatar on Feedback in builder

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.15",
-        "@dust-tt/sparkle": "^0.3.9",
+        "@dust-tt/sparkle": "^0.3.10",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.9.tgz",
-      "integrity": "sha512-GPOx7PHbv1jvpn/rK/HtkJsFTsbAYCKfwCtyhBsOvWCS3O3YWVEIKLIJwEPidg1bnDlNFLAhRabSCHILfHlXCA==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.10.tgz",
+      "integrity": "sha512-TqwYgLaPG3C7IzeKHcC0huxfAItnO+NA5EdCaftT1coy5vAa7DXsIbr4g0AqAS+YNF38NBLGBqaqL76TipqABg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.15",
-    "@dust-tt/sparkle": "^0.3.9",
+    "@dust-tt/sparkle": "^0.3.10",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/FeedbacksSection.tsx
+++ b/front/components/agent_builder/FeedbacksSection.tsx
@@ -295,15 +295,11 @@ function FeedbackCard({ owner, feedback, className }: FeedbackCardProps) {
       }
     >
       <div className="flex flex-shrink-0 items-center gap-3 px-4 py-3">
-        {feedback.userImageUrl ? (
-          <Avatar
-            size="sm"
-            visual={feedback.userImageUrl}
-            name={feedback.userName}
-          />
-        ) : (
-          <Spinner size="sm" />
-        )}
+        <Avatar
+          size="sm"
+          visual={feedback.userImageUrl}
+          name={feedback.userName}
+        />
         <div className="flex flex-col">
           <div className="font-semibold">{feedback.userName}</div>
           <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.3.9",
+        "@dust-tt/sparkle": "^0.3.10",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1154,10 +1154,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.9.tgz",
-      "integrity": "sha512-GPOx7PHbv1jvpn/rK/HtkJsFTsbAYCKfwCtyhBsOvWCS3O3YWVEIKLIJwEPidg1bnDlNFLAhRabSCHILfHlXCA==",
-      "license": "ISC",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.10.tgz",
+      "integrity": "sha512-TqwYgLaPG3C7IzeKHcC0huxfAItnO+NA5EdCaftT1coy5vAa7DXsIbr4g0AqAS+YNF38NBLGBqaqL76TipqABg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -29,7 +29,7 @@
     "@elastic/elasticsearch": "^8.15.0",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.3.9",
+    "@dust-tt/sparkle": "^0.3.10",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

Some users have empty string or null in `imageUrl`.
This PR solves the never ending loading issue and bump sparkle so that in case of empty string we show the default first letter avatar. 

I realized while testing there's another display issue when the user don't have an `imageUrl`, in the admin member list page, that requires an update of the `DataTable.CellContent` component in Sparkle. I'll handle in another PR. 

Fixes https://github.com/dust-tt/tasks/issues/4620

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 