### PR TITLE
enh: untrusted fetch utility

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -28,7 +28,6 @@ import { MCPOAuthRequiredError } from "@app/lib/actions/mcp_oauth_error";
 import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
-import config from "@app/lib/api/config";
 import type {
   InternalMCPServerDefinitionType,
   MCPServerDefinitionType,
@@ -38,6 +37,7 @@ import type {
 import type { Authenticator } from "@app/lib/auth";
 import { isWorkspaceUsingStaticIP } from "@app/lib/misc";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import { getUntrustedEgressAgent } from "@app/lib/untrusted_egress";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase, OAuthProvider, Result } from "@app/types";
@@ -123,25 +123,21 @@ export type MCPConnectionParams =
   | ClientSideMCPConnectionParams;
 
 function createMCPDispatcher(auth: Authenticator): ProxyAgent | undefined {
-  // Default to the generic proxy.
-  let proxyHost = config.getUntrustedEgressProxyHost();
-  let proxyPort = config.getUntrustedEgressProxyPort();
-
   if (isWorkspaceUsingStaticIP(auth.getNonNullableWorkspace())) {
-    proxyHost = `${EnvironmentConfig.getEnvVariable(
+    const proxyHost = `${EnvironmentConfig.getEnvVariable(
       "PROXY_USER_NAME"
     )}:${EnvironmentConfig.getEnvVariable(
       "PROXY_USER_PASSWORD"
     )}@${EnvironmentConfig.getEnvVariable("PROXY_HOST")}`;
-    proxyPort = EnvironmentConfig.getEnvVariable("PROXY_PORT");
+    const proxyPort = EnvironmentConfig.getEnvVariable("PROXY_PORT");
+
+    if (proxyHost && proxyPort) {
+      const proxyUrl = `http://${proxyHost}:${proxyPort}`;
+      return new ProxyAgent(proxyUrl);
+    }
   }
 
-  if (proxyHost && proxyPort) {
-    const proxyUrl = `http://${proxyHost}:${proxyPort}`;
-    return new ProxyAgent(proxyUrl);
-  }
-
-  return undefined;
+  return getUntrustedEgressAgent();
 }
 
 export const connectToMCPServer = async (

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -12,6 +12,7 @@ import { parseUploadRequest } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { untrustedFetch } from "@app/lib/untrusted_egress";
 import { transcribeFile } from "@app/lib/utils/transcribe_service";
 import logger from "@app/logger/logger";
 import type {
@@ -81,11 +82,11 @@ const uploadToPublicBucket: ProcessingFunction = async (
 // Images processing.
 
 const createReadableFromUrl = async (url: string): Promise<Readable> => {
-  const response = await fetch(url);
+  const response = await untrustedFetch(url);
   if (!response.ok || !response.body) {
     throw new Error(`Failed to fetch from URL: ${response.statusText}`);
   }
-  return Readable.fromWeb(response.body as any); // Type assertion needed due to Node.js types mismatch
+  return Readable.fromWeb(response.body);
 };
 
 const resizeAndUploadToFileStorage: ProcessingFunction = async (
@@ -659,7 +660,7 @@ export async function processAndStoreFromUrl(
   }
 
   try {
-    const response = await fetch(url);
+    const response = await untrustedFetch(url);
     if (!response.ok) {
       return new Err({
         name: "dust_error",
@@ -707,7 +708,7 @@ export async function processAndStoreFromUrl(
       file,
       content: {
         type: "readable",
-        value: Readable.fromWeb(response.body as any),
+        value: Readable.fromWeb(response.body),
       },
     });
   } catch (error) {

--- a/front/lib/untrusted_egress.ts
+++ b/front/lib/untrusted_egress.ts
@@ -1,0 +1,29 @@
+import type { RequestInfo, RequestInit, Response } from "undici";
+import { fetch as undiciFetch, ProxyAgent } from "undici";
+
+import config from "@app/lib/api/config";
+
+export function getUntrustedEgressAgent(): ProxyAgent | undefined {
+  const proxyHost = config.getUntrustedEgressProxyHost();
+  const proxyPort = config.getUntrustedEgressProxyPort();
+
+  if (proxyHost && proxyPort) {
+    const proxyUrl = `http://${proxyHost}:${proxyPort}`;
+    return new ProxyAgent(proxyUrl);
+  }
+
+  return undefined;
+}
+
+// Fetch helper that automatically routes outbound requests through the untrusted egress proxy
+// when configured. If the proxy is not configured, it falls back to a direct fetch.
+export function untrustedFetch(
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<Response> {
+  const dispatcher = getUntrustedEgressAgent();
+  const finalInit: RequestInit | undefined = dispatcher
+    ? { ...(init ?? {}), dispatcher }
+    : init;
+  return undiciFetch(input, finalInit);
+}


### PR DESCRIPTION
## Description

Add `getUntrustedEgressAgent` and `untrustedFetch` helpers.
The former returns a dispatcher for our untrusted egress proxy and the latter is a drop-in replacement of `fetch` based on undici fetch that uses our egress proxy.

- switch to `untrustedFetch` in upload.ts
- use `getUntrustedEgressAgent` in mcp_metadata.ts

## Tests

Local

## Risk

Critical path of MCP

## Deploy Plan

Deploy front