### PR TITLE
enh(dsfs): enforce dsviews canread in dsfs and warehouses tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
@@ -23,10 +23,8 @@ import {
   getSchemaContent,
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/schema";
 import { getAgentDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import {
-  ensureAuthorizedDataSourceViews,
-  makeInternalMCPServer,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
@@ -23,7 +23,10 @@ import {
   getSchemaContent,
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/schema";
 import { getAgentDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import {
+  ensureAuthorizedDataSourceViews,
+  makeInternalMCPServer,
+} from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
@@ -104,6 +107,14 @@ function createServer(
 
         const agentDataSourceConfigurations =
           dataSourceConfigurationsResult.value;
+
+        const authRes = await ensureAuthorizedDataSourceViews(
+          auth,
+          agentDataSourceConfigurations.map((c) => c.dataSourceViewId)
+        );
+        if (authRes.isErr()) {
+          return new Err(authRes.error);
+        }
 
         const result =
           nodeId === null
@@ -212,6 +223,14 @@ function createServer(
         const agentDataSourceConfigurations =
           dataSourceConfigurationsResult.value;
 
+        const authRes = await ensureAuthorizedDataSourceViews(
+          auth,
+          agentDataSourceConfigurations.map((c) => c.dataSourceViewId)
+        );
+        if (authRes.isErr()) {
+          return new Err(authRes.error);
+        }
+
         const result = await getWarehouseNodes(
           auth,
           agentDataSourceConfigurations,
@@ -288,6 +307,14 @@ function createServer(
 
         const agentDataSourceConfigurations =
           dataSourceConfigurationsResult.value;
+
+        const authRes = await ensureAuthorizedDataSourceViews(
+          auth,
+          agentDataSourceConfigurations.map((c) => c.dataSourceViewId)
+        );
+        if (authRes.isErr()) {
+          return new Err(authRes.error);
+        }
 
         const validationResult = await validateTables(
           auth,
@@ -395,6 +422,14 @@ function createServer(
 
         const agentDataSourceConfigurations =
           dataSourceConfigurationsResult.value;
+
+        const authRes = await ensureAuthorizedDataSourceViews(
+          auth,
+          agentDataSourceConfigurations.map((c) => c.dataSourceViewId)
+        );
+        if (authRes.isErr()) {
+          return new Err(authRes.error);
+        }
 
         const validationResult = await validateTables(
           auth,

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -20,7 +20,10 @@ import {
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import {
+  ensureAuthorizedDataSourceViews,
+  makeInternalMCPServer,
+} from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
@@ -98,6 +101,14 @@ export async function searchFunction({
   const coreSearchArgs = removeNulls(
     coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
   );
+
+  const authRes = await ensureAuthorizedDataSourceViews(
+    auth,
+    coreSearchArgs.map((a) => a.dataSourceView.sId)
+  );
+  if (authRes.isErr()) {
+    return authRes;
+  }
 
   if (coreSearchArgs.length === 0) {
     return new Err(

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -20,10 +20,8 @@ import {
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import {
-  ensureAuthorizedDataSourceViews,
-  makeInternalMCPServer,
-} from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -10,7 +10,7 @@ import {
   getAgentDataSourceConfigurations,
   makeDataSourceViewFilter,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils";
+import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -10,6 +10,7 @@ import {
   getAgentDataSourceConfigurations,
   makeDataSourceViewFilter,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
@@ -86,6 +87,14 @@ export function registerCatTool(
           return new Err(new MCPError(fetchResult.error.message));
         }
         const agentDataSourceConfigurations = fetchResult.value;
+
+        const authRes = await ensureAuthorizedDataSourceViews(
+          auth,
+          agentDataSourceConfigurations.map((c) => c.dataSourceViewId)
+        );
+        if (authRes.isErr()) {
+          return new Err(authRes.error);
+        }
 
         // Search the node using our search api.
         const searchResult = await coreAPI.searchNodes({

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -15,6 +15,7 @@ import {
   getAgentDataSourceConfigurations,
   makeDataSourceViewFilter,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
@@ -116,6 +117,14 @@ export function registerListTool(
           return new Err(new MCPError(fetchResult.error.message));
         }
         const agentDataSourceConfigurations = fetchResult.value;
+
+        const authRes = await ensureAuthorizedDataSourceViews(
+          auth,
+          agentDataSourceConfigurations.map((c) => c.dataSourceViewId)
+        );
+        if (authRes.isErr()) {
+          return new Err(authRes.error);
+        }
 
         const options = {
           cursor: nextPageCursor,

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -15,7 +15,7 @@ import {
   getAgentDataSourceConfigurations,
   makeDataSourceViewFilter,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils";
+import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -6,7 +6,6 @@ import {
 } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AGENT_MEMORY_SERVER_NAME,
@@ -19,18 +18,14 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/events";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionOutputItem } from "@app/lib/models/assistant/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type {
   AgentConfigurationType,
   AgentMessageType,
   ConversationType,
   OAuthProvider,
 } from "@app/types";
-import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
 
 export function makeInternalMCPServer(
   serverName: InternalMCPServerNameType,
@@ -188,18 +183,4 @@ export function isJITMCPServerView(view: MCPServerViewType): boolean {
     // Only tools that do not require any configuration can be enabled directly in a conversation.
     getMCPServerRequirements(view).noRequirement
   );
-}
-
-export async function ensureAuthorizedDataSourceViews(
-  auth: Authenticator,
-  viewIds: string[]
-): Promise<Result<DataSourceViewResource[], MCPError>> {
-  const unique = [...new Set(viewIds)];
-  const views = await DataSourceViewResource.fetchByIds(auth, unique);
-  if (views.length !== unique.length || views.some((v) => !v.canRead(auth))) {
-    return new Err(
-      new MCPError("Access denied to one or more configured data sources.")
-    );
-  }
-  return new Ok(views);
 }

--- a/front/lib/actions/mcp_internal_actions/utils/data_source_views.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/data_source_views.ts
@@ -1,0 +1,19 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+export async function ensureAuthorizedDataSourceViews(
+  auth: Authenticator,
+  viewIds: string[]
+): Promise<Result<DataSourceViewResource[], MCPError>> {
+  const unique = [...new Set(viewIds)];
+  const views = await DataSourceViewResource.fetchByIds(auth, unique);
+  if (views.length !== unique.length || views.some((v) => !v.canRead(auth))) {
+    return new Err(
+      new MCPError("Access denied to one or more configured data sources.")
+    );
+  }
+  return new Ok(views);
+}


### PR DESCRIPTION
## Description

We are not currently checking that the data source params of tools only utilize views that are authorized by the Authenticator.

In practice this isn't exploitable because you cannot override the data source configs at tool execution time, but it still feels cleaner to check it.

## Tests

Local

## Risk

Need to fetch data source views to perform the check

## Deploy Plan

Deploy front