### PR TITLE
[front] enh(MCP): improve logging across internal MCP servers

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -154,9 +154,9 @@ export async function getInternalMCPServer(
     case "jira":
       return jiraServer(auth, agentLoopContext);
     case "microsoft_drive":
-      return microsoftDriveServer(auth);
+      return microsoftDriveServer(auth, agentLoopContext);
     case "microsoft_teams":
-      return microsoftTeamsServer(auth);
+      return microsoftTeamsServer(auth, agentLoopContext);
     case "monday":
       return mondayServer(auth, agentLoopContext);
     case "slack":

--- a/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
@@ -63,6 +63,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async (_, { authInfo }) => {
@@ -104,6 +105,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ issueKey, fields }, { authInfo }) => {
@@ -154,6 +156,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async (_, { authInfo }) => {
@@ -189,6 +192,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ projectKey }, { authInfo }) => {
@@ -231,6 +235,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ projectKey }, { authInfo }) => {
@@ -275,6 +280,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ issueKey }, { authInfo }) => {
@@ -324,6 +330,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async (
@@ -406,6 +413,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
@@ -466,6 +474,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
@@ -515,6 +524,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ projectKey }, { authInfo }) => {
@@ -566,6 +576,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ projectKey, issueTypeId }, { authInfo }) => {
@@ -613,6 +624,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async (_, { authInfo }) => {
@@ -656,6 +668,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ issueKey, transitionId }, { authInfo }) => {
@@ -729,6 +742,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ issueData }, { authInfo }) => {
@@ -773,6 +787,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ issueKey, updateData }, { authInfo }) => {
@@ -834,6 +849,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ linkData }, { authInfo }) => {
@@ -882,6 +898,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ linkId }, { authInfo }) => {
@@ -917,6 +934,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async (_, { authInfo }) => {
@@ -985,6 +1003,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async (
@@ -1104,6 +1123,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ issueKey, attachment }, { authInfo }) => {
@@ -1230,6 +1250,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ issueKey }, { authInfo }) => {
@@ -1297,6 +1318,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ issueKey, attachmentId }, { authInfo }) => {

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_drive.ts
@@ -3,9 +3,12 @@ import { Readable } from "stream";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { getGraphClient } from "@app/lib/actions/mcp_internal_actions/servers/microsoft/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import {
   Err,
@@ -15,9 +18,10 @@ import {
 } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-import { getGraphClient } from "./utils";
-
-const createServer = (auth: any): McpServer => {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("microsoft_drive");
 
   server.tool(
@@ -40,7 +44,7 @@ const createServer = (auth: any): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "microsoft_drive" },
+      { toolNameForMonitoring: "microsoft_drive", agentLoopContext },
       async ({ query, dataSource, maximumResults }, { authInfo }) => {
         const client = await getGraphClient(authInfo);
         if (!client) {
@@ -92,7 +96,7 @@ const createServer = (auth: any): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "microsoft_drive" },
+      { toolNameForMonitoring: "microsoft_drive", agentLoopContext },
       async ({ query }, { authInfo }) => {
         const client = await getGraphClient(authInfo);
         if (!client) {
@@ -156,7 +160,7 @@ const createServer = (auth: any): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "microsoft_drive" },
+      { toolNameForMonitoring: "microsoft_drive", agentLoopContext },
       async ({ itemId, driveId, siteId }, { authInfo }) => {
         const client = await getGraphClient(authInfo);
         if (!client) {
@@ -243,6 +247,6 @@ const createServer = (auth: any): McpServer => {
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams.ts
@@ -2,14 +2,18 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { getGraphClient } from "@app/lib/actions/mcp_internal_actions/servers/microsoft/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-import { getGraphClient } from "./utils";
-
-const createServer = (auth: any): McpServer => {
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
   const server = makeInternalMCPServer("microsoft_teams");
 
   server.tool(
@@ -22,7 +26,7 @@ const createServer = (auth: any): McpServer => {
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "microsoft_teams" },
+      { toolNameForMonitoring: "microsoft_teams", agentLoopContext },
       async ({ query }, { authInfo }) => {
         const client = await getGraphClient(authInfo);
         if (!client) {
@@ -66,6 +70,6 @@ const createServer = (auth: any): McpServer => {
   );
 
   return server;
-};
+}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -49,7 +49,7 @@ function createServer(
       {},
       withToolLogging(
         auth,
-        { toolNameForMonitoring: "placeholder_tool" },
+        { toolNameForMonitoring: "placeholder_tool", agentLoopContext },
         async () => {
           return new Ok([{ type: "text", text: "No action name found" }]);
         }

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -330,6 +330,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ query, type, relativeTimeFrame }, { authInfo }) => {
@@ -490,6 +491,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ pageId }, { authInfo }) => {
@@ -511,6 +513,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ databaseId }, { authInfo }) => {
@@ -539,6 +542,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async (
@@ -577,6 +581,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async (
@@ -613,6 +618,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ parent, properties, icon, cover }, { authInfo }) => {
@@ -637,6 +643,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ databaseId, properties, icon, cover }, { authInfo }) => {
@@ -674,6 +681,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ parent, title, properties, icon, cover }, { authInfo }) => {
@@ -697,6 +705,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ pageId, properties }, { authInfo }) => {
@@ -718,6 +727,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ blockId }, { authInfo }) => {
@@ -744,6 +754,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ blockId, start_cursor, page_size }, { authInfo }) => {
@@ -775,6 +786,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ blockId, children }, { authInfo }) => {
@@ -813,6 +825,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ parent_page_id, discussion_id, comment }, { authInfo }) => {
@@ -852,6 +865,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ blockId }, { authInfo }) => {
@@ -876,6 +890,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ blockId }, { authInfo }) => {
@@ -898,6 +913,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ pageId, properties }, { authInfo }) => {
@@ -920,6 +936,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ databaseId, properties }, { authInfo }) => {
@@ -940,6 +957,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async (_, { authInfo }) => {
@@ -958,6 +976,7 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ userId }, { authInfo }) => {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -28,7 +28,7 @@ export function withToolLogging<T>(
     skipAlerting = false,
   }: {
     toolNameForMonitoring: string;
-    agentLoopContext?: AgentLoopContextType;
+    agentLoopContext: AgentLoopContextType | undefined;
     skipAlerting?: boolean;
   },
   toolCallback: (


### PR DESCRIPTION
## Description

- This PR passes the `agentLoopContext` to `withToolLogging` calls, which allows adding some useful IDs (agent, conversation, message, etc..) to the logs emitted in `withToolLogging`.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
