### PR TITLE
[front] Parse tool inputs from params instead of output resources

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -11,6 +11,12 @@ import {
 import { useEffect, useState } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import {
+  makeQueryTextForDataSourceSearch,
+  makeQueryTextForFind,
+  makeQueryTextForInclude,
+  makeQueryTextForList,
+} from "@app/components/actions/mcp/details/input_rendering";
 import { MCPAgentManagementActionDetails } from "@app/components/actions/mcp/details/MCPAgentManagementActionDetails";
 import { MCPBrowseActionDetails } from "@app/components/actions/mcp/details/MCPBrowseActionDetails";
 import {
@@ -54,16 +60,17 @@ import {
   isResourceContentWithText,
   isTextContent,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { makeQueryResource } from "@app/lib/actions/mcp_internal_actions/rendering";
+import {
+  isDataSourceFilesystemFindInputType,
+  isDataSourceFilesystemListInputType,
+  isIncludeInputType,
+  isSearchInputType,
+  isWebsearchInputType,
+} from "@app/lib/actions/mcp_internal_actions/types";
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils";
 import { isValidJSON } from "@app/lib/utils/json";
 import type { LightWorkspaceType } from "@app/types";
-import {
-  asDisplayName,
-  isString,
-  isSupportedImageContentType,
-  parseTimeFrame,
-} from "@app/types";
+import { asDisplayName, isSupportedImageContentType } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 export interface MCPActionDetailsProps {
@@ -124,26 +131,20 @@ export function MCPActionDetails({
     isInternalMCPServerOfName(mcpServerId, "search") ||
     isInternalMCPServerOfName(mcpServerId, "data_sources_file_system")
   ) {
-    if (toolName === SEARCH_TOOL_NAME && isString(params.relativeTimeFrame)) {
-      const timeFrame = parseTimeFrame(params.relativeTimeFrame);
-      // TODO: remove these typecasts
-      const queryResource = makeQueryResource({
-        query: params.query as string,
-        timeFrame: timeFrame,
-        tagsIn: params.tagsIn as string[],
-        tagsNot: params.tagsNot as string[],
-        nodeIds: params.nodeIds as string[],
-      });
-
+    if (toolName === SEARCH_TOOL_NAME) {
       return (
         <SearchResultDetails
           viewType={viewType}
-          defaultQuery={queryResource.text}
           actionName={
             viewType === "conversation" ? "Searching data" : "Search data"
           }
           actionOutput={output}
           visual={MagnifyingGlassIcon}
+          query={
+            isSearchInputType(params)
+              ? makeQueryTextForDataSourceSearch(params)
+              : null
+          }
         />
       );
     }
@@ -161,6 +162,13 @@ export function MCPActionDetails({
               : "Browse data sources"
           }
           actionOutput={output}
+          query={
+            isDataSourceFilesystemFindInputType(params)
+              ? makeQueryTextForFind(params)
+              : isDataSourceFilesystemListInputType(params)
+                ? makeQueryTextForList(params)
+                : null
+          }
           visual={ActionDocumentTextIcon}
         />
       );
@@ -185,6 +193,11 @@ export function MCPActionDetails({
           }
           actionOutput={output}
           visual={ClockIcon}
+          query={
+            isIncludeInputType(params)
+              ? makeQueryTextForInclude({ timeFrame: params.timeFrame ?? null })
+              : null
+          }
         />
       );
     }
@@ -195,7 +208,7 @@ export function MCPActionDetails({
       return (
         <SearchResultDetails
           viewType={viewType}
-          defaultQuery={params.query as string}
+          query={isWebsearchInputType(params) ? params.query : null}
           actionName={
             viewType === "conversation" ? "Searching the web" : "Web search"
           }

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -28,12 +28,9 @@ import type {
 import {
   isDataSourceNodeContentType,
   isDataSourceNodeListType,
-  isIncludeQueryResourceType,
   isIncludeResultResourceType,
-  isSearchQueryResourceType,
   isSearchResultResourceType,
   isWarningResourceType,
-  isWebsearchQueryResourceType,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getDocumentIcon } from "@app/lib/content_nodes";
@@ -178,37 +175,20 @@ export function ToolGeneratedFileDetails({
 
 interface SearchResultProps {
   actionName: string;
-  defaultQuery?: string;
   visual: React.ComponentType<{ className?: string }>;
   actionOutput: CallToolResult["content"] | null;
   viewType: "conversation" | "sidebar";
+  query: string | null;
 }
 
 export function SearchResultDetails({
   actionName,
-  defaultQuery,
   visual,
   viewType,
   actionOutput,
+  query,
 }: SearchResultProps) {
-  const query =
-    actionOutput
-      ?.map((r) => {
-        if (
-          isSearchQueryResourceType(r) ||
-          isWebsearchQueryResourceType(r) ||
-          isIncludeQueryResourceType(r)
-        ) {
-          return r.resource.text.trim();
-        }
-        return null;
-      })
-      .filter(Boolean)
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      .join("\n") ||
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    defaultQuery ||
-    "No query provided";
+  const displayQuery = query ?? "No query provided";
 
   const warning = actionOutput
     ?.filter(isWarningResourceType)
@@ -288,7 +268,7 @@ export function SearchResultDetails({
     >
       {viewType === "conversation" ? (
         <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-          {query}
+          {displayQuery}
         </div>
       ) : (
         <div className="flex flex-col gap-4 pl-6 pt-4">
@@ -297,7 +277,7 @@ export function SearchResultDetails({
               Query
             </span>
             <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-              {query}
+              {displayQuery}
             </div>
             {warning && (
               <Tooltip

--- a/front/components/actions/mcp/details/input_rendering.ts
+++ b/front/components/actions/mcp/details/input_rendering.ts
@@ -1,0 +1,100 @@
+import type {
+  DataSourceFilesystemFindInputType,
+  DataSourceFilesystemListInputType,
+  SearchInputTypeWithTags,
+} from "@app/lib/actions/mcp_internal_actions/types";
+import type { TimeFrame } from "@app/types";
+import { parseTimeFrame } from "@app/types";
+
+function renderMimeType(mimeType: string) {
+  return mimeType
+    .replace("application/vnd.dust.", "")
+    .replace("-", " ")
+    .replace(".", " ");
+}
+
+function renderRelativeTimeFrame(relativeTimeFrame: TimeFrame | null): string {
+  return relativeTimeFrame
+    ? "over the last " +
+        (relativeTimeFrame.duration > 1
+          ? `${relativeTimeFrame.duration} ${relativeTimeFrame.unit}s`
+          : `${relativeTimeFrame.unit}`)
+    : "across all time periods";
+}
+
+function renderTagsForToolOutput(
+  tagsIn?: string[],
+  tagsNot?: string[]
+): string {
+  const tagsInAsString =
+    tagsIn && tagsIn.length > 0 ? `, with labels ${tagsIn?.join(", ")}` : "";
+  const tagsNotAsString =
+    tagsNot && tagsNot.length > 0
+      ? `, excluding labels ${tagsNot?.join(", ")}`
+      : "";
+  return `${tagsInAsString}${tagsNotAsString}`;
+}
+
+function renderSearchNodeIds(nodeIds?: string[]): string {
+  return nodeIds && nodeIds.length > 0
+    ? `within ${nodeIds.length} different subtrees `
+    : "";
+}
+
+export function makeQueryTextForDataSourceSearch({
+  query,
+  relativeTimeFrame,
+  tagsIn,
+  tagsNot,
+  nodeIds,
+}: SearchInputTypeWithTags): string {
+  const timeFrameAsString = renderRelativeTimeFrame(
+    parseTimeFrame(relativeTimeFrame)
+  );
+  const tagsAsString = renderTagsForToolOutput(tagsIn, tagsNot);
+  const nodeIdsAsString = renderSearchNodeIds(nodeIds);
+
+  return query
+    ? `Searching "${query}" ${nodeIdsAsString}${timeFrameAsString}${tagsAsString}.`
+    : `Searching ${timeFrameAsString}${tagsAsString}.`;
+}
+
+export function makeQueryTextForFind({
+  query,
+  rootNodeId,
+  mimeTypes,
+  nextPageCursor,
+}: DataSourceFilesystemFindInputType): string {
+  const queryText = query ? ` "${query}"` : " all content";
+  const scope = rootNodeId
+    ? ` under ${rootNodeId}`
+    : " across the entire data sources";
+  const types = mimeTypes?.length
+    ? ` (${mimeTypes.map(renderMimeType).join(", ")} files)`
+    : "";
+  const pagination = nextPageCursor ? " - next page" : "";
+
+  return `Searching for${queryText}${scope}${types}${pagination}.`;
+}
+
+export function makeQueryTextForList({
+  nodeId,
+  mimeTypes,
+  nextPageCursor,
+}: DataSourceFilesystemListInputType): string {
+  const location = nodeId ? ` within node "${nodeId}"` : " at the root level";
+  const types = mimeTypes?.length
+    ? ` (${mimeTypes.map(renderMimeType).join(", ")} files)`
+    : "";
+  const pagination = nextPageCursor ? " - next page" : "";
+
+  return `Listing content${location}${types}${pagination}.`;
+}
+
+export function makeQueryTextForInclude({
+  timeFrame,
+}: {
+  timeFrame: TimeFrame | null;
+}): string {
+  return renderRelativeTimeFrame(timeFrame);
+}

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -59,6 +59,20 @@ export const TagsInputSchema = z.object({
     ),
 });
 
+type TagsInputType = z.infer<typeof TagsInputSchema>;
+
+export type SearchInputTypeWithTags = SearchWithNodesInputType & TagsInputType;
+
+export function isSearchInputType(
+  input: Record<string, unknown>
+): input is SearchInputTypeWithTags {
+  return (
+    SearchWithNodesInputSchema.safeParse(input).success ||
+    SearchWithNodesInputSchema.extend(TagsInputSchema.shape).safeParse(input)
+      .success
+  );
+}
+
 export const IncludeInputSchema = z.object({
   timeFrame:
     ConfigurableToolInputSchemas[
@@ -67,6 +81,17 @@ export const IncludeInputSchema = z.object({
   dataSources:
     ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
 });
+
+export type IncludeInputType = z.infer<typeof IncludeInputSchema>;
+
+export function isIncludeInputType(
+  input: Record<string, unknown>
+): input is IncludeInputType {
+  return (
+    IncludeInputSchema.safeParse(input).success ||
+    IncludeInputSchema.extend(TagsInputSchema.shape).safeParse(input).success
+  );
+}
 
 export const WebsearchInputSchema = z.object({
   query: z
@@ -85,6 +110,14 @@ export const WebsearchInputSchema = z.object({
         " to go deeper into the search results for a specific query."
     ),
 });
+
+export type WebsearchInputType = z.infer<typeof WebsearchInputSchema>;
+
+export function isWebsearchInputType(
+  input: Record<string, unknown>
+): input is WebsearchInputType {
+  return WebsearchInputSchema.safeParse(input).success;
+}
 
 export const DataSourceFilesystemFindInputSchema = z.object({
   query: z
@@ -131,6 +164,16 @@ export const DataSourceFilesystemFindInputSchema = z.object({
     ),
 });
 
+export type DataSourceFilesystemFindInputType = z.infer<
+  typeof DataSourceFilesystemFindInputSchema
+>;
+
+export function isDataSourceFilesystemFindInputType(
+  input: Record<string, unknown>
+): input is DataSourceFilesystemFindInputType {
+  return DataSourceFilesystemFindInputSchema.safeParse(input).success;
+}
+
 export const DataSourceFilesystemListInputSchema = z.object({
   nodeId: z
     .string()
@@ -173,3 +216,13 @@ export const DataSourceFilesystemListInputSchema = z.object({
         "the previous search result."
     ),
 });
+
+export type DataSourceFilesystemListInputType = z.infer<
+  typeof DataSourceFilesystemListInputSchema
+>;
+
+export function isDataSourceFilesystemListInputType(
+  input: Record<string, unknown>
+): input is DataSourceFilesystemListInputType {
+  return DataSourceFilesystemListInputSchema.safeParse(input).success;
+}


### PR DESCRIPTION
## Description

- Part of ongoing work to stop returning the inputs of a tool in its output.
- This PR starts by reading the data from the tool inputs rather than the output.
- Another PR will do the same for the Chrome extension.
- Once published, we'll be able to remove the outputs.

## Tests

- Tested locally and on front-edge.

## Risk

- Touches a lot of critical tools

## Deploy Plan

- Deploy front.
