### PR TITLE
[MCP] Use one-off timeout for heartbeat in tryCallMCPTool

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -394,7 +394,7 @@ export async function* tryCallMCPTool(
     // Frequently heartbeat to get notified of cancellation.
     const getHeartbeatPromise = (): Promise<void> =>
       new Promise((resolve) => {
-        setInterval(() => {
+        setTimeout(() => {
           heartbeat();
           resolve();
         }, TOOL_ACTIVITY_HEARTBEAT_TIMEOUT / 2);


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/4668

Replace `setInterval` with `setTimeout` for the heartbeat inside `tryCallMCPTool`'s `getHeartbeatPromise`. Using an interval caused the promise to resolve on the first tick but the interval to keep firing, leading to unnecessary repeated heartbeats and a lingering timer. A one-off timeout maintains the intended single tick and avoids timer leaks.

## Risks
Blast radius: MCP tool execution heartbeat/cancellation detection in front.
Risk: low

## Deploy Plan
- deploy front
