### PR TITLE
ConversationMessage: reduce avatar size

### DIFF
--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -198,20 +198,11 @@ export const ConversationMessageHeader = React.forwardRef<
         {...props}
       >
         <Avatar
-          className="@sm:s-hidden"
           name={name}
           visual={avatarUrl}
           busy={isBusy}
           disabled={isDisabled}
           size="xs"
-        />
-        <Avatar
-          className="s-hidden @sm:s-flex"
-          name={name}
-          visual={avatarUrl}
-          busy={isBusy}
-          disabled={isDisabled}
-          size="sm"
         />
         <div className="s-inline-flex s-w-full s-justify-between s-gap-0.5">
           <div className="s-inline-flex s-items-baseline s-gap-2 s-text-foreground dark:s-text-foreground-night">

--- a/sparkle/src/stories/ConversationMessage.stories.tsx
+++ b/sparkle/src/stories/ConversationMessage.stories.tsx
@@ -202,7 +202,7 @@ export const ConversationHandoffExample = () => {
           </ConversationMessage>
           <ConversationMessage
             type="agent"
-            name="@soupinou"
+            name="soupinou"
             timestamp="17:10"
             pictureUrl="https://avatars.githubusercontent.com/u/138893015?&v=4"
             buttons={[
@@ -227,7 +227,7 @@ export const ConversationHandoffExample = () => {
             />
           </ConversationMessage>
           <ConversationMessage
-            name="@deep-dive"
+            name="deep-dive"
             type="agent"
             completionStatus={
               <span className="s-flex s-cursor-pointer s-items-center s-gap-1 s-text-xs">


### PR DESCRIPTION
## Description

Are you sure it's not too small? (Screenshots are from Sparkle so not exactly the in-app conversation layout)

### Before: 
<kbd>
<img width="998" height="1153" alt="Screenshot 2025-10-21 at 09 44 41" src="https://github.com/user-attachments/assets/80d1846e-7539-4e12-a6ed-461af69fb27c" />
</kbd>

### After: 
<kbd>
<img width="992" height="1140" alt="Screenshot 2025-10-21 at 09 44 55" src="https://github.com/user-attachments/assets/dc6ba3ec-aea5-4a16-904d-8aae9859c074" />
</kbd>

## Tests

Manual on Sparkle. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish Sparkle. 
