### PR TITLE
[LLM Router] Remove fragment in renderConversation return type

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -14,8 +14,8 @@ import type {
   ConversationType,
   FunctionCallType,
   FunctionMessageTypeModel,
+  MessageTypeMultiActions,
   ModelConfigurationType,
-  ModelMessageTypeMultiActions,
   UserMessageType,
 } from "@app/types";
 import { removeNulls } from "@app/types";
@@ -229,9 +229,7 @@ export async function getSteps(
 /**
  * Renders a user message with metadata
  */
-export function renderUserMessage(
-  m: UserMessageType
-): ModelMessageTypeMultiActions {
+export function renderUserMessage(m: UserMessageType): MessageTypeMultiActions {
   // Replace all `:mention[{name}]{.*}` with `@name`.
   const content = m.content.replaceAll(
     /:mention\[([^\]]+)\]\{[^}]+\}/g,
@@ -318,7 +316,7 @@ export async function renderContentFragment(
   conversation: ConversationType,
   model: ModelConfigurationType,
   excludeImages: boolean
-): Promise<ModelMessageTypeMultiActions | null> {
+): Promise<MessageTypeMultiActions | null> {
   const renderedContentFragment = await renderLightContentFragmentForModel(
     auth,
     m,

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -160,31 +160,33 @@ export async function renderConversationForModel(
   for (let i = prunedMessagesWithTokens.length - 1; i >= 0; i--) {
     const cfMessage = prunedMessagesWithTokens[i];
 
-    if (isContentFragmentMessageTypeModel(cfMessage)) {
-      const userMessage = prunedMessagesWithTokens[i + 1];
-      if (!userMessage || userMessage.role !== "user") {
-        logger.error(
-          {
-            workspaceId: conversation.owner.sId,
-            conversationId: conversation.sId,
-            selected: prunedMessagesWithTokens.map((m) => ({
-              ...m,
-              content:
-                getTextContentFromMessage(m)?.slice(0, 100) + " (truncated...)",
-            })),
-          },
-          "Unexpected state, cannot find user message after a Content Fragment"
-        );
-        throw new Error(
-          "Unexpected state, cannot find user message after a Content Fragment"
-        );
-      }
-
-      userMessage.content = [...cfMessage.content, ...userMessage.content];
-      selected.push(userMessage);
-    } else {
+    if (!isContentFragmentMessageTypeModel(cfMessage)) {
       selected.push(cfMessage);
+
+      continue;
     }
+
+    const userMessage = prunedMessagesWithTokens[i + 1];
+    if (!userMessage || userMessage.role !== "user") {
+      logger.error(
+        {
+          workspaceId: conversation.owner.sId,
+          conversationId: conversation.sId,
+          selected: prunedMessagesWithTokens.map((m) => ({
+            ...m,
+            content:
+              getTextContentFromMessage(m)?.slice(0, 100) + " (truncated...)",
+          })),
+        },
+        "Unexpected state, cannot find user message after a Content Fragment"
+      );
+      throw new Error(
+        "Unexpected state, cannot find user message after a Content Fragment"
+      );
+    }
+
+    userMessage.content = [...cfMessage.content, ...userMessage.content];
+    selected.push(userMessage);
   }
 
   if (selected.length === 0) {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -152,7 +152,7 @@ export async function renderConversationForModel(
     }
   }
 
-  const selected: (ModelMessageTypeMultiActions & {
+  const selectedWithoutContentFragments: (ModelMessageTypeMultiActions & {
     tokenCount: number;
   })[] = [];
 
@@ -161,7 +161,7 @@ export async function renderConversationForModel(
     const cfMessage = prunedMessagesWithTokens[i];
 
     if (!isContentFragmentMessageTypeModel(cfMessage)) {
-      selected.push(cfMessage);
+      selectedWithoutContentFragments.push(cfMessage);
 
       continue;
     }
@@ -186,10 +186,10 @@ export async function renderConversationForModel(
     }
 
     userMessage.content = [...cfMessage.content, ...userMessage.content];
-    selected.push(userMessage);
+    selectedWithoutContentFragments.push(userMessage);
   }
 
-  if (selected.length === 0) {
+  if (selectedWithoutContentFragments.length === 0) {
     logger.error(
       {
         workspaceId: conversation.owner.sId,
@@ -203,7 +203,7 @@ export async function renderConversationForModel(
   }
 
   // Remove tokenCount from final messages
-  const finalMessages: ModelMessageTypeMultiActions[] = selected.map(
+  const finalMessages: ModelMessageTypeMultiActions[] = selectedWithoutContentFragments.map(
     ({ tokenCount: _tokenCount, ...msg }) => msg
   );
 

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -157,7 +157,7 @@ export async function renderConversationForModel(
   })[] = [];
 
   // Merge content fragments into user messages.
-  for (let i = selected.length - 1; i >= 0; i--) {
+  for (let i = 0; i <= selected.length - 1; i++) {
     const cfMessage = selected[i];
 
     if (!isContentFragmentMessageTypeModel(cfMessage)) {

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -5,9 +5,9 @@ import { tokenCountForTexts } from "@app/lib/tokenization";
 import logger from "@app/logger/logger";
 import type {
   ConversationType,
+  MessageTypeMultiActions,
   ModelConfigurationType,
   ModelConversationTypeMultiActions,
-  ModelMessageTypeMultiActions,
   Result,
 } from "@app/types";
 import {
@@ -193,7 +193,7 @@ export async function renderConversationForModel(
   }
 
   // Remove tokenCount from final messages
-  const finalMessages: ModelMessageTypeMultiActions[] = selected.map(
+  const finalMessages: MessageTypeMultiActions[] = selected.map(
     ({ tokenCount: _tokenCount, ...msg }) => msg
   );
 
@@ -275,7 +275,7 @@ function groupMessagesIntoInteractions(
 }
 
 async function countTokensForMessages(
-  messages: ModelMessageTypeMultiActions[],
+  messages: MessageTypeMultiActions[],
   model: ModelConfigurationType
 ): Promise<Result<MessageWithTokens[], Error>> {
   const textRepresentations: string[] = [];

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -152,7 +152,7 @@ export async function renderConversationForModel(
     }
   }
 
-  const selected: (MessageTypeMultiActions & {
+  const selected: (ModelMessageTypeMultiActions & {
     tokenCount: number;
   })[] = [];
 
@@ -203,7 +203,7 @@ export async function renderConversationForModel(
   }
 
   // Remove tokenCount from final messages
-  const finalMessages: MessageTypeMultiActions[] = selected.map(
+  const finalMessages: ModelMessageTypeMultiActions[] = selected.map(
     ({ tokenCount: _tokenCount, ...msg }) => msg
   );
 

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -15,8 +15,8 @@ import type {
   AssistantContentMessageTypeModel,
   AssistantFunctionCallMessageTypeModel,
   ConversationType,
+  MessageTypeMultiActions,
   ModelConfigurationType,
-  ModelMessageTypeMultiActions,
 } from "@app/types";
 import {
   assertNever,
@@ -34,8 +34,8 @@ export function renderAgentSteps(
   message: AgentMessageType,
   conversation: ConversationType,
   excludeActions: boolean
-): ModelMessageTypeMultiActions[] {
-  const messages: ModelMessageTypeMultiActions[] = [];
+): MessageTypeMultiActions[] {
+  const messages: MessageTypeMultiActions[] = [];
 
   if (excludeActions) {
     // In Exclude Actions mode, we only render the last step that has text content.
@@ -142,8 +142,8 @@ export async function renderAllMessages(
     excludeImages?: boolean;
     onMissingAction: "inject-placeholder" | "skip";
   }
-): Promise<ModelMessageTypeMultiActions[]> {
-  const messages: ModelMessageTypeMultiActions[] = [];
+): Promise<MessageTypeMultiActions[]> {
+  const messages: MessageTypeMultiActions[] = [];
 
   // Render loop: render all messages and all actions.
   for (const versions of conversation.content) {

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -1,4 +1,4 @@
-import type { ModelMessageTypeMultiActions } from "@app/types";
+import type { MessageTypeMultiActions } from "@app/types";
 
 const CURRENT_INTERACTION_PRUNED_RESULT_PLACEHOLDER =
   "<dust_system>This function result is no longer available." +
@@ -9,7 +9,7 @@ const PREVIOUS_INTERACTIONS_PRUNED_RESULT_PLACEHOLDER =
   "<dust_system>This function result is no longer available.</dust_system>";
 const PREVIOUS_INTERACTIONS_PRUNED_TOOL_RESULT_TOKENS = 20;
 
-export type MessageWithTokens = ModelMessageTypeMultiActions & {
+export type MessageWithTokens = MessageTypeMultiActions & {
   tokenCount: number;
 };
 

--- a/front/lib/api/assistant/utils.ts
+++ b/front/lib/api/assistant/utils.ts
@@ -1,8 +1,8 @@
-import type { ModelMessageTypeMultiActions } from "@app/types";
+import type { MessageTypeMultiActions } from "@app/types";
 import { isImageContent, isTextContent } from "@app/types";
 
 export function getTextContentFromMessage(
-  message: ModelMessageTypeMultiActions
+  message: MessageTypeMultiActions
 ): string {
   const { content } = message;
 
@@ -35,7 +35,7 @@ export function getTextContentFromMessage(
 
 // This function is used to get the text representation of the messages to calculate the token amount
 export function getTextRepresentationFromMessages(
-  messages: ModelMessageTypeMultiActions[]
+  messages: MessageTypeMultiActions[]
 ): string[] {
   return [
     ...messages.map((m) => {

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -81,14 +81,15 @@ export interface FunctionMessageTypeModel {
   content: string | Content[];
 }
 
-// export type ModelMessageTypeMultiActions =
-
-export type MessageTypeMultiActions =
-  | ContentFragmentMessageTypeModel
+export type ModelMessageTypeMultiActions =
   | UserMessageTypeModel
   | AssistantFunctionCallMessageTypeModel
   | AssistantContentMessageTypeModel
   | FunctionMessageTypeModel;
+
+export type MessageTypeMultiActions =
+  | ModelMessageTypeMultiActions
+  | ContentFragmentMessageTypeModel;
 
 export function isContentFragmentMessageTypeModel(
   contentFragment: MessageTypeMultiActions
@@ -97,7 +98,7 @@ export function isContentFragmentMessageTypeModel(
 }
 
 export type ModelConversationTypeMultiActions = {
-  messages: MessageTypeMultiActions[];
+  messages: ModelMessageTypeMultiActions[];
 };
 
 /**

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -81,7 +81,9 @@ export interface FunctionMessageTypeModel {
   content: string | Content[];
 }
 
-export type ModelMessageTypeMultiActions =
+// export type ModelMessageTypeMultiActions =
+
+export type MessageTypeMultiActions =
   | ContentFragmentMessageTypeModel
   | UserMessageTypeModel
   | AssistantFunctionCallMessageTypeModel
@@ -89,13 +91,13 @@ export type ModelMessageTypeMultiActions =
   | FunctionMessageTypeModel;
 
 export function isContentFragmentMessageTypeModel(
-  contentFragment: ModelMessageTypeMultiActions
+  contentFragment: MessageTypeMultiActions
 ): contentFragment is ContentFragmentMessageTypeModel {
   return contentFragment.role === "content_fragment";
 }
 
 export type ModelConversationTypeMultiActions = {
-  messages: ModelMessageTypeMultiActions[];
+  messages: MessageTypeMultiActions[];
 };
 
 /**


### PR DESCRIPTION
## Description

This PR paves the way for the LLM Router basics. We need clear generic types of what to send to each models, so each model can then transform this types into their own input types.

Currently the return type of function renderConversationForModel has ContentFragmentMessages, whereas it does not return such data since they are merged into TextMessages.

With this, PR the return type of renderConversationForModel does not include ContentFragmentMessages anymore.

## Tests

- Locally - conversations still working with fragments

## Risk

- low

## Deploy Plan

front
