### PR TITLE
Move datasourceview access check to inside fetchByIds

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
@@ -83,23 +83,6 @@ type TablesQueryOutputResources =
   | ToolGeneratedFileType
   | ToolMarkerResourceType;
 
-/**
- * Verifies that the user has read access to all provided data source views.
- * @returns null if user has access to all views, MCPError if access is denied
- */
-function verifyDataSourceViewReadAccess(
-  auth: Authenticator,
-  dataSourceViews: DataSourceViewResource[]
-): MCPError | null {
-  const unreadableViews = dataSourceViews.filter((dsv) => !dsv.canRead(auth));
-  if (unreadableViews.length > 0) {
-    return new MCPError(
-      `Access denied: You do not have read permission to all the required documents.`
-    );
-  }
-  return null;
-}
-
 function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
@@ -145,15 +128,6 @@ function createServer(
         const dataSourceViews = await DataSourceViewResource.fetchByIds(auth, [
           ...new Set(tableConfigurations.map((t) => t.dataSourceViewId)),
         ]);
-
-        // Security check: Verify user has canRead access to all data source views
-        const accessError = verifyDataSourceViewReadAccess(
-          auth,
-          dataSourceViews
-        );
-        if (accessError) {
-          return new Err(accessError);
-        }
 
         const dataSourceViewsMap = new Map(
           dataSourceViews.map((dsv) => [dsv.sId, dsv])
@@ -259,15 +233,6 @@ function createServer(
         const dataSourceViews = await DataSourceViewResource.fetchByIds(auth, [
           ...new Set(tableConfigurations.map((t) => t.dataSourceViewId)),
         ]);
-
-        // Security check: Verify user has canRead access to all data source views
-        const accessError = verifyDataSourceViewReadAccess(
-          auth,
-          dataSourceViews
-        );
-        if (accessError) {
-          return new Err(accessError);
-        }
 
         const dataSourceViewsMap = new Map(
           dataSourceViews.map((dsv) => [dsv.sId, dsv])

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -421,10 +421,19 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       }
     );
 
-    // Verify that the user has read access to all data source views
+    // Verify that the user has read access to all data source views.
     const unreadableViews = dataSourceViews.filter((dsv) => !dsv.canRead(auth));
     if (unreadableViews.length > 0) {
-      throw new Error("Access denied to the requested data.");
+      logger.warn(
+        {
+          userId: auth.user()?.id,
+          viewIds: unreadableViews.map((dsv) => dsv.id),
+        },
+        "There was an attempt to access unreadable data source views"
+      );
+
+      // Instead of returning an error, return an empty list to reduce disruption on calling code.
+      return [];
     }
 
     return dataSourceViews ?? [];

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -421,6 +421,12 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       }
     );
 
+    // Verify that the user has read access to all data source views
+    const unreadableViews = dataSourceViews.filter((dsv) => !dsv.canRead(auth));
+    if (unreadableViews.length > 0) {
+      throw new Error("Access denied to the requested data.");
+    }
+
     return dataSourceViews ?? [];
   }
 


### PR DESCRIPTION
## Description

This is a continuation of https://github.com/dust-tt/dust/pull/16901, as discussed in comment https://github.com/dust-tt/dust/pull/16901#discussion_r2431823958.

We move the canRead() check inside `DataSourceViewResource.fetchByIds` so it applies to all callers. Do need to carefully review that the check should apply for all callers. Other than the one from the last PR, the callers are:
1. `getDataSourcesDetails()` in front/lib/actions/mcp_internal_actions/servers/process/index.ts
2. `getAgentConfigurationRequirementsFromActions()` in front/lib/api/assistant/permissions.ts
3. `TrackerConfigurationResource.fetchAllWatchedForDocument()`
4. The handler in front/pages/api/w/[wId]/data_source_views/tags/search.ts

I would think that it should apply to all, but I'm not super familiar with all the scenarios. The first one may be the most interesting, as it's called from `getConfigForProcessDustApp()`, and Dust apps are always a bit special.

**Update**: there are more places, because `fetchByIds` is called by `fetchById`, which has a number of callers.

The code logs a warning, so we can easily monitor if this happens. In theory, we should never get this warning, so I think we should:
- Deploy the change
- Instantly monitor logs for the warning
- If any fires, revert the change so we have time to analyze the situation and check if it's legit

This way we minimize and regression to just a few minutes.

## Tests

Manual

## Risk

Could break something if one of these scenarios is using auth is an unusual way. Will need to carefully monitor.

## Deploy Plan

Front