### PR TITLE
[MCP Utilities] Change wait tool max to 3 minutes

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
@@ -8,7 +8,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { Ok } from "@app/types";
 
 const RANDOM_INTEGER_DEFAULT_MAX = 1_000_000;
-const MAX_WAIT_DURATION_MS = 30 * 60 * 1_000;
+const MAX_WAIT_DURATION_MS = 3 * 60 * 1_000;
 
 function createServer(
   auth: Authenticator,
@@ -82,9 +82,9 @@ function createServer(
         .positive()
         .max(
           MAX_WAIT_DURATION_MS,
-          `Duration must be less than or equal to ${MAX_WAIT_DURATION_MS} milliseconds (30 minutes).`
+          `Duration must be less than or equal to ${MAX_WAIT_DURATION_MS} milliseconds (3 minutes).`
         )
-        .describe("The time to wait in milliseconds, up to 30 minutes."),
+        .describe("The time to wait in milliseconds, up to 3 minutes."),
     },
     withToolLogging(
       auth,


### PR DESCRIPTION
## Description
- Fix: set common utilities MCP server wait tool max duration to 3 minutes.
- Rationale: the tool invocation has a 3-minute timeout; 30 minutes was inconsistent and likely a mistake. Updated validation/help text accordingly.

## Risks
Blast radius: common_utilities internal MCP server (wait tool only)
Risk: low

## Deploy Plan
- deploy front