### PR TITLE
Drain the upsert queue before updating parents

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -54,6 +54,7 @@ import {
   deleteDataSourceDocument,
   deleteDataSourceTable,
   deleteDataSourceTableRow,
+  drainDataSourceUpsertQueue,
   ignoreTablesError,
   MAX_DOCUMENT_TXT_LEN,
   MAX_PREFIX_CHARS,
@@ -1302,6 +1303,25 @@ export async function updateParentsFields({
 
   localLogger.info({ nbUpdated, nextCursors }, "Updated parents fields.");
   return nextCursors;
+}
+
+export async function drainDocumentUpsertQueue({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}) {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error("Could not find connector");
+  }
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  await drainDataSourceUpsertQueue({
+    dataSourceConfig,
+    loggerArgs: {
+      connectorId,
+    },
+  });
 }
 
 export async function markParentsAsUpdated({

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,4 +1,4 @@
-const WORKFLOW_VERSION = 48;
+const WORKFLOW_VERSION = 49;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;
 export const GARBAGE_COLLECT_QUEUE_NAME = `notion-gc-queue-v${WORKFLOW_VERSION}`;
 

--- a/connectors/src/connectors/notion/temporal/workflows/index.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/index.ts
@@ -41,7 +41,7 @@ const {
 });
 
 const { drainDocumentUpsertQueue } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "20 seconds",
+  startToCloseTimeout: "1 minute",
 });
 
 const {

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -38,6 +38,7 @@ import { DataSourceViewModel } from "./storage/models/data_source_view";
 export type FetchDataSourceOrigin =
   | "registry_lookup"
   | "v1_data_sources_search"
+  | "v1_data_sources_check_upsert_queue"
   | "v1_data_sources_documents"
   | "v1_data_sources_documents_document_get_or_upsert"
   | "v1_data_sources_documents_document_parents"

--- a/front/lib/temporal.ts
+++ b/front/lib/temporal.ts
@@ -105,3 +105,28 @@ export async function getTemporalClientForFrontNamespace() {
 export async function getTemporalClientForConnectorsNamespace() {
   return getTemporalClientForNamespace("connectors");
 }
+
+/**
+ * Checks if there are any running upsert workflows for a specific datasource.
+ * Returns the count of running workflows.
+ */
+export async function checkRunningUpsertWorkflows({
+  workspaceId,
+  dataSourceId,
+}: {
+  workspaceId: string;
+  dataSourceId: string;
+}): Promise<number> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  // Query for all Active upsert workflows for this datasource
+  const query = `WorkflowId STARTS_WITH "upsert-queue-document-${workspaceId}-${dataSourceId}-" AND ExecutionStatus="Running"`;
+  const workflows = client.workflow.list({ query });
+
+  let count = 0;
+  for await (const _workflow of workflows) {
+    count++;
+  }
+
+  return count;
+}

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/check_upsert_queue.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/check_upsert_queue.ts
@@ -1,0 +1,8 @@
+/* eslint-disable dust/enforce-client-types-in-public-api */
+import handler from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/check_upsert_queue";
+
+/**
+ * @ignoreswagger
+ * Endpoint used only from Connectors. since we it doesn't know the space id.
+ */
+export default handler;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/check_upsert_queue.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/check_upsert_queue.ts
@@ -1,0 +1,158 @@
+import type { CheckUpsertQueueResponseType } from "@dust-tt/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { checkRunningUpsertWorkflows } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/spaces/{spaceId}/data_sources/{dsId}/check_upsert_queue:
+ *   get:
+ *     summary: Check the upsert queue status for a data source
+ *     description: Returns the number of running document upsert workflows for this data source. This endpoint is only accessible with system API keys (e.g., from connectors).
+ *     tags:
+ *       - Datasources
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: dsId
+ *         required: true
+ *         description: ID of the data source
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Status of the upsert queue
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 running_count:
+ *                   type: number
+ *                   description: Number of currently running upsert workflows
+ *       400:
+ *         description: Bad Request. Missing or invalid parameters.
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       403:
+ *         description: Forbidden. Only system keys can access this endpoint.
+ *       404:
+ *         description: Data source not found.
+ *       405:
+ *         description: Method not supported.
+ *       500:
+ *         description: Internal Server Error.
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<CheckUpsertQueueResponseType>>,
+  auth: Authenticator
+): Promise<void> {
+  const { dsId } = req.query;
+  if (typeof dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  // Only allow system keys (connectors) to access this endpoint
+  if (!auth.isSystemKey()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message: "Only system keys can check the upsert queue.",
+      },
+    });
+  }
+
+  const dataSource = await DataSourceResource.fetchByNameOrId(auth, dsId, {
+    origin: "v1_data_sources_check_upsert_queue",
+  });
+
+  if (!dataSource || !dataSource.canRead(auth)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const owner = auth.getNonNullableWorkspace();
+
+      try {
+        const runningCount = await checkRunningUpsertWorkflows({
+          workspaceId: owner.sId,
+          dataSourceId: dataSource.sId,
+        });
+
+        logger.info(
+          {
+            workspaceId: owner.sId,
+            dataSourceId: dataSource.sId,
+            runningCount,
+          },
+          "[CheckUpsertQueue] Checked upsert queue status"
+        );
+
+        return res.status(200).json({ running_count: runningCount });
+      } catch (error) {
+        logger.error(
+          {
+            workspaceId: owner.sId,
+            dataSourceId: dataSource.sId,
+            error,
+          },
+          "[CheckUpsertQueue] Failed to check upsert queue"
+        );
+
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to check upsert queue.",
+          },
+        });
+      }
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/check_upsert_queue.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/check_upsert_queue.ts
@@ -4,7 +4,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { checkRunningUpsertWorkflows } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2308,6 +2308,13 @@ const PostParentsResponseSchema = z.object({
 });
 export type PostParentsResponseType = z.infer<typeof PostParentsResponseSchema>;
 
+const CheckUpsertQueueResponseSchema = z.object({
+  running_count: z.number(),
+});
+export type CheckUpsertQueueResponseType = z.infer<
+  typeof CheckUpsertQueueResponseSchema
+>;
+
 const GetDocumentsResponseSchema = z.object({
   documents: z.array(CoreAPIDocumentSchema),
   total: z.number(),


### PR DESCRIPTION
## Description

In `notionSyncWorkflow`, we have an issue the first time we sync a Notion datasource.

The basic logic is:

1. Phase 1: do all the doc upserts, and set the parents to ‘syncing’ when we don’t yet know the parent. That eventually calls core’s `data_sources_documents_upsert`
2. Phase 2: now that we have all the docs, call notionUpdateAllParentsFieldsWorkflow() to resolve all the parents, eventually calling core’s `data_sources_documents_update_parents`

The problem is that the calls to `data_sources_documents_upsert` go through the upsert queue in Front (in front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts), while notionUpdateAllParentsFieldsWorkflow() happens synchronously. So we can end up with calls to `data_sources_documents_update_parents` happening before `data_sources_documents_upsert`, and this overwrites the resolved parent chain!  In practice, this repros 100% of the time on my test scenario, and we know many customers are hitting it.

The fix is to drain the document upsert queue before calling notionUpdateAllParentsFieldsWorkflow().

## Tests

Manual

## Risk

Low

## Deploy Plan

Front, then Connector