### PR TITLE
[front] refactor(MCP): uniformize default values handling

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -98,9 +98,18 @@ describe("getDefaultConfiguration", () => {
             {
               key: "is_enabled",
               description: "Whether the feature is enabled",
+              default: null,
             },
-            { key: "admin_mode", description: "Admin mode setting" },
-            { key: "nested.deep.flag", description: "A deeply nested boolean" },
+            {
+              key: "admin_mode",
+              description: "Admin mode setting",
+              default: null,
+            },
+            {
+              key: "nested.deep.flag",
+              description: "A deeply nested boolean",
+              default: null,
+            },
           ],
           requiredEnums: {},
           requiredLists: {},
@@ -139,8 +148,16 @@ describe("getDefaultConfiguration", () => {
               description: "Feature enabled",
               default: true,
             },
-            { key: "debug_mode", description: "Debug mode", default: false },
-            { key: "auto_save", description: "Auto save" }, // no explicit default
+            {
+              key: "debug_mode",
+              description: "Debug mode",
+              default: false,
+            },
+            {
+              key: "auto_save",
+              description: "Auto save",
+              default: null,
+            },
           ],
           requiredEnums: {},
           requiredLists: {},
@@ -204,6 +221,7 @@ describe("getDefaultConfiguration", () => {
                 { value: "high", label: "High" },
               ],
               description: "Priority level",
+              default: null,
             },
             category: {
               options: [
@@ -212,6 +230,7 @@ describe("getDefaultConfiguration", () => {
                 { value: "C", label: "Option C" },
               ],
               description: "Category selection",
+              default: null,
             },
             "nested.enum": {
               options: [
@@ -219,6 +238,7 @@ describe("getDefaultConfiguration", () => {
                 { value: "option2", label: "Option 2" },
               ],
               description: "Nested enum",
+              default: null,
             },
           },
           requiredLists: {},
@@ -257,10 +277,12 @@ describe("getDefaultConfiguration", () => {
                 { value: "option2", label: "Option 2" },
               ],
               description: "Valid enum",
+              default: null,
             },
             empty_enum: {
               options: [],
               description: "Empty enum",
+              default: null,
             },
           },
           requiredLists: {},
@@ -305,7 +327,8 @@ describe("getDefaultConfiguration", () => {
                 { value: "published", label: "Published" },
                 { value: "archived", label: "Archived" },
               ],
-              description: "Status", // no explicit default, should use first
+              description: "Status",
+              default: null,
             },
           },
           requiredLists: {},
@@ -344,6 +367,7 @@ describe("getDefaultConfiguration", () => {
                 { value: "tag2", label: "Tag 2" },
               ],
               description: "Available tags",
+              default: null,
             },
             categories: {
               options: [
@@ -351,10 +375,12 @@ describe("getDefaultConfiguration", () => {
                 { value: "cat2", label: "Category 2" },
               ],
               description: "Available categories",
+              default: null,
             },
             "nested.lists": {
               options: [{ value: "item1", label: "Item 1" }],
               description: "Nested list",
+              default: null,
             },
           },
           requiresDustAppConfiguration: false,
@@ -395,7 +421,11 @@ describe("getDefaultConfiguration", () => {
               description: "Endpoint URL",
               default: "https://api.example.com",
             },
-            { key: "user_name", description: "User Name" }, // no default
+            {
+              key: "user_name",
+              description: "User Name",
+              default: null,
+            },
           ],
           requiredNumbers: [],
           requiredBooleans: [],
@@ -431,7 +461,7 @@ describe("getDefaultConfiguration", () => {
           requiredNumbers: [
             { key: "timeout", description: "Timeout in seconds", default: 30 },
             { key: "max_retries", description: "Maximum retries", default: 3 },
-            { key: "port", description: "Port number" }, // no default
+            { key: "port", description: "Port number", default: null },
           ],
           requiredBooleans: [],
           requiredEnums: {},
@@ -468,7 +498,9 @@ describe("getDefaultConfiguration", () => {
           requiredNumbers: [
             { key: "timeout", description: "Timeout", default: 30 },
           ],
-          requiredBooleans: [{ key: "is_enabled", description: "Enabled" }],
+          requiredBooleans: [
+            { key: "is_enabled", description: "Enabled", default: null },
+          ],
           requiredEnums: {
             priority: {
               options: [
@@ -477,12 +509,14 @@ describe("getDefaultConfiguration", () => {
                 { value: "high", label: "High" },
               ],
               description: "Priority",
+              default: null,
             },
           },
           requiredLists: {
             tags: {
               options: [{ value: "tag1", label: "Tag 1" }],
               description: "Tags",
+              default: null,
             },
           },
           requiresDustAppConfiguration: false,
@@ -514,8 +548,16 @@ describe("getDefaultConfiguration", () => {
           mayRequireTimeFrameConfiguration: false,
           mayRequireJsonSchemaConfiguration: false,
           requiredStrings: [
-            { key: "api.key", description: "API Key", default: "dev-key-123" },
-            { key: "api.endpoint", description: "API Endpoint" }, // no default
+            {
+              key: "api.key",
+              description: "API Key",
+              default: "dev-key-123",
+            },
+            {
+              key: "api.endpoint",
+              description: "API Endpoint",
+              default: null,
+            },
             {
               key: "database.connection.string",
               description: "DB Connection",
@@ -523,9 +565,21 @@ describe("getDefaultConfiguration", () => {
             },
           ],
           requiredNumbers: [
-            { key: "api.timeout", description: "API Timeout", default: 5000 },
-            { key: "database.pool.max", description: "Max Pool Size" }, // no default
-            { key: "server.port", description: "Server Port", default: 3000 },
+            {
+              key: "api.timeout",
+              description: "API Timeout",
+              default: 5000,
+            },
+            {
+              key: "database.pool.max",
+              description: "Max Pool Size",
+              default: null,
+            },
+            {
+              key: "server.port",
+              description: "Server Port",
+              default: 3000,
+            },
           ],
           requiredBooleans: [
             {
@@ -533,7 +587,11 @@ describe("getDefaultConfiguration", () => {
               description: "Auth enabled",
               default: true,
             },
-            { key: "features.logging.debug", description: "Debug logging" }, // no default (will use false)
+            {
+              key: "features.logging.debug",
+              description: "Debug logging",
+              default: null,
+            },
           ],
           requiredEnums: {
             "logging.level": {
@@ -552,7 +610,8 @@ describe("getDefaultConfiguration", () => {
                 { value: "staging", label: "Staging" },
                 { value: "production", label: "Production" },
               ],
-              description: "Environment", // no default (will use first)
+              description: "Environment",
+              default: null,
             },
           },
           requiredLists: {
@@ -569,7 +628,8 @@ describe("getDefaultConfiguration", () => {
                 { value: "localhost", label: "Localhost" },
                 { value: "example.com", label: "Example" },
               ],
-              description: "Allowed origins", // no default (will use empty array)
+              description: "Allowed origins",
+              default: null,
             },
           },
           requiresDustAppConfiguration: false,
@@ -627,7 +687,11 @@ describe("getDefaultConfiguration", () => {
           requiredStrings: [],
           requiredNumbers: [],
           requiredBooleans: [
-            { key: "level1.level2.level3.deep_flag", description: "Deep flag" },
+            {
+              key: "level1.level2.level3.deep_flag",
+              description: "Deep flag",
+              default: null,
+            },
           ],
           requiredEnums: {
             "a.b.c.d.enum": {
@@ -636,12 +700,14 @@ describe("getDefaultConfiguration", () => {
                 { value: "y", label: "Y" },
               ],
               description: "Deeply nested enum",
+              default: null,
             },
           },
           requiredLists: {
             "config.advanced.options": {
               options: [{ value: "opt1", label: "Option 1" }],
               description: "Advanced options",
+              default: null,
             },
           },
           requiresDustAppConfiguration: false,

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -50,7 +50,7 @@ export function getDefaultConfiguration(
   for (const [key, { options, default: defaultValue }] of Object.entries(
     requiredEnums
   )) {
-    if (defaultValue !== undefined) {
+    if (defaultValue !== null) {
       set(additionalConfig, key, defaultValue);
     } else if (options.length > 0) {
       set(additionalConfig, key, options[0].value);
@@ -60,21 +60,17 @@ export function getDefaultConfiguration(
   for (const [key, { default: defaultValue }] of Object.entries(
     requiredLists
   )) {
-    set(
-      additionalConfig,
-      key,
-      defaultValue !== undefined ? [defaultValue] : []
-    );
+    set(additionalConfig, key, defaultValue !== null ? [defaultValue] : []);
   }
 
   for (const { key, default: defaultValue } of requiredStrings) {
-    if (defaultValue !== undefined) {
+    if (defaultValue !== null) {
       set(additionalConfig, key, defaultValue);
     }
   }
 
   for (const { key, default: defaultValue } of requiredNumbers) {
-    if (defaultValue !== undefined) {
+    if (defaultValue !== null) {
       set(additionalConfig, key, defaultValue);
     }
   }

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -312,17 +312,22 @@ export function findPathsToConfiguration({
   return matches;
 }
 
+function extractSchemaDefault(schema: JSONSchema | null) {
+  if (
+    schema?.default &&
+    typeof schema.default === "object" &&
+    "value" in schema.default
+  ) {
+    return schema.default.value;
+  }
+
+  return null;
+}
+
 function getDefaultValueAtPath(inputSchema: JSONSchema, keyPath: string) {
   const property = findSchemaAtPath(inputSchema, keyPath.split("."));
 
-  if (
-    property?.default &&
-    typeof property.default === "object" &&
-    "value" in property.default
-  ) {
-    return property.default.value;
-  }
-  return null;
+  return extractSchemaDefault(property);
 }
 
 /**
@@ -448,18 +453,6 @@ export function augmentInputsWithConfiguration({
   });
 
   return inputs;
-}
-
-function extractSchemaDefault(schema: JSONSchema) {
-  if (
-    schema.default &&
-    typeof schema.default === "object" &&
-    "value" in schema.default
-  ) {
-    return schema.default.value;
-  }
-
-  return null;
 }
 
 export interface MCPServerRequirements {

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -683,10 +683,9 @@ export function getMCPServerRequirements(
                 return {
                   value: v.properties.value.const,
                   label: v.properties.label.const,
-                  description:
-                    typeof v.description === "string"
-                      ? v.description
-                      : undefined,
+                  description: isString(v.description)
+                    ? v.description
+                    : undefined,
                 };
               }
               return null;
@@ -747,8 +746,9 @@ export function getMCPServerRequirements(
               return {
                 value: v.properties.value.const,
                 label: v.properties.label.const,
-                description:
-                  typeof v.description === "string" ? v.description : undefined,
+                description: isString(v.description)
+                  ? v.description
+                  : undefined,
               };
             }
             return null;

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -814,11 +814,11 @@ export function getMCPServerRequirements(
       !requiresReasoningConfiguration &&
       !mayRequireTimeFrameConfiguration &&
       !mayRequireJsonSchemaConfiguration &&
-      !requiredStrings.some((c) => c.default === undefined) &&
-      !requiredNumbers.some((c) => c.default === undefined) &&
-      !requiredBooleans.some((c) => c.default === undefined) &&
-      !Object.values(requiredEnums).some((c) => c.default === undefined) &&
-      !Object.values(requiredLists).some((c) => c.default === undefined) &&
+      !requiredStrings.some((c) => c.default === null) &&
+      !requiredNumbers.some((c) => c.default === null) &&
+      !requiredBooleans.some((c) => c.default === null) &&
+      !Object.values(requiredEnums).some((c) => c.default === null) &&
+      !Object.values(requiredLists).some((c) => c.default === null) &&
       !requiresDustAppConfiguration &&
       !requiresSecretConfiguration,
   };


### PR DESCRIPTION
## Description

- This PR refactors the function `extractSchemaDefault`, which is redundant with `getDefaultValueAtPath` and both retrieves a value on a JSON schema and typeguards it in a way that is very much not consistent wrt to our codebase's standards.

## Tests

- Checked locally.

## Risk

- Medium, critical code path but not a very widely used feature (defaults).

## Deploy Plan

- Deploy front.
