### PR TITLE
[DX] Add rule to remove unused imports on save

### DIFF
--- a/connectors/.eslintrc.js
+++ b/connectors/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
   ],
-  plugins: ["import", "simple-import-sort"],
+  plugins: ["import", "simple-import-sort", "eslint-plugin-unused-imports"],
   rules: {
     curly: ["error", "all"],
     "simple-import-sort/imports": [
@@ -29,6 +29,7 @@ module.exports = {
         ],
       },
     ],
+    "unused-imports/no-unused-imports": "error",
     "simple-import-sort/exports": "error",
     "@typescript-eslint/consistent-type-imports": "error",
     "import/consistent-type-specifier-style": ["error", "prefer-top-level"],

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -90,6 +90,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-simple-import-sort": "^12.1.0",
+        "eslint-plugin-unused-imports": "^4.2.0",
         "lint-staged": "^16.1.6",
         "prettier": "^3.0",
         "tsx": "^4.10.2",
@@ -9428,6 +9429,22 @@
       "dev": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz",
+      "integrity": "sha512-hLbJ2/wnjKq4kGA9AUaExVFIbNzyxYdVo49QZmKCnhk5pc9wcYRbfgLHvWJ8tnsdcseGhoUAddm9gn/lt+d74w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -100,6 +100,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-simple-import-sort": "^12.1.0",
+    "eslint-plugin-unused-imports": "^4.2.0",
     "lint-staged": "^16.1.6",
     "prettier": "^3.0",
     "tsx": "^4.10.2",

--- a/extension/.eslintrc.js
+++ b/extension/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
   ],
-  plugins: ["import", "simple-import-sort"],
+  plugins: ["import", "simple-import-sort", "eslint-plugin-unused-imports"],
   rules: {
     "import/no-cycle": "error",
     "@typescript-eslint/consistent-type-imports": "error",
@@ -44,6 +44,7 @@ module.exports = {
       },
     ],
     "simple-import-sort/exports": "error",
+    "unused-imports/no-unused-imports": "error",
   },
   overrides: [
     {

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -63,6 +63,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react": "^7.37.1",
         "eslint-plugin-simple-import-sort": "^12.1.1",
+        "eslint-plugin-unused-imports": "^4.2.0",
         "html-webpack-plugin": "^5.6.3",
         "postcss": "^8.4.47",
         "postcss-loader": "^8.1.1",
@@ -7713,6 +7714,22 @@
       "dev": true,
       "peerDependencies": {
         "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz",
+      "integrity": "sha512-hLbJ2/wnjKq4kGA9AUaExVFIbNzyxYdVo49QZmKCnhk5pc9wcYRbfgLHvWJ8tnsdcseGhoUAddm9gn/lt+d74w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-unused-imports": "^4.2.0",
     "html-webpack-plugin": "^5.6.3",
     "postcss": "^8.4.47",
     "postcss-loader": "^8.1.1",

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -5,7 +5,12 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
   ],
-  plugins: ["import", "simple-import-sort", "dust"],
+  plugins: [
+    "import",
+    "simple-import-sort",
+    "dust",
+    "eslint-plugin-unused-imports",
+  ],
   rules: {
     "import/no-cycle": "error",
     curly: ["error", "all"],
@@ -20,6 +25,7 @@ module.exports = {
         varsIgnorePattern: "^_",
       },
     ],
+    "unused-imports/no-unused-imports": "error",
     "no-case-declarations": 0,
     "@next/next/no-img-element": 0,
     "@typescript-eslint/no-floating-promises": "error",

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -6,7 +6,6 @@ import {
   VirtuosoMessageList,
   VirtuosoMessageListLicense,
 } from "@virtuoso.dev/message-list";
-import _ from "lodash";
 import debounce from "lodash/debounce";
 import React, {
   useCallback,

--- a/front/lib/api/assistant/global_agents/configurations/dust/noop.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/noop.ts
@@ -1,4 +1,3 @@
-import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
 import type { AgentConfigurationType } from "@app/types";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types";
 import { GLOBAL_AGENTS_SID, NOOP_MODEL_CONFIG } from "@app/types";

--- a/viz/.eslintrc.json
+++ b/viz/.eslintrc.json
@@ -4,10 +4,12 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended"
   ],
+  "plugins": ["eslint-plugin-unused-imports"],
   "rules": {
     "eqeqeq": "error",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
-    "@typescript-eslint/no-explicit-any": "error"
+    "@typescript-eslint/no-explicit-any": "error",
+    "unused-imports/no-unused-imports": "error"
   }
 }

--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -71,6 +71,7 @@
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "eslint": "^8",
         "eslint-config-next": "14.2.5",
+        "eslint-plugin-unused-imports": "^4.2.0",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -4130,6 +4131,22 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz",
+      "integrity": "sha512-hLbJ2/wnjKq4kGA9AUaExVFIbNzyxYdVo49QZmKCnhk5pc9wcYRbfgLHvWJ8tnsdcseGhoUAddm9gn/lt+d74w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/viz/package.json
+++ b/viz/package.json
@@ -72,6 +72,7 @@
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "eslint": "^8",
     "eslint-config-next": "14.2.5",
+    "eslint-plugin-unused-imports": "^4.2.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"


### PR DESCRIPTION
## Description

I've seen multiple commits just removing unused imports after a refactor in front files. This means waiting for the CI to run, adding a commit (potentially context switching) and re-waiting for the new CI run.

Although there is already the `@typescript-eslint/no-unused-vars` rule set up, with this new rule and VSCode `codeActionsOnSave`, these unused imports would be automatically removed.