### PR TITLE
Add ability to acquire timezone of calendar attendees

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -293,6 +293,7 @@ describe("makeToolsWithStakesAndTimeout", () => {
         update_event: "low",
         delete_event: "low",
         check_availability: "never_ask",
+        get_user_timezones: "never_ask",
       },
       serverTimeoutMs: undefined,
     });

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -489,6 +489,7 @@ The directive should be used to display a clickable version of the agent name in
       update_event: "low",
       delete_event: "low",
       check_availability: "never_ask",
+      get_user_timezones: "never_ask",
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,
@@ -505,7 +506,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "GcalLogo",
       documentationUrl: "https://docs.dust.tt/docs/google-calendar",
       instructions:
-        "By default when creating a meeting, (1) set the calling user as the organizer and an attendee (2) check availability for attendees using the check_availability tool.",
+        "By default when creating a meeting, (1) set the calling user as the organizer and an attendee (2) check availability for attendees using the check_availability tool (3) use get_user_timezones to check attendee timezones for better scheduling.",
     },
   },
   conversation_files: {

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -659,6 +659,7 @@ const createServer = (
     {
       emails: z
         .array(z.string())
+        .max(50, "Maximum 50 email addresses allowed")
         .describe("Array of email addresses to get timezone information for"),
     },
     withToolLogging(
@@ -683,13 +684,13 @@ const createServer = (
             results.push({
               email,
               timeZone: res.data.timeZone,
+              calendarAccessible: true,
             });
           } catch (err) {
             results.push({
               email,
               timeZone: null,
-              summary: null,
-              accessible: false,
+              calendarAccessible: false,
               error: normalizeError(err).message,
             });
           }
@@ -705,7 +706,8 @@ const createServer = (
             text: JSON.stringify(
               {
                 attendees: results,
-                accessibleCount: results.filter((r) => r.accessible).length,
+                accessibleCount: results.filter((r) => r.calendarAccessible)
+                  .length,
                 totalCount: results.length,
               },
               null,


### PR DESCRIPTION
## Description

* Add ability to acquire timezone based on email. This will only work if the person's calendar is shared with you.

## Tests

<img width="482" height="638" alt="Screenshot 2025-10-14 at 5 37 25 PM" src="https://github.com/user-attachments/assets/58dd9121-2208-4569-875f-82240dc8b384" />


## Risk

* None

## Deploy Plan

* Deploy front