### PR TITLE
[Tool cancellation] Temp: nullate changes from cancel signal from #16311

### DIFF
--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -65,7 +65,7 @@ export async function* runToolWithStreaming(
 
   const { toolConfiguration, status, augmentedInputs: inputs } = action;
 
-  const signal = options?.signal;
+  // const signal = options?.signal;
 
   const localLogger = logger.child({
     actionConfigurationId: toolConfiguration.sId,
@@ -102,7 +102,6 @@ export async function* runToolWithStreaming(
           conversation,
           agentMessage,
         }),
-      signal,
     }
   );
 

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -50,7 +50,7 @@ export async function* runToolWithStreaming(
     agentMessage: AgentMessageType;
     conversation: ConversationType;
   },
-  options?: { signal?: AbortSignal }
+  _options?: { signal?: AbortSignal }
 ): AsyncGenerator<
   | MCPApproveExecutionEvent
   | MCPErrorEvent

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -39,7 +39,7 @@ const { runModelAndCreateActionsActivity } = proxyActivities<
 const { runToolActivity } = proxyActivities<typeof runToolActivities>({
   // Activity timeout keeps a short buffer above the tool timeout to detect worker restarts promptly.
   startToCloseTimeout: toolActivityStartToCloseTimeout,
-  heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
+  // heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
   retry: {
     // Do not retry tool activities. Those are not idempotent.
     maximumAttempts: 1,
@@ -50,7 +50,7 @@ const { runToolActivity: runRetryableToolActivity } = proxyActivities<
   typeof runToolActivities
 >({
   startToCloseTimeout: toolActivityStartToCloseTimeout,
-  heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
+  //heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
   retry: {
     maximumAttempts: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
   },


### PR DESCRIPTION
Description
---

Fixes issue described in
[thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1760622737439439?thread_ts=1760621535.401499&cid=C050SM8NSPK) (temporary, while we fix underlying issue)

It seems cancel signals from tools introduced by https://github.com/dust-tt/dust/pull/16311 are overlistened by run_agent, who cancels itself without user request and leaves main loop pending.

Risks
---
low

Deploy
---
front
