### PR TITLE
chore(front): replace deprecated parameter in temporal

### DIFF
--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -12,7 +12,6 @@ import { maybeTrackTokenUsageCost } from "@app/lib/api/public_api_limits";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { Authenticator as AuthenticatorClass } from "@app/lib/auth";
 import type { AgentMessage } from "@app/lib/models/assistant/conversation";
-import { ConversationModel } from "@app/lib/models/assistant/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -47,9 +47,11 @@ export async function runAgentLoopWorker() {
     // See https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling
     maxHeartbeatThrottleInterval: "20 seconds",
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/data_retention/worker.ts
+++ b/front/temporal/data_retention/worker.ts
@@ -18,9 +18,11 @@ export async function runDataRetentionWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/labs/transcripts/utils.ts
+++ b/front/temporal/labs/transcripts/utils.ts
@@ -1,5 +1,4 @@
 import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
-import type { ModelId } from "@app/types";
 
 export function makeRetrieveTranscriptWorkflowId(
   transcriptsConfiguration: LabsTranscriptsConfigurationResource

--- a/front/temporal/labs/transcripts/worker.ts
+++ b/front/temporal/labs/transcripts/worker.ts
@@ -18,9 +18,11 @@ export async function runLabsTranscriptsWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/mentions_count_queue/worker.ts
+++ b/front/temporal/mentions_count_queue/worker.ts
@@ -18,9 +18,11 @@ export async function runMentionsCountWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/permissions_queue/worker.ts
+++ b/front/temporal/permissions_queue/worker.ts
@@ -19,9 +19,11 @@ export async function runPermissionsWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/production_checks/worker.ts
+++ b/front/temporal/production_checks/worker.ts
@@ -17,9 +17,11 @@ export async function runProductionChecksWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/relocation/worker.ts
+++ b/front/temporal/relocation/worker.ts
@@ -34,9 +34,11 @@ export async function runRelocationWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/remote_tools/worker.ts
+++ b/front/temporal/remote_tools/worker.ts
@@ -1,13 +1,12 @@
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import * as activities from "@app/temporal/remote_tools/activities";
-
 import { QUEUE_NAME } from "@app/temporal/remote_tools/config";
-import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 export async function runRemoteToolsSyncWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
@@ -18,9 +17,11 @@ export async function runRemoteToolsSyncWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/scrub_workspace/worker.ts
+++ b/front/temporal/scrub_workspace/worker.ts
@@ -18,9 +18,11 @@ export async function runScrubWorkspaceQueueWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/tracker/worker.ts
+++ b/front/temporal/tracker/worker.ts
@@ -19,9 +19,11 @@ export async function runTrackerWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },
@@ -40,9 +42,11 @@ export async function runTrackerNotificationWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/upsert_queue/worker.ts
+++ b/front/temporal/upsert_queue/worker.ts
@@ -19,9 +19,11 @@ export async function runUpsertQueueWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/upsert_tables/worker.ts
+++ b/front/temporal/upsert_tables/worker.ts
@@ -21,9 +21,11 @@ export async function runUpsertTableQueueWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/usage_queue/worker.ts
+++ b/front/temporal/usage_queue/worker.ts
@@ -18,9 +18,11 @@ export async function runUpdateWorkspaceUsageWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },

--- a/front/temporal/workos_events_queue/worker.ts
+++ b/front/temporal/workos_events_queue/worker.ts
@@ -18,9 +18,11 @@ export async function runWorkOSEventsWorker() {
     connection,
     namespace,
     interceptors: {
-      activityInbound: [
+      activity: [
         (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger);
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
         },
       ],
     },


### PR DESCRIPTION
## Description

In temporal API, `activityInbound` is deprecated in favor of `activity`. This PR changes that

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
