### PR TITLE
[LLM Router] Filter renderConversationForModel output

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -8,6 +8,7 @@ import type {
   ModelConfigurationType,
   ModelConversationTypeMultiActions,
   ModelMessageTypeMultiActions,
+  ModelMessageTypeMultiActionsWithoutContentFragment,
   Result,
 } from "@app/types";
 import {
@@ -192,10 +193,17 @@ export async function renderConversationForModel(
     );
   }
 
-  // Remove tokenCount from final messages
-  const finalMessages: ModelMessageTypeMultiActions[] = selected.map(
-    ({ tokenCount: _tokenCount, ...msg }) => msg
-  );
+  // Remove tokenCount from final messages and remove content fragments from return type
+  const finalMessages = selected
+    .map(({ tokenCount: _tokenCount, ...msg }) => msg)
+    // There should be no content fragments as they have been merged into user messages
+    // TODO: refactor how we define the selected array
+    .filter(
+      (
+        message
+      ): message is ModelMessageTypeMultiActionsWithoutContentFragment =>
+        message.role !== "content_fragment"
+    );
 
   logger.info(
     {

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -81,12 +81,15 @@ export interface FunctionMessageTypeModel {
   content: string | Content[];
 }
 
-export type ModelMessageTypeMultiActions =
-  | ContentFragmentMessageTypeModel
+export type ModelMessageTypeMultiActionsWithoutContentFragment =
   | UserMessageTypeModel
   | AssistantFunctionCallMessageTypeModel
   | AssistantContentMessageTypeModel
   | FunctionMessageTypeModel;
+
+export type ModelMessageTypeMultiActions =
+  | ModelMessageTypeMultiActionsWithoutContentFragment
+  | ContentFragmentMessageTypeModel;
 
 export function isContentFragmentMessageTypeModel(
   contentFragment: ModelMessageTypeMultiActions
@@ -95,7 +98,7 @@ export function isContentFragmentMessageTypeModel(
 }
 
 export type ModelConversationTypeMultiActions = {
-  messages: ModelMessageTypeMultiActions[];
+  messages: ModelMessageTypeMultiActionsWithoutContentFragment[];
 };
 
 /**


### PR DESCRIPTION
## Description

Update the return type of renderConversationForModel (cf https://github.com/dust-tt/dust/pull/16988 that was reverted because it introduced a bug when multiple content fragments were included).

## Tests

Locally, with multiple fragments

## Risk

low

## Deploy Plan

front
