### PR TITLE
[front] Remove extra index on `userId` in membership model

### DIFF
--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -56,6 +56,7 @@ MembershipModel.init(
       { fields: ["startAt"] },
       { fields: ["endAt"] },
       { fields: ["workspaceId", "userId", "startAt", "endAt"] },
+      { fields: ["userId"] },
     ],
   }
 );

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -56,7 +56,6 @@ MembershipModel.init(
       { fields: ["startAt"] },
       { fields: ["endAt"] },
       { fields: ["workspaceId", "userId", "startAt", "endAt"] },
-      { fields: ["userId"] },
     ],
   }
 );

--- a/front/migrations/db/migration_384.sql
+++ b/front/migrations/db/migration_384.sql
@@ -1,0 +1,2 @@
+-- Migration created on Oct 17, 2025
+CREATE INDEX "memberships_userId_fk" ON public.memberships USING btree ("userId")

--- a/front/migrations/db/migration_384.sql
+++ b/front/migrations/db/migration_384.sql
@@ -1,2 +1,2 @@
 -- Migration created on Oct 17, 2025
-CREATE INDEX "memberships_userId_fk" ON public.memberships USING btree ("userId")
+CREATE INDEX CONCURRENTLY "memberships_userId_fk" ON public.memberships USING btree ("userId")

--- a/front/migrations/db/migration_384.sql
+++ b/front/migrations/db/migration_384.sql
@@ -1,2 +1,2 @@
 -- Migration created on Oct 17, 2025
-CREATE INDEX CONCURRENTLY "memberships_userId_fk" ON public.memberships USING btree ("userId")
+DROP INDEX CONCURRENTLY "memberships_userId_fk";


### PR DESCRIPTION
## Description

- We have a discrepancy across regions in the indexes we have on the `memberships` table.
- This PR adds a migration script to remove it in the region that has the extra index.

## Tests

## Risk

## Deploy Plan

- Run migration in US.
