### PR TITLE
[Poke] Enabled pokefy test on local env

### DIFF
--- a/front/lib/utils/url-to-poke.ts
+++ b/front/lib/utils/url-to-poke.ts
@@ -132,12 +132,15 @@ export function convertUrlToPoke(url: string): string | null {
   try {
     const urlObj = new URL(url);
 
-    // Check if it's a Dust domain (dust.tt or any subdomain like eu.dust.tt)
+    // Check if it's a Dust domain (dust.tt or any subdomain like eu.dust.tt) or localhost
     // Must be exactly dust.tt or *.dust.tt (not *dust.tt which would match notdust.tt)
-    if (
-      urlObj.hostname !== "dust.tt" &&
-      !urlObj.hostname.endsWith(".dust.tt")
-    ) {
+    const isValidHostname =
+      urlObj.hostname === "dust.tt" ||
+      urlObj.hostname.endsWith(".dust.tt") ||
+      urlObj.hostname === "localhost" ||
+      urlObj.hostname === "127.0.0.1";
+
+    if (!isValidHostname) {
       return null;
     }
 
@@ -180,12 +183,15 @@ export function convertPokeToUrl(pokeUrl: string): string | null {
   try {
     const urlObj = new URL(pokeUrl);
 
-    // Check if it's a Dust domain (dust.tt or any subdomain like eu.dust.tt)
+    // Check if it's a Dust domain (dust.tt or any subdomain like eu.dust.tt) or localhost
     // Must be exactly dust.tt or *.dust.tt (not *dust.tt which would match notdust.tt)
-    if (
-      urlObj.hostname !== "dust.tt" &&
-      !urlObj.hostname.endsWith(".dust.tt")
-    ) {
+    const isValidHostname =
+      urlObj.hostname === "dust.tt" ||
+      urlObj.hostname.endsWith(".dust.tt") ||
+      urlObj.hostname === "localhost" ||
+      urlObj.hostname === "127.0.0.1";
+
+    if (!isValidHostname) {
       return null;
     }
 

--- a/front/pages/poke/pokefy.tsx
+++ b/front/pages/poke/pokefy.tsx
@@ -29,7 +29,8 @@ function PokefyPage() {
       if (fullUrl.startsWith("dust.tt/") || fullUrl.startsWith("eu.dust.tt/")) {
         fullUrl = "https://" + fullUrl;
       } else if (fullUrl.startsWith("w/")) {
-        fullUrl = `https://${window.location.hostname}/${fullUrl}`;
+        // Use current protocol and host (includes port for localhost:3000)
+        fullUrl = `${window.location.protocol}//${window.location.host}/${fullUrl}`;
       } else {
         fullUrl = "https://" + fullUrl;
       }

--- a/front/pages/poke/pokefy.tsx
+++ b/front/pages/poke/pokefy.tsx
@@ -29,7 +29,9 @@ function PokefyPage() {
       if (fullUrl.startsWith("dust.tt/") || fullUrl.startsWith("eu.dust.tt/")) {
         fullUrl = "https://" + fullUrl;
       } else if (fullUrl.startsWith("w/")) {
-        // Use current protocol and host (includes port for localhost:3000)
+        // Use current protocol and host
+        // - In dev: http://localhost:3000
+        // - In prod: https://dust.tt (or https://eu.dust.tt)
         fullUrl = `${window.location.protocol}//${window.location.host}/${fullUrl}`;
       } else {
         fullUrl = "https://" + fullUrl;


### PR DESCRIPTION
## Description

Enables the pokefy URL conversion tool to work in local development environments by allowing localhost and 127.0.0.1 hostnames in the hostname validation logic. This change affects both URL-to-poke and poke-to-URL conversion functions, and updates the pokefy page to use the current protocol and host for relative URLs instead of hardcoding https.

## Test

Local

## Risk

Low risk as this only affects local development environments and the poke tool functionality.

## Deploy Plan

Run Front