### PR TITLE
fix(front): logger for failed MCP actions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -98,7 +98,9 @@ export function withToolLogging<T>(
         ]);
       }
 
-      logger.error(
+      // If the error is tracked, then we want to surface it with `logger.error`, otherwise just a warning, so we don't loose them if needed
+      const logFunction = result.error.tracked ? logger.error : logger.warn;
+      logFunction(
         {
           error: result.error,
           ...loggerArgs,


### PR DESCRIPTION
## Description

Reduce log level when we don't want to track MCP errors.

Error => warning, so we still have the log but we see it less in the monitoring

ex: I didn't expect to see this [log](https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40toolName%3Arun_agent%20%22Tool%20execution%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZnr2D-EXcUi7gAAABhBWm5yMkVueEFBQXFGc196WjE3cE1RQVoAAAAkZjE5OWViZDktYzRjMC00OWIxLWE4MDktNjIzOWZjODE3Mzg5AALCGw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760594654000&to_ts=1760598554000&live=false) in our monitoring [here](https://app.datadoghq.eu/monitors/90736454?group=tool%3Arun_agent&from_ts=1760597354000&to_ts=1760598554000&event_id=8327126017021399374&link_source=monitor_notif).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
