### PR TITLE
[front] fix(logging): ensure correct binding of logger methods in MCP actions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -271,14 +271,16 @@ async function withNotionClient<T>(
   fn: (notion: Client) => Promise<T>,
   authInfo?: AuthInfo
 ): Promise<Result<CallToolResult["content"], MCPError>> {
+  const accessToken = authInfo?.token;
+  if (!accessToken) {
+    return new Ok(makePersonalAuthenticationError("notion").content);
+  }
+
   try {
-    const accessToken = authInfo?.token;
-    if (!accessToken) {
-      return new Ok(makePersonalAuthenticationError("notion").content);
-    }
     const notion = new Client({ auth: accessToken });
 
     const result = await fn(notion);
+
     return new Ok([
       { type: "text" as const, text: "Success" },
       { type: "text" as const, text: JSON.stringify(result, null, 2) },

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -130,7 +130,7 @@ export function withToolLogging<T>(
       );
     }
 
-    logger.info(
+    logger.info.bind(logger)(
       {
         ...loggerArgs,
         duration: elapsed,

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -74,7 +74,7 @@ export function withToolLogging<T>(
       };
     }
 
-    logger.info(loggerArgs, "Tool execution start");
+    logger.info.bind(logger)(loggerArgs, "Tool execution start");
 
     const tags = [
       `tool:${toolNameForMonitoring}`,
@@ -106,9 +106,9 @@ export function withToolLogging<T>(
         error: result.error,
       };
       if (result.error.tracked) {
-        logger.error(logContext, "Tool execution error");
+        logger.error.bind(logger)(logContext, "Tool execution error");
       } else {
-        logger.warn(logContext, "Tool execution error");
+        logger.warn.bind(logger)(logContext, "Tool execution error");
       }
 
       return {


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/4622.
- This code snippet crashes hard:

```typescript
import pino from 'pino'

const log = pino()
Promise.reject("FAIL").catch(log.error);
```

- The goal of this PR is to add some logs to actually locate where the unhandled rejection comes from (most likely the SDK code but everything seems to be correctly wrapped in try catches).
- From then we'll be able to find out where the error comes from and fix accordingly.

## Tests

## Risk

## Deploy Plan

- Deploy front.
