### PR TITLE
[front] Add script to backfill misconfigured data sources

### DIFF
--- a/front/lib/models/assistant/actions/data_sources.ts
+++ b/front/lib/models/assistant/actions/data_sources.ts
@@ -97,13 +97,6 @@ AgentDataSourceConfiguration.init(
     sequelize: frontSequelize,
     hooks: {
       beforeValidate: (dsConfig: AgentDataSourceConfiguration) => {
-        // Checking parents.
-        if (
-          (dsConfig.parentsIn === null) !==
-          (dsConfig.parentsNotIn === null)
-        ) {
-          throw new Error("Parents must be both set or both null");
-        }
         // Checking tags.
         if ((dsConfig.tagsIn === null) !== (dsConfig.tagsNotIn === null)) {
           throw new Error("Tags must be both set or both null");

--- a/front/migrations/20251015_backfill_misconfigured_data_sources.ts
+++ b/front/migrations/20251015_backfill_misconfigured_data_sources.ts
@@ -16,7 +16,9 @@ makeScript({}, async ({ execute }, logger) => {
   const dataSourceConfigurations = await AgentDataSourceConfiguration.findAll({
     where: {
       parentsIn: [],
-      parentsNotIn: { [Op.not]: null },
+      parentsNotIn: {
+        [Op.and]: [{ [Op.not]: null }, { [Op.ne]: [] }],
+      },
     },
   });
 

--- a/front/migrations/20251015_backfill_misconfigured_data_sources.ts
+++ b/front/migrations/20251015_backfill_misconfigured_data_sources.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs";
+import { Op } from "sequelize";
+
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+
+const UPDATE_CONCURRENCY = 10;
+
+makeScript({}, async ({ execute }, logger) => {
+  let revertSql = "";
+
+  logger.info("Starting migration of AgentDataSourceConfiguration parentsIn");
+
+  const configurations = await AgentDataSourceConfiguration.findAll({
+    where: {
+      parentsIn: [],
+      parentsNotIn: { [Op.not]: null },
+    },
+  });
+
+  logger.info(`Found ${configurations.length} configurations to process`);
+
+  await concurrentExecutor(
+    configurations,
+    async (config) => {
+      const configLogger = logger.child({ configId: config.id });
+
+      // Generate revert SQL for this configuration
+      revertSql += `UPDATE "agent_data_source_configurations" SET "parentsIn" = '{}' WHERE "id" = ${config.id};\n`;
+
+      if (execute) {
+        await config.update({
+          parentsIn: null,
+        });
+        configLogger.info("Updated parentsIn to null", {
+          oldParentsIn: config.parentsIn,
+          parentsNotIn: config.parentsNotIn,
+        });
+      } else {
+        configLogger.info("Would update parentsIn to null (dry run)", {
+          oldParentsIn: config.parentsIn,
+          parentsNotIn: config.parentsNotIn,
+        });
+      }
+    },
+    { concurrency: UPDATE_CONCURRENCY }
+  );
+
+  if (execute && revertSql) {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const revertFileName = `revert_agent_data_source_config_parents_${timestamp}.sql`;
+    fs.writeFileSync(revertFileName, revertSql);
+    logger.info(`Revert SQL written to ${revertFileName}`);
+  }
+
+  logger.info(
+    `Migration completed. Processed ${configurations.length} configurations`
+  );
+});

--- a/front/migrations/20251015_backfill_misconfigured_data_sources.ts
+++ b/front/migrations/20251015_backfill_misconfigured_data_sources.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import * as fs from "fs";
 import { Op } from "sequelize";
 
@@ -26,6 +27,16 @@ makeScript({}, async ({ execute }, logger) => {
   await concurrentExecutor(
     dataSourceConfigurations,
     async (configuration) => {
+      assert(
+        configuration.parentsNotIn !== null,
+        "parentsNotIn should be not null"
+      );
+      assert(
+        Array.isArray(configuration.parentsIn) &&
+          configuration.parentsIn.length === 0,
+        "parentsIn should be an empty array"
+      );
+
       revertSql += `UPDATE "agent_data_source_configurations" SET "parentsIn" = '{}' WHERE "id" = ${configuration.id};\n`;
 
       if (execute) {


### PR DESCRIPTION
## Description

- Part of https://dust4ai.slack.com/archives/C05B529FHV1/p1760453688983949.
- This PR adds a script to backfill the misconfigured agent data source configurations and generate a revert SQL.

## Tests

- Checked locally.

## Risk

## Deploy Plan

- No deploy.
