### PR TITLE
[hootl User only retrieve views for their spaces

### DIFF
--- a/front/components/agent_builder/triggers/WebhookEditionModal.tsx
+++ b/front/components/agent_builder/triggers/WebhookEditionModal.tsx
@@ -26,12 +26,12 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import type { AgentBuilderWebhookTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { RecentWebhookRequests } from "@app/components/agent_builder/triggers/RecentWebhookRequests";
 import { TriggerFilterRenderer } from "@app/components/agent_builder/triggers/TriggerFilterRenderer";
 import { useWebhookFilterGeneration } from "@app/components/agent_builder/triggers/useWebhookFilterGeneration";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { WebhookSourceViewIcon } from "@app/components/triggers/WebhookSourceViewIcon";
-import { useSpaces } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
 import { useWebhookSourceViewsFromSpaces } from "@app/lib/swr/webhook_source";
 import type { LightWorkspaceType } from "@app/types";
@@ -97,7 +97,7 @@ export function WebhookEditionModal({
   const selectedEvent = form.watch("event");
   const includePayload = form.watch("includePayload");
 
-  const { spaces } = useSpaces({ workspaceId: owner.sId, disabled: !isOpen });
+  const { spaces } = useSpacesContext();
   const { webhookSourceViews, isLoading: isWebhookSourceViewsLoading } =
     useWebhookSourceViewsFromSpaces(owner, spaces, !isOpen);
 

--- a/front/components/triggers/WebhookSourceViewIcon.tsx
+++ b/front/components/triggers/WebhookSourceViewIcon.tsx
@@ -5,17 +5,17 @@ import {
   getAvatarFromIcon,
   ResourceAvatar,
 } from "@app/components/resources/resources_icons";
-import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP } from "@app/types/triggers/webhooks";
 
 export const WebhookSourceViewIcon = ({
   webhookSourceView,
   size = "sm",
 }: {
-  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
+  webhookSourceView: WebhookSourceViewType;
   size?: ComponentProps<typeof Avatar>["size"];
 }) => {
-  const kind = webhookSourceView.webhookSource.kind;
+  const kind = webhookSourceView.kind;
 
   if (kind === "custom") {
     return getAvatarFromIcon(webhookSourceView.icon, size);

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -10,9 +10,12 @@ import type { DeleteWebhookSourceResponseBody } from "@app/pages/api/w/[wId]/web
 import type { GetWebhookSourceViewsResponseBody as GetSpecificWebhookSourceViewsResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views";
 import type { GetWebhookSourceViewsListResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/views";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type {
-  WebhookSourceViewType} from "@app/types/triggers/webhooks";
-import type {PostWebhookSourcesBody, WebhookSourceType, WebhookSourceViewWithWebhookSourceType} from "@app/types/triggers/webhooks";
+  PostWebhookSourcesBody,
+  WebhookSourceType,
+  WebhookSourceViewWithWebhookSourceType,
+} from "@app/types/triggers/webhooks";
 
 export function useWebhookSourceViews({
   owner,

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -8,6 +8,7 @@ import type { GetWebhookSourceViewsResponseBody } from "@app/pages/api/w/[wId]/s
 import type { GetWebhookSourcesResponseBody } from "@app/pages/api/w/[wId]/webhook_sources";
 import type { DeleteWebhookSourceResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/[webhookSourceId]";
 import type { GetWebhookSourceViewsResponseBody as GetSpecificWebhookSourceViewsResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views";
+import type { GetWebhookSourceViewsListResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/views";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 import type {
   PostWebhookSourcesBody,
@@ -45,6 +46,28 @@ export function useWebhookSourceViews({
     webhookSourceViews,
     isWebhookSourceViewsLoading: !error && !data && !disabled,
     isWebhookSourceViewsError: error,
+    mutateWebhookSourceViews: mutate,
+  };
+}
+
+export function useWebhookSourceViewsFromSpaces(
+  owner: LightWorkspaceType,
+  spaces: SpaceType[],
+  disabled?: boolean
+) {
+  const configFetcher: Fetcher<GetWebhookSourceViewsListResponseBody> = fetcher;
+
+  const spaceIds = spaces.map((s) => s.sId).join(",");
+
+  const url = `/api/w/${owner.sId}/webhook_sources/views?spaceIds=${spaceIds}`;
+  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
+    disabled,
+  });
+
+  return {
+    webhookSourceViews: data?.webhookSourceViews ?? emptyArray(),
+    isLoading: !error && !data && spaces.length !== 0,
+    isError: error,
     mutateWebhookSourceViews: mutate,
   };
 }

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -11,10 +11,8 @@ import type { GetWebhookSourceViewsResponseBody as GetSpecificWebhookSourceViews
 import type { GetWebhookSourceViewsListResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/views";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 import type {
-  PostWebhookSourcesBody,
-  WebhookSourceType,
-  WebhookSourceViewWithWebhookSourceType,
-} from "@app/types/triggers/webhooks";
+  WebhookSourceViewType} from "@app/types/triggers/webhooks";
+import type {PostWebhookSourcesBody, WebhookSourceType, WebhookSourceViewWithWebhookSourceType} from "@app/types/triggers/webhooks";
 
 export function useWebhookSourceViews({
   owner,
@@ -65,7 +63,8 @@ export function useWebhookSourceViewsFromSpaces(
   });
 
   return {
-    webhookSourceViews: data?.webhookSourceViews ?? emptyArray(),
+    webhookSourceViews:
+      data?.webhookSourceViews ?? emptyArray<WebhookSourceViewType>(),
     isLoading: !error && !data && spaces.length !== 0,
     isError: error,
     mutateWebhookSourceViews: mutate,

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.ts
@@ -85,7 +85,7 @@ async function handler(
         .flat()
         .filter((v): v is WebhookSourceViewWithWebhookSourceType => v !== null)
         // map to WebhookSourceViewType: copy all fields but the webhookSource field
-        .map(({ webhookSource, ...rest }) => rest);
+        .map(({ webhookSource: _, ...rest }) => rest);
 
       return res.status(200).json({
         success: true,


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/4750

Using the new endpoint in WebhookEditionModal (the modal to pick a webhook in the AgentBuilder)
The user which is not admin should only have access to the views of his spaces and nothing else.

## Tests

Manual test: the modal still work

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
