### PR TITLE
[front] refactor(MCP): DRY additional configuration prop typing

### DIFF
--- a/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
@@ -18,10 +18,9 @@ import { useController } from "react-hook-form";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { ConfigurationSectionContainer } from "@app/components/agent_builder/capabilities/shared/ConfigurationSectionContainer";
+import type { MCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { asDisplayName } from "@app/types";
-
-type OptionalDescribedKey = { key: string; description?: string };
 
 function formatKeyForDisplay(key: string): string {
   const segments = key.split(".");
@@ -34,9 +33,12 @@ function getKeyPrefix(key: string): string {
 }
 
 function groupKeysByPrefix(
-  items: OptionalDescribedKey[]
-): Record<string, OptionalDescribedKey[]> {
-  const groups: Record<string, OptionalDescribedKey[]> = {};
+  items:
+    | MCPServerRequirements["requiredNumbers"]
+    | MCPServerRequirements["requiredStrings"]
+    | MCPServerRequirements["requiredBooleans"]
+): Record<string, { key: string; description?: string }[]> {
+  const groups: Record<string, { key: string; description?: string }[]> = {};
 
   items.forEach((item) => {
     const prefix = getKeyPrefix(item.key);
@@ -49,13 +51,15 @@ function groupKeysByPrefix(
   return groups;
 }
 
+interface BaseConfigurationInputProps {
+  configKey: string;
+  description?: string;
+}
+
 function BooleanConfigurationInput({
   configKey,
   description,
-}: {
-  configKey: string;
-  description?: string;
-}) {
+}: BaseConfigurationInputProps) {
   const { field } = useController<MCPFormData>({
     name: `configuration.additionalConfiguration.${configKey}`,
   });
@@ -88,11 +92,12 @@ function BooleanConfigurationInput({
   );
 }
 
+interface BooleanConfigurationSectionProps
+  extends Pick<MCPServerRequirements, "requiredBooleans"> {}
+
 function BooleanConfigurationSection({
   requiredBooleans,
-}: {
-  requiredBooleans: OptionalDescribedKey[];
-}) {
+}: BooleanConfigurationSectionProps) {
   if (requiredBooleans.length === 0) {
     return null;
   }
@@ -106,13 +111,15 @@ function BooleanConfigurationSection({
   ));
 }
 
+interface NumberConfigurationInputProps {
+  configKey: string;
+  description?: string;
+}
+
 function NumberConfigurationInput({
   configKey,
   description,
-}: {
-  configKey: string;
-  description?: string;
-}) {
+}: NumberConfigurationInputProps) {
   const { field, fieldState } = useController<MCPFormData>({
     name: `configuration.additionalConfiguration.${configKey}`,
   });
@@ -151,11 +158,12 @@ function NumberConfigurationInput({
   );
 }
 
+interface NumberConfigurationSectionProps
+  extends Pick<MCPServerRequirements, "requiredNumbers"> {}
+
 function NumberConfigurationSection({
   requiredNumbers,
-}: {
-  requiredNumbers: OptionalDescribedKey[];
-}) {
+}: NumberConfigurationSectionProps) {
   if (requiredNumbers.length === 0) {
     return null;
   }
@@ -169,13 +177,15 @@ function NumberConfigurationSection({
   ));
 }
 
+interface StringConfigurationInputProps {
+  configKey: string;
+  description?: string;
+}
+
 function StringConfigurationInput({
   configKey,
   description,
-}: {
-  configKey: string;
-  description?: string;
-}) {
+}: StringConfigurationInputProps) {
   const { field, fieldState } = useController<MCPFormData>({
     name: `configuration.additionalConfiguration.${configKey}`,
   });
@@ -214,11 +224,12 @@ function StringConfigurationInput({
   );
 }
 
+interface StringConfigurationSectionProps
+  extends Pick<MCPServerRequirements, "requiredStrings"> {}
+
 function StringConfigurationSection({
   requiredStrings,
-}: {
-  requiredStrings: OptionalDescribedKey[];
-}) {
+}: StringConfigurationSectionProps) {
   if (requiredStrings.length === 0) {
     return null;
   }
@@ -232,15 +243,17 @@ function StringConfigurationSection({
   ));
 }
 
+interface EnumConfigurationInputProps {
+  configKey: string;
+  enumOptions: MCPServerRequirements["requiredEnums"][string]["options"];
+  description?: string;
+}
+
 function EnumConfigurationInput({
   configKey,
   enumOptions,
   description,
-}: {
-  configKey: string;
-  enumOptions: { value: string; label: string; description?: string }[];
-  description?: string;
-}) {
+}: EnumConfigurationInputProps) {
   const { field, fieldState } = useController<MCPFormData>({
     name: `configuration.additionalConfiguration.${configKey}`,
   });
@@ -310,17 +323,12 @@ function EnumConfigurationInput({
   );
 }
 
+interface EnumConfigurationSectionProps
+  extends Pick<MCPServerRequirements, "requiredEnums"> {}
+
 function EnumConfigurationSection({
   requiredEnums,
-}: {
-  requiredEnums: Record<
-    string,
-    {
-      options: { value: string; label: string; description?: string }[];
-      description?: string;
-    }
-  >;
-}) {
+}: EnumConfigurationSectionProps) {
   if (Object.keys(requiredEnums).length === 0) {
     return null;
   }
@@ -337,15 +345,17 @@ function EnumConfigurationSection({
   );
 }
 
+interface ListConfigurationInputProps {
+  configKey: string;
+  listOptions: MCPServerRequirements["requiredLists"][string]["options"];
+  description?: string;
+}
+
 function ListConfigurationInput({
   configKey,
   listOptions,
   description,
-}: {
-  configKey: string;
-  listOptions: { value: string; label: string; description?: string }[];
-  description?: string;
-}) {
+}: ListConfigurationInputProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const { field, fieldState } = useController<MCPFormData>({
     name: `configuration.additionalConfiguration.${configKey}`,
@@ -433,17 +443,12 @@ function ListConfigurationInput({
   );
 }
 
+interface ListConfigurationSectionProps
+  extends Pick<MCPServerRequirements, "requiredLists"> {}
+
 function ListConfigurationSection({
   requiredLists,
-}: {
-  requiredLists: Record<
-    string,
-    {
-      options: { value: string; label: string; description?: string }[];
-      description?: string;
-    }
-  >;
-}) {
+}: ListConfigurationSectionProps) {
   if (Object.keys(requiredLists).length === 0) {
     return null;
   }
@@ -460,25 +465,16 @@ function ListConfigurationSection({
   );
 }
 
-interface GroupedConfigurationSectionProps {
+interface GroupedConfigurationSectionProps
+  extends Pick<
+    MCPServerRequirements,
+    | "requiredStrings"
+    | "requiredNumbers"
+    | "requiredBooleans"
+    | "requiredEnums"
+    | "requiredLists"
+  > {
   prefix: string;
-  requiredStrings: OptionalDescribedKey[];
-  requiredNumbers: OptionalDescribedKey[];
-  requiredBooleans: OptionalDescribedKey[];
-  requiredEnums: Record<
-    string,
-    {
-      options: { value: string; label: string; description?: string }[];
-      description?: string;
-    }
-  >;
-  requiredLists: Record<
-    string,
-    {
-      options: { value: string; label: string; description?: string }[];
-      description?: string;
-    }
-  >;
 }
 
 function GroupedConfigurationSection({
@@ -518,25 +514,15 @@ function GroupedConfigurationSection({
   );
 }
 
-interface AdditionalConfigurationSectionProps {
-  requiredStrings: OptionalDescribedKey[];
-  requiredNumbers: OptionalDescribedKey[];
-  requiredBooleans: OptionalDescribedKey[];
-  requiredEnums: Record<
-    string,
-    {
-      options: { value: string; label: string; description?: string }[];
-      description?: string;
-    }
-  >;
-  requiredLists: Record<
-    string,
-    {
-      options: { value: string; label: string; description?: string }[];
-      description?: string;
-    }
-  >;
-}
+interface AdditionalConfigurationSectionProps
+  extends Pick<
+    MCPServerRequirements,
+    | "requiredStrings"
+    | "requiredNumbers"
+    | "requiredBooleans"
+    | "requiredEnums"
+    | "requiredLists"
+  > {}
 
 export function AdditionalConfigurationSection({
   requiredStrings,

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -294,8 +294,8 @@ export function findPathsToConfiguration({
 
   const disabledToolNames =
     toolsMetadata
-      ?.filter(({ enabled }) => !enabled)
-      .map(({ toolName }) => toolName) ?? [];
+      ?.filter((tool) => !tool.enabled)
+      .map((tool) => tool.toolName) ?? [];
 
   return mcpServer.tools.reduce((acc: Record<string, JSONSchema>, tool) => {
     if (disabledToolNames.includes(tool.name) || !tool.inputSchema) {


### PR DESCRIPTION
## Description

- The types for MCP server requirements were repeated in many places, notably in component props.
- This PR centralizes the typing around the existing `MCPServerRequirements` interface.

## Tests

- Checked locally.

## Risk

- Low, only affects typing, no runtime change.

## Deploy Plan

- Deploy front.
