### PR TITLE
Slack Bot: fix error condition when personal auth is required

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -214,7 +214,7 @@ async function streamAgentAnswerToSlack(
             connector.workspaceId,
             conversation.sId
           );
-          await postSlackMessageUpdate({
+          await debouncedPostSlackMessageUpdate({
             messageUpdate: {
               text:
                 "The agent took an action that requires personal authentication. " +

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1259,7 +1259,7 @@ export function isMCPServerPersonalAuthRequiredError(
   return (
     error.code === "mcp_server_personal_authentication_required" &&
     error.metadata &&
-    "mcpServerId" in error.metadata
+    "mcp_server_id" in error.metadata
   );
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/4505
r? @flvndvd

There was two problem. First in sdk/js a type guard was erroneous (only used in connectors) for the
personal auth errors. Second, the debouncing of the postMessage was overwriting the error message
posted after a tool_error event with a generic "Agent is thinking" which was the debounced
postMessage from the tool_params event coming right before.

Before:
Blinking of an unhandled error message and then stuck with
<img width="447" height="297" alt="Screenshot 2025-10-16 at 13 22 40" src="https://github.com/user-attachments/assets/5917b41f-e436-48fc-9b05-28fd68ab58aa" />


After:
<img width="438" height="374" alt="Screenshot 2025-10-16 at 13 22 11" src="https://github.com/user-attachments/assets/25bd7510-e2d6-4c1e-9e1c-f360a85fff8d" />

## Tests

Tested locally
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- deploy `connectors`
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
