### PR TITLE
Show sourceUrl to the model for node attachment.

### DIFF
--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -45,6 +45,7 @@ export type ContentNodeAttachmentType = BaseConversationAttachmentType & {
   nodeId: string;
   nodeDataSourceViewId: string;
   nodeType: ContentNodeType;
+  sourceUrl: string | null;
 };
 
 export type ConversationAttachmentType =
@@ -131,6 +132,7 @@ export function getAttachmentFromContentNodeContentFragment(
     contentFragmentId: cf.contentFragmentId,
     nodeId: cf.nodeId,
     nodeType: cf.nodeType,
+    sourceUrl: cf.sourceUrl,
   };
 }
 
@@ -226,6 +228,10 @@ export function renderAttachmentXml({
     `isQueryable="${attachment.isQueryable}"`,
     `isSearchable="${attachment.isSearchable}"`,
   ];
+
+  if (isContentNodeAttachmentType(attachment) && attachment.sourceUrl) {
+    params.push(`sourceUrl="${attachment.sourceUrl}"`);
+  }
 
   let tag = `<attachment ${params.join(" ")}`;
 


### PR DESCRIPTION
## Description

Show `sourceUrl` when you attach a content node (which happen auto-magically when you copy paste an url that is ingested in the datasource).
Otherwise, **the agent has no way to now** and the url is quite useful :-)
(eg: to figure out github repo, issue number etc..)

## Tests

<img width="890" height="760" alt="image" src="https://github.com/user-attachments/assets/94ddcd25-fc42-44e1-a4c9-cccab60515da" />

## Risk

A slight increase in tokens, but well worth the price :)

## Deploy Plan

Deploy front