### PR TITLE
[front] enh(oauth): add check on workspace ID

### DIFF
--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -280,23 +280,11 @@ export async function checkConnectionOwnership(
   });
   if (
     connectionRes.isErr() ||
-    connectionRes.value.connection.metadata.user_id !== auth.user()?.sId
+    connectionRes.value.connection.metadata.user_id !== auth.user()?.sId ||
+    connectionRes.value.connection.metadata.workspace_id !==
+      auth.workspace()?.sId
   ) {
     return new Err(new Error("Invalid connection"));
-  }
-  if (
-    connectionRes.value.connection.metadata.workspace_id !==
-    auth.workspace()?.sId
-  ) {
-    logger.error(
-      {
-        connectionWorkspaceId:
-          connectionRes.value.connection.metadata.workspace_id,
-        workspaceId: auth.workspace()?.sId,
-        userId: connectionRes.value.connection.metadata.user_id,
-      },
-      "OAuth: Connection does not belong to this workspace"
-    );
   }
 
   return new Ok(undefined);


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/4747.
- Follow up on https://github.com/dust-tt/dust/pull/17075, turns the log into a check.
- Will merge at 5pm today

## Tests

- No log [here](https://app.datadoghq.eu/logs?query=%22OAuth%3A%20Connection%20does%20not%20belong%20to%20this%20workspace%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760427993854&to_ts=1761032793854&live=true) for a day.

## Risk

## Deploy Plan

- Deploy front.
