### PR TITLE
Secure webhooks endpoints

### DIFF
--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
@@ -23,6 +23,16 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only admin can manage webhook sources.",
+      },
+    });
+  }
+
   const { webhookSourceId } = req.query;
   if (typeof webhookSourceId !== "string") {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
@@ -5,8 +5,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { apiError } from "@app/logger/withlogging";
-import type {WithAPIErrorResponse} from "@app/types";
-import { isString  } from "@app/types";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 export type DeleteWebhookSourceResponseBody = {
   success: true;

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
@@ -2,9 +2,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types";
+import type {WithAPIErrorResponse} from "@app/types";
+import { isString  } from "@app/types";
 
 export type DeleteWebhookSourceResponseBody = {
   success: true;
@@ -23,7 +25,8 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isAdmin()) {
+  const isAdmin = await SpaceResource.canAdministrateSystemSpace(auth);
+  if (!isAdmin) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -34,7 +37,7 @@ async function handler(
   }
 
   const { webhookSourceId } = req.query;
-  if (typeof webhookSourceId !== "string") {
+  if (!isString(webhookSourceId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -37,6 +37,15 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const { method } = req;
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only admin can manage webhook sources.",
+      },
+    });
+  }
 
   switch (method) {
     case "GET": {

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -37,7 +37,8 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const { method } = req;
-  if (!auth.isAdmin()) {
+  const isAdmin = await SpaceResource.canAdministrateSystemSpace(auth);
+  if (!isAdmin) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
@@ -1,6 +1,7 @@
 import type { RequestMethod } from "node-mocks-http";
 import { describe, expect, it, vi } from "vitest";
 
+import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -86,7 +87,11 @@ describe("GET /api/w/[wId]/webhook_sources/views/[viewId]", () => {
   it("should work for user role when accessing valid webhook source view", async () => {
     const { req, res, workspace } = await setupTest("user", "GET");
 
-    const globalSpace = await SpaceFactory.global(workspace);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const { globalSpace } = await SpaceFactory.defaults(adminAuth);
     const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
     const webhookSourceView =
       await webhookSourceViewFactory.create(globalSpace);
@@ -100,6 +105,21 @@ describe("GET /api/w/[wId]/webhook_sources/views/[viewId]", () => {
     const responseData = res._getJSONData();
     expect(responseData.webhookSourceView).toBeDefined();
     expect(responseData.webhookSourceView.sId).toBe(webhookSourceView.sId);
+  });
+
+  it("should return nothing if user does not have access to webhook source view", async () => {
+    const { req, res, workspace } = await setupTest("user", "GET");
+
+    const space = await SpaceFactory.regular(workspace);
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView = await webhookSourceViewFactory.create(space);
+
+    expect(webhookSourceView).not.toBeNull();
+    req.query.viewId = webhookSourceView.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
   });
 });
 
@@ -208,7 +228,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/views/[viewId]", () => {
     req.body = { name: "Updated Name" };
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(401);
+    expect(res._getStatusCode()).toBe(403);
     const responseData = res._getJSONData();
     expect(responseData.error.type).toBe("webhook_source_view_auth_error");
   });

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -7,6 +7,7 @@ import type {
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import { apiError } from "@app/logger/withlogging";
@@ -75,7 +76,8 @@ async function handler(
     }
 
     case "PATCH": {
-      if (!auth.isAdmin()) {
+      const isAdmin = await SpaceResource.canAdministrateSystemSpace(auth);
+      if (!isAdmin) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/4750

All webhook source endpoints are now only available to admin only
The webhook view get endpoint are available to users with read access to the space
The webhook patch/post/delete are available to admin only 

## Tests



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
