### PR TITLE
feat(front): up version of scrub_workspace temporal workflow

### DIFF
--- a/front/temporal/scrub_workspace/config.ts
+++ b/front/temporal/scrub_workspace/config.ts
@@ -1,4 +1,4 @@
-const QUEUE_VERSION = 1;
+const QUEUE_VERSION = 2;
 export const QUEUE_NAME = `scrub-workspace-queue-v${QUEUE_VERSION}`;
 
 export const DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID =


### PR DESCRIPTION
## Description

We see ["Non determinism" logs](https://app.datadoghq.eu/logs?query=Nondeterminism%20shouldStillScrubData%20pauseAllConnectors&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760454979000&to_ts=1760458879000&live=false
) from the `shouldStillScrubData` activity

I _suppose_ it comes from [this change I made yesterday](https://github.com/dust-tt/dust/commit/5c2023030eab65a3891585ceaf7222731539afbc). 

So we should update the version of the workflow.


⚠️ I'm 20% sure this is the right thing to do


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
