### PR TITLE
[front] - feat: add observability feature flag for Agent Builder

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -204,6 +204,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Microsoft Drive MCP server",
     stage: "dust_only",
   },
+  agent_builder_observability: {
+    description:
+      "Observability tab in the Agent Builder (charts powered by Elasticsearch)",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -692,6 +692,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "noop_model_feature"
   | "discord_bot"
   | "elevenlabs_tool"
+  | "agent_builder_observability"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

This PR introduces a new feature flag for enabling the Observability tab in the Agent Builder. Ensure the feature is only available in the "dust_only" stage for initial testing and evaluation

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front