### PR TITLE
[front] enh(logging): track tool execution duration in logs

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -89,6 +89,8 @@ export function withToolLogging<T>(
 
     const result = await toolCallback(params, extra);
 
+    const elapsed = performance.now() - startTime;
+
     // When we get an Err, we monitor it if tracked and return it as a text content.
     if (result.isErr()) {
       if (enableAlerting && result.error.tracked) {
@@ -98,7 +100,11 @@ export function withToolLogging<T>(
         ]);
       }
 
-      const logContext = { ...loggerArgs, error: result.error };
+      const logContext = {
+        ...loggerArgs,
+        duration: elapsed,
+        error: result.error,
+      };
       if (result.error.tracked) {
         logger.error(logContext, "Tool execution error");
       } else {
@@ -116,7 +122,6 @@ export function withToolLogging<T>(
       };
     }
 
-    const elapsed = performance.now() - startTime;
     if (enableAlerting) {
       statsDClient.distribution(
         "run_tool.duration.distribution",


### PR DESCRIPTION
## Description

- This PR uniformizes the logging around tool executions by adding the duration of the executions in the error log (already there in the success log).

## Tests

## Risk

## Deploy Plan

- Deploy front.
