### PR TITLE
Preserve visualizationEnabled in the PublicAPI

### DIFF
--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -171,6 +171,8 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
       templateId: agent.templateId
         ? TemplateResource.modelIdToSId({ id: agent.templateId })
         : null,
+      // TODO(2025-10-20 flav): Remove once SDK JS does not rely on it anymore.
+      visualizationEnabled: false,
       // TODO(2025-10-17 thomas): Remove requestedGroupIds.
       requestedGroupIds: agent.requestedGroupIds.map((groups) =>
         groups.map((id) =>

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -386,6 +386,11 @@ function getGlobalAgent({
       return null;
   }
 
+  // TODO(2025-10-20 flav): Remove once SDK JS does not rely on it anymore.
+  if (agentConfiguration) {
+    agentConfiguration.visualizationEnabled = false;
+  }
+
   return agentConfiguration;
 }
 

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -139,6 +139,9 @@ export type LightAgentConfigurationType = {
 
   templateId: string | null;
 
+  // TODO(2025-10-20 flav): Remove once SDK JS does not rely on it anymore.
+  visualizationEnabled?: boolean;
+
   // TODO(2025-10-17 thomas): Remove this.
   // Group restrictions for accessing the agent/conversation. Deprecated
   // The array of arrays represents permission requirements:

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -843,7 +843,7 @@ const LightAgentConfigurationSchema = z.object({
   usage: AgentUsageTypeSchema.optional(),
   maxStepsPerRun: z.number(),
   // TODO(2025-10-20 flav): Remove once SDK JS does not rely on it anymore.
-  visualizationEnabled: z.boolean(),
+  visualizationEnabled: z.boolean().optional(),
   templateId: z.string().nullable(),
   groupIds: z.array(z.string()).optional(),
   requestedGroupIds: z.array(z.array(z.string())),

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -842,6 +842,8 @@ const LightAgentConfigurationSchema = z.object({
   lastAuthors: AgentRecentAuthorsSchema.optional(),
   usage: AgentUsageTypeSchema.optional(),
   maxStepsPerRun: z.number(),
+  // TODO(2025-10-20 flav): Remove once SDK JS does not rely on it anymore.
+  visualizationEnabled: z.boolean(),
   templateId: z.string().nullable(),
   groupIds: z.array(z.string()).optional(),
   requestedGroupIds: z.array(z.array(z.string())),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/16990 which introduced a regression by removing `visualizationEnabled` too quickly from the SDK JS leading to issue on Public API usage.

This PR adds it back as optional and always set the value to false.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
