### PR TITLE
[front] fix: update dependency array for webhook source cleanup callback

### DIFF
--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -576,7 +576,13 @@ function WebhookSourceSheetContent({
     if (deleted) {
       onClose();
     }
-  }, [confirm, webhookSource, deleteWebhookSource, onClose]);
+  }, [
+    confirm,
+    webhookSourcesWithViews,
+    webhookSource,
+    deleteWebhookSource,
+    onClose,
+  ]);
 
   const footerButtons = useMemo(() => {
     if (currentPageId === "create") {


### PR DESCRIPTION
## Description

- The dependencies array for a `useCallback` in `WebhookSourceSheet` were missing a value.
- This PR fixes that.

## Tests

## Risk

## Deploy Plan

- Deploy front.
