### PR TITLE
Enable filters for custom webhooks

### DIFF
--- a/front/components/agent_builder/triggers/TriggerFilterRenderer.tsx
+++ b/front/components/agent_builder/triggers/TriggerFilterRenderer.tsx
@@ -164,10 +164,17 @@ export function TriggerFilterRenderer({ data }: TriggerFilterRendererProps) {
       </div>
     );
   } catch (error) {
+    const errorMessage =
+      error instanceof Error &&
+      "message" in error &&
+      typeof error.message === "string"
+        ? error.message
+        : "unknown error";
     return (
       <div className="overflow-hidden px-4 py-4">
         <p className="text-sm text-warning">
-          Error parsing filter expression. Please check the filter syntax.
+          Error parsing filter expression: {errorMessage}. Please check the
+          filter syntax.
         </p>
       </div>
     );

--- a/front/components/agent_builder/triggers/WebhookEditionModal.tsx
+++ b/front/components/agent_builder/triggers/WebhookEditionModal.tsx
@@ -438,37 +438,62 @@ export function WebhookEditionModal({
               )}
 
               {/* Filters input */}
-              {selectedPreset && availableEvents.length > 0 && (
-                <div className="space-y-1">
-                  <Label htmlFor="trigger-filter-description">
-                    Filter Description (optional)
-                  </Label>
-                  <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    Describe in natural language the conditions under which the
-                    agent should trigger. Will always trigger if left empty.
-                  </p>
-                  <TextArea
-                    id="trigger-filter-description"
-                    placeholder='e.g. "New pull requests that changes more than 500 lines of code, or have the `auto-review` label."'
-                    rows={3}
-                    value={naturalDescription}
-                    disabled={!isEditor}
-                    onChange={(e) => {
-                      if (!selectedEvent || !selectedPreset) {
-                        form.setError("event", {
-                          type: "manual",
-                          message: "Please select an event first",
-                        });
-                        return;
+              <div className="space-y-1">
+                {selectedPreset && availableEvents.length > 0 && (
+                  <>
+                    <Label htmlFor="trigger-filter-description">
+                      Filter Description (optional)
+                    </Label>
+                    <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      Describe in natural language the conditions under which
+                      the agent should trigger. Will always trigger if left
+                      empty.
+                    </p>
+                    <TextArea
+                      id="trigger-filter-description"
+                      placeholder='e.g. "New pull requests that changes more than 500 lines of code, or have the `auto-review` label."'
+                      rows={3}
+                      value={naturalDescription}
+                      disabled={!isEditor}
+                      onChange={(e) => {
+                        if (!selectedEvent || !selectedPreset) {
+                          form.setError("event", {
+                            type: "manual",
+                            message: "Please select an event first",
+                          });
+                          return;
+                        }
+
+                        setNaturalDescription(e.target.value);
+                      }}
+                    />
+                  </>
+                )}
+
+                {selectedWebhookSource?.kind === "custom" && (
+                  <>
+                    <Label htmlFor="trigger-filter-description">
+                      Filter Expression (optional)
+                    </Label>
+                    <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      Enter a filter that will be used to filter the webhook
+                      payload JSON. Will always trigger if left empty.
+                    </p>
+                    <TextArea
+                      id="trigger-filter-description"
+                      placeholder={
+                        'example:\n\n(and\n  (eq "action" "opened")\n  (exists "pull_request")\n)'
                       }
+                      rows={6}
+                      {...form.register("filter")}
+                      disabled={!isEditor}
+                      error={form.formState.errors.filter?.message}
+                    />
+                  </>
+                )}
 
-                      setNaturalDescription(e.target.value);
-                    }}
-                  />
-
-                  <div className="pt-2">{filterGenerationResult}</div>
-                </div>
-              )}
+                <div className="pt-2">{filterGenerationResult}</div>
+              </div>
 
               <div className="flex items-center justify-between">
                 <div className="flex flex-col space-y-1">

--- a/front/lib/matcher/parser.test.ts
+++ b/front/lib/matcher/parser.test.ts
@@ -195,8 +195,14 @@ describe("parseMatcherExpression", () => {
       expect(() => parseMatcherExpression("()")).toThrow("Empty expression");
     });
 
+    it("should throw on unbalanced parentheses", () => {
+      expect(() => parseMatcherExpression('(eq "field" "value"')).toThrow(
+        "Unbalanced parentheses"
+      );
+    });
+
     it("should throw on missing opening paren", () => {
-      expect(() => parseMatcherExpression('eq "field" "value")')).toThrow(
+      expect(() => parseMatcherExpression('e(q "field" "value")')).toThrow(
         "Expression must start with '('"
       );
     });

--- a/front/lib/matcher/parser.ts
+++ b/front/lib/matcher/parser.ts
@@ -19,6 +19,19 @@ import {
 export function parseMatcherExpression(expression: string): MatcherExpression {
   let index = 0;
 
+  // Check that it has a balanced number of parentheses.
+  let openParentheses = 0;
+  for (let i = 0; i < expression.length; i++) {
+    if (expression[i] === "(") {
+      openParentheses++;
+    } else if (expression[i] === ")") {
+      openParentheses--;
+    }
+  }
+  if (openParentheses !== 0) {
+    throw new Error("Unbalanced parentheses");
+  }
+
   function skipWhitespace() {
     while (index < expression.length && /\s/.test(expression[index])) {
       index++;


### PR DESCRIPTION
## Description

Allow custom webhook to use manual filter (no schema so no generation for them).
Show an input box.
Improved error message.

## Tests

Local

<img width="771" height="811" alt="image" src="https://github.com/user-attachments/assets/080d3883-0b00-4df1-b571-153455123ce9" />


## Risk

Low

## Deploy Plan

Deploy front