### PR TITLE
Gemini Pro 2.5: Do not offer light thinking, just default one

### DIFF
--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -249,6 +249,6 @@ export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   generationTokensCount: 64_000,
   supportsVision: true,
   minimumReasoningEffort: "none",
-  maximumReasoningEffort: "light",
-  defaultReasoningEffort: "light",
+  maximumReasoningEffort: "none",
+  defaultReasoningEffort: "none",
 };


### PR DESCRIPTION
## Description

Following eng runner card: https://github.com/dust-tt/tasks/issues/4729

Do not allow light thinking for gemini 2.5 pro and let the default settings. 

## Tests

Locally: 
- we're not offering anymore the option. 
- an agent set with the light settings still works (answers if pinged and can be still edited)

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
From my local test looks like I don't need to run a migration? 
