### PR TITLE
[Agent Loop] Wait on prior run before restart during tool validation

### DIFF
--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -168,6 +168,9 @@ export async function validateAction(
       conversationId
     );
 
+  // Harmless very rare race condition here where 2 validations get
+  // blockedActions.length === 0. launchAgentLoopWorkflow will be called twice,
+  // but only one will succeed.
   if (blockedActions.length > 0) {
     logger.info(
       {

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -15,7 +15,6 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
-import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import type { ConversationType, Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -201,7 +201,6 @@ export async function validateAction(
     // validation. This avoids race conditions where validation re-triggers the
     // agent loop before it completes, and thus throws a workflow already
     // started error.
-    // CODEX TODO: add this option to the launchAgentLoopWorkflow function.
     waitForCompletion: true,
   });
 

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -15,9 +15,9 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import type { ConversationType, Result } from "@app/types";
 import { Err, Ok } from "@app/types";
-import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 
 async function getUserMessageIdFromMessageId(
   auth: Authenticator,
@@ -178,12 +178,6 @@ export async function validateAction(
     );
     return new Ok(undefined);
   }
-
-  const workflowId = makeAgentLoopWorkflowId({
-    workspaceId: owner.sId,
-    conversationId,
-    agentMessageId,
-  });
 
   await launchAgentLoopWorkflow({
     auth,


### PR DESCRIPTION
## Description
Context: https://dust4ai.slack.com/archives/C05B529FHV1/p1760458916960479?thread_ts=1760457171.975409&cid=C05B529FHV1

Fix race condition when validating tools -- the agent loop workflow may not be finished, we want to avoid workflow already running errors.

- Added `waitForCompletion?: boolean` to `front/temporal/agent_loop/client.ts`.
- When set, we await the current workflow handle's `result()` to finish (ignore not-found/failure) before starting a new run.

## Risks
Blast radius: agent loop launch on tool validation path only
Risk: low

## Deploy Plan
- deploy front