### PR TITLE
hootl: Do not retry the temporal workflow if the trigger does not exists

### DIFF
--- a/front/lib/triggers/temporal/common/activities.ts
+++ b/front/lib/triggers/temporal/common/activities.ts
@@ -191,7 +191,7 @@ export async function runTriggeredAgentsActivity({
   });
 
   if (!agentConfiguration) {
-    throw new Error(
+    throw new TriggerNonRetryableError(
       `Agent configuration with ID ${trigger.agentConfigurationId} not found in workspace ${auth.getNonNullableWorkspace().id}.`
     );
   }
@@ -203,12 +203,14 @@ export async function runTriggeredAgentsActivity({
 
   const triggerResource = await TriggerResource.fetchById(auth, trigger.sId);
   if (!triggerResource) {
-    throw new Error(`Trigger with ID ${trigger.sId} not found.`);
+    throw new TriggerNonRetryableError(
+      `Trigger with ID ${trigger.sId} not found.`
+    );
   }
 
   const subscribers = await triggerResource.getSubscribers(auth);
   if (subscribers.isErr()) {
-    throw new Error("Error getting trigger subscribers.");
+    throw new TriggerNonRetryableError("Error getting trigger subscribers.");
   }
 
   let lastRunAt: Date | null = null;


### PR DESCRIPTION
## Description

Do not retry the temporal workflow for a triger in the following cases:
 - If the trigger cannot be found: it means it has been deleted
 - if the agent can be found: it means the agent has been deleted
 - if the trigger resource cannot be found: not sure about this one, but I don't see how rerunning would recover the issue

## Tests

No

## Risk

Low, may prevent retry which are legit but I doubt it

## Deploy Plan

deploy front
