### PR TITLE
Phase out Dust App - Add LLM wrapper

### DIFF
--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -55,7 +55,7 @@ export type LLMOutput = z.infer<typeof LLMOutputSchema>;
  * This provides a unified interface for calling LLMs while we transition away from individual Dust
  * apps. Once we have the direct LLM router ready, this wrapper will be fully removed.
  */
-export async function callLLM(
+export async function runMultiActionsAgent(
   auth: Authenticator,
   config: LLMConfig,
   input: LLMInput,

--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -1,0 +1,123 @@
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { runActionStreamed } from "@app/lib/actions/server";
+import type { Authenticator } from "@app/lib/auth";
+import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+export interface LLMConfig {
+  functionCall?: string | null;
+  modelId: string;
+  promptCaching?: boolean;
+  providerId: string;
+  reasoningEffort?: string;
+  responseFormat?: string;
+  temperature?: number;
+  useCache?: boolean;
+  useStream?: boolean;
+}
+
+export interface LLMInput {
+  conversation: unknown;
+  prompt: string;
+  specifications?: Array<{
+    name: string;
+    description: string;
+    inputSchema: any;
+  }>;
+}
+
+export interface LLMOptions {
+  tracingRecords?: Record<string, string>;
+}
+
+// Zod schema to validate runActionStreamed output.
+const LLMOutputSchema = z.object({
+  actions: z
+    .array(
+      z.object({
+        name: z.string(),
+        functionCallId: z.string().optional(),
+        arguments: z.record(z.any()),
+      })
+    )
+    .optional(),
+  generation: z.string().nullable().optional(),
+});
+
+export type LLMOutput = z.infer<typeof LLMOutputSchema>;
+
+/**
+ * Temporary wrapper around assistant-v2-multi-actions-agent Dust app to consolidate LLM interactions.
+ * This provides a unified interface for calling LLMs while we transition away from individual Dust
+ * apps. Once we have the direct LLM router ready, this wrapper will be fully removed.
+ */
+export async function callLLM(
+  auth: Authenticator,
+  config: LLMConfig,
+  input: LLMInput,
+  options: LLMOptions = {}
+): Promise<Result<LLMOutput, Error>> {
+  // Clone base config and apply overrides.
+  const runConfig = cloneBaseConfig(
+    getDustProdAction("assistant-v2-multi-actions-agent").config
+  );
+
+  // Override model configuration.
+  runConfig.MODEL.provider_id = config.providerId;
+  runConfig.MODEL.model_id = config.modelId;
+  runConfig.MODEL.temperature = config.temperature ?? 0;
+  runConfig.MODEL.function_call = config.functionCall ?? null;
+  runConfig.MODEL.use_cache = config.useCache ?? false;
+  runConfig.MODEL.use_stream = config.useStream ?? true;
+
+  const res = await runActionStreamed(
+    auth,
+    "assistant-v2-multi-actions-agent",
+    runConfig,
+    [input],
+    options.tracingRecords ?? {}
+  );
+
+  if (res.isErr()) {
+    return new Err(new Error(`LLM execution failed: ${res.error.message}`));
+  }
+
+  const { eventStream } = res.value;
+
+  for await (const event of eventStream) {
+    if (event.type === "error") {
+      return new Err(new Error(`LLM error: ${event.content.message}`));
+    }
+
+    if (event.type === "block_execution") {
+      const e = event.content.execution[0][0];
+      if (e.error) {
+        return new Err(new Error(`Block execution error: ${e.error}`));
+      }
+
+      if (event.content.block_name === "OUTPUT" && e.value) {
+        const parseResult = LLMOutputSchema.safeParse(e.value);
+        if (!parseResult.success) {
+          logger.error(
+            {
+              error: fromError(parseResult.error).toString(),
+            },
+            "Invalid LLM output schema"
+          );
+
+          return new Err(
+            new Error(`Invalid LLM output schema: ${parseResult.error.message}`)
+          );
+        }
+
+        return new Ok(parseResult.data);
+      }
+    }
+  }
+
+  return new Err(new Error("No output found in LLM response"));
+}

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 import { callLLM } from "@app/lib/api/assistant/call_llm";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -1,4 +1,4 @@
-import { callLLM } from "@app/lib/api/assistant/call_llm";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AuthenticatorType } from "@app/lib/auth";
@@ -143,7 +143,7 @@ async function generateConversationTitle(
     );
   }
 
-  const res = await callLLM(
+  const res = await runMultiActionsAgent(
     auth,
     {
       providerId: PROVIDER_ID,

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -30,20 +30,6 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-  "assistant-v2-title-generator": {
-    app: {
-      appId: "84dfc1d4f7",
-      appHash:
-        "6ea231add2ae690ee959c5d8d5d06420ea2feae7dd32ac13a4e655910087e313",
-    },
-    config: {
-      MODEL: {
-        // `provider_id` and `model_id` must be set by caller.
-        function_call: "update_title",
-        use_cache: false,
-      },
-    },
-  },
   "assistant-v2-retrieval": {
     app: {
       appId: "471b6aa923",

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -14,7 +14,6 @@ import { TriggerSubscriberModel } from "@app/lib/models/assistant/triggers/trigg
 import { TriggerModel } from "@app/lib/models/assistant/triggers/triggers";
 import { WebhookRequestModel } from "@app/lib/models/assistant/triggers/webhook_request";
 import { WebhookRequestTriggerModel } from "@app/lib/models/assistant/triggers/webhook_request_trigger";
-import { WebhookSourceModel } from "@app/lib/models/assistant/triggers/webhook_source";
 import { WebhookSourcesViewModel } from "@app/lib/models/assistant/triggers/webhook_sources_view";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
As we move forward we removing Dust apps that power Dust today to bundle this in `front`, we've decided to consolidate all LLMs interactions through the `assistant-v2-multi-actions-agent` Dust app.

This PR adds a temporary wrapper around this app, so we can use it to abstract interactions with the Dust app. To show how it works, I replaced the `assistant-v2-title-generator` Dust app which is responsible to generate a title for the conversation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
