### PR TITLE
[front] remove useless preconnect

### DIFF
--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -13,12 +13,6 @@ class MyDocument extends Document {
             <script src="https://unpkg.com/react-scan/dist/auto.global.js" />
           )}
           <base href={process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL} />
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link
-            rel="preconnect"
-            href="https://fonts.gstatic.com"
-            crossOrigin="anonymous"
-          />
           {process.env.NEXT_PUBLIC_ENABLE_BOT_CRAWLING !== "true" && (
             <meta name="robots" content="noindex" />
           )}


### PR DESCRIPTION
## Description
Found this while testing [Debug the network dependency tree with Gemini](https://developer.chrome.com/blog/new-in-devtools-141#mcp), we only use geist and no google font so we should be able to remove them 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
