### PR TITLE
Consistent style between agent label and user label in conversation

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -445,7 +445,7 @@ export function AgentMessage({
 
   const renderName = useCallback(
     () => (
-      <span className="inline-flex items-center text-muted-foreground dark:text-muted-foreground-night">
+      <span className="inline-flex items-center">
         <AgentHandle
           assistant={{
             sId: agentConfiguration.sId,

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -65,7 +65,7 @@ export function UserMessage({
   );
 
   const renderName = useCallback((name: string | null) => {
-    return <div className="heading-base">{name}</div>;
+    return <div>{name}</div>;
   }, []);
 
   return (


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/4771
Ed wanted: "pick color of the User message and size of agent message ^^"

<kbd>
<img width="865" height="386" alt="Screenshot 2025-10-20 at 23 05 10" src="https://github.com/user-attachments/assets/7369193e-627a-4012-81c3-6b4cb19eabdb" />
</kbd>

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 
