### PR TITLE
[GitHub actions] fix(CC review): remove unsupported property

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,7 +49,6 @@ jobs:
         id: code-review
         uses: anthropics/claude-code-action@v1
         with:
-          track_progress: true
           # Define the review focus areas
           prompt: >-
             Code Review Agent

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -117,5 +117,6 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-5-20250929
             --allowed-tools "Bash(git diff --name-only HEAD~1),Bash(git diff HEAD~1),View,GlobTool,GrepTool"
+            --max-turns 36
 
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Description

- Reverts dust-tt/dust#16891
- `track_progress` is incompatible with the `labeled` trigger type (trigger only when adding the label).
- Example [here](https://github.com/dust-tt/dust/actions/runs/18511687022/job/52753811294?pr=16890).
- Somewhat unrelated but this PR adds a max turn value.

## Tests

## Risk

- Low.

## Deploy Plan

- No deploy.
