### PR TITLE
[hootl] Remove webhook source admin info when retrieveing view

### DIFF
--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -32,17 +32,15 @@ import {
   normalizeWebhookIcon,
 } from "@app/lib/webhookSource";
 import type { LightWorkspaceType } from "@app/types";
-import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewForAdminType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP } from "@app/types/triggers/webhooks";
 
 type WebhookSourceDetailsInfoProps = {
-  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
+  webhookSourceView: WebhookSourceViewForAdminType;
   owner: LightWorkspaceType;
 };
 
-const getEditedLabel = (
-  webhookSourceView: WebhookSourceViewWithWebhookSourceType
-) => {
+const getEditedLabel = (webhookSourceView: WebhookSourceViewForAdminType) => {
   if (
     webhookSourceView.editedByUser === null ||
     (webhookSourceView.editedByUser.editedAt === null &&

--- a/front/components/triggers/WebhookSourceGithubDetails.tsx
+++ b/front/components/triggers/WebhookSourceGithubDetails.tsx
@@ -1,9 +1,9 @@
 import { ExternalLinkIcon, Page } from "@dust-tt/sparkle";
 
-import type { WebhookSourceType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceForAdminType } from "@app/types/triggers/webhooks";
 
 type WebhookSourceGithubDetailsProps = {
-  webhookSource: WebhookSourceType;
+  webhookSource: WebhookSourceForAdminType;
 };
 
 export function WebhookSourceGithubDetails({

--- a/front/components/triggers/forms/webhookSourceFormSchema.ts
+++ b/front/components/triggers/forms/webhookSourceFormSchema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { DEFAULT_WEBHOOK_ICON } from "@app/lib/webhookSource";
-import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 export type WebhookSourceFormValues = {
   name: string;
@@ -11,7 +11,7 @@ export type WebhookSourceFormValues = {
 };
 
 export function getWebhookSourceFormDefaults(
-  view: WebhookSourceViewWithWebhookSourceType,
+  view: WebhookSourceViewType,
   webhookSourceWithViews?: { views: Array<{ spaceId: string }> },
   spaces?: Array<{ sId: string; kind: string }>
 ): WebhookSourceFormValues {

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -21,7 +21,10 @@ import { DEFAULT_WEBHOOK_ICON } from "@app/lib/webhookSource";
 import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok, redactString } from "@app/types";
-import type { WebhookSourceType } from "@app/types/triggers/webhooks";
+import type {
+  WebhookSourceForAdminType as WebhookSourceForAdminType,
+  WebhookSourceType,
+} from "@app/types/triggers/webhooks";
 
 const SECRET_REDACTION_COOLDOWN_IN_MINUTES = 10;
 
@@ -273,6 +276,18 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
   }
 
   toJSON(): WebhookSourceType {
+    return {
+      id: this.id,
+      sId: this.sId(),
+      name: this.name,
+      kind: this.kind,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      subscribedEvents: this.subscribedEvents,
+    };
+  }
+
+  toJSONForAdmin(): WebhookSourceForAdminType {
     // Redact secret when outside of the 10-minute window after creation.
     const currentTime = new Date();
     const createdAt = new Date(this.createdAt);
@@ -287,19 +302,13 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
       : null;
 
     return {
-      id: this.id,
-      sId: this.sId(),
-      name: this.name,
+      ...this.toJSON(),
       secret,
       urlSecret: this.urlSecret,
-      kind: this.kind,
-      subscribedEvents: this.subscribedEvents,
       signatureHeader: this.signatureHeader,
       signatureAlgorithm: this.signatureAlgorithm,
       remoteMetadata: this.remoteMetadata,
       oauthConnectionId: this.oauthConnectionId,
-      createdAt: this.createdAt.getTime(),
-      updatedAt: this.updatedAt.getTime(),
     };
   }
 }

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -21,7 +21,10 @@ import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resourc
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import type { ModelId, Result } from "@app/types";
 import { Err, formatUserFullName, Ok, removeNulls } from "@app/types";
-import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
+import type {
+  WebhookSourceViewForAdminType,
+  WebhookSourceViewType,
+} from "@app/types/triggers/webhooks";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -533,8 +536,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     };
   }
 
-  // Serialization.
-  toJSON(): WebhookSourceViewWithWebhookSourceType {
+  toJSON(): WebhookSourceViewType {
     const webhookSource = this.getWebhookSourceResource();
     return {
       id: this.id,
@@ -548,6 +550,28 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
       updatedAt: this.updatedAt.getTime(),
       spaceId: this.space.sId,
       webhookSource: webhookSource.toJSON(),
+      editedByUser: this.makeEditedBy(
+        this.editedByUser,
+        this.webhookSource ? this.webhookSource.updatedAt : this.updatedAt
+      ),
+    };
+  }
+
+  // Serialization.
+  toJSONForAdmin(): WebhookSourceViewForAdminType {
+    const webhookSource = this.getWebhookSourceResource();
+    return {
+      id: this.id,
+      sId: this.sId,
+      customName: this.customName ?? webhookSource.name,
+      description: this.description,
+      icon: normalizeWebhookIcon(this.icon),
+      kind: webhookSource.kind,
+      subscribedEvents: webhookSource.subscribedEvents,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      spaceId: this.space.sId,
+      webhookSource: webhookSource.toJSONForAdmin(),
       editedByUser: this.makeEditedBy(
         this.editedByUser,
         this.webhookSource ? this.webhookSource.updatedAt : this.updatedAt

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -13,8 +13,8 @@ import type { LightWorkspaceType, SpaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type {
   PostWebhookSourcesBody,
-  WebhookSourceType,
-  WebhookSourceViewWithWebhookSourceType,
+  WebhookSourceForAdminType,
+  WebhookSourceViewForAdminType,
 } from "@app/types/triggers/webhooks";
 
 export function useWebhookSourceViews({
@@ -120,7 +120,7 @@ export function useCreateWebhookSource({
   const sendNotification = useSendNotification();
   const createWebhookSource = async (
     input: PostWebhookSourcesBody
-  ): Promise<WebhookSourceType | null> => {
+  ): Promise<WebhookSourceForAdminType | null> => {
     try {
       const response = await fetch(`/api/w/${owner.sId}/webhook_sources`, {
         method: "POST",
@@ -316,7 +316,7 @@ export function useAddWebhookSourceViewToSpace({
       webhookSource,
     }: {
       space: SpaceType;
-      webhookSource: WebhookSourceType;
+      webhookSource: WebhookSourceForAdminType;
     }): Promise<void> => {
       try {
         const response = await fetch(
@@ -371,7 +371,7 @@ export function useRemoveWebhookSourceViewFromSpace({
       webhookSourceView,
       space,
     }: {
-      webhookSourceView: WebhookSourceViewWithWebhookSourceType;
+      webhookSourceView: WebhookSourceViewForAdminType;
       space: SpaceType;
     }): Promise<void> => {
       try {

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -18,7 +18,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, errorToString, Ok } from "@app/types";
 import type { TriggerType } from "@app/types/assistant/triggers";
-import type { WebhookSourceType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceForAdminType } from "@app/types/triggers/webhooks";
 
 const WORKSPACE_MESSAGE_LIMIT_MULTIPLIER = 0.1; // 10% of workspace message limit
 const HEADERS_ALLOWED_LIST = ["x-github-event"]; // To avoid storing all headers in GCS, they might contain sensitive information
@@ -117,7 +117,7 @@ export const processWebhookRequest = async (
     headers,
     body,
   }: {
-    webhookSource: WebhookSourceType;
+    webhookSource: WebhookSourceForAdminType;
     headers: IncomingHttpHeaders;
     body: any;
   }

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -141,7 +141,7 @@ async function handler(
   }
 
   await processWebhookRequest(auth, {
-    webhookSource: webhookSource.toJSON(),
+    webhookSource: webhookSource.toJSONForAdmin(),
     headers,
     body,
   });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
@@ -105,6 +105,9 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
         id: expect.any(Number),
         sId: expect.any(String),
         spaceId: regularSpace.sId,
+        webhookSource: expect.objectContaining({
+          sId: webhookSource.sId(),
+        }),
       }),
     });
   });
@@ -140,6 +143,9 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
         id: expect.any(Number),
         sId: expect.any(String),
         spaceId: globalSpace.sId,
+        webhookSource: expect.objectContaining({
+          sId: webhookSource.sId(),
+        }),
       }),
     });
   });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
@@ -105,9 +105,6 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
         id: expect.any(Number),
         sId: expect.any(String),
         spaceId: regularSpace.sId,
-        webhookSource: expect.objectContaining({
-          sId: webhookSource.sId(),
-        }),
       }),
     });
   });
@@ -143,9 +140,6 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
         id: expect.any(Number),
         sId: expect.any(String),
         spaceId: globalSpace.sId,
-        webhookSource: expect.objectContaining({
-          sId: webhookSource.sId(),
-        }),
       }),
     });
   });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
