### PR TITLE
Deep Dive tool: do not pass dust instructions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -31,7 +31,7 @@ function createServer(
   const owner = auth.getNonNullableWorkspace();
 
   server.tool(
-    "handoff_deep_dive",
+    "handoff",
     `Launch a handoff to the :mention[${DEEP_DIVE_NAME}]{sId=${GLOBAL_AGENTS_SID.DEEP_DIVE}} agent`,
     {},
     withToolLogging(

--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -14,7 +14,13 @@ import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { Err, getHeaderFromUserEmail, GLOBAL_AGENTS_SID, Ok } from "@app/types";
+import {
+  Err,
+  getHeaderFromUserEmail,
+  GLOBAL_AGENTS_SID,
+  isGlobalAgentId,
+  Ok,
+} from "@app/types";
 
 function createServer(
   auth: Authenticator,
@@ -25,7 +31,7 @@ function createServer(
   const owner = auth.getNonNullableWorkspace();
 
   server.tool(
-    "handoff",
+    "handoff_deep_dive",
     `Launch a handoff to the :mention[${DEEP_DIVE_NAME}]{sId=${GLOBAL_AGENTS_SID.DEEP_DIVE}} agent`,
     {},
     withToolLogging(
@@ -56,7 +62,16 @@ function createServer(
         const runContext = agentLoopContext.runContext;
         const { agentConfiguration, conversation, agentMessage } = runContext;
         const instructions = agentConfiguration.instructions;
-        const query = `The user's query is being handed off to you from @${agentConfiguration.name} within the same conversation. The calling agent's instructions are: <caller_agent_instructions>${instructions ?? ""}</caller_agent_instructions>`;
+        let query = `The user's query is being handed off to you from @${agentConfiguration.name} within the same conversation.`;
+
+        const shouldIncludeAgentInstructions =
+          agentConfiguration.instructions &&
+          agentConfiguration.instructions.length > 0 &&
+          !isGlobalAgentId(agentConfiguration.sId);
+
+        if (shouldIncludeAgentInstructions) {
+          query += ` The calling agent's instructions are: <caller_agent_instructions>${instructions ?? ""}</caller_agent_instructions>`;
+        }
 
         const convRes = await getOrCreateConversation(api, runContext, {
           childAgentBlob: {

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -106,7 +106,7 @@ export function _getDustGlobalAgent(
   - It requires doing several web searches, or browsing 3+ web pages
   - It requires running SQL queries
   - It requires 3+ steps of tool uses
-  - The user specifically asks for a "deep dive", a "deep research", a "comprehensive analysis" or other terms that indicate a deep research task
+  - The user specifically asks for a "deep dive", a "deep research", a "comprehensive search", a "comprehensive analysis" or "comprehensive report" or other terms that indicate a deep research task
 
   Any other request is considered "simple".
 


### PR DESCRIPTION
## Description

Do not pass the instruction of caller agent in Deep Dive tool if: 
- the caller has no instruction 😅 
- the caller is a global agent (dust or any raw agent when tool is JITted)

## Tests

Locally it works. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
