### PR TITLE
feat(connector): keep stacktrace in temporal errors

### DIFF
--- a/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
@@ -29,6 +29,7 @@ export class ConfluenceCastKnownErrorsInterceptor
               throw ApplicationFailure.create({
                 message: `${err.message}. Retry after ${err.retryAfterMs}ms`,
                 nextRetryDelay: err.retryAfterMs,
+                cause: err,
               });
             }
 

--- a/connectors/src/connectors/slack/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/slack/temporal/cast_known_errors.ts
@@ -23,6 +23,7 @@ export class SlackCastKnownErrorsInterceptor
           throw ApplicationFailure.create({
             message: `${err.message}. Retry after ${err.retryAfter / 1000}s`,
             nextRetryDelay: err.retryAfter,
+            cause: err,
           });
         }
       }

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -157,6 +157,7 @@ export class ActivityInboundLogInterceptor
           )}s`,
           type: err.type, // "transient_upstream_activity_error"
           nextRetryDelay: err.retryAfterMs,
+          cause: err,
         });
       }
 


### PR DESCRIPTION
## Description

When we create exception in temporal with `ApplicationFailure.create` we were loosing the stacktrace.
Example in this [one](https://app.datadoghq.eu/dashboard/eza-jyh-pwy?fromUser=false&refresh_mode=sliding&storage=hot&from_ts=1760943289105&to_ts=1760946889105&live=true)
```
ApplicationFailure: Rate limited: A rate-limit has been reached, you may retry this request in 10 seconds (retry after 10s). Retry after 10s
    at Function.create (/app/node_modules/@temporalio/common/src/failure.ts:228:12)
    at SlackCastKnownErrorsInterceptor.execute (/app/src/connectors/slack/temporal/cast_known_errors.ts:23:36)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ActivityInboundLogInterceptor.execute (/app/src/lib/temporal_monitoring.ts:124:14)
    at async Activity.execute (/app/node_modules/@temporalio/worker/src/activity.ts:128:14)
    at async <anonymous> (/app/node_modules/@temporalio/worker/src/activity.ts:160:24)
    at async <anonymous> (/app/node_modules/@temporalio/worker/src/worker.ts:1066:24)
```

we only get the `ApplicationFailure.create` created in `cast_known_errors.ts` but we don't have the source. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
