### PR TITLE
fix(front): double extension in generated file names

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -1,4 +1,5 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { extname } from "path";
 import type { Logger } from "pino";
 
 import {
@@ -225,16 +226,19 @@ export async function processToolResults(
             isSupportedFileContentType(block.resource.mimeType)
           ) {
             if (isBlobResource(block)) {
-              const extension =
+              const extensionFromContentType =
                 extensionsForContentType(
                   block.resource.mimeType as SupportedFileContentType
                 )[0] || "";
-              const fileName = `${block.resource.uri}${extension}`;
+              const extensionFromURI = extname(block.resource.uri);
+              const fileName = extensionFromURI
+                ? block.resource.uri
+                : `${block.resource.uri}${extensionFromContentType}`;
 
               return handleBase64Upload(auth, {
                 base64Data: block.resource.blob,
                 mimeType: block.resource.mimeType,
-                fileName,
+                fileName: fileName,
                 block,
                 fileUseCase,
                 fileUseCaseMetadata,


### PR DESCRIPTION
## Description

I introduced a bug in this [PR](https://github.com/dust-tt/dust/pull/16810), it was adding 2 times the extension of a generated file, see [here](https://github.com/dust-tt/tasks/issues/4618#issuecomment-3402683874).

This Pr fixes it

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
