### PR TITLE
Remove duplicate source name in webhook source description modal

### DIFF
--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -198,10 +198,6 @@ export function WebhookSourceDetailsInfo({
           />
         )}
 
-        <div>
-          <Page.H variant="h6">Source Name</Page.H>
-          <Page.P>{webhookSourceView.webhookSource.name}</Page.P>
-        </div>
         {webhookSourceView.webhookSource.kind !== "custom" &&
           WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP[
             webhookSourceView.webhookSource.kind


### PR DESCRIPTION
## Description

Remove useless Source name field.
The name is already present in the title of the popup

<img width="500" height="800" alt="image" src="https://github.com/user-attachments/assets/ad38dec1-3c23-4fc5-a494-3f09eecb0d18" />

## Tests

Manual

## Risk

No

## Deploy Plan

Deploy front
