### PR TITLE
[front] chore(tool-validation): improve error message on validation 400

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -133,7 +133,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "action_not_blocked",
-            message: "Action not blocked.",
+            message: result.error.message,
           },
         });
       case "action_not_found":
@@ -141,7 +141,7 @@ async function handler(
           status_code: 404,
           api_error: {
             type: "action_not_found",
-            message: "Action not found.",
+            message: result.error.message,
           },
         });
       default:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -79,7 +79,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "action_not_blocked",
-            message: "Action not blocked.",
+            message: result.error.message,
           },
         });
       case "action_not_found":
@@ -87,7 +87,7 @@ async function handler(
           status_code: 404,
           api_error: {
             type: "action_not_found",
-            message: "Action not found.",
+            message: result.error.message,
           },
         });
       default:


### PR DESCRIPTION
## Description

- The message shown in the log is currently not the most useful, see [here](https://app.datadoghq.eu/logs?query=%40url%3A%2Fapi%2Fw%2Fee616a51bc%2Fassistant%2F%2A%2Fvalidate-action&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZnsHBmqxG6RogAAABhBWm5zSEI1VUFBQTdNeTVsanFLSUJRQWwAAAAkZjE5OWVjMWMtZmI0My00MDkzLThhMDItZmY1NWY5NWRkZmEyAAUoUQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1733653464474&to_ts=1733657064474&live=true) (it just repeats the type).
- This PR adds back the original error message, which turns out is the same but contains the current status for action not blocked.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