@@ -9,10 +9,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { SpaceKind, WithAPIErrorResponse } from "@app/types";
-import type {
-  WebhookSourceViewType,
-  WebhookSourceViewWithWebhookSourceType,
-} from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 export type GetWebhookSourceViewsResponseBody = {
   success: boolean;
@@ -27,13 +24,6 @@ export type PostWebhookSourceViewResponseBody = {
 const postWebhookSourceViewBodySchema = z.object({
   webhookSourceId: z.string(),
 });
-
-function removeWebhookSourceFromView(
-  view: WebhookSourceViewWithWebhookSourceType
-): WebhookSourceViewType {
-  const { webhookSource: _, ...rest } = view;
-  return rest;
-}
 
 async function handler(
   req: NextApiRequest,
@@ -54,11 +44,9 @@ async function handler(
 
       return res.status(200).json({
         success: true,
-        webhookSourceViews: webhookSourceViewResources
-          .map((webhookSourceViewResource) =>
-            webhookSourceViewResource.toJSON()
-          )
-          .map(removeWebhookSourceFromView),
+        webhookSourceViews: webhookSourceViewResources.map(
+          (webhookSourceViewResource) => webhookSourceViewResource.toJSON()
+        ),
       });
     }
     case "POST": {
@@ -123,9 +111,7 @@ async function handler(
 
       return res.status(200).json({
         success: true,
-        webhookSourceView: removeWebhookSourceFromView(
-          webhookSourceView.toJSON()
-        ),
+        webhookSourceView: webhookSourceView.toJSON(),
       });
     }
     default: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
@@ -9,21 +9,31 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { SpaceKind, WithAPIErrorResponse } from "@app/types";
-import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
+import type {
+  WebhookSourceViewType,
+  WebhookSourceViewWithWebhookSourceType,
+} from "@app/types/triggers/webhooks";
 
 export type GetWebhookSourceViewsResponseBody = {
   success: boolean;
-  webhookSourceViews: WebhookSourceViewWithWebhookSourceType[];
+  webhookSourceViews: WebhookSourceViewType[];
 };
 
 export type PostWebhookSourceViewResponseBody = {
   success: boolean;
-  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
+  webhookSourceView: WebhookSourceViewType;
 };
 
 const postWebhookSourceViewBodySchema = z.object({
   webhookSourceId: z.string(),
 });
+
+function removeWebhookSourceFromView(
+  view: WebhookSourceViewWithWebhookSourceType
+): WebhookSourceViewType {
+  const { webhookSource: _, ...rest } = view;
+  return rest;
+}
 
 async function handler(
   req: NextApiRequest,
@@ -44,9 +54,11 @@ async function handler(
 
       return res.status(200).json({
         success: true,
-        webhookSourceViews: webhookSourceViewResources.map(
-          (webhookSourceViewResource) => webhookSourceViewResource.toJSON()
-        ),
+        webhookSourceViews: webhookSourceViewResources
+          .map((webhookSourceViewResource) =>
+            webhookSourceViewResource.toJSON()
+          )
+          .map(removeWebhookSourceFromView),
       });
     }
     case "POST": {
@@ -111,7 +123,9 @@ async function handler(
 
       return res.status(200).json({
         success: true,
-        webhookSourceView: webhookSourceView.toJSON(),
+        webhookSourceView: removeWebhookSourceFromView(
+          webhookSourceView.toJSON()
+        ),
       });
     }
     default: {

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
@@ -6,11 +6,11 @@ import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resourc
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 export type GetWebhookSourceViewsResponseBody = {
   success: true;
-  views: WebhookSourceViewWithWebhookSourceType[];
+  views: WebhookSourceViewType[];
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -12,7 +12,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import type {
-  WebhookSourceType,
+  WebhookSourceForAdminType,
   WebhookSourceWithViewsAndUsageType,
 } from "@app/types/triggers/webhooks";
 import { postWebhookSourcesSchema } from "@app/types/triggers/webhooks";
@@ -24,7 +24,7 @@ export type GetWebhookSourcesResponseBody = {
 
 export type PostWebhookSourcesResponseBody = {
   success: true;
-  webhookSource: WebhookSourceType;
+  webhookSource: WebhookSourceForAdminType;
 };
 
 async function handler(
@@ -58,14 +58,14 @@ async function handler(
         const webhookSourcesWithViews = await concurrentExecutor(
           webhookSourceResources,
           async (webhookSourceResource) => {
-            const webhookSource = webhookSourceResource.toJSON();
+            const webhookSource = webhookSourceResource.toJSONForAdmin();
             const webhookSourceViewResources =
               await WebhookSourcesViewResource.listByWebhookSource(
                 auth,
                 webhookSource.id
               );
             const views = webhookSourceViewResources.map((view) =>
-              view.toJSON()
+              view.toJSONForAdmin()
             );
 
             return { ...webhookSource, views };
@@ -143,7 +143,7 @@ async function handler(
           throw new Error(webhookSourceRes.error.message);
         }
 
-        const webhookSource = webhookSourceRes.value.toJSON();
+        const webhookSource = webhookSourceRes.value.toJSONForAdmin();
 
         if (includeGlobal) {
           const systemView =

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
@@ -39,7 +39,7 @@ describe("GET /api/w/[wId]/webhook_sources/views/[viewId]", () => {
       await webhookSourceViewFactory.create(globalSpace);
 
     // Get the webhook source name from the toJSON() output since customName can be null
-    const webhookSourceName = webhookSourceView.toJSON().customName;
+    const webhookSourceName = webhookSourceView.toJSONForAdmin().customName;
 
     expect(webhookSourceView).not.toBeNull();
     req.query.viewId = webhookSourceView.sId;
@@ -273,7 +273,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/views/[viewId]", () => {
         .mockResolvedValue(
           new Err(new DustError("internal_error", "Test error"))
         ),
-      toJSON: vi.fn().mockReturnValue(webhookSourceView.toJSON()),
+      toJSON: vi.fn().mockReturnValue(webhookSourceView.toJSONForAdmin()),
     };
 
     const fetchByIdSpy = vi

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -13,15 +13,15 @@ import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import { apiError } from "@app/logger/withlogging";
 import type { Result, WithAPIErrorResponse } from "@app/types";
 import { assertNever, Err, Ok } from "@app/types";
-import type { WebhookSourceViewWithWebhookSourceType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { patchWebhookSourceViewBodySchema } from "@app/types/triggers/webhooks";
 
 export type GetWebhookSourceViewResponseBody = {
-  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
+  webhookSourceView: WebhookSourceViewType;
 };
 
 export type PatchWebhookSourceViewResponseBody = {
-  webhookSourceView: WebhookSourceViewWithWebhookSourceType;
+  webhookSourceView: WebhookSourceViewType;
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.ts
@@ -10,10 +10,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
-import type {
-  WebhookSourceViewType,
-  WebhookSourceViewWithWebhookSourceType,
-} from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 const GetWebhookSourceViewsRequestSchema = z.object({
   spaceIds: z.array(z.string()),
@@ -83,9 +80,7 @@ async function handler(
 
       const flattenedWebhookSourceViews = webhookSourceViews
         .flat()
-        .filter((v): v is WebhookSourceViewWithWebhookSourceType => v !== null)
-        // map to WebhookSourceViewType: copy all fields but the webhookSource field
-        .map(({ webhookSource: _, ...rest }) => rest);
+        .filter((v): v is WebhookSourceViewType => v !== null);
 
       return res.status(200).json({
         success: true,

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -46,19 +46,22 @@ export type WebhookSourceType = {
   id: ModelId;
   sId: string;
   name: string;
-  urlSecret: string;
   kind: WebhookSourceKind;
-  secret: string | null;
-  signatureHeader: string | null;
-  signatureAlgorithm: WebhookSourceSignatureAlgorithm | null;
-  remoteMetadata: Record<string, any> | null;
-  oauthConnectionId: string | null;
   createdAt: number;
   updatedAt: number;
   subscribedEvents: string[];
 };
 
-export type WebhookSourceViewType = {
+export type WebhookSourceForAdminType = WebhookSourceType & {
+  urlSecret: string;
+  secret: string | null;
+  signatureHeader: string | null;
+  signatureAlgorithm: WebhookSourceSignatureAlgorithm | null;
+  remoteMetadata: Record<string, any> | null;
+  oauthConnectionId: string | null;
+};
+
+type BaseWebhookSourceViewType = {
   id: ModelId;
   sId: string;
   customName: string;
@@ -71,17 +74,20 @@ export type WebhookSourceViewType = {
   spaceId: string;
   editedByUser: EditedByUser | null;
 };
-
-export type WebhookSourceViewWithWebhookSourceType = WebhookSourceViewType & {
+export type WebhookSourceViewType = BaseWebhookSourceViewType & {
   webhookSource: WebhookSourceType;
 };
 
-export type WebhookSourceWithViewsType = WebhookSourceType & {
-  views: WebhookSourceViewWithWebhookSourceType[];
+export type WebhookSourceViewForAdminType = BaseWebhookSourceViewType & {
+  webhookSource: WebhookSourceForAdminType;
+};
+
+export type WebhookSourceWithViewsType = WebhookSourceForAdminType & {
+  views: WebhookSourceViewForAdminType[];
 };
 
 export type WebhookSourceWithSystemViewType = WebhookSourceWithViewsType & {
-  systemView: WebhookSourceViewWithWebhookSourceType | null;
+  systemView: WebhookSourceViewForAdminType | null;
 };
 
 export type WebhookSourceWithViewsAndUsageType = WebhookSourceWithViewsType & {


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/4750

Change returned type of webhook source view endpoint to not return the webhook source info

## Tests

manual test

## Risk

low

## Deploy Plan

deploy front
