### PR TITLE
Add Teams MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -91,6 +91,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "slideshow",
   "jira",
   "microsoft_drive",
+  "microsoft_teams",
   "missing_action_catcher",
   "monday",
   "notion",
@@ -1090,7 +1091,35 @@ The directive should be used to display a clickable version of the agent name in
           "User.Read Files.Read.All Sites.Read.All ExternalItem.Read.All" as const,
       },
       icon: "MicrosoftLogo",
-      documentationUrl: "https://docs.dust.tt/docs/microsoft-tool-setup",
+      documentationUrl: "https://docs.dust.tt/docs/microsoft-drive-tool-setup",
+      instructions: null,
+    },
+  },
+  microsoft_teams: {
+    id: 36,
+    availability: "manual",
+    allowMultipleInstances: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("microsoft_teams_mcp_server");
+    },
+    isPreview: false,
+    tools_stakes: {
+      search_messages: "never_ask",
+    },
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "microsoft_teams",
+      version: "1.0.0",
+      description: "Search messages in Microsoft Teams.",
+      authorization: {
+        provider: "microsoft_tools" as const,
+        supported_use_cases: ["personal_actions"] as const,
+        scope:
+          "User.Read Chat.Read ChatMessage.Read ChannelMessage.Read.All" as const,
+      },
+      icon: "MicrosoftLogo", // TODO: Add Microsoft Teams icon
+      documentationUrl: "https://docs.dust.tt/docs/microsoft-teams-tool-setup",
       instructions: null,
     },
   },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -28,6 +28,7 @@ import { default as interactiveContentServer } from "@app/lib/actions/mcp_intern
 import { default as jiraServer } from "@app/lib/actions/mcp_internal_actions/servers/jira";
 import { default as jitTestingServer } from "@app/lib/actions/mcp_internal_actions/servers/jit_testing";
 import { default as microsoftDriveServer } from "@app/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive";
+import { default as microsoftTeamsServer } from "@app/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams";
 import { default as missingActionCatcherServer } from "@app/lib/actions/mcp_internal_actions/servers/missing_action_catcher";
 import { default as mondayServer } from "@app/lib/actions/mcp_internal_actions/servers/monday";
 import { default as notionServer } from "@app/lib/actions/mcp_internal_actions/servers/notion";
@@ -154,6 +155,8 @@ export async function getInternalMCPServer(
       return jiraServer(auth, agentLoopContext);
     case "microsoft_drive":
       return microsoftDriveServer(auth);
+    case "microsoft_teams":
+      return microsoftTeamsServer(auth);
     case "monday":
       return mondayServer(auth, agentLoopContext);
     case "slack":

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
@@ -1,6 +1,3 @@
-import type { Client } from "@microsoft/microsoft-graph-client";
-import { Client as GraphClient } from "@microsoft/microsoft-graph-client";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Readable } from "stream";
 import { z } from "zod";
@@ -18,19 +15,10 @@ import {
 } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+import { getGraphClient } from "./utils";
+
 const createServer = (auth: any): McpServer => {
   const server = makeInternalMCPServer("microsoft_drive");
-
-  async function getGraphClient(authInfo?: AuthInfo): Promise<Client | null> {
-    const accessToken = authInfo?.token;
-    if (!accessToken) {
-      return null;
-    }
-
-    return GraphClient.init({
-      authProvider: (done) => done(null, accessToken),
-    });
-  }
 
   server.tool(
     "search_in_files",

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams.ts
@@ -1,0 +1,71 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import { Err, Ok } from "@app/types";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+import { getGraphClient } from "./utils";
+
+const createServer = (auth: any): McpServer => {
+  const server = makeInternalMCPServer("microsoft_teams");
+
+  server.tool(
+    "search_messages",
+    "Search for messages in Microsoft Teams chats and channels. Returns the results in relevance order.",
+    {
+      query: z
+        .string()
+        .describe("Search query to find relevant messages in Teams."),
+    },
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "microsoft_teams" },
+      async ({ query }, { authInfo }) => {
+        const client = await getGraphClient(authInfo);
+        if (!client) {
+          return new Err(
+            new MCPError("Failed to authenticate with Microsoft Graph")
+          );
+        }
+
+        try {
+          const endpoint = `/search/query`;
+
+          const requestBody = {
+            requests: [
+              {
+                entityTypes: ["chatMessage"],
+                query: {
+                  queryString: query,
+                },
+                enableTopResults: true,
+              },
+            ],
+          };
+
+          const response = await client.api(endpoint).post(requestBody);
+
+          return new Ok([
+            {
+              type: "text" as const,
+              text: JSON.stringify(response.value[0].hitsContainers, null, 2),
+            },
+          ]);
+        } catch (err) {
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to search Teams messages"
+            )
+          );
+        }
+      }
+    )
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/utils.ts
@@ -1,0 +1,16 @@
+import type { Client } from "@microsoft/microsoft-graph-client";
+import { Client as GraphClient } from "@microsoft/microsoft-graph-client";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+
+export async function getGraphClient(
+  authInfo?: AuthInfo
+): Promise<Client | null> {
+  const accessToken = authInfo?.token;
+  if (!accessToken) {
+    return null;
+  }
+
+  return GraphClient.init({
+    authProvider: (done) => done(null, accessToken),
+  });
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -195,6 +195,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Microsoft Drive MCP server",
     stage: "dust_only",
   },
+  microsoft_teams_mcp_server: {
+    description: "Microsoft Teams MCP server",
+    stage: "dust_only",
+  },
   agent_builder_observability: {
     description:
       "Observability tab in the Agent Builder (charts powered by Elasticsearch)",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -670,6 +670,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_transcripts"
   | "microsoft_teams_bot"
   | "microsoft_drive_mcp_server"
+  | "microsoft_teams_mcp_server"
   | "monday_tool"
   | "notion_private_integration"
   | "openai_o1_custom_assistants_feature"


### PR DESCRIPTION
## Description

Create a new MCP server for Microsoft Teams.
Only one tool for the moment to search through Team messages

## Tests

Send some random messages in your Teams workspace and ask an agent questions about your messages content.

## Risk

Low

## Deploy Plan

Deploy front
