### PR TITLE
[front] chore(webtools): include error details in logged errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -286,7 +286,18 @@ function createServer(
           );
           if (!hasAnySuccess) {
             return new Err(
-              new MCPError("All web browsing and summarization attempts failed")
+              new MCPError(
+                "All web browsing and summarization attempts failed",
+                {
+                  cause: new Error(
+                    perUrlContents
+                      .flatMap((result) =>
+                        result.contentBlocks.map((block) => block.text)
+                      )
+                      .join("\n")
+                  ),
+                }
+              )
             );
           }
 


### PR DESCRIPTION
## Description

- This PR adds some logs to errors on the webtools. The logs are currently not very exploitable as is (example [here](https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40toolName%3Awebbrowser%20%22Tool%20execution%20error%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZoBVW3CN6Pu2gAAABhBWm9CVlhLMEFBQV9rSG1oNXlSUk1RQUQAAAAkZjE5YTAxNTgtMmU2OS00YmEyLTllN2MtYTcwNzdlNDI0ODI4AAL1KQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760957834000&to_ts=1760959034000&live=false)).

## Tests

## Risk

## Deploy Plan

- Deploy front.
