### PR TITLE
[GitHub actions] fix missing PR context in CC review action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,6 +49,7 @@ jobs:
         id: code-review
         uses: anthropics/claude-code-action@v1
         with:
+          track_progress: true
           # Define the review focus areas
           prompt: >-
             Code Review Agent


### PR DESCRIPTION
## Description

- The Claude Code code review action doesn't see the PR context properly.
- Example [here](https://github.com/dust-tt/dust/actions/runs/18509934223/job/52748194181), for comparison here's what it's supposed to see: https://github.com/dust-tt/dust/actions/runs/18419219356/job/52489876967.
- Following the suggestion here https://github.com/anthropics/claude-code-action/issues/557 and adding `track_progress` to the config.

## Tests

## Risk

- Low.

## Deploy Plan

- No deploy.
