### PR TITLE
Let users always allows comment creation.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -134,6 +134,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: {
       create_issue: "low",
+      comment_on_issue: "low",
       add_issue_to_project: "low",
       get_pull_request: "never_ask",
       list_organization_projects: "never_ask",


### PR DESCRIPTION
## Description

Allow user to "always allow" comment creation (useful for automation).

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front