### PR TITLE
Fix HTML to csv conversion logic

### DIFF
--- a/connectors/src/types/shared/text_extraction/transformToCSV.ts
+++ b/connectors/src/types/shared/text_extraction/transformToCSV.ts
@@ -70,7 +70,7 @@ export function transformStreamToCSV(
 
         if (currentTag === selector) {
           htmlParsingTransform.push(`${TABLE_PREFIX}${text}\n`);
-        } else if (currentTag === HTML_TAGS.CELL) {
+        } else if (state.insideCell) {
           state.currentCellText += text;
         }
       },

--- a/connectors/src/types/shared/text_extraction/transformToCSV.ts
+++ b/connectors/src/types/shared/text_extraction/transformToCSV.ts
@@ -9,6 +9,8 @@ const TABLE_PREFIX = "TABLE:";
 interface ParserState {
   tags: string[];
   currentRow: string[];
+  insideCell: boolean;
+  currentCellText: string;
 }
 
 const HTML_TAGS = {
@@ -48,6 +50,8 @@ export function transformStreamToCSV(
   const state: ParserState = {
     tags: [],
     currentRow: [],
+    insideCell: false,
+    currentCellText: "",
   };
 
   // Create a single parser instance for the entire stream.
@@ -55,6 +59,10 @@ export function transformStreamToCSV(
     {
       onopentag(name) {
         state.tags.push(name);
+        if (name === HTML_TAGS.CELL) {
+          state.insideCell = true;
+          state.currentCellText = "";
+        }
       },
 
       ontext(text) {
@@ -63,7 +71,7 @@ export function transformStreamToCSV(
         if (currentTag === selector) {
           htmlParsingTransform.push(`${TABLE_PREFIX}${text}\n`);
         } else if (currentTag === HTML_TAGS.CELL) {
-          state.currentRow.push(text);
+          state.currentCellText += text;
         }
       },
 
@@ -76,6 +84,10 @@ export function transformStreamToCSV(
             const csv = stringify([state.currentRow]);
             htmlParsingTransform.push(csv);
             state.currentRow = [];
+          }
+          if (lastTag === HTML_TAGS.CELL) {
+            state.currentRow.push(state.currentCellText);
+            state.insideCell = false;
           }
         }
       },

--- a/front/types/shared/text_extraction/transformToCSV.ts
+++ b/front/types/shared/text_extraction/transformToCSV.ts
@@ -69,7 +69,7 @@ export function transformStreamToCSV(
 
         if (currentTag === selector) {
           htmlParsingTransform.push(`${TABLE_PREFIX}${text}\n`);
-        } else if (currentTag === HTML_TAGS.CELL) {
+        } else if (state.insideCell) {
           state.currentCellText += text;
         }
       },


### PR DESCRIPTION
## Description

The code was not handling the fact that we can get multiple calls to `ontext` within one cell. This can happen e.g. when there is an ampersand, which is sent separately.

Fixes https://github.com/dust-tt/tasks/issues/6746

## Tests

Manual

## Risk

Low

## Deploy Plan

Front