### PR TITLE
[LLM Router] Move dust-apps specific code in new file

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_action.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_action.ts
@@ -85,7 +85,7 @@ export async function getOutputFromAction(
   Result<
     {
       output: Output;
-      dustRunId: Promise<string>;
+      dustRunId: string;
       nativeChainOfThought: string;
     },
     | { type: "shouldRetryMessage"; message: string }
@@ -311,7 +311,7 @@ export async function getOutputFromAction(
 
   return new Ok({
     output: blockExecutionOutput,
-    dustRunId: blockExecutionDustRunId,
+    dustRunId: await blockExecutionDustRunId,
     nativeChainOfThought: blockExecutionNativeChainOfThought,
   });
 }

--- a/front/temporal/agent_loop/lib/get_output_from_action.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_action.ts
@@ -1,0 +1,313 @@
+import { CancelledFailure, heartbeat, sleep } from "@temporalio/activity";
+
+import {
+  isDustAppChatBlockType,
+  runActionStreamed,
+} from "@app/lib/actions/server";
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import type { AgentMessageContentParser } from "@app/lib/api/assistant/agent_message_content_parser";
+import { config as regionsConfig } from "@app/lib/api/regions/config";
+import type { Authenticator } from "@app/lib/auth";
+import type { AgentMessage } from "@app/lib/models/assistant/conversation";
+import logger from "@app/logger/logger";
+import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
+import type {
+  AgentConfigurationType,
+  AgentMessageType,
+  ConversationType,
+  ModelConfigurationType,
+  ModelConversationTypeMultiActions,
+  Ok,
+  UserMessageType,
+} from "@app/types";
+import type {
+  FunctionCallContentType,
+  ReasoningContentType,
+  TextContentType,
+} from "@app/types/assistant/agent_message_content";
+
+type Output = {
+  actions: Array<{
+    functionCallId: string;
+    name: string | null;
+    arguments: Record<string, string | boolean | number> | null;
+  }>;
+  generation: string | null;
+  contents: Array<
+    TextContentType | FunctionCallContentType | ReasoningContentType
+  >;
+};
+
+type GetOutputFromActionResponse =
+  | { shouldRetryMessage: string }
+  | {
+      output: Output;
+      dustRunId: Promise<string>;
+      nativeChainOfThought: string;
+    }
+  | { shouldReturnNull: true };
+
+type GetOutputFromActionInput = {
+  modelConversationRes: Ok<{
+    modelConversation: ModelConversationTypeMultiActions;
+    tokensUsed: number;
+  }>;
+  conversation: ConversationType;
+  userMessage: UserMessageType;
+  runConfig: any;
+  specifications: AgentActionSpecification[];
+  flushParserTokens: () => Promise<void>;
+  contentParser: AgentMessageContentParser;
+  agentMessageRow: AgentMessage;
+  step: number;
+  agentConfiguration: AgentConfigurationType;
+  agentMessage: AgentMessageType;
+  model: ModelConfigurationType;
+  publishAgentError: (error: {
+    code: string;
+    message: string;
+    metadata: Record<string, string | number | boolean> | null;
+  }) => Promise<void>;
+  prompt: string;
+};
+
+export async function getOutputFromAction(
+  auth: Authenticator,
+  {
+    modelConversationRes,
+    conversation,
+    userMessage,
+    runConfig,
+    specifications,
+    flushParserTokens,
+    contentParser,
+    agentMessageRow,
+    step,
+    agentConfiguration,
+    agentMessage,
+    model,
+    publishAgentError,
+    prompt,
+  }: GetOutputFromActionInput
+): Promise<GetOutputFromActionResponse> {
+  let blockExecutionOutput: Output | null = null;
+  let blockExecutionNativeChainOfThought = "";
+  let blockExecutionDustRunId: Promise<string>;
+
+  const res = await runActionStreamed(
+    auth,
+    "assistant-v2-multi-actions-agent",
+    runConfig,
+    [
+      {
+        conversation: modelConversationRes.value.modelConversation,
+        specifications,
+        prompt,
+      },
+    ],
+    {
+      conversationId: conversation.sId,
+      workspaceId: conversation.owner.sId,
+      userMessageId: userMessage.sId,
+    }
+  );
+
+  if (res.isErr()) {
+    return { shouldRetryMessage: res.error.message };
+  }
+
+  const { eventStream, dustRunId: dustRunIdValue } = res.value;
+  // eslint-disable-next-line prefer-const
+  blockExecutionDustRunId = dustRunIdValue;
+
+  let isGeneration = true;
+
+  for await (const event of eventStream) {
+    if (event.type === "function_call") {
+      isGeneration = false;
+    }
+
+    if (event.type === "error") {
+      await flushParserTokens();
+      return { shouldRetryMessage: event.content.message };
+    }
+
+    // Heartbeat & sleep allow the activity to be cancelled, e.g. on a "Stop
+    // agent" request. Upon experimentation, both are needed to ensure the
+    // activity receives the cancellation signal. The delay until which is the
+    // signal is received is governed by heartbeat
+    // [throttling](https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling).
+    heartbeat();
+    try {
+      await sleep(1);
+    } catch (err) {
+      if (err instanceof CancelledFailure) {
+        logger.info("Activity cancelled, stopping");
+        return { shouldReturnNull: true };
+      }
+      throw err;
+    }
+
+    if (event.type === "tokens" && isGeneration) {
+      for await (const tokenEvent of contentParser.emitTokens(
+        event.content.tokens.text
+      )) {
+        await updateResourceAndPublishEvent(auth, {
+          event: tokenEvent,
+          agentMessageRow,
+          conversation,
+          step,
+        });
+      }
+    }
+
+    if (event.type === "reasoning_tokens") {
+      await updateResourceAndPublishEvent(auth, {
+        event: {
+          type: "generation_tokens",
+          classification: "chain_of_thought",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          text: event.content.tokens.text,
+        },
+        agentMessageRow,
+        conversation,
+        step,
+      });
+
+      blockExecutionNativeChainOfThought += event.content.tokens.text;
+    }
+
+    if (event.type === "reasoning_item") {
+      await updateResourceAndPublishEvent(auth, {
+        event: {
+          type: "generation_tokens",
+          classification: "chain_of_thought",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          messageId: agentMessage.sId,
+          text: "\n\n",
+        },
+        agentMessageRow,
+        conversation,
+        step,
+      });
+
+      blockExecutionNativeChainOfThought += "\n\n";
+    }
+
+    if (event.type === "block_execution") {
+      const e = event.content.execution[0][0];
+      if (e.error) {
+        await flushParserTokens();
+        return { shouldRetryMessage: e.error };
+      }
+
+      if (event.content.block_name === "MODEL" && e.value) {
+        // Flush early as we know the generation is terminated here.
+        await flushParserTokens();
+
+        const block = e.value;
+        if (!isDustAppChatBlockType(block)) {
+          return {
+            shouldRetryMessage: "Received unparsable MODEL block.",
+          };
+        }
+
+        // Extract token usage from block execution metadata
+        const meta = e.meta as {
+          token_usage?: {
+            prompt_tokens: number;
+            completion_tokens: number;
+            reasoning_tokens?: number;
+            cached_tokens?: number;
+          };
+        } | null;
+        const reasoningTokens = meta?.token_usage?.reasoning_tokens ?? 0;
+
+        // Pass the current region, which helps decide whether encrypted blocks are usable
+        const currentRegion = regionsConfig.getCurrentRegion();
+        let region: "us" | "eu";
+        switch (currentRegion) {
+          case "europe-west1":
+            region = "eu";
+            break;
+          case "us-central1":
+            region = "us";
+            break;
+          default:
+            throw new Error(`Unexpected region: ${currentRegion}`);
+        }
+
+        const contents = (block.message.contents ?? []).map((content) => {
+          if (content.type === "reasoning") {
+            return {
+              ...content,
+              value: {
+                ...content.value,
+                tokens: 0, // Will be updated for the last reasoning item
+                provider: model.providerId,
+                region,
+              },
+            } satisfies ReasoningContentType;
+          }
+          return content;
+        });
+
+        // We unfortunately don't currently have a proper breakdown of reasoning tokens per item,
+        // so we set the reasoning token count on the last reasoning item.
+        for (let i = contents.length - 1; i >= 0; i--) {
+          const content = contents[i];
+          if (content.type === "reasoning") {
+            content.value.tokens = reasoningTokens;
+            contents[i] = content;
+            break;
+          }
+        }
+
+        blockExecutionOutput = {
+          actions: [],
+          generation: null,
+          contents,
+        };
+
+        if (block.message.function_calls?.length) {
+          for (const fc of block.message.function_calls) {
+            try {
+              const args = JSON.parse(fc.arguments);
+              blockExecutionOutput.actions.push({
+                name: fc.name,
+                functionCallId: fc.id,
+                arguments: args,
+              });
+            } catch (error) {
+              await publishAgentError({
+                code: "function_call_error",
+                message: `Error parsing function call arguments: ${error}`,
+                metadata: null,
+              });
+              return { shouldReturnNull: true };
+            }
+          }
+        } else {
+          blockExecutionOutput.generation = block.message.content ?? null;
+        }
+      }
+    }
+  }
+
+  await flushParserTokens();
+
+  if (!blockExecutionOutput) {
+    return {
+      shouldRetryMessage: "Agent execution didn't complete.",
+    };
+  }
+
+  return {
+    output: blockExecutionOutput,
+    dustRunId: blockExecutionDustRunId,
+    nativeChainOfThought: blockExecutionNativeChainOfThought,
+  };
+}

--- a/front/temporal/agent_loop/lib/get_output_from_action.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_action.ts
@@ -94,7 +94,6 @@ export async function getOutputFromAction(
 > {
   let blockExecutionOutput: Output | null = null;
   let blockExecutionNativeChainOfThought = "";
-  let blockExecutionDustRunId: Promise<string>;
 
   const res = await runActionStreamed(
     auth,
@@ -118,9 +117,7 @@ export async function getOutputFromAction(
     return new Err({ type: "shouldRetryMessage", message: res.error.message });
   }
 
-  const { eventStream, dustRunId: dustRunIdValue } = res.value;
-  // eslint-disable-next-line prefer-const
-  blockExecutionDustRunId = dustRunIdValue;
+  const { eventStream, dustRunId: blockExecutionDustRunId } = res.value;
 
   let isGeneration = true;
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1,4 +1,3 @@
-import { CancelledFailure, heartbeat, sleep } from "@temporalio/activity";
 import assert from "assert";
 
 import { buildToolSpecification } from "@app/lib/actions/mcp";
@@ -7,10 +6,6 @@ import {
   tryListMCPTools,
 } from "@app/lib/actions/mcp_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import {
-  isDustAppChatBlockType,
-  runActionStreamed,
-} from "@app/lib/actions/server";
 import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { computeStepContexts } from "@app/lib/actions/utils";
@@ -32,7 +27,6 @@ import { isLegacyAgentConfiguration } from "@app/lib/api/assistant/legacy_agent"
 import { fetchMessageInConversation } from "@app/lib/api/assistant/messages";
 import config from "@app/lib/api/config";
 import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
-import { config as regionsConfig } from "@app/lib/api/regions/config";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
@@ -42,21 +36,10 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
+import { getOutputFromAction } from "@app/temporal/agent_loop/lib/get_output_from_action";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
-import type {
-  AgentActionsEvent,
-  ConversationType,
-  ModelConversationTypeMultiActions,
-  ModelId,
-  Ok,
-  UserMessageType,
-} from "@app/types";
+import type { AgentActionsEvent, ModelId } from "@app/types";
 import { removeNulls } from "@app/types";
-import type {
-  FunctionCallContentType,
-  ReasoningContentType,
-  TextContentType,
-} from "@app/types/assistant/agent_message_content";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 
 const MAX_AUTO_RETRY = 3;
@@ -422,278 +405,35 @@ export async function runModelActivity(
     getDelimitersConfiguration({ agentConfiguration })
   );
 
-  type Output = {
-    actions: Array<{
-      functionCallId: string;
-      name: string | null;
-      arguments: Record<string, string | boolean | number> | null;
-    }>;
-    generation: string | null;
-    contents: Array<
-      TextContentType | FunctionCallContentType | ReasoningContentType
-    >;
-  };
-
-  type GetOutputFromActionResponse =
-    | { shouldRetryMessage: string }
-    | {
-        output: Output;
-        dustRunId: Promise<string>;
-        nativeChainOfThought: string;
-      }
-    | { shouldReturnNull: true };
-
-  type GetOutputFromActionInput = {
-    modelConversationRes: Ok<{
-      modelConversation: ModelConversationTypeMultiActions;
-      tokensUsed: number;
-    }>;
-    conversation: ConversationType;
-    userMessage: UserMessageType;
-  };
-
-  async function getOutputFromAction({
+  const getOutputFromActionResponse = await getOutputFromAction(auth, {
     modelConversationRes,
     conversation,
     userMessage,
-  }: GetOutputFromActionInput): Promise<GetOutputFromActionResponse> {
-    let blockExecutionOutput: Output | null = null;
-    let blockExecutionNativeChainOfThought = "";
-    let blockExecutionDustRunId: Promise<string>;
-
-    const res = await runActionStreamed(
-      auth,
-      "assistant-v2-multi-actions-agent",
-      runConfig,
-      [
-        {
-          conversation: modelConversationRes.value.modelConversation,
-          specifications,
-          prompt,
-        },
-      ],
-      {
-        conversationId: conversation.sId,
-        workspaceId: conversation.owner.sId,
-        userMessageId: userMessage.sId,
-      }
-    );
-
-    if (res.isErr()) {
-      return { shouldRetryMessage: res.error.message };
-    }
-
-    const { eventStream, dustRunId: dustRunIdValue } = res.value;
-    // eslint-disable-next-line prefer-const
-    blockExecutionDustRunId = dustRunIdValue;
-
-    let isGeneration = true;
-
-    for await (const event of eventStream) {
-      if (event.type === "function_call") {
-        isGeneration = false;
-      }
-
-      if (event.type === "error") {
-        await flushParserTokens();
-        return { shouldRetryMessage: event.content.message };
-      }
-
-      // Heartbeat & sleep allow the activity to be cancelled, e.g. on a "Stop
-      // agent" request. Upon experimentation, both are needed to ensure the
-      // activity receives the cancellation signal. The delay until which is the
-      // signal is received is governed by heartbeat
-      // [throttling](https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling).
-      heartbeat();
-      try {
-        await sleep(1);
-      } catch (err) {
-        if (err instanceof CancelledFailure) {
-          logger.info("Activity cancelled, stopping");
-          return { shouldReturnNull: true };
-        }
-        throw err;
-      }
-
-      if (event.type === "tokens" && isGeneration) {
-        for await (const tokenEvent of contentParser.emitTokens(
-          event.content.tokens.text
-        )) {
-          await updateResourceAndPublishEvent(auth, {
-            event: tokenEvent,
-            agentMessageRow,
-            conversation,
-            step,
-          });
-        }
-      }
-
-      if (event.type === "reasoning_tokens") {
-        await updateResourceAndPublishEvent(auth, {
-          event: {
-            type: "generation_tokens",
-            classification: "chain_of_thought",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            messageId: agentMessage.sId,
-            text: event.content.tokens.text,
-          },
-          agentMessageRow,
-          conversation,
-          step,
-        });
-
-        blockExecutionNativeChainOfThought += event.content.tokens.text;
-      }
-
-      if (event.type === "reasoning_item") {
-        await updateResourceAndPublishEvent(auth, {
-          event: {
-            type: "generation_tokens",
-            classification: "chain_of_thought",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            messageId: agentMessage.sId,
-            text: "\n\n",
-          },
-          agentMessageRow,
-          conversation,
-          step,
-        });
-
-        blockExecutionNativeChainOfThought += "\n\n";
-      }
-
-      if (event.type === "block_execution") {
-        const e = event.content.execution[0][0];
-        if (e.error) {
-          await flushParserTokens();
-          return { shouldRetryMessage: e.error };
-        }
-
-        if (event.content.block_name === "MODEL" && e.value) {
-          // Flush early as we know the generation is terminated here.
-          await flushParserTokens();
-
-          const block = e.value;
-          if (!isDustAppChatBlockType(block)) {
-            return {
-              shouldRetryMessage: "Received unparsable MODEL block.",
-            };
-          }
-
-          // Extract token usage from block execution metadata
-          const meta = e.meta as {
-            token_usage?: {
-              prompt_tokens: number;
-              completion_tokens: number;
-              reasoning_tokens?: number;
-              cached_tokens?: number;
-            };
-          } | null;
-          const reasoningTokens = meta?.token_usage?.reasoning_tokens ?? 0;
-
-          // Pass the current region, which helps decide whether encrypted blocks are usable
-          const currentRegion = regionsConfig.getCurrentRegion();
-          let region: "us" | "eu";
-          switch (currentRegion) {
-            case "europe-west1":
-              region = "eu";
-              break;
-            case "us-central1":
-              region = "us";
-              break;
-            default:
-              throw new Error(`Unexpected region: ${currentRegion}`);
-          }
-
-          const contents = (block.message.contents ?? []).map((content) => {
-            if (content.type === "reasoning") {
-              return {
-                ...content,
-                value: {
-                  ...content.value,
-                  tokens: 0, // Will be updated for the last reasoning item
-                  provider: model.providerId,
-                  region,
-                },
-              } satisfies ReasoningContentType;
-            }
-            return content;
-          });
-
-          // We unfortunately don't currently have a proper breakdown of reasoning tokens per item,
-          // so we set the reasoning token count on the last reasoning item.
-          for (let i = contents.length - 1; i >= 0; i--) {
-            const content = contents[i];
-            if (content.type === "reasoning") {
-              content.value.tokens = reasoningTokens;
-              contents[i] = content;
-              break;
-            }
-          }
-
-          blockExecutionOutput = {
-            actions: [],
-            generation: null,
-            contents,
-          };
-
-          if (block.message.function_calls?.length) {
-            for (const fc of block.message.function_calls) {
-              try {
-                const args = JSON.parse(fc.arguments);
-                blockExecutionOutput.actions.push({
-                  name: fc.name,
-                  functionCallId: fc.id,
-                  arguments: args,
-                });
-              } catch (error) {
-                await publishAgentError({
-                  code: "function_call_error",
-                  message: `Error parsing function call arguments: ${error}`,
-                  metadata: null,
-                });
-                return { shouldReturnNull: true };
-              }
-            }
-          } else {
-            blockExecutionOutput.generation = block.message.content ?? null;
-          }
-        }
-      }
-    }
-
-    await flushParserTokens();
-
-    if (!blockExecutionOutput) {
-      return {
-        shouldRetryMessage: "Agent execution didn't complete.",
-      };
-    }
-
-    return {
-      output: blockExecutionOutput,
-      dustRunId: blockExecutionDustRunId,
-      nativeChainOfThought: blockExecutionNativeChainOfThought,
-    };
-  }
-
-  const fakeResponse = await getOutputFromAction({
-    modelConversationRes,
-    conversation,
-    userMessage,
+    runConfig,
+    specifications,
+    flushParserTokens,
+    contentParser,
+    agentMessageRow,
+    step,
+    agentConfiguration,
+    agentMessage,
+    model,
+    publishAgentError,
+    prompt,
   });
 
-  if ("shouldRetryMessage" in fakeResponse) {
-    return handlePossiblyRetryableError(fakeResponse.shouldRetryMessage);
+  if ("shouldRetryMessage" in getOutputFromActionResponse) {
+    return handlePossiblyRetryableError(
+      getOutputFromActionResponse.shouldRetryMessage
+    );
   }
 
-  if ("shouldReturnNull" in fakeResponse) {
+  if ("shouldReturnNull" in getOutputFromActionResponse) {
     return null;
   }
 
-  const { dustRunId, nativeChainOfThought, output } = fakeResponse;
+  const { dustRunId, nativeChainOfThought, output } =
+    getOutputFromActionResponse;
 
   // Create a new object to avoid mutation
   const updatedFunctionCallStepContentIds = { ...functionCallStepContentIds };

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -415,7 +415,7 @@ export async function runModelActivity(
     getDelimitersConfiguration({ agentConfiguration })
   );
 
-  let output: {
+  type Output = {
     actions: Array<{
       functionCallId: string;
       name: string | null;
@@ -425,7 +425,9 @@ export async function runModelActivity(
     contents: Array<
       TextContentType | FunctionCallContentType | ReasoningContentType
     >;
-  } | null = null;
+  };
+
+  let output: Output | null = null;
   let nativeChainOfThought = "";
   let dustRunId: Promise<string>;
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -492,7 +492,8 @@ export async function runModelActivity(
       } catch (err) {
         if (err instanceof CancelledFailure) {
           logger.info("Activity cancelled, stopping");
-          return null;
+          fakeResponse = { shouldReturnNull: true };
+          break getOutputFromAction;
         }
         throw err;
       }
@@ -638,7 +639,8 @@ export async function runModelActivity(
                   message: `Error parsing function call arguments: ${error}`,
                   metadata: null,
                 });
-                return null;
+                fakeResponse = { shouldReturnNull: true };
+                break getOutputFromAction;
               }
             }
           } else {
@@ -660,6 +662,10 @@ export async function runModelActivity(
 
   if ("shouldRetryMessage" in fakeResponse) {
     return handlePossiblyRetryableError(fakeResponse.shouldRetryMessage);
+  }
+
+  if ("shouldReturnNull" in fakeResponse) {
+    return null;
   }
 
   // Create a new object to avoid mutation

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -516,7 +516,7 @@ export async function runModelActivity(
         configurationId: agentConfiguration.sId,
         messageId: agentMessage.sId,
         message: agentMessage,
-        runIds: [...runIds, await dustRunId],
+        runIds: [...runIds, dustRunId],
       },
       agentMessageRow,
       conversation,
@@ -690,7 +690,7 @@ export async function runModelActivity(
 
   return {
     actions,
-    runId: await dustRunId,
+    runId: dustRunId,
     functionCallStepContentIds: updatedFunctionCallStepContentIds,
     stepContexts,
   };

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -431,213 +431,215 @@ export async function runModelActivity(
   let nativeChainOfThought = "";
   let dustRunId: Promise<string>;
 
-  const res = await runActionStreamed(
-    auth,
-    "assistant-v2-multi-actions-agent",
-    runConfig,
-    [
+  {
+    const res = await runActionStreamed(
+      auth,
+      "assistant-v2-multi-actions-agent",
+      runConfig,
+      [
+        {
+          conversation: modelConversationRes.value.modelConversation,
+          specifications,
+          prompt,
+        },
+      ],
       {
-        conversation: modelConversationRes.value.modelConversation,
-        specifications,
-        prompt,
-      },
-    ],
-    {
-      conversationId: conversation.sId,
-      workspaceId: conversation.owner.sId,
-      userMessageId: userMessage.sId,
-    }
-  );
-
-  if (res.isErr()) {
-    return handlePossiblyRetryableError(res.error.message);
-  }
-
-  const { eventStream, dustRunId: dustRunIdValue } = res.value;
-  // eslint-disable-next-line prefer-const
-  dustRunId = dustRunIdValue;
-
-  let isGeneration = true;
-
-  for await (const event of eventStream) {
-    if (event.type === "function_call") {
-      isGeneration = false;
-    }
-
-    if (event.type === "error") {
-      await flushParserTokens();
-      return handlePossiblyRetryableError(event.content.message);
-    }
-
-    // Heartbeat & sleep allow the activity to be cancelled, e.g. on a "Stop
-    // agent" request. Upon experimentation, both are needed to ensure the
-    // activity receives the cancellation signal. The delay until which is the
-    // signal is received is governed by heartbeat
-    // [throttling](https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling).
-    heartbeat();
-    try {
-      await sleep(1);
-    } catch (err) {
-      if (err instanceof CancelledFailure) {
-        logger.info("Activity cancelled, stopping");
-        return null;
+        conversationId: conversation.sId,
+        workspaceId: conversation.owner.sId,
+        userMessageId: userMessage.sId,
       }
-      throw err;
+    );
+
+    if (res.isErr()) {
+      return handlePossiblyRetryableError(res.error.message);
     }
 
-    if (event.type === "tokens" && isGeneration) {
-      for await (const tokenEvent of contentParser.emitTokens(
-        event.content.tokens.text
-      )) {
+    const { eventStream, dustRunId: dustRunIdValue } = res.value;
+    // eslint-disable-next-line prefer-const
+    dustRunId = dustRunIdValue;
+
+    let isGeneration = true;
+
+    for await (const event of eventStream) {
+      if (event.type === "function_call") {
+        isGeneration = false;
+      }
+
+      if (event.type === "error") {
+        await flushParserTokens();
+        return handlePossiblyRetryableError(event.content.message);
+      }
+
+      // Heartbeat & sleep allow the activity to be cancelled, e.g. on a "Stop
+      // agent" request. Upon experimentation, both are needed to ensure the
+      // activity receives the cancellation signal. The delay until which is the
+      // signal is received is governed by heartbeat
+      // [throttling](https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling).
+      heartbeat();
+      try {
+        await sleep(1);
+      } catch (err) {
+        if (err instanceof CancelledFailure) {
+          logger.info("Activity cancelled, stopping");
+          return null;
+        }
+        throw err;
+      }
+
+      if (event.type === "tokens" && isGeneration) {
+        for await (const tokenEvent of contentParser.emitTokens(
+          event.content.tokens.text
+        )) {
+          await updateResourceAndPublishEvent(auth, {
+            event: tokenEvent,
+            agentMessageRow,
+            conversation,
+            step,
+          });
+        }
+      }
+
+      if (event.type === "reasoning_tokens") {
         await updateResourceAndPublishEvent(auth, {
-          event: tokenEvent,
+          event: {
+            type: "generation_tokens",
+            classification: "chain_of_thought",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            messageId: agentMessage.sId,
+            text: event.content.tokens.text,
+          },
           agentMessageRow,
           conversation,
           step,
         });
-      }
-    }
 
-    if (event.type === "reasoning_tokens") {
-      await updateResourceAndPublishEvent(auth, {
-        event: {
-          type: "generation_tokens",
-          classification: "chain_of_thought",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          messageId: agentMessage.sId,
-          text: event.content.tokens.text,
-        },
-        agentMessageRow,
-        conversation,
-        step,
-      });
-
-      nativeChainOfThought += event.content.tokens.text;
-    }
-
-    if (event.type === "reasoning_item") {
-      await updateResourceAndPublishEvent(auth, {
-        event: {
-          type: "generation_tokens",
-          classification: "chain_of_thought",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          messageId: agentMessage.sId,
-          text: "\n\n",
-        },
-        agentMessageRow,
-        conversation,
-        step,
-      });
-
-      nativeChainOfThought += "\n\n";
-    }
-
-    if (event.type === "block_execution") {
-      const e = event.content.execution[0][0];
-      if (e.error) {
-        await flushParserTokens();
-        return handlePossiblyRetryableError(e.error);
+        nativeChainOfThought += event.content.tokens.text;
       }
 
-      if (event.content.block_name === "MODEL" && e.value) {
-        // Flush early as we know the generation is terminated here.
-        await flushParserTokens();
-
-        const block = e.value;
-        if (!isDustAppChatBlockType(block)) {
-          return handlePossiblyRetryableError(
-            "Received unparsable MODEL block."
-          );
-        }
-
-        // Extract token usage from block execution metadata
-        const meta = e.meta as {
-          token_usage?: {
-            prompt_tokens: number;
-            completion_tokens: number;
-            reasoning_tokens?: number;
-            cached_tokens?: number;
-          };
-        } | null;
-        const reasoningTokens = meta?.token_usage?.reasoning_tokens ?? 0;
-
-        // Pass the current region, which helps decide whether encrypted blocks are usable
-        const currentRegion = regionsConfig.getCurrentRegion();
-        let region: "us" | "eu";
-        switch (currentRegion) {
-          case "europe-west1":
-            region = "eu";
-            break;
-          case "us-central1":
-            region = "us";
-            break;
-          default:
-            throw new Error(`Unexpected region: ${currentRegion}`);
-        }
-
-        const contents = (block.message.contents ?? []).map((content) => {
-          if (content.type === "reasoning") {
-            return {
-              ...content,
-              value: {
-                ...content.value,
-                tokens: 0, // Will be updated for the last reasoning item
-                provider: model.providerId,
-                region,
-              },
-            } satisfies ReasoningContentType;
-          }
-          return content;
+      if (event.type === "reasoning_item") {
+        await updateResourceAndPublishEvent(auth, {
+          event: {
+            type: "generation_tokens",
+            classification: "chain_of_thought",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            messageId: agentMessage.sId,
+            text: "\n\n",
+          },
+          agentMessageRow,
+          conversation,
+          step,
         });
 
-        // We unfortunately don't currently have a proper breakdown of reasoning tokens per item,
-        // so we set the reasoning token count on the last reasoning item.
-        for (let i = contents.length - 1; i >= 0; i--) {
-          const content = contents[i];
-          if (content.type === "reasoning") {
-            content.value.tokens = reasoningTokens;
-            contents[i] = content;
-            break;
-          }
+        nativeChainOfThought += "\n\n";
+      }
+
+      if (event.type === "block_execution") {
+        const e = event.content.execution[0][0];
+        if (e.error) {
+          await flushParserTokens();
+          return handlePossiblyRetryableError(e.error);
         }
 
-        output = {
-          actions: [],
-          generation: null,
-          contents,
-        };
+        if (event.content.block_name === "MODEL" && e.value) {
+          // Flush early as we know the generation is terminated here.
+          await flushParserTokens();
 
-        if (block.message.function_calls?.length) {
-          for (const fc of block.message.function_calls) {
-            try {
-              const args = JSON.parse(fc.arguments);
-              output.actions.push({
-                name: fc.name,
-                functionCallId: fc.id,
-                arguments: args,
-              });
-            } catch (error) {
-              await publishAgentError({
-                code: "function_call_error",
-                message: `Error parsing function call arguments: ${error}`,
-                metadata: null,
-              });
-              return null;
+          const block = e.value;
+          if (!isDustAppChatBlockType(block)) {
+            return handlePossiblyRetryableError(
+              "Received unparsable MODEL block."
+            );
+          }
+
+          // Extract token usage from block execution metadata
+          const meta = e.meta as {
+            token_usage?: {
+              prompt_tokens: number;
+              completion_tokens: number;
+              reasoning_tokens?: number;
+              cached_tokens?: number;
+            };
+          } | null;
+          const reasoningTokens = meta?.token_usage?.reasoning_tokens ?? 0;
+
+          // Pass the current region, which helps decide whether encrypted blocks are usable
+          const currentRegion = regionsConfig.getCurrentRegion();
+          let region: "us" | "eu";
+          switch (currentRegion) {
+            case "europe-west1":
+              region = "eu";
+              break;
+            case "us-central1":
+              region = "us";
+              break;
+            default:
+              throw new Error(`Unexpected region: ${currentRegion}`);
+          }
+
+          const contents = (block.message.contents ?? []).map((content) => {
+            if (content.type === "reasoning") {
+              return {
+                ...content,
+                value: {
+                  ...content.value,
+                  tokens: 0, // Will be updated for the last reasoning item
+                  provider: model.providerId,
+                  region,
+                },
+              } satisfies ReasoningContentType;
+            }
+            return content;
+          });
+
+          // We unfortunately don't currently have a proper breakdown of reasoning tokens per item,
+          // so we set the reasoning token count on the last reasoning item.
+          for (let i = contents.length - 1; i >= 0; i--) {
+            const content = contents[i];
+            if (content.type === "reasoning") {
+              content.value.tokens = reasoningTokens;
+              contents[i] = content;
+              break;
             }
           }
-        } else {
-          output.generation = block.message.content ?? null;
+
+          output = {
+            actions: [],
+            generation: null,
+            contents,
+          };
+
+          if (block.message.function_calls?.length) {
+            for (const fc of block.message.function_calls) {
+              try {
+                const args = JSON.parse(fc.arguments);
+                output.actions.push({
+                  name: fc.name,
+                  functionCallId: fc.id,
+                  arguments: args,
+                });
+              } catch (error) {
+                await publishAgentError({
+                  code: "function_call_error",
+                  message: `Error parsing function call arguments: ${error}`,
+                  metadata: null,
+                });
+                return null;
+              }
+            }
+          } else {
+            output.generation = block.message.content ?? null;
+          }
         }
       }
     }
-  }
 
-  await flushParserTokens();
+    await flushParserTokens();
 
-  if (!output) {
-    return handlePossiblyRetryableError("Agent execution didn't complete.");
+    if (!output) {
+      return handlePossiblyRetryableError("Agent execution didn't complete.");
+    }
   }
 
   // Create a new object to avoid mutation

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -431,6 +431,15 @@ export async function runModelActivity(
   let nativeChainOfThought = "";
   let dustRunId: Promise<string>;
 
+  let _fakeResponse:
+    | { shouldRetryMessage: string }
+    | {
+        output: Output;
+        dustRunId: Promise<string>;
+        nativeChainOfThought: string;
+      }
+    | { shouldReturnNull: true };
+
   {
     const res = await runActionStreamed(
       auth,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -427,6 +427,7 @@ export async function runModelActivity(
     >;
   } | null = null;
   let nativeChainOfThought = "";
+  let dustRunId: Promise<string>;
 
   const res = await runActionStreamed(
     auth,
@@ -450,7 +451,9 @@ export async function runModelActivity(
     return handlePossiblyRetryableError(res.error.message);
   }
 
-  const { eventStream, dustRunId } = res.value;
+  const { eventStream, dustRunId: dustRunIdValue } = res.value;
+  // eslint-disable-next-line prefer-const
+  dustRunId = dustRunIdValue;
 
   let isGeneration = true;
 


### PR DESCRIPTION
## Description

This PR refactors run_model to separate dust-apps specific code into a new dedicated function.
This way we will be able to easily switch between dust apps and direct llm calls

There should be no changes in code behavior

## Tests

locally

## Risk

Medium: should be no changes in code behavior, but code changed is in the heart of conversations

## Deploy Plan

front
