### PR TITLE
Add endpoint to retrieve webhook source views by spaces

### DIFF
--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -32,15 +32,17 @@ import {
   normalizeWebhookIcon,
 } from "@app/lib/webhookSource";
 import type { LightWorkspaceType } from "@app/types";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP } from "@app/types/triggers/webhooks";
 
 type WebhookSourceDetailsInfoProps = {
-  webhookSourceView: WebhookSourceViewType;
+  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
   owner: LightWorkspaceType;
 };
 
-const getEditedLabel = (webhookSourceView: WebhookSourceViewType) => {
+const getEditedLabel = (
+  webhookSourceView: WebhookSourceViewWithWebhookSourceType
+) => {
   if (
     webhookSourceView.editedByUser === null ||
     (webhookSourceView.editedByUser.editedAt === null &&

--- a/front/components/triggers/WebhookSourceViewIcon.tsx
+++ b/front/components/triggers/WebhookSourceViewIcon.tsx
@@ -5,14 +5,14 @@ import {
   getAvatarFromIcon,
   ResourceAvatar,
 } from "@app/components/resources/resources_icons";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP } from "@app/types/triggers/webhooks";
 
 export const WebhookSourceViewIcon = ({
   webhookSourceView,
   size = "sm",
 }: {
-  webhookSourceView: WebhookSourceViewType;
+  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
   size?: ComponentProps<typeof Avatar>["size"];
 }) => {
   const kind = webhookSourceView.webhookSource.kind;

--- a/front/components/triggers/forms/webhookSourceFormSchema.ts
+++ b/front/components/triggers/forms/webhookSourceFormSchema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { DEFAULT_WEBHOOK_ICON } from "@app/lib/webhookSource";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
 
 export type WebhookSourceFormValues = {
   name: string;
@@ -11,7 +11,7 @@ export type WebhookSourceFormValues = {
 };
 
 export function getWebhookSourceFormDefaults(
-  view: WebhookSourceViewType,
+  view: WebhookSourceViewWithWebhookSourceType,
   webhookSourceWithViews?: { views: Array<{ spaceId: string }> },
   spaces?: Array<{ sId: string; kind: string }>
 ): WebhookSourceFormValues {

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -239,12 +239,18 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     spaces: SpaceResource[],
     options?: ResourceFindOptions<WebhookSourcesViewModel>
   ): Promise<WebhookSourcesViewResource[]> {
+    const allowedSpaces = spaces.filter((space) =>
+      space.canReadOrAdministrate(auth)
+    );
+    if (allowedSpaces.length === 0) {
+      return [];
+    }
     return this.baseFetch(auth, {
       ...options,
       where: {
         ...options?.where,
         workspaceId: auth.getNonNullableWorkspace().id,
-        vaultId: spaces.map((s) => s.id),
+        vaultId: allowedSpaces.map((s) => s.id),
       },
     });
   }
@@ -254,6 +260,9 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     space: SpaceResource,
     options?: ResourceFindOptions<WebhookSourcesViewModel>
   ): Promise<WebhookSourcesViewResource[]> {
+    if (!space.canReadOrAdministrate(auth)) {
+      return [];
+    }
     return this.listBySpaces(auth, [space], options);
   }
 
@@ -262,7 +271,6 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     options?: ResourceFindOptions<WebhookSourcesViewModel>
   ) {
     const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-
     return this.listBySpace(auth, systemSpace, options);
   }
 

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -21,7 +21,7 @@ import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resourc
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import type { ModelId, Result } from "@app/types";
 import { Err, formatUserFullName, Ok, removeNulls } from "@app/types";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -526,7 +526,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
   }
 
   // Serialization.
-  toJSON(): WebhookSourceViewType {
+  toJSON(): WebhookSourceViewWithWebhookSourceType {
     return {
       id: this.id,
       sId: this.sId,

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -12,7 +12,7 @@ import type { LightWorkspaceType, SpaceType } from "@app/types";
 import type {
   PostWebhookSourcesBody,
   WebhookSourceType,
-  WebhookSourceViewType,
+  WebhookSourceViewWithWebhookSourceType,
 } from "@app/types/triggers/webhooks";
 
 export function useWebhookSourceViews({
@@ -346,7 +346,7 @@ export function useRemoveWebhookSourceViewFromSpace({
       webhookSourceView,
       space,
     }: {
-      webhookSourceView: WebhookSourceViewType;
+      webhookSourceView: WebhookSourceViewWithWebhookSourceType;
       space: SpaceType;
     }): Promise<void> => {
       try {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
@@ -9,16 +9,16 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { SpaceKind, WithAPIErrorResponse } from "@app/types";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
 
 export type GetWebhookSourceViewsResponseBody = {
   success: boolean;
-  webhookSourceViews: WebhookSourceViewType[];
+  webhookSourceViews: WebhookSourceViewWithWebhookSourceType[];
 };
 
 export type PostWebhookSourceViewResponseBody = {
   success: boolean;
-  webhookSourceView: WebhookSourceViewType;
+  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
 };
 
 const postWebhookSourceViewBodySchema = z.object({

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
@@ -6,11 +6,11 @@ import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resourc
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
 
 export type GetWebhookSourceViewsResponseBody = {
   success: true;
-  views: WebhookSourceViewType[];
+  views: WebhookSourceViewWithWebhookSourceType[];
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -12,15 +12,15 @@ import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import { apiError } from "@app/logger/withlogging";
 import type { Result, WithAPIErrorResponse } from "@app/types";
 import { assertNever, Err, Ok } from "@app/types";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
 import { patchWebhookSourceViewBodySchema } from "@app/types/triggers/webhooks";
 
 export type GetWebhookSourceViewResponseBody = {
-  webhookSourceView: WebhookSourceViewType;
+  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
 };
 
 export type PatchWebhookSourceViewResponseBody = {
-  webhookSourceView: WebhookSourceViewType;
+  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.test.ts
@@ -1,0 +1,382 @@
+import type { RequestMethod } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WebhookSourceFactory } from "@app/tests/utils/WebhookSourceFactory";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+
+import handler from "./index";
+
+async function setupTest(
+  role: "builder" | "user" | "admin" = "admin",
+  method: RequestMethod = "GET"
+) {
+  const { req, res, workspace, authenticator } =
+    await createPrivateApiMockRequest({
+      role,
+      method,
+    });
+
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  await SpaceFactory.defaults(adminAuth);
+
+  // Set up common query parameters
+  req.query.wId = workspace.sId;
+
+  return { req, res, workspace, authenticator };
+}
+
+describe("GET /api/w/[wId]/webhook_sources/views", () => {
+  it("should return all webhook source views from specified spaces", async () => {
+    const { req, res, workspace, authenticator } = await setupTest(
+      "admin",
+      "GET"
+    );
+
+    // Create webhook sources and views
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const result1 = await webhookSourceFactory.create({
+      name: "Test Webhook Source 1",
+    });
+    const result2 = await webhookSourceFactory.create({
+      name: "Test Webhook Source 2",
+    });
+
+    if (result1.isErr() || result2.isErr()) {
+      throw new Error("Failed to create webhook sources");
+    }
+
+    const webhookSource1 = result1.value;
+    const webhookSource2 = result2.value;
+
+    // Get the existing spaces
+    const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
+    const globalSpace = spaces.find((s) => s.kind === "global");
+    if (!globalSpace) {
+      throw new Error("Global space not found");
+    }
+
+    // Create additional views for the webhook sources
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    await webhookSourceViewFactory.create(globalSpace, {
+      webhookSourceId: webhookSource1.sId(),
+    });
+    await webhookSourceViewFactory.create(globalSpace, {
+      webhookSourceId: webhookSource2.sId(),
+    });
+
+    // Query for views in the global space
+    req.query.spaceIds = globalSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData).toEqual({
+      success: true,
+      webhookSourceViews: expect.any(Array),
+    });
+
+    // Should have at least 2 views (the ones we created in the global space)
+    expect(responseData.webhookSourceViews.length).toBeGreaterThanOrEqual(2);
+
+    // Check the structure of returned views
+    const firstView = responseData.webhookSourceViews[0];
+    expect(firstView).toHaveProperty("sId");
+    expect(firstView).toHaveProperty("customName");
+    expect(firstView).toHaveProperty("description");
+    expect(firstView).toHaveProperty("icon");
+    expect(firstView).toHaveProperty("spaceId");
+    expect(firstView).toHaveProperty("createdAt");
+    expect(firstView).toHaveProperty("updatedAt");
+    expect(firstView).toHaveProperty("editedByUser");
+  });
+
+  it("should return views from multiple spaces when multiple spaceIds provided", async () => {
+    const { req, res, workspace, authenticator } = await setupTest(
+      "admin",
+      "GET"
+    );
+
+    // Create webhook source
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const result = await webhookSourceFactory.create({
+      name: "Test Webhook Source",
+    });
+
+    if (result.isErr()) {
+      throw new Error("Failed to create webhook source");
+    }
+
+    const webhookSource = result.value;
+
+    // Get existing spaces
+    const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
+    const globalSpace = spaces.find((s) => s.kind === "global");
+    const systemSpace = spaces.find((s) => s.kind === "system");
+
+    if (!globalSpace || !systemSpace) {
+      throw new Error("Required spaces not found");
+    }
+
+    // Create views in both spaces
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    await webhookSourceViewFactory.create(globalSpace, {
+      webhookSourceId: webhookSource.sId(),
+    });
+
+    // Query for views in both spaces (comma-separated)
+    req.query.spaceIds = `${globalSpace.sId},${systemSpace.sId}`;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+
+    expect(responseData.webhookSourceViews.length).toBeGreaterThanOrEqual(2);
+    const spaceIds = responseData.webhookSourceViews.map((v: any) => v.spaceId);
+    expect(spaceIds).toContain(globalSpace.sId);
+    expect(spaceIds).toContain(systemSpace.sId);
+  });
+
+  it("should return 400 when spaceIds is missing", async () => {
+    const { req, res } = await setupTest("admin", "GET");
+
+    // Don't set spaceIds query parameter
+    delete req.query.spaceIds;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+
+    const responseData = res._getJSONData();
+    expect(responseData.error).toEqual({
+      type: "invalid_request_error",
+      message: "Invalid query parameters",
+    });
+  });
+
+  it("should return 400 when spaceIds is not a string", async () => {
+    const { req, res } = await setupTest("admin", "GET");
+
+    req.query.spaceIds = ["invalid", "array"];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+
+    const responseData = res._getJSONData();
+    expect(responseData.error).toEqual({
+      type: "invalid_request_error",
+      message: "Invalid query parameters",
+    });
+  });
+
+  it("should handle non-existent space IDs gracefully", async () => {
+    const { req, res } = await setupTest("admin", "GET");
+
+    // Use non-existent space IDs
+    req.query.spaceIds = "non-existent-space-1,non-existent-space-2";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData).toEqual({
+      success: true,
+      webhookSourceViews: [],
+    });
+  });
+
+  it("should work for user role when accessing spaces they have access to", async () => {
+    const { req, res, workspace, authenticator } = await setupTest(
+      "user",
+      "GET"
+    );
+
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const result = await webhookSourceFactory.create({
+      name: "Test Webhook Source",
+    });
+
+    if (result.isErr()) {
+      throw new Error("Failed to create webhook source");
+    }
+
+    const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
+    const globalSpace = spaces.find((s) => s.kind === "global");
+    if (!globalSpace) {
+      throw new Error("Global space not found");
+    }
+
+    req.query.spaceIds = globalSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData).toEqual({
+      success: true,
+      webhookSourceViews: expect.any(Array),
+    });
+  });
+
+  it("should work for builder role when accessing spaces they have access to", async () => {
+    const { req, res, workspace, authenticator } = await setupTest(
+      "builder",
+      "GET"
+    );
+
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const result = await webhookSourceFactory.create({
+      name: "Test Webhook Source",
+    });
+
+    if (result.isErr()) {
+      throw new Error("Failed to create webhook source");
+    }
+
+    const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
+    const globalSpace = spaces.find((s) => s.kind === "global");
+    if (!globalSpace) {
+      throw new Error("Global space not found");
+    }
+
+    req.query.spaceIds = globalSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData).toEqual({
+      success: true,
+      webhookSourceViews: expect.any(Array),
+    });
+  });
+
+  it("should only return views from spaces the user has access to", async () => {
+    const { req, res, workspace, authenticator } = await setupTest(
+      "admin",
+      "GET"
+    );
+
+    // Create webhook source
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const result = await webhookSourceFactory.create({
+      name: "Test Webhook Source",
+    });
+
+    if (result.isErr()) {
+      throw new Error("Failed to create webhook source");
+    }
+
+    const webhookSource = result.value;
+
+    // Get spaces
+    const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
+    const globalSpace = spaces.find((s) => s.kind === "global");
+
+    if (!globalSpace) {
+      throw new Error("Global space not found");
+    }
+
+    // Create view in global space
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    await webhookSourceViewFactory.create(globalSpace, {
+      webhookSourceId: webhookSource.sId(),
+    });
+
+    // Try to query with both valid and invalid space IDs
+    req.query.spaceIds = `${globalSpace.sId},invalid-space-id`;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData.webhookSourceViews.length).toBeGreaterThanOrEqual(1);
+
+    // All returned views should be from accessible spaces
+    responseData.webhookSourceViews.forEach((view: any) => {
+      expect(view.spaceId).toBe(globalSpace.sId);
+    });
+  });
+});
+
+describe("Method Support /api/w/[wId]/webhook_sources/views", () => {
+  it("should return 405 for POST method", async () => {
+    const { req, res, authenticator } = await setupTest("admin", "POST");
+
+    const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
+    const globalSpace = spaces.find((s) => s.kind === "global");
+    if (!globalSpace) {
+      throw new Error("Global space not found");
+    }
+
+    req.query.spaceIds = globalSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+
+    const responseData = res._getJSONData();
+    expect(responseData.error).toEqual({
+      type: "method_not_supported_error",
+      message: "The method passed is not supported, GET is expected.",
+    });
+  });
+
+  it("should return 405 for PUT method", async () => {
+    const { req, res, authenticator } = await setupTest("admin", "PUT");
+
+    const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
+    const globalSpace = spaces.find((s) => s.kind === "global");
+    if (!globalSpace) {
+      throw new Error("Global space not found");
+    }
+
+    req.query.spaceIds = globalSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+
+    const responseData = res._getJSONData();
+    expect(responseData.error).toEqual({
+      type: "method_not_supported_error",
+      message: "The method passed is not supported, GET is expected.",
+    });
+  });
+
+  it("should return 405 for DELETE method", async () => {
+    const { req, res, authenticator } = await setupTest("admin", "DELETE");
+
+    const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
+    const globalSpace = spaces.find((s) => s.kind === "global");
+    if (!globalSpace) {
+      throw new Error("Global space not found");
+    }
+
+    req.query.spaceIds = globalSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+
+    const responseData = res._getJSONData();
+    expect(responseData.error).toEqual({
+      type: "method_not_supported_error",
+      message: "The method passed is not supported, GET is expected.",
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.ts
@@ -11,8 +11,8 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
 import type {
-  WebhookSourceViewInfoType,
   WebhookSourceViewType,
+  WebhookSourceViewWithWebhookSourceType,
 } from "@app/types/triggers/webhooks";
 
 const GetWebhookSourceViewsRequestSchema = z.object({
@@ -21,7 +21,7 @@ const GetWebhookSourceViewsRequestSchema = z.object({
 
 export type GetWebhookSourceViewsListResponseBody = {
   success: boolean;
-  webhookSourceViews: WebhookSourceViewInfoType[];
+  webhookSourceViews: WebhookSourceViewType[];
 };
 
 async function handler(
@@ -83,7 +83,7 @@ async function handler(
 
       const flattenedWebhookSourceViews = webhookSourceViews
         .flat()
-        .filter((v): v is WebhookSourceViewType => v !== null)
+        .filter((v): v is WebhookSourceViewWithWebhookSourceType => v !== null)
         // map to WebhookSourceViewInfoType: copy all fields but the webhookSource field
         .map(({ webhookSource, ...rest }) => rest);
 

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.ts
@@ -1,0 +1,107 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+import type {
+  WebhookSourceViewInfoType,
+  WebhookSourceViewType,
+} from "@app/types/triggers/webhooks";
+
+const GetWebhookSourceViewsRequestSchema = z.object({
+  spaceIds: z.array(z.string()),
+});
+
+export type GetWebhookSourceViewsListResponseBody = {
+  success: boolean;
+  webhookSourceViews: WebhookSourceViewInfoType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetWebhookSourceViewsListResponseBody>
+  >,
+  auth: Authenticator
+) {
+  const { method } = req;
+
+  switch (method) {
+    case "GET": {
+      const spaceIds = req.query.spaceIds;
+
+      if (!isString(spaceIds)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid query parameters",
+          },
+        });
+      }
+
+      const normalizedQuery = {
+        ...req.query,
+        spaceIds: spaceIds.split(","),
+      };
+
+      const r = GetWebhookSourceViewsRequestSchema.safeParse(normalizedQuery);
+      if (r.error) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: fromError(r.error).toString(),
+          },
+        });
+      }
+
+      const query = r.data;
+
+      const webhookSourceViews = await concurrentExecutor(
+        query.spaceIds,
+        async (spaceId) => {
+          const space = await SpaceResource.fetchById(auth, spaceId);
+          if (!space || !space.canReadOrAdministrate(auth)) {
+            return null;
+          }
+          const views = await WebhookSourcesViewResource.listBySpace(
+            auth,
+            space
+          );
+          return views.map((v) => v.toJSON());
+        },
+        { concurrency: 10 }
+      );
+
+      const flattenedWebhookSourceViews = webhookSourceViews
+        .flat()
+        .filter((v): v is WebhookSourceViewType => v !== null)
+        // map to WebhookSourceViewInfoType: copy all fields but the webhookSource field
+        .map(({ webhookSource, ...rest }) => rest);
+
+      return res.status(200).json({
+        success: true,
+        webhookSourceViews: flattenedWebhookSourceViews,
+      });
+    }
+    default: {
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+    }
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -59,17 +59,21 @@ export type WebhookSourceType = {
   subscribedEvents: string[];
 };
 
-export type WebhookSourceViewType = {
+export type WebhookSourceViewInfoType = {
   id: ModelId;
   sId: string;
   customName: string | null;
   description: string;
   icon: InternalAllowedIconType | CustomResourceIconType;
+  subscribedEvents: string[];
   createdAt: number;
   updatedAt: number;
   spaceId: string;
-  webhookSource: WebhookSourceType;
   editedByUser: EditedByUser | null;
+};
+
+export type WebhookSourceViewType = WebhookSourceViewInfoType & {
+  webhookSource: WebhookSourceType;
 };
 
 export type WebhookSourceWithViewsType = WebhookSourceType & {

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -59,7 +59,7 @@ export type WebhookSourceType = {
   subscribedEvents: string[];
 };
 
-export type WebhookSourceViewInfoType = {
+export type WebhookSourceViewType = {
   id: ModelId;
   sId: string;
   customName: string | null;
@@ -71,16 +71,16 @@ export type WebhookSourceViewInfoType = {
   editedByUser: EditedByUser | null;
 };
 
-export type WebhookSourceViewType = WebhookSourceViewInfoType & {
+export type WebhookSourceViewWithWebhookSourceType = WebhookSourceViewType & {
   webhookSource: WebhookSourceType;
 };
 
 export type WebhookSourceWithViewsType = WebhookSourceType & {
-  views: WebhookSourceViewType[];
+  views: WebhookSourceViewWithWebhookSourceType[];
 };
 
 export type WebhookSourceWithSystemViewType = WebhookSourceWithViewsType & {
-  systemView: WebhookSourceViewType | null;
+  systemView: WebhookSourceViewWithWebhookSourceType | null;
 };
 
 export type WebhookSourceWithViewsAndUsageType = WebhookSourceWithViewsType & {

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -65,7 +65,6 @@ export type WebhookSourceViewInfoType = {
   customName: string | null;
   description: string;
   icon: InternalAllowedIconType | CustomResourceIconType;
-  subscribedEvents: string[];
   createdAt: number;
   updatedAt: number;
   spaceId: string;


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/4750

Introduce a new type for Webhook source view without the webhook source data
This type is returned by a new endpoint which allows to list the webhook views for a given list of spaces

## Tests

Unit tests

## Risk
No

## Deploy Plan

deploy front
