### PR TITLE
Allow Power Automate Origin

### DIFF
--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -6,6 +6,8 @@ const STATIC_ALLOWED_ORIGINS = [
   "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn",
   // Documentation website.
   "https://docs.dust.tt",
+  // Microsoft Power Automate.
+  "https://make.powerautomate.com",
 ] as const;
 
 const ALLOWED_ORIGIN_PATTERNS = [


### PR DESCRIPTION
## Description

When Power Automate calls our endpoint, there is a Origin header equal to 
You must whitelist this origin to make the api calls work from Power Automate.
Confirmed by Claude: https://dust.tt/w/0ec9852c2f/conversation/TGUMLn2VBH

## Tests

Created a new Custom Connector on Power Automate and use their test tool to call the Dust api.

## Risk

Low

## Deploy Plan

Deploy front
