### PR TITLE
[front] enh(logging): add `workspaceId` and `userId` to tool validation logs

### DIFF
--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -74,6 +74,7 @@ export async function validateAction(
   }
 ): Promise<Result<void, DustError>> {
   const owner = auth.getNonNullableWorkspace();
+  const user = auth.user();
   const { sId: conversationId, title: conversationTitle } = conversation;
 
   logger.info(
@@ -83,7 +84,7 @@ export async function validateAction(
       approvalState,
       conversationId,
       workspaceId: owner.sId,
-      userId: auth.user()?.sId,
+      userId: user?.sId,
     },
     "Tool validation request"
   );
@@ -129,15 +130,12 @@ export async function validateAction(
     getMCPApprovalStateFromUserApprovalState(approvalState)
   );
 
-  if (approvalState === "always_approved") {
-    const user = auth.user();
-    if (user) {
-      await setUserAlwaysApprovedTool({
-        user,
-        mcpServerId: action.toolConfiguration.toolServerId,
-        functionCallName: action.functionCallName,
-      });
-    }
+  if (approvalState === "always_approved" && user) {
+    await setUserAlwaysApprovedTool({
+      user,
+      mcpServerId: action.toolConfiguration.toolServerId,
+      functionCallName: action.functionCallName,
+    });
   }
 
   if (updatedCount === 0) {
@@ -147,7 +145,7 @@ export async function validateAction(
         messageId,
         approvalState,
         workspaceId: owner.sId,
-        userId: auth.user()?.sId,
+        userId: user?.sId,
       },
       "Action already approved or rejected"
     );

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -73,6 +73,7 @@ export async function validateAction(
     messageId: string;
   }
 ): Promise<Result<void, DustError>> {
+  const owner = auth.getNonNullableWorkspace();
   const { sId: conversationId, title: conversationTitle } = conversation;
 
   logger.info(
@@ -81,6 +82,8 @@ export async function validateAction(
       messageId,
       approvalState,
       conversationId,
+      workspaceId: owner.sId,
+      userId: auth.user()?.sId,
     },
     "Tool validation request"
   );
@@ -143,6 +146,8 @@ export async function validateAction(
         actionId,
         messageId,
         approvalState,
+        workspaceId: owner.sId,
+        userId: auth.user()?.sId,
       },
       "Action already approved or rejected"
     );


### PR DESCRIPTION
## Description

- This PR adds the workspaceId and userId to the two tool validation log.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
