### PR TITLE
Fix error message displayed when max number of seats in workspace is reached

### DIFF
--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -121,11 +121,13 @@ export async function sendInvitations({
       });
     }
 
+    const errorMessage =
+      data?.error?.message || "Failed to invite new members to workspace";
+
     sendNotification({
       type: "error",
       title: "Invite failed",
-      description:
-        "Failed to invite new members to workspace: " + res.statusText,
+      description: errorMessage,
     });
   } else {
     const result: PostInvitationResponseBody = await res.json();


### PR DESCRIPTION
## Description

Runner card: https://github.com/dust-tt/tasks/issues/4648

The workspace on the card has more seats than what's in the plan trialing so they get an error:  "Not enough seats lefts (-19 seats remaining). Please upgrade or remove inactive members to add more."

This PR just fixes the incoherent message we display + display the error message in the notification instead of "Bad request" 😅 

## Tests

No tested 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
