### PR TITLE
feat(front linter): discourage use of global fetch

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -12,6 +12,16 @@ module.exports = {
     "eslint-plugin-unused-imports",
   ],
   rules: {
+    // Intentionally discourage direct global fetch; prefer explicit egress helpers.
+    // For now set to "warn" so we can migrate incrementally.
+    "no-restricted-globals": [
+      "warn",
+      {
+        name: "fetch",
+        message:
+          "Use trustedFetch or untrustedFetch from @app/lib/egress instead of the global fetch to make egress intent explicit.",
+      },
+    ],
     "import/no-cycle": "error",
     curly: ["error", "all"],
     "react/no-unescaped-entities": 0,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -35,9 +35,9 @@ import type {
   MCPToolType,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { getUntrustedEgressAgent } from "@app/lib/egress";
 import { isWorkspaceUsingStaticIP } from "@app/lib/misc";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
-import { getUntrustedEgressAgent } from "@app/lib/untrusted_egress";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase, OAuthProvider, Result } from "@app/types";

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -10,9 +10,9 @@ import { fileSync } from "tmp";
 import config from "@app/lib/api/config";
 import { parseUploadRequest } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
+import { untrustedFetch } from "@app/lib/egress";
 import type { DustError } from "@app/lib/error";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { untrustedFetch } from "@app/lib/untrusted_egress";
 import { transcribeFile } from "@app/lib/utils/transcribe_service";
 import logger from "@app/logger/logger";
 import type {

--- a/front/lib/egress.ts
+++ b/front/lib/egress.ts
@@ -27,3 +27,12 @@ export function untrustedFetch(
     : init;
   return undiciFetch(input, finalInit);
 }
+
+// Fetch helper for trusted, first‑party egress or intra‑VPC calls.
+// This is just the regular fetch without any proxy injection.
+export function trustedFetch(
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<Response> {
+  return undiciFetch(input, init);
+}


### PR DESCRIPTION
## Description

- rename `untrusted_egress.ts` into `egress.ts`
- adds a new `trustedFetch` function that is a simple alias of `fetch`
- adds a new linter to discourage usage of global `fetch`, in favor of using either `untrustedFetch` (for destrinations we don't control) or `trustedfetch` (for destinations we control)

<img width="765" height="249" alt="Screenshot 2025-10-17 at 17 12 48" src="https://github.com/user-attachments/assets/852b9fad-8320-43c6-a169-31db6655f5a3" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
