### PR TITLE
feat(front): don't trace image generations 500s errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -171,7 +171,9 @@ function createServer(
                 `Error generating image. Image generation service error: Status: ` +
                   `${error.status}, Code: ${error.code}, Message: ${error.message}`,
                 {
-                  tracked: error.code !== "moderation_blocked",
+                  // Don't track the error if we know it's not our fault: when openAI returns a 500, error.code is null.
+                  tracked:
+                    error.code !== null && error.code !== "moderation_blocked",
                 }
               )
             );


### PR DESCRIPTION
## Description

No need to track 500s from openAI, like this https://app.datadoghq.eu/logs?query=region%3Aeurope-west1%20%40toolName%3Agenerate_image%20%22Tool%20execution%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZnnBiNqWGZyzwAAABhBWm5uQmpYV0FBQTFJVUxFU1NYWE53QUwAAAAkZjE5OWU3MDYtNDFlNS00YWZhLWI1ZTItYjkzMzc4ZTA0NzZjAABRPQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760513827000&to_ts=1760517727000&live=false

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
