### PR TITLE
Add tool to retrieve interactive content share url

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
@@ -7,6 +7,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME,
   RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
@@ -22,7 +23,7 @@ import {
   revertClientExecutableFileChanges,
 } from "@app/lib/api/files/client_executable";
 import type { Authenticator } from "@app/lib/auth";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import type { InteractiveContentFileContentType } from "@app/types";
 import {
   Err,
@@ -457,25 +458,57 @@ function createServer(
     )
   );
 
-  // TODO(INTERACTIVE_CONTENT 2025-09-01): Register data source file system tools for the Interactive
-  // Content server once supported in the agent builder.
-  // // Register data source file system tools for the Interactive Content server with custom
-  // // descriptions tailored for Frame use cases (visual assets and templates).
-  // registerListTool(auth, server, agentLoopContext, {
-  //   name: "list_assets",
-  //   extraDescription:
-  //     "Browse available visual assets and templates in the connected data sources. " +
-  //     "Use this to explore folders containing images, icons, slideshow templates, " +
-  //     "or other resources that can be incorporated into Frame files.",
-  // });
+  server.tool(
+    GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME,
+    "Get the share URL for an Interactive Content file. Returns the share URL if the file is " +
+      "currently shared.",
+    {
+      file_id: z
+        .string()
+        .describe(
+          "The ID of the Interactive Content file to get share URL for (e.g., 'fil_abc123')"
+        ),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: false,
+      },
+      async ({ file_id }) => {
+        const fileResource = await FileResource.fetchById(auth, file_id);
+        if (!fileResource) {
+          return new Err(new MCPError(`File with ID '${file_id}' not found.`));
+        }
 
-  // registerCatTool(auth, server, agentLoopContext, {
-  //   name: "cat_assets",
-  //   extraDescription:
-  //     "Read template files or asset configurations from the connected data sources. " +
-  //     "Use this to retrieve slideshow templates, HTML/CSS snippets, React component examples, " +
-  //     "or configuration files that can serve as a starting point or be incorporated into Frame files.",
-  // });
+        if (!fileResource.isInteractiveContent) {
+          return new Err(
+            new MCPError(
+              `File '${file_id}' is not an Interactive Content file and cannot be shared.`
+            )
+          );
+        }
+
+        const shareInfo = await fileResource.getShareInfo();
+        if (!shareInfo) {
+          return new Ok([
+            {
+              type: "text",
+              text: `File '${file_id}' (${fileResource.fileName}) is not currently shared.`,
+            },
+          ]);
+        }
+
+        return new Ok([
+          {
+            type: "text",
+            text: ` URL: ${shareInfo.shareUrl}`,
+          },
+        ]);
+      }
+    )
+  );
 
   return server;
 }

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/types.ts
@@ -8,3 +8,5 @@ export const REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
   "revert_interactive_content_file";
 export const RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
   "rename_interactive_content_file";
+export const GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME =
+  "get_interactive_content_file_share_url";

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -779,3 +779,28 @@ export async function revertClientExecutableFileChanges(
     });
   }
 }
+
+export async function getClientExecutableFileShareUrl(
+  auth: Authenticator,
+  fileId: string
+): Promise<Result<string, Error>> {
+  const fileResource = await FileResource.fetchById(auth, fileId);
+  if (!fileResource) {
+    return new Err(new Error(`File not found: ${fileId}`));
+  }
+
+  if (!fileResource.isInteractiveContent) {
+    return new Err(
+      new Error(
+        `File '${fileId}' is not an Interactive Content file and cannot be shared.`
+      )
+    );
+  }
+
+  const shareInfo = await fileResource.getShareInfo();
+  if (!shareInfo) {
+    return new Err(new Error(`File '${fileId}' isn't shared.`));
+  }
+
+  return new Ok(shareInfo.shareUrl);
+}

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -144,6 +144,14 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return new Ok(undefined);
   }
 
+  /**
+   * Getters
+   */
+
+  get canShareInteractiveContentPublicly(): boolean {
+    return this.blob.metadata?.allowContentCreationFileSharing !== false;
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }

--- a/front/pages/api/v1/public/frames/[token]/files/[fileId].ts
+++ b/front/pages/api/v1/public/frames/[token]/files/[fileId].ts
@@ -90,6 +90,20 @@ async function handler(
     });
   }
 
+  // If file is shared publicly, ensure workspace allows it.
+  if (
+    shareScope === "public" &&
+    !workspace.canShareInteractiveContentPublicly
+  ) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  }
+
   // For workspace sharing, check authentication.
   if (shareScope === "workspace") {
     const auth = await getAuthForSharedEndpointWorkspaceMembersOnly(

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -55,7 +55,6 @@ async function handler(
   const workspace = await WorkspaceResource.fetchByModelId(
     result.file.workspaceId
   );
-
   if (!workspace) {
     return apiError(req, res, {
       status_code: 404,
@@ -86,6 +85,20 @@ async function handler(
       api_error: {
         type: "invalid_request_error",
         message: "File is not safe for public display.",
+      },
+    });
+  }
+
+  // If file is shared publicly, ensure workspace allows it.
+  if (
+    shareScope === "public" &&
+    !workspace.canShareInteractiveContentPublicly
+  ) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "File not found.",
       },
     });
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a tool on the `interactive_content` server to retrieve the share url of an interactive content file. This is required if you want your agent to post a message somewhere with the proper url.

<img width="849" height="374" alt="image" src="https://github.com/user-attachments/assets/6d1c33d5-6d6c-416a-aab8-a42d2b791d9f" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
