### PR TITLE
fix: update deprecated /agent/ path to /conversation/ in Frames and Slack

### DIFF
--- a/connectors/src/connectors/slack/chat/utils.ts
+++ b/connectors/src/connectors/slack/chat/utils.ts
@@ -9,7 +9,7 @@ export function makeConversationUrl(
   conversationId?: string | null
 ) {
   if (workspaceId && conversationId) {
-    return makeDustAppUrl(`/w/${workspaceId}/agent/${conversationId}`);
+    return makeDustAppUrl(`/w/${workspaceId}/conversation/${conversationId}`);
   }
   return null;
 }

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -6,6 +6,7 @@ import config from "@app/lib/api/config";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { getConversationRoute } from "@app/lib/utils/router";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { frameContentType } from "@app/types";
@@ -130,7 +131,12 @@ async function handler(
     file: file.toJSON(),
     // Only return the conversation URL if the user is a participant of the conversation.
     conversationUrl: isParticipant
-      ? `${config.getClientFacingUrl()}/w/${workspace.sId}/agent/${conversationId}`
+      ? getConversationRoute(
+          workspace.sId,
+          conversationId,
+          undefined,
+          config.getClientFacingUrl()
+        )
       : null,
   });
 }


### PR DESCRIPTION
## Summary

Fixed hardcoded conversation URLs using deprecated `/agent/` path instead of `/conversation/` in two locations:

1. **Frames API**: Updated to use `getConversationRoute()` utility with proper `/conversation/` path
2. **Slack connector**: Changed hardcoded `/agent/` to `/conversation/` path

## Changes

- `front/pages/api/v1/public/frames/[token]/index.ts`: Now uses `getConversationRoute()` helper
- `connectors/src/connectors/slack/chat/utils.ts`: Updated path in `makeConversationUrl()`

## Testing

- ✅ TypeScript compilation passed for front project
- ✅ TypeScript compilation passed for connectors project

Fixes #16927

🤖 Generated with [Claude Code](https://claude.ai/code)