### PR TITLE
Fix: marking conversation as requiring action

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -170,6 +170,7 @@ export async function runToolActivity(
 
       case "tool_personal_auth_required":
       case "tool_approve_execution":
+        // Note from seb to pr: is it still possible to reach that place now that we block on approval https://github.com/dust-tt/dust/blob/15fac5beeb615f37c90bc81871699ee0b6466721/front/temporal/agent_loop/workflows.ts#L277 ?
         // Defer personal auth events to be sent after all tools complete.
         deferredEvents.push({
           event,


### PR DESCRIPTION
## Description

We had a regression since https://github.com/dust-tt/dust/pull/16445 as we evaluate if the action needs approval before trying to run them, we send `tool_approve_execution` event right away and stop the loop.

Before, they were deferred until the end of the loop and we had code in place to mark the conversation as action required. I believe this code is never reach now.

I lack context but as a follow up, I think:
- we should check if the tool_approve_execution can reach https://github.com/dust-tt/dust/blob/82ce73a0f1b9ef323193309a4f962ac8eedf26fa/front/temporal/agent_loop/activities/run_tool.ts#L186
  - if not, maybe we should be explicit about it (by removing the event type from the expectations)
- what about when the `tool_personal_auth_required` event type ? 

## Tests

Local before/after

## Risk

Low

## Deploy Plan

Deploy front