### PR TITLE
feat(@dust): 4.5 Haiku as default model for Dust global agent (gated)

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -19,8 +19,10 @@ import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_r
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
+  WhitelistableFeature,
 } from "@app/types";
 import {
+  CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
@@ -39,6 +41,7 @@ export function _getDustGlobalAgent(
     searchMCPServerView,
     deepDiveMCPServerView,
     interactiveContentMCPServerView,
+    featureFlags,
   }: {
     settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
@@ -47,6 +50,7 @@ export function _getDustGlobalAgent(
     searchMCPServerView: MCPServerViewResource | null;
     deepDiveMCPServerView: MCPServerViewResource | null;
     interactiveContentMCPServerView: MCPServerViewResource | null;
+    featureFlags: WhitelistableFeature[];
   }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
@@ -61,6 +65,12 @@ export function _getDustGlobalAgent(
     }
 
     if (isProviderWhitelisted(owner, "anthropic")) {
+      // When the `dust_default_haiku_feature` feature flag is enabled for this workspace,
+      // use Claude 4.5 Haiku as the default model for the @dust global agent instead of Sonnet.
+      if (featureFlags.includes("dust_default_haiku_feature")) {
+        return CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;
+      }
+
       return CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG;
     }
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -57,6 +57,7 @@ import type {
   AgentConfigurationType,
   AgentFetchVariant,
   GlobalAgentStatus,
+  WhitelistableFeature,
 } from "@app/types";
 import { isDevelopment } from "@app/types";
 import {
@@ -81,6 +82,7 @@ function getGlobalAgent({
   dataWarehousesMCPServerView,
   slideshowMCPServerView,
   deepDiveMCPServerView,
+  featureFlags,
 }: {
   auth: Authenticator;
   sId: string | number;
@@ -97,6 +99,7 @@ function getGlobalAgent({
   dataWarehousesMCPServerView: MCPServerViewResource | null;
   slideshowMCPServerView: MCPServerViewResource | null;
   deepDiveMCPServerView: MCPServerViewResource | null;
+  featureFlags: WhitelistableFeature[];
 }): AgentConfigurationType | null {
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
@@ -337,6 +340,7 @@ function getGlobalAgent({
         searchMCPServerView,
         deepDiveMCPServerView,
         interactiveContentMCPServerView,
+        featureFlags,
       });
       break;
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
@@ -568,6 +572,7 @@ export async function getGlobalAgents(
       dataWarehousesMCPServerView,
       slideshowMCPServerView,
       deepDiveMCPServerView,
+      featureFlags: flags,
     })
   );
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -209,6 +209,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Discord bot integration for workspace-level Discord integration",
     stage: "dust_only",
   },
+  dust_default_haiku_feature: {
+    description:
+      "Use Claude 4.5 Haiku as the default model for the @dust global agent",
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -694,6 +694,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "elevenlabs_tool"
   | "agent_builder_observability"
   | "legacy_dust_apps"
+  | "dust_default_haiku_feature"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Adds a feature flag that makes Claude 4.5 Haiku the default model for `@dust` 

## Tests



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
