### PR TITLE
[feat] - feat(obs): add usage metric

### DIFF
--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -1,5 +1,3 @@
-import { Page } from "@dust-tt/sparkle";
-
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { UsageMetricsChart } from "@app/components/agent_builder/observability/UsageMetricsChart";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
@@ -41,10 +39,10 @@ export function AgentBuilderObservability({
   return (
     <div className="flex h-full flex-col space-y-6 overflow-y-auto">
       <div>
-        <Page.H variant="h5">Observability</Page.H>
-        <Page.P>
+        <h2 className="text-lg font-semibold text-foreground">Observability</h2>
+        <p className="text-sm text-muted-foreground">
           Monitor key metrics and performance indicators for your agent.
-        </Page.P>
+        </p>
       </div>
 
       <div className="grid grid-cols-1 gap-6">

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -1,0 +1,58 @@
+import { Page } from "@dust-tt/sparkle";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { UsageMetricsChart } from "@app/components/agent_builder/observability/UsageMetricsChart";
+import { useAgentConfiguration } from "@app/lib/swr/assistants";
+
+function NoAgentState() {
+  return (
+    <div className="flex h-full min-h-0 items-center justify-center">
+      <div className="px-4 text-center">
+        <div className="mb-2 text-lg font-medium text-foreground">
+          No Observability Data Available
+        </div>
+        <div className="max-w-sm text-muted-foreground">
+          Observability metrics will be available after your agent is created
+          and used in conversations.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface AgentBuilderObservabilityProps {
+  agentConfigurationSId?: string;
+}
+
+export function AgentBuilderObservability({
+  agentConfigurationSId,
+}: AgentBuilderObservabilityProps) {
+  const { owner } = useAgentBuilderContext();
+
+  const { agentConfiguration } = useAgentConfiguration({
+    workspaceId: owner.sId,
+    agentConfigurationId: agentConfigurationSId ?? null,
+  });
+
+  if (!agentConfiguration) {
+    return <NoAgentState />;
+  }
+
+  return (
+    <div className="flex h-full flex-col space-y-6 overflow-y-auto">
+      <div>
+        <Page.H variant="h5">Observability</Page.H>
+        <Page.P>
+          Monitor key metrics and performance indicators for your agent.
+        </Page.P>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6">
+        <UsageMetricsChart
+          workspaceId={owner.sId}
+          agentConfigurationId={agentConfiguration.sId}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -2,24 +2,8 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import { UsageMetricsChart } from "@app/components/agent_builder/observability/UsageMetricsChart";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 
-function NoAgentState() {
-  return (
-    <div className="flex h-full min-h-0 items-center justify-center">
-      <div className="px-4 text-center">
-        <div className="mb-2 text-lg font-medium text-foreground">
-          No Observability Data Available
-        </div>
-        <div className="max-w-sm text-muted-foreground">
-          Observability metrics will be available after your agent is created
-          and used in conversations.
-        </div>
-      </div>
-    </div>
-  );
-}
-
 interface AgentBuilderObservabilityProps {
-  agentConfigurationSId?: string;
+  agentConfigurationSId: string;
 }
 
 export function AgentBuilderObservability({
@@ -29,11 +13,11 @@ export function AgentBuilderObservability({
 
   const { agentConfiguration } = useAgentConfiguration({
     workspaceId: owner.sId,
-    agentConfigurationId: agentConfigurationSId ?? null,
+    agentConfigurationId: agentConfigurationSId,
   });
 
   if (!agentConfiguration) {
-    return <NoAgentState />;
+    return null;
   }
 
   return (

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -185,7 +185,7 @@ function ExpandedContent({
           />
         </div>
       )}
-      {selectedTab === "observability" && (
+      {selectedTab === "observability" && agentConfigurationSId && (
         <div className="flex-1 overflow-y-auto p-4">
           <AgentBuilderObservability
             agentConfigurationSId={agentConfigurationSId}
@@ -207,7 +207,8 @@ export function AgentBuilderRightPanel({
     usePreviewPanelContext();
   const { assistantTemplate, owner } = useAgentBuilderContext();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
-  const showObservability = hasFeature("agent_builder_observability");
+  const showObservability =
+    hasFeature("agent_builder_observability") && !!agentConfigurationSId;
 
   const hasTemplate = !!assistantTemplate;
 

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -10,15 +10,22 @@ import {
   TabsTrigger,
   TestTubeIcon,
 } from "@dust-tt/sparkle";
+import { ActivityIcon } from "lucide-react";
 import React, { useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { AgentBuilderObservability } from "@app/components/agent_builder/AgentBuilderObservability";
 import { AgentBuilderPerformance } from "@app/components/agent_builder/AgentBuilderPerformance";
 import { AgentBuilderPreview } from "@app/components/agent_builder/AgentBuilderPreview";
 import { AgentBuilderTemplate } from "@app/components/agent_builder/AgentBuilderTemplate";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
-type AgentBuilderRightPanelTabType = "testing" | "performance" | "template";
+type AgentBuilderRightPanelTabType =
+  | "testing"
+  | "performance"
+  | "template"
+  | "observability";
 
 interface PanelHeaderProps {
   isPreviewPanelOpen: boolean;
@@ -26,6 +33,7 @@ interface PanelHeaderProps {
   onTogglePanel: () => void;
   onTabChange: (tab: AgentBuilderRightPanelTabType) => void;
   hasTemplate: boolean;
+  showObservability: boolean;
 }
 
 function PanelHeader({
@@ -34,6 +42,7 @@ function PanelHeader({
   onTogglePanel,
   onTabChange,
   hasTemplate,
+  showObservability,
 }: PanelHeaderProps) {
   return (
     <div className="flex h-16 items-end">
@@ -61,6 +70,14 @@ function PanelHeader({
                   icon={BarChartIcon}
                   onClick={() => onTabChange("performance")}
                 />
+                {showObservability && (
+                  <TabsTrigger
+                    value="observability"
+                    label="Observability"
+                    icon={ActivityIcon}
+                    onClick={() => onTabChange("observability")}
+                  />
+                )}
                 {hasTemplate && (
                   <TabsTrigger
                     value="template"
@@ -91,9 +108,14 @@ function PanelHeader({
 interface CollapsedTabsProps {
   onTabSelect: (tab: AgentBuilderRightPanelTabType) => void;
   hasTemplate: boolean;
+  showObservability: boolean;
 }
 
-function CollapsedTabs({ onTabSelect, hasTemplate }: CollapsedTabsProps) {
+function CollapsedTabs({
+  onTabSelect,
+  hasTemplate,
+  showObservability,
+}: CollapsedTabsProps) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4">
       <Button
@@ -110,6 +132,15 @@ function CollapsedTabs({ onTabSelect, hasTemplate }: CollapsedTabsProps) {
         tooltip="Performance"
         onClick={() => onTabSelect("performance")}
       />
+      {showObservability && (
+        <Button
+          icon={ActivityIcon}
+          variant="ghost"
+          size="sm"
+          tooltip="Observability"
+          onClick={() => onTabSelect("observability")}
+        />
+      )}
       {hasTemplate && (
         <Button
           icon={MagicIcon}
@@ -154,6 +185,13 @@ function ExpandedContent({
           />
         </div>
       )}
+      {selectedTab === "observability" && (
+        <div className="flex-1 overflow-y-auto p-4">
+          <AgentBuilderObservability
+            agentConfigurationSId={agentConfigurationSId}
+          />
+        </div>
+      )}
     </div>
   );
 }
@@ -167,7 +205,9 @@ export function AgentBuilderRightPanel({
 }: AgentBuilderRightPanelProps) {
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     usePreviewPanelContext();
-  const { assistantTemplate } = useAgentBuilderContext();
+  const { assistantTemplate, owner } = useAgentBuilderContext();
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+  const showObservability = hasFeature("agent_builder_observability");
 
   const hasTemplate = !!assistantTemplate;
 
@@ -197,6 +237,7 @@ export function AgentBuilderRightPanel({
           onTogglePanel={handleTogglePanel}
           onTabChange={handleTabChange}
           hasTemplate={hasTemplate}
+          showObservability={showObservability}
         />
       </div>
       {isPreviewPanelOpen ? (
@@ -208,6 +249,7 @@ export function AgentBuilderRightPanel({
         <CollapsedTabs
           onTabSelect={handleTabSelect}
           hasTemplate={hasTemplate}
+          showObservability={showObservability}
         />
       )}
     </div>

--- a/front/components/agent_builder/observability/ChartTooltip.tsx
+++ b/front/components/agent_builder/observability/ChartTooltip.tsx
@@ -1,11 +1,10 @@
 import { cn } from "@dust-tt/sparkle";
-import React from "react";
 
-interface LegendItemProps {
+interface LegendDotProps {
   className: string;
 }
 
-export function LegendDot({ className }: LegendItemProps) {
+export function LegendDot({ className }: LegendDotProps) {
   return (
     <span
       className={cn(
@@ -45,7 +44,7 @@ export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
           {r.colorClass && <LegendDot className={r.colorClass} />}
           <span className="text-muted-foreground">{r.label}</span>
           <span className="ml-auto font-medium">{r.value}</span>
-          {r.percent && (
+          {r.percent !== null && r.percent !== undefined && (
             <span className="text-muted-foreground">({r.percent}%)</span>
           )}
         </div>

--- a/front/components/agent_builder/observability/ChartTooltip.tsx
+++ b/front/components/agent_builder/observability/ChartTooltip.tsx
@@ -15,12 +15,12 @@ export function LegendDot({ className }: LegendDotProps) {
   );
 }
 
-export type TooltipRow = {
+interface TooltipRow {
   label: string;
   value: string | number;
-  colorClass?: string;
+  colorClassName?: string;
   percent?: number | null;
-};
+}
 
 interface ChartTooltipProps {
   title?: string;
@@ -41,7 +41,7 @@ export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
           key={r.label}
           className="mt-1 flex items-center gap-2 text-xs first:mt-0"
         >
-          {r.colorClass && <LegendDot className={r.colorClass} />}
+          {r.colorClassName && <LegendDot className={r.colorClassName} />}
           <span className="text-muted-foreground">{r.label}</span>
           <span className="ml-auto font-medium">{r.value}</span>
           {r.percent !== null && r.percent !== undefined && (

--- a/front/components/agent_builder/observability/ChartTooltip.tsx
+++ b/front/components/agent_builder/observability/ChartTooltip.tsx
@@ -44,7 +44,7 @@ export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
           {r.colorClassName && <LegendDot className={r.colorClassName} />}
           <span className="text-muted-foreground">{r.label}</span>
           <span className="ml-auto font-medium">{r.value}</span>
-          {r.percent !== null && r.percent !== undefined && (
+          {typeof r.percent === "number" && (
             <span className="text-muted-foreground">({r.percent}%)</span>
           )}
         </div>

--- a/front/components/agent_builder/observability/ChartTooltip.tsx
+++ b/front/components/agent_builder/observability/ChartTooltip.tsx
@@ -1,0 +1,60 @@
+import { cn } from "@dust-tt/sparkle";
+import React from "react";
+
+interface LegendItemProps {
+  className: string;
+}
+
+export function LegendDot({ className }: LegendItemProps) {
+  return (
+    <span
+      className={cn(
+        "inline-block h-2.5 w-2.5 rounded-sm bg-current",
+        className
+      )}
+    />
+  );
+}
+
+export type TooltipRow = {
+  label: string;
+  value: string | number;
+  colorClass?: string;
+  percent?: number | null;
+};
+
+interface ChartTooltipProps {
+  title?: string;
+  rows: TooltipRow[];
+  footer?: string;
+}
+
+export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
+  return (
+    <div className="bg-card rounded-md border border-border p-3 text-foreground shadow-md">
+      {title && (
+        <div className="mb-2 text-xs font-medium text-muted-foreground">
+          {title}
+        </div>
+      )}
+      {rows.map((r) => (
+        <div
+          key={r.label}
+          className="mt-1 flex items-center gap-2 text-xs first:mt-0"
+        >
+          {r.colorClass && <LegendDot className={r.colorClass} />}
+          <span className="text-muted-foreground">{r.label}</span>
+          <span className="ml-auto font-medium">{r.value}</span>
+          {r.percent && (
+            <span className="text-muted-foreground">({r.percent}%)</span>
+          )}
+        </div>
+      ))}
+      {footer && (
+        <div className="mt-2 border-t border-border pt-2 text-xs text-muted-foreground">
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -1,0 +1,200 @@
+import { cn, Spinner } from "@dust-tt/sparkle";
+import { useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+import { ChartTooltipCard } from "@app/components/agent_builder/observability/ChartTooltip";
+import type {
+  ObservabilityIntervalType,
+  ObservabilityTimeRangeType,
+} from "@app/components/agent_builder/observability/constants";
+import {
+  OBSERVABILITY_INTERVALS,
+  OBSERVABILITY_TIME_RANGE,
+  USAGE_METRICS_PALETTE,
+} from "@app/components/agent_builder/observability/constants";
+import { useAgentUsageMetrics } from "@app/lib/swr/assistants";
+
+export function UsageMetricsChart({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}) {
+  const [period, setPeriod] = useState<ObservabilityTimeRangeType>("14d");
+  const [interval, setInterval] = useState<ObservabilityIntervalType>("day");
+
+  const days = period === "7d" ? 7 : period === "14d" ? 14 : 30;
+  const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
+    useAgentUsageMetrics({
+      workspaceId,
+      agentConfigurationId,
+      days,
+      interval,
+      disabled: !workspaceId || !agentConfigurationId,
+    });
+
+  const data = usageMetrics?.points ?? [];
+
+  return (
+    <div className="bg-card rounded-lg border border-border p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-medium text-foreground">Usage Metrics</h3>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            {OBSERVABILITY_TIME_RANGE.map((p) => (
+              <button
+                key={p}
+                onClick={() => setPeriod(p)}
+                type="button"
+                className={cn(
+                  "rounded px-2 py-1 text-xs",
+                  period === p
+                    ? "bg-foreground text-background"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            {OBSERVABILITY_INTERVALS.map((i) => (
+              <button
+                key={i}
+                onClick={() => setInterval(i)}
+                type="button"
+                className={cn(
+                  "rounded px-2 py-1 text-xs",
+                  interval === i
+                    ? "bg-foreground text-background"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {i}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      {isUsageMetricsLoading ? (
+        <div className="flex h-[260px] items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      ) : isUsageMetricsError ? (
+        <div className="flex h-[260px] items-center justify-center">
+          <p className="text-sm text-muted-foreground">
+            Failed to load usage metrics.
+          </p>
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart
+            data={data}
+            margin={{ top: 10, right: 30, left: 10, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis dataKey="date" className="text-xs text-muted-foreground" />
+            <YAxis className="text-xs text-muted-foreground" />
+            <Tooltip
+              cursor={{ stroke: "hsl(var(--border))", strokeWidth: 1 }}
+              content={(props: TooltipContentProps<number, string>) => {
+                const { active, payload, label } = props;
+                if (!active || !payload || payload.length === 0) {
+                  return null;
+                }
+                const first = payload[0];
+                if (!first?.payload) {
+                  return null;
+                }
+                const row = first.payload;
+                if (
+                  typeof row !== "object" ||
+                  !("messages" in row) ||
+                  !("conversations" in row) ||
+                  !("activeUsers" in row)
+                ) {
+                  return null;
+                }
+                return (
+                  <ChartTooltipCard
+                    title={String(label ?? "")}
+                    rows={[
+                      {
+                        label: "Messages",
+                        value: row.messages,
+                        colorClass: USAGE_METRICS_PALETTE.messages,
+                      },
+                      {
+                        label: "Conversations",
+                        value: row.conversations,
+                        colorClass: USAGE_METRICS_PALETTE.conversations,
+                      },
+                      {
+                        label: "Active users",
+                        value: row.activeUsers,
+                        colorClass: USAGE_METRICS_PALETTE.activeUsers,
+                      },
+                    ]}
+                  />
+                );
+              }}
+            />
+            <Line
+              dataKey="messages"
+              name="Messages"
+              stroke="currentColor"
+              className={USAGE_METRICS_PALETTE.messages}
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              dataKey="conversations"
+              name="Conversations"
+              stroke="currentColor"
+              className={USAGE_METRICS_PALETTE.conversations}
+              strokeWidth={2}
+              dot={false}
+            />
+            <Line
+              dataKey="activeUsers"
+              name="Active users"
+              stroke="currentColor"
+              className={USAGE_METRICS_PALETTE.activeUsers}
+              strokeWidth={2}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+      <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
+        {(
+          [
+            { k: "messages", label: "Messages" },
+            { k: "conversations", label: "Conversations" },
+            { k: "activeUsers", label: "Active users" },
+          ] as const
+        ).map(({ k, label }) => (
+          <div key={k} className="flex items-center gap-2">
+            <span
+              className={cn(
+                "inline-block h-3 w-3 rounded-sm bg-current",
+                USAGE_METRICS_PALETTE[k]
+              )}
+            />
+            <span className="text-sm text-muted-foreground">{label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -63,17 +63,17 @@ function UsageMetricsTooltip(
         {
           label: "Messages",
           value: row.messages,
-          colorClass: USAGE_METRICS_PALETTE.messages,
+          colorClassName: USAGE_METRICS_PALETTE.messages,
         },
         {
           label: "Conversations",
           value: row.conversations,
-          colorClass: USAGE_METRICS_PALETTE.conversations,
+          colorClassName: USAGE_METRICS_PALETTE.conversations,
         },
         {
           label: "Active users",
           value: row.activeUsers,
-          colorClass: USAGE_METRICS_PALETTE.activeUsers,
+          colorClassName: USAGE_METRICS_PALETTE.activeUsers,
         },
       ]}
     />
@@ -113,7 +113,6 @@ export function UsageMetricsChart({
               <button
                 key={p}
                 onClick={() => setPeriod(p)}
-                type="button"
                 className={cn(
                   "rounded px-2 py-1 text-xs",
                   period === p
@@ -130,7 +129,6 @@ export function UsageMetricsChart({
               <button
                 key={i}
                 onClick={() => setInterval(i)}
-                type="button"
                 className={cn(
                   "rounded px-2 py-1 text-xs",
                   interval === i

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@app/components/agent_builder/observability/constants";
 import {
   CHART_HEIGHT,
+  DEFAULT_PERIOD_DAYS,
   OBSERVABILITY_INTERVALS,
   OBSERVABILITY_TIME_RANGE,
   USAGE_METRICS_LEGEND,
@@ -56,9 +57,10 @@ function UsageMetricsTooltip(
     return null;
   }
   const row = first.payload;
+  const title = typeof label === "string" ? label : String(label ?? "");
   return (
     <ChartTooltipCard
-      title={String(label ?? "")}
+      title={title}
       rows={[
         {
           label: "Messages",
@@ -90,7 +92,8 @@ export function UsageMetricsChart({
   const [period, setPeriod] = useState<ObservabilityTimeRangeType>("14d");
   const [interval, setInterval] = useState<ObservabilityIntervalType>("day");
 
-  const days = period === "7d" ? 7 : period === "14d" ? 14 : 30;
+  const days =
+    period === "7d" ? 7 : period === "14d" ? 14 : DEFAULT_PERIOD_DAYS;
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     useAgentUsageMetrics({
       workspaceId,

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -1,9 +1,11 @@
 import { cn, Spinner } from "@dust-tt/sparkle";
 import { useState } from "react";
 import {
+  Bar,
+  BarChart,
   CartesianGrid,
-  Line,
-  LineChart,
+  Label,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -98,6 +100,7 @@ export function UsageMetricsChart({
     });
 
   const data = usageMetrics?.points ?? [];
+  const versionMarkers = usageMetrics?.versionMarkers ?? [];
 
   return (
     <div className="bg-card rounded-lg border border-border p-4">
@@ -158,7 +161,7 @@ export function UsageMetricsChart({
         </div>
       ) : (
         <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-          <LineChart
+          <BarChart
             data={data}
             margin={{ top: 10, right: 30, left: 10, bottom: 0 }}
           >
@@ -166,21 +169,35 @@ export function UsageMetricsChart({
             <XAxis dataKey="date" className="text-xs text-muted-foreground" />
             <YAxis className="text-xs text-muted-foreground" />
             <Tooltip
-              cursor={{ stroke: "hsl(var(--border))", strokeWidth: 1 }}
+              cursor={{ fill: "hsl(var(--border) / 0.1)" }}
               content={UsageMetricsTooltip}
             />
             {USAGE_METRICS_LEGEND.map(({ key, label }) => (
-              <Line
+              <Bar
                 key={key}
                 dataKey={key}
                 name={label}
-                stroke="currentColor"
+                fill="currentColor"
                 className={USAGE_METRICS_PALETTE[key]}
-                strokeWidth={2}
-                dot={false}
               />
             ))}
-          </LineChart>
+            {versionMarkers.map((marker) => (
+              <ReferenceLine
+                key={marker.version}
+                x={marker.timestamp}
+                stroke="hsl(var(--warning))"
+                strokeWidth={2}
+                strokeDasharray="3 3"
+              >
+                <Label
+                  value={`v${marker.version}`}
+                  position="top"
+                  className="fill-warning text-xs"
+                  offset={10}
+                />
+              </ReferenceLine>
+            ))}
+          </BarChart>
         </ResponsiveContainer>
       )}
       <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -27,7 +27,10 @@ import {
   USAGE_METRICS_PALETTE,
   VERSION_MARKER_STYLE,
 } from "@app/components/agent_builder/observability/constants";
-import { useAgentUsageMetrics } from "@app/lib/swr/assistants";
+import {
+  useAgentUsageMetrics,
+  useAgentVersionMarkers,
+} from "@app/lib/swr/assistants";
 
 interface UsageMetricsData {
   messages: number;
@@ -102,8 +105,18 @@ export function UsageMetricsChart({
       disabled: !workspaceId || !agentConfigurationId,
     });
 
+  const { versionMarkers, isVersionMarkersLoading, isVersionMarkersError } =
+    useAgentVersionMarkers({
+      workspaceId,
+      agentConfigurationId,
+      days: period,
+      disabled: !workspaceId || !agentConfigurationId,
+    });
+
   const data = usageMetrics?.points ?? [];
-  const versionMarkers = usageMetrics?.versionMarkers ?? [];
+  const markers = versionMarkers ?? [];
+  const isLoading = isUsageMetricsLoading || isVersionMarkersLoading;
+  const isError = isUsageMetricsError || isVersionMarkersError;
 
   return (
     <div className="bg-card rounded-lg border border-border p-4">
@@ -144,20 +157,20 @@ export function UsageMetricsChart({
           </div>
         </div>
       </div>
-      {isUsageMetricsLoading ? (
+      {isLoading ? (
         <div
           className="flex items-center justify-center"
           style={{ height: CHART_HEIGHT }}
         >
           <Spinner size="lg" />
         </div>
-      ) : isUsageMetricsError ? (
+      ) : isError ? (
         <div
           className="flex items-center justify-center"
           style={{ height: CHART_HEIGHT }}
         >
           <p className="text-sm text-muted-foreground">
-            Failed to load usage metrics.
+            Failed to load observability data.
           </p>
         </div>
       ) : (
@@ -182,7 +195,7 @@ export function UsageMetricsChart({
                 className={USAGE_METRICS_PALETTE[key]}
               />
             ))}
-            {versionMarkers.map((marker, index) => (
+            {markers.map((marker, index) => (
               <ReferenceLine
                 key={`${marker.version}-${marker.timestamp}`}
                 x={marker.timestamp}

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -89,16 +89,15 @@ export function UsageMetricsChart({
   workspaceId: string;
   agentConfigurationId: string;
 }) {
-  const [period, setPeriod] = useState<ObservabilityTimeRangeType>("14d");
+  const [period, setPeriod] =
+    useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
   const [interval, setInterval] = useState<ObservabilityIntervalType>("day");
 
-  const days =
-    period === "7d" ? 7 : period === "14d" ? 14 : DEFAULT_PERIOD_DAYS;
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     useAgentUsageMetrics({
       workspaceId,
       agentConfigurationId,
-      days,
+      days: period,
       interval,
       disabled: !workspaceId || !agentConfigurationId,
     });
@@ -123,7 +122,7 @@ export function UsageMetricsChart({
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >
-                {p}
+                {p}d
               </button>
             ))}
           </div>

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -60,7 +60,7 @@ function UsageMetricsTooltip(
     return null;
   }
   const row = first.payload;
-  const title = typeof label === "string" ? label : String(label ?? "");
+  const title = typeof label === "string" ? label : String(label);
   return (
     <ChartTooltipCard
       title={title}

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -24,6 +24,7 @@ import {
   OBSERVABILITY_TIME_RANGE,
   USAGE_METRICS_LEGEND,
   USAGE_METRICS_PALETTE,
+  VERSION_MARKER_STYLE,
 } from "@app/components/agent_builder/observability/constants";
 import { useAgentUsageMetrics } from "@app/lib/swr/assistants";
 
@@ -181,19 +182,24 @@ export function UsageMetricsChart({
                 className={USAGE_METRICS_PALETTE[key]}
               />
             ))}
-            {versionMarkers.map((marker) => (
+            {versionMarkers.map((marker, index) => (
               <ReferenceLine
-                key={marker.version}
+                key={`${marker.version}-${marker.timestamp}`}
                 x={marker.timestamp}
-                stroke="hsl(var(--warning))"
-                strokeWidth={2}
-                strokeDasharray="3 3"
+                stroke={VERSION_MARKER_STYLE.stroke}
+                strokeWidth={VERSION_MARKER_STYLE.strokeWidth}
+                strokeDasharray={VERSION_MARKER_STYLE.strokeDasharray}
+                ifOverflow="extendDomain"
               >
                 <Label
                   value={`v${marker.version}`}
                   position="top"
-                  className="fill-warning text-xs"
-                  offset={10}
+                  fill={VERSION_MARKER_STYLE.stroke}
+                  fontSize={VERSION_MARKER_STYLE.labelFontSize}
+                  offset={
+                    VERSION_MARKER_STYLE.labelOffsetBase +
+                    index * VERSION_MARKER_STYLE.labelOffsetIncrement
+                  }
                 />
               </ReferenceLine>
             ))}

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -1,8 +1,8 @@
-export const OBSERVABILITY_TIME_RANGE = ["7d", "14d", "30d"] as const;
+export const OBSERVABILITY_TIME_RANGE = [7, 14, 30] as const;
 export type ObservabilityTimeRangeType =
   (typeof OBSERVABILITY_TIME_RANGE)[number];
 
-export const DEFAULT_PERIOD_DAYS = 30;
+export const DEFAULT_PERIOD_DAYS = 14;
 
 export const OBSERVABILITY_INTERVALS = ["day", "week"] as const;
 export type ObservabilityIntervalType =

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -19,3 +19,12 @@ export const USAGE_METRICS_LEGEND = [
 ] as const;
 
 export const CHART_HEIGHT = 260;
+
+export const VERSION_MARKER_STYLE = {
+  stroke: "#f59e0b",
+  strokeWidth: 2,
+  strokeDasharray: "5 5",
+  labelFontSize: 12,
+  labelOffsetBase: 10,
+  labelOffsetIncrement: 15,
+} as const;

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -1,0 +1,13 @@
+export const OBSERVABILITY_TIME_RANGE = ["7d", "14d", "30d"] as const;
+export type ObservabilityTimeRangeType =
+  (typeof OBSERVABILITY_TIME_RANGE)[number];
+
+export const OBSERVABILITY_INTERVALS = ["day", "week"] as const;
+export type ObservabilityIntervalType =
+  (typeof OBSERVABILITY_INTERVALS)[number];
+
+export const USAGE_METRICS_PALETTE = {
+  messages: "text-blue-500",
+  conversations: "text-amber-500",
+  activeUsers: "text-emerald-500",
+} as const;

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -2,6 +2,8 @@ export const OBSERVABILITY_TIME_RANGE = ["7d", "14d", "30d"] as const;
 export type ObservabilityTimeRangeType =
   (typeof OBSERVABILITY_TIME_RANGE)[number];
 
+export const DEFAULT_PERIOD_DAYS = 30;
+
 export const OBSERVABILITY_INTERVALS = ["day", "week"] as const;
 export type ObservabilityIntervalType =
   (typeof OBSERVABILITY_INTERVALS)[number];

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -11,3 +11,11 @@ export const USAGE_METRICS_PALETTE = {
   conversations: "text-amber-500",
   activeUsers: "text-emerald-500",
 } as const;
+
+export const USAGE_METRICS_LEGEND = [
+  { key: "messages", label: "Messages" },
+  { key: "conversations", label: "Conversations" },
+  { key: "activeUsers", label: "Active users" },
+] as const;
+
+export const CHART_HEIGHT = 260;

--- a/front/lib/api/assistant/observability/usage_metrics.ts
+++ b/front/lib/api/assistant/observability/usage_metrics.ts
@@ -5,8 +5,10 @@ import {
   formatUTCDateFromMillis,
   searchAnalytics,
 } from "@app/lib/api/elasticsearch";
-import { Err, Ok } from "@app/types/shared/result";
 import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const DEFAULT_METRIC_VALUE = 0;
 
 export type UsageMetricsPoint = {
   date: string;
@@ -64,9 +66,11 @@ export async function fetchUsageMetrics(
     const date = formatUTCDateFromMillis(b.key);
     return {
       date,
-      messages: b.doc_count ?? 0,
-      conversations: Math.round(b.unique_conversations?.value ?? 0),
-      activeUsers: Math.round(b.active_users?.value ?? 0),
+      messages: b.doc_count ?? DEFAULT_METRIC_VALUE,
+      conversations: Math.round(
+        b.unique_conversations?.value ?? DEFAULT_METRIC_VALUE
+      ),
+      activeUsers: Math.round(b.active_users?.value ?? DEFAULT_METRIC_VALUE),
     };
   });
 

--- a/front/lib/api/assistant/observability/usage_metrics.ts
+++ b/front/lib/api/assistant/observability/usage_metrics.ts
@@ -1,0 +1,74 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import {
+  bucketsToArray,
+  formatUTCDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { Err, Ok } from "@app/types/shared/result";
+import type { Result } from "@app/types/shared/result";
+
+export type UsageMetricsPoint = {
+  date: string;
+  messages: number;
+  conversations: number;
+  activeUsers: number;
+};
+
+type ByIntervalBucket = {
+  key: number;
+  doc_count: number;
+  unique_conversations?: estypes.AggregationsCardinalityAggregate;
+  active_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+type UsageMetricsAggs = {
+  by_interval?: estypes.AggregationsMultiBucketAggregateBase<ByIntervalBucket>;
+};
+
+type UsageMetricsInterval = "day" | "week";
+
+export async function fetchUsageMetrics(
+  baseQuery: estypes.QueryDslQueryContainer,
+  interval: UsageMetricsInterval
+): Promise<Result<UsageMetricsPoint[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_interval: {
+      date_histogram: {
+        field: "timestamp",
+        calendar_interval: interval,
+      },
+      aggs: {
+        unique_conversations: {
+          cardinality: { field: "conversation_id" },
+        },
+        active_users: { cardinality: { field: "user_id" } },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<unknown, UsageMetricsAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const buckets = bucketsToArray<ByIntervalBucket>(
+    result.value.aggregations?.by_interval?.buckets
+  );
+
+  const points: UsageMetricsPoint[] = buckets.map((b) => {
+    const date = formatUTCDateFromMillis(b.key);
+    return {
+      date,
+      messages: b.doc_count ?? 0,
+      conversations: Math.round(b.unique_conversations?.value ?? 0),
+      activeUsers: Math.round(b.active_users?.value ?? 0),
+    };
+  });
+
+  return new Ok(points);
+}

--- a/front/lib/api/assistant/observability/version_markers.ts
+++ b/front/lib/api/assistant/observability/version_markers.ts
@@ -8,6 +8,9 @@ import {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
+const MAX_VERSIONS_TO_FETCH = 100;
+const DEFAULT_TIMESTAMP_MS = 0;
+
 export type AgentVersionMarker = {
   version: string;
   timestamp: string;
@@ -30,7 +33,7 @@ export async function fetchVersionMarkers(
     by_version: {
       terms: {
         field: "agent_version",
-        size: 100,
+        size: MAX_VERSIONS_TO_FETCH,
       },
       aggs: {
         first_seen: {
@@ -62,7 +65,7 @@ export async function fetchVersionMarkers(
           ? firstSeenValue
           : typeof firstSeenString === "string"
             ? parseInt(firstSeenString, 10)
-            : 0;
+            : DEFAULT_TIMESTAMP_MS;
 
       return {
         version: b.key,

--- a/front/lib/api/assistant/observability/version_markers.ts
+++ b/front/lib/api/assistant/observability/version_markers.ts
@@ -1,0 +1,78 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import {
+  bucketsToArray,
+  formatUTCDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type AgentVersionMarker = {
+  version: string;
+  timestamp: string;
+};
+
+type VersionBucket = {
+  key: string;
+  doc_count: number;
+  first_seen?: estypes.AggregationsMinAggregate;
+};
+
+type VersionMarkersAggs = {
+  by_version?: estypes.AggregationsMultiBucketAggregateBase<VersionBucket>;
+};
+
+export async function fetchVersionMarkers(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Result<AgentVersionMarker[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_version: {
+      terms: {
+        field: "agent_version",
+        size: 100,
+      },
+      aggs: {
+        first_seen: {
+          min: { field: "timestamp" },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<unknown, VersionMarkersAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const versionBuckets = bucketsToArray<VersionBucket>(
+    result.value.aggregations?.by_version?.buckets
+  );
+
+  const versionMarkers: AgentVersionMarker[] = versionBuckets
+    .map((b) => {
+      const firstSeenValue = b.first_seen?.value;
+      const firstSeenString = b.first_seen?.value_as_string;
+      const timestampMs =
+        typeof firstSeenValue === "number"
+          ? firstSeenValue
+          : typeof firstSeenString === "string"
+            ? parseInt(firstSeenString, 10)
+            : 0;
+
+      return {
+        version: b.key,
+        timestamp: formatUTCDateFromMillis(timestampMs),
+      };
+    })
+    .sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+
+  return new Ok(versionMarkers);
+}

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -42,6 +42,7 @@ function getClient(): Client {
   esClient = new Client({
     node: url,
     auth: { username, password },
+    tls: { rejectUnauthorized: false },
   });
   return esClient;
 }

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 import { useSWRConfig } from "swr";
 
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type {
   AgentMessageFeedbackType,
@@ -770,7 +771,7 @@ export function useBatchUpdateAgentScope({
 export function useAgentUsageMetrics({
   workspaceId,
   agentConfigurationId,
-  days = 30,
+  days = DEFAULT_PERIOD_DAYS,
   interval = "day",
   disabled,
 }: {
@@ -799,7 +800,7 @@ export function useAgentUsageMetrics({
 export function useAgentVersionMarkers({
   workspaceId,
   agentConfigurationId,
-  days = 30,
+  days = DEFAULT_PERIOD_DAYS,
   disabled,
 }: {
   workspaceId: string;

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -19,6 +19,7 @@ import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[t
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentConfigurationAnalyticsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics";
 import type { GetUsageMetricsResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics";
+import type { GetVersionMarkersResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers";
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent";
 import type { PostAgentUserFavoriteRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_favorite";
@@ -792,5 +793,32 @@ export function useAgentUsageMetrics({
     isUsageMetricsLoading: !error && !data && !disabled,
     isUsageMetricsError: error,
     isUsageMetricsValidating: isValidating,
+  };
+}
+
+export function useAgentVersionMarkers({
+  workspaceId,
+  agentConfigurationId,
+  days = 30,
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetVersionMarkersResponse> = fetcher;
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/version-markers?days=${days}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    versionMarkers: data?.versionMarkers ?? null,
+    isVersionMarkersLoading: !error && !data && !disabled,
+    isVersionMarkersError: error,
+    isVersionMarkersValidating: isValidating,
   };
 }

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -18,6 +18,7 @@ import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentConfigurationAnalyticsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics";
+import type { GetUsageMetricsResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics";
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent";
 import type { PostAgentUserFavoriteRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_favorite";
@@ -252,6 +253,7 @@ interface AgentConfigurationFeedbacksByDescVersionProps {
   agentConfigurationId: string | null;
   limit: number;
 }
+
 export function useAgentConfigurationFeedbacksByDescVersion({
   workspaceId,
   agentConfigurationId,
@@ -349,6 +351,7 @@ export function useAgentConfigurationHistory({
     mutateAgentConfigurationHistory: mutate,
   };
 }
+
 export function useAgentConfigurationLastAuthor({
   workspaceId,
   agentConfigurationId,
@@ -761,4 +764,33 @@ export function useBatchUpdateAgentScope({
   );
 
   return batchUpdateAgentScope;
+}
+
+export function useAgentUsageMetrics({
+  workspaceId,
+  agentConfigurationId,
+  days = 30,
+  interval = "day",
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  interval?: "day" | "week";
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetUsageMetricsResponse> = fetcher;
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/usage-metrics?days=${days}&interval=${interval}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    usageMetrics: data ?? null,
+    isUsageMetricsLoading: !error && !data && !disabled,
+    isUsageMetricsError: error,
+    isUsageMetricsValidating: isValidating,
+  };
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -117,6 +117,7 @@
         "react-markdown": "^8.0.7",
         "react-multi-select-component": "^4.3.4",
         "react-textarea-autosize": "^8.4.0",
+        "recharts": "^3.2.1",
         "redis": "^4.6.8",
         "sanitize-html": "^2.13.0",
         "sequelize": "^6.31.0",
@@ -8002,6 +8003,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remirror/core-constants": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
@@ -8585,6 +8611,16 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@statoscope/extensions": {
       "version": "5.28.1",
@@ -14137,6 +14173,11 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
       "license": "MIT",
@@ -14829,6 +14870,15 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.40.0.tgz",
+      "integrity": "sha512-8o6w0KFmU0CiIl0/Q/BCEOabF2IJaELM1T2PWj6e8KqzHv1gdx+7JtFnDwOx1kJH/isJ5NwlDG1nCr1HrRF94Q==",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
@@ -18765,8 +18815,6 @@
       "version": "10.1.3",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
       "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
-      "optional": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -25085,6 +25133,36 @@
         "react-dom": "^16 || ^17 || ^18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -25267,6 +25345,45 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/recharts/node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -25293,6 +25410,19 @@
         "@redis/json": "1.0.6",
         "@redis/search": "1.1.5",
         "@redis/time-series": "1.0.5"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -25962,6 +26092,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -28514,6 +28649,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -29662,6 +29802,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/front/package.json
+++ b/front/package.json
@@ -138,6 +138,7 @@
     "react-markdown": "^8.0.7",
     "react-multi-select-component": "^4.3.4",
     "react-textarea-autosize": "^8.4.0",
+    "recharts": "^3.2.1",
     "redis": "^4.6.8",
     "sanitize-html": "^2.13.0",
     "sequelize": "^6.31.0",

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -20,6 +20,8 @@ const QuerySchema = t.type({
   interval: t.union([t.literal("day"), t.literal("week"), t.undefined]),
 });
 
+const DEFAULT_PERIOD = 30;
+
 type ByIntervalBucket = {
   key: number;
   doc_count: number;
@@ -100,7 +102,7 @@ async function handler(
         });
       }
 
-      const days = q.right.days ? parseInt(q.right.days, 10) : 30;
+      const days = q.right.days ? parseInt(q.right.days, 10) : DEFAULT_PERIOD;
       const interval =
         (q.right.interval as "day" | "week" | undefined) ?? "day";
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -1,0 +1,163 @@
+import type { estypes } from "@elastic/elasticsearch";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  bucketsToArray,
+  formatUTCDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QuerySchema = t.type({
+  days: t.union([t.string, t.undefined]),
+  interval: t.union([t.literal("day"), t.literal("week"), t.undefined]),
+});
+
+type ByIntervalBucket = {
+  key: number;
+  doc_count: number;
+  unique_conversations?: estypes.AggregationsCardinalityAggregate;
+  active_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+type UsageAggs = {
+  by_interval?: estypes.AggregationsMultiBucketAggregateBase<ByIntervalBucket>;
+};
+
+export type UsageMetricsPoint = {
+  date: string;
+  messages: number;
+  conversations: number;
+  activeUsers: number;
+};
+
+export type GetUsageMetricsResponse = {
+  interval: "day" | "week";
+  points: UsageMetricsPoint[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetUsageMetricsResponse>>,
+  auth: Authenticator
+) {
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: req.query.aId as string,
+    variant: "light",
+  });
+
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  if (!assistant.canEdit && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only editors can get agent observability.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.decode(req.query);
+      if (isLeft(q)) {
+        const msg = reporter.formatValidationErrors(q.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${msg}`,
+          },
+        });
+      }
+
+      const days = q.right.days ? parseInt(q.right.days, 10) : 30;
+      const interval =
+        (q.right.interval as "day" | "week" | undefined) ?? "day";
+
+      const owner = auth.getNonNullableWorkspace();
+
+      const qdsl: estypes.QueryDslQueryContainer = {
+        bool: {
+          filter: [
+            { term: { workspace_id: owner.sId } },
+            { term: { agent_id: assistant.sId } },
+            { range: { timestamp: { gte: `now-${days}d/d` } } },
+          ],
+        },
+      };
+
+      const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+        by_interval: {
+          date_histogram: {
+            field: "timestamp",
+            calendar_interval: interval,
+          },
+          aggs: {
+            unique_conversations: {
+              cardinality: { field: "conversation_id" },
+            },
+            active_users: { cardinality: { field: "user_id" } },
+          },
+        },
+      };
+
+      const result = await searchAnalytics<unknown, UsageAggs>(qdsl, {
+        aggregations: aggs,
+        size: 0,
+      });
+      if (result.isErr()) {
+        const e = result.error;
+        return apiError(req, res, {
+          status_code: e.statusCode ?? 502,
+          api_error: {
+            type: "elasticsearch_error",
+            message: e.message,
+          },
+        });
+      }
+      const json = result.value;
+      const buckets = bucketsToArray<ByIntervalBucket>(
+        json.aggregations?.by_interval?.buckets
+      );
+
+      const points: UsageMetricsPoint[] = buckets.map((b) => {
+        const date = formatUTCDateFromMillis(b.key);
+        return {
+          date,
+          messages: b.doc_count ?? 0,
+          conversations: Math.round(b.unique_conversations?.value ?? 0),
+          activeUsers: Math.round(b.active_users?.value ?? 0),
+        };
+      });
+
+      return res.status(200).json({ interval, points });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -3,12 +3,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { UsageMetricsPoint } from "@app/lib/api/assistant/observability/usage_metrics";
+import { fetchUsageMetrics } from "@app/lib/api/assistant/observability/usage_metrics";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import {
-  bucketsToArray,
-  formatUTCDateFromMillis,
-  searchAnalytics,
-} from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -20,40 +17,9 @@ const QuerySchema = z.object({
   interval: z.enum(["day", "week"]).optional(),
 });
 
-type ByIntervalBucket = {
-  key: number;
-  doc_count: number;
-  unique_conversations?: estypes.AggregationsCardinalityAggregate;
-  active_users?: estypes.AggregationsCardinalityAggregate;
-};
-
-type VersionBucket = {
-  key: string;
-  doc_count: number;
-  first_seen?: estypes.AggregationsMinAggregate;
-};
-
-type UsageAggs = {
-  by_interval?: estypes.AggregationsMultiBucketAggregateBase<ByIntervalBucket>;
-  by_version?: estypes.AggregationsMultiBucketAggregateBase<VersionBucket>;
-};
-
-export type UsageMetricsPoint = {
-  date: string;
-  messages: number;
-  conversations: number;
-  activeUsers: number;
-};
-
-export type AgentVersionMarker = {
-  version: string;
-  timestamp: string;
-};
-
 export type GetUsageMetricsResponse = {
   interval: "day" | "week";
   points: UsageMetricsPoint[];
-  versionMarkers: AgentVersionMarker[];
 };
 
 function buildAgentAnalyticsBaseQuery(
@@ -120,91 +86,29 @@ async function handler(
 
       const owner = auth.getNonNullableWorkspace();
 
-      const qdsl = buildAgentAnalyticsBaseQuery(owner.sId, assistant.sId, days);
+      const baseQuery = buildAgentAnalyticsBaseQuery(
+        owner.sId,
+        assistant.sId,
+        days
+      );
 
-      const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
-        by_interval: {
-          date_histogram: {
-            field: "timestamp",
-            calendar_interval: interval,
-          },
-          aggs: {
-            unique_conversations: {
-              cardinality: { field: "conversation_id" },
-            },
-            active_users: { cardinality: { field: "user_id" } },
-          },
-        },
-        by_version: {
-          terms: {
-            field: "agent_version",
-            size: 100,
-          },
-          aggs: {
-            first_seen: {
-              min: { field: "timestamp" },
-            },
-          },
-        },
-      };
+      const usageMetricsResult = await fetchUsageMetrics(baseQuery, interval);
 
-      const result = await searchAnalytics<unknown, UsageAggs>(qdsl, {
-        aggregations: aggs,
-        size: 0,
-      });
-      if (result.isErr()) {
-        const e = result.error;
-        const statusCode =
-          e.type === "connection_error" ? 503 : e.statusCode ?? 500;
+      if (usageMetricsResult.isErr()) {
+        const e = usageMetricsResult.error;
         return apiError(req, res, {
-          status_code: statusCode,
+          status_code: 500,
           api_error: {
             type: "internal_server_error",
             message: `Failed to retrieve usage metrics: ${e.message}`,
           },
         });
       }
-      const json = result.value;
-      const buckets = bucketsToArray<ByIntervalBucket>(
-        json.aggregations?.by_interval?.buckets
-      );
 
-      const points: UsageMetricsPoint[] = buckets.map((b) => {
-        const date = formatUTCDateFromMillis(b.key);
-        return {
-          date,
-          messages: b.doc_count ?? 0,
-          conversations: Math.round(b.unique_conversations?.value ?? 0),
-          activeUsers: Math.round(b.active_users?.value ?? 0),
-        };
+      return res.status(200).json({
+        interval,
+        points: usageMetricsResult.value,
       });
-
-      const versionBuckets = bucketsToArray<VersionBucket>(
-        json.aggregations?.by_version?.buckets
-      );
-
-      const versionMarkers: AgentVersionMarker[] = versionBuckets
-        .map((b) => {
-          const firstSeenValue = b.first_seen?.value;
-          const firstSeenString = b.first_seen?.value_as_string;
-          const timestampMs =
-            typeof firstSeenValue === "number"
-              ? firstSeenValue
-              : typeof firstSeenString === "string"
-                ? parseInt(firstSeenString, 10)
-                : 0;
-
-          return {
-            version: b.key,
-            timestamp: formatUTCDateFromMillis(timestampMs),
-          };
-        })
-        .sort(
-          (a, b) =>
-            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-        );
-
-      return res.status(200).json({ interval, points, versionMarkers });
     }
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -176,12 +176,21 @@ async function handler(
       );
 
       const versionMarkers: AgentVersionMarker[] = versionBuckets
-        .map((b) => ({
-          version: b.key,
-          timestamp: formatUTCDateFromMillis(
-            b.first_seen?.value ?? b.first_seen?.value_as_string ?? 0
-          ),
-        }))
+        .map((b) => {
+          const firstSeenValue = b.first_seen?.value;
+          const firstSeenString = b.first_seen?.value_as_string;
+          const timestampMs =
+            typeof firstSeenValue === "number"
+              ? firstSeenValue
+              : typeof firstSeenString === "string"
+                ? parseInt(firstSeenString, 10)
+                : 0;
+
+          return {
+            version: b.key,
+            timestamp: formatUTCDateFromMillis(timestampMs),
+          };
+        })
         .sort(
           (a, b) =>
             new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
@@ -3,8 +3,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { UsageMetricsPoint } from "@app/lib/api/assistant/observability/usage_metrics";
-import { fetchUsageMetrics } from "@app/lib/api/assistant/observability/usage_metrics";
+import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
+import { fetchVersionMarkers } from "@app/lib/api/assistant/observability/version_markers";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -14,12 +14,10 @@ const DEFAULT_PERIOD = 30;
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional(),
-  interval: z.enum(["day", "week"]).optional(),
 });
 
-export type GetUsageMetricsResponse = {
-  interval: "day" | "week";
-  points: UsageMetricsPoint[];
+export type GetVersionMarkersResponse = {
+  versionMarkers: AgentVersionMarker[];
 };
 
 function buildAgentAnalyticsBaseQuery(
@@ -40,7 +38,7 @@ function buildAgentAnalyticsBaseQuery(
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetUsageMetricsResponse>>,
+  res: NextApiResponse<WithAPIErrorResponse<GetVersionMarkersResponse>>,
   auth: Authenticator
 ) {
   if (typeof req.query.aId !== "string") {
@@ -92,7 +90,6 @@ async function handler(
       }
 
       const days = q.data.days ?? DEFAULT_PERIOD;
-      const interval = q.data.interval ?? "day";
 
       const owner = auth.getNonNullableWorkspace();
 
@@ -102,22 +99,21 @@ async function handler(
         days
       );
 
-      const usageMetricsResult = await fetchUsageMetrics(baseQuery, interval);
+      const versionMarkersResult = await fetchVersionMarkers(baseQuery);
 
-      if (usageMetricsResult.isErr()) {
-        const e = usageMetricsResult.error;
+      if (versionMarkersResult.isErr()) {
+        const e = versionMarkersResult.error;
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to retrieve usage metrics: ${e.message}`,
+            message: `Failed to retrieve version markers: ${e.message}`,
           },
         });
       }
 
       return res.status(200).json({
-        interval,
-        points: usageMetricsResult.value,
+        versionMarkers: versionMarkersResult.value,
       });
     }
     default:


### PR DESCRIPTION
## Description

This PR introduces usage metrics visualization for agent configurations, adding an observability tab to the agent builder with interactive charts. The implementation includes a new API endpoint that retrieves usage metrics from Elasticsearch, displays them in a bar chart using `recharts`, and shows agent version markers to track changes over time. The observability tab is controlled by the agent_builder_observability feature flag and requires admin or editor permissions to access.

Note: this is a big WIP and design isn't final at all, for now we want to be able to see metrics and assess what insights could be derived from there.

<img width="954" height="574" alt="Screenshot 2025-10-16 at 12 11 03" src="https://github.com/user-attachments/assets/2a6f98d8-335e-427b-8e09-177f8437ba11" />
<img width="968" height="498" alt="Screenshot 2025-10-16 at 14 43 01" src="https://github.com/user-attachments/assets/37857ba8-7a14-454b-80b3-590c7b4636d2" />

## Tests

- Locally
- Front-edge

## Risk

Low, behind FF

## Deploy Plan

Deploy front
