### PR TITLE
[front] Use mcpServerId

### DIFF
--- a/front/lib/api/assistant/permissions.ts
+++ b/front/lib/api/assistant/permissions.ts
@@ -136,7 +136,9 @@ export async function getAgentConfigurationRequirementsFromActions(
     // We skip the permissions for internal tools as they are automatically available to all users.
     // This mimic the previous behavior of generic internal tools (search etc..).
     if (view.serverType === "internal") {
-      const availability = getAvailabilityOfInternalMCPServerById(view.sId);
+      const availability = getAvailabilityOfInternalMCPServerById(
+        view.mcpServerId
+      );
       switch (availability) {
         case "auto":
         case "auto_hidden_builder":


### PR DESCRIPTION
## Description

getAvailabilityOfInternalMCPServerById takes in internal_mcp_server id as parameter - if it gets a mcp_server_view id, it will  always return "manual". This leads to handling auto tools as any other tools : takes the space and adds it to the requestedGroupId , which is not what is expected looking at the comment. 
This is actually not an issue as auto-tools are set in company data, which is available to everybody - but this should be fixed for consistency.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

front
