### PR TITLE
If incident banner, do not display subscription end banner

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -22,6 +22,7 @@ import { HelpDropdown } from "@app/components/navigation/HelpDropdown";
 import { useNavigationLoading } from "@app/components/sparkle/NavigationLoadingContext";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { UserMenu } from "@app/components/UserMenu";
+import type { AppStatus } from "@app/lib/api/status";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -89,16 +90,18 @@ export const NavigationSidebar = React.forwardRef<
 
   const { setSidebarOpen } = useContext(SidebarContext);
 
-  // We display the banner if the end date is in 30 days or less.
+  const { appStatus } = useAppStatus();
+
+  const hasIncidentBanner =
+    appStatus?.dustStatus !== null || appStatus?.providersStatus !== null;
   const endDate = subscription.endDate;
-  const shouldDisplaySubscriptionEndBanner =
-    endDate && endDate < Date.now() + 30 * 24 * 60 * 60 * 1000;
+  const in30Days = Date.now() + 30 * 24 * 60 * 60 * 1000;
 
   return (
     <div ref={ref} className="flex min-w-0 grow flex-col">
       <div className="flex flex-col gap-2 pt-3">
-        <AppStatusBanner />
-        {shouldDisplaySubscriptionEndBanner && endDate && (
+        {appStatus && <AppStatusBanner appStatus={appStatus} />}
+        {!hasIncidentBanner && endDate && endDate < in30Days && (
           <SubscriptionEndBanner
             endDate={endDate}
             isFreePlan={isFreePlan(subscription.plan.code)}
@@ -260,13 +263,7 @@ function StatusBanner({
   );
 }
 
-function AppStatusBanner() {
-  const { appStatus } = useAppStatus();
-
-  if (!appStatus) {
-    return null;
-  }
-
+function AppStatusBanner({ appStatus }: { appStatus: AppStatus }) {
   const { providersStatus, dustStatus } = appStatus;
 
   if (dustStatus) {

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -263,7 +263,10 @@ function StatusBanner({
   );
 }
 
-function AppStatusBanner({ appStatus }: { appStatus: AppStatus }) {
+interface AppStatusBannerProps {
+  appStatus: AppStatus;
+}
+function AppStatusBanner({ appStatus }: AppStatusBannerProps) {
   const { providersStatus, dustStatus } = appStatus;
 
   if (dustStatus) {

--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -2,7 +2,19 @@ import config from "@app/lib/api/config";
 import { getUnresolvedIncidents } from "@app/lib/api/status/status_page";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import { isDevelopment } from "@app/types";
-async function getProvidersStatus() {
+
+interface AppStatusComponent {
+  description: string;
+  link: string;
+  name: string;
+}
+
+export interface AppStatus {
+  dustStatus: AppStatusComponent | null;
+  providersStatus: AppStatusComponent | null;
+}
+
+async function getProvidersStatus(): Promise<AppStatusComponent | null> {
   if (isDevelopment()) {
     return null;
   }
@@ -26,7 +38,7 @@ async function getProvidersStatus() {
   return null;
 }
 
-async function getDustStatus() {
+async function getDustStatus(): Promise<AppStatusComponent | null> {
   if (isDevelopment()) {
     return null;
   }

--- a/front/lib/swr/useAppStatus.ts
+++ b/front/lib/swr/useAppStatus.ts
@@ -1,10 +1,10 @@
 import type { Fetcher } from "swr";
 
+import type { AppStatus } from "@app/lib/api/status";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetAppStatusResponseBody } from "@app/pages/api/app-status";
 
 export function useAppStatus() {
-  const appStatusFetcher: Fetcher<GetAppStatusResponseBody> = fetcher;
+  const appStatusFetcher: Fetcher<AppStatus> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
     "/api/app-status",

--- a/front/pages/api/app-status.ts
+++ b/front/pages/api/app-status.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import type { AppStatus } from "@app/lib/api/status";
 import {
   getDustStatusMemoized,
   getProviderStatusMemoized,
@@ -9,22 +10,9 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
-export interface GetAppStatusResponseBody {
-  dustStatus: {
-    description: string;
-    link: string;
-    name: string;
-  } | null;
-  providersStatus: {
-    description: string;
-    link: string;
-    name: string;
-  } | null;
-}
-
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetAppStatusResponseBody>>,
+  res: NextApiResponse<WithAPIErrorResponse<AppStatus>>,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- session is passed by the auth wrapper
   session: SessionWithUser
 ): Promise<void> {


### PR DESCRIPTION
## Description

Fixes feedback from: https://dust4ai.slack.com/archives/C066R3PMUAU/p1759230963599329

If there's an ongoing incident, we prefer not showing the end banner to not overload the navigation bar. 

## Tests

Locally, faking an incident in the incident route with an harcoded response. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 