### PR TITLE
Dust Apps: hide them if not gated in

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -317,10 +317,9 @@ The directive should be used to display a clickable version of the agent name in
     id: 10,
     availability: "auto",
     allowMultipleInstances: true,
-    isRestricted: undefined,
-    // isRestricted: ({ featureFlags }) => {
-    //   return !featureFlags.includes("legacy_dust_apps");
-    // },
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("legacy_dust_apps");
+    },
     isPreview: false,
     tools_stakes: undefined,
     tools_retry_policies: undefined,

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -127,7 +127,7 @@ export const CATEGORY_DETAILS: {
   apps: {
     label: "Apps",
     icon: CommandLineIcon,
-    // flag: "legacy_dust_apps",
+    flag: "legacy_dust_apps",
   },
   actions: {
     label: "Tools",


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/4673
Workspaces have been gated in both EU and US with https://github.com/dust-tt/dust/pull/16961

## Tests

Tested locally

## Risk

Hiding to some workspaces unexpectedly. Easy to tweaak.
This is just hiding stuff, not preventing any access or use.

## Deploy Plan

- deploy `front`
