### PR TITLE
[.github] - chore: change concurrency cancel-in-progress policy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ permissions:
 
 concurrency:
   group: "deploy_${{ inputs.component }}"
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: false
 
 jobs:
   check-branch:


### PR DESCRIPTION
## Description

This PR disables automatic cancellation of in-progress deployments when a newer one starts

## Tests

N/A

## Risk

None

## Deploy Plan

N/A