### PR TITLE
hootl: Support multiple repos and orgs in webhooks creation

### DIFF
--- a/front/components/triggers/CreateWebhookGithubConnection.tsx
+++ b/front/components/triggers/CreateWebhookGithubConnection.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ChevronDownIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -9,12 +8,17 @@ import {
   ExternalLinkIcon,
   GithubLogo,
   Label,
+  PlusIcon,
   Spinner,
+  XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useGithubRepositories } from "@app/lib/swr/useGithubRepositories";
+import {
+  useGithubOrganizations,
+  useGithubRepositories,
+} from "@app/lib/swr/useGithubRepositories";
 import type { LightWorkspaceType, OAuthConnectionType } from "@app/types";
 import { setupOAuthConnection } from "@app/types";
 
@@ -23,7 +27,8 @@ type CreateWebhookGithubConnectionProps = {
   onGithubDataChange?: (
     data: {
       connectionId: string;
-      repository: string;
+      repositories: string[];
+      organizations: string[];
     } | null
   ) => void;
   onReadyToSubmitChange?: (isReady: boolean) => void;
@@ -40,23 +45,39 @@ export function CreateWebhookGithubConnection({
   const [isConnectingGithub, setIsConnectingGithub] = useState(false);
   const { githubRepositories, isFetchingRepos, fetchGithubRepositories } =
     useGithubRepositories(owner);
-  const [selectedRepository, setSelectedRepository] = useState<string | null>(
-    null
+  const { githubOrganizations, isFetchingOrgs, fetchGithubOrganizations } =
+    useGithubOrganizations(owner);
+  const [selectedRepositories, setSelectedRepositories] = useState<string[]>(
+    []
+  );
+  const [selectedOrganizations, setSelectedOrganizations] = useState<string[]>(
+    []
   );
   const [repoSearchQuery, setRepoSearchQuery] = useState("");
+  const [orgSearchQuery, setOrgSearchQuery] = useState("");
+  const [showRepoDropdown, setShowRepoDropdown] = useState(false);
+  const [showOrgDropdown, setShowOrgDropdown] = useState(false);
 
   const filteredRepositories = githubRepositories.filter((repo) =>
     repo.full_name.toLowerCase().includes(repoSearchQuery.toLowerCase())
   );
 
+  const filteredOrganizations = githubOrganizations.filter((org) =>
+    org.login.toLowerCase().includes(orgSearchQuery.toLowerCase())
+  );
+
   // Notify parent component when GitHub data changes
   useEffect(() => {
-    const isReady = !!(githubConnection && selectedRepository);
+    const isReady = !!(
+      githubConnection &&
+      (selectedRepositories.length > 0 || selectedOrganizations.length > 0)
+    );
 
     if (isReady && onGithubDataChange) {
       onGithubDataChange({
         connectionId: githubConnection.connection_id,
-        repository: selectedRepository,
+        repositories: selectedRepositories,
+        organizations: selectedOrganizations,
       });
     } else if (onGithubDataChange) {
       onGithubDataChange(null);
@@ -68,7 +89,8 @@ export function CreateWebhookGithubConnection({
     }
   }, [
     githubConnection,
-    selectedRepository,
+    selectedRepositories,
+    selectedOrganizations,
     onGithubDataChange,
     onReadyToSubmitChange,
   ]);
@@ -99,10 +121,13 @@ export function CreateWebhookGithubConnection({
         sendNotification({
           type: "success",
           title: "Connected to GitHub",
-          description: "Fetching your repositories...",
+          description: "Fetching your repositories and organizations...",
         });
-        // Fetch repositories after successful connection
-        await fetchGithubRepositories(connectionRes.value.connection_id);
+        // Fetch both repositories and organizations after successful connection
+        await Promise.all([
+          fetchGithubRepositories(connectionRes.value.connection_id),
+          fetchGithubOrganizations(connectionRes.value.connection_id),
+        ]);
       }
     } catch (error) {
       sendNotification({
@@ -115,100 +140,249 @@ export function CreateWebhookGithubConnection({
     }
   };
 
+  const handleAddRepository = (repoFullName: string) => {
+    if (!selectedRepositories.includes(repoFullName)) {
+      setSelectedRepositories([...selectedRepositories, repoFullName]);
+    }
+    setRepoSearchQuery("");
+    setShowRepoDropdown(false);
+  };
+
+  const handleRemoveRepository = (repoFullName: string) => {
+    setSelectedRepositories(
+      selectedRepositories.filter((r) => r !== repoFullName)
+    );
+  };
+
+  const handleAddOrganization = (orgLogin: string) => {
+    if (!selectedOrganizations.includes(orgLogin)) {
+      setSelectedOrganizations([...selectedOrganizations, orgLogin]);
+    }
+    setOrgSearchQuery("");
+    setShowOrgDropdown(false);
+  };
+
+  const handleRemoveOrganization = (orgLogin: string) => {
+    setSelectedOrganizations(
+      selectedOrganizations.filter((o) => o !== orgLogin)
+    );
+  };
+
   return (
-    <div className="flex flex-col space-y-2">
-      <Label>GitHub Connection</Label>
-      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        Connect your GitHub account to select repositories to follow.
-      </p>
-      <div className="flex items-center gap-2">
-        <Button
-          variant={"outline"}
-          label={githubConnection ? "Connected to GitHub" : "Connect to GitHub"}
-          icon={GithubLogo}
-          onClick={handleConnectGithub}
-          disabled={isConnectingGithub || !!githubConnection}
-        />
-        {githubConnection && (
-          <a
-            href={`https://github.com/settings/connections/applications/${process.env.NEXT_PUBLIC_OAUTH_GITHUB_APP_WEBHOOKS_CLIENT_ID}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-sm"
-          >
-            Edit connection
-            <ExternalLinkIcon className="h-3 w-3" />
-          </a>
-        )}
-        {isConnectingGithub && <Spinner size="sm" />}
-      </div>
-      {githubConnection && (
-        <div className="mt-3">
-          <Label>
-            Select Repository <span className="text-warning">*</span>
-          </Label>
-          {isFetchingRepos ? (
-            <div className="flex items-center gap-2 py-2">
-              <Spinner size="sm" />
-              <span className="text-sm text-muted-foreground">
-                Loading repositories...
-              </span>
-            </div>
-          ) : githubRepositories.length > 0 ? (
-            <>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    label={
-                      selectedRepository
-                        ? selectedRepository
-                        : "Select a repository..."
-                    }
-                    variant="outline"
-                    icon={ChevronDownIcon}
-                    className="mt-2 w-full justify-between"
-                  />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-80">
-                  <DropdownMenuSearchbar
-                    name="repository"
-                    placeholder="Search repositories..."
-                    value={repoSearchQuery}
-                    onChange={setRepoSearchQuery}
-                  />
-                  <div className="max-h-64 overflow-y-auto">
-                    {filteredRepositories.length > 0 ? (
-                      filteredRepositories.map((repo) => (
-                        <DropdownMenuItem
-                          key={repo.id}
-                          onClick={() => {
-                            setSelectedRepository(repo.full_name);
-                            setRepoSearchQuery("");
-                          }}
-                        >
-                          {repo.full_name}
-                        </DropdownMenuItem>
-                      ))
-                    ) : (
-                      <div className="px-2 py-6 text-center text-sm text-muted-foreground">
-                        No repositories found
-                      </div>
-                    )}
-                  </div>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              {!selectedRepository && (
-                <p className="dark:text-warning-night mt-1 text-xs text-warning">
-                  Please select a repository to create the webhook
-                </p>
-              )}
-            </>
-          ) : (
-            <p className="mt-2 text-sm text-muted-foreground">
-              No repositories found
-            </p>
+    <div className="flex flex-col space-y-4">
+      <div>
+        <Label>GitHub Connection</Label>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Connect your GitHub account to select repositories and organizations
+          to follow.
+        </p>
+        <div className="mt-2 flex items-center gap-2">
+          <Button
+            variant={"outline"}
+            label={
+              githubConnection ? "Connected to GitHub" : "Connect to GitHub"
+            }
+            icon={GithubLogo}
+            onClick={handleConnectGithub}
+            disabled={isConnectingGithub || !!githubConnection}
+          />
+          {githubConnection && (
+            <a
+              href={`https://github.com/settings/connections/applications/${process.env.NEXT_PUBLIC_OAUTH_GITHUB_APP_WEBHOOKS_CLIENT_ID}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-sm"
+            >
+              Edit connection
+              <ExternalLinkIcon className="h-3 w-3" />
+            </a>
           )}
+          {isConnectingGithub && <Spinner size="sm" />}
         </div>
+      </div>
+
+      {githubConnection && (
+        <>
+          <div>
+            <Label>
+              Repositories{" "}
+              {selectedRepositories.length === 0 &&
+                selectedOrganizations.length === 0 && (
+                  <span className="text-warning">*</span>
+                )}
+            </Label>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Select repositories to monitor for events
+            </p>
+            {isFetchingRepos ? (
+              <div className="mt-2 flex items-center gap-2 py-2">
+                <Spinner size="sm" />
+                <span className="text-sm text-muted-foreground">
+                  Loading repositories...
+                </span>
+              </div>
+            ) : (
+              <>
+                <div className="mt-2 flex flex-col gap-2">
+                  {selectedRepositories.map((repo) => (
+                    <div
+                      key={repo}
+                      className="border-border-light bg-background-light dark:bg-background-dark flex items-center justify-between rounded border px-3 py-2 dark:border-border-dark"
+                    >
+                      <span className="text-sm font-medium">{repo}</span>
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        icon={XMarkIcon}
+                        onClick={() => handleRemoveRepository(repo)}
+                      />
+                    </div>
+                  ))}
+                  {githubRepositories.length > 0 && (
+                    <DropdownMenu
+                      open={showRepoDropdown}
+                      onOpenChange={setShowRepoDropdown}
+                    >
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          label="Add repository"
+                          variant="outline"
+                          icon={PlusIcon}
+                          className="w-full"
+                        />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="w-80">
+                        <DropdownMenuSearchbar
+                          name="repository"
+                          placeholder="Search repositories..."
+                          value={repoSearchQuery}
+                          onChange={setRepoSearchQuery}
+                        />
+                        <div className="max-h-64 overflow-y-auto">
+                          {filteredRepositories.length > 0 ? (
+                            filteredRepositories
+                              .filter(
+                                (repo) =>
+                                  !selectedRepositories.includes(repo.full_name)
+                              )
+                              .map((repo) => (
+                                <DropdownMenuItem
+                                  key={repo.id}
+                                  onClick={() =>
+                                    handleAddRepository(repo.full_name)
+                                  }
+                                >
+                                  {repo.full_name}
+                                </DropdownMenuItem>
+                              ))
+                          ) : (
+                            <div className="px-2 py-6 text-center text-sm text-muted-foreground">
+                              No repositories found
+                            </div>
+                          )}
+                        </div>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+
+          <div>
+            <Label>
+              Organizations{" "}
+              {selectedRepositories.length === 0 &&
+                selectedOrganizations.length === 0 && (
+                  <span className="text-warning">*</span>
+                )}
+            </Label>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Select organizations to monitor all their repositories
+            </p>
+            {isFetchingOrgs ? (
+              <div className="mt-2 flex items-center gap-2 py-2">
+                <Spinner size="sm" />
+                <span className="text-sm text-muted-foreground">
+                  Loading organizations...
+                </span>
+              </div>
+            ) : (
+              <>
+                <div className="mt-2 flex flex-col gap-2">
+                  {selectedOrganizations.map((org) => (
+                    <div
+                      key={org}
+                      className="border-border-light bg-background-light dark:bg-background-dark flex items-center justify-between rounded border px-3 py-2 dark:border-border-dark"
+                    >
+                      <span className="text-sm font-medium">{org}</span>
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        icon={XMarkIcon}
+                        onClick={() => handleRemoveOrganization(org)}
+                      />
+                    </div>
+                  ))}
+                  {githubOrganizations.length > 0 && (
+                    <DropdownMenu
+                      open={showOrgDropdown}
+                      onOpenChange={setShowOrgDropdown}
+                    >
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          label="Add organization"
+                          variant="outline"
+                          icon={PlusIcon}
+                          className="w-full"
+                        />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="w-80">
+                        <DropdownMenuSearchbar
+                          name="organization"
+                          placeholder="Search organizations..."
+                          value={orgSearchQuery}
+                          onChange={setOrgSearchQuery}
+                        />
+                        <div className="max-h-64 overflow-y-auto">
+                          {filteredOrganizations.length > 0 ? (
+                            filteredOrganizations
+                              .filter(
+                                (org) =>
+                                  !selectedOrganizations.includes(org.login)
+                              )
+                              .map((org) => (
+                                <DropdownMenuItem
+                                  key={org.id}
+                                  onClick={() =>
+                                    handleAddOrganization(org.login)
+                                  }
+                                >
+                                  {org.login}
+                                </DropdownMenuItem>
+                              ))
+                          ) : (
+                            <div className="px-2 py-6 text-center text-sm text-muted-foreground">
+                              No organizations found
+                            </div>
+                          )}
+                        </div>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+
+          {selectedRepositories.length === 0 &&
+            selectedOrganizations.length === 0 && (
+              <p className="dark:text-warning-night mt-1 text-xs text-warning">
+                Please select at least one repository or organization to create
+                the webhook
+              </p>
+            )}
+        </>
       )}
     </div>
   );

--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -48,7 +48,8 @@ export type BaseRemoteData = {
 };
 
 export type RemoteGithubData = BaseRemoteData & {
-  repository: string;
+  repositories: string[];
+  organizations: string[];
 };
 
 export type RemoteProviderData = RemoteGithubData;

--- a/front/components/triggers/WebhookSourceGithubDetails.tsx
+++ b/front/components/triggers/WebhookSourceGithubDetails.tsx
@@ -9,30 +9,84 @@ type WebhookSourceGithubDetailsProps = {
 export function WebhookSourceGithubDetails({
   webhookSource,
 }: WebhookSourceGithubDetailsProps) {
-  if (
-    webhookSource.kind !== "github" ||
-    !webhookSource.remoteMetadata?.repository
-  ) {
+  if (webhookSource.kind !== "github" || !webhookSource.remoteMetadata) {
     return null;
   }
 
-  const repository = webhookSource.remoteMetadata.repository;
+  const metadata = webhookSource.remoteMetadata;
+
+  // Normalize legacy format (single repository) into array format
+  const legacyRepository = metadata.repository as string | undefined;
+  let repositories = (metadata.repositories as string[]) || [];
+
+  // If legacy format exists and no new format, use it
+  if (legacyRepository && repositories.length === 0) {
+    repositories = [legacyRepository];
+  }
+
+  const organizations = (metadata.organizations as string[]) || [];
+
+  const hasRepositories = repositories.length > 0;
+  const hasOrganizations = organizations.length > 0;
+
+  if (!hasRepositories && !hasOrganizations) {
+    return null;
+  }
 
   return (
-    <div>
-      <Page.H variant="h6">GitHub Repository</Page.H>
-      <div className="flex items-center gap-2">
-        <Page.P>{repository}</Page.P>
-        <a
-          href={`https://github.com/${repository}/settings/hooks`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-sm"
-        >
-          View webhooks
-          <ExternalLinkIcon className="h-3 w-3" />
-        </a>
-      </div>
+    <div className="space-y-4">
+      {hasRepositories && (
+        <div>
+          <Page.H variant="h6">
+            GitHub {repositories.length === 1 ? "Repository" : "Repositories"}
+          </Page.H>
+          <div className="space-y-2">
+            {repositories.map((repository) => (
+              <div key={repository} className="flex items-center gap-2">
+                <span className="font-mono text-sm text-foreground dark:text-foreground-night">
+                  {repository}
+                </span>
+                <a
+                  href={`https://github.com/${repository}/settings/hooks`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-xs"
+                >
+                  View webhooks
+                  <ExternalLinkIcon className="h-3 w-3" />
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {hasOrganizations && (
+        <div>
+          <Page.H variant="h6">
+            GitHub{" "}
+            {organizations.length === 1 ? "Organization" : "Organizations"}
+          </Page.H>
+          <div className="space-y-2">
+            {organizations.map((organization) => (
+              <div key={organization} className="flex items-center gap-2">
+                <span className="font-mono text-sm text-foreground dark:text-foreground-night">
+                  {organization}
+                </span>
+                <a
+                  href={`https://github.com/organizations/${organization}/settings/hooks`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-xs"
+                >
+                  View webhooks
+                  <ExternalLinkIcon className="h-3 w-3" />
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/front/lib/api/oauth/providers/github.ts
+++ b/front/lib/api/oauth/providers/github.ts
@@ -40,7 +40,7 @@ export class GithubOAuthProvider implements BaseOAuthStrategyProvider {
         `client_id=${clientId}` +
         `&state=${connection.connection_id}` +
         `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-        `&scope=repo,admin:repo_hook,read:org`;
+        `&scope=repo,admin:repo_hook,read:org,admin:org_hook`;
 
       return url;
     }

--- a/front/lib/swr/useGithubRepositories.ts
+++ b/front/lib/swr/useGithubRepositories.ts
@@ -9,6 +9,13 @@ type GithubRepository = {
   id: number;
 };
 
+type GithubOrganization = {
+  id: number;
+  login: string;
+  avatar_url: string;
+  description: string | null;
+};
+
 export function useGithubRepositories(owner: LightWorkspaceType | null) {
   const sendNotification = useSendNotification();
   const [githubRepositories, setGithubRepositories] = useState<
@@ -51,5 +58,50 @@ export function useGithubRepositories(owner: LightWorkspaceType | null) {
     githubRepositories,
     isFetchingRepos,
     fetchGithubRepositories,
+  };
+}
+
+export function useGithubOrganizations(owner: LightWorkspaceType | null) {
+  const sendNotification = useSendNotification();
+  const [githubOrganizations, setGithubOrganizations] = useState<
+    GithubOrganization[]
+  >([]);
+  const [isFetchingOrgs, setIsFetchingOrgs] = useState(false);
+
+  const fetchGithubOrganizations = useCallback(
+    async (connectionId: string) => {
+      if (!owner) {
+        return;
+      }
+
+      setIsFetchingOrgs(true);
+      try {
+        const response = await fetch(
+          `/api/w/${owner.sId}/github/${connectionId}/orgs`
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch organizations");
+        }
+
+        const data = await response.json();
+        setGithubOrganizations(data.organizations || []);
+      } catch (error) {
+        sendNotification({
+          type: "error",
+          title: "Failed to fetch organizations",
+          description: error instanceof Error ? error.message : "Unknown error",
+        });
+      } finally {
+        setIsFetchingOrgs(false);
+      }
+    },
+    [owner, sendNotification]
+  );
+
+  return {
+    githubOrganizations,
+    isFetchingOrgs,
+    fetchGithubOrganizations,
   };
 }

--- a/front/lib/triggers/services/github_webhook_service.ts
+++ b/front/lib/triggers/services/github_webhook_service.ts
@@ -19,7 +19,7 @@ export class GitHubWebhookService implements RemoteWebhookService {
   }): Promise<
     Result<
       {
-        webhookIds: Record<string, string>;
+        updatedRemoteMetadata: Record<string, any>;
         errors?: string[];
       },
       Error
@@ -180,7 +180,10 @@ export class GitHubWebhookService implements RemoteWebhookService {
       }
 
       return new Ok({
-        webhookIds,
+        updatedRemoteMetadata: {
+          ...remoteMetadata,
+          webhookIds,
+        },
         errors: errors.length > 0 ? errors : undefined,
       });
     } catch (error: any) {

--- a/front/lib/triggers/services/remote_webhook_service.ts
+++ b/front/lib/triggers/services/remote_webhook_service.ts
@@ -15,7 +15,7 @@ export interface RemoteWebhookService {
   }): Promise<
     Result<
       {
-        webhookIds: Record<string, string>;
+        updatedRemoteMetadata: Record<string, any>;
         errors?: string[];
       },
       Error

--- a/front/pages/api/w/[wId]/github/[connectionId]/orgs.ts
+++ b/front/pages/api/w/[wId]/github/[connectionId]/orgs.ts
@@ -1,0 +1,148 @@
+import { Octokit } from "@octokit/core";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { OAuthAPI } from "@app/types";
+
+const ORGS_PER_PAGE = 100; // GitHub max is 100
+
+export type GetGithubOrganizationsResponseType = {
+  organizations: Array<{
+    id: number;
+    login: string;
+    avatar_url: string;
+    description: string | null;
+  }>;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetGithubOrganizationsResponseType>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "GET":
+      // Only builders can access GitHub organizations
+      if (!auth.isBuilder()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Only builders can access GitHub organizations",
+          },
+        });
+      }
+
+      const { connectionId } = req.query;
+
+      if (!connectionId || typeof connectionId !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "connectionId is required",
+          },
+        });
+      }
+
+      try {
+        // Get access token from OAuth API
+        const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), console);
+
+        // First, verify the connection belongs to this workspace
+        const metadataRes = await oauthAPI.getConnectionMetadata({
+          connectionId,
+        });
+
+        if (metadataRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "invalid_request_error",
+              message: "GitHub connection not found",
+            },
+          });
+        }
+
+        const workspace = auth.workspace();
+        if (!workspace) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "workspace_not_found",
+              message: "Workspace not found",
+            },
+          });
+        }
+
+        const workspaceId = metadataRes.value.connection.metadata.workspace_id;
+        if (!workspaceId || workspaceId !== workspace.sId) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: "Connection does not belong to this workspace",
+            },
+          });
+        }
+
+        const tokenRes = await oauthAPI.getAccessToken({ connectionId });
+
+        if (tokenRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to get GitHub access token",
+            },
+          });
+        }
+
+        const accessToken = tokenRes.value.access_token;
+
+        // Fetch organizations using Octokit
+        const octokit = new Octokit({ auth: accessToken });
+
+        const { data: orgs } = await octokit.request("GET /user/orgs", {
+          per_page: ORGS_PER_PAGE,
+        });
+
+        const organizations = orgs.map((org: any) => ({
+          id: org.id,
+          login: org.login,
+          avatar_url: org.avatar_url,
+          description: org.description,
+        }));
+
+        return res.status(200).json({ organizations });
+      } catch (error) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to fetch organizations",
+          },
+        });
+      }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -206,12 +206,9 @@ async function handler(
           }
 
           // Update the webhook source with the id of the webhook
-          const webhookIds = Object.values(result.value.webhookIds);
+          const updatedRemoteMetadata = result.value.updatedRemoteMetadata;
           await webhookSource.updateRemoteMetadata({
-            remoteMetadata: {
-              ...remoteMetadata,
-              webhookIds,
-            },
+            remoteMetadata: updatedRemoteMetadata,
             oauthConnectionId: connectionId,
           });
         }

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -206,11 +206,11 @@ async function handler(
           }
 
           // Update the webhook source with the id of the webhook
-          const webhookId = Object.values(result.value.webhookIds)[0];
+          const webhookIds = Object.values(result.value.webhookIds);
           await webhookSource.updateRemoteMetadata({
             remoteMetadata: {
               ...remoteMetadata,
-              webhookId,
+              webhookIds,
             },
             oauthConnectionId: connectionId,
           });

--- a/front/types/triggers/test_webhook_source_presets.ts
+++ b/front/types/triggers/test_webhook_source_presets.ts
@@ -38,7 +38,7 @@ class TestWebhookService implements RemoteWebhookService {
   }): Promise<
     Result<
       {
-        webhookIds: Record<string, string>;
+        updatedRemoteMetadata: Record<string, any>;
         errors?: string[];
       },
       Error
@@ -46,7 +46,10 @@ class TestWebhookService implements RemoteWebhookService {
   > {
     logger.info("Creating webhooks with params:", params);
     return new Ok({
-      webhookIds: { test_event: `test-webhook-id-${Date.now()}` },
+      updatedRemoteMetadata: {
+        ...params.remoteMetadata,
+        webhookIds: { test_event: `test-webhook-id-${Date.now()}` },
+      },
     });
   }
 


### PR DESCRIPTION
## Description

Allow a list of organizations and repositories when creating github webhooks

<img width="550" height="850" alt="image" src="https://github.com/user-attachments/assets/b357a4c4-1ea5-48f0-a55e-747e7b20b3b9" />

<img width="550" height="850" alt="image" src="https://github.com/user-attachments/assets/f6468dbd-ea6b-4017-a5cc-aee00965ee35" />


## Tests

Manual tests

## Risk

Low risk, feature behind flag
Format of stored data has changed but backward compatibility should be kept

## Deploy Plan

Deploy front
