### PR TITLE
Defer some rate limit logic to Slack client

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -41,6 +41,10 @@ export function reportSlackUsage({
   statsDClient.increment("slack_api_call.count", 1, tags);
 }
 
+interface SlackClientOptions {
+  rejectOnRateLimit?: boolean;
+}
+
 /**
  * Creates a Slack WebClient instance for making API calls.
  *
@@ -61,12 +65,17 @@ export function reportSlackUsage({
  * const result = await slackClient.conversations.list({ types: "public_channel" });
  * ```
  */
-export async function getSlackClient(connectorId: ModelId): Promise<WebClient>;
 export async function getSlackClient(
-  slackAccessToken: string
+  connectorId: ModelId,
+  options?: SlackClientOptions
 ): Promise<WebClient>;
 export async function getSlackClient(
-  connectorIdOrAccessToken: string | ModelId
+  slackAccessToken: string,
+  options?: SlackClientOptions
+): Promise<WebClient>;
+export async function getSlackClient(
+  connectorIdOrAccessToken: string | ModelId,
+  options?: SlackClientOptions
 ): Promise<WebClient> {
   let slackAccessToken: string | undefined = undefined;
   if (typeof connectorIdOrAccessToken === "number") {
@@ -80,13 +89,19 @@ export async function getSlackClient(
   } else {
     slackAccessToken = connectorIdOrAccessToken;
   }
+
+  // By default, we want to reject on rate limit errors.
+  const { rejectOnRateLimit = true } = options ?? {};
+
   const slackClient = new WebClient(slackAccessToken, {
     timeout: SLACK_NETWORK_TIMEOUT_MS,
-    rejectRateLimitedCalls: true,
-    // retryConfig: {
-    //   retries: 1,
-    //   factor: 1,
-    // },
+    rejectRateLimitedCalls: rejectOnRateLimit,
+    retryConfig: rejectOnRateLimit
+      ? undefined
+      : {
+          retries: 5,
+          factor: 2,
+        },
   });
 
   return slackClient;

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -102,7 +102,9 @@ export async function syncChannel(
     throw new Error(`Connector ${connectorId} not found`);
   }
 
-  const slackClient = await getSlackClient(connectorId);
+  const slackClient = await getSlackClient(connectorId, {
+    rejectOnRateLimit: false,
+  });
 
   const remoteChannel = await withSlackErrorHandling(() =>
     getChannelById(slackClient, connectorId, channelId)
@@ -301,7 +303,9 @@ export async function getMessagesForChannel(
   limit = 100,
   nextCursor?: string
 ): Promise<ConversationsHistoryResponse> {
-  const slackClient = await getSlackClient(connectorId);
+  const slackClient = await getSlackClient(connectorId, {
+    rejectOnRateLimit: false,
+  });
 
   reportSlackUsage({
     connectorId,
@@ -772,7 +776,9 @@ export async function syncThread(
     throw new Error(`Connector ${connectorId} not found`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const slackClient = await getSlackClient(connectorId);
+  const slackClient = await getSlackClient(connectorId, {
+    rejectOnRateLimit: false,
+  });
 
   let allMessages: MessageElement[] = [];
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See context in [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1760512157018739). 

We've observed not very reliable `retryAfter` headers sent back when hitting a rate limit on the Slack API (it always send back 10 seconds).

This PR defers some rate limits to Slack client which offers a way to handle this internally without throwing any error. We do it exclusively on functions used in Temporal activities as we don't want the API endpoints to hang for too long. The current retry strategy is based on the default values that the client has.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
