### PR TITLE
[front] Add space groups info in poke

### DIFF
--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -27,12 +27,14 @@ function prepareMembersForDisplay(
 }
 
 interface MembersDataTableProps {
+  groupName?: string;
   members: UserTypeWithWorkspaces[];
   owner: WorkspaceType;
   readonly?: boolean;
 }
 
 export function MembersDataTable({
+  groupName,
   members,
   owner,
   readonly,
@@ -98,7 +100,9 @@ export function MembersDataTable({
     <>
       <div className="border-material-200 my-4 flex w-full flex-col rounded-lg border p-4">
         <div className="flex justify-between gap-3">
-          <h2 className="text-md mb-4 font-bold">Members:</h2>
+          <h2 className="text-md mb-4 font-bold">
+            {groupName ? `"${groupName}" Members:` : "Members:"}
+          </h2>
         </div>
         <PokeDataTable
           columns={makeColumnsForMembers({

--- a/front/components/poke/spaces/view.tsx
+++ b/front/components/poke/spaces/view.tsx
@@ -54,6 +54,21 @@ export function ViewSpaceViewTable({ space }: ViewSpaceTableProps) {
                 </PokeTableCell>
               </PokeTableRow>
               <PokeTableRow>
+                <PokeTableHead>Management Mode</PokeTableHead>
+                <PokeTableCell>{space.managementMode}</PokeTableCell>
+              </PokeTableRow>
+              {space.managementMode === "group" && (
+                <PokeTableRow>
+                  <PokeTableHead>Groups</PokeTableHead>
+                  <PokeTableCell>
+                    {space.groups
+                      .filter((g) => g.kind === "provisioned")
+                      .map((g) => g.name)
+                      .join(", ")}
+                  </PokeTableCell>
+                </PokeTableRow>
+              )}
+              <PokeTableRow>
                 <PokeTableHead>Created At</PokeTableHead>
                 <PokeTableCell>
                   {formatTimestampToFriendlyDate(space.createdAt)}


### PR DESCRIPTION
## Description

- Gives more information about space management mode (SCIM / not SCIM) in poke
- Make separate members tables per group

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
