### PR TITLE
Do not hide the rootProps onOpenChange if passed in to CollaspibleComponent.

### DIFF
--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -173,7 +173,10 @@ const CollapsibleComponent = React.forwardRef<
         ref={ref}
         {...rootProps}
         open={open}
-        onOpenChange={(open) => setOpen(open)}
+        onOpenChange={(open) => {
+          setOpen(open);
+          rootProps?.onOpenChange?.(open);
+        }}
       >
         <CollapsibleTrigger {...triggerProps} isOpen={open}>
           {triggerChildren}


### PR DESCRIPTION
## Description

We hide the onOpenChange if passed to the Collapsible.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy sparkle