### PR TITLE
Fix: can only list mcpserverviews you have access to.

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -117,4 +117,247 @@ describe("MCPServerViewResource", () => {
       expect(views2[1].workspaceId).toBe(workspace2.id);
     });
   });
+
+  describe("listBySpaces", () => {
+    it("should only return views from spaces the user has access to", async () => {
+      // Create a workspace
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+
+      // Create spaces
+      await SpaceFactory.defaults(adminAuth);
+      const accessibleSpace = await SpaceFactory.regular(workspace);
+      const restrictedSpace = await SpaceFactory.regular(workspace);
+
+      // Create feature flag to enable MCP actions
+      await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
+
+      // Mock the INTERNAL_MCP_SERVERS config
+      const originalConfig = INTERNAL_MCP_SERVERS["primitive_types_debugger"];
+      Object.defineProperty(INTERNAL_MCP_SERVERS, "primitive_types_debugger", {
+        value: {
+          ...originalConfig,
+          availability: "auto",
+          isRestricted: ({
+            featureFlags,
+          }: {
+            plan: PlanType;
+            featureFlags: WhitelistableFeature[];
+          }) => {
+            return !featureFlags.includes("dev_mcp_actions");
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Create internal MCP server
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth,
+        {
+          name: "primitive_types_debugger",
+          useCase: null,
+        }
+      );
+
+      // Create MCP server views in multiple spaces
+      const viewInAccessible = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        accessibleSpace
+      );
+      const viewInRestricted = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        restrictedSpace
+      );
+
+      // Create a regular user
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+
+      // Set up space permissions:
+      // - User is in a group that has access to accessibleSpace
+      // - User is NOT in any group for restrictedSpace
+
+      // Add user to the group that accesses accessibleSpace
+      const addMemberResult = await accessibleSpace.groups[0].addMember(
+        adminAuth,
+        user.toJSON()
+      );
+      expect(addMemberResult.isOk()).toBe(true);
+
+      // Create auth for the regular user
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Test: User calls listBySpaces with both spaces
+      const results = await MCPServerViewResource.listBySpaces(userAuth, [
+        accessibleSpace,
+        restrictedSpace,
+      ]);
+
+      // Should only return the view from the accessible space
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(viewInAccessible.id);
+      expect(results[0].vaultId).toBe(accessibleSpace.id);
+
+      // Verify the restricted view was NOT returned
+      const restrictedIds = results.map((v) => v.id);
+      expect(restrictedIds).not.toContain(viewInRestricted.id);
+    });
+
+    it("should return empty list when user has no access to any of the provided spaces", async () => {
+      // Create a workspace
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      // Create spaces
+      await SpaceFactory.defaults(adminAuth);
+      const space1 = await SpaceFactory.regular(workspace);
+      const space2 = await SpaceFactory.regular(workspace);
+
+      // Create feature flag to enable MCP actions
+      await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
+
+      // Mock the INTERNAL_MCP_SERVERS config
+      const originalConfig = INTERNAL_MCP_SERVERS["primitive_types_debugger"];
+      Object.defineProperty(INTERNAL_MCP_SERVERS, "primitive_types_debugger", {
+        value: {
+          ...originalConfig,
+          availability: "auto",
+          isRestricted: ({
+            featureFlags,
+          }: {
+            plan: PlanType;
+            featureFlags: WhitelistableFeature[];
+          }) => {
+            return !featureFlags.includes("dev_mcp_actions");
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Create internal MCP server
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth,
+        {
+          name: "primitive_types_debugger",
+          useCase: null,
+        }
+      );
+
+      // Create MCP server views in both spaces
+      await MCPServerViewFactory.create(workspace, internalServer.id, space1);
+      await MCPServerViewFactory.create(workspace, internalServer.id, space2);
+
+      // Create a regular user with no group membership
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+
+      // Create auth for the regular user
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Test: User calls listBySpaces with spaces they don't have access to
+      const results = await MCPServerViewResource.listBySpaces(userAuth, [
+        space1,
+        space2,
+      ]);
+
+      // Should return empty list since user has no access to any space
+      expect(results).toHaveLength(0);
+    });
+
+    it("should return all views when user passes both accessible and restricted spaces", async () => {
+      // Create a workspace
+      const workspace = await WorkspaceFactory.basic();
+      // Get admin auth to set up the MCP servers
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+
+      // Create spaces
+      await SpaceFactory.defaults(adminAuth);
+      const space1 = await SpaceFactory.regular(workspace);
+      const space2 = await SpaceFactory.regular(workspace);
+
+      // Create feature flag to enable MCP actions
+      await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
+
+      // Mock the INTERNAL_MCP_SERVERS config
+      const originalConfig = INTERNAL_MCP_SERVERS["primitive_types_debugger"];
+      Object.defineProperty(INTERNAL_MCP_SERVERS, "primitive_types_debugger", {
+        value: {
+          ...originalConfig,
+          availability: "auto",
+          isRestricted: ({
+            featureFlags,
+          }: {
+            plan: PlanType;
+            featureFlags: WhitelistableFeature[];
+          }) => {
+            return !featureFlags.includes("dev_mcp_actions");
+          },
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Create internal MCP server
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth,
+        {
+          name: "primitive_types_debugger",
+          useCase: null,
+        }
+      );
+
+      // Create MCP server views in both spaces
+      const view1 = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        space1
+      );
+      const view2 = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        space2
+      );
+
+      // Create a regular user
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+
+      // Add user to both groups
+      await space1.groups[0].addMember(adminAuth, user.toJSON());
+      await space2.groups[0].addMember(adminAuth, user.toJSON());
+
+      // Create auth for the regular user
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Test: User calls listBySpaces with spaces they have access to
+      const results = await MCPServerViewResource.listBySpaces(userAuth, [
+        space1,
+        space2,
+      ]);
+
+      // Should return all views since user has access to all spaces
+      expect(results).toHaveLength(2);
+      const resultIds = results.map((v) => v.id).sort();
+      const expectedIds = [view1.id, view2.id].sort();
+      expect(resultIds).toEqual(expectedIds);
+    });
+  });
 });

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -344,12 +344,19 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     spaces: SpaceResource[],
     options?: ResourceFindOptions<MCPServerViewModel>
   ): Promise<MCPServerViewResource[]> {
+    // Filter out spaces that the user does not have read or administrate access to
+    const accessibleSpaces = spaces.filter((s) =>
+      s.canReadOrAdministrate(auth)
+    );
+    if (accessibleSpaces.length === 0) {
+      return [];
+    }
     return this.baseFetch(auth, {
       ...options,
       where: {
         ...options?.where,
         workspaceId: auth.getNonNullableWorkspace().id,
-        vaultId: spaces.map((s) => s.id),
+        vaultId: accessibleSpaces.map((s) => s.id),
       },
       order: [["id", "ASC"]],
     });

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -79,7 +79,7 @@ export const createPrivateApiMockRequest = async ({
       authenticationMethod: "GoogleOAuth",
       isSSO: false,
       workspaceId: workspace.sId,
-      organizationId: workspace.workOSOrganizationId || undefined,
+      organizationId: workspace.workOSOrganizationId ?? undefined,
       region: "us-central1",
     })
   );


### PR DESCRIPTION
## Description

Fix https://github.com/dust-tt/tasks/issues/4749 by adding space's read access filtering to `MCPServerViewResource.listBySpaces()` (used by all the other list methods).

## Tests

Added.

## Risk

Medium as it impact multiples endpoints but:
1/ the code now behave as the original expectation
2/ we have relatively strong tests coverage for the MCP part.

## Deploy Plan

Deploy front