### PR TITLE
Add Microsoft tools to search without Copilot

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1073,7 +1073,9 @@ The directive should be used to display a clickable version of the agent name in
     },
     isPreview: false,
     tools_stakes: {
-      search_files: "never_ask",
+      search_in_files: "never_ask",
+      search_drive_items: "never_ask",
+      get_file_content: "never_ask",
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
@@ -2,12 +2,15 @@ import type { Client } from "@microsoft/microsoft-graph-client";
 import { Client as GraphClient } from "@microsoft/microsoft-graph-client";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Readable } from "stream";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import { Err, Ok } from "@app/types";
+import config from "@app/lib/api/config";
+import logger from "@app/logger/logger";
+import { Err, Ok, TextExtraction } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const createServer = (auth: any): McpServer => {
@@ -25,7 +28,7 @@ const createServer = (auth: any): McpServer => {
   }
 
   server.tool(
-    "search_files",
+    "search_in_files",
     "Search in files in Microsoft OneDrive and SharePoint using Microsoft Copilot retrieval API.",
     {
       query: z
@@ -44,7 +47,7 @@ const createServer = (auth: any): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "microsoft" },
+      { toolNameForMonitoring: "microsoft_drive" },
       async ({ query, dataSource, maximumResults }, { authInfo }) => {
         const client = await getGraphClient(authInfo);
         if (!client) {
@@ -77,6 +80,184 @@ const createServer = (auth: any): McpServer => {
           return new Err(
             new MCPError(
               normalizeError(err).message || "Failed to search files"
+            )
+          );
+        }
+      }
+    )
+  );
+
+  server.tool(
+    "search_drive_items",
+    "Search OneDrive and SharePoint content using Microsoft Graph Search API to find relevant files and documents. This tool returns the results in relevance order.",
+    {
+      query: z
+        .string()
+        .describe(
+          "Search query to find relevant files and content in OneDrive and SharePoint."
+        ),
+    },
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "microsoft_drive" },
+      async ({ query }, { authInfo }) => {
+        const client = await getGraphClient(authInfo);
+        if (!client) {
+          return new Err(
+            new MCPError("Failed to authenticate with Microsoft Graph")
+          );
+        }
+
+        try {
+          const endpoint = `/search/query`;
+
+          const requestBody = {
+            requests: [
+              {
+                entityTypes: ["driveItem"],
+                query: {
+                  queryString: query,
+                },
+              },
+            ],
+          };
+
+          const response = await client
+            .api(endpoint)
+            .version("beta")
+            .post(requestBody);
+
+          return new Ok([
+            {
+              type: "text" as const,
+              text: JSON.stringify(response.value[0].hitsContainers, null, 2),
+            },
+          ]);
+        } catch (err) {
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to search drive items"
+            )
+          );
+        }
+      }
+    )
+  );
+
+  server.tool(
+    "get_file_content",
+    "Retrieve the content of files from SharePoint/OneDrive (Powerpoint, Word, Excel, etc.). Uses driveId if provided, otherwise falls back to siteId.",
+    {
+      itemId: z
+        .string()
+        .describe("The ID of the file item to retrieve content from."),
+      driveId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the drive containing the file. Takes priority over siteId if provided."
+        ),
+      siteId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the SharePoint site containing the file. Used if driveId is not provided."
+        ),
+    },
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "microsoft_drive" },
+      async ({ itemId, driveId, siteId }, { authInfo }) => {
+        const client = await getGraphClient(authInfo);
+        if (!client) {
+          return new Err(
+            new MCPError("Failed to authenticate with Microsoft Graph")
+          );
+        }
+
+        try {
+          let endpoint: string;
+
+          if (driveId) {
+            // Use driveId if provided (takes priority)
+            endpoint = `/drives/${driveId}/items/${itemId}`;
+          } else if (siteId) {
+            // Fall back to siteId if driveId is not provided
+            endpoint = `/sites/${siteId}/drive/items/${itemId}`;
+          } else {
+            return new Err(
+              new MCPError("Either driveId or siteId must be provided")
+            );
+          }
+
+          const response = await client.api(endpoint).get();
+
+          const downloadUrl = response["@microsoft.graph.downloadUrl"];
+          const mimeType = response.file.mimeType;
+
+          const docResponse = await fetch(downloadUrl);
+          const buffer = Buffer.from(await docResponse.arrayBuffer());
+
+          // Convert buffer to string based on mime type
+          let content: string = "";
+
+          if (mimeType.startsWith("text/")) {
+            content = buffer.toString("utf-8");
+          } else {
+            switch (mimeType) {
+              case "application/openxmlformats-officedocument.wordprocessingml.document": // Word document
+              case "application/vnd.openxmlformats-officedocument.presentationml.presentation": // PowerPoint document
+              case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": // Excel document
+              case "application/pdf": // PDF document
+                try {
+                  const textExtraction = new TextExtraction(
+                    config.getTextExtractionUrl(),
+                    {
+                      enableOcr: true,
+                      logger,
+                    }
+                  );
+
+                  const bufferStream = Readable.from(buffer);
+                  const textStream = await textExtraction.fromStream(
+                    bufferStream,
+                    mimeType as Parameters<typeof textExtraction.fromStream>[1]
+                  );
+
+                  const chunks: string[] = [];
+                  for await (const chunk of textStream) {
+                    chunks.push(chunk.toString());
+                  }
+
+                  content = chunks.join("");
+                } catch (error) {
+                  return new Err(
+                    new MCPError(
+                      `Failed to extract text: ${normalizeError(error).message}`
+                    )
+                  );
+                }
+                break;
+              case "application/vnd.ms-excel": // csv document
+                content = buffer.toString("utf-8");
+                break;
+              default:
+                return new Err(
+                  new MCPError(`Unsupported mime type: ${mimeType}`)
+                );
+            }
+          }
+
+          return new Ok([
+            {
+              type: "text" as const,
+              text: content,
+            },
+          ]);
+        } catch (err) {
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to retrieve file content"
             )
           );
         }


### PR DESCRIPTION
## Description

This PR adds search tools to the Microsoft MCP server, enabling clients without Copilot to search file content directly.
These tools also serve as a fallback for agents when Copilot searches don't return relevant results.

## Tests

Created some test files in the https://casquedelumiere-my.sharepoint.com/ Sharepoint.
Files used:
- Employees.xslx
- Christophe Resume.docx
- Dust presentation.pptx
- Jules_Belveze_CV.pdf

NOTE: OneNote is not handled by these tools

## Risk

Low

## Deploy Plan

Deploy front
