### PR TITLE
[front] - fix(AB): data selection

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -45,8 +45,7 @@ import { useEditors } from "@app/lib/swr/editors";
 import { emptyArray } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { LightAgentConfigurationType } from "@app/types";
-import { isBuilder, removeNulls } from "@app/types";
-import { normalizeError } from "@app/types";
+import { isBuilder, normalizeError, removeNulls } from "@app/types";
 
 function processActionsFromStorage(
   actions: AssistantBuilderMCPConfigurationWithId[],

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -133,7 +133,9 @@ export function transformSelectionConfigurationsToTree(
     const { dataSourceView } = config;
     const baseParts = buildDataSourcePath(dataSourceView);
 
-    // If all nodes are selected, just add the data source path
+    // If all nodes are selected, add the data source path.
+    // Do NOT early return: we still need to append exclusions below so
+    // the UI can render a partial state on parents.
     if (config.isSelectAll) {
       inPaths.push({
         path: baseParts,
@@ -142,7 +144,6 @@ export function transformSelectionConfigurationsToTree(
         dataSourceView,
         tagsFilter: config.tagsFilter,
       });
-      continue;
     }
 
     // UI reconstruction guard:

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -100,7 +100,8 @@ export function transformTreeToSelectionConfigurations(
         dataSourceView,
         selectedResources: [],
         excludedResources: [],
-        isSelectAll: false,
+        // By default, we consider the data source to be selected when we start by excluding nodes.
+        isSelectAll: true,
         tagsFilter: null,
       };
     }

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -53,7 +53,8 @@ export function transformTreeToSelectionConfigurations(
     // Check if this is a full data source selection or specific nodes
     const isFullDataSource =
       item.type === "data_source" &&
-      isNodeSelected(tree, item.path.split("/")) === true;
+      (isNodeSelected(tree, item.path.split("/")) === true ||
+        isNodeSelected(tree, item.path.split("/")) === "partial");
 
     // Initialize configuration if not exists
     if (!configurations[dataSourceView.sId]) {

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -53,8 +53,7 @@ export function transformTreeToSelectionConfigurations(
     // Check if this is a full data source selection or specific nodes
     const isFullDataSource =
       item.type === "data_source" &&
-      (isNodeSelected(tree, item.path.split("/")) === true ||
-        isNodeSelected(tree, item.path.split("/")) === "partial");
+      isNodeSelected(tree, item.path.split("/")) === true;
 
     // Initialize configuration if not exists
     if (!configurations[dataSourceView.sId]) {
@@ -101,8 +100,7 @@ export function transformTreeToSelectionConfigurations(
         dataSourceView,
         selectedResources: [],
         excludedResources: [],
-        // By default, we consider the data source to be selected when we start by excluding nodes.
-        isSelectAll: true,
+        isSelectAll: false,
         tagsFilter: null,
       };
     }

--- a/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
@@ -198,7 +198,6 @@ export function SelectedDataSources() {
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",
   });
-
   const { mcpServerViewsWithKnowledge } = useMCPServerViewsContext();
 
   const internalMcpServerView = mcpServerViewsWithKnowledge.find(
@@ -206,8 +205,7 @@ export function SelectedDataSources() {
   );
 
   const isTableOrWarehouseServer = tablesServer.includes(
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    internalMcpServerView?.server.name || ""
+    internalMcpServerView?.server.name ?? ""
   );
 
   const dataSourceViews = useMemo(() => {
@@ -236,6 +234,8 @@ export function SelectedDataSources() {
 
     return inclusionViews;
   }, [sources.in, sources.notIn]);
+
+  console.log(">>>>> dataSourceViews", dataSourceViews);
 
   const hasDataSources = Object.values(dataSourceViews).length > 0;
 

--- a/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
@@ -235,8 +235,6 @@ export function SelectedDataSources() {
     return inclusionViews;
   }, [sources.in, sources.notIn]);
 
-  console.log(">>>>> dataSourceViews", dataSourceViews);
-
   const hasDataSources = Object.values(dataSourceViews).length > 0;
 
   if (!hasDataSources) {

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -43,7 +43,14 @@ function processDataSourceConfigurations(
     workspaceId: owner.sId,
     filter: {
       parents: config.isSelectAll
-        ? null
+        ? config.excludedResources.length > 0
+          ? {
+              in: null,
+              not: config.excludedResources.map(
+                (resource) => resource.internalId
+              ),
+            }
+          : null
         : {
             in: config.selectedResources.map((resource) => resource.internalId),
             not: config.excludedResources.map(

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -42,21 +42,12 @@ function processDataSourceConfigurations(
     dataSourceViewId: config.dataSourceView.sId,
     workspaceId: owner.sId,
     filter: {
-      parents: config.isSelectAll
-        ? config.excludedResources.length > 0
-          ? {
-              in: null,
-              not: config.excludedResources.map(
-                (resource) => resource.internalId
-              ),
-            }
-          : null
-        : {
-            in: config.selectedResources.map((resource) => resource.internalId),
-            not: config.excludedResources.map(
-              (resource) => resource.internalId
-            ),
-          },
+      parents: {
+        in: config.isSelectAll
+          ? null
+          : config.selectedResources.map((resource) => resource.internalId),
+        not: config.excludedResources.map((resource) => resource.internalId),
+      },
       tags: config.tagsFilter
         ? {
             in: config.tagsFilter.in,

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -114,6 +114,9 @@ export function AssistantKnowledgeSection({
                   existingFilter.not.concat(ds.filter.parents.not)
                 );
               }
+              // We need to remove duplicates
+              existingFilter.in = _.uniq(existingFilter.in);
+              existingFilter.not = _.uniq(existingFilter.not);
             }
           } else {
             // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
@@ -156,6 +159,9 @@ export function AssistantKnowledgeSection({
                   existingFilter.not.concat(ds.filter.parents.not)
                 );
               }
+              // We need to remove duplicates
+              existingFilter.in = _.uniq(existingFilter.in);
+              existingFilter.not = _.uniq(existingFilter.not);
             }
           } else {
             // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -100,16 +100,18 @@ export function AssistantKnowledgeSection({
               const existingFilter = acc[ds.dataSourceViewId].filter.parents;
               // Merge the filters if they are not null
               if (existingFilter) {
-                existingFilter.in = existingFilter.in.concat(
-                  ds.filter.parents.in
+                // Handle case where in or not could be null
+                if (existingFilter.in !== null && ds.filter.parents.in !== null) {
+                  existingFilter.in = _.uniq(
+                    existingFilter.in.concat(ds.filter.parents.in)
+                  );
+                } else if (ds.filter.parents.in === null) {
+                  // If the new filter has in: null, it means "all", so we keep null
+                  existingFilter.in = null;
+                }
+                existingFilter.not = _.uniq(
+                  existingFilter.not.concat(ds.filter.parents.not)
                 );
-                existingFilter.not = existingFilter.not.concat(
-                  ds.filter.parents.not
-                );
-
-                // We need to remove duplicates
-                existingFilter.in = _.uniq(existingFilter.in);
-                existingFilter.not = _.uniq(existingFilter.not);
               }
             } else {
               // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
@@ -139,16 +141,18 @@ export function AssistantKnowledgeSection({
               const existingFilter = acc[ds.dataSourceViewId].filter.parents;
               // Merge the filters if they are not null
               if (existingFilter) {
-                existingFilter.in = existingFilter.in.concat(
-                  ds.filter.parents.in
+                // Handle case where in or not could be null
+                if (existingFilter.in !== null && ds.filter.parents.in !== null) {
+                  existingFilter.in = _.uniq(
+                    existingFilter.in.concat(ds.filter.parents.in)
+                  );
+                } else if (ds.filter.parents.in === null) {
+                  // If the new filter has in: null, it means "all", so we keep null
+                  existingFilter.in = null;
+                }
+                existingFilter.not = _.uniq(
+                  existingFilter.not.concat(ds.filter.parents.not)
                 );
-                existingFilter.not = existingFilter.not.concat(
-                  ds.filter.parents.not
-                );
-
-                // We need to remove duplicates
-                existingFilter.in = _.uniq(existingFilter.in);
-                existingFilter.not = _.uniq(existingFilter.not);
               }
             } else {
               // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
@@ -246,9 +250,12 @@ function getDataSourceConfigurationsForTableAction(
         }
 
         if (dataSourceView) {
-          dsConfigs[table.dataSourceViewId].filter.parents?.in.push(
-            getContentNodeInternalIdFromTableId(dataSourceView, table.tableId)
-          );
+          const parents = dsConfigs[table.dataSourceViewId].filter.parents;
+          if (parents && parents.in) {
+            parents.in.push(
+              getContentNodeInternalIdFromTableId(dataSourceView, table.tableId)
+            );
+          }
         }
 
         return dsConfigs;

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -486,63 +486,57 @@ function DataSourceViewSelectedNodes({
     viewType,
   });
 
-  return (
-    <>
-      {nodes.map((node) => (
-        <Tree.Item
-          key={node.internalId}
-          label={node.title}
-          type={node.expandable && viewType !== "table" ? "node" : "leaf"}
-          visual={getVisualForDataSourceViewContentNode(node)}
-          className="whitespace-nowrap"
-          actions={
-            <div className="mr-8 flex flex-row gap-2">
-              <IconButton
-                size="xs"
-                icon={ExternalLinkIcon}
-                onClick={() => {
-                  if (node.sourceUrl) {
-                    window.open(node.sourceUrl, "_blank");
-                  }
-                }}
-                className={classNames(
-                  node.sourceUrl ? "" : "pointer-events-none opacity-0"
-                )}
-                disabled={!node.sourceUrl}
-                variant="ghost"
-              />
-              <IconButton
-                size="xs"
-                icon={BracesIcon}
-                onClick={() => {
-                  if (node.type === "document") {
-                    setDataSourceViewToDisplay(dataSourceView);
-                    setDocumentToDisplay(node.internalId);
-                  }
-                }}
-                className={classNames(
-                  node.type === "document"
-                    ? ""
-                    : "pointer-events-none opacity-0"
-                )}
-                disabled={node.type !== "document"}
-                variant="outline"
-              />
-            </div>
-          }
-        >
-          <DataSourceViewPermissionTree
-            owner={owner}
-            dataSourceView={dataSourceView}
-            parentId={node.internalId}
-            onDocumentViewClick={(documentId: string) => {
-              setDataSourceViewToDisplay(dataSourceView);
-              setDocumentToDisplay(documentId);
+  return nodes.map((node) => (
+    <Tree.Item
+      key={node.internalId}
+      label={node.title}
+      type={node.expandable && viewType !== "table" ? "node" : "leaf"}
+      visual={getVisualForDataSourceViewContentNode(node)}
+      className="whitespace-nowrap"
+      actions={
+        <div className="mr-8 flex flex-row gap-2">
+          <IconButton
+            size="xs"
+            icon={ExternalLinkIcon}
+            onClick={() => {
+              if (node.sourceUrl) {
+                window.open(node.sourceUrl, "_blank");
+              }
             }}
-            viewType="all"
+            className={classNames(
+              node.sourceUrl ? "" : "pointer-events-none opacity-0"
+            )}
+            disabled={!node.sourceUrl}
+            variant="ghost"
           />
-        </Tree.Item>
-      ))}
-    </>
-  );
+          <IconButton
+            size="xs"
+            icon={BracesIcon}
+            onClick={() => {
+              if (node.type === "document") {
+                setDataSourceViewToDisplay(dataSourceView);
+                setDocumentToDisplay(node.internalId);
+              }
+            }}
+            className={classNames(
+              node.type === "document" ? "" : "pointer-events-none opacity-0"
+            )}
+            disabled={node.type !== "document"}
+            variant="outline"
+          />
+        </div>
+      }
+    >
+      <DataSourceViewPermissionTree
+        owner={owner}
+        dataSourceView={dataSourceView}
+        parentId={node.internalId}
+        onDocumentViewClick={(documentId: string) => {
+          setDataSourceViewToDisplay(dataSourceView);
+          setDocumentToDisplay(documentId);
+        }}
+        viewType="all"
+      />
+    </Tree.Item>
+  ));
 }

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -258,12 +258,9 @@ function getDataSourceConfigurationsForTableAction(
         }
 
         if (dataSourceView) {
-          const parents = dsConfigs[table.dataSourceViewId].filter.parents;
-          if (parents && parents.in) {
-            parents.in.push(
-              getContentNodeInternalIdFromTableId(dataSourceView, table.tableId)
-            );
-          }
+          dsConfigs[table.dataSourceViewId].filter.parents?.in?.push(
+            getContentNodeInternalIdFromTableId(dataSourceView, table.tableId)
+          );
         }
 
         return dsConfigs;

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -99,19 +99,17 @@ export function AssistantKnowledgeSection({
             const existingFilter = acc[ds.dataSourceViewId].filter.parents;
             // Merge the filters if they are not null
             if (existingFilter) {
-              if (ds.filter.parents.in === null) {
-                // If the new filter has in: null, it means "all", so we keep null.
-                existingFilter.in = null;
-              } else if (existingFilter.in !== null) {
-                existingFilter.in = _.uniq(
-                  existingFilter.in.concat(ds.filter.parents.in)
+              if (existingFilter.in !== null || ds.filter.parents.in !== null) {
+                existingFilter.in = (existingFilter.in ?? []).concat(
+                  ds.filter.parents.in ?? []
                 );
               }
-              if (ds.filter.parents.not === null) {
-                existingFilter.not = null;
-              } else if (existingFilter.not !== null) {
-                existingFilter.not = _.uniq(
-                  existingFilter.not.concat(ds.filter.parents.not)
+              if (
+                existingFilter.not !== null ||
+                ds.filter.parents.not !== null
+              ) {
+                existingFilter.not = (existingFilter.not ?? []).concat(
+                  ds.filter.parents.not ?? []
                 );
               }
               // We need to remove duplicates
@@ -144,19 +142,17 @@ export function AssistantKnowledgeSection({
             const existingFilter = acc[ds.dataSourceViewId].filter.parents;
             // Merge the filters if they are not null
             if (existingFilter) {
-              if (ds.filter.parents.in === null) {
-                // If the new filter has in: null, it means "all", so we keep null.
-                existingFilter.in = null;
-              } else if (existingFilter.in !== null) {
-                existingFilter.in = _.uniq(
-                  existingFilter.in.concat(ds.filter.parents.in)
+              if (existingFilter.in !== null || ds.filter.parents.in !== null) {
+                existingFilter.in = (existingFilter.in ?? []).concat(
+                  ds.filter.parents.in ?? []
                 );
               }
-              if (ds.filter.parents.not === null) {
-                existingFilter.not = null;
-              } else if (existingFilter.not !== null) {
-                existingFilter.not = _.uniq(
-                  existingFilter.not.concat(ds.filter.parents.not)
+              if (
+                existingFilter.not !== null ||
+                ds.filter.parents.not !== null
+              ) {
+                existingFilter.not = (existingFilter.not ?? []).concat(
+                  ds.filter.parents.not ?? []
                 );
               }
               // We need to remove duplicates

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -95,28 +95,29 @@ export function AssistantKnowledgeSection({
           if (!acc[ds.dataSourceViewId]) {
             // First one sets the filter
             acc[ds.dataSourceViewId] = ds;
-          } else {
-            if (ds.filter.parents) {
-              const existingFilter = acc[ds.dataSourceViewId].filter.parents;
-              // Merge the filters if they are not null
-              if (existingFilter) {
-                // Handle case where in or not could be null
-                if (existingFilter.in !== null && ds.filter.parents.in !== null) {
-                  existingFilter.in = _.uniq(
-                    existingFilter.in.concat(ds.filter.parents.in)
-                  );
-                } else if (ds.filter.parents.in === null) {
-                  // If the new filter has in: null, it means "all", so we keep null
-                  existingFilter.in = null;
-                }
+          } else if (ds.filter.parents) {
+            const existingFilter = acc[ds.dataSourceViewId].filter.parents;
+            // Merge the filters if they are not null
+            if (existingFilter) {
+              if (ds.filter.parents.in === null) {
+                // If the new filter has in: null, it means "all", so we keep null.
+                existingFilter.in = null;
+              } else if (existingFilter.in !== null) {
+                existingFilter.in = _.uniq(
+                  existingFilter.in.concat(ds.filter.parents.in)
+                );
+              }
+              if (ds.filter.parents.not === null) {
+                existingFilter.not = null;
+              } else if (existingFilter.not !== null) {
                 existingFilter.not = _.uniq(
                   existingFilter.not.concat(ds.filter.parents.not)
                 );
               }
-            } else {
-              // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
-              acc[ds.dataSourceViewId].filter.parents = null;
             }
+          } else {
+            // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
+            acc[ds.dataSourceViewId].filter.parents = null;
           }
         });
       }
@@ -136,28 +137,29 @@ export function AssistantKnowledgeSection({
           if (!acc[ds.dataSourceViewId]) {
             // First one sets the filter
             acc[ds.dataSourceViewId] = ds;
-          } else {
-            if (ds.filter.parents) {
-              const existingFilter = acc[ds.dataSourceViewId].filter.parents;
-              // Merge the filters if they are not null
-              if (existingFilter) {
-                // Handle case where in or not could be null
-                if (existingFilter.in !== null && ds.filter.parents.in !== null) {
-                  existingFilter.in = _.uniq(
-                    existingFilter.in.concat(ds.filter.parents.in)
-                  );
-                } else if (ds.filter.parents.in === null) {
-                  // If the new filter has in: null, it means "all", so we keep null
-                  existingFilter.in = null;
-                }
+          } else if (ds.filter.parents) {
+            const existingFilter = acc[ds.dataSourceViewId].filter.parents;
+            // Merge the filters if they are not null
+            if (existingFilter) {
+              if (ds.filter.parents.in === null) {
+                // If the new filter has in: null, it means "all", so we keep null.
+                existingFilter.in = null;
+              } else if (existingFilter.in !== null) {
+                existingFilter.in = _.uniq(
+                  existingFilter.in.concat(ds.filter.parents.in)
+                );
+              }
+              if (ds.filter.parents.not === null) {
+                existingFilter.not = null;
+              } else if (existingFilter.not !== null) {
                 existingFilter.not = _.uniq(
                   existingFilter.not.concat(ds.filter.parents.not)
                 );
               }
-            } else {
-              // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
-              acc[ds.dataSourceViewId].filter.parents = null;
             }
+          } else {
+            // But if the new one is null, we reset the filter (as it means "all" and all wins over specific)
+            acc[ds.dataSourceViewId].filter.parents = null;
           }
         });
       }

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -207,70 +207,37 @@ async function renderDataSourcesConfigurations(
 
       const serializedDataSourceView = dataSourceView.toJSON();
 
-      if (!sr.resources) {
-        // No explicit included resources means either true select-all or
-        // select-all-with-exclusions. In both cases, preserve and materialize
-        // excluded resources if provided so the UI can reconstruct the tree.
-        let excludedResources: DataSourceViewContentNode[] = [];
-        if (sr.excludedResources && sr.excludedResources.length > 0) {
-          const excludedContentNodes = await getContentNodesForDataSourceView(
-            dataSourceView,
-            { internalIds: sr.excludedResources, viewType: "all" }
-          );
-          if (excludedContentNodes.isErr()) {
-            localLogger.error(
-              {
-                dataSourceView: dataSourceView.toTraceJSON(),
-                error: excludedContentNodes.error,
-                internalIds: sr.excludedResources,
-                workspace: {
-                  id: dataSourceView.workspaceId,
-                },
-              },
-              "Agent Builder: Error fetching excluded content nodes for documents."
-            );
-          } else {
-            excludedResources = excludedContentNodes.value.nodes;
-          }
-        }
-
-        return {
-          dataSourceView: serializedDataSourceView,
-          selectedResources: [],
-          excludedResources,
-          isSelectAll: sr.isSelectAll,
-          tagsFilter: sr.tagsFilter,
-        };
-      }
-
-      const contentNodesRes = await getContentNodesForDataSourceView(
-        dataSourceView,
-        {
-          internalIds: sr.resources,
-          viewType: "document",
-        }
-      );
-
-      if (contentNodesRes.isErr()) {
-        localLogger.error(
+      let selectedResources: DataSourceViewContentNode[] = [];
+      if (sr.resources && sr.resources.length > 0) {
+        const contentNodesRes = await getContentNodesForDataSourceView(
+          dataSourceView,
           {
-            dataSourceView: dataSourceView.toTraceJSON(),
-            error: contentNodesRes.error,
             internalIds: sr.resources,
-            workspace: {
-              id: dataSourceView.workspaceId,
-            },
-          },
-          "Agent Builder: Error fetching content nodes for documents."
+            viewType: "document",
+          }
         );
 
-        return {
-          dataSourceView: serializedDataSourceView,
-          selectedResources: [],
-          excludedResources: [],
-          isSelectAll: sr.isSelectAll,
-          tagsFilter: sr.tagsFilter,
-        };
+        if (contentNodesRes.isErr()) {
+          localLogger.error(
+            {
+              dataSourceView: dataSourceView.toTraceJSON(),
+              error: contentNodesRes.error,
+              internalIds: sr.resources,
+              workspace: {
+                id: dataSourceView.workspaceId,
+              },
+            },
+            "Agent Builder: Error fetching content nodes for documents."
+          );
+          return {
+            dataSourceView: serializedDataSourceView,
+            selectedResources: [],
+            excludedResources: [],
+            isSelectAll: sr.isSelectAll,
+            tagsFilter: sr.tagsFilter,
+          };
+        }
+        selectedResources = contentNodesRes.value.nodes;
       }
 
       let excludedResources: DataSourceViewContentNode[] = [];
@@ -298,7 +265,7 @@ async function renderDataSourcesConfigurations(
 
       return {
         dataSourceView: serializedDataSourceView,
-        selectedResources: contentNodesRes.value.nodes,
+        selectedResources,
         excludedResources,
         isSelectAll: sr.isSelectAll,
         tagsFilter: sr.tagsFilter,

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -193,8 +193,7 @@ async function renderDataSourcesConfigurations(
       resources: parents?.in ?? null,
       excludedResources: parents?.not ?? null,
       isSelectAll,
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      tagsFilter: ds.filter.tags || null, // todo(TAF) Remove this when we don't need to support optional tags from builder.
+      tagsFilter: ds.filter.tags ?? null,
     };
   });
 

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -181,12 +181,9 @@ async function renderDataSourcesConfigurations(
 
   const selectedResources = action.dataSources.map((ds) => {
     const parents = ds.filter.parents;
-    // Treat the case where parents.in is null and parents.not has values as
-    // "select all with exclusions". Historically this was serialized with
-    // parents present, which made `!parents` false and incorrectly flipped
-    // `isSelectAll` to false in the builder reconstruction.
-    const isSelectAll =
-      !parents || (parents?.in == null && (parents?.not?.length ?? 0) > 0);
+    // Select-all when no parents filter, or when parents.in is null
+    // (possibly with exclusions via parents.not).
+    const isSelectAll = !parents || parents.in == null;
 
     return {
       dataSourceViewId: ds.dataSourceViewId,

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -179,14 +179,24 @@ async function renderDataSourcesConfigurations(
     },
   });
 
-  const selectedResources = action.dataSources.map((ds) => ({
-    dataSourceViewId: ds.dataSourceViewId,
-    resources: ds.filter.parents?.in ?? null,
-    excludedResources: ds.filter.parents?.not ?? null,
-    isSelectAll: !ds.filter.parents,
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    tagsFilter: ds.filter.tags || null, // todo(TAF) Remove this when we don't need to support optional tags from builder.
-  }));
+  const selectedResources = action.dataSources.map((ds) => {
+    const parents = ds.filter.parents;
+    // Treat the case where parents.in is null and parents.not has values as
+    // "select all with exclusions". Historically this was serialized with
+    // parents present, which made `!parents` false and incorrectly flipped
+    // `isSelectAll` to false in the builder reconstruction.
+    const isSelectAll =
+      !parents || (parents?.in == null && (parents?.not?.length ?? 0) > 0);
+
+    return {
+      dataSourceViewId: ds.dataSourceViewId,
+      resources: parents?.in ?? null,
+      excludedResources: parents?.not ?? null,
+      isSelectAll,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      tagsFilter: ds.filter.tags || null, // todo(TAF) Remove this when we don't need to support optional tags from builder.
+    };
+  });
 
   const dataSourceConfigurationsArray = await Promise.all(
     selectedResources.map(async (sr) => {
@@ -202,10 +212,36 @@ async function renderDataSourcesConfigurations(
       const serializedDataSourceView = dataSourceView.toJSON();
 
       if (!sr.resources) {
+        // No explicit included resources means either true select-all or
+        // select-all-with-exclusions. In both cases, preserve and materialize
+        // excluded resources if provided so the UI can reconstruct the tree.
+        let excludedResources: DataSourceViewContentNode[] = [];
+        if (sr.excludedResources && sr.excludedResources.length > 0) {
+          const excludedContentNodes = await getContentNodesForDataSourceView(
+            dataSourceView,
+            { internalIds: sr.excludedResources, viewType: "all" }
+          );
+          if (excludedContentNodes.isErr()) {
+            localLogger.error(
+              {
+                dataSourceView: dataSourceView.toTraceJSON(),
+                error: excludedContentNodes.error,
+                internalIds: sr.excludedResources,
+                workspace: {
+                  id: dataSourceView.workspaceId,
+                },
+              },
+              "Agent Builder: Error fetching excluded content nodes for documents."
+            );
+          } else {
+            excludedResources = excludedContentNodes.value.nodes;
+          }
+        }
+
         return {
           dataSourceView: serializedDataSourceView,
           selectedResources: [],
-          excludedResources: [],
+          excludedResources,
           isSelectAll: sr.isSelectAll,
           tagsFilter: sr.tagsFilter,
         };
@@ -264,23 +300,27 @@ async function renderDataSourcesConfigurations(
         }
       }
 
-      return {
+      const withResourcesResult = {
         dataSourceView: serializedDataSourceView,
         selectedResources: contentNodesRes.value.nodes,
         excludedResources,
         isSelectAll: sr.isSelectAll,
         tagsFilter: sr.tagsFilter,
       };
+
+      return withResourcesResult;
     })
   );
 
-  return dataSourceConfigurationsArray.reduce(
+  const reduced = dataSourceConfigurationsArray.reduce(
     (acc, curr) => ({
       ...acc,
       [curr.dataSourceView.sId]: curr,
     }),
     {} as DataSourceViewSelectionConfigurations
   );
+
+  return reduced;
 }
 
 async function renderTableDataSourcesConfigurations(

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -296,27 +296,23 @@ async function renderDataSourcesConfigurations(
         }
       }
 
-      const withResourcesResult = {
+      return {
         dataSourceView: serializedDataSourceView,
         selectedResources: contentNodesRes.value.nodes,
         excludedResources,
         isSelectAll: sr.isSelectAll,
         tagsFilter: sr.tagsFilter,
       };
-
-      return withResourcesResult;
     })
   );
 
-  const reduced = dataSourceConfigurationsArray.reduce(
+  return dataSourceConfigurationsArray.reduce(
     (acc, curr) => ({
       ...acc,
       [curr.dataSourceView.sId]: curr,
     }),
     {} as DataSourceViewSelectionConfigurations
   );
-
-  return reduced;
 }
 
 async function renderTableDataSourcesConfigurations(

--- a/front/lib/actions/configuration/helpers.ts
+++ b/front/lib/actions/configuration/helpers.ts
@@ -43,7 +43,8 @@ export function renderDataSourceConfiguration(
     }),
     filter: {
       parents:
-        dataSourceConfig.parentsIn && dataSourceConfig.parentsNotIn
+        dataSourceConfig.parentsIn !== null ||
+        dataSourceConfig.parentsNotIn !== null
           ? {
               in: dataSourceConfig.parentsIn,
               not: dataSourceConfig.parentsNotIn,

--- a/front/lib/api/assistant/configuration/types.ts
+++ b/front/lib/api/assistant/configuration/types.ts
@@ -3,7 +3,7 @@ import type { Order } from "sequelize";
 import type { AgentConfigurationType, TagsFilter } from "@app/types";
 
 export type DataSourceFilter = {
-  parents: { in: string[]; not: string[] } | null;
+  parents: { in: string[] | null; not: string[] } | null;
   tags?: TagsFilter;
 };
 

--- a/front/lib/api/assistant/configuration/types.ts
+++ b/front/lib/api/assistant/configuration/types.ts
@@ -3,7 +3,7 @@ import type { Order } from "sequelize";
 import type { AgentConfigurationType, TagsFilter } from "@app/types";
 
 export type DataSourceFilter = {
-  parents: { in: string[] | null; not: string[] } | null;
+  parents: { in: string[] | null; not: string[] | null } | null;
   tags?: TagsFilter;
 };
 

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -47,8 +47,8 @@ export const GetAgentConfigurationsHistoryQuerySchema = t.type({
 
 const DataSourceFilterParentsCodec = t.union([
   t.type({
-    in: t.array(t.string),
-    not: t.array(t.string),
+    in: t.union([t.array(t.string), t.null]),
+    not: t.union([t.array(t.string), t.null]),
   }),
   t.null,
 ]);


### PR DESCRIPTION
## Description

This PR fixes critical data source selection logic in the Agent Builder to properly handle "select all with exclusions" scenarios. The issue occurred when users selected an entire data source then excluded specific nodes - the system would incorrectly serialize this as `isSelectAll: false` with empty `selectedResources`, causing searches to fail.

Key fixes:
- Updates `isFullDataSource` detection to include partial selections in transformations
- Ensures `parents.not` is always included in filter structure, even for select-all cases
- Fixes server-side props helpers to correctly detect select-all state when `parents.in` is null
- Materializes excluded resources for UI reconstruction in select-all scenarios

**References:**
- Branched from @aubin-tchoi's work https://github.com/dust-tt/dust/pull/16867
- https://github.com/dust-tt/tasks/issues/4550

## Risk

Medium - affects core Agent Builder knowledge selection functionality. Changes data source configuration serialization and parent filter logic that could impact existing agent configurations.

## Deploy Plan

Deploy front and run backfill script to fix existing agent configurations with `parentsIn = []` and `parentsNotIn != []`.
