### PR TITLE
[Tool Cancellation] Distinguish 'cancel' abort from other aborts

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -306,14 +306,14 @@ export default async function createServer(
           toolsetsToAdd,
           fileOrContentFragmentIds,
         },
-        { sendNotification, _meta }
+        { sendNotification, _meta, signal }
       ) => {
         assert(
           agentLoopContext?.runContext,
           "agentLoopContext is required to run the run_agent tool"
         );
 
-        const abortSignal = null;
+        const abortSignal = signal ?? null;
         let childCancellationPromise: Promise<void> | null = null;
         const finalizeAndReturn = async <T>(
           result: Result<T, MCPError>
@@ -460,7 +460,7 @@ export default async function createServer(
           }
         };
 
-        /*if (abortSignal) {
+        if (abortSignal) {
           if (abortSignal.aborted) {
             requestChildCancellation();
             return finalizeAndReturn(
@@ -471,7 +471,7 @@ export default async function createServer(
           abortSignal.addEventListener("abort", requestChildCancellation, {
             once: true,
           });
-        }*/
+        }
 
         if (isNewConversation) {
           logger.info(

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -50,7 +50,7 @@ export async function* runToolWithStreaming(
     agentMessage: AgentMessageType;
     conversation: ConversationType;
   },
-  _options?: { signal?: AbortSignal }
+  options?: { signal?: AbortSignal }
 ): AsyncGenerator<
   | MCPApproveExecutionEvent
   | MCPErrorEvent
@@ -65,7 +65,7 @@ export async function* runToolWithStreaming(
 
   const { toolConfiguration, status, augmentedInputs: inputs } = action;
 
-  // const signal = options?.signal;
+  const signal = options?.signal;
 
   const localLogger = logger.child({
     actionConfigurationId: toolConfiguration.sId,
@@ -102,6 +102,7 @@ export async function* runToolWithStreaming(
           conversation,
           agentMessage,
         }),
+      signal,
     }
   );
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -28,7 +28,7 @@ import type {
 } from "@app/types/assistant/agent_run";
 
 const toolActivityStartToCloseTimeout = `${DEFAULT_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1} minutes`;
-export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT = 10_000; // 10 seconds.
+export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT = 20_000;
 
 const { runModelAndCreateActionsActivity } = proxyActivities<
   typeof runModelAndCreateWrapperActivities

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -39,7 +39,7 @@ const { runModelAndCreateActionsActivity } = proxyActivities<
 const { runToolActivity } = proxyActivities<typeof runToolActivities>({
   // Activity timeout keeps a short buffer above the tool timeout to detect worker restarts promptly.
   startToCloseTimeout: toolActivityStartToCloseTimeout,
-  // heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
+  heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
   retry: {
     // Do not retry tool activities. Those are not idempotent.
     maximumAttempts: 1,
@@ -50,7 +50,7 @@ const { runToolActivity: runRetryableToolActivity } = proxyActivities<
   typeof runToolActivities
 >({
   startToCloseTimeout: toolActivityStartToCloseTimeout,
-  //heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
+  heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
   retry: {
     maximumAttempts: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
   },


### PR DESCRIPTION
## Description
Fixes issue from [this thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1760644238552799?thread_ts=1760639595.361049&cid=C050SM8NSPK)
Re-reverts PRs #16968 and #17005

Explanations:
- Run_agent is retryable and resumable on interrupt, so it endures timeouts, deploys, etc. 
- To cancel tools, we passed an abort signal in PR #16311. On trigger, the signal cancels the. This signal aborts the tool both on unintended interruptions and on requested cancellations. But for run agent, behaviour differs on those cases: on 1 we want to retry, while on 2. we do want to cancel

This PR distinguishes that.

Also, raises too agressive heartbeattimeout, which should fix https://github.com/dust-tt/tasks/issues/4668 . 


## Risk
standard

## Deploy Plan
front
