### PR TITLE
[Common Utilities] Add wait and time tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1196,7 +1196,7 @@ The directive should be used to display a clickable version of the agent name in
       name: "common_utilities",
       version: "1.0.0",
       description:
-        "Miscellaneous helper tools such as random numbers, timestamps, and timers.",
+        "Miscellaneous helper tools such as random numbers, time retrieval, and timers.",
       icon: "ActionAtomIcon",
       authorization: null,
       documentationUrl: null,

--- a/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
@@ -111,9 +111,9 @@ function createServer(
     {
       include_formats: z
         .array(
-          z.enum(["iso", "utc", "timestamp", "locale"]).describe(
-            "Specify which formats to return. Defaults to all."
-          )
+          z
+            .enum(["iso", "utc", "timestamp", "locale"])
+            .describe("Specify which formats to return. Defaults to all.")
         )
         .max(4)
         .optional(),

--- a/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
@@ -8,6 +8,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { Ok } from "@app/types";
 
 const RANDOM_INTEGER_DEFAULT_MAX = 1_000_000;
+const MAX_WAIT_DURATION_MS = 30 * 60 * 1_000;
 
 function createServer(
   auth: Authenticator,
@@ -65,6 +66,88 @@ function createServer(
           {
             type: "text",
             text: `Random float: ${value}`,
+          },
+        ]);
+      }
+    )
+  );
+
+  server.tool(
+    "wait",
+    `Pause execution for the provided number of milliseconds (maximum ${MAX_WAIT_DURATION_MS}).`,
+    {
+      duration_ms: z
+        .number()
+        .int()
+        .positive()
+        .max(
+          MAX_WAIT_DURATION_MS,
+          `Duration must be less than or equal to ${MAX_WAIT_DURATION_MS} milliseconds (30 minutes).`
+        )
+        .describe("The time to wait in milliseconds, up to 30 minutes."),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: "wait",
+        agentLoopContext,
+      },
+      async ({ duration_ms }) => {
+        await new Promise((resolve) => setTimeout(resolve, duration_ms));
+
+        return new Ok([
+          {
+            type: "text",
+            text: `Waited for ${duration_ms} milliseconds.`,
+          },
+        ]);
+      }
+    )
+  );
+
+  server.tool(
+    "get_current_time",
+    "Return the current date and time in multiple convenient formats.",
+    {
+      include_formats: z
+        .array(
+          z.enum(["iso", "utc", "timestamp", "locale"]).describe(
+            "Specify which formats to return. Defaults to all."
+          )
+        )
+        .max(4)
+        .optional(),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: "get_current_time",
+        agentLoopContext,
+      },
+      async ({ include_formats }) => {
+        const now = new Date();
+        const formats = new Set(
+          include_formats ?? ["iso", "utc", "timestamp", "locale"]
+        );
+
+        const parts: string[] = [];
+        if (formats.has("iso")) {
+          parts.push(`ISO: ${now.toISOString()}`);
+        }
+        if (formats.has("utc")) {
+          parts.push(`UTC: ${now.toUTCString()}`);
+        }
+        if (formats.has("timestamp")) {
+          parts.push(`UNIX (ms): ${now.getTime()}`);
+        }
+        if (formats.has("locale")) {
+          parts.push(`Locale: ${now.toLocaleString()}`);
+        }
+
+        return new Ok([
+          {
+            type: "text",
+            text: parts.join("\n"),
           },
         ]);
       }

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -109,6 +109,7 @@ export async function getJITServers(
     jitServers.push(conversationFilesServer);
   }
 
+<<<<<<< HEAD
   if (!commonUtilitiesView) {
     logger.warn(
       {
@@ -119,6 +120,16 @@ export async function getJITServers(
     );
   } else if (!agentMcpServerViewIds.includes(commonUtilitiesView.sId)) {
     const commonUtilitiesViewJSON = commonUtilitiesView.toJSON();
+=======
+  assert(
+    commonUtilitiesView,
+    "MCP server view not found for common_utilities. Ensure auto tools are created."
+  );
+
+  const commonUtilitiesViewJSON = commonUtilitiesView.toJSON();
+
+  if (!agentMcpServerViewIds.includes(commonUtilitiesViewJSON.sId)) {
+>>>>>>> 18c8701bcb (feat(front): add common utilities internal mcp server)
     const commonUtilitiesServer: ServerSideMCPServerConfigurationType = {
       id: -1,
       sId: generateRandomModelSId(),

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -109,10 +109,6 @@ export async function getJITServers(
     jitServers.push(conversationFilesServer);
   }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d58fcdfb0e (fixes)
   if (!commonUtilitiesView) {
     logger.warn(
       {
@@ -123,19 +119,6 @@ export async function getJITServers(
     );
   } else if (!agentMcpServerViewIds.includes(commonUtilitiesView.sId)) {
     const commonUtilitiesViewJSON = commonUtilitiesView.toJSON();
-<<<<<<< HEAD
-=======
-  assert(
-    commonUtilitiesView,
-    "MCP server view not found for common_utilities. Ensure auto tools are created."
-  );
-
-  const commonUtilitiesViewJSON = commonUtilitiesView.toJSON();
-
-  if (!agentMcpServerViewIds.includes(commonUtilitiesViewJSON.sId)) {
->>>>>>> 18c8701bcb (feat(front): add common utilities internal mcp server)
-=======
->>>>>>> d58fcdfb0e (fixes)
     const commonUtilitiesServer: ServerSideMCPServerConfigurationType = {
       id: -1,
       sId: generateRandomModelSId(),

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -110,6 +110,9 @@ export async function getJITServers(
   }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> d58fcdfb0e (fixes)
   if (!commonUtilitiesView) {
     logger.warn(
       {
@@ -120,6 +123,7 @@ export async function getJITServers(
     );
   } else if (!agentMcpServerViewIds.includes(commonUtilitiesView.sId)) {
     const commonUtilitiesViewJSON = commonUtilitiesView.toJSON();
+<<<<<<< HEAD
 =======
   assert(
     commonUtilitiesView,
@@ -130,6 +134,8 @@ export async function getJITServers(
 
   if (!agentMcpServerViewIds.includes(commonUtilitiesViewJSON.sId)) {
 >>>>>>> 18c8701bcb (feat(front): add common utilities internal mcp server)
+=======
+>>>>>>> d58fcdfb0e (fixes)
     const commonUtilitiesServer: ServerSideMCPServerConfigurationType = {
       id: -1,
       sId: generateRandomModelSId(),


### PR DESCRIPTION
## Description
Add wait tool to delay execution up to 30 minutes and get_current_time returning standard time formats

## Risks
Blast radius: Internal MCP common utilities server and JIT auto-added tools
Risk: low

## Deploy Plan
- deploy front
