### PR TITLE
[front] enh(alerting): Switch alerting on tool errors to be opt-in

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -32,7 +32,11 @@ function createServer(
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "agent_router", agentLoopContext },
+      {
+        toolNameForMonitoring: "agent_router",
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async () => {
         const owner = auth.getNonNullableWorkspace();
         const requestedGroupIds = auth.groups().map((g) => g.sId);
@@ -94,7 +98,11 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "agent_router", agentLoopContext },
+      {
+        toolNameForMonitoring: "agent_router",
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({ userMessage }) => {
         const owner = auth.getNonNullableWorkspace();
         const requestedGroupIds = auth.groups().map((g) => g.sId);

--- a/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/index.ts
@@ -31,7 +31,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (_, { authInfo }) => {
@@ -82,7 +81,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (params, { authInfo }) => {
@@ -147,7 +145,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (params, { authInfo }) => {
@@ -220,7 +217,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: CONFLUENCE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (params, { authInfo }) => {

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -396,7 +396,11 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FILESYSTEM_FIND_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: FILESYSTEM_FIND_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({
         query,
         dataSources,
@@ -501,7 +505,11 @@ function createServer(
       SearchToolInputSchema.shape,
       withToolLogging(
         auth,
-        { toolNameForMonitoring: SEARCH_TOOL_NAME, agentLoopContext },
+        {
+          toolNameForMonitoring: SEARCH_TOOL_NAME,
+          agentLoopContext,
+          enableAlerting: true,
+        },
         async (params) => searchCallback(auth, agentLoopContext, params)
       )
     );
@@ -540,7 +548,11 @@ function createServer(
       },
       withToolLogging(
         auth,
-        { toolNameForMonitoring: SEARCH_TOOL_NAME, agentLoopContext },
+        {
+          toolNameForMonitoring: SEARCH_TOOL_NAME,
+          agentLoopContext,
+          enableAlerting: true,
+        },
         async (params) =>
           searchCallback(auth, agentLoopContext, params, {
             tagsIn: params.tagsIn,
@@ -568,6 +580,7 @@ function createServer(
       {
         toolNameForMonitoring: FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
         agentLoopContext,
+        enableAlerting: true,
       },
       async ({ nodeId, dataSources }) => {
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
@@ -78,7 +78,11 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({ nodeId, limit, nextPageCursor, dataSources }) => {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
@@ -181,7 +185,11 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({ query, rootNodeId, limit, nextPageCursor, dataSources }) => {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
@@ -257,7 +265,11 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({ dataSources, tableIds }) => {
         const dataSourceConfigurationsResult =
           await getAgentDataSourceConfigurations(
@@ -352,7 +364,11 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: TABLES_FILESYSTEM_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({ dataSources, tableIds, query, fileName }) => {
         if (!agentLoopContext?.runContext) {
           return new Err(

--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -36,7 +36,11 @@ function createServer(
     {},
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "handoff", agentLoopContext },
+      {
+        toolNameForMonitoring: "handoff",
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async () => {
         if (!agentLoopContext?.runContext) {
           return new Err(new MCPError("No conversation context available"));

--- a/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/freshservice/index.ts
@@ -206,7 +206,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ filter, fields, page, per_page }, { authInfo }) => {
@@ -286,7 +285,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ ticket_id, fields, include }, { authInfo }) => {
@@ -347,7 +345,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (_, { authInfo }) => {
@@ -402,7 +399,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -521,7 +517,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -599,7 +594,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ ticket_id, body, private: isPrivate }, { authInfo }) => {
@@ -643,7 +637,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ ticket_id, body }, { authInfo }) => {
@@ -685,7 +678,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ ticket_id }, { authInfo }) => {
@@ -725,7 +717,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ ticket_id, task_id }, { authInfo }) => {
@@ -780,7 +771,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -878,7 +868,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -958,7 +947,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ ticket_id, task_id }, { authInfo }) => {
@@ -999,7 +987,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
@@ -1045,7 +1032,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
@@ -1091,7 +1077,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
@@ -1137,7 +1122,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
@@ -1188,7 +1172,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ category_id, page, per_page }, { authInfo }) => {
@@ -1255,7 +1238,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -1312,7 +1294,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ display_id }, { authInfo }) => {
@@ -1353,7 +1334,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ display_id }, { authInfo }) => {
@@ -1422,7 +1402,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -1527,7 +1506,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
@@ -1573,7 +1551,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ category_id, page, per_page }, { authInfo }) => {
@@ -1631,7 +1608,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ folder_id, category_id, page, per_page }, { authInfo }) => {
@@ -1694,7 +1670,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ article_id }, { authInfo }) => {
@@ -1744,7 +1719,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ title, description, folder_id, status, tags }, { authInfo }) => {
@@ -1805,7 +1779,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ email, mobile, phone, page, per_page }, { authInfo }) => {
@@ -1859,7 +1832,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ requester_id }, { authInfo }) => {
@@ -1900,7 +1872,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ page, per_page }, { authInfo }) => {
@@ -1943,7 +1914,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (_, { authInfo }) => {
@@ -1985,7 +1955,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ search }, { authInfo }) => {
@@ -2055,7 +2024,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -2115,7 +2083,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ response_id }, { authInfo }) => {
@@ -2155,7 +2122,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ ticket_id, approval_id }, { authInfo }) => {
@@ -2194,7 +2160,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ ticket_id }, { authInfo }) => {
@@ -2254,7 +2219,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: FRESHSERVICE_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -81,7 +81,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: "gmail",
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ q, pageToken }, { authInfo }) => {
@@ -169,7 +168,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: "gmail",
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ to, cc, bcc, subject, contentType, body }, { authInfo }) => {
@@ -256,7 +254,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: "gmail",
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ draftId, subject, to }, { authInfo }) => {
@@ -313,7 +310,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: "gmail",
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ q, maxResults = 10, pageToken }, { authInfo }) => {
@@ -453,7 +449,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: "gmail",
-        skipAlerting: true,
         agentLoopContext,
       },
       async (

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -124,7 +124,6 @@ function createServer(
       {
         toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ pageToken, maxResults }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
@@ -184,7 +183,6 @@ function createServer(
       {
         toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (
         { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
@@ -269,7 +267,6 @@ function createServer(
       {
         toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
@@ -333,7 +330,6 @@ function createServer(
       {
         toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (
         {
@@ -437,7 +433,6 @@ function createServer(
       {
         toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (
         {
@@ -534,7 +529,6 @@ function createServer(
       {
         toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ calendarId = "primary", eventId }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
@@ -587,7 +581,6 @@ function createServer(
       {
         toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ email, startTime, endTime, timeZone }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);
@@ -667,7 +660,6 @@ function createServer(
       {
         toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ emails }, { authInfo }) => {
         const calendar = await getCalendarClient(authInfo);

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -52,7 +52,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: "google_drive",
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ pageToken }, { authInfo }) => {
@@ -147,7 +146,6 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       auth,
       {
         toolNameForMonitoring: "google_drive",
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -237,7 +235,6 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       auth,
       {
         toolNameForMonitoring: "google_drive",
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ fileId, offset, limit }, { authInfo }) => {

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -68,7 +68,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
@@ -125,7 +124,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ spreadsheetId, includeGridData }, { authInfo }) => {
@@ -179,7 +177,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -241,7 +238,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -310,7 +306,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -370,7 +365,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ spreadsheetId, range }, { authInfo }) => {
@@ -415,7 +409,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ title, sheetTitles }, { authInfo }) => {
@@ -472,7 +465,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ spreadsheetId, title, rowCount, columnCount }, { authInfo }) => {
@@ -528,7 +520,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ spreadsheetId, sheetId }, { authInfo }) => {
@@ -608,7 +599,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -690,7 +680,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -737,7 +726,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
@@ -797,7 +785,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
@@ -116,6 +116,7 @@ function createServer(
       {
         toolNameForMonitoring: CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
         agentLoopContext,
+        enableAlerting: true,
       },
       async (
         { file_name, mime_type, content, description },
@@ -232,6 +233,7 @@ function createServer(
       {
         toolNameForMonitoring: EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
         agentLoopContext,
+        enableAlerting: true,
       },
       async (
         { file_id, old_string, new_string, expected_replacements },
@@ -298,6 +300,7 @@ function createServer(
       {
         toolNameForMonitoring: REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
         agentLoopContext,
+        enableAlerting: true,
       },
       async ({ file_id }, { sendNotification, _meta }) => {
         if (!agentLoopContext?.runContext) {
@@ -369,6 +372,7 @@ function createServer(
       {
         toolNameForMonitoring: RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
         agentLoopContext,
+        enableAlerting: true,
       },
       async ({ file_id, new_file_name }, { sendNotification, _meta }) => {
         const { agentConfiguration } = agentLoopContext?.runContext ?? {};
@@ -430,6 +434,7 @@ function createServer(
       {
         toolNameForMonitoring: RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
         agentLoopContext,
+        enableAlerting: true,
       },
       async ({ file_id }) => {
         const result = await getClientExecutableFileContent(auth, file_id);

--- a/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
@@ -567,8 +567,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        agentLoopContext,
-        skipAlerting: true,
       },
       async ({ projectKey, issueTypeId }, { authInfo }) => {
         return withAuth({

--- a/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/index.ts
@@ -64,7 +64,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (_, { authInfo }) => {
         return withAuth({
@@ -106,7 +105,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ issueKey, fields }, { authInfo }) => {
         return withAuth({
@@ -157,7 +155,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (_, { authInfo }) => {
         return withAuth({
@@ -193,7 +190,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
@@ -236,7 +232,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
@@ -281,7 +276,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
@@ -331,7 +325,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (
         { issueKey, comment, visibilityType, visibilityValue },
@@ -414,7 +407,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
         return withAuth({
@@ -475,7 +467,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
         return withAuth({
@@ -525,7 +516,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ projectKey }, { authInfo }) => {
         return withAuth({
@@ -577,6 +567,7 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
+        agentLoopContext,
         skipAlerting: true,
       },
       async ({ projectKey, issueTypeId }, { authInfo }) => {
@@ -625,7 +616,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (_, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -669,7 +659,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ issueKey, transitionId }, { authInfo }) => {
         return withAuth({
@@ -743,7 +732,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ issueData }, { authInfo }) => {
         return withAuth({
@@ -788,7 +776,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ issueKey, updateData }, { authInfo }) => {
         return withAuth({
@@ -850,7 +837,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ linkData }, { authInfo }) => {
         return withAuth({
@@ -899,7 +885,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ linkId }, { authInfo }) => {
         return withAuth({
@@ -935,7 +920,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (_, { authInfo }) => {
         return withAuth({
@@ -1004,7 +988,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (
         { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
@@ -1124,7 +1107,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ issueKey, attachment }, { authInfo }) => {
         return withAuth({
@@ -1251,7 +1233,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ issueKey }, { authInfo }) => {
         return withAuth({
@@ -1319,7 +1300,6 @@ function createServer(
       {
         toolNameForMonitoring: JIRA_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ issueKey, attachmentId }, { authInfo }) => {
         return withAuth({

--- a/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/index.ts
@@ -57,7 +57,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (_params, { authInfo }) => {
@@ -86,7 +85,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ boardId }, { authInfo }) => {
@@ -115,7 +113,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ itemId }, { authInfo }) => {
@@ -176,7 +173,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -250,7 +246,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ boardId, itemName, groupId, columnValues }, { authInfo }) => {
@@ -290,7 +285,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ itemId, columnValues }, { authInfo }) => {
@@ -325,7 +319,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: MONDAY_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ itemId, body }, { authInfo }) => {

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -331,7 +331,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ query, type, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
@@ -492,7 +491,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ pageId }, { authInfo }) => {
         return withNotionClient(
@@ -514,7 +512,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ databaseId }, { authInfo }) => {
         return withNotionClient(
@@ -543,7 +540,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
@@ -582,7 +578,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (
         { databaseId, filter, sorts, start_cursor, page_size },
@@ -619,7 +614,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ parent, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
@@ -644,7 +638,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ databaseId, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
@@ -682,7 +675,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ parent, title, properties, icon, cover }, { authInfo }) => {
         return withNotionClient(
@@ -706,7 +698,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
@@ -728,7 +719,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
@@ -755,7 +745,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ blockId, start_cursor, page_size }, { authInfo }) => {
         return withNotionClient(
@@ -787,7 +776,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ blockId, children }, { authInfo }) => {
         return withNotionClient(
@@ -826,7 +814,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ parent_page_id, discussion_id, comment }, { authInfo }) => {
         return withNotionClient((notion) => {
@@ -866,7 +853,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
@@ -891,7 +877,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ blockId }, { authInfo }) => {
         return withNotionClient(
@@ -914,7 +899,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ pageId, properties }, { authInfo }) => {
         return withNotionClient(
@@ -937,7 +921,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ databaseId, properties }, { authInfo }) => {
         return withNotionClient(
@@ -958,7 +941,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (_, { authInfo }) => {
         return withNotionClient((notion) => notion.users.list({}), authInfo);
@@ -977,7 +959,6 @@ function createServer(
       {
         toolNameForMonitoring: NOTION_TOOL_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ userId }, { authInfo }) => {
         return withNotionClient(

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -25,7 +25,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (_, { authInfo }) => {
@@ -85,7 +84,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ top = 250, skip = 0, userTimezone }, { authInfo }) => {
@@ -155,7 +153,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -219,7 +216,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ calendarId, eventId, userTimezone }, { authInfo }) => {
@@ -302,7 +298,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -404,7 +399,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -482,7 +476,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ calendarId, eventId, userTimezone }, { authInfo }) => {
@@ -540,7 +533,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_CALENDAR_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
@@ -107,7 +107,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ search, top = 10, skip = 0, select }, { authInfo }) => {
@@ -193,7 +192,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ search, top = 10, skip = 0 }, { authInfo }) => {
@@ -288,7 +286,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -372,7 +369,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ messageId, subject, to }, { authInfo }) => {
@@ -441,7 +437,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -569,7 +564,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ search, top = 20, skip = 0, select }, { authInfo }) => {
@@ -663,7 +657,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (
@@ -787,7 +780,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: OUTLOOK_TOOL_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async (

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -243,7 +243,11 @@ export default async function createServer(
       configurableProperties,
       withToolLogging(
         auth,
-        { toolNameForMonitoring: RUN_AGENT_TOOL_LOG_NAME, agentLoopContext },
+        {
+          toolNameForMonitoring: RUN_AGENT_TOOL_LOG_NAME,
+          agentLoopContext,
+          enableAlerting: true,
+        },
         async () => new Err(new MCPError("No child agent configured"))
       )
     );
@@ -289,7 +293,11 @@ export default async function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: RUN_AGENT_TOOL_LOG_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: RUN_AGENT_TOOL_LOG_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async (
         {
           query,

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce/index.ts
@@ -36,7 +36,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ query }, { authInfo }) => {
@@ -74,7 +73,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ filter }, { authInfo }) => {
@@ -118,7 +116,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ objectName }, { authInfo }) => {
@@ -231,7 +228,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ recordId }, { authInfo }) => {
@@ -297,7 +293,6 @@ function createServer(
       auth,
       {
         toolNameForMonitoring: SALESFORCE_TOOL_LOG_NAME,
-        skipAlerting: true,
         agentLoopContext,
       },
       async ({ recordId, attachmentId }, { authInfo }) => {

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -270,7 +270,11 @@ function createServer(
       commonInputsSchema,
       withToolLogging(
         auth,
-        { toolNameForMonitoring: SEARCH_TOOL_NAME, agentLoopContext },
+        {
+          toolNameForMonitoring: SEARCH_TOOL_NAME,
+          agentLoopContext,
+          enableAlerting: true,
+        },
         async (args) => searchFunction({ ...args, auth, agentLoopContext })
       )
     );
@@ -286,7 +290,11 @@ function createServer(
       },
       withToolLogging(
         auth,
-        { toolNameForMonitoring: SEARCH_TOOL_NAME, agentLoopContext },
+        {
+          toolNameForMonitoring: SEARCH_TOOL_NAME,
+          agentLoopContext,
+          enableAlerting: true,
+        },
         async (args) => searchFunction({ ...args, auth, agentLoopContext })
       )
     );

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -320,7 +320,6 @@ async function createServer(
         {
           toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
           agentLoopContext,
-          skipAlerting: true,
         },
         async (
           {
@@ -625,7 +624,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ channel, relativeTimeFrame }, { authInfo }) => {
         if (!agentLoopContext?.runContext) {
@@ -770,7 +768,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -816,7 +813,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -849,7 +845,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -883,7 +878,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;

--- a/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
@@ -57,7 +57,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ to, message, threadTs, fileId }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -100,7 +99,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -132,7 +130,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ userId }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -165,7 +162,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ nameFilter }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -217,7 +213,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ channel, limit = 20, cursor, oldest, latest }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -300,7 +295,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async (
         { channel, threadTs, limit = 20, cursor, oldest, latest },
@@ -386,7 +380,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;
@@ -444,7 +437,6 @@ async function createServer(
       {
         toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
         agentLoopContext,
-        skipAlerting: true,
       },
       async ({ channel, timestamp, name }, { authInfo }) => {
         const accessToken = authInfo?.token;

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
@@ -118,6 +118,7 @@ function createServer(
       {
         toolNameForMonitoring: GET_DATABASE_SCHEMA_TOOL_NAME,
         agentLoopContext,
+        enableAlerting: true,
       },
       async ({ tables }) => {
         // Fetch table configurations
@@ -224,6 +225,7 @@ function createServer(
       {
         toolNameForMonitoring: EXECUTE_DATABASE_QUERY_TOOL_NAME,
         agentLoopContext,
+        enableAlerting: true,
       },
       async ({ tables, query, fileName }) => {
         // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -64,7 +64,11 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: WEBSEARCH_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: WEBSEARCH_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({ query, page }) => {
         if (!agentLoopContext?.runContext) {
           throw new Error(
@@ -156,7 +160,11 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: WEBBROWSER_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: WEBBROWSER_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({
         urls,
         format = "markdown",

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -64,7 +64,11 @@ export function registerCatTool(
     catToolInputSchema,
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FILESYSTEM_CAT_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: FILESYSTEM_CAT_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({ dataSources, nodeId, offset, limit, grep }) => {
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -93,7 +93,11 @@ export function registerListTool(
     ListToolInputSchema,
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FILESYSTEM_LIST_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: FILESYSTEM_LIST_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({
         nodeId,
         dataSources,

--- a/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
@@ -54,7 +54,11 @@ export function registerFindTagsTool(
     findTagsSchema,
     withToolLogging(
       auth,
-      { toolNameForMonitoring: FIND_TAGS_TOOL_NAME, agentLoopContext },
+      {
+        toolNameForMonitoring: FIND_TAGS_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
+      },
       async ({
         query,
         dataSources,

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -99,11 +99,11 @@ export function withToolLogging<T>(
       }
 
       // If the error is tracked, then we want to surface it with `logger.error`, otherwise just a warning, so we don't lose them if needed
-      const logContext = { error: result.error, ...loggerArgs };
-      if (result.error.tracked && !skipAlerting) {
+      const logContext = { ...loggerArgs, error: result.error };
+      if (result.error.tracked) {
         logger.error(logContext, "Tool execution error");
       } else {
-        logger.warn(logContext, "Tool execution warning");
+        logger.warn(logContext, "Tool execution error");
       }
 
       return {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -25,11 +25,11 @@ export function withToolLogging<T>(
   {
     toolNameForMonitoring,
     agentLoopContext,
-    skipAlerting = false,
+    enableAlerting = false,
   }: {
     toolNameForMonitoring: string;
     agentLoopContext: AgentLoopContextType | undefined;
-    skipAlerting?: boolean;
+    enableAlerting?: boolean;
   },
   toolCallback: (
     params: T,
@@ -82,7 +82,7 @@ export function withToolLogging<T>(
       `workspace_plan_code:${auth.plan()?.code ?? null}`,
     ];
 
-    if (!skipAlerting) {
+    if (enableAlerting) {
       statsDClient.increment("use_tools.count", 1, tags);
     }
     const startTime = performance.now();
@@ -91,7 +91,7 @@ export function withToolLogging<T>(
 
     // When we get an Err, we monitor it if tracked and return it as a text content.
     if (result.isErr()) {
-      if (result.error.tracked && !skipAlerting) {
+      if (enableAlerting && result.error.tracked) {
         statsDClient.increment("use_tools_error.count", 1, [
           "error_type:run_error",
           ...tags,
@@ -118,7 +118,7 @@ export function withToolLogging<T>(
     }
 
     const elapsed = performance.now() - startTime;
-    if (!skipAlerting) {
+    if (enableAlerting) {
       statsDClient.distribution(
         "run_tool.duration.distribution",
         elapsed,

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -98,7 +98,6 @@ export function withToolLogging<T>(
         ]);
       }
 
-      // If the error is tracked, then we want to surface it with `logger.error`, otherwise just a warning, so we don't lose them if needed
       const logContext = { ...loggerArgs, error: result.error };
       if (result.error.tracked) {
         logger.error(logContext, "Tool execution error");


### PR DESCRIPTION
## Description

- This PR swaps the `skipAlerting` flag in `withToolLogging` around to make the alerting opt-in.
- New rule: only the core features will be tracked and fall onto the eng on-call's responsibility, this wrapper is now a tool that can be used by whomever develops an internal MCP server to monitor the use of the tool, but should only be enabled when the tool reaches a very sane state. Until then, the idea is to monitor via the logs mostly, will share an example DD notebook that can be tweaked to monitor the executions of a certain tool.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
