### PR TITLE
[front,core] Add additional parents filter in `nodes/search` endpoint

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -805,7 +805,7 @@ impl ElasticsearchSearchStore {
 
                 counter.add(1);
                 let mut bool_query =
-                    Query::bool().filter(Query::term("data_source_id", f.data_source_id.clone()));
+                    Query::bool().filter(Query::term("data_source_id", f.data_source_id));
 
                 // Only add parents filter if the index supports it.
                 if index_name == DATA_SOURCE_NODE_INDEX_NAME && !f.view_filter.is_empty() {

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -815,7 +815,7 @@ impl ElasticsearchSearchStore {
 
                 // Apply additional filter if present (in addition to view_filter).
                 if let Some(ref filter) = f.filter {
-                    if index_name == DATA_SOURCE_NODE_INDEX_NAME && !filter.is_empty() && !counter.is_full() {
+                    if index_name == DATA_SOURCE_NODE_INDEX_NAME && !filter.is_empty() {
                         counter.add(1);
                         bool_query = bool_query.filter(Query::terms("parents", filter.clone()));
                     }

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -38,7 +38,7 @@ import {
 import {
   getAgentDataSourceConfigurations,
   getCoreSearchArgs,
-  makeDataSourceViewFilter,
+  makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -291,7 +291,9 @@ async function searchCallback(
     const searchResult = await coreAPI.searchNodes({
       filter: {
         node_ids: searchNodeIds,
-        data_source_views: makeDataSourceViewFilter(agentDataSourceConfigurations),
+        data_source_views: makeCoreSearchNodesFilters(
+          agentDataSourceConfigurations
+        ),
       },
       options: {
         limit: searchNodeIds.length,
@@ -428,7 +430,9 @@ function createServer(
         // are searched. It is not straightforward to guess which data source it
         // belongs to, this is why irrelevant data sources are not directly
         // filtered out.
-        let viewFilter = makeDataSourceViewFilter(agentDataSourceConfigurations);
+        let viewFilter = makeCoreSearchNodesFilters(
+          agentDataSourceConfigurations
+        );
 
         if (dataSourceNodeId) {
           viewFilter = viewFilter.filter(
@@ -634,7 +638,7 @@ function createServer(
         const searchResult = await coreAPI.searchNodes({
           filter: {
             node_ids: [nodeId],
-            data_source_views: makeDataSourceViewFilter(
+            data_source_views: makeCoreSearchNodesFilters(
               agentDataSourceConfigurations
             ),
           },
@@ -661,7 +665,7 @@ function createServer(
           const pathSearchResult = await coreAPI.searchNodes({
             filter: {
               node_ids: parentNodeIds,
-              data_source_views: makeDataSourceViewFilter(
+              data_source_views: makeCoreSearchNodesFilters(
                 agentDataSourceConfigurations
               ),
             },

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -291,10 +291,7 @@ async function searchCallback(
     const searchResult = await coreAPI.searchNodes({
       filter: {
         node_ids: searchNodeIds,
-        data_source_views: coreSearchArgs.map((args) => ({
-          data_source_id: args.dataSourceId,
-          view_filter: args.filter.parents?.in ?? [],
-        })),
+        data_source_views: makeDataSourceViewFilter(agentDataSourceConfigurations),
       },
       options: {
         limit: searchNodeIds.length,
@@ -431,9 +428,7 @@ function createServer(
         // are searched. It is not straightforward to guess which data source it
         // belongs to, this is why irrelevant data sources are not directly
         // filtered out.
-        let viewFilter = makeDataSourceViewFilter(
-          agentDataSourceConfigurations
-        );
+        let viewFilter = makeDataSourceViewFilter(agentDataSourceConfigurations);
 
         if (dataSourceNodeId) {
           viewFilter = viewFilter.filter(

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/helpers.ts
@@ -8,7 +8,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { WAREHOUSES_BROWSE_MIME_TYPE } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ResolvedDataSourceConfiguration } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import { makeDataSourceViewFilter } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { makeCoreSearchNodesFilters } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -27,7 +27,7 @@ export async function getAvailableWarehouses(
   >
 > {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const dataSourceViewFilter = makeDataSourceViewFilter(
+  const dataSourceViewFilter = makeCoreSearchNodesFilters(
     dataSourceConfigurations
   ).map((view) => ({
     ...view,
@@ -153,7 +153,7 @@ export async function getWarehouseNodes(
   const result = await coreAPI.searchNodes({
     query,
     filter: {
-      data_source_views: makeDataSourceViewFilter(configsToUse),
+      data_source_views: makeCoreSearchNodesFilters(configsToUse),
       parent_id: parentIdToUse ?? undefined,
       node_ids: nodeIdsToUse,
     },
@@ -302,7 +302,7 @@ export async function validateTables(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const searchResult = await coreAPI.searchNodes({
     filter: {
-      data_source_views: makeDataSourceViewFilter([relevantConfig]),
+      data_source_views: makeCoreSearchNodesFilters([relevantConfig]),
       node_ids: parsedTables.map((t) => t.nodeId),
     },
   });

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -8,7 +8,7 @@ import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_acti
 import { renderNode } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
   getAgentDataSourceConfigurations,
-  makeDataSourceViewFilter,
+  makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -91,7 +91,7 @@ export function registerCatTool(
         const searchResult = await coreAPI.searchNodes({
           filter: {
             node_ids: [nodeId],
-            data_source_views: makeDataSourceViewFilter(
+            data_source_views: makeCoreSearchNodesFilters(
               agentDataSourceConfigurations
             ),
           },

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -13,7 +13,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/utils";
 import {
   getAgentDataSourceConfigurations,
-  makeDataSourceViewFilter,
+  makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -134,7 +134,7 @@ export function registerListTool(
 
         if (!nodeId) {
           // When nodeId is null, search for data sources only.
-          const dataSourceViewFilter = makeDataSourceViewFilter(
+          const dataSourceViewFilter = makeCoreSearchNodesFilters(
             agentDataSourceConfigurations
           ).map((view) => ({
             ...view,
@@ -171,7 +171,7 @@ export function registerListTool(
 
           searchResult = await coreAPI.searchNodes({
             filter: {
-              data_source_views: makeDataSourceViewFilter([dataSourceConfig]),
+              data_source_views: makeCoreSearchNodesFilters([dataSourceConfig]),
               node_ids: dataSourceConfig.filter.parents?.in ?? undefined,
               parent_id: dataSourceConfig.filter.parents?.in
                 ? undefined
@@ -182,7 +182,7 @@ export function registerListTool(
           });
         } else {
           // Regular node listing.
-          const dataSourceViewFilter = makeDataSourceViewFilter(
+          const dataSourceViewFilter = makeCoreSearchNodesFilters(
             agentDataSourceConfigurations
           );
 

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -331,25 +331,19 @@ export async function getAgentDataSourceConfigurations(
             dataSourceViewId: dataSourceViewSId,
             filter: {
               parents:
-                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                agentConfig.parentsIn || agentConfig.parentsNotIn
+                agentConfig.parentsIn !== null ||
+                agentConfig.parentsNotIn !== null
                   ? {
-                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                      in: agentConfig.parentsIn || [],
-                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                      not: agentConfig.parentsNotIn || [],
+                      in: agentConfig.parentsIn ?? [],
+                      not: agentConfig.parentsNotIn ?? [],
                     }
                   : null,
               tags:
-                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                agentConfig.tagsIn || agentConfig.tagsNotIn
+                agentConfig.tagsIn !== null || agentConfig.tagsNotIn != null
                   ? {
-                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                      in: agentConfig.tagsIn || [],
-                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                      not: agentConfig.tagsNotIn || [],
-                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                      mode: agentConfig.tagsMode || "custom",
+                      in: agentConfig.tagsIn ?? [],
+                      not: agentConfig.tagsNotIn ?? [],
+                      mode: agentConfig.tagsMode ?? "custom",
                     }
                   : undefined,
             },
@@ -503,16 +497,12 @@ export async function getCoreSearchArgs(
         dataSourceId: dataSource.dustAPIDataSourceId,
         filter: {
           tags: {
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            in: config.filter.tags?.in || null,
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            not: config.filter.tags?.not || null,
+            in: config.filter.tags?.in ?? null,
+            not: config.filter.tags?.not ?? null,
           },
           parents: {
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            in: config.filter.parents?.in || null,
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            not: config.filter.parents?.not || null,
+            in: config.filter.parents?.in ?? null,
+            not: config.filter.parents?.not ?? null,
           },
         },
         view_filter: dataSourceView.toViewFilter(),

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -339,7 +339,7 @@ export async function getAgentDataSourceConfigurations(
                     }
                   : null,
               tags:
-                agentConfig.tagsIn !== null || agentConfig.tagsNotIn != null
+                agentConfig.tagsIn !== null || agentConfig.tagsNotIn !== null
                   ? {
                       in: agentConfig.tagsIn ?? [],
                       not: agentConfig.tagsNotIn ?? [],

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -40,7 +40,7 @@ export type ResolvedDataSourceConfiguration = DataSourceConfiguration & {
   dataSourceView: DataSourceViewResource;
 };
 
-export function makeDataSourceViewFilter(
+export function makeCoreSearchNodesFilters(
   agentDataSourceConfigurations: ResolvedDataSourceConfiguration[]
 ): CoreAPIDatasourceViewFilter[] {
   return agentDataSourceConfigurations.map(

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -229,6 +229,7 @@ export const CoreAPIDatasourceViewFilterSchema = t.intersection([
   }),
   t.partial({
     search_scope: CoreAPISearchScopeSchema,
+    filter: t.array(t.string),
   }),
 ]);
 


### PR DESCRIPTION
## Description

- The `/nodes/search` endpoint allows for only one parents filter, populated with the data source view's when getting content nodes in `getContentNodesForDataSourceView`.
- In the FS tools this filter is set using the agent data source configuration's `parentsIn`, which is technically a subset of its data source view's `parentsIn` but without any additional check at runtime.
- To ensure we respect the data source view filter, this PR adds a separate (optional) `filter` field in the endpoint for the agent data source configuration's filter.

## Tests

- Tested locally with a private space.

## Risk

- Medium.

## Deploy Plan

- Deploy core.
- Deploy front.
