### PR TITLE
[ab] fix unselect all logic

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
@@ -241,7 +241,24 @@ export function DataSourceList({
           ...item.entry,
         });
       }
+
+      // Also remove the current parent if it's in the tree
+      // This handles the case where we selected all within a folder view
+      const currentPath = computeNavigationPath(navigationHistory);
+      const currentPathStr = pathToString(currentPath);
+      if (
+        newTreeValue.in.some((item) => item.path === currentPathStr) &&
+        navigationHistory.length > 0
+      ) {
+        const currentEntry = navigationHistory[navigationHistory.length - 1];
+        newTreeValue = removeNodeFromTree(newTreeValue, {
+          path: currentPathStr,
+          name: navigationHistoryEntryTitle(currentEntry),
+          ...currentEntry,
+        });
+      }
     }
+
     field.onChange(newTreeValue);
   }, [
     items,

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
@@ -231,6 +231,8 @@ export function DataSourceList({
       }
 
       // Remove each node from the tree
+      // TODO(yuka 17/10/2025): I don't think we need to compute every node path if its parentId is `in`,
+      // we can simple remove that instead of going through each item (and it should be the same when you select all).
       for (const item of itemsToUnselect) {
         const nodePath = computeNavigationPath(navigationHistory);
         nodePath.push(getLastNavigationHistoryEntryId(item.entry));


### PR DESCRIPTION
## Description
This PR is to fix this https://github.com/dust-tt/tasks/issues/4631 

I tried to understand and refactor this logic since it felt unnecessary complicated, but I didn't feel super confident after spending an entire afternoon so I added a fix for this specific issue. 

If I understand it correctly, what's happening is: 

When you select parent item (let's say `Google Drive > [Team] Product`, we add id of `[Team] Product` inside `in`:
```
in: [
    {
        "path": "root/vlt_M3noynRxIM/managed/dsv_q03Y149aTx/gdrive-0ALcjGNU347hKUk9PVA",
        "name": "[Team] Product",
        "type": "node",
        "node": {
            "internalId": "gdrive-0ALcjGNU347hKUk9PVA",
            "parentInternalId": null,
            "title": "[Team] Product",
            "sourceUrl": "https://drive.google.com/drive/folders/0ALcjGNU347hKUk9PVA",
            "permission": "read",
            "lastUpdatedAt": 1742814881631,
            "providerVisibility": null,
            "parentInternalIds": [
                "gdrive-0ALcjGNU347hKUk9PVA"
            ],
            "type": "folder",
           ...
]
```
<img width="1486" height="886" alt="CleanShot 2025-10-17 at 09 46 01@2x" src="https://github.com/user-attachments/assets/650bf47c-0231-4ef9-a0b8-0d21175007b9" />

However when you select all inside the `[Team] Product`, you add each item to `in` (and this doesn't select un-fetched items if there is a pagination)
`{in: Array(82), notIn: Array(0)}`
<img width="1494" height="1610" alt="CleanShot 2025-10-17 at 10 02 55@2x" src="https://github.com/user-attachments/assets/270eff39-aae9-4dbd-9f0d-3f66a3446832" />

So naturally (?) when you unselect all inside from `[Team Product]`, it tries to removes each items from `in`, but this doesn't work if you select all from parent level, because it has only parent id inside `in`. Instead of removing the parent id, it adds them all inside `notIn` (since it cannot find the item id inside `in`), and parent Id stays inside `in`, which you will end up in a weird state (fetched items will be unselected since they are inside `notIn`, but un-fetched items are not and parent Id stays inside `in`).

So I think you can add only parent Id to `in` when you select all, but I don't feel super confident to change this since we already had so many selection issues before. I thought about removing only parent id from `in`  when you unselect all, and not go through each items, but given that I don't feel confortable to touch select all logic, I just added an operation to remove parent Id from in if there is one (and this should clear out all the child items from notIn). 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
