### PR TITLE
feat: add render for model layer for tool output resources (gated)

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -60,6 +60,7 @@ export function renderActionForMultiActionsModel(
   );
 
   let output;
+
   if (outputItems.length === 0) {
     output = "Successfully executed action, no output.";
   } else if (outputItems.every((item) => isTextContent(item))) {
@@ -70,6 +71,7 @@ export function renderActionForMultiActionsModel(
     } else {
       output = outputItems
         .map((item) => renderResourceForModel(item))
+        .filter((item) => !!item.trim().length)
         .join("\n\n");
     }
   }

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -1,6 +1,7 @@
 import { renderAllMessages } from "@app/lib/api/assistant/conversation_rendering/message_rendering";
 import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import logger from "@app/logger/logger";
 import type {
@@ -66,12 +67,15 @@ export async function renderConversationForModel(
 > {
   const now = Date.now();
 
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+
   const messages = await renderAllMessages(auth, {
     conversation,
     model,
     excludeActions,
     excludeImages,
     onMissingAction,
+    featureFlags,
   });
 
   const messagesWithTokensRes = await countTokensForMessages(messages, model);

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -17,6 +17,7 @@ import type {
   ConversationType,
   ModelConfigurationType,
   ModelMessageTypeMultiActions,
+  WhitelistableFeature,
 } from "@app/types";
 import {
   assertNever,
@@ -135,12 +136,14 @@ export async function renderAllMessages(
     excludeActions,
     excludeImages,
     onMissingAction,
+    featureFlags,
   }: {
     conversation: ConversationType;
     model: ModelConfigurationType;
     excludeActions?: boolean;
     excludeImages?: boolean;
     onMissingAction: "inject-placeholder" | "skip";
+    featureFlags: WhitelistableFeature[];
   }
 ): Promise<ModelMessageTypeMultiActions[]> {
   const messages: ModelMessageTypeMultiActions[] = [];
@@ -156,6 +159,7 @@ export async function renderAllMessages(
         workspaceId: conversation.owner.sId,
         conversationId: conversation.sId,
         onMissingAction,
+        useResourceRendering: featureFlags.includes("use_resource_rendering"),
       });
 
       const agentMessages = renderAgentSteps(

--- a/front/lib/model_rendering/resource_renderers.ts
+++ b/front/lib/model_rendering/resource_renderers.ts
@@ -1,0 +1,37 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import {
+  isRunAgentQueryResourceType,
+  isRunAgentResultResourceType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
+
+export function renderResourceForModel(
+  block: CallToolResult["content"][number]
+): string {
+  if (isRunAgentQueryResourceType(block)) {
+    // Don't render run agent queries (already contained in tool call args).
+    return "";
+  }
+
+  if (isRunAgentResultResourceType(block)) {
+    const refs = block.resource.refs;
+    if (refs) {
+      const maybeRenderLink = (c: { title: string; href?: string }) => {
+        if (c.href) {
+          return `[${c.title}](${c.href})`;
+        }
+        return c.title;
+      };
+
+      const refsText = Object.entries(refs)
+        .map(([ref, citation]) => {
+          return `- ${ref}: ${maybeRenderLink({ title: citation.title, href: citation.href })} - ${citation.provider}`;
+        })
+        .join("\n");
+
+      return `# Citations references:\n${refsText}\n\n# Output:\n${block.resource.text}`;
+    }
+  }
+
+  return JSON.stringify(block);
+}

--- a/front/lib/model_rendering/resource_renderers.ts
+++ b/front/lib/model_rendering/resource_renderers.ts
@@ -1,37 +1,104 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import {
+  isBrowseResultResourceType,
+  isDataSourceNodeListType,
+  isIncludeQueryResourceType,
   isRunAgentQueryResourceType,
   isRunAgentResultResourceType,
+  isSearchQueryResourceType,
+  isSearchResultResourceType,
+  isToolMarkerResourceType,
+  isWebsearchQueryResourceType,
+  isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
 export function renderResourceForModel(
   block: CallToolResult["content"][number]
 ): string {
-  if (isRunAgentQueryResourceType(block)) {
-    // Don't render run agent queries (already contained in tool call args).
+  if (
+    isRunAgentQueryResourceType(block) ||
+    isSearchQueryResourceType(block) ||
+    isIncludeQueryResourceType(block) ||
+    isWebsearchQueryResourceType(block) ||
+    isToolMarkerResourceType(block)
+  ) {
+    // We explicitly ignore those.
     return "";
-  }
-
-  if (isRunAgentResultResourceType(block)) {
+  } else if (isRunAgentResultResourceType(block)) {
     const refs = block.resource.refs;
-    if (refs) {
-      const maybeRenderLink = (c: { title: string; href?: string }) => {
-        if (c.href) {
-          return `[${c.title}](${c.href})`;
-        }
-        return c.title;
-      };
 
+    let text = "";
+
+    if (refs && Object.keys(refs).length > 0) {
       const refsText = Object.entries(refs)
         .map(([ref, citation]) => {
-          return `- ${ref}: ${maybeRenderLink({ title: citation.title, href: citation.href })} - ${citation.provider}`;
+          return `- ${ref}: ${maybeRenderLink(citation.title, citation.href)} - ${citation.provider}`;
         })
         .join("\n");
 
-      return `# Citations references:\n${refsText}\n\n# Output:\n${block.resource.text}`;
+      text += `# Citations references:\n${refsText}\n`;
     }
-  }
 
-  return JSON.stringify(block);
+    text += `# Output:\n${block.resource.text}`;
+
+    return text;
+  } else if (isDataSourceNodeListType(block)) {
+    let text = `Retrieved ${block.resource.resultCount} nodes (next page cursor: ${block.resource.nextPageCursor}):`;
+
+    for (const node of block.resource.data) {
+      text += "\n-----------\n";
+      text += `${maybeRenderLink(node.title, node.sourceUrl)}\n`;
+      text += `mimeType: ${node.mimeType}${node.connectorProvider ? ` (connector provider: ${node.connectorProvider})` : ""}\n`;
+      text += `hasChildren: ${node.hasChildren}\n`;
+      text += `lastUpdatedAt: ${node.lastUpdatedAt}\n`;
+      text += `connectorProvider: ${node.connectorProvider}\n`;
+      text += `parentTitle: ${node.parentTitle} (path: ${node.path})\n`;
+    }
+
+    return text;
+  } else if (isSearchResultResourceType(block)) {
+    let text = `Search result: ${block.resource.text}\n`;
+    text += `id: ${block.resource.id}\n`;
+    text += `uri: ${block.resource.uri}\n`;
+    text += `ref: ${block.resource.ref}\n`;
+    text += `source: ${block.resource.source.provider}\n`;
+    text += `mimeType: ${block.resource.mimeType}\n`;
+
+    if (block.resource.tags.length > 0) {
+      text += `tags: ${block.resource.tags.join(", ")}\n`;
+    }
+    if (block.resource.chunks.length > 0) {
+      text += `retrieved chunks:\n-----------\n${block.resource.chunks.join("------------")}`;
+    }
+    return text;
+  } else if (isWebsearchResultResourceType(block)) {
+    let text = `${maybeRenderLink(block.resource.title, block.resource.uri)}\n`;
+    text += `ref: ${block.resource.reference}\n`;
+    text += `${block.resource.text}\n`;
+    return text;
+  } else if (isBrowseResultResourceType(block)) {
+    let text = `${maybeRenderLink(block.resource.title ?? "Web page", block.resource.uri)}\n`;
+    if (block.resource.html) {
+      text += `${block.resource.html}\n`;
+    } else {
+      text += `${block.resource.text}\n`;
+    }
+    if (block.resource.errorMessage) {
+      text += `error: ${block.resource.errorMessage}\n`;
+    }
+    if (block.resource.responseCode !== "200") {
+      text += `response code: ${block.resource.responseCode}\n`;
+    }
+    return text;
+  } else {
+    return JSON.stringify(block);
+  }
+}
+
+function maybeRenderLink(t: string, href?: string | null) {
+  if (href) {
+    return `[${t}](${href})`;
+  }
+  return t;
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -226,6 +226,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Use direct LLM call over Dust app run in a conversation.",
     stage: "on_demand",
   },
+  use_resource_rendering: {
+    description: "Use resource rendering for agent outputs (instead of JSON)",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -698,6 +698,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "legacy_dust_apps"
   | "dust_default_haiku_feature"
   | "llm_router_direct_requests"
+  | "use_resource_rendering"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Our tool outputs are currently rendered to the model as noisy JSON blobs.

This PR introduces a layer that converts tool output resources to a more token-efficient plain text representation.
This is currently gated by a feature flag (no op for workspaces that aren't gated).

Only some of the most common resources are handled at the moment (data source search, content node lists, web browsing, web search, sub agents).

This reduces token usage significantly (between 10% and 70% reduction depending on the cases)

Next step is implementation for the remaining resources.

We'll also want to update some of the tools so they stop returning collections, and instead return a single resource so we can better optimize.

## Tests

Local

## Risk

Low (gated)

## Deploy Plan

front