### PR TITLE
[sparkle] fix quote copy button

### DIFF
--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -11,6 +11,7 @@ export const blockquoteVariants = cva(
         surface: [
           "s-text-foreground dark:s-text-foreground-night",
           "s-bg-muted-background dark:s-bg-muted-background-night",
+          "s-border border-border dark:border-border-dark",
         ],
       },
     },
@@ -43,7 +44,11 @@ export function BlockquoteBlock({
     : undefined;
 
   return (
-    <ContentBlockWrapper content={clipboardContent} className="s-my-2">
+    <ContentBlockWrapper
+      content={clipboardContent}
+      className="s-my-2"
+      buttonDisplay="inside"
+    >
       <blockquote className={blockquoteVariants({ variant })}>
         {children}
       </blockquote>

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -11,7 +11,7 @@ export const blockquoteVariants = cva(
         surface: [
           "s-text-foreground dark:s-text-foreground-night",
           "s-bg-muted-background dark:s-bg-muted-background-night",
-          "s-border border-border dark:border-border-dark",
+          "s-border border-border dark:border-border-night",
         ],
       },
     },

--- a/sparkle/src/stories/ColorPalette.stories.tsx
+++ b/sparkle/src/stories/ColorPalette.stories.tsx
@@ -254,3 +254,28 @@ export const ExtendedColorPalette = () => {
     </div>
   );
 };
+
+const backgroundColors = ["background", "muted-background"] as const;
+
+export const BackgroundColors = () => {
+  return (
+    <div className="s-flex s-flex-col s-gap-8">
+      <div className="s-flex s-flex-col s-gap-2">
+        <h2 className="s-text-xl s-font-semibold">Background Colors</h2>
+        <p className="s-text-sm s-text-primary-600 dark:s-text-primary-400">
+          Background colors used for structural elements in the UI.
+        </p>
+      </div>
+      <div className="s-flex s-flex-wrap s-gap-4">
+        {backgroundColors.map((bg) => (
+          <div key={bg}>
+            <ColorSwatch
+              colorClass={`s-bg-${bg} dark:s-bg-${bg}-night`}
+              label={bg}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

Reported by @fontanierh [here](https://dust4ai.slack.com/archives/C066R3PMUAU/p1760442064419479) 

The copy button is now inside the block and it has border color: 

<img width="1638" height="654" alt="CleanShot 2025-10-17 at 14 26 25@2x" src="https://github.com/user-attachments/assets/731190c4-cfdf-458d-9d11-a8fc83f10e0d" />

<img width="1636" height="460" alt="CleanShot 2025-10-17 at 14 26 18@2x" src="https://github.com/user-attachments/assets/f6780782-2af4-4abc-877e-7cc6f340ea09" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
