### PR TITLE
fix: erroneous wording on attachment download button tooltip

### DIFF
--- a/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
@@ -166,7 +166,7 @@ export const AttachmentViewer = ({
                 onClick={onClickDownload}
                 icon={ArrowDownOnSquareIcon}
                 size="mini"
-                tooltip="Download audio file"
+                tooltip="Download file"
                 variant="ghost"
                 className={"mr-2 align-middle"}
               />


### PR DESCRIPTION
Closes [tasks#4743](https://github.com/dust-tt/tasks/issues/4743)