### PR TITLE
[front] - feat(Obs): tool usage metric

### DIFF
--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -1,4 +1,5 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { ToolExecutionChart } from "@app/components/agent_builder/observability/ToolExecutionChart";
 import { UsageMetricsChart } from "@app/components/agent_builder/observability/UsageMetricsChart";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 
@@ -31,6 +32,10 @@ export function AgentBuilderObservability({
 
       <div className="grid grid-cols-1 gap-6">
         <UsageMetricsChart
+          workspaceId={owner.sId}
+          agentConfigurationId={agentConfiguration.sId}
+        />
+        <ToolExecutionChart
           workspaceId={owner.sId}
           agentConfigurationId={agentConfiguration.sId}
         />

--- a/front/components/agent_builder/observability/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/ChartContainer.tsx
@@ -28,50 +28,40 @@ export function ChartContainer({
   children,
   additionalControls,
 }: ChartContainerProps) {
+  const message = isLoading ? null : errorMessage ?? emptyMessage;
+
   return (
     <div className="bg-card rounded-lg border border-border p-4">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-medium text-foreground">{title}</h3>
         <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2">
-            {OBSERVABILITY_TIME_RANGE.map((p) => (
-              <button
-                key={p}
-                onClick={() => onPeriodChange(p)}
-                className={cn(
-                  "rounded px-2 py-1 text-xs",
-                  period === p
-                    ? "bg-foreground text-background"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                {p}d
-              </button>
-            ))}
-          </div>
+          {OBSERVABILITY_TIME_RANGE.map((p) => (
+            <button
+              key={p}
+              onClick={() => onPeriodChange(p)}
+              className={cn(
+                "rounded px-2 py-1 text-xs",
+                period === p
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {p}d
+            </button>
+          ))}
           {additionalControls}
         </div>
       </div>
-      {isLoading ? (
+      {isLoading || message ? (
         <div
           className="flex items-center justify-center"
           style={{ height: CHART_HEIGHT }}
         >
-          <Spinner size="lg" />
-        </div>
-      ) : errorMessage ? (
-        <div
-          className="flex items-center justify-center"
-          style={{ height: CHART_HEIGHT }}
-        >
-          <span className="text-sm text-muted-foreground">{errorMessage}</span>
-        </div>
-      ) : emptyMessage ? (
-        <div
-          className="flex items-center justify-center"
-          style={{ height: CHART_HEIGHT }}
-        >
-          <span className="text-sm text-muted-foreground">{emptyMessage}</span>
+          {isLoading ? (
+            <Spinner size="lg" />
+          ) : (
+            <span className="text-sm text-muted-foreground">{message}</span>
+          )}
         </div>
       ) : (
         children

--- a/front/components/agent_builder/observability/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/ChartContainer.tsx
@@ -1,0 +1,85 @@
+import { cn, Spinner } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import {
+  CHART_HEIGHT,
+  OBSERVABILITY_TIME_RANGE,
+} from "@app/components/agent_builder/observability/constants";
+
+interface ChartContainerProps {
+  title: string;
+  period: ObservabilityTimeRangeType;
+  onPeriodChange: (period: ObservabilityTimeRangeType) => void;
+  isLoading: boolean;
+  isError: boolean;
+  isEmpty?: boolean;
+  errorMessage?: string;
+  emptyMessage?: string;
+  children: ReactNode;
+  additionalControls?: ReactNode;
+}
+
+export function ChartContainer({
+  title,
+  period,
+  onPeriodChange,
+  isLoading,
+  isError,
+  isEmpty = false,
+  errorMessage = "Failed to load chart data.",
+  emptyMessage = "No data available for this period.",
+  children,
+  additionalControls,
+}: ChartContainerProps) {
+  return (
+    <div className="bg-card rounded-lg border border-border p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-medium text-foreground">{title}</h3>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            {OBSERVABILITY_TIME_RANGE.map((p) => (
+              <button
+                key={p}
+                onClick={() => onPeriodChange(p)}
+                className={cn(
+                  "rounded px-2 py-1 text-xs",
+                  period === p
+                    ? "bg-foreground text-background"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {p}d
+              </button>
+            ))}
+          </div>
+          {additionalControls}
+        </div>
+      </div>
+      {isLoading ? (
+        <div
+          className="flex items-center justify-center"
+          style={{ height: CHART_HEIGHT }}
+        >
+          <Spinner size="lg" />
+        </div>
+      ) : isError ? (
+        <div
+          className="flex items-center justify-center"
+          style={{ height: CHART_HEIGHT }}
+        >
+          <p className="text-sm text-muted-foreground">{errorMessage}</p>
+        </div>
+      ) : isEmpty ? (
+        <div
+          className="flex items-center justify-center"
+          style={{ height: CHART_HEIGHT }}
+        >
+          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}

--- a/front/components/agent_builder/observability/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/ChartContainer.tsx
@@ -12,8 +12,6 @@ interface ChartContainerProps {
   period: ObservabilityTimeRangeType;
   onPeriodChange: (period: ObservabilityTimeRangeType) => void;
   isLoading: boolean;
-  isError: boolean;
-  isEmpty?: boolean;
   errorMessage?: string;
   emptyMessage?: string;
   children: ReactNode;
@@ -25,10 +23,8 @@ export function ChartContainer({
   period,
   onPeriodChange,
   isLoading,
-  isError,
-  isEmpty = false,
-  errorMessage = "Failed to load chart data.",
-  emptyMessage = "No data available for this period.",
+  errorMessage,
+  emptyMessage,
   children,
   additionalControls,
 }: ChartContainerProps) {
@@ -63,19 +59,19 @@ export function ChartContainer({
         >
           <Spinner size="lg" />
         </div>
-      ) : isError ? (
+      ) : errorMessage ? (
         <div
           className="flex items-center justify-center"
           style={{ height: CHART_HEIGHT }}
         >
-          <p className="text-sm text-muted-foreground">{errorMessage}</p>
+          <span className="text-sm text-muted-foreground">{errorMessage}</span>
         </div>
-      ) : isEmpty ? (
+      ) : emptyMessage ? (
         <div
           className="flex items-center justify-center"
           style={{ height: CHART_HEIGHT }}
         >
-          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+          <span className="text-sm text-muted-foreground">{emptyMessage}</span>
         </div>
       ) : (
         children

--- a/front/components/agent_builder/observability/ChartLegend.tsx
+++ b/front/components/agent_builder/observability/ChartLegend.tsx
@@ -1,0 +1,24 @@
+import { LegendDot } from "@app/components/agent_builder/observability/ChartTooltip";
+
+interface LegendItem {
+  key: string;
+  label: string;
+  colorClassName: string;
+}
+
+interface ChartLegendProps {
+  items: LegendItem[];
+}
+
+export function ChartLegend({ items }: ChartLegendProps) {
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
+      {items.map((item) => (
+        <div key={item.key} className="flex items-center gap-2">
+          <LegendDot className={item.colorClassName} />
+          <span className="text-sm text-muted-foreground">{item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/front/components/agent_builder/observability/ToolExecutionChart.tsx
+++ b/front/components/agent_builder/observability/ToolExecutionChart.tsx
@@ -58,7 +58,7 @@ export function ToolExecutionChart({
         allToolsSet.add(toolName);
         toolTotalCounts.set(
           toolName,
-          (toolTotalCounts.get(toolName) || 0) + toolData.count
+          (toolTotalCounts.get(toolName) ?? 0) + toolData.count
         );
       });
     });
@@ -109,13 +109,18 @@ export function ToolExecutionChart({
       return null;
     }
 
+    const getColorForTool = (toolName: string) => {
+      const idx = topTools.indexOf(toolName);
+      return TOOL_COLORS[(idx >= 0 ? idx : 0) % TOOL_COLORS.length];
+    };
+
     const rows = payload
       .filter((p) => typeof p.value === "number" && p.value > 0)
-      .sort((a, b) => (b.value as number) - (a.value as number))
-      .map((p, idx) => ({
+      .sort((a, b) => b.value - a.value)
+      .map((p) => ({
         label: p.name || "",
         value: `${p.value}%`,
-        colorClassName: TOOL_COLORS[idx % TOOL_COLORS.length],
+        colorClassName: getColorForTool(p.name || ""),
       }));
 
     return (

--- a/front/components/agent_builder/observability/ToolExecutionChart.tsx
+++ b/front/components/agent_builder/observability/ToolExecutionChart.tsx
@@ -148,51 +148,46 @@ export function ToolExecutionChart({
           : undefined
       }
     >
-      <>
-        <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-          <BarChart
-            data={chartData}
-            margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
-          >
-            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-            <XAxis
-              dataKey="version"
-              className="text-xs text-muted-foreground"
+      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+        <BarChart
+          data={chartData}
+          margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+          <XAxis dataKey="version" className="text-xs text-muted-foreground" />
+          <YAxis
+            className="text-xs text-muted-foreground"
+            label={{
+              value: "Usage %",
+              angle: -90,
+              position: "insideLeft",
+              style: { textAnchor: "middle" },
+            }}
+          />
+          <Tooltip
+            cursor={{ fill: "hsl(var(--border) / 0.1)" }}
+            content={renderTooltip}
+          />
+          {topTools.map((toolName, idx) => (
+            <Bar
+              key={toolName}
+              dataKey={(row: ChartRow) => row.values[toolName] ?? 0}
+              stackId="a"
+              fill="currentColor"
+              className={TOOL_COLORS[idx % TOOL_COLORS.length]}
+              name={toolName}
             />
-            <YAxis
-              className="text-xs text-muted-foreground"
-              label={{
-                value: "Usage %",
-                angle: -90,
-                position: "insideLeft",
-                style: { textAnchor: "middle" },
-              }}
-            />
-            <Tooltip
-              cursor={{ fill: "hsl(var(--border) / 0.1)" }}
-              content={renderTooltip}
-            />
-            {topTools.map((toolName, idx) => (
-              <Bar
-                key={toolName}
-                dataKey={(row: ChartRow) => row.values[toolName] ?? 0}
-                stackId="a"
-                fill="currentColor"
-                className={TOOL_COLORS[idx % TOOL_COLORS.length]}
-                name={toolName}
-              />
-            ))}
-          </BarChart>
-        </ResponsiveContainer>
-        <ChartLegend items={legendItems} />
-        <div className="mt-4 text-xs text-muted-foreground">
-          <p>
-            Shows the relative usage frequency (%) of the top{" "}
-            {MAX_TOOLS_DISPLAYED} tools for each agent version. Higher
-            percentages indicate more frequent tool usage within that version.
-          </p>
-        </div>
-      </>
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+      <ChartLegend items={legendItems} />
+      <div className="mt-4 text-xs text-muted-foreground">
+        <p>
+          Shows the relative usage frequency (%) of the top{" "}
+          {MAX_TOOLS_DISPLAYED} tools for each agent version. Higher percentages
+          indicate more frequent tool usage within that version.
+        </p>
+      </div>
     </ChartContainer>
   );
 }

--- a/front/components/agent_builder/observability/ToolExecutionChart.tsx
+++ b/front/components/agent_builder/observability/ToolExecutionChart.tsx
@@ -1,0 +1,193 @@
+import { useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+import { ChartContainer } from "@app/components/agent_builder/observability/ChartContainer";
+import { ChartLegend } from "@app/components/agent_builder/observability/ChartLegend";
+import { ChartTooltipCard } from "@app/components/agent_builder/observability/ChartTooltip";
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import {
+  CHART_HEIGHT,
+  DEFAULT_PERIOD_DAYS,
+  MAX_TOOLS_DISPLAYED,
+  PERCENTAGE_MULTIPLIER,
+  TOOL_COLORS,
+} from "@app/components/agent_builder/observability/constants";
+import { useAgentToolExecution } from "@app/lib/swr/assistants";
+
+export function ToolExecutionChart({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}) {
+  const [period, setPeriod] =
+    useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
+
+  const {
+    toolExecutionByVersion,
+    isToolExecutionLoading,
+    isToolExecutionError,
+  } = useAgentToolExecution({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    disabled: !workspaceId || !agentConfigurationId,
+  });
+
+  const { chartData, topTools } = useMemo(() => {
+    if (!toolExecutionByVersion || toolExecutionByVersion.length === 0) {
+      return { chartData: [], topTools: [] };
+    }
+
+    // Collect all unique tools across all versions
+    const allToolsSet = new Set<string>();
+    const toolTotalCounts = new Map<string, number>();
+
+    toolExecutionByVersion.forEach((versionData) => {
+      Object.entries(versionData.tools).forEach(([toolName, toolData]) => {
+        allToolsSet.add(toolName);
+        toolTotalCounts.set(
+          toolName,
+          (toolTotalCounts.get(toolName) || 0) + toolData.count
+        );
+      });
+    });
+
+    // Get top tools by total usage
+    const sortedTools = Array.from(toolTotalCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, MAX_TOOLS_DISPLAYED)
+      .map(([toolName]) => toolName);
+
+    // Transform data for stacked bar chart
+    const data = toolExecutionByVersion.map((versionData) => {
+      const dataPoint: Record<string, string | number> = {
+        version: `v${versionData.version}`,
+      };
+
+      // Calculate total for this version
+      let versionTotal = 0;
+      Object.entries(versionData.tools).forEach(([, toolData]) => {
+        versionTotal += toolData.count;
+      });
+
+      // Add tool counts as percentages
+      sortedTools.forEach((toolName) => {
+        const toolData = versionData.tools[toolName];
+        if (toolData) {
+          const percentage =
+            versionTotal > 0
+              ? Math.round(
+                  (toolData.count / versionTotal) * PERCENTAGE_MULTIPLIER
+                )
+              : 0;
+          dataPoint[toolName] = percentage;
+        } else {
+          dataPoint[toolName] = 0;
+        }
+      });
+
+      return dataPoint;
+    });
+
+    return { chartData: data, topTools: sortedTools };
+  }, [toolExecutionByVersion]);
+
+  function CustomTooltip(props: TooltipContentProps<number, string>) {
+    const { active, payload, label } = props;
+    if (!active || !payload || payload.length === 0) {
+      return null;
+    }
+
+    const rows = payload
+      .filter((p) => typeof p.value === "number" && p.value > 0)
+      .sort((a, b) => (b.value as number) - (a.value as number))
+      .map((p, idx) => ({
+        label: p.name || "",
+        value: `${p.value}%`,
+        colorClassName: TOOL_COLORS[idx % TOOL_COLORS.length],
+      }));
+
+    return (
+      <ChartTooltipCard
+        title={typeof label === "string" ? label : String(label ?? "")}
+        rows={rows}
+      />
+    );
+  }
+
+  const legendItems = topTools.map((toolName, idx) => ({
+    key: toolName,
+    label: toolName,
+    colorClassName: TOOL_COLORS[idx % TOOL_COLORS.length],
+  }));
+
+  return (
+    <ChartContainer
+      title="Tool Usage by Version"
+      period={period}
+      onPeriodChange={setPeriod}
+      isLoading={isToolExecutionLoading}
+      isError={isToolExecutionError}
+      isEmpty={chartData.length === 0}
+      errorMessage="Failed to load tool execution data."
+      emptyMessage="No tool execution data available for this period."
+    >
+      <>
+        <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+          <BarChart
+            data={chartData}
+            margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis
+              dataKey="version"
+              className="text-xs text-muted-foreground"
+            />
+            <YAxis
+              className="text-xs text-muted-foreground"
+              label={{
+                value: "Usage %",
+                angle: -90,
+                position: "insideLeft",
+                style: { textAnchor: "middle" },
+              }}
+            />
+            <Tooltip
+              cursor={{ fill: "hsl(var(--border) / 0.1)" }}
+              content={CustomTooltip}
+            />
+            {topTools.map((toolName, idx) => (
+              <Bar
+                key={toolName}
+                dataKey={toolName}
+                stackId="a"
+                fill="currentColor"
+                className={TOOL_COLORS[idx % TOOL_COLORS.length]}
+                name={toolName}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+        <ChartLegend items={legendItems} />
+        <div className="mt-4 text-xs text-muted-foreground">
+          <p>
+            Shows the relative usage frequency (%) of the top{" "}
+            {MAX_TOOLS_DISPLAYED} tools for each agent version. Higher
+            percentages indicate more frequent tool usage within that version.
+          </p>
+        </div>
+      </>
+    </ChartContainer>
+  );
+}

--- a/front/components/agent_builder/observability/ToolExecutionChart.tsx
+++ b/front/components/agent_builder/observability/ToolExecutionChart.tsx
@@ -143,10 +143,14 @@ export function ToolExecutionChart({
       period={period}
       onPeriodChange={setPeriod}
       isLoading={isToolExecutionLoading}
-      isError={isToolExecutionError}
-      isEmpty={chartData.length === 0}
-      errorMessage="Failed to load tool execution data."
-      emptyMessage="No tool execution data available for this period."
+      errorMessage={
+        isToolExecutionError ? "Failed to load tool execution data." : undefined
+      }
+      emptyMessage={
+        chartData.length === 0
+          ? "No tool execution data available for this period."
+          : undefined
+      }
     >
       <>
         <ResponsiveContainer width="100%" height={CHART_HEIGHT}>

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -187,8 +187,7 @@ export function UsageMetricsChart({
       period={period}
       onPeriodChange={setPeriod}
       isLoading={isLoading}
-      isError={isError}
-      errorMessage="Failed to load observability data."
+      errorMessage={isError ? "Failed to load observability data." : undefined}
       additionalControls={intervalControls}
     >
       <>

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -1,4 +1,4 @@
-import { cn, Spinner } from "@dust-tt/sparkle";
+import { cn } from "@dust-tt/sparkle";
 import { useState } from "react";
 import {
   Bar,
@@ -13,6 +13,8 @@ import {
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
+import { ChartContainer } from "@app/components/agent_builder/observability/ChartContainer";
+import { ChartLegend } from "@app/components/agent_builder/observability/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/ChartTooltip";
 import type {
   ObservabilityIntervalType,
@@ -118,62 +120,40 @@ export function UsageMetricsChart({
   const isLoading = isUsageMetricsLoading || isVersionMarkersLoading;
   const isError = isUsageMetricsError || isVersionMarkersError;
 
+  const legendItems = USAGE_METRICS_LEGEND.map(({ key, label }) => ({
+    key,
+    label,
+    colorClassName: USAGE_METRICS_PALETTE[key],
+  }));
+
   return (
-    <div className="bg-card rounded-lg border border-border p-4">
-      <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-lg font-medium text-foreground">Usage Metrics</h3>
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2">
-            {OBSERVABILITY_TIME_RANGE.map((p) => (
-              <button
-                key={p}
-                onClick={() => setPeriod(p)}
-                className={cn(
-                  "rounded px-2 py-1 text-xs",
-                  period === p
-                    ? "bg-foreground text-background"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                {p}d
-              </button>
-            ))}
-          </div>
-          <div className="flex items-center gap-2">
-            {OBSERVABILITY_INTERVALS.map((i) => (
-              <button
-                key={i}
-                onClick={() => setInterval(i)}
-                className={cn(
-                  "rounded px-2 py-1 text-xs",
-                  interval === i
-                    ? "bg-foreground text-background"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                {i}
-              </button>
-            ))}
-          </div>
+    <ChartContainer
+      title="Usage Metrics"
+      period={period}
+      onPeriodChange={setPeriod}
+      isLoading={isLoading}
+      isError={isError}
+      errorMessage="Failed to load observability data."
+      additionalControls={
+        <div className="flex items-center gap-2">
+          {OBSERVABILITY_INTERVALS.map((i) => (
+            <button
+              key={i}
+              onClick={() => setInterval(i)}
+              className={cn(
+                "rounded px-2 py-1 text-xs",
+                interval === i
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {i}
+            </button>
+          ))}
         </div>
-      </div>
-      {isLoading ? (
-        <div
-          className="flex items-center justify-center"
-          style={{ height: CHART_HEIGHT }}
-        >
-          <Spinner size="lg" />
-        </div>
-      ) : isError ? (
-        <div
-          className="flex items-center justify-center"
-          style={{ height: CHART_HEIGHT }}
-        >
-          <p className="text-sm text-muted-foreground">
-            Failed to load observability data.
-          </p>
-        </div>
-      ) : (
+      }
+    >
+      <>
         <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
           <BarChart
             data={data}
@@ -218,20 +198,8 @@ export function UsageMetricsChart({
             ))}
           </BarChart>
         </ResponsiveContainer>
-      )}
-      <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
-        {USAGE_METRICS_LEGEND.map(({ key, label }) => (
-          <div key={key} className="flex items-center gap-2">
-            <span
-              className={cn(
-                "inline-block h-3 w-3 rounded-sm bg-current",
-                USAGE_METRICS_PALETTE[key]
-              )}
-            />
-            <span className="text-sm text-muted-foreground">{label}</span>
-          </div>
-        ))}
-      </div>
-    </div>
+        <ChartLegend items={legendItems} />
+      </>
+    </ChartContainer>
   );
 }

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -128,6 +128,7 @@ export function UsageMetricsChart({
               <button
                 key={p}
                 onClick={() => setPeriod(p)}
+                type="button"
                 className={cn(
                   "rounded px-2 py-1 text-xs",
                   period === p
@@ -144,6 +145,7 @@ export function UsageMetricsChart({
               <button
                 key={i}
                 onClick={() => setInterval(i)}
+                type="button"
                 className={cn(
                   "rounded px-2 py-1 text-xs",
                   interval === i

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -128,7 +128,6 @@ export function UsageMetricsChart({
               <button
                 key={p}
                 onClick={() => setPeriod(p)}
-                type="button"
                 className={cn(
                   "rounded px-2 py-1 text-xs",
                   period === p
@@ -145,7 +144,6 @@ export function UsageMetricsChart({
               <button
                 key={i}
                 onClick={() => setInterval(i)}
-                type="button"
                 className={cn(
                   "rounded px-2 py-1 text-xs",
                   interval === i

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -31,3 +31,19 @@ export const VERSION_MARKER_STYLE = {
   labelOffsetBase: 10,
   labelOffsetIncrement: 15,
 } as const;
+
+export const TOOL_COLORS = [
+  "text-blue-500",
+  "text-emerald-500",
+  "text-amber-500",
+  "text-purple-500",
+  "text-pink-500",
+  "text-cyan-500",
+  "text-orange-500",
+  "text-teal-500",
+  "text-indigo-500",
+  "text-rose-500",
+] as const;
+
+export const MAX_TOOLS_DISPLAYED = 10;
+export const PERCENTAGE_MULTIPLIER = 100;

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -4,6 +4,7 @@ export type ObservabilityTimeRangeType =
 
 export const DEFAULT_PERIOD_DAYS = 14;
 
+
 export const OBSERVABILITY_INTERVALS = ["day", "week"] as const;
 export type ObservabilityIntervalType =
   (typeof OBSERVABILITY_INTERVALS)[number];

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -4,7 +4,6 @@ export type ObservabilityTimeRangeType =
 
 export const DEFAULT_PERIOD_DAYS = 14;
 
-
 export const OBSERVABILITY_INTERVALS = ["day", "week"] as const;
 export type ObservabilityIntervalType =
   (typeof OBSERVABILITY_INTERVALS)[number];

--- a/front/lib/api/assistant/observability/tool_execution.ts
+++ b/front/lib/api/assistant/observability/tool_execution.ts
@@ -29,6 +29,7 @@ type VersionBucket = TermBucket & {
   tools?: {
     tool_names?: estypes.AggregationsMultiBucketAggregateBase<ToolBucket>;
   };
+  first_seen?: estypes.AggregationsMinAggregate;
 };
 
 type ToolExecutionAggs = {
@@ -43,9 +44,13 @@ export async function fetchToolExecutionMetrics(
       terms: {
         field: "agent_version",
         size: 100,
-        order: { _key: "desc" },
+        // Order versions chronologically by their first observed timestamp
+        order: { first_seen: "asc" },
       },
       aggs: {
+        first_seen: {
+          min: { field: "timestamp" },
+        },
         tools: {
           nested: { path: "tools_used" },
           aggs: {

--- a/front/lib/api/assistant/observability/tool_execution.ts
+++ b/front/lib/api/assistant/observability/tool_execution.ts
@@ -1,0 +1,111 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const DEFAULT_METRIC_VALUE = 0;
+
+export type ToolExecutionByVersion = {
+  version: string;
+  tools: {
+    [toolName: string]: {
+      count: number;
+      successRate: number;
+    };
+  };
+};
+
+type TermBucket = {
+  key: string;
+  doc_count: number;
+};
+
+type ToolBucket = TermBucket & {
+  statuses?: estypes.AggregationsMultiBucketAggregateBase<TermBucket>;
+};
+
+type VersionBucket = TermBucket & {
+  tools?: {
+    tool_names?: estypes.AggregationsMultiBucketAggregateBase<ToolBucket>;
+  };
+};
+
+type ToolExecutionAggs = {
+  by_version?: estypes.AggregationsMultiBucketAggregateBase<VersionBucket>;
+};
+
+export async function fetchToolExecutionMetrics(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Result<ToolExecutionByVersion[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_version: {
+      terms: {
+        field: "agent_version",
+        size: 100,
+        order: { _key: "desc" },
+      },
+      aggs: {
+        tools: {
+          nested: { path: "tools_used" },
+          aggs: {
+            tool_names: {
+              terms: {
+                field: "tools_used.tool_name",
+                size: 50,
+              },
+              aggs: {
+                statuses: {
+                  terms: { field: "tools_used.status" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<unknown, ToolExecutionAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const versionBuckets = bucketsToArray<VersionBucket>(
+    result.value.aggregations?.by_version?.buckets
+  );
+
+  const byVersion: ToolExecutionByVersion[] = versionBuckets.map((vb) => {
+    const toolBuckets = bucketsToArray<ToolBucket>(
+      vb.tools?.tool_names?.buckets
+    );
+
+    const tools: ToolExecutionByVersion["tools"] = {};
+
+    toolBuckets.forEach((tb) => {
+      const total = tb.doc_count || DEFAULT_METRIC_VALUE;
+      const statuses = bucketsToArray<TermBucket>(tb.statuses?.buckets);
+      const succeeded =
+        statuses.find((s) => s.key === "succeeded")?.doc_count ??
+        DEFAULT_METRIC_VALUE;
+
+      const successRate = total > 0 ? Math.round((succeeded / total) * 100) : 0;
+
+      tools[tb.key] = {
+        count: total,
+        successRate,
+      };
+    });
+
+    return {
+      version: vb.key,
+      tools,
+    };
+  });
+
+  return new Ok(byVersion);
+}

--- a/front/lib/api/assistant/observability/usage_metrics.ts
+++ b/front/lib/api/assistant/observability/usage_metrics.ts
@@ -28,7 +28,7 @@ type UsageMetricsAggs = {
   by_interval?: estypes.AggregationsMultiBucketAggregateBase<ByIntervalBucket>;
 };
 
-type UsageMetricsInterval = "day" | "week";
+export type UsageMetricsInterval = "day" | "week";
 
 export async function fetchUsageMetrics(
   baseQuery: estypes.QueryDslQueryContainer,

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -19,6 +19,7 @@ import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentConfigurationAnalyticsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics";
+import type { GetToolExecutionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution";
 import type { GetUsageMetricsResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics";
 import type { GetVersionMarkersResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers";
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
@@ -821,5 +822,33 @@ export function useAgentVersionMarkers({
     isVersionMarkersLoading: !error && !data && !disabled,
     isVersionMarkersError: error,
     isVersionMarkersValidating: isValidating,
+  };
+}
+
+export function useAgentToolExecution({
+  workspaceId,
+  agentConfigurationId,
+  days = 30,
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  size?: number;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetToolExecutionResponse> = fetcher;
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/tool-execution?days=${days}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    toolExecutionByVersion: data?.byVersion ?? null,
+    isToolExecutionLoading: !error && !data && !disabled,
+    isToolExecutionError: error,
+    isToolExecutionValidating: isValidating,
   };
 }

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -828,13 +828,12 @@ export function useAgentVersionMarkers({
 export function useAgentToolExecution({
   workspaceId,
   agentConfigurationId,
-  days = 30,
+  days = DEFAULT_PERIOD_DAYS,
   disabled,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   days?: number;
-  size?: number;
   disabled?: boolean;
 }) {
   const fetcherFn: Fetcher<GetToolExecutionResponse> = fetcher;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
@@ -2,6 +2,7 @@ import type { estypes } from "@elastic/elasticsearch";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { ToolExecutionByVersion } from "@app/lib/api/assistant/observability/tool_execution";
 import { fetchToolExecutionMetrics } from "@app/lib/api/assistant/observability/tool_execution";
@@ -9,8 +10,6 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-
-const DEFAULT_PERIOD = 30;
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional(),
@@ -89,7 +88,7 @@ async function handler(
         });
       }
 
-      const days = q.data.days ?? DEFAULT_PERIOD;
+      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
       const owner = auth.getNonNullableWorkspace();
 
       const baseQuery = buildAgentAnalyticsBaseQuery(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
@@ -1,0 +1,129 @@
+import type { estypes } from "@elastic/elasticsearch";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { ToolExecutionByVersion } from "@app/lib/api/assistant/observability/tool_execution";
+import { fetchToolExecutionMetrics } from "@app/lib/api/assistant/observability/tool_execution";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const DEFAULT_PERIOD = 30;
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional(),
+});
+
+export type GetToolExecutionResponse = {
+  byVersion: ToolExecutionByVersion[];
+};
+
+function buildAgentAnalyticsBaseQuery(
+  workspaceId: string,
+  agentId: string,
+  days: number
+): estypes.QueryDslQueryContainer {
+  return {
+    bool: {
+      filter: [
+        { term: { workspace_id: workspaceId } },
+        { term: { agent_id: agentId } },
+        { range: { timestamp: { gte: `now-${days}d/d` } } },
+      ],
+    },
+  };
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetToolExecutionResponse>>,
+  auth: Authenticator
+) {
+  if (typeof req.query.aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent configuration ID.",
+      },
+    });
+  }
+
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: req.query.aId,
+    variant: "light",
+  });
+
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  if (!assistant.canEdit && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only editors can get agent observability.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const days = q.data.days ?? DEFAULT_PERIOD;
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery(
+        owner.sId,
+        assistant.sId,
+        days
+      );
+
+      const toolExecutionResult = await fetchToolExecutionMetrics(baseQuery);
+
+      if (toolExecutionResult.isErr()) {
+        const e = toolExecutionResult.error;
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve tool execution metrics: ${e.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        byVersion: toolExecutionResult.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -3,7 +3,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { UsageMetricsPoint } from "@app/lib/api/assistant/observability/usage_metrics";
+import type {
+  UsageMetricsInterval,
+  UsageMetricsPoint,
+} from "@app/lib/api/assistant/observability/usage_metrics";
 import { fetchUsageMetrics } from "@app/lib/api/assistant/observability/usage_metrics";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -18,7 +21,7 @@ const QuerySchema = z.object({
 });
 
 export type GetUsageMetricsResponse = {
-  interval: "day" | "week";
+  interval: UsageMetricsInterval;
   points: UsageMetricsPoint[];
 };
 


### PR DESCRIPTION
## Description

This PR adds a new tool execution chart to the agent observability dashboard. The chart displays the relative usage frequency of the top 10 tools across different agent versions using a stacked bar chart with percentage-based visualization. The implementation includes:

- A new `ToolExecutionChart` component that fetches tool execution metrics from Elasticsearch
- A backend API endpoint (`/observability/tool-execution`) that aggregates tool usage data by agent version
- Chart components (`ChartContainer`, `ChartLegend`) to standardize observability UI patterns
- Enhancements to the existing usage metrics chart with better modularity and version marker snapping

**References:**
- https://github.com/dust-tt/tasks/issues/4700

## Test

- [x] Locally
- [x] Front-edge

## Risk

Low risk as the feature is behind the `agent_builder_observability` FF

## Deploy Plan

 Deploy front
