### PR TITLE
[GitHub actions] enh: bump Claude Code max turns

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,7 +59,7 @@ jobs:
 
           claude_args: |
             --model claude-sonnet-4-5-20250929
-            --max-turns 12
+            --max-turns 36
             --allowed-tools Agent,Bash,Edit,Glob,Grep,LS,MultiEdit,NotebookEdit,NotebookRead,Read,TodoRead,TodoWrite,WebFetch,WebSearch,Write
             --system-prompt "
             ### 1. General Principles


### PR DESCRIPTION
## Description

- We are often hitting the limit https://github.com/dust-tt/dust/actions/runs/18509555509/job/52746876855, https://github.com/dust-tt/dust/actions/runs/18509468845/job/52746589444
- This PR bumps the max number of turns from 12 to 36.
- The cost is very very reasonable (around 30 cents for 12 turns).

## Tests

## Risk

- None, adjacent to the production.

## Deploy Plan

- No deploy.
