### PR TITLE
feat(front): add stacktrace on generated SQL

### DIFF
--- a/front/lib/resources/storage/wrappers/sqlcommenter.ts
+++ b/front/lib/resources/storage/wrappers/sqlcommenter.ts
@@ -1,0 +1,100 @@
+import type { Sequelize } from "sequelize";
+
+const hasComment = (sql: string | null) => {
+  if (!sql) {
+    return false;
+  }
+
+  // See https://docs.oracle.com/cd/B12037_01/server.101/b10759/sql_elements006.htm
+  // for how to detect comments.
+  const indexOpeningDashDashComment = sql.indexOf("--");
+  if (indexOpeningDashDashComment >= 0) {
+    return true;
+  }
+
+  const indexOpeningSlashComment = sql.indexOf("/*");
+  if (indexOpeningSlashComment < 0) {
+    return false;
+  }
+
+  // Check if it is a well formed comment.
+  const indexClosingSlashComment = sql.indexOf("*/");
+
+  /* c8 ignore next */
+  return indexOpeningSlashComment < indexClosingSlashComment;
+};
+
+const makeMinimalUsefulStacktrace = (): string | null => {
+  const stacktrace = new Error().stack;
+
+  if (!stacktrace) {
+    return null;
+  }
+
+  // Most Sequelize queries contain something of the form "at Function.{query}",
+  // e.g. "at Function.findAll". This is a hint to help us find useful
+  // context.
+  const indexOfUsefulInfoForQuery = stacktrace.lastIndexOf("node_modules/");
+  let minimalUsefulStacktrace = stacktrace.slice(
+    indexOfUsefulInfoForQuery >= 0
+      ? indexOfUsefulInfoForQuery
+      : stacktrace.indexOf("at")
+  );
+
+  // Only get about 4 lines of context
+  minimalUsefulStacktrace = minimalUsefulStacktrace
+    .split("\n")
+    .slice(1, 5)
+    .map((stackLine) => stackLine.trim())
+    .join("\n");
+
+  return minimalUsefulStacktrace;
+};
+
+export function wrapSequelize(
+  sequelize: Sequelize & {
+    ___alreadySQLCommenterWrapped___?: boolean;
+  }
+) {
+  /* c8 ignore next 2 */
+  if (sequelize.___alreadySQLCommenterWrapped___) {
+    return;
+  }
+
+  // @ts-expect-error - access to a private property of sequelize
+  const originalRunFunction = sequelize.dialect.Query.prototype.run;
+  // Please don't change this prototype from an explicit function
+  // to use arrow functions lest we'll get bugs with not resolving "this".
+  // @ts-expect-error - access to a private property of sequelize
+  sequelize.dialect.Query.prototype.run = function (
+    sql: string | null,
+    sql_options: any
+  ) {
+    // If a comment already exists, do not insert a new one.
+    if (hasComment(sql)) {
+      // Just proceed with the next function ASAP
+      return originalRunFunction.apply(this, [sql, sql_options]);
+    }
+
+    // Allow only alphanumeric, periods, slashes, dashes, underscores,
+    // spaces, newlines. The main concern is preventing injection of '*/
+    // within the stacktrace.
+    //
+    // We also don't include any quotes with the stacktrace because
+    const stacktrace = makeMinimalUsefulStacktrace();
+    if (!stacktrace) {
+      return originalRunFunction.apply(this, [sql, sql_options]);
+    }
+
+    const commentStr = `stacktrace=\n${stacktrace.replace(/[^\w.:/\\\-\s\n]/g, "")}`;
+
+    if (commentStr && commentStr.length > 0) {
+      sql = `${sql} /* ${commentStr} */`;
+    }
+
+    return originalRunFunction.apply(this, [sql, sql_options]);
+  };
+
+  // Mark the object as having already been wrapped.
+  sequelize.___alreadySQLCommenterWrapped___ = true;
+}


### PR DESCRIPTION
## Description

To ease debugging this PR adds comments in all SQL queries with part of the stacktrace. If we agree this is a good add, I'll do it in connectors too.

Those comments can be understood by datadog in the context of the DB APM (that we don't have yet)

It's inspired by: 
* https://github.com/google/sqlcommenter
* https://github.com/wanderlog/sqlcommenter-sequelize

Note: I didn't reuse any of those librairies because:
* the google one doesn't add the stacktrace
* the wanderlog one _only_ adds the stacktrace, and I would like to add more metadatas later on

## Tests

Locally, the app still works and we see the comments in the generated SQL
```
[17:21:43.358] INFO (50136): Sequelize executed query: `SELECT "createdAt", "updatedAt", "action", "unread", "actionRequired", "workspaceId", "id", "conversationId", "userId" FROM "conversation_participants" AS "conversation_participant" WHERE "conversation_participant"."conversationId" = 108 AND "conversation_participant"."workspaceId" = 1 AND "conversation_participant"."userId" = 1 LIMIT 1; /* stacktrace=
at async ConversationResource.getActionRequiredAndUnreadForUser webpack-internal:///api/./lib/resources/conversation_resource.ts:465:29
at async ConversationResource.fetchConversationWithoutContent webpack-internal:///api/./lib/resources/conversation_resource.ts:262:44
at async handler webpack-internal:///api/./pages/api/w/wId/assistant/conversations/cId/events.ts:26:29
at async eval webpack-internal:///api/./logger/withlogging.ts:79:13 */`
```



## Risk

Low, it adds a bit of overhead for each query, but I think it's worth it

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
