### PR TITLE
[ab] fix form state update

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -160,6 +160,9 @@ export default function AgentBuilder({
       }));
   }, [agentConfiguration, slackChannelsLinkedWithAgent]);
 
+  // This defaultValues should be computed only with data from backend.
+  // Any other values we are fetching on client side should be updated inside
+  // the useEffect below.
   const defaultValues = useMemo(() => {
     if (duplicateAgentId && agentConfiguration) {
       // Handle agent duplication case


### PR DESCRIPTION
## Description
Currently we compute the form value to override the form state, but since `agentConfiguration` comes from backend, when triggers or any other dependencies change, we override the form state with the agentConfiguration, which might not be the latest change since it never gets updated. I think it makes sense to calculate `defaultValues` only with the values from backend, and modify the form state inside the useEffect whenever we finish fetching the data.


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
