### PR TITLE
[front] chore(MCP): remove JSON schema ref inlining

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -202,16 +202,10 @@ export type TablesConfigurationToolType = z.infer<
  * and the JSON schema resulting from the Zod schema defined above.
  */
 export const ConfigurableToolInputJSONSchemas = Object.fromEntries(
-  Object.entries(ConfigurableToolInputSchemas).map(([key, schema]) => {
-    const jsonSchema = zodToJsonSchema(schema, {
-      // Use 'none' to inline all references instead of creating $ref pointers
-      $refStrategy: "none",
-    });
-    // Remove $schema property since these are property definitions, not standalone schemas
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { $schema, ...schemaWithoutDollarSchema } = jsonSchema;
-    return [key, schemaWithoutDollarSchema];
-  })
+  Object.entries(ConfigurableToolInputSchemas).map(([key, schema]) => [
+    key,
+    zodToJsonSchema(schema),
+  ])
 ) as Omit<
   Record<InternalToolInputMimeType, JSONSchema>,
   typeof INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM


### PR DESCRIPTION
## Description

- This PR removes custom handling of local references within JSON schemas.
- We have build up a strong conviction that this inlining is not reliable, and it was never necessary to being with.
- This PR cleans it up to go back to the state at the release of Agent Builder v2.

## Tests

- Checked locally, tested extensively with extract, reasoning (reusing an agent that had it) and sub agent.

## Risk

- Medium, sensitive code path but going back to an implementation that underwent more tests than the current one.

## Deploy Plan

- Deploy front.
