### PR TITLE
[front] enh(FS tools): Add server-level instructions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
 import {
+  DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS,
   FRESHSERVICE_SERVER_INSTRUCTIONS,
   JIRA_SERVER_INSTRUCTIONS,
   SALESFORCE_SERVER_INSTRUCTIONS,
@@ -1284,7 +1285,7 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
-      instructions: null,
+      instructions: DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS,
     },
   },
   agent_management: {

--- a/front/lib/actions/mcp_internal_actions/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/instructions.ts
@@ -97,3 +97,14 @@ export const FRESHSERVICE_SERVER_INSTRUCTIONS = `
         4. request_service_item(display_id: 123, fields: {field1: "value1", field2: "value2"})
         \`\`\`
     `;
+
+export const DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS =
+  "The tools can be used to browse and search content with a filesystem-like navigation." +
+  "Content is structured in nodes. Nodes are identified by a unique ID called `nodeId`. " +
+  "The `list` tool can be used to list the direct contents under a node, like 'ls' in Unix. " +
+  "Can be used to explore the filesystem structure step by step " +
+  "by being called repeatedly with the 'nodeId' output in a step passed to the next step's nodeId. " +
+  "The `find` tool can be used to find content based on their title starting from a specific root node, like using 'find' in Unix." +
+  "The `cat` tool can be used to read the actual content in a document node, like 'cat in Unix." +
+  "The `locate_in_tree` tool can be used to find the path to a node in the filesystem tree." +
+  "The `semantic_search` tool can be used to perform a semantic search within the folders and files designated by `nodeIds`.";

--- a/front/lib/actions/mcp_internal_actions/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/instructions.ts
@@ -101,6 +101,7 @@ export const FRESHSERVICE_SERVER_INSTRUCTIONS = `
 export const DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS =
   "The tools can be used to browse and search content with a filesystem-like navigation.\n" +
   "Content is structured in nodes. Nodes are identified by a unique ID called `nodeId`.\n" +
+  "Node IDs are exposed in the outputs of the tools described below.\n" +
   "The `list` tool can be used to list the direct content under a node, like 'ls' in Unix.\n" +
   "Can be used to explore the filesystem structure step by step " +
   "by being called repeatedly with the 'nodeId' output in a step passed to the next step's nodeId.\n" +

--- a/front/lib/actions/mcp_internal_actions/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/instructions.ts
@@ -104,7 +104,7 @@ export const DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS =
   "Node IDs are exposed in the outputs of the tools described below.\n" +
   "The `list` tool can be used to list the direct content under a node, like 'ls' in Unix.\n" +
   "Can be used to explore the filesystem structure step by step " +
-  "by being called repeatedly with the 'nodeId' output in a step passed to the next step's nodeId.\n" +
+  "by being called recursively with the 'nodeId' output in a step passed to the next step's nodeId.\n" +
   "The `find` tool can be used to find content based on their title starting from a specific root node, like using 'find' in Unix.\n" +
   "The `cat` tool can be used to read the actual content in a document node, like 'cat in Unix.\n" +
   "The `locate_in_tree` tool can be used to find the path to a node in the filesystem tree.\n" +

--- a/front/lib/actions/mcp_internal_actions/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/instructions.ts
@@ -99,12 +99,12 @@ export const FRESHSERVICE_SERVER_INSTRUCTIONS = `
     `;
 
 export const DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS =
-  "The tools can be used to browse and search content with a filesystem-like navigation." +
-  "Content is structured in nodes. Nodes are identified by a unique ID called `nodeId`. " +
-  "The `list` tool can be used to list the direct contents under a node, like 'ls' in Unix. " +
+  "The tools can be used to browse and search content with a filesystem-like navigation.\n" +
+  "Content is structured in nodes. Nodes are identified by a unique ID called `nodeId`.\n" +
+  "The `list` tool can be used to list the direct content under a node, like 'ls' in Unix.\n" +
   "Can be used to explore the filesystem structure step by step " +
-  "by being called repeatedly with the 'nodeId' output in a step passed to the next step's nodeId. " +
-  "The `find` tool can be used to find content based on their title starting from a specific root node, like using 'find' in Unix." +
-  "The `cat` tool can be used to read the actual content in a document node, like 'cat in Unix." +
-  "The `locate_in_tree` tool can be used to find the path to a node in the filesystem tree." +
+  "by being called repeatedly with the 'nodeId' output in a step passed to the next step's nodeId.\n" +
+  "The `find` tool can be used to find content based on their title starting from a specific root node, like using 'find' in Unix.\n" +
+  "The `cat` tool can be used to read the actual content in a document node, like 'cat in Unix.\n" +
+  "The `locate_in_tree` tool can be used to find the path to a node in the filesystem tree.\n" +
   "The `semantic_search` tool can be used to perform a semantic search within the folders and files designated by `nodeIds`.";

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -20,7 +20,11 @@ import { CoreAPI, Err, Ok } from "@app/types";
 const catToolInputSchema = {
   dataSources:
     ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
-  nodeId: z.string().describe("The ID of the node to read."),
+  nodeId: z
+    .string()
+    .describe(
+      "The ID of the node to read. This is not the human-readable node title."
+    ),
   offset: z
     .number()
     .optional()


### PR DESCRIPTION
## Description

- Found out that the model often tries to pass a node title in the node id, which may hint at the fact that the model could be confused as to what node IDs and even maybe nodes are.
- This PR adds some server level instructions, rather than only relying on the tool descriptions.

## Tests

- Checked locally

## Risk

- Change in behavior expected.

## Deploy Plan

- Deploy front.
