### PR TITLE
[front] enh: extend content filtering in `renderActionForMultiActionsModel`

### DIFF
--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -6,9 +6,12 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { MAX_RESOURCE_CONTENT_SIZE } from "@app/lib/actions/action_output_limits";
 import {
   isBlobResource,
+  isIncludeQueryResourceType,
+  isRunAgentQueryResourceType,
   isSearchQueryResourceType,
   isToolGeneratedFile,
   isToolMarkerResourceType,
+  isWebsearchQueryResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   getAttachmentFromToolOutput,
@@ -99,7 +102,13 @@ export function rewriteContentForModel(
     };
   }
 
-  if (isSearchQueryResourceType(content) || isToolMarkerResourceType(content)) {
+  if (
+    isToolMarkerResourceType(content) ||
+    isSearchQueryResourceType(content) ||
+    isIncludeQueryResourceType(content) ||
+    isWebsearchQueryResourceType(content) ||
+    isRunAgentQueryResourceType(content)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Description

- This PR hides a few tool outputs from the models, focusing on ones that are actually tool inputs we send in the outputs to have them available for displaying in the front-end.
- A follow up PR will removes them completely.

## Tests

## Risk

- Affects the rendering for model.

## Deploy Plan

- Deploy front.
