### PR TITLE
Thomas/teams bot/messages handling

### DIFF
--- a/connectors/migrations/20250213_validate_microsoft_error_catching.ts
+++ b/connectors/migrations/20250213_validate_microsoft_error_catching.ts
@@ -1,6 +1,6 @@
 import { makeScript } from "scripts/helpers";
 
-import { getClient } from "@connectors/connectors/microsoft";
+import { getMicrosoftClient } from "@connectors/connectors/microsoft";
 import { isMicrosoftSignInError } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
@@ -16,7 +16,7 @@ makeScript(
 
     if (execute) {
       try {
-        await getClient(connector.connectionId);
+        await getMicrosoftClient(connector.connectionId);
       } catch (error) {
         logger.info({
           error,

--- a/connectors/migrations/db/migration_100.sql
+++ b/connectors/migrations/db/migration_100.sql
@@ -4,14 +4,11 @@ CREATE TABLE IF NOT EXISTS "microsoft_bot_messages" (
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
     "connectorId" BIGINT NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-    "message" TEXT NOT NULL,
-    "userId" VARCHAR(255) NOT NULL,
     "userAadObjectId" VARCHAR(255),
     "email" VARCHAR(255) NOT NULL,
-    "userName" VARCHAR(255) NOT NULL,
     "conversationId" VARCHAR(255) NOT NULL,
-    "activityId" VARCHAR(255) NOT NULL,
-    "channelId" VARCHAR(255) NOT NULL,
+    "userActivityId" VARCHAR(255) NOT NULL,
+    "agentActivityId" VARCHAR(255) NOT NULL,
     "replyToId" VARCHAR(255),
     "dustConversationId" VARCHAR(255),
     PRIMARY KEY ("id")
@@ -19,5 +16,4 @@ CREATE TABLE IF NOT EXISTS "microsoft_bot_messages" (
 
 CREATE INDEX "microsoft_bot_messages_connector_id" ON "microsoft_bot_messages" ("connectorId");
 CREATE INDEX "microsoft_bot_messages_connector_id_conversation_id" ON "microsoft_bot_messages" ("connectorId", "conversationId");
-CREATE INDEX "microsoft_bot_messages_connector_id_user_id" ON "microsoft_bot_messages" ("connectorId", "userId");
 CREATE INDEX "microsoft_bot_messages_connector_id_dust_conversation_id" ON "microsoft_bot_messages" ("connectorId", "dustConversationId");

--- a/connectors/migrations/db/migration_100.sql
+++ b/connectors/migrations/db/migration_100.sql
@@ -1,0 +1,23 @@
+-- Migration created on Oct 14, 2025
+CREATE TABLE IF NOT EXISTS "microsoft_bot_messages" (
+    "id" BIGSERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "connectorId" BIGINT NOT NULL REFERENCES "connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "message" TEXT NOT NULL,
+    "userId" VARCHAR(255) NOT NULL,
+    "userAadObjectId" VARCHAR(255),
+    "email" VARCHAR(255) NOT NULL,
+    "userName" VARCHAR(255) NOT NULL,
+    "conversationId" VARCHAR(255) NOT NULL,
+    "activityId" VARCHAR(255) NOT NULL,
+    "channelId" VARCHAR(255) NOT NULL,
+    "replyToId" VARCHAR(255),
+    "dustConversationId" VARCHAR(255),
+    PRIMARY KEY ("id")
+);
+
+CREATE INDEX "microsoft_bot_messages_connector_id" ON "microsoft_bot_messages" ("connectorId");
+CREATE INDEX "microsoft_bot_messages_connector_id_conversation_id" ON "microsoft_bot_messages" ("connectorId", "conversationId");
+CREATE INDEX "microsoft_bot_messages_connector_id_user_id" ON "microsoft_bot_messages" ("connectorId", "userId");
+CREATE INDEX "microsoft_bot_messages_connector_id_dust_conversation_id" ON "microsoft_bot_messages" ("connectorId", "dustConversationId");

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -37,7 +37,6 @@ import {
   IntercomWorkspaceModel,
 } from "@connectors/lib/models/intercom";
 import {
-  MicrosoftBotConfigurationModel,
   MicrosoftConfigurationModel,
   MicrosoftNodeModel,
   MicrosoftRootModel,
@@ -85,6 +84,7 @@ import logger from "@connectors/logger/logger";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import { sendInitDbMessage } from "@connectors/types";
+import { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
 
 async function main(): Promise<void> {
   await sendInitDbMessage({

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -42,6 +42,10 @@ import {
   MicrosoftRootModel,
 } from "@connectors/lib/models/microsoft";
 import {
+  MicrosoftBotConfigurationModel,
+  MicrosoftBotMessage,
+} from "@connectors/lib/models/microsoft_bot";
+import {
   NotionConnectorBlockCacheEntry,
   NotionConnectorPageCacheEntry,
   NotionConnectorResourcesToCheckCacheEntry,
@@ -84,7 +88,6 @@ import logger from "@connectors/logger/logger";
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import { sendInitDbMessage } from "@connectors/types";
-import { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
 
 async function main(): Promise<void> {
   await sendInitDbMessage({
@@ -119,6 +122,7 @@ async function main(): Promise<void> {
   await MicrosoftRootModel.sync({ alter: true });
   await MicrosoftNodeModel.sync({ alter: true });
   await MicrosoftBotConfigurationModel.sync({ alter: true });
+  await MicrosoftBotMessage.sync({ alter: true });
   await NotionConnectorBlockCacheEntry.sync({ alter: true });
   await NotionConnectorPageCacheEntry.sync({ alter: true });
   await NotionConnectorResourcesToCheckCacheEntry.sync({ alter: true });

--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -1,0 +1,329 @@
+import type { LightAgentConfigurationType } from "@dust-tt/client";
+import type { AdaptiveCard } from "@microsoft/teams-ai";
+import type { Activity } from "botbuilder";
+
+import { apiConfig } from "@connectors/lib/api/config";
+
+const DUST_URL = "https://dust.tt/home";
+const TEAMS_HELP_URL = "https://docs.dust.tt/docs/teams";
+
+export function makeDustAppUrl(path: string) {
+  return `${apiConfig.getDustFrontAPIUrl()}${path}`;
+}
+
+export function makeConversationUrl(
+  workspaceId?: string,
+  conversationId?: string | null
+) {
+  if (workspaceId && conversationId) {
+    return makeDustAppUrl(`/w/${workspaceId}/assistant/${conversationId}`);
+  }
+  return null;
+}
+
+/**
+ * Creates an Adaptive Card for Teams with the AI response, conversation link, and agent selector
+ */
+export function createResponseAdaptiveCard({
+  response,
+  assistantName,
+  conversationUrl,
+  workspaceId,
+  agentConfigurations,
+  originalMessage,
+  isError = false,
+}: {
+  response: string;
+  assistantName: string;
+  conversationUrl: string | null;
+  workspaceId: string;
+  agentConfigurations: LightAgentConfigurationType[];
+  originalMessage?: string;
+  isError?: boolean;
+}): Partial<Activity> {
+  const card: AdaptiveCard = {
+    type: "AdaptiveCard",
+    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+    version: "1.4",
+    body: [
+      // Main response content
+      {
+        type: "TextBlock",
+        text: response,
+        wrap: true,
+        spacing: "Medium",
+        color: isError ? "Attention" : "Default",
+      },
+    ],
+    actions: [],
+  };
+
+  // Add separator and footer section
+  card.body.push({
+    type: "Container",
+    spacing: "Medium",
+    separator: true,
+    items: [
+      // Agent attribution and links
+      {
+        type: "TextBlock",
+        text: createFooterText({
+          assistantName,
+          conversationUrl,
+          workspaceId,
+          isError,
+        }),
+        wrap: true,
+        size: "Small",
+        color: "Good",
+      },
+    ],
+  });
+
+  // Add agent selector if we have multiple agents
+  if (agentConfigurations.length > 1) {
+    // Add top 5 most popular agents as quick action buttons
+    const topAgents = agentConfigurations
+      .sort(
+        (a, b) => (b.usage?.messageCount ?? 0) - (a.usage?.messageCount ?? 0)
+      )
+      .slice(0, 5);
+
+    topAgents.forEach((agent) => {
+      card.actions.push({
+        type: "Action.Submit",
+        title: `Ask ${agent.name}`,
+        data: {
+          verb: "ask_agent",
+          action: "ask_agent",
+          agentId: agent.sId,
+          agentName: agent.name,
+          originalMessage: originalMessage || "",
+        },
+      });
+    });
+  }
+
+  return {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: card,
+      },
+    ],
+  };
+}
+
+/**
+ * Creates a streaming adaptive card (no buttons, just content)
+ */
+export function createStreamingAdaptiveCard({
+  response,
+}: {
+  response: string;
+  assistantName: string;
+  conversationUrl: string | null;
+  workspaceId: string;
+}): Partial<Activity> {
+  return {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: {
+          type: "AdaptiveCard",
+          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+          version: "1.4",
+          body: [
+            // Main response content
+            {
+              type: "TextBlock",
+              text: response,
+              wrap: true,
+              spacing: "Medium",
+            },
+            // Footer with assistant name and link (no buttons)
+            // {
+            //   type: "Container",
+            //   spacing: "Medium",
+            //   separator: true,
+            //   items: [
+            //     {
+            //       type: "TextBlock",
+            //       text: createFooterText({
+            //         assistantName,
+            //         conversationUrl,
+            //         workspaceId,
+            //       }),
+            //       wrap: true,
+            //       size: "Small",
+            //       color: "Good",
+            //     },
+            //   ],
+            // },
+          ],
+          // No actions for streaming
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Creates a simple adaptive card for thinking/loading state
+ */
+export function createThinkingAdaptiveCard(): Partial<Activity> {
+  return {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: {
+          type: "AdaptiveCard",
+          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+          version: "1.4",
+          body: [
+            {
+              type: "TextBlock",
+              text: `Thinking...`,
+              wrap: true,
+              color: "Accent",
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Creates an error adaptive card
+ */
+export function createErrorAdaptiveCard({
+  error,
+  workspaceId,
+  conversationUrl = null,
+}: {
+  error: string;
+  workspaceId: string;
+  conversationUrl?: string | null;
+}): Partial<Activity> {
+  return {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: {
+          type: "AdaptiveCard",
+          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+          version: "1.4",
+          body: [
+            {
+              type: "TextBlock",
+              text: `❌ ${error}`,
+              wrap: true,
+              color: "Attention",
+            },
+            {
+              type: "Container",
+              spacing: "Medium",
+              separator: true,
+              items: [
+                {
+                  type: "TextBlock",
+                  text: createFooterText({
+                    workspaceId,
+                    conversationUrl,
+                    isError: true,
+                  }),
+                  wrap: true,
+                  size: "Small",
+                  color: "Good",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Creates an agent selection adaptive card
+ */
+export function createAgentSelectionCard(
+  agentConfigurations: LightAgentConfigurationType[],
+  originalMessage: string
+): Partial<Activity> {
+  return {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: {
+          type: "AdaptiveCard",
+          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+          version: "1.4",
+          body: [
+            {
+              type: "TextBlock",
+              text: "**Choose an agent to answer your question:**",
+              wrap: true,
+              weight: "Bolder",
+              spacing: "Medium",
+            },
+            {
+              type: "TextBlock",
+              text: `_"${originalMessage.substring(0, 100)}${originalMessage.length > 100 ? "..." : ""}"_`,
+              wrap: true,
+              isSubtle: true,
+              spacing: "Small",
+            },
+          ],
+          actions: agentConfigurations.slice(0, 5).map((ac) => ({
+            type: "Action.Submit",
+            title: ac.name,
+            data: {
+              verb: "ask_agent",
+              action: "ask_agent",
+              agentId: ac.sId,
+              agentName: ac.name,
+              originalMessage: originalMessage,
+            },
+          })),
+        },
+      },
+    ],
+  };
+}
+
+function createFooterText({
+  assistantName,
+  conversationUrl,
+  workspaceId,
+  isError = false,
+}: {
+  assistantName?: string;
+  conversationUrl?: string | null;
+  workspaceId: string;
+  isError?: boolean;
+}): string {
+  const assistantsUrl = makeDustAppUrl(`/w/${workspaceId}/assistant/new`);
+
+  let attribution = "";
+  if (assistantName) {
+    if (isError) {
+      attribution = `**${assistantName}** encountered an error | `;
+    } else {
+      attribution = `Answered by **${assistantName}** | `;
+    }
+  }
+
+  const baseLinks = `[Browse agents](${assistantsUrl}) | [Use Dust in Teams](${TEAMS_HELP_URL}) | [Learn more](${DUST_URL})`;
+
+  return conversationUrl
+    ? `${attribution}[Go to full conversation](${conversationUrl}) | ${baseLinks}`
+    : `${attribution}${baseLinks}`;
+}

--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -29,16 +29,12 @@ export function createResponseAdaptiveCard({
   assistantName,
   conversationUrl,
   workspaceId,
-  agentConfigurations,
-  originalMessage,
   isError = false,
 }: {
   response: string;
   assistantName: string;
   conversationUrl: string | null;
   workspaceId: string;
-  agentConfigurations: LightAgentConfigurationType[];
-  originalMessage?: string;
   isError?: boolean;
 }): Partial<Activity> {
   const card: AdaptiveCard = {
@@ -46,7 +42,6 @@ export function createResponseAdaptiveCard({
     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
     version: "1.4",
     body: [
-      // Main response content
       {
         type: "TextBlock",
         text: response,
@@ -64,7 +59,6 @@ export function createResponseAdaptiveCard({
     spacing: "Medium",
     separator: true,
     items: [
-      // Agent attribution and links
       {
         type: "TextBlock",
         text: createFooterText({
@@ -79,30 +73,6 @@ export function createResponseAdaptiveCard({
       },
     ],
   });
-
-  // Add agent selector if we have multiple agents
-  if (agentConfigurations.length > 1) {
-    // Add top 5 most popular agents as quick action buttons
-    const topAgents = agentConfigurations
-      .sort(
-        (a, b) => (b.usage?.messageCount ?? 0) - (a.usage?.messageCount ?? 0)
-      )
-      .slice(0, 5);
-
-    topAgents.forEach((agent) => {
-      card.actions.push({
-        type: "Action.Submit",
-        title: `Ask ${agent.name}`,
-        data: {
-          verb: "ask_agent",
-          action: "ask_agent",
-          agentId: agent.sId,
-          agentName: agent.name,
-          originalMessage: originalMessage || "",
-        },
-      });
-    });
-  }
 
   return {
     type: "message",
@@ -143,27 +113,7 @@ export function createStreamingAdaptiveCard({
               wrap: true,
               spacing: "Medium",
             },
-            // Footer with assistant name and link (no buttons)
-            // {
-            //   type: "Container",
-            //   spacing: "Medium",
-            //   separator: true,
-            //   items: [
-            //     {
-            //       type: "TextBlock",
-            //       text: createFooterText({
-            //         assistantName,
-            //         conversationUrl,
-            //         workspaceId,
-            //       }),
-            //       wrap: true,
-            //       size: "Small",
-            //       color: "Good",
-            //     },
-            //   ],
-            // },
           ],
-          // No actions for streaming
         },
       },
     ],

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -19,6 +19,8 @@ import { getHeaderFromUserEmail } from "@connectors/types";
 
 const DEFAULT_AGENTS = ["dust", "claude-4-sonnet", "gpt-5"];
 
+import { getActionName } from "@connectors/lib/tools_utils";
+
 import {
   createResponseAdaptiveCard,
   createStreamingAdaptiveCard,
@@ -409,93 +411,4 @@ const sendTeamsResponse = async (
 
   // Send new streaming message
   return sendActivity(context, adaptiveCard);
-};
-
-export const SEARCH_TOOL_NAME = "semantic_search";
-export const INCLUDE_TOOL_NAME = "retrieve_recent_documents";
-export const WEBSEARCH_TOOL_NAME = "websearch";
-export const WEBBROWSER_TOOL_NAME = "webbrowser";
-export const QUERY_TABLES_TOOL_NAME = "query_tables";
-export const GET_DATABASE_SCHEMA_TOOL_NAME = "get_database_schema";
-export const EXECUTE_DATABASE_QUERY_TOOL_NAME = "execute_database_query";
-export const PROCESS_TOOL_NAME = "extract_information_from_documents";
-export const RUN_AGENT_TOOL_NAME = "run_agent";
-export const CREATE_AGENT_TOOL_NAME = "create_agent";
-export const FIND_TAGS_TOOL_NAME = "find_tags";
-export const FILESYSTEM_CAT_TOOL_NAME = "cat";
-export const FILESYSTEM_FIND_TOOL_NAME = "find";
-export const FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME = "locate_in_tree";
-export const FILESYSTEM_LIST_TOOL_NAME = "list";
-
-const getActionName = (action: AgentActionPublicType) => {
-  const { functionCallName, internalMCPServerName } = action;
-
-  const parts = functionCallName ? functionCallName.split("__") : [];
-  const toolName = parts[parts.length - 1];
-
-  if (
-    internalMCPServerName === "search" ||
-    internalMCPServerName === "data_sources_file_system"
-  ) {
-    if (toolName === SEARCH_TOOL_NAME) {
-      return "Searching";
-    }
-
-    if (
-      toolName === FILESYSTEM_LIST_TOOL_NAME ||
-      toolName === FILESYSTEM_FIND_TOOL_NAME
-    ) {
-      return "Browsing data sources";
-    }
-
-    if (toolName === FILESYSTEM_CAT_TOOL_NAME) {
-      return "Viewing data source";
-    }
-
-    if (toolName === FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME) {
-      return "Locating in tree";
-    }
-  }
-
-  if (internalMCPServerName === "include_data") {
-    if (toolName === INCLUDE_TOOL_NAME) {
-      return "Including data";
-    }
-  }
-
-  if (internalMCPServerName === "web_search_&_browse") {
-    if (toolName === WEBSEARCH_TOOL_NAME) {
-      return "Searching the web";
-    }
-    if (toolName === WEBBROWSER_TOOL_NAME) {
-      return "Browsing the web";
-    }
-  }
-
-  if (internalMCPServerName === "query_tables") {
-    if (toolName === QUERY_TABLES_TOOL_NAME) {
-      return "Querying tables";
-    }
-  }
-
-  if (internalMCPServerName === "query_tables_v2") {
-    if (toolName === GET_DATABASE_SCHEMA_TOOL_NAME) {
-      return "Getting database schema";
-    }
-    if (toolName === EXECUTE_DATABASE_QUERY_TOOL_NAME) {
-      return "Executing database query";
-    }
-  }
-
-  if (internalMCPServerName === "reasoning") {
-    return "Reasoning";
-  }
-
-  if (internalMCPServerName === "extract_data") {
-    if (toolName === PROCESS_TOOL_NAME) {
-      return "Extracting data";
-    }
-  }
-
-  return "Executing tool";
 };

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -1,0 +1,633 @@
+import type {
+  AgentActionPublicType,
+  ConversationPublicType,
+  LightAgentConfigurationType,
+  Result,
+  UserMessageType,
+} from "@dust-tt/client";
+import { DustAPI, Err, Ok } from "@dust-tt/client";
+import type { Activity, TurnContext } from "botbuilder";
+import removeMarkdown from "remove-markdown";
+import jaroWinkler from "talisman/metrics/jaro-winkler";
+
+import { getClient } from "@connectors/connectors/microsoft/index";
+import {
+  createErrorAdaptiveCard,
+  createResponseAdaptiveCard,
+  createStreamingAdaptiveCard,
+  makeConversationUrl,
+} from "./adaptive_cards";
+import { sendActivity, updateActivity } from "./bot_messaging_utils";
+import { apiConfig } from "@connectors/lib/api/config";
+import { TeamsMessage } from "@connectors/lib/models/microsoft_bot";
+import logger from "@connectors/logger/logger";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import { getHeaderFromUserEmail } from "@connectors/types";
+
+export async function botAnswerTeamsMessage(
+  context: TurnContext,
+  message: string,
+  connector: ConnectorResource,
+  streamingMessages: Map<string, string>
+): Promise<Result<undefined, Error>> {
+  try {
+    const res = await answerTeamsMessage(
+      context,
+      message,
+      connector,
+      streamingMessages
+    );
+
+    if (res.isErr()) {
+      await sendTeamsResponse(
+        context,
+        false,
+        streamingMessages,
+        createErrorAdaptiveCard({
+          error: res.error.message,
+          workspaceId: connector.workspaceId,
+        })
+      );
+    }
+
+    return res;
+  } catch (e) {
+    logger.error(
+      {
+        error: e,
+        connectorId: connector.id,
+      },
+      "Unexpected exception answering to Teams message"
+    );
+
+    await sendTeamsResponse(
+      context,
+      false,
+      streamingMessages,
+      createErrorAdaptiveCard({
+        error: "An unexpected error occurred. Our team has been notified",
+        workspaceId: connector.workspaceId,
+      })
+    );
+    return new Err(new Error("An unexpected error occurred"));
+  }
+}
+
+async function answerTeamsMessage(
+  context: TurnContext,
+  message: string,
+  connector: ConnectorResource,
+  streamingMessages: Map<string, string>
+): Promise<Result<undefined, Error>> {
+  const {
+    conversation: { id: conversationId },
+    from: { id: userId, aadObjectId: userAadObjectId },
+    id: activityId,
+    channelId,
+    replyToId,
+  } = context.activity;
+  // Check for existing Dust conversation for this Teams conversation
+  let lastTeamsMessage: TeamsMessage | null = null;
+
+  // Always look for previous messages in the same Teams conversation
+  // to maintain conversation continuity - first try to find one with dustConversationId
+  const allTeamsMessages = await TeamsMessage.findAll({
+    where: {
+      connectorId: connector.id,
+      conversationId: conversationId,
+    },
+    order: [["createdAt", "DESC"]],
+  });
+
+  // Find the most recent message that has a Dust conversation ID
+  lastTeamsMessage =
+    allTeamsMessages.find((msg) => msg.dustConversationId) || null;
+
+  // Get Microsoft Graph client
+  const client = await getClient(connector.connectionId);
+
+  // Get user info from Microsoft Graph
+  let userInfo: {
+    id: string;
+    displayName?: string;
+    mail?: string;
+    userPrincipalName?: string;
+  } | null = null;
+  try {
+    if (userAadObjectId) {
+      userInfo = await client.api(`/users/${userAadObjectId}`).get();
+    } else {
+      // Fallback: try to get user info by userId (though this might not work for all scenarios)
+      userInfo = await client.api(`/users/${userId}`).get();
+    }
+  } catch (e) {
+    logger.warn(
+      {
+        error: e,
+        userId,
+        userAadObjectId,
+        connectorId: connector.id,
+      },
+      "Failed to get user info from Microsoft Graph"
+    );
+    // Create minimal user info
+    userInfo = {
+      id: userId,
+      displayName: "Unknown User",
+      mail: "unknown@example.com",
+    };
+  }
+
+  const displayName = userInfo?.displayName || "Unknown User";
+  const email =
+    userInfo?.mail || userInfo?.userPrincipalName || "unknown@example.com";
+
+  const teamsMessage = await TeamsMessage.create({
+    connectorId: connector.id,
+    message: message,
+    userId: userId,
+    userAadObjectId: userAadObjectId,
+    email: email,
+    userName: displayName,
+    conversationId: conversationId,
+    activityId: activityId || "",
+    channelId: channelId,
+    replyToId: replyToId,
+    dustConversationId: lastTeamsMessage?.dustConversationId,
+  });
+
+  const dustAPI = new DustAPI(
+    { url: apiConfig.getDustFrontAPIUrl() },
+    {
+      workspaceId: connector.workspaceId,
+      apiKey: connector.workspaceAPIKey,
+      extraHeaders: {
+        ...getHeaderFromUserEmail(
+          email !== "unknown@example.com" ? email : undefined
+        ),
+      },
+    },
+    logger
+  );
+
+  const agentConfigurationsRes = await dustAPI.getAgentConfigurations({});
+  if (agentConfigurationsRes.isErr()) {
+    return new Err(new Error(agentConfigurationsRes.error.message));
+  }
+
+  const activeAgentConfigurations = agentConfigurationsRes.value.filter(
+    (ac) => ac.status === "active"
+  );
+
+  // Process mentions in Teams messages (similar to Slack but for Teams format)
+  // Teams mentions come in a different format than Slack
+  const messageWithoutMarkdown = removeMarkdown(message);
+
+  let mention: { assistantName: string; assistantId: string } | undefined;
+
+  // Extract all @mentions, ~mentions and +mentions (Teams typically uses @)
+  const mentionCandidates =
+    messageWithoutMarkdown.match(
+      /(?<!\S)[@+~]([a-zA-Z0-9_-]{1,40})(?=\s|,|\.|$|)/g
+    ) || [];
+
+  if (mentionCandidates.length > 1) {
+    return new Err(
+      new Error("Only one agent at a time can be called through Teams.")
+    );
+  }
+
+  const [mentionCandidate] = mentionCandidates;
+  if (mentionCandidate) {
+    let bestCandidate:
+      | {
+          assistantId: string;
+          assistantName: string;
+          distance: number;
+        }
+      | undefined = undefined;
+
+    for (const agentConfiguration of activeAgentConfigurations) {
+      const distance =
+        1 -
+        jaroWinkler(
+          mentionCandidate.slice(1).toLowerCase(),
+          agentConfiguration.name.toLowerCase()
+        );
+
+      if (bestCandidate === undefined || bestCandidate.distance > distance) {
+        bestCandidate = {
+          assistantId: agentConfiguration.sId,
+          assistantName: agentConfiguration.name,
+          distance: distance,
+        };
+      }
+    }
+
+    if (bestCandidate) {
+      mention = {
+        assistantId: bestCandidate.assistantId,
+        assistantName: bestCandidate.assistantName,
+      };
+      message = message.replace(
+        mentionCandidate,
+        `:mention[${bestCandidate.assistantName}]{sId=${bestCandidate.assistantId}}`
+      );
+    } else {
+      return new Err(
+        new Error(`Assistant ${mentionCandidate} has not been found.`)
+      );
+    }
+  }
+
+  if (!mention) {
+    // Use default agent if no mention found
+    let defaultAssistant: LightAgentConfigurationType | null = null;
+    defaultAssistant =
+      activeAgentConfigurations.find((ac) => ac.sId === "dust") || null;
+    if (!defaultAssistant || defaultAssistant.status !== "active") {
+      defaultAssistant =
+        activeAgentConfigurations.find((ac) => ac.sId === "gpt-4") || null;
+    }
+    if (!defaultAssistant) {
+      return new Err(
+        new Error("No agent has been configured to reply on Teams.")
+      );
+    }
+    mention = {
+      assistantId: defaultAssistant.sId,
+      assistantName: defaultAssistant.name,
+    };
+  }
+
+  const mostPopularAgentConfigurations = [...activeAgentConfigurations]
+    .sort((a, b) => (b.usage?.messageCount ?? 0) - (a.usage?.messageCount ?? 0))
+    .splice(0, 100)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Skip Graph API messaging - Teams app handles "thinking" message via Bot Framework
+
+  if (!message.includes(":mention")) {
+    // if the message does not contain the mention, we add it as a prefix.
+    message = `:mention[${mention.assistantName}]{sId=${mention.assistantId}} ${message}`;
+  }
+
+  const messageReqBody = {
+    content: message,
+    mentions: [{ configurationId: mention.assistantId }],
+    context: {
+      timezone: "UTC", // Teams doesn't provide timezone info easily
+      username: displayName,
+      fullName: displayName,
+      email: email,
+      profilePictureUrl: null,
+      origin: "slack" as const,
+    },
+  };
+
+  let conversation: ConversationPublicType | undefined = undefined;
+  let userMessage: UserMessageType | undefined = undefined;
+
+  if (lastTeamsMessage?.dustConversationId) {
+    logger.info(
+      {
+        connectorId: connector.id,
+        teamsConversationId: conversationId,
+        dustConversationId: lastTeamsMessage.dustConversationId,
+      },
+      "Reusing existing Dust conversation for Teams conversation"
+    );
+
+    // Check conversation existence (it might have been deleted between two messages).
+    const existsRes = await dustAPI.getConversation({
+      conversationId: lastTeamsMessage.dustConversationId,
+    });
+
+    // If it doesn't exist, we will create a new one later.
+    if (existsRes.isOk()) {
+      const messageRes = await dustAPI.postUserMessage({
+        conversationId: lastTeamsMessage.dustConversationId,
+        message: messageReqBody,
+      });
+      if (messageRes.isErr()) {
+        return new Err(new Error(messageRes.error.message));
+      }
+      userMessage = messageRes.value;
+
+      const conversationRes = await dustAPI.getConversation({
+        conversationId: lastTeamsMessage.dustConversationId,
+      });
+      if (conversationRes.isErr()) {
+        return new Err(new Error(conversationRes.error.message));
+      }
+      conversation = conversationRes.value;
+    } else {
+      logger.warn(
+        {
+          connectorId: connector.id,
+          teamsConversationId: conversationId,
+          dustConversationId: lastTeamsMessage.dustConversationId,
+        },
+        "Dust conversation not found, will create new one"
+      );
+    }
+  }
+
+  if (!conversation || !userMessage) {
+    logger.info(
+      {
+        connectorId: connector.id,
+        teamsConversationId: conversationId,
+      },
+      "Creating new Dust conversation for Teams conversation"
+    );
+
+    const convRes = await dustAPI.createConversation({
+      title: null,
+      visibility: "unlisted",
+      message: messageReqBody,
+    });
+    if (convRes.isErr()) {
+      return new Err(new Error(convRes.error.message));
+    }
+
+    conversation = convRes.value.conversation;
+    userMessage = convRes.value.message;
+
+    if (!userMessage) {
+      return new Err(new Error("Failed to retrieve the created message."));
+    }
+
+    logger.info(
+      {
+        connectorId: connector.id,
+        teamsConversationId: conversationId,
+        dustConversationId: conversation.sId,
+      },
+      "Created new Dust conversation and linked to Teams conversation"
+    );
+
+    await teamsMessage.update({ dustConversationId: conversation.sId });
+  }
+
+  // For Bot Framework approach with streaming updates
+  const streamRes = await dustAPI.streamAgentAnswerEvents({
+    conversation,
+    userMessageId: userMessage.sId,
+  });
+
+  if (streamRes.isErr()) {
+    return new Err(new Error(streamRes.error.message));
+  }
+
+  // Collect the full response and stream updates
+  let finalResponse = "";
+  let agentMessageSuccess = undefined;
+  let lastUpdateTime = Date.now();
+  let streamingUsed = false;
+  let chainOfThought = "";
+  let agentState = "thinking";
+  const UPDATE_INTERVAL_MS = 100; // Update every second
+
+  for await (const event of streamRes.value.eventStream) {
+    switch (event.type) {
+      case "agent_error":
+      case "user_message_error":
+      case "tool_error": {
+        return new Err(new Error(event.error.message));
+      }
+      case "agent_message_success": {
+        agentMessageSuccess = event;
+        finalResponse = event.message.content ?? "";
+        break;
+      }
+      case "generation_tokens": {
+        // Stream updates at intervals to avoid rate limits
+        if (event.classification === "tokens") {
+          finalResponse += event.text;
+          agentState = "writing";
+        } else if (event.classification === "chain_of_thought") {
+          if (event.text === "\n\n") {
+            chainOfThought = "";
+          } else {
+            chainOfThought += event.text;
+          }
+          agentState = "thinking";
+        }
+
+        const now = Date.now();
+        if (now - lastUpdateTime > UPDATE_INTERVAL_MS) {
+          lastUpdateTime = now;
+          streamingUsed = true;
+          const text =
+            agentState === "thinking" ? chainOfThought : finalResponse;
+          if (text.trim()) {
+            const streamingCard = createStreamingAdaptiveCard({
+              response: text,
+              assistantName: mention.assistantName,
+              conversationUrl: null,
+              workspaceId: connector.workspaceId,
+            });
+
+            // Send streaming update to Teams app webhook endpoint
+            await sendTeamsResponse(
+              context,
+              true,
+              streamingMessages,
+              streamingCard
+            );
+          }
+        }
+        break;
+      }
+      case "tool_params": {
+        const action = getActionName(event.action);
+        const streamingCard = createStreamingAdaptiveCard({
+          response: action,
+          assistantName: mention.assistantName,
+          conversationUrl: null,
+          workspaceId: connector.workspaceId,
+        });
+        agentState = "acting";
+        await sendTeamsResponse(
+          context,
+          true,
+          streamingMessages,
+          streamingCard
+        );
+
+        break;
+      }
+      default:
+        // Ignore other events
+        break;
+    }
+  }
+
+  if (agentMessageSuccess) {
+    // Send final clean message if streaming was used
+    if (streamingUsed) {
+      try {
+        const finalCard = createResponseAdaptiveCard({
+          response: finalResponse,
+          assistantName: mention.assistantName,
+          conversationUrl: makeConversationUrl(
+            connector.workspaceId,
+            conversation.sId
+          ),
+          workspaceId: connector.workspaceId,
+          agentConfigurations: mostPopularAgentConfigurations,
+          originalMessage: message,
+        });
+
+        await sendTeamsResponse(context, false, streamingMessages, finalCard);
+      } catch (finalError) {
+        logger.warn(
+          { error: finalError },
+          "Failed to send final message to Teams"
+        );
+      }
+    }
+
+    // Return the result with streaming info
+    return new Ok(undefined);
+  } else {
+    return new Err(new Error("No response generated"));
+  }
+}
+
+const sendTeamsResponse = async (
+  context: TurnContext,
+  isStreaming: boolean,
+  streamingMessages: Map<string, string>,
+  adaptiveCard: Partial<Activity>
+) => {
+  try {
+    // If we have direct Bot Framework context, use it directly
+    const conversationId = context.activity.conversation?.id;
+
+    if (isStreaming && conversationId) {
+      // Update existing message for streaming
+      const existingActivityId = streamingMessages.get(conversationId);
+      if (existingActivityId) {
+        try {
+          await updateActivity(context, {
+            ...adaptiveCard,
+            id: existingActivityId,
+          });
+          return;
+        } catch (updateError) {
+          logger.warn(
+            { error: updateError },
+            "Failed to update streaming message, sending new one"
+          );
+        }
+      }
+
+      // Send new streaming message
+      const sentActivity = await sendActivity(context, adaptiveCard);
+      if (sentActivity?.id) {
+        streamingMessages.set(conversationId, sentActivity.id);
+      }
+    } else {
+      // Final message - send and clean up
+      await sendActivity(context, adaptiveCard);
+      streamingMessages.delete(conversationId);
+    }
+    return;
+  } catch (updateError) {
+    logger.warn(
+      { error: updateError },
+      "Failed to send streaming update to Teams"
+    );
+  }
+};
+
+export const SEARCH_TOOL_NAME = "semantic_search";
+export const INCLUDE_TOOL_NAME = "retrieve_recent_documents";
+export const WEBSEARCH_TOOL_NAME = "websearch";
+export const WEBBROWSER_TOOL_NAME = "webbrowser";
+export const QUERY_TABLES_TOOL_NAME = "query_tables";
+export const GET_DATABASE_SCHEMA_TOOL_NAME = "get_database_schema";
+export const EXECUTE_DATABASE_QUERY_TOOL_NAME = "execute_database_query";
+export const PROCESS_TOOL_NAME = "extract_information_from_documents";
+export const RUN_AGENT_TOOL_NAME = "run_agent";
+export const CREATE_AGENT_TOOL_NAME = "create_agent";
+export const FIND_TAGS_TOOL_NAME = "find_tags";
+export const FILESYSTEM_CAT_TOOL_NAME = "cat";
+export const FILESYSTEM_FIND_TOOL_NAME = "find";
+export const FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME = "locate_in_tree";
+export const FILESYSTEM_LIST_TOOL_NAME = "list";
+
+const getActionName = (action: AgentActionPublicType) => {
+  const { functionCallName, internalMCPServerName } = action;
+
+  const parts = functionCallName ? functionCallName.split("__") : [];
+  const toolName = parts[parts.length - 1];
+
+  if (
+    internalMCPServerName === "search" ||
+    internalMCPServerName === "data_sources_file_system"
+  ) {
+    if (toolName === SEARCH_TOOL_NAME) {
+      return "Searching";
+    }
+
+    if (
+      toolName === FILESYSTEM_LIST_TOOL_NAME ||
+      toolName === FILESYSTEM_FIND_TOOL_NAME
+    ) {
+      return "Browsing data sources";
+    }
+
+    if (toolName === FILESYSTEM_CAT_TOOL_NAME) {
+      return "Viewing data source";
+    }
+
+    if (toolName === FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME) {
+      return "Locating in tree";
+    }
+  }
+
+  if (internalMCPServerName === "include_data") {
+    if (toolName === INCLUDE_TOOL_NAME) {
+      return "Including data";
+    }
+  }
+
+  if (internalMCPServerName === "web_search_&_browse") {
+    if (toolName === WEBSEARCH_TOOL_NAME) {
+      return "Searching the web";
+    }
+    if (toolName === WEBBROWSER_TOOL_NAME) {
+      return "Browsing the web";
+    }
+  }
+
+  if (internalMCPServerName === "query_tables") {
+    if (toolName === QUERY_TABLES_TOOL_NAME) {
+      return "Querying tables";
+    }
+  }
+
+  if (internalMCPServerName === "query_tables_v2") {
+    if (toolName === GET_DATABASE_SCHEMA_TOOL_NAME) {
+      return "Getting database schema";
+    }
+    if (toolName === EXECUTE_DATABASE_QUERY_TOOL_NAME) {
+      return "Executing database query";
+    }
+  }
+
+  if (internalMCPServerName === "reasoning") {
+    return "Reasoning";
+  }
+
+  if (internalMCPServerName === "extract_data") {
+    if (toolName === PROCESS_TOOL_NAME) {
+      return "Extracting data";
+    }
+  }
+
+  return "Executing tool";
+};

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -1,5 +1,4 @@
 import type {
-  AgentActionPublicType,
   ConversationPublicType,
   LightAgentConfigurationType,
   Result,

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -11,6 +11,12 @@ import removeMarkdown from "remove-markdown";
 import jaroWinkler from "talisman/metrics/jaro-winkler";
 
 import { getClient } from "@connectors/connectors/microsoft/index";
+import { apiConfig } from "@connectors/lib/api/config";
+import { TeamsMessage } from "@connectors/lib/models/microsoft_bot";
+import logger from "@connectors/logger/logger";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import { getHeaderFromUserEmail } from "@connectors/types";
+
 import {
   createErrorAdaptiveCard,
   createResponseAdaptiveCard,
@@ -18,11 +24,6 @@ import {
   makeConversationUrl,
 } from "./adaptive_cards";
 import { sendActivity, updateActivity } from "./bot_messaging_utils";
-import { apiConfig } from "@connectors/lib/api/config";
-import { TeamsMessage } from "@connectors/lib/models/microsoft_bot";
-import logger from "@connectors/logger/logger";
-import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import { getHeaderFromUserEmail } from "@connectors/types";
 
 export async function botAnswerTeamsMessage(
   context: TurnContext,
@@ -260,13 +261,6 @@ async function answerTeamsMessage(
     };
   }
 
-  const mostPopularAgentConfigurations = [...activeAgentConfigurations]
-    .sort((a, b) => (b.usage?.messageCount ?? 0) - (a.usage?.messageCount ?? 0))
-    .splice(0, 100)
-    .sort((a, b) => a.name.localeCompare(b.name));
-
-  // Skip Graph API messaging - Teams app handles "thinking" message via Bot Framework
-
   if (!message.includes(":mention")) {
     // if the message does not contain the mention, we add it as a prefix.
     message = `:mention[${mention.assistantName}]{sId=${mention.assistantId}} ${message}`;
@@ -476,8 +470,6 @@ async function answerTeamsMessage(
             conversation.sId
           ),
           workspaceId: connector.workspaceId,
-          agentConfigurations: mostPopularAgentConfigurations,
-          originalMessage: message,
         });
 
         await sendTeamsResponse(context, false, streamingMessages, finalCard);

--- a/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
+++ b/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
@@ -122,3 +122,87 @@ export async function sendActivity(
     throw error;
   }
 }
+
+/**
+ * Reliable replacement for context.updateActivity()
+ * Uses tenant-specific token for authentication
+ */
+export async function updateActivity(
+  context: TurnContext,
+  activity: Partial<Activity>
+): Promise<void> {
+  const token = await getTenantSpecificToken();
+  if (!token) {
+    logger.error("Cannot update activity - no valid token");
+    return;
+  }
+
+  if (!activity.id) {
+    logger.error("Cannot update activity - no activity ID provided");
+    return;
+  }
+
+  try {
+    const response = await axios.put(
+      `${context.activity.serviceUrl}/v3/conversations/${context.activity.conversation.id}/activities/${activity.id}`,
+      activity,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        timeout: 10000,
+      }
+    );
+
+    logger.debug(
+      {
+        activityId: activity.id,
+        statusCode: response.status,
+      },
+      "Activity updated successfully"
+    );
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        serviceUrl: context.activity.serviceUrl,
+        conversationId: context.activity.conversation?.id,
+        activityId: activity.id,
+      },
+      "Failed to update activity"
+    );
+    throw error;
+  }
+}
+
+/**
+ * Helper function to send a text message
+ */
+export async function sendTextMessage(
+  context: TurnContext,
+  text: string
+): Promise<{ id?: string } | undefined> {
+  return sendActivity(context, {
+    type: "message",
+    text,
+  });
+}
+
+/**
+ * Helper function to send an adaptive card
+ */
+export async function sendAdaptiveCard(
+  context: TurnContext,
+  card: any
+): Promise<{ id?: string } | undefined> {
+  return sendActivity(context, {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: card,
+      },
+    ],
+  });
+}

--- a/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
+++ b/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
@@ -188,21 +188,3 @@ export async function sendTextMessage(
     text,
   });
 }
-
-/**
- * Helper function to send an adaptive card
- */
-export async function sendAdaptiveCard(
-  context: TurnContext,
-  card: any
-): Promise<{ id?: string } | undefined> {
-  return sendActivity(context, {
-    type: "message",
-    attachments: [
-      {
-        contentType: "application/vnd.microsoft.card.adaptive",
-        content: card,
-      },
-    ],
-  });
-}

--- a/connectors/src/api/webhooks/teams/utils.ts
+++ b/connectors/src/api/webhooks/teams/utils.ts
@@ -1,9 +1,9 @@
 import type { TurnContext } from "botbuilder";
 
-import { sendActivity } from "@connectors/api/webhooks/teams/bot_messaging_utils";
+import { sendTextMessage } from "@connectors/api/webhooks/teams/bot_messaging_utils";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_resource";
+import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_bot_resources";
 
 export async function getConnector(context: TurnContext) {
   // Extract tenant ID from Teams context
@@ -20,10 +20,10 @@ export async function getConnector(context: TurnContext) {
 
   if (!tenantId) {
     logger.error("No tenant ID found in Teams context");
-    await sendActivity(context, {
-      type: "message",
-      text: "❌ Unable to identify tenant for this Teams message",
-    });
+    await sendTextMessage(
+      context,
+      "❌ Unable to identify tenant for this Teams message"
+    );
     return;
   }
 
@@ -38,10 +38,10 @@ export async function getConnector(context: TurnContext) {
       { tenantId },
       "No Microsoft Bot configuration found for tenant"
     );
-    await sendActivity(context, {
-      type: "message",
-      text: "❌ Microsoft Teams Integration is not enabled for your Organization.",
-    });
+    await sendTextMessage(
+      context,
+      "❌ Microsoft Teams Integration is not enabled for your Organization."
+    );
     return;
   }
 
@@ -56,10 +56,10 @@ export async function getConnector(context: TurnContext) {
       },
       "Connector not found for bot configuration"
     );
-    await sendActivity(context, {
-      type: "message",
-      text: "❌ Microsoft Teams Integration is not enabled for your Organization.",
-    });
+    await sendTextMessage(
+      context,
+      "❌ Microsoft Teams Integration is not enabled for your Organization."
+    );
     return;
   }
 

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -1,10 +1,16 @@
+import { DustAPI } from "@dust-tt/client";
+import type { TurnContext } from "botbuilder";
 import {
   CloudAdapter,
   ConfigurationBotFrameworkAuthentication,
-  TurnContext,
 } from "botbuilder";
 import type { Request, Response } from "express";
 
+import {
+  createErrorAdaptiveCard,
+  createThinkingAdaptiveCard,
+} from "@connectors/api/webhooks/teams/adaptive_cards";
+import { botAnswerMessage } from "@connectors/api/webhooks/teams/bot";
 import {
   sendActivity,
   sendTextMessage,
@@ -15,16 +21,10 @@ import {
   validateBotFrameworkToken,
 } from "@connectors/api/webhooks/teams/jwt_validation";
 import { getConnector } from "@connectors/api/webhooks/teams/utils";
+import { apiConfig } from "@connectors/lib/api/config";
 import logger from "@connectors/logger/logger";
 import { apiError } from "@connectors/logger/withlogging";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { DustAPI } from "@dust-tt/client";
-import { apiConfig } from "@connectors/lib/api/config";
-import {
-  createErrorAdaptiveCard,
-  createThinkingAdaptiveCard,
-} from "@connectors/api/webhooks/teams/adaptive_cards";
-import { botAnswerTeamsMessage } from "@connectors/api/webhooks/teams/bot";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
 // CloudAdapter configuration - simplified for incoming message validation only
 const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication({
@@ -243,7 +243,7 @@ async function handleAgentSelection(
     .trim();
   const agentMessage = `@${agentName} ${cleanMessage}`;
 
-  await processTeamsMessage(context, agentMessage, connector);
+  await processMicrosoftBotMessage(context, agentMessage, connector);
 }
 
 async function handleTextMessage(
@@ -292,7 +292,7 @@ async function handleTextMessage(
     );
   }
 
-  await processTeamsMessage(context, context.activity.text, connector);
+  await processMicrosoftBotMessage(context, context.activity.text, connector);
 }
 
 async function handleMessageExtension(
@@ -388,13 +388,13 @@ async function handleMessageExtension(
   }
 }
 
-async function processTeamsMessage(
+async function processMicrosoftBotMessage(
   context: TurnContext,
   message: string,
   connector: ConnectorResource
 ) {
   try {
-    const result = await botAnswerTeamsMessage(
+    const result = await botAnswerMessage(
       context,
       message,
       connector,

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -1,10 +1,14 @@
 import {
   CloudAdapter,
   ConfigurationBotFrameworkAuthentication,
+  TurnContext,
 } from "botbuilder";
 import type { Request, Response } from "express";
 
-import { sendActivity } from "@connectors/api/webhooks/teams/bot_messaging_utils";
+import {
+  sendActivity,
+  sendTextMessage,
+} from "@connectors/api/webhooks/teams/bot_messaging_utils";
 import {
   extractBearerToken,
   generateTeamsRateLimitKey,
@@ -13,6 +17,14 @@ import {
 import { getConnector } from "@connectors/api/webhooks/teams/utils";
 import logger from "@connectors/logger/logger";
 import { apiError } from "@connectors/logger/withlogging";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { DustAPI } from "@dust-tt/client";
+import { apiConfig } from "@connectors/lib/api/config";
+import {
+  createErrorAdaptiveCard,
+  createThinkingAdaptiveCard,
+} from "@connectors/api/webhooks/teams/adaptive_cards";
+import { botAnswerTeamsMessage } from "@connectors/api/webhooks/teams/bot";
 
 // CloudAdapter configuration - simplified for incoming message validation only
 const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication({
@@ -23,6 +35,8 @@ const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication({
 });
 
 const adapter = new CloudAdapter(botFrameworkAuthentication);
+
+const streamingMessages = new Map<string, string>();
 
 // Error handler for the adapter
 adapter.onTurnError = async (context, error) => {
@@ -38,10 +52,10 @@ adapter.onTurnError = async (context, error) => {
 
   // Try to send error message if context allows
   try {
-    await sendActivity(context, {
-      type: "message",
-      text: "❌ An error occurred processing your request.",
-    });
+    await sendTextMessage(
+      context,
+      "❌ An error occurred processing your request."
+    );
   } catch (e) {
     logger.error("Failed to send error activity", e);
   }
@@ -168,11 +182,7 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
       // Handle different activity types
       switch (context.activity.type) {
         case "message":
-          // TODO: Handle message
-          logger.info(
-            { activityType: context.activity.type },
-            "Handling message"
-          );
+          await handleMessage(context, connector);
           break;
 
         default:
@@ -186,5 +196,229 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
   } catch (error) {
     logger.error({ error }, "Error in Teams messages webhook");
     res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+async function handleMessage(
+  context: TurnContext,
+  connector: ConnectorResource
+) {
+  // Check if it's an adaptive card submit
+  if (context.activity.value?.action === "ask_agent") {
+    await handleAgentSelection(context, connector);
+    return;
+  }
+
+  // Handle regular text messages
+  if (context.activity.text?.trim()) {
+    await handleTextMessage(context, connector);
+  }
+}
+
+async function handleAgentSelection(
+  context: TurnContext,
+  connector: ConnectorResource
+) {
+  const { agentId, agentName, originalMessage } = context.activity.value;
+
+  logger.info(
+    { agentId, agentName, originalMessage },
+    "Handling agent selection from adaptive card"
+  );
+
+  // Send thinking message
+  const thinkingCard = createThinkingAdaptiveCard();
+  const thinkingActivity = await sendActivity(context, thinkingCard);
+
+  if (thinkingActivity?.id) {
+    streamingMessages.set(
+      context.activity.conversation.id,
+      thinkingActivity.id
+    );
+  }
+
+  // Clean the message and add agent mention
+  const cleanMessage = originalMessage
+    .replace(/^[@+~][a-zA-Z0-9_-]+\s*/, "")
+    .trim();
+  const agentMessage = `@${agentName} ${cleanMessage}`;
+
+  await processTeamsMessage(context, agentMessage, connector);
+}
+
+async function handleTextMessage(
+  context: TurnContext,
+  connector: ConnectorResource
+) {
+  logger.info({ text: context.activity.text }, "Handling regular text message");
+
+  // Send thinking message
+  let thinkingActivity;
+  try {
+    const thinkingCard = createThinkingAdaptiveCard();
+
+    logger.info(
+      {
+        serviceUrl: context.activity.serviceUrl,
+        conversationId: context.activity.conversation?.id,
+        cardType: "ThinkingCard",
+        credentials: {
+          hasAppId: !!process.env.MICROSOFT_BOT_ID,
+          hasAppPassword: !!process.env.MICROSOFT_BOT_PASSWORD,
+        },
+      },
+      "About to send thinking card to Bot Framework"
+    );
+
+    // Use utility function for reliable messaging
+    thinkingActivity = await sendActivity(context, thinkingCard);
+    logger.info(
+      { activityId: thinkingActivity?.id },
+      "Successfully sent thinking card"
+    );
+  } catch (error) {
+    logger.error(
+      {
+        error,
+      },
+      "Failed to send thinking card - detailed error"
+    );
+  }
+
+  if (thinkingActivity?.id) {
+    streamingMessages.set(
+      context.activity.conversation.id,
+      thinkingActivity.id
+    );
+  }
+
+  await processTeamsMessage(context, context.activity.text, connector);
+}
+
+async function handleMessageExtension(
+  context: TurnContext,
+  connector: ConnectorResource
+) {
+  try {
+    const query = context.activity.value;
+    logger.info({ query }, "Handling message extension query");
+
+    const dustAPI = new DustAPI(
+      { url: apiConfig.getDustFrontAPIUrl() },
+      {
+        workspaceId: connector.workspaceId,
+        apiKey: connector.workspaceAPIKey,
+      },
+      logger
+    );
+
+    const agentConfigurationsRes = await dustAPI.getAgentConfigurations({});
+
+    if (agentConfigurationsRes.isErr()) {
+      logger.error(
+        { error: agentConfigurationsRes.error },
+        "Failed to get agent configurations"
+      );
+      return;
+    }
+
+    const agents = agentConfigurationsRes.value
+      .filter((ac) => ac.status === "active")
+      .map((ac) => ({
+        sId: ac.sId,
+        name: ac.name,
+        description: ac.description,
+        usage: ac.usage,
+      }))
+      // Sort by usage (most popular first)
+      .sort(
+        (a, b) => (b.usage?.messageCount ?? 0) - (a.usage?.messageCount ?? 0)
+      );
+
+    // Filter agents based on search query
+    const searchTerm = query.parameters?.searchQuery?.toLowerCase() || "";
+    const filteredAgents = agents.filter(
+      (agent) =>
+        agent.name.toLowerCase().includes(searchTerm) ||
+        agent.description?.toLowerCase().includes(searchTerm)
+    );
+
+    // Return agent results
+    const results = filteredAgents.slice(0, 10).map((agent) => ({
+      contentType: "application/vnd.microsoft.card.hero",
+      content: {
+        title: agent.name,
+        subtitle: agent.description || `Ask ${agent.name} a question`,
+        tap: {
+          type: "imBack",
+          value: `@${agent.name} `,
+        },
+      },
+    }));
+
+    const composeResponse = {
+      composeExtension: {
+        type: "result",
+        attachmentLayout: "list",
+        attachments:
+          results.length > 0
+            ? results
+            : [
+                {
+                  contentType: "application/vnd.microsoft.card.hero",
+                  content: {
+                    title: "No agents found",
+                    subtitle: `No agents match "${searchTerm}"`,
+                    tap: {
+                      type: "imBack",
+                      value: "@dust ",
+                    },
+                  },
+                },
+              ],
+      },
+    };
+
+    await sendActivity(context, { value: composeResponse });
+  } catch (error) {
+    logger.error({ error }, "Error handling message extension");
+    await sendActivity(context, {
+      value: { composeExtension: { type: "result", attachments: [] } },
+    });
+  }
+}
+
+async function processTeamsMessage(
+  context: TurnContext,
+  message: string,
+  connector: ConnectorResource
+) {
+  try {
+    const result = await botAnswerTeamsMessage(
+      context,
+      message,
+      connector,
+      streamingMessages
+    );
+
+    if (result.isErr()) {
+      logger.error({ error: result.error }, "Error processing Teams message");
+      await sendActivity(
+        context,
+        createErrorAdaptiveCard({
+          error: result.error.message,
+          workspaceId: connector!.workspaceId,
+        })
+      );
+    }
+  } catch (error) {
+    logger.error({ error }, "Error processing Teams message");
+    await sendActivity(
+      context,
+      createErrorAdaptiveCard({
+        error: "An unexpected error occurred",
+        workspaceId: connector!.workspaceId,
+      })
+    );
   }
 }

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -71,7 +71,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
   }): Promise<Result<string, ConnectorManagerError<CreateConnectorErrorCode>>> {
-    const client = await getClient(connectionId);
+    const client = await getMicrosoftClient(connectionId);
 
     try {
       // Sanity checks - check connectivity and permissions. User should be able to access the sites and teams list.
@@ -127,10 +127,10 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     if (connectionId) {
       try {
         const logger = getActivityLogger(connector);
-        const client = await getClient(connector.connectionId);
+        const client = await getMicrosoftClient(connector.connectionId);
         const currentOrg = await clientApiGet(logger, client, "/organization");
 
-        const newClient = await getClient(connectionId);
+        const newClient = await getMicrosoftClient(connectionId);
         const newOrg = await clientApiGet(logger, newClient, "/organization");
 
         if (
@@ -254,7 +254,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       return new Ok(nRes.value);
     }
 
-    const client = await getClient(connector.connectionId);
+    const client = await getMicrosoftClient(connector.connectionId);
     const nodes = [];
 
     const selectedResources = (
@@ -604,7 +604,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
   }
 }
 
-export async function getClient(connectionId: string) {
+export async function getMicrosoftClient(connectionId: string) {
   const { access_token: accessToken } =
     await getOAuthConnectionAccessTokenWithThrow({
       logger,

--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -4,7 +4,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
 import { getConnectorManager } from "@connectors/connectors";
-import { getClient } from "@connectors/connectors/microsoft";
+import { getMicrosoftClient } from "@connectors/connectors/microsoft";
 import {
   getItem,
   getParentReferenceInternalId,
@@ -142,7 +142,7 @@ export const microsoft = async ({
         args.internalId
       );
       const logger = getActivityLogger(connector);
-      const client = await getClient(connector.connectionId);
+      const client = await getMicrosoftClient(connector.connectionId);
       const driveItem = (await getItem(
         logger,
         client,
@@ -253,7 +253,7 @@ export const microsoft = async ({
       const internalIds = parseInternalIds(idsFile, internalId);
 
       // Get node from MS Graph API.
-      const client = await getClient(connector.connectionId);
+      const client = await getMicrosoftClient(connector.connectionId);
 
       for (const internalId of internalIds) {
         const node = await MicrosoftNodeResource.fetchByInternalId(
@@ -392,7 +392,7 @@ export const microsoft = async ({
 
       const internalIds = parseInternalIds(idsFile, internalId);
 
-      const client = await getClient(connector.connectionId);
+      const client = await getMicrosoftClient(connector.connectionId);
 
       for (const internalId of internalIds) {
         const { nodeType, itemAPIPath } = typeAndPathFromInternalId(internalId);

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -5,7 +5,7 @@ import type { Client } from "@microsoft/microsoft-graph-client";
 import { GraphError } from "@microsoft/microsoft-graph-client";
 import * as _ from "lodash";
 
-import { getClient } from "@connectors/connectors/microsoft";
+import { getMicrosoftClient } from "@connectors/connectors/microsoft";
 import {
   clientApiPost,
   extractPath,
@@ -90,7 +90,7 @@ export async function getRootNodesToSyncFromResources(
   }
 
   const logger = getActivityLogger(connector);
-  const client = await getClient(connector.connectionId);
+  const client = await getMicrosoftClient(connector.connectionId);
 
   // get root folders and drives and drill down site-root and sites to their
   // child drives (converted to MicrosoftNode types)
@@ -263,7 +263,7 @@ export async function populateDeltas(connectorId: ModelId, nodeIds: string[]) {
     throw new Error(`Connector ${connectorId} not found`);
   }
   const logger = getActivityLogger(connector);
-  const client = await getClient(connector.connectionId);
+  const client = await getMicrosoftClient(connector.connectionId);
 
   for (const [driveId, nodeIds] of Object.entries(groupedItems)) {
     const { deltaLink } = await getDeltaResults({
@@ -446,7 +446,7 @@ export async function syncFiles({
     },
     `[SyncFiles] Start sync`
   );
-  const client = await getClient(connector.connectionId);
+  const client = await getMicrosoftClient(connector.connectionId);
 
   // TODO(pr): handle pagination
   const childrenResult = await getFilesAndFolders(
@@ -623,7 +623,7 @@ export async function syncDeltaForRootNodesInDrive({
     return;
   }
 
-  const client = await getClient(connector.connectionId);
+  const client = await getMicrosoftClient(connector.connectionId);
 
   const logger = getActivityLogger(connector);
   logger.info({ connectorId, rootNodeIds }, "Syncing delta for node");
@@ -953,7 +953,7 @@ export async function fetchDeltaForRootNodesInDrive({
     return { gcsFilePath: null };
   }
 
-  const client = await getClient(connector.connectionId);
+  const client = await getMicrosoftClient(connector.connectionId);
 
   logger.info({ connectorId, rootNodeIds }, "Fetching delta for node");
 
@@ -1377,7 +1377,7 @@ export async function microsoftGarbageCollectionActivity({
     { connectorId, idCursor },
     "Garbage collection activity for cursor"
   );
-  const client = await getClient(connector.connectionId);
+  const client = await getMicrosoftClient(connector.connectionId);
 
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
@@ -1898,7 +1898,7 @@ export async function processDeltaChangesFromGCS({
           skipped++;
         }
       } else {
-        const client = await getClient(connector.connectionId);
+        const client = await getMicrosoftClient(connector.connectionId);
         const { item, type } = driveItem.root
           ? {
               item: await getItem(

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -1,7 +1,7 @@
 import type { Result } from "@dust-tt/client";
 import axios from "axios";
 
-import { getClient } from "@connectors/connectors/microsoft";
+import { getMicrosoftClient } from "@connectors/connectors/microsoft";
 import {
   getDriveItemInternalId,
   getItem,
@@ -135,7 +135,7 @@ export async function syncOneFile({
   localLogger.info("Syncing file");
   await heartbeat();
 
-  const client = await getClient(connector.connectionId);
+  const client = await getMicrosoftClient(connector.connectionId);
   const { itemAPIPath } = typeAndPathFromInternalId(documentId);
 
   let url = file["@microsoft.graph.downloadUrl"];

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -5,7 +5,7 @@ import { GraphError } from "@microsoft/microsoft-graph-client";
 import type { WorkbookWorksheet } from "@microsoft/microsoft-graph-types";
 import { stringify } from "csv-stringify/sync";
 
-import { getClient } from "@connectors/connectors/microsoft";
+import { getMicrosoftClient } from "@connectors/connectors/microsoft";
 import {
   getAllPaginatedEntities,
   getDriveItemInternalId,
@@ -231,7 +231,7 @@ async function processSheet({
     const tags = await getColumnsFromListItem(
       spreadsheet,
       spreadsheet.listItem?.fields,
-      await getClient(connector.connectionId),
+      await getMicrosoftClient(connector.connectionId),
       localLogger
     );
 
@@ -308,7 +308,7 @@ export async function handleSpreadSheet({
     throw new Error(`Connector with id ${connectorId} not found`);
   }
 
-  const client = await getClient(connector.connectionId);
+  const client = await getMicrosoftClient(connector.connectionId);
 
   if (!file.file) {
     return new Err(new Error(`Spreadsheet is not a file: ${file.name}`));

--- a/connectors/src/connectors/microsoft_bot/index.ts
+++ b/connectors/src/connectors/microsoft_bot/index.ts
@@ -12,8 +12,8 @@ import { getClient } from "@connectors/connectors/microsoft";
 import { getOrganization } from "@connectors/connectors/microsoft/lib/graph_api";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_resource";
 import type { ContentNode, DataSourceConfig } from "@connectors/types";
+import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_bot_resources";
 
 export class MicrosoftBotConnectorManager extends BaseConnectorManager<null> {
   readonly provider: ConnectorProvider = "microsoft_bot";

--- a/connectors/src/connectors/microsoft_bot/index.ts
+++ b/connectors/src/connectors/microsoft_bot/index.ts
@@ -12,8 +12,8 @@ import { getClient } from "@connectors/connectors/microsoft";
 import { getOrganization } from "@connectors/connectors/microsoft/lib/graph_api";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ContentNode, DataSourceConfig } from "@connectors/types";
 import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_bot_resources";
+import type { ContentNode, DataSourceConfig } from "@connectors/types";
 
 export class MicrosoftBotConnectorManager extends BaseConnectorManager<null> {
   readonly provider: ConnectorProvider = "microsoft_bot";

--- a/connectors/src/connectors/microsoft_bot/index.ts
+++ b/connectors/src/connectors/microsoft_bot/index.ts
@@ -8,7 +8,7 @@ import type {
   UpdateConnectorErrorCode,
 } from "@connectors/connectors/interface";
 import { BaseConnectorManager } from "@connectors/connectors/interface";
-import { getClient } from "@connectors/connectors/microsoft";
+import { getMicrosoftClient } from "@connectors/connectors/microsoft";
 import { getOrganization } from "@connectors/connectors/microsoft/lib/graph_api";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -25,7 +25,7 @@ export class MicrosoftBotConnectorManager extends BaseConnectorManager<null> {
     dataSourceConfig: DataSourceConfig;
     connectionId: string;
   }): Promise<Result<string, ConnectorManagerError<CreateConnectorErrorCode>>> {
-    const client = await getClient(connectionId);
+    const client = await getMicrosoftClient(connectionId);
 
     const org = await getOrganization(logger, client);
 

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -79,6 +79,8 @@ const SLACK_ERROR_TEXT =
 
 const MAX_FILE_SIZE_TO_UPLOAD = 10 * 1024 * 1024; // 10 MB
 
+const DEFAULT_AGENTS = ["dust", "claude-4-sonnet", "gpt-5"];
+
 type BotAnswerParams = {
   responseUrl?: string;
   slackTeamId: string;
@@ -841,12 +843,14 @@ async function answerMessage(
       };
     } else {
       // If no mention is found and no channel-based routing rule is found, we use the default agent.
-      let defaultAssistant: LightAgentConfigurationType | null = null;
-      defaultAssistant =
-        activeAgentConfigurations.find((ac) => ac.sId === "dust") || null;
-      if (!defaultAssistant || defaultAssistant.status !== "active") {
-        defaultAssistant =
-          activeAgentConfigurations.find((ac) => ac.sId === "gpt-4") || null;
+      let defaultAssistant: LightAgentConfigurationType | undefined = undefined;
+      for (const agent of DEFAULT_AGENTS) {
+        defaultAssistant = activeAgentConfigurations.find(
+          (ac) => ac.sId === agent && ac.status === "active"
+        );
+        if (defaultAssistant) {
+          break;
+        }
       }
       if (!defaultAssistant) {
         return new Err(

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -89,45 +89,6 @@ MicrosoftRootModel.init(
   }
 );
 
-export class MicrosoftBotConfigurationModel extends ConnectorBaseModel<MicrosoftBotConfigurationModel> {
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-  declare botEnabled: boolean;
-  declare tenantId: string;
-}
-MicrosoftBotConfigurationModel.init(
-  {
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    botEnabled: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    },
-    tenantId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-  },
-  {
-    sequelize: sequelizeConnection,
-    modelName: "microsoft_bot_configurations",
-    indexes: [
-      { fields: ["connectorId"], unique: true },
-      { fields: ["tenantId"], unique: true },
-    ],
-    relationship: "hasOne",
-  }
-);
-
 // MicrosftNode stores nodes (e.g. files, folder, channels, ...) synced from Microsoft.
 export class MicrosoftNodeModel extends ConnectorBaseModel<MicrosoftNodeModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/microsoft_bot.ts
+++ b/connectors/src/lib/models/microsoft_bot.ts
@@ -113,7 +113,7 @@ MicrosoftBotMessage.init(
     },
   },
   {
-    modelName: "teams_messages",
+    modelName: "microsoft_bot_messages",
     sequelize: sequelizeConnection,
     indexes: [
       {

--- a/connectors/src/lib/models/microsoft_bot.ts
+++ b/connectors/src/lib/models/microsoft_bot.ts
@@ -1,0 +1,131 @@
+import { sequelizeConnection } from "@connectors/resources/storage";
+import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
+import { CreationOptional, DataTypes } from "sequelize";
+
+export class MicrosoftBotConfigurationModel extends ConnectorBaseModel<MicrosoftBotConfigurationModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare botEnabled: boolean;
+  declare tenantId: string;
+}
+MicrosoftBotConfigurationModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    botEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    tenantId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: sequelizeConnection,
+    modelName: "microsoft_bot_configurations",
+    indexes: [
+      { fields: ["connectorId"], unique: true },
+      { fields: ["tenantId"], unique: true },
+    ],
+    relationship: "hasOne",
+  }
+);
+
+export class TeamsMessage extends ConnectorBaseModel<TeamsMessage> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare message: string;
+  declare userId: string;
+  declare userAadObjectId?: string;
+  declare email: string;
+  declare userName: string;
+  declare conversationId: string;
+  declare activityId: string;
+  declare channelId: string;
+  declare replyToId?: string;
+  declare dustConversationId?: string;
+}
+
+TeamsMessage.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    message: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    userId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    userAadObjectId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    userName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    conversationId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    activityId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    channelId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    replyToId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    dustConversationId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+  },
+  {
+    modelName: "teams_messages",
+    sequelize: sequelizeConnection,
+    indexes: [
+      {
+        fields: ["connectorId"],
+      },
+      {
+        fields: ["connectorId", "conversationId"],
+      },
+      {
+        fields: ["connectorId", "userId"],
+      },
+      {
+        fields: ["connectorId", "dustConversationId"],
+      },
+    ],
+  }
+);

--- a/connectors/src/lib/models/microsoft_bot.ts
+++ b/connectors/src/lib/models/microsoft_bot.ts
@@ -43,7 +43,7 @@ MicrosoftBotConfigurationModel.init(
   }
 );
 
-export class TeamsMessage extends ConnectorBaseModel<TeamsMessage> {
+export class MicrosoftBotMessage extends ConnectorBaseModel<MicrosoftBotMessage> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -59,7 +59,7 @@ export class TeamsMessage extends ConnectorBaseModel<TeamsMessage> {
   declare dustConversationId?: string;
 }
 
-TeamsMessage.init(
+MicrosoftBotMessage.init(
   {
     createdAt: {
       type: DataTypes.DATE,

--- a/connectors/src/lib/models/microsoft_bot.ts
+++ b/connectors/src/lib/models/microsoft_bot.ts
@@ -1,6 +1,8 @@
+import type { CreationOptional } from "sequelize";
+import { DataTypes } from "sequelize";
+
 import { sequelizeConnection } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
-import { CreationOptional, DataTypes } from "sequelize";
 
 export class MicrosoftBotConfigurationModel extends ConnectorBaseModel<MicrosoftBotConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/microsoft_bot.ts
+++ b/connectors/src/lib/models/microsoft_bot.ts
@@ -47,14 +47,11 @@ export class MicrosoftBotMessage extends ConnectorBaseModel<MicrosoftBotMessage>
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare message: string;
-  declare userId: string;
   declare userAadObjectId?: string;
-  declare email: string;
-  declare userName: string;
+  declare email?: string;
   declare conversationId: string;
-  declare activityId: string;
-  declare channelId: string;
+  declare userActivityId: string;
+  declare agentActivityId: string;
   declare replyToId?: string;
   declare dustConversationId?: string;
 }
@@ -71,35 +68,23 @@ MicrosoftBotMessage.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    message: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-    },
-    userId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
     userAadObjectId: {
       type: DataTypes.STRING,
       allowNull: true,
     },
     email: {
       type: DataTypes.STRING,
-      allowNull: false,
-    },
-    userName: {
-      type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
     },
     conversationId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
-    activityId: {
+    userActivityId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
-    channelId: {
+    agentActivityId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -121,9 +106,6 @@ MicrosoftBotMessage.init(
       },
       {
         fields: ["connectorId", "conversationId"],
-      },
-      {
-        fields: ["connectorId", "userId"],
       },
       {
         fields: ["connectorId", "dustConversationId"],

--- a/connectors/src/lib/tools_utils.ts
+++ b/connectors/src/lib/tools_utils.ts
@@ -1,0 +1,90 @@
+import type { AgentActionPublicType } from "@dust-tt/client";
+
+export const SEARCH_TOOL_NAME = "semantic_search";
+export const INCLUDE_TOOL_NAME = "retrieve_recent_documents";
+export const WEBSEARCH_TOOL_NAME = "websearch";
+export const WEBBROWSER_TOOL_NAME = "webbrowser";
+export const QUERY_TABLES_TOOL_NAME = "query_tables";
+export const GET_DATABASE_SCHEMA_TOOL_NAME = "get_database_schema";
+export const EXECUTE_DATABASE_QUERY_TOOL_NAME = "execute_database_query";
+export const PROCESS_TOOL_NAME = "extract_information_from_documents";
+export const RUN_AGENT_TOOL_NAME = "run_agent";
+export const CREATE_AGENT_TOOL_NAME = "create_agent";
+export const FIND_TAGS_TOOL_NAME = "find_tags";
+export const FILESYSTEM_CAT_TOOL_NAME = "cat";
+export const FILESYSTEM_FIND_TOOL_NAME = "find";
+export const FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME = "locate_in_tree";
+export const FILESYSTEM_LIST_TOOL_NAME = "list";
+
+export const getActionName = (action: AgentActionPublicType) => {
+  const { functionCallName, internalMCPServerName } = action;
+
+  const parts = functionCallName ? functionCallName.split("__") : [];
+  const toolName = parts[parts.length - 1];
+
+  if (
+    internalMCPServerName === "search" ||
+    internalMCPServerName === "data_sources_file_system"
+  ) {
+    if (toolName === SEARCH_TOOL_NAME) {
+      return "Searching";
+    }
+
+    if (
+      toolName === FILESYSTEM_LIST_TOOL_NAME ||
+      toolName === FILESYSTEM_FIND_TOOL_NAME
+    ) {
+      return "Browsing data sources";
+    }
+
+    if (toolName === FILESYSTEM_CAT_TOOL_NAME) {
+      return "Viewing data source";
+    }
+
+    if (toolName === FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME) {
+      return "Locating item";
+    }
+  }
+
+  if (internalMCPServerName === "include_data") {
+    if (toolName === INCLUDE_TOOL_NAME) {
+      return "Including data";
+    }
+  }
+
+  if (internalMCPServerName === "web_search_&_browse") {
+    if (toolName === WEBSEARCH_TOOL_NAME) {
+      return "Searching the web";
+    }
+    if (toolName === WEBBROWSER_TOOL_NAME) {
+      return "Browsing the web";
+    }
+  }
+
+  if (internalMCPServerName === "query_tables") {
+    if (toolName === QUERY_TABLES_TOOL_NAME) {
+      return "Querying tables";
+    }
+  }
+
+  if (internalMCPServerName === "query_tables_v2") {
+    if (toolName === GET_DATABASE_SCHEMA_TOOL_NAME) {
+      return "Getting database schema";
+    }
+    if (toolName === EXECUTE_DATABASE_QUERY_TOOL_NAME) {
+      return "Executing database query";
+    }
+  }
+
+  if (internalMCPServerName === "reasoning") {
+    return "Reasoning";
+  }
+
+  if (internalMCPServerName === "extract_data") {
+    if (toolName === PROCESS_TOOL_NAME) {
+      return "Extracting data";
+    }
+  }
+
+  return "Running a tool";
+};

--- a/connectors/src/resources/connector/microsoft_bot.ts
+++ b/connectors/src/resources/connector/microsoft_bot.ts
@@ -1,5 +1,6 @@
 import type { Transaction } from "sequelize";
 
+import type { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
 import type {
   ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
@@ -7,9 +8,8 @@ import type {
   WithCreationAttributes,
 } from "@connectors/resources/connector/strategy";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ModelId } from "@connectors/types";
-import { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
 import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_bot_resources";
+import type { ModelId } from "@connectors/types";
 
 export class MicrosoftBotConnectorStrategy
   implements ConnectorProviderStrategy<"microsoft_bot">

--- a/connectors/src/resources/connector/microsoft_bot.ts
+++ b/connectors/src/resources/connector/microsoft_bot.ts
@@ -1,6 +1,5 @@
 import type { Transaction } from "sequelize";
 
-import type { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft";
 import type {
   ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
@@ -8,8 +7,9 @@ import type {
   WithCreationAttributes,
 } from "@connectors/resources/connector/strategy";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_resource";
 import type { ModelId } from "@connectors/types";
+import { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
+import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_bot_resources";
 
 export class MicrosoftBotConnectorStrategy
   implements ConnectorProviderStrategy<"microsoft_bot">

--- a/connectors/src/resources/connector/strategy.ts
+++ b/connectors/src/resources/connector/strategy.ts
@@ -10,6 +10,7 @@ import type { GongConfigurationModel } from "@connectors/lib/models/gong";
 import type { GoogleDriveConfig } from "@connectors/lib/models/google_drive";
 import type { IntercomWorkspaceModel } from "@connectors/lib/models/intercom";
 import type { MicrosoftConfigurationModel } from "@connectors/lib/models/microsoft";
+import type { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
 import type { NotionConnectorState } from "@connectors/lib/models/notion";
 import type { SalesforceConfigurationModel } from "@connectors/lib/models/salesforce";
 import type { SlackConfigurationModel } from "@connectors/lib/models/slack";
@@ -39,7 +40,6 @@ import type {
 import type { ModelId } from "@connectors/types";
 
 import type { BaseResource } from "../base_resource";
-import { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
 
 export type WithCreationAttributes<T extends Model> = CreationAttributes<T>;
 

--- a/connectors/src/resources/connector/strategy.ts
+++ b/connectors/src/resources/connector/strategy.ts
@@ -9,10 +9,7 @@ import type { GithubConnectorState } from "@connectors/lib/models/github";
 import type { GongConfigurationModel } from "@connectors/lib/models/gong";
 import type { GoogleDriveConfig } from "@connectors/lib/models/google_drive";
 import type { IntercomWorkspaceModel } from "@connectors/lib/models/intercom";
-import type {
-  MicrosoftBotConfigurationModel,
-  MicrosoftConfigurationModel,
-} from "@connectors/lib/models/microsoft";
+import type { MicrosoftConfigurationModel } from "@connectors/lib/models/microsoft";
 import type { NotionConnectorState } from "@connectors/lib/models/notion";
 import type { SalesforceConfigurationModel } from "@connectors/lib/models/salesforce";
 import type { SlackConfigurationModel } from "@connectors/lib/models/slack";
@@ -42,6 +39,7 @@ import type {
 import type { ModelId } from "@connectors/types";
 
 import type { BaseResource } from "../base_resource";
+import { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
 
 export type WithCreationAttributes<T extends Model> = CreationAttributes<T>;
 

--- a/connectors/src/resources/microsoft_bot_resources.ts
+++ b/connectors/src/resources/microsoft_bot_resources.ts
@@ -1,0 +1,116 @@
+import type { Result } from "@dust-tt/client";
+import { Ok } from "@dust-tt/client";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+import { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
+import { BaseResource } from "@connectors/resources/base_resource";
+import type { WithCreationAttributes } from "@connectors/resources/connector/strategy";
+import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
+import type { ModelId } from "@connectors/types";
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface MicrosoftBotConfigurationResource
+  extends ReadonlyAttributesType<MicrosoftBotConfigurationModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class MicrosoftBotConfigurationResource extends BaseResource<MicrosoftBotConfigurationModel> {
+  static model: ModelStatic<MicrosoftBotConfigurationModel> =
+    MicrosoftBotConfigurationModel;
+
+  constructor(
+    model: ModelStatic<MicrosoftBotConfigurationModel>,
+    blob: Attributes<MicrosoftBotConfigurationModel>
+  ) {
+    super(MicrosoftBotConfigurationModel, blob);
+  }
+
+  async postFetchHook(): Promise<void> {
+    return;
+  }
+
+  static async makeNew(
+    blob: WithCreationAttributes<MicrosoftBotConfigurationModel>,
+    transaction: Transaction
+  ): Promise<MicrosoftBotConfigurationResource> {
+    const config = await this.model.create(
+      {
+        ...blob,
+      },
+      { transaction }
+    );
+
+    return new this(this.model, config.get());
+  }
+
+  static async fetchByConnectorId(connectorId: ModelId) {
+    const blob = await this.model.findOne({
+      where: {
+        connectorId: connectorId,
+      },
+    });
+    if (!blob) {
+      return null;
+    }
+
+    return new this(this.model, blob.get());
+  }
+
+  static async fetchByConnectorIds(
+    connectorIds: ModelId[]
+  ): Promise<Record<ModelId, MicrosoftBotConfigurationResource>> {
+    const blobs = await this.model.findAll({
+      where: {
+        connectorId: connectorIds,
+      },
+    });
+
+    return blobs.reduce(
+      (acc, blob) => {
+        acc[blob.connectorId] = new this(this.model, blob.get());
+        return acc;
+      },
+      {} as Record<ModelId, MicrosoftBotConfigurationResource>
+    );
+  }
+
+  static async fetchByTenantId(tenantId: string) {
+    const blob = await this.model.findOne({
+      where: {
+        tenantId: tenantId,
+      },
+    });
+    if (!blob) {
+      return null;
+    }
+
+    return new this(this.model, blob.get());
+  }
+
+  async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        connectorId: this.connectorId,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+
+  toJSON(): {
+    id: number;
+    connectorId: number;
+    botEnabled: boolean;
+    tenantId: string;
+  } {
+    return {
+      id: this.id,
+      connectorId: this.connectorId,
+      botEnabled: this.botEnabled,
+      tenantId: this.tenantId,
+    };
+  }
+}

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -9,7 +9,6 @@ import type {
 } from "@connectors/connectors/microsoft/lib/types";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
-  MicrosoftBotConfigurationModel,
   MicrosoftConfigurationModel,
   MicrosoftNodeModel,
   MicrosoftRootModel,
@@ -475,112 +474,5 @@ export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {
     const hyphens = "\n" + "-".repeat(level * 2);
 
     return `${this.name}${this.nodeType === "folder" ? "/" : ""}${childrenStrings.length > 0 ? hyphens + childrenStrings.join(hyphens) : ""}`;
-  }
-}
-
-// Attributes are marked as read-only to reflect the stateless nature of our Resource.
-// This design will be moved up to BaseResource once we transition away from Sequelize.
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface MicrosoftBotConfigurationResource
-  extends ReadonlyAttributesType<MicrosoftBotConfigurationModel> {}
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class MicrosoftBotConfigurationResource extends BaseResource<MicrosoftBotConfigurationModel> {
-  static model: ModelStatic<MicrosoftBotConfigurationModel> =
-    MicrosoftBotConfigurationModel;
-
-  constructor(
-    model: ModelStatic<MicrosoftBotConfigurationModel>,
-    blob: Attributes<MicrosoftBotConfigurationModel>
-  ) {
-    super(MicrosoftBotConfigurationModel, blob);
-  }
-
-  async postFetchHook(): Promise<void> {
-    return;
-  }
-
-  static async makeNew(
-    blob: WithCreationAttributes<MicrosoftBotConfigurationModel>,
-    transaction: Transaction
-  ): Promise<MicrosoftBotConfigurationResource> {
-    const config = await this.model.create(
-      {
-        ...blob,
-      },
-      { transaction }
-    );
-
-    return new this(this.model, config.get());
-  }
-
-  static async fetchByConnectorId(connectorId: ModelId) {
-    const blob = await this.model.findOne({
-      where: {
-        connectorId: connectorId,
-      },
-    });
-    if (!blob) {
-      return null;
-    }
-
-    return new this(this.model, blob.get());
-  }
-
-  static async fetchByConnectorIds(
-    connectorIds: ModelId[]
-  ): Promise<Record<ModelId, MicrosoftBotConfigurationResource>> {
-    const blobs = await this.model.findAll({
-      where: {
-        connectorId: connectorIds,
-      },
-    });
-
-    return blobs.reduce(
-      (acc, blob) => {
-        acc[blob.connectorId] = new this(this.model, blob.get());
-        return acc;
-      },
-      {} as Record<ModelId, MicrosoftBotConfigurationResource>
-    );
-  }
-
-  static async fetchByTenantId(tenantId: string) {
-    const blob = await this.model.findOne({
-      where: {
-        tenantId: tenantId,
-      },
-    });
-    if (!blob) {
-      return null;
-    }
-
-    return new this(this.model, blob.get());
-  }
-
-  async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
-    await this.model.destroy({
-      where: {
-        connectorId: this.connectorId,
-      },
-      transaction,
-    });
-
-    return new Ok(undefined);
-  }
-
-  toJSON(): {
-    id: number;
-    connectorId: number;
-    botEnabled: boolean;
-    tenantId: string;
-  } {
-    return {
-      id: this.id,
-      connectorId: this.connectorId,
-      botEnabled: this.botEnabled,
-      tenantId: this.tenantId,
-    };
   }
 }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -73,6 +73,7 @@ export type UserMessageOrigin =
   | "n8n"
   | "raycast"
   | "slack"
+  | "teams"
   | "triggered"
   | "web"
   | "zapier"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -318,6 +318,7 @@ const UserMessageOriginSchema = FlexibleEnumSchema<
   | "n8n"
   | "raycast"
   | "slack"
+  | "teams"
   | "triggered"
   | "web"
   | "zapier"


### PR DESCRIPTION
## Description

- Send reply messages. Create conversation if needed, post message and stream result.
- Store the mapping between teams and dust conversation/messages in MicrosoftBotMessage model, as we do for slack. 
- Added utility methods to send messages + adptive cards
- Moved bot models/resource to dedicated files

![Oct-15-2025 09-54-58](https://github.com/user-attachments/assets/210c880d-579b-4f9b-8f68-46138b286069)

## Tests

locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

run migration
deploy connectors
