### PR TITLE
[front] fix(logging): remove unnecessary `bind` usage in MCP action logger

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -74,7 +74,7 @@ export function withToolLogging<T>(
       };
     }
 
-    logger.info.bind(logger)(loggerArgs, "Tool execution start");
+    logger.info(loggerArgs, "Tool execution start");
 
     const tags = [
       `tool:${toolNameForMonitoring}`,
@@ -106,9 +106,9 @@ export function withToolLogging<T>(
         error: result.error,
       };
       if (result.error.tracked) {
-        logger.error.bind(logger)(logContext, "Tool execution error");
+        logger.error(logContext, "Tool execution error");
       } else {
-        logger.warn.bind(logger)(logContext, "Tool execution error");
+        logger.warn(logContext, "Tool execution error");
       }
 
       return {
@@ -130,7 +130,7 @@ export function withToolLogging<T>(
       );
     }
 
-    logger.info.bind(logger)(
+    logger.info(
       {
         ...loggerArgs,
         duration: elapsed,


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/4622.
- Follow up on https://github.com/dust-tt/dust/pull/17084.
- The initial error came from https://github.com/dust-tt/dust/pull/16935 and was fixed in https://github.com/dust-tt/dust/pull/16952 (see https://github.com/dust-tt/tasks/issues/4622#issuecomment-3423694352).
- So the binds here are not needed.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
