### PR TITLE
FIx getDefaultAgentFormData: use fallback if preferred model provider is not whitelisted

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -169,9 +169,12 @@ export default function AgentBuilder({
     } else if (agentConfiguration) {
       baseValues = transformAgentConfigurationToFormData(agentConfiguration);
     } else if (assistantTemplate) {
-      baseValues = transformTemplateToFormData(assistantTemplate, user);
+      baseValues = transformTemplateToFormData(assistantTemplate, user, owner);
     } else {
-      baseValues = getDefaultAgentFormData(user);
+      baseValues = getDefaultAgentFormData({
+        owner,
+        user,
+      });
     }
 
     return {
@@ -201,6 +204,7 @@ export default function AgentBuilder({
       },
     };
   }, [
+    owner,
     agentConfiguration,
     assistantTemplate,
     user,


### PR DESCRIPTION
## Description

If you deactivate anthropic provider (since it's our default model), you can't use the agent in preview and if you save it then you cannot use it since you will get the error: 
> "Assistant soupinou is based on a model that was disabled by your workspace admin. Please edit the agent to use another model (advanced settings in the Instructions panel)."

This PR fixes it and sets another model if the preferred one is deactivated. 
Note: if all providers are deactivated (currently possible), then we keep anthropic as default.  

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 