### PR TITLE
refactor(connector): rename variable of the sequelize connection

### DIFF
--- a/connectors/migrations/20230626_gdrive_multiple_webhooks.ts
+++ b/connectors/migrations/20230626_gdrive_multiple_webhooks.ts
@@ -1,10 +1,10 @@
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 async function main() {
-  await sequelizeConnection.query(
+  await connectorsSequelize.query(
     "drop index google_drive_webhooks_connector_id"
   );
-  await sequelizeConnection.query(
+  await connectorsSequelize.query(
     'UPDATE google_drive_webhooks SET "renewAt" = "expiresAt"'
   );
 }

--- a/connectors/migrations/20230828_notion_pages_title_search_vector.ts
+++ b/connectors/migrations/20230828_notion_pages_title_search_vector.ts
@@ -1,11 +1,11 @@
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 async function main() {
-  await sequelizeConnection.query(`
+  await connectorsSequelize.query(`
     UPDATE "notion_pages"
     SET "titleSearchVector" = to_tsvector('english', unaccent(coalesce("title", '')));
   `);
-  await sequelizeConnection.query(`
+  await connectorsSequelize.query(`
     UPDATE "notion_databases"
     SET "titleSearchVector" = to_tsvector('english', unaccent(coalesce("title", '')));
   `);

--- a/connectors/migrations/20240129_cleanup_orphaned_notion_cache.ts
+++ b/connectors/migrations/20240129_cleanup_orphaned_notion_cache.ts
@@ -1,7 +1,7 @@
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 async function main() {
-  await sequelizeConnection.query(`
+  await connectorsSequelize.query(`
         DELETE FROM notion_connector_page_cache_entries WHERE "connectorId" IS NULL;
         DELETE FROM notion_connector_block_cache_entries WHERE "connectorId" IS NULL;
         DELETE FROM notion_connector_resources_to_check_cache_entries WHERE "connectorId" IS NULL;

--- a/connectors/migrations/20240129_drop_notion_connector_caches_indexes.ts
+++ b/connectors/migrations/20240129_drop_notion_connector_caches_indexes.ts
@@ -1,7 +1,7 @@
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 async function main() {
-  await sequelizeConnection.query(`
+  await connectorsSequelize.query(`
         DROP INDEX IF EXISTS "uq_notion_block_id_conn_id_page_id";
         DROP INDEX IF EXISTS "notion_connector_page_cache_entries_notion_page_id_connector_id";
         DROP INDEX IF EXISTS "uq_notion_to_check_notion_id_conn_id";

--- a/connectors/migrations/20240131_migrate_all_notion_connectors_to_dual_workflow.ts
+++ b/connectors/migrations/20240131_migrate_all_notion_connectors_to_dual_workflow.ts
@@ -1,7 +1,7 @@
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 async function main() {
-  await sequelizeConnection.query(`
+  await connectorsSequelize.query(`
         UPDATE notion_connector_states SET "useDualWorkflow" = true;
     `);
 }

--- a/connectors/migrations/20240216_make_notion_cache_tables_unlogged.ts
+++ b/connectors/migrations/20240216_make_notion_cache_tables_unlogged.ts
@@ -1,7 +1,7 @@
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 async function main() {
-  await sequelizeConnection.query(`
+  await connectorsSequelize.query(`
         ALTER TABLE notion_connector_page_cache_entries SET UNLOGGED;
         ALTER TABLE notion_connector_block_cache_entries SET UNLOGGED;
         ALTER TABLE notion_connector_resources_to_check_cache_entries SET UNLOGGED;

--- a/connectors/migrations/20240529_clean_gdrive_folders.ts
+++ b/connectors/migrations/20240529_clean_gdrive_folders.ts
@@ -12,7 +12,7 @@ import {
 } from "@connectors/lib/models/google_drive";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 const { LIVE } = process.env;
 
@@ -29,7 +29,7 @@ async function main() {
   ORDER BY folders."updatedAt" DESC;
 `;
 
-  const results = await sequelizeConnection.query(query, {
+  const results = await connectorsSequelize.query(query, {
     type: QueryTypes.SELECT,
   });
 

--- a/connectors/migrations/20241218_force_resync_page.ts
+++ b/connectors/migrations/20241218_force_resync_page.ts
@@ -3,12 +3,12 @@ import { makeScript } from "scripts/helpers";
 import { QUEUE_NAME } from "@connectors/connectors/notion/temporal/config";
 import { upsertPageWorkflow } from "@connectors/connectors/notion/temporal/workflows/admins";
 import { getTemporalClient } from "@connectors/lib/temporal";
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 makeScript({}, async (execute, logger) => {
   const client = await getTemporalClient();
 
-  const [rows] = await sequelizeConnection.query(`
+  const [rows] = await connectorsSequelize.query(`
       SELECT "connectorId", "notionPageId" as "pageId" 
       FROM notion_pages 
       WHERE "lastUpsertedTs" is null 

--- a/connectors/migrations/20250430_init_last_upserted_notion_databases.ts
+++ b/connectors/migrations/20250430_init_last_upserted_notion_databases.ts
@@ -1,7 +1,7 @@
 import { makeScript } from "scripts/helpers";
 
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 makeScript({}, async ({ execute }, logger) => {
   const notionConnectors = await ConnectorResource.listByType("notion", {});
@@ -18,7 +18,7 @@ makeScript({}, async ({ execute }, logger) => {
     // We initialize lastUpsertedRunTs to firstSeenTs (to allow prioritizing
     // databases that were never upserted yet).
     if (execute) {
-      await sequelizeConnection.query(
+      await connectorsSequelize.query(
         `UPDATE notion_databases SET "lastUpsertedRunTs" = "firstSeenTs" WHERE "connectorId" = :connectorId`,
         {
           replacements: { connectorId: c.id },

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -85,7 +85,7 @@ import {
   ZendeskTimestampCursorModel,
 } from "@connectors/lib/models/zendesk";
 import logger from "@connectors/logger/logger";
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import { sendInitDbMessage } from "@connectors/types";
 
@@ -155,16 +155,16 @@ async function main(): Promise<void> {
   await GongUserModel.sync({ alter: true });
 
   // enable the `unaccent` extension
-  await sequelizeConnection.query("CREATE EXTENSION IF NOT EXISTS unaccent;");
+  await connectorsSequelize.query("CREATE EXTENSION IF NOT EXISTS unaccent;");
 
   await addSearchVectorTrigger(
-    sequelizeConnection,
+    connectorsSequelize,
     "notion_pages",
     "notion_pages_vector_update",
     "notion_pages_trigger"
   );
   await addSearchVectorTrigger(
-    sequelizeConnection,
+    connectorsSequelize,
     "notion_databases",
     "notion_databases_vector_update",
     "notion_databases_trigger"

--- a/connectors/src/lib/models/bigquery.ts
+++ b/connectors/src/lib/models/bigquery.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export class BigQueryConfigurationModel extends ConnectorBaseModel<BigQueryConfigurationModel> {
@@ -28,7 +28,7 @@ BigQueryConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "bigquery_configurations",
     indexes: [{ fields: ["connectorId"], unique: true }],
   }

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export class ConfluenceConfiguration extends ConnectorBaseModel<ConfluenceConfiguration> {
@@ -38,7 +38,7 @@ ConfluenceConfiguration.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "confluence_configurations",
     indexes: [
       { fields: ["connectorId"], unique: true },
@@ -88,7 +88,7 @@ ConfluenceSpace.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "confluence_spaces",
     indexes: [{ fields: ["connectorId", "spaceId"], unique: true }],
   }
@@ -162,7 +162,7 @@ ConfluencePage.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["connectorId", "pageId"], unique: true },
       { fields: ["connectorId", "spaceId", "parentId"] },
@@ -240,7 +240,7 @@ ConfluenceFolder.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["connectorId", "folderId"], unique: true },
       { fields: ["connectorId", "spaceId", "parentId"] },

--- a/connectors/src/lib/models/discord.ts
+++ b/connectors/src/lib/models/discord.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export class DiscordConfigurationModel extends ConnectorBaseModel<DiscordConfigurationModel> {
@@ -34,7 +34,7 @@ DiscordConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["guildId"] },
       { fields: ["connectorId"], unique: true },

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export class GithubConnectorState extends ConnectorBaseModel<GithubConnectorState> {
@@ -39,7 +39,7 @@ GithubConnectorState.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "github_connector_states",
     indexes: [
       { fields: ["connectorId"], unique: true },
@@ -84,7 +84,7 @@ GithubIssue.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["repoId", "issueNumber", "connectorId"], unique: true },
       { fields: ["connectorId"] },
@@ -123,7 +123,7 @@ GithubDiscussion.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["repoId", "discussionNumber", "connectorId"], unique: true },
       { fields: ["connectorId"] },
@@ -197,7 +197,7 @@ GithubCodeRepository.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [{ fields: ["connectorId", "repoId"], unique: true }],
     modelName: "github_code_repositories",
   }
@@ -271,7 +271,7 @@ GithubCodeFile.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["connectorId", "repoId", "documentId"], unique: true },
       { fields: ["connectorId", "repoId", "lastSeenAt"] },
@@ -337,7 +337,7 @@ GithubCodeDirectory.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["connectorId", "repoId", "internalId"], unique: true },
       { fields: ["connectorId", "repoId", "lastSeenAt"] },

--- a/connectors/src/lib/models/gong.ts
+++ b/connectors/src/lib/models/gong.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export class GongConfigurationModel extends ConnectorBaseModel<GongConfigurationModel> {
@@ -56,7 +56,7 @@ GongConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "gong_configurations",
     indexes: [{ fields: ["connectorId"], unique: true }],
     relationship: "hasOne",
@@ -107,7 +107,7 @@ GongUserModel.init(
     indexes: [{ fields: ["connectorId", "gongId"], unique: true }],
     modelName: "gong_users",
     relationship: "hasMany",
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
   }
 );
 
@@ -151,7 +151,7 @@ GongTranscriptModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "gong_transcripts",
     indexes: [{ fields: ["connectorId", "callId"], unique: true }],
   }

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -2,7 +2,7 @@ import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import type { TablesErrorType } from "@connectors/lib/error";
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
@@ -43,7 +43,7 @@ GoogleDriveConfig.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "google_drive_configs",
     indexes: [{ fields: ["connectorId"], unique: true }],
     relationship: "hasOne",
@@ -75,7 +75,7 @@ GoogleDriveFolders.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "google_drive_folders",
     indexes: [{ fields: ["connectorId", "folderId"], unique: true }],
   }
@@ -143,7 +143,7 @@ GoogleDriveFiles.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "google_drive_files",
     indexes: [
       { fields: ["connectorId", "driveFileId"], unique: true },
@@ -191,7 +191,7 @@ GoogleDriveSheet.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "google_drive_sheets",
     indexes: [
       { fields: ["connectorId", "driveFileId", "driveSheetId"], unique: true },
@@ -234,7 +234,7 @@ GoogleDriveSyncToken.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "google_drive_sync_tokens",
     indexes: [{ fields: ["connectorId", "driveId"], unique: true }],
   }

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -2,7 +2,7 @@ import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import type { IntercomSyncAllConversationsStatus } from "@connectors/connectors/intercom/lib/types";
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export const DEFAULT_CONVERSATIONS_SLIDING_WINDOW = 180;
@@ -61,7 +61,7 @@ IntercomWorkspaceModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       {
         fields: ["connectorId", "intercomWorkspaceId"],
@@ -130,7 +130,7 @@ IntercomHelpCenterModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       {
         fields: ["connectorId", "helpCenterId"],
@@ -212,7 +212,7 @@ IntercomCollectionModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       {
         fields: ["connectorId", "collectionId"],
@@ -304,7 +304,7 @@ IntercomArticleModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       {
         fields: ["connectorId", "articleId"],
@@ -359,7 +359,7 @@ IntercomTeamModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       {
         fields: ["connectorId", "teamId"],
@@ -412,7 +412,7 @@ IntercomConversationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       {
         fields: ["connectorId", "conversationId"],

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -2,7 +2,7 @@ import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/types";
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export class MicrosoftConfigurationModel extends ConnectorBaseModel<MicrosoftConfigurationModel> {
@@ -41,7 +41,7 @@ MicrosoftConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "microsoft_configurations",
     indexes: [{ fields: ["connectorId"], unique: true }],
     relationship: "hasOne",
@@ -80,7 +80,7 @@ MicrosoftRootModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "microsoft_roots",
     indexes: [
       { fields: ["connectorId", "internalId"], unique: true },
@@ -159,7 +159,7 @@ MicrosoftNodeModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "microsoft_nodes",
     indexes: [
       { fields: ["internalId", "connectorId"], unique: true },

--- a/connectors/src/lib/models/microsoft_bot.ts
+++ b/connectors/src/lib/models/microsoft_bot.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export class MicrosoftBotConfigurationModel extends ConnectorBaseModel<MicrosoftBotConfigurationModel> {
@@ -33,7 +33,7 @@ MicrosoftBotConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "microsoft_bot_configurations",
     indexes: [
       { fields: ["connectorId"], unique: true },
@@ -99,7 +99,7 @@ MicrosoftBotMessage.init(
   },
   {
     modelName: "microsoft_bot_messages",
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       {
         fields: ["connectorId"],

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { NotionBlockType, PageObjectProperties } from "@connectors/types";
 
@@ -51,7 +51,7 @@ NotionConnectorState.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "notion_connector_states",
     indexes: [{ fields: ["connectorId"], unique: true }],
     relationship: "hasOne",
@@ -129,7 +129,7 @@ NotionPage.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["connectorId"], concurrently: true },
       { fields: ["notionPageId", "connectorId"], unique: true },
@@ -246,7 +246,7 @@ NotionDatabase.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["connectorId"], concurrently: true },
       { fields: ["notionDatabaseId", "connectorId"], unique: true },
@@ -345,7 +345,7 @@ NotionConnectorPageCacheEntry.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "notion_connector_page_cache_entries",
     indexes: [
       {
@@ -426,7 +426,7 @@ NotionConnectorBlockCacheEntry.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "notion_connector_block_cache_entries",
     indexes: [
       {
@@ -483,7 +483,7 @@ NotionConnectorResourcesToCheckCacheEntry.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "notion_connector_resources_to_check_cache_entries",
     indexes: [
       {

--- a/connectors/src/lib/models/remote_databases.ts
+++ b/connectors/src/lib/models/remote_databases.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 type AllowedPermissions = "selected" | "unselected" | "inherited";
@@ -45,7 +45,7 @@ RemoteDatabaseModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "remote_databases",
     indexes: [{ fields: ["connectorId", "internalId"], unique: true }],
   }
@@ -96,7 +96,7 @@ RemoteSchemaModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "remote_schemas",
     indexes: [{ fields: ["connectorId", "internalId"], unique: true }],
   }
@@ -152,7 +152,7 @@ RemoteTableModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "remote_tables",
     indexes: [{ fields: ["connectorId", "internalId"], unique: true }],
   }

--- a/connectors/src/lib/models/salesforce.ts
+++ b/connectors/src/lib/models/salesforce.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export class SalesforceConfigurationModel extends ConnectorBaseModel<SalesforceConfigurationModel> {
@@ -23,7 +23,7 @@ SalesforceConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "salesforce_configurations",
     indexes: [{ fields: ["connectorId"], unique: true }],
     relationship: "hasOne",
@@ -78,7 +78,7 @@ SalesforceSyncedQueryModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "salesforce_synced_queries",
     indexes: [{ fields: ["connectorId"], unique: false }],
   }

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type {
   ConnectorPermission,
@@ -57,7 +57,7 @@ SlackConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       { fields: ["slackTeamId"] },
       { fields: ["connectorId"], unique: true },
@@ -110,7 +110,7 @@ SlackMessages.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "slack_messages",
     indexes: [
       { fields: ["connectorId", "channelId", "documentId"], unique: true },
@@ -177,7 +177,7 @@ SlackChannel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "slack_channels",
     indexes: [
       { fields: ["connectorId", "slackChannelId"], unique: true },
@@ -270,7 +270,7 @@ SlackChatBotMessage.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "slack_chat_bot_messages",
     indexes: [{ fields: ["connectorId", "channelId", "threadTs"] }],
   }
@@ -312,7 +312,7 @@ SlackBotWhitelistModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [{ fields: ["connectorId", "botName"], unique: true }],
     modelName: "slack_bot_whitelist",
     tableName: "slack_bot_whitelist",

--- a/connectors/src/lib/models/snowflake.ts
+++ b/connectors/src/lib/models/snowflake.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 export class SnowflakeConfigurationModel extends ConnectorBaseModel<SnowflakeConfigurationModel> {
@@ -22,7 +22,7 @@ SnowflakeConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "snowflake_configurations",
     indexes: [{ fields: ["connectorId"], unique: true }],
   }

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -2,7 +2,7 @@ import type { Action } from "@mendable/firecrawl-js";
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CrawlingFrequency, DepthOption } from "@connectors/types";
 
@@ -75,7 +75,7 @@ WebCrawlerConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [],
     modelName: "webcrawler_configurations",
   }
@@ -113,7 +113,7 @@ WebCrawlerConfigurationHeader.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "webcrawler_configuration_headers",
     indexes: [
       {
@@ -172,7 +172,7 @@ WebCrawlerFolder.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       {
         unique: true,
@@ -241,7 +241,7 @@ WebCrawlerPage.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     indexes: [
       {
         unique: true,

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
 function throwOnUnsafeInteger(value: number | null) {
@@ -36,7 +36,7 @@ ZendeskTimestampCursorModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "zendesk_timestamp_cursors",
     indexes: [{ fields: ["connectorId"], unique: true }],
   }
@@ -117,7 +117,7 @@ ZendeskConfigurationModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "zendesk_configurations",
     indexes: [{ fields: ["connectorId"], unique: true }],
     relationship: "hasOne",
@@ -182,7 +182,7 @@ ZendeskBrandModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "zendesk_brands",
     indexes: [
       {
@@ -254,7 +254,7 @@ ZendeskCategoryModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "zendesk_categories",
     indexes: [
       {
@@ -331,7 +331,7 @@ ZendeskArticleModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "zendesk_articles",
     indexes: [
       {
@@ -411,7 +411,7 @@ ZendeskTicketModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "zendesk_tickets",
     indexes: [
       {

--- a/connectors/src/resources/storage/index.ts
+++ b/connectors/src/resources/storage/index.ts
@@ -35,7 +35,7 @@ types.setTypeParser(types.builtins.INT8, function (val: unknown) {
 const statsDClient = getStatsDClient();
 const CONNECTION_ACQUISITION_THRESHOLD_MS = 100;
 
-export const sequelizeConnection = new Sequelize(
+export const connectorsSequelize = new Sequelize(
   dbConfig.getRequiredDatabaseURI(),
   {
     pool: {

--- a/connectors/src/resources/storage/models/connector_model.ts
+++ b/connectors/src/resources/storage/models/connector_model.ts
@@ -2,7 +2,7 @@ import type { ConnectorProvider } from "@dust-tt/client";
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 import { BaseModel } from "@connectors/resources/storage/wrappers/base";
 import type {
   ConnectorErrorType,
@@ -116,7 +116,7 @@ ConnectorModel.init(
     },
   },
   {
-    sequelize: sequelizeConnection,
+    sequelize: connectorsSequelize,
     modelName: "connectors",
     indexes: [{ fields: ["workspaceId", "dataSourceId"], unique: true }],
   }

--- a/connectors/src/types/shared/utils/sql_utils.ts
+++ b/connectors/src/types/shared/utils/sql_utils.ts
@@ -1,7 +1,7 @@
 import type { Transaction } from "sequelize";
 import { Sequelize } from "sequelize";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 function getCurrentTransaction(): Transaction | null {
   // We use CLS in tests to isolate tests in separate transactions.
@@ -32,5 +32,5 @@ export async function withTransaction<T>(
     );
   }
 
-  return sequelizeConnection.transaction(fn);
+  return connectorsSequelize.transaction(fn);
 }

--- a/connectors/vite.setup.ts
+++ b/connectors/vite.setup.ts
@@ -2,7 +2,7 @@ import { default as cls } from "cls-hooked";
 import { Sequelize } from "sequelize";
 import { afterEach, beforeEach, vi } from "vitest";
 
-import { sequelizeConnection } from "@connectors/resources/storage";
+import { connectorsSequelize } from "@connectors/resources/storage";
 
 beforeEach(async (c) => {
   vi.clearAllMocks();
@@ -14,7 +14,7 @@ beforeEach(async (c) => {
   Sequelize.useCLS(namespace);
   const context = namespace.createContext();
   namespace.enter(context);
-  const transaction = await sequelizeConnection.transaction({
+  const transaction = await connectorsSequelize.transaction({
     autocommit: false,
   });
   namespace.set("transaction", transaction);

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -1,7 +1,8 @@
 import { Context } from "@temporalio/activity";
-import { QueryTypes, Sequelize } from "sequelize";
+import type { Sequelize } from "sequelize";
+import { QueryTypes } from "sequelize";
 
-import config from "@app/lib/production_checks/config";
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
 import logger from "@app/logger/logger";
 import type {
   RunExecutionRow,
@@ -15,10 +16,7 @@ import {
 const BATCH_SIZE = 100;
 
 export async function purgeExpiredRunExecutionsActivity() {
-  const primaryCoreDatabaseUri = config.getCoreDatabasePrimaryUri();
-  const coreSequelize = new Sequelize(primaryCoreDatabaseUri, {
-    logging: false,
-  });
+  const coreSequelize = getCorePrimaryDbConnection();
 
   const cutoffDate = getRunExecutionsDeletionCutoffDate();
 


### PR DESCRIPTION
## Description

Rename `sequelizeConnection` to `connectorsSequelize` to match the one in the front that is named `frontSequelize` [here](https://github.com/dust-tt/dust/blob/3137a12ac083af113dd10808d6b32a5875bde332/front/lib/resources/storage/index.ts#L39-L38)


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
