### PR TITLE
[sparkle] re-add icon to nav list

### DIFF
--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -3,6 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import {
+  Icon,
   LinkWrapper,
   LinkWrapperProps,
   ScrollArea,
@@ -80,6 +81,7 @@ const NavigationListItem = React.forwardRef<
       className,
       selected,
       label,
+      icon,
       href,
       target,
       rel,
@@ -152,6 +154,7 @@ const NavigationListItem = React.forwardRef<
                 )}
               />
             )}
+            {icon && <Icon visual={icon} size="sm" />}
             {label && (
               <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap group-hover/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8">
                 {label}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Re add the icon to the navigation list in sparkle to have the icons of Connections/Tools/Triggers back 

Regression was introduced here https://github.com/dust-tt/dust/pull/16682/files

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy sparkle, bump in next PR