### PR TITLE
[growth] add utm_source to public frame

### DIFF
--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
@@ -47,7 +47,7 @@ export function PublicInteractiveContentHeader({
           {!user && (
             <Button
               label="Try it yourself"
-              href="/home"
+              href={`/home?utm_source=public-frames`}
               variant="outline"
               icon={RocketIcon}
               onClick={withTracking(TRACKING_AREAS.FRAMES, "sign_up")}


### PR DESCRIPTION
## Description
As discussed IRL, this PR is to add `utm_source=public-frames` in Try it yourself button. We have a logic to carry around utm_params in public site so once you accept cookies we can track people coming from public frame links  

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
