### PR TITLE
[Mentions] GPT-5 before GPT-4 in mention dropdown

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/suggestion.ts
+++ b/front/components/assistant/conversation/input_bar/editor/suggestion.ts
@@ -20,6 +20,10 @@ const SUGGESTION_DISPLAY_LIMIT = 7;
 const SUGGESTION_PRIORITY: Record<string, number> = {
   [GLOBAL_AGENTS_SID.DUST]: 1,
   [GLOBAL_AGENTS_SID.DEEP_DIVE]: 2,
+  // Ensure GPT-5 appears before GPT-4 in mentions dropdown when sorting
+  // by fuzzy match results. Lower numbers mean higher priority.
+  [GLOBAL_AGENTS_SID.GPT5]: 3,
+  [GLOBAL_AGENTS_SID.GPT4]: 4,
 };
 
 function filterAndSortSuggestions(


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/4734

Adjust mention dropdown sorting so GPT-5 appears before GPT-4 when filtering suggestions by query. Implemented via explicit priority in the mention suggestion sorter, without altering overall fuzzy-match ranking or display limit.

## Risks
Blast radius: assistant mention dropdown ordering only.
Risk: low

## Deploy Plan
- deploy front
