### PR TITLE
[front] - chore(obs): polish charts

### DIFF
--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -1,8 +1,3 @@
-import { useState } from "react";
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import { ToolExecutionChart } from "@app/components/agent_builder/observability/ToolExecutionChart";
-import { ToolLatencyChart } from "@app/components/agent_builder/observability/ToolLatencyChart";
-import { UsageMetricsChart } from "@app/components/agent_builder/observability/UsageMetricsChart";
 import {
   Button,
   DropdownMenu,
@@ -10,12 +5,17 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
-import { useAgentConfiguration } from "@app/lib/swr/assistants";
-import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { OBSERVABILITY_TIME_RANGE } from "@app/components/agent_builder/observability/constants";
 import {
-  DEFAULT_PERIOD_DAYS,
-  OBSERVABILITY_TIME_RANGE,
-} from "@app/components/agent_builder/observability/constants";
+  ObservabilityProvider,
+  useObservability,
+} from "@app/components/agent_builder/observability/ObservabilityContext";
+import { ToolExecutionChart } from "@app/components/agent_builder/observability/ToolExecutionChart";
+import { ToolLatencyChart } from "@app/components/agent_builder/observability/ToolLatencyChart";
+import { UsageMetricsChart } from "@app/components/agent_builder/observability/UsageMetricsChart";
+import { useAgentConfiguration } from "@app/lib/swr/assistants";
 
 interface AgentBuilderObservabilityProps {
   agentConfigurationSId: string;
@@ -35,58 +35,58 @@ export function AgentBuilderObservability({
     return null;
   }
 
-  const [period, setPeriod] =
-    useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
-
   return (
-    <div className="flex h-full flex-col space-y-6 overflow-y-auto">
-      <div className="flex items-start justify-between">
-        <div>
-          <h2 className="text-lg font-semibold text-foreground">
-            Observability
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            Monitor key metrics and performance indicators for your agent.
-          </p>
+    <ObservabilityProvider>
+      <div className="flex h-full flex-col space-y-6 overflow-y-auto">
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">
+              Observability
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Monitor key metrics and performance indicators for your agent.
+            </p>
+          </div>
+          <HeaderPeriodDropdown />
         </div>
-        <div className="flex items-center gap-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button label={`${period}d`} size="xs" variant="outline" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              {OBSERVABILITY_TIME_RANGE.map((p) => (
-                <DropdownMenuItem
-                  key={p}
-                  label={`${p}d`}
-                  onClick={() => setPeriod(p)}
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
 
-      <div className="grid grid-cols-1 gap-6">
-        <UsageMetricsChart
-          workspaceId={owner.sId}
-          agentConfigurationId={agentConfiguration.sId}
-          period={period}
-          onPeriodChange={setPeriod}
-        />
-        <ToolExecutionChart
-          workspaceId={owner.sId}
-          agentConfigurationId={agentConfiguration.sId}
-          period={period}
-          onPeriodChange={setPeriod}
-        />
-        <ToolLatencyChart
-          workspaceId={owner.sId}
-          agentConfigurationId={agentConfiguration.sId}
-          period={period}
-          onPeriodChange={setPeriod}
-        />
+        <div className="grid grid-cols-1 gap-6">
+          <UsageMetricsChart
+            workspaceId={owner.sId}
+            agentConfigurationId={agentConfiguration.sId}
+          />
+          <ToolExecutionChart
+            workspaceId={owner.sId}
+            agentConfigurationId={agentConfiguration.sId}
+          />
+          <ToolLatencyChart
+            workspaceId={owner.sId}
+            agentConfigurationId={agentConfiguration.sId}
+          />
+        </div>
       </div>
+    </ObservabilityProvider>
+  );
+}
+
+function HeaderPeriodDropdown() {
+  const { period, setPeriod } = useObservability();
+  return (
+    <div className="flex items-center gap-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button label={`${period}d`} size="xs" variant="outline" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          {OBSERVABILITY_TIME_RANGE.map((p) => (
+            <DropdownMenuItem
+              key={p}
+              label={`${p}d`}
+              onClick={() => setPeriod(p)}
+            />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -1,8 +1,21 @@
+import { useState } from "react";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { ToolExecutionChart } from "@app/components/agent_builder/observability/ToolExecutionChart";
 import { ToolLatencyChart } from "@app/components/agent_builder/observability/ToolLatencyChart";
 import { UsageMetricsChart } from "@app/components/agent_builder/observability/UsageMetricsChart";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import {
+  DEFAULT_PERIOD_DAYS,
+  OBSERVABILITY_TIME_RANGE,
+} from "@app/components/agent_builder/observability/constants";
 
 interface AgentBuilderObservabilityProps {
   agentConfigurationSId: string;
@@ -22,27 +35,56 @@ export function AgentBuilderObservability({
     return null;
   }
 
+  const [period, setPeriod] =
+    useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
+
   return (
     <div className="flex h-full flex-col space-y-6 overflow-y-auto">
-      <div>
-        <h2 className="text-lg font-semibold text-foreground">Observability</h2>
-        <p className="text-sm text-muted-foreground">
-          Monitor key metrics and performance indicators for your agent.
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">
+            Observability
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Monitor key metrics and performance indicators for your agent.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button label={`${period}d`} size="xs" variant="outline" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {OBSERVABILITY_TIME_RANGE.map((p) => (
+                <DropdownMenuItem
+                  key={p}
+                  label={`${p}d`}
+                  onClick={() => setPeriod(p)}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 gap-6">
         <UsageMetricsChart
           workspaceId={owner.sId}
           agentConfigurationId={agentConfiguration.sId}
+          period={period}
+          onPeriodChange={setPeriod}
         />
         <ToolExecutionChart
           workspaceId={owner.sId}
           agentConfigurationId={agentConfiguration.sId}
+          period={period}
+          onPeriodChange={setPeriod}
         />
         <ToolLatencyChart
           workspaceId={owner.sId}
           agentConfigurationId={agentConfiguration.sId}
+          period={period}
+          onPeriodChange={setPeriod}
         />
       </div>
     </div>

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Label,
 } from "@dust-tt/sparkle";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -43,9 +44,9 @@ export function AgentBuilderObservability({
             <h2 className="text-lg font-semibold text-foreground">
               Observability
             </h2>
-            <p className="text-sm text-muted-foreground">
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground">
               Monitor key metrics and performance indicators for your agent.
-            </p>
+            </span>
           </div>
           <HeaderPeriodDropdown />
         </div>
@@ -72,12 +73,13 @@ export function AgentBuilderObservability({
 function HeaderPeriodDropdown() {
   const { period, setPeriod } = useObservability();
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 pr-2">
+      <Label>Period:</Label>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button label={`${period}d`} size="xs" variant="outline" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent>
+        <DropdownMenuContent align="end">
           {OBSERVABILITY_TIME_RANGE.map((p) => (
             <DropdownMenuItem
               key={p}

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -77,7 +77,7 @@ function HeaderPeriodDropdown() {
       <Label>Period:</Label>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button label={`${period}d`} size="xs" variant="outline" />
+          <Button label={`${period}d`} size="xs" variant="outline" isSelect />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           {OBSERVABILITY_TIME_RANGE.map((p) => (

--- a/front/components/agent_builder/observability/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/ChartContainer.tsx
@@ -16,6 +16,7 @@ interface ChartContainerProps {
   emptyMessage?: string;
   children: ReactNode;
   additionalControls?: ReactNode;
+  showPeriodSelector?: boolean;
 }
 
 export function ChartContainer({
@@ -27,6 +28,7 @@ export function ChartContainer({
   emptyMessage,
   children,
   additionalControls,
+  showPeriodSelector = true,
 }: ChartContainerProps) {
   const message = isLoading ? null : errorMessage ?? emptyMessage;
 
@@ -35,20 +37,24 @@ export function ChartContainer({
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-medium text-foreground">{title}</h3>
         <div className="flex items-center gap-3">
-          {OBSERVABILITY_TIME_RANGE.map((p) => (
-            <button
-              key={p}
-              onClick={() => onPeriodChange(p)}
-              className={cn(
-                "rounded px-2 py-1 text-xs",
-                period === p
-                  ? "bg-foreground text-background"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              {p}d
-            </button>
-          ))}
+          {showPeriodSelector && (
+            <div className="flex items-center gap-2">
+              {OBSERVABILITY_TIME_RANGE.map((p) => (
+                <button
+                  key={p}
+                  onClick={() => onPeriodChange(p)}
+                  className={cn(
+                    "rounded px-2 py-1 text-xs",
+                    period === p
+                      ? "bg-foreground text-background"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  {p}d
+                </button>
+              ))}
+            </div>
+          )}
           {additionalControls}
         </div>
       </div>

--- a/front/components/agent_builder/observability/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/ChartContainer.tsx
@@ -1,34 +1,24 @@
-import { cn, Spinner } from "@dust-tt/sparkle";
+import { Spinner } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
-import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import {
-  CHART_HEIGHT,
-  OBSERVABILITY_TIME_RANGE,
-} from "@app/components/agent_builder/observability/constants";
+import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
 
 interface ChartContainerProps {
   title: string;
-  period: ObservabilityTimeRangeType;
-  onPeriodChange: (period: ObservabilityTimeRangeType) => void;
   isLoading: boolean;
   errorMessage?: string;
   emptyMessage?: string;
   children: ReactNode;
   additionalControls?: ReactNode;
-  showPeriodSelector?: boolean;
 }
 
 export function ChartContainer({
   title,
-  period,
-  onPeriodChange,
   isLoading,
   errorMessage,
   emptyMessage,
   children,
   additionalControls,
-  showPeriodSelector = true,
 }: ChartContainerProps) {
   const message = isLoading ? null : errorMessage ?? emptyMessage;
 
@@ -36,27 +26,7 @@ export function ChartContainer({
     <div className="bg-card rounded-lg border border-border p-4">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-medium text-foreground">{title}</h3>
-        <div className="flex items-center gap-3">
-          {showPeriodSelector && (
-            <div className="flex items-center gap-2">
-              {OBSERVABILITY_TIME_RANGE.map((p) => (
-                <button
-                  key={p}
-                  onClick={() => onPeriodChange(p)}
-                  className={cn(
-                    "rounded px-2 py-1 text-xs",
-                    period === p
-                      ? "bg-foreground text-background"
-                      : "text-muted-foreground hover:text-foreground"
-                  )}
-                >
-                  {p}d
-                </button>
-              ))}
-            </div>
-          )}
-          {additionalControls}
-        </div>
+        <div className="flex items-center gap-3">{additionalControls}</div>
       </div>
       {isLoading || message ? (
         <div

--- a/front/components/agent_builder/observability/ChartTooltip.tsx
+++ b/front/components/agent_builder/observability/ChartTooltip.tsx
@@ -7,6 +7,8 @@ interface LegendDotProps {
 export function LegendDot({ className }: LegendDotProps) {
   return (
     <span
+      aria-hidden
+      role="presentation"
       className={cn(
         "inline-block h-2.5 w-2.5 rounded-sm bg-current",
         className
@@ -31,13 +33,13 @@ interface ChartTooltipProps {
 export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
   return (
     <div
-      className="grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl"
-      style={{ opacity: 1 }}
+      role="tooltip"
+      className="min-w-32 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl"
     >
-      {title && <div className="font-medium text-foreground">{title}</div>}
-      <div className="grid gap-1.5">
+      {title && <div className="mb-1 font-medium text-foreground">{title}</div>}
+      <ul className="space-y-1.5">
         {rows.map((r) => (
-          <div key={r.label} className="flex items-center gap-2">
+          <li key={r.label} className="flex items-center gap-2">
             {r.colorClassName && <LegendDot className={r.colorClassName} />}
             <span className="text-muted-foreground">{r.label}</span>
             <span className="ml-auto font-mono font-medium tabular-nums text-foreground">
@@ -46,9 +48,9 @@ export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
             {typeof r.percent === "number" && (
               <span className="text-muted-foreground">({r.percent}%)</span>
             )}
-          </div>
+          </li>
         ))}
-      </div>
+      </ul>
       {footer && (
         <div className="mt-1 border-t border-border/50 pt-1 text-muted-foreground">
           {footer}

--- a/front/components/agent_builder/observability/ChartTooltip.tsx
+++ b/front/components/agent_builder/observability/ChartTooltip.tsx
@@ -30,27 +30,27 @@ interface ChartTooltipProps {
 
 export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
   return (
-    <div className="bg-card rounded-md border border-border p-3 text-foreground shadow-md">
-      {title && (
-        <div className="mb-2 text-xs font-medium text-muted-foreground">
-          {title}
-        </div>
-      )}
-      {rows.map((r) => (
-        <div
-          key={r.label}
-          className="mt-1 flex items-center gap-2 text-xs first:mt-0"
-        >
-          {r.colorClassName && <LegendDot className={r.colorClassName} />}
-          <span className="text-muted-foreground">{r.label}</span>
-          <span className="ml-auto font-medium">{r.value}</span>
-          {typeof r.percent === "number" && (
-            <span className="text-muted-foreground">({r.percent}%)</span>
-          )}
-        </div>
-      ))}
+    <div
+      className="border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
+      style={{ opacity: 1 }}
+    >
+      {title && <div className="font-medium text-foreground">{title}</div>}
+      <div className="grid gap-1.5">
+        {rows.map((r) => (
+          <div key={r.label} className="flex items-center gap-2">
+            {r.colorClassName && <LegendDot className={r.colorClassName} />}
+            <span className="text-muted-foreground">{r.label}</span>
+            <span className="ml-auto font-mono font-medium tabular-nums text-foreground">
+              {r.value}
+            </span>
+            {typeof r.percent === "number" && (
+              <span className="text-muted-foreground">({r.percent}%)</span>
+            )}
+          </div>
+        ))}
+      </div>
       {footer && (
-        <div className="mt-2 border-t border-border pt-2 text-xs text-muted-foreground">
+        <div className="mt-1 border-t border-border/50 pt-1 text-muted-foreground">
           {footer}
         </div>
       )}

--- a/front/components/agent_builder/observability/ChartTooltip.tsx
+++ b/front/components/agent_builder/observability/ChartTooltip.tsx
@@ -31,7 +31,7 @@ interface ChartTooltipProps {
 export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
   return (
     <div
-      className="border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
+      className="grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl"
       style={{ opacity: 1 }}
     >
       {title && <div className="font-medium text-foreground">{title}</div>}

--- a/front/components/agent_builder/observability/ObservabilityContext.tsx
+++ b/front/components/agent_builder/observability/ObservabilityContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useState } from "react";
+
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+
+type ObservabilityContextValue = {
+  period: ObservabilityTimeRangeType;
+  setPeriod: (p: ObservabilityTimeRangeType) => void;
+};
+
+const ObservabilityContext = createContext<ObservabilityContextValue | null>(
+  null
+);
+
+export function ObservabilityProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [period, setPeriod] =
+    useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
+
+  return (
+    <ObservabilityContext.Provider value={{ period, setPeriod }}>
+      {children}
+    </ObservabilityContext.Provider>
+  );
+}
+
+export function useObservability() {
+  const ctx = useContext(ObservabilityContext);
+  if (!ctx) {
+    throw new Error(
+      "useObservability must be used within an ObservabilityProvider"
+    );
+  }
+  return ctx;
+}

--- a/front/components/agent_builder/observability/ToolExecutionChart.tsx
+++ b/front/components/agent_builder/observability/ToolExecutionChart.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import {
   Bar,
   BarChart,
@@ -13,13 +13,12 @@ import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 import { ChartContainer } from "@app/components/agent_builder/observability/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/ChartTooltip";
-import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import {
   CHART_HEIGHT,
-  DEFAULT_PERIOD_DAYS,
   MAX_TOOLS_DISPLAYED,
   PERCENTAGE_MULTIPLIER,
 } from "@app/components/agent_builder/observability/constants";
+import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { getToolColor } from "@app/components/agent_builder/observability/utils";
 import { useAgentToolExecution } from "@app/lib/swr/assistants";
 
@@ -28,8 +27,6 @@ type ChartRow = { version: string; values: Record<string, number> };
 interface ToolExecutionChartProps {
   workspaceId: string;
   agentConfigurationId: string;
-  period: ObservabilityTimeRangeType;
-  onPeriodChange: (p: ObservabilityTimeRangeType) => void;
 }
 
 function ToolExecutionTooltip({
@@ -57,9 +54,8 @@ function ToolExecutionTooltip({
 export function ToolExecutionChart({
   workspaceId,
   agentConfigurationId,
-  period,
-  onPeriodChange,
 }: ToolExecutionChartProps) {
+  const { period, setPeriod } = useObservability();
   const {
     toolExecutionByVersion,
     isToolExecutionLoading,
@@ -132,10 +128,7 @@ export function ToolExecutionChart({
   return (
     <ChartContainer
       title="Tool Usage by Version"
-      period={period}
-      onPeriodChange={onPeriodChange}
       isLoading={isToolExecutionLoading}
-      showPeriodSelector={false}
       errorMessage={
         isToolExecutionError ? "Failed to load tool execution data." : undefined
       }

--- a/front/components/agent_builder/observability/ToolExecutionChart.tsx
+++ b/front/components/agent_builder/observability/ToolExecutionChart.tsx
@@ -28,6 +28,8 @@ type ChartRow = { version: string; values: Record<string, number> };
 interface ToolExecutionChartProps {
   workspaceId: string;
   agentConfigurationId: string;
+  period: ObservabilityTimeRangeType;
+  onPeriodChange: (p: ObservabilityTimeRangeType) => void;
 }
 
 function ToolExecutionTooltip({
@@ -55,10 +57,9 @@ function ToolExecutionTooltip({
 export function ToolExecutionChart({
   workspaceId,
   agentConfigurationId,
+  period,
+  onPeriodChange,
 }: ToolExecutionChartProps) {
-  const [period, setPeriod] =
-    useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
-
   const {
     toolExecutionByVersion,
     isToolExecutionLoading,
@@ -132,8 +133,9 @@ export function ToolExecutionChart({
     <ChartContainer
       title="Tool Usage by Version"
       period={period}
-      onPeriodChange={setPeriod}
+      onPeriodChange={onPeriodChange}
       isLoading={isToolExecutionLoading}
+      showPeriodSelector={false}
       errorMessage={
         isToolExecutionError ? "Failed to load tool execution data." : undefined
       }
@@ -172,7 +174,12 @@ export function ToolExecutionChart({
             cursor={false}
             content={renderTooltip}
             wrapperStyle={{ outline: "none" }}
-            contentStyle={{ background: "transparent", border: "none", padding: 0, boxShadow: "none" }}
+            contentStyle={{
+              background: "transparent",
+              border: "none",
+              padding: 0,
+              boxShadow: "none",
+            }}
           />
           {topTools.map((toolName, idx) => (
             <Bar

--- a/front/components/agent_builder/observability/ToolExecutionChart.tsx
+++ b/front/components/agent_builder/observability/ToolExecutionChart.tsx
@@ -148,10 +148,19 @@ export function ToolExecutionChart({
           data={chartData}
           margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
         >
-          <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-          <XAxis dataKey="version" className="text-xs text-muted-foreground" />
+          <CartesianGrid vertical={false} className="stroke-border" />
+          <XAxis
+            dataKey="version"
+            className="text-xs text-muted-foreground"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+          />
           <YAxis
             className="text-xs text-muted-foreground"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
             label={{
               value: "Usage %",
               angle: -90,
@@ -160,10 +169,12 @@ export function ToolExecutionChart({
             }}
           />
           <Tooltip
-            cursor={{ fill: "hsl(var(--border) / 0.1)" }}
+            cursor={false}
             content={renderTooltip}
+            wrapperStyle={{ outline: "none" }}
+            contentStyle={{ background: "transparent", border: "none", padding: 0, boxShadow: "none" }}
           />
-          {topTools.map((toolName) => (
+          {topTools.map((toolName, idx) => (
             <Bar
               key={toolName}
               dataKey={(row: ChartRow) => row.values[toolName] ?? 0}
@@ -171,6 +182,11 @@ export function ToolExecutionChart({
               fill="currentColor"
               className={getToolColor(toolName, topTools)}
               name={toolName}
+              radius={
+                idx === topTools.length - 1
+                  ? ([4, 4, 0, 0] as [number, number, number, number])
+                  : ([0, 0, 0, 0] as [number, number, number, number])
+              }
             />
           ))}
         </BarChart>

--- a/front/components/agent_builder/observability/ToolLatencyChart.tsx
+++ b/front/components/agent_builder/observability/ToolLatencyChart.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import {
-  Bar,
-  BarChart,
+  Area,
+  AreaChart,
   CartesianGrid,
   ResponsiveContainer,
   Tooltip,
@@ -19,11 +19,7 @@ import {
   DEFAULT_PERIOD_DAYS,
   MAX_TOOLS_DISPLAYED,
 } from "@app/components/agent_builder/observability/constants";
-import {
-  calculateTopTools,
-  getToolColor,
-} from "@app/components/agent_builder/observability/utils";
-import type { ToolLatencyByVersion } from "@app/lib/api/assistant/observability/tool_latency";
+import { calculateTopTools } from "@app/components/agent_builder/observability/utils";
 import { useAgentToolLatency } from "@app/lib/swr/assistants";
 
 type ChartRow = { version: string; values: Record<string, number> };
@@ -33,60 +29,22 @@ interface ToolLatencyChartProps {
   agentConfigurationId: string;
 }
 
-function ToolLatencyTooltip({
+function AreaLatencyTooltip({
   active,
   payload,
   label,
-  topTools,
-  toolLatencyByVersion,
-}: TooltipContentProps<number, string> & {
-  topTools: string[];
-  toolLatencyByVersion: ToolLatencyByVersion[];
-}) {
+}: TooltipContentProps<number, string> & {}) {
   if (!active || !payload || payload.length === 0) {
     return null;
   }
 
-  // Extract version from label (format: "v123")
-  const version = String(label).replace(/^v/, "");
-  const versionData = toolLatencyByVersion.find((v) => v.version === version);
-
   const rows = payload
-    .filter((p) => typeof p.value === "number" && p.value > 0)
-    .sort((a, b) => b.value - a.value)
-    .flatMap((p) => {
-      const toolName = p.name || "";
-      const toolData = versionData?.tools[toolName];
-      const colorClassName = getToolColor(toolName, topTools);
-
-      if (!toolData) {
-        return [
-          {
-            label: toolName,
-            value: `${p.value}ms`,
-            colorClassName,
-          },
-        ];
-      }
-
-      return [
-        {
-          label: `${toolName} (avg)`,
-          value: `${toolData.avgLatencyMs}ms`,
-          colorClassName,
-        },
-        {
-          label: `${toolName} (p50)`,
-          value: `${toolData.p50LatencyMs}ms`,
-          colorClassName,
-        },
-        {
-          label: `${toolName} (p95)`,
-          value: `${toolData.p95LatencyMs}ms`,
-          colorClassName,
-        },
-      ];
-    });
+    .filter((p) => typeof p.value === "number")
+    .sort((a, b) => (b.name || "").localeCompare(a.name || ""))
+    .map((p) => ({
+      label: String(p.name),
+      value: `${p.value}ms`,
+    }));
 
   return <ChartTooltipCard title={String(label)} rows={rows} />;
 }
@@ -97,6 +55,7 @@ export function ToolLatencyChart({
 }: ToolLatencyChartProps) {
   const [period, setPeriod] =
     useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
+  const [selectedTool, setSelectedTool] = useState<string | null>(null);
 
   const { toolLatencyByVersion, isToolLatencyLoading, isToolLatencyError } =
     useAgentToolLatency({
@@ -106,9 +65,18 @@ export function ToolLatencyChart({
       disabled: !workspaceId || !agentConfigurationId,
     });
 
-  const { chartData, topTools } = useMemo(() => {
+  const { versions, topTools, areaData } = useMemo(() => {
     if (!toolLatencyByVersion || toolLatencyByVersion.length === 0) {
-      return { chartData: [], topTools: [] };
+      return {
+        versions: [],
+        topTools: [],
+        areaData: [] as Array<{
+          tool: string;
+          avg: number;
+          p50: number;
+          p95: number;
+        }>,
+      };
     }
 
     // Calculate top tools by weighted average latency
@@ -118,36 +86,30 @@ export function ToolLatencyChart({
       MAX_TOOLS_DISPLAYED
     );
 
-    // Build rows with average latency values for each tool
-    const rows: ChartRow[] = toolLatencyByVersion.map((v) => {
-      const toolValues: Record<string, number> = {};
-      for (const toolName of top) {
-        const t = v.tools[toolName];
-        toolValues[toolName] = t ? t.avgLatencyMs : 0;
-      }
+    const versions = toolLatencyByVersion.map((v) => v.version);
+    const toolToUse = selectedTool ?? top[0];
+    const areaData = toolLatencyByVersion.map((v) => ({
+      version: `v${v.version}`,
+      avg: v.tools[toolToUse]?.avgLatencyMs ?? 0,
+      p50: v.tools[toolToUse]?.p50LatencyMs ?? 0,
+      p95: v.tools[toolToUse]?.p95LatencyMs ?? 0,
+    }));
 
-      return { version: `v${v.version}`, values: toolValues };
-    });
-
-    return { chartData: rows, topTools: top };
-  }, [toolLatencyByVersion]);
+    return { versions, topTools: top, areaData };
+  }, [toolLatencyByVersion, selectedTool]);
 
   const renderTooltip = useCallback(
     (props: TooltipContentProps<number, string>) => (
-      <ToolLatencyTooltip
-        {...props}
-        topTools={topTools}
-        toolLatencyByVersion={toolLatencyByVersion ?? []}
-      />
+      <AreaLatencyTooltip {...props} />
     ),
-    [topTools, toolLatencyByVersion]
+    []
   );
 
-  const legendItems = topTools.map((toolName) => ({
-    key: toolName,
-    label: toolName,
-    colorClassName: getToolColor(toolName, topTools),
-  }));
+  const legendItems = [
+    { key: "avg", label: "avg", colorClassName: "text-[hsl(var(--chart-1))]" },
+    { key: "p50", label: "p50", colorClassName: "text-[hsl(var(--chart-2))]" },
+    { key: "p95", label: "p95", colorClassName: "text-[hsl(var(--chart-3))]" },
+  ];
 
   return (
     <ChartContainer
@@ -155,26 +117,84 @@ export function ToolLatencyChart({
       period={period}
       onPeriodChange={setPeriod}
       isLoading={isToolLatencyLoading}
+      additionalControls={
+        <select
+          className="bg-card rounded border border-border px-2 py-1 text-xs"
+          value={selectedTool ?? topTools[0] ?? ""}
+          onChange={(e) => setSelectedTool(e.target.value)}
+        >
+          {topTools.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      }
       errorMessage={
         isToolLatencyError ? "Failed to load tool latency data." : undefined
       }
       emptyMessage={
-        chartData.length === 0
+        areaData.length === 0
           ? "No tool latency data available for this period."
           : undefined
       }
     >
       <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-        <BarChart
-          data={chartData}
+        <AreaChart
+          data={areaData}
           margin={{ top: 10, right: 30, left: 20, bottom: 20 }}
-          barGap={2}
-          barCategoryGap="20%"
         >
-          <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-          <XAxis dataKey="version" className="text-xs text-muted-foreground" />
+          <defs>
+            <linearGradient id="fillAvg" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="hsl(var(--chart-1))"
+                stopOpacity={0.8}
+              />
+              <stop
+                offset="95%"
+                stopColor="hsl(var(--chart-1))"
+                stopOpacity={0.1}
+              />
+            </linearGradient>
+            <linearGradient id="fillP50" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="hsl(var(--chart-2))"
+                stopOpacity={0.8}
+              />
+              <stop
+                offset="95%"
+                stopColor="hsl(var(--chart-2))"
+                stopOpacity={0.1}
+              />
+            </linearGradient>
+            <linearGradient id="fillP95" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="hsl(var(--chart-3))"
+                stopOpacity={0.8}
+              />
+              <stop
+                offset="95%"
+                stopColor="hsl(var(--chart-3))"
+                stopOpacity={0.1}
+              />
+            </linearGradient>
+          </defs>
+          <CartesianGrid vertical={false} className="stroke-border" />
+          <XAxis
+            dataKey="version"
+            className="text-xs text-muted-foreground"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+          />
           <YAxis
             className="text-xs text-muted-foreground"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
             label={{
               value: "Latency (ms)",
               angle: -90,
@@ -183,26 +203,42 @@ export function ToolLatencyChart({
             }}
           />
           <Tooltip
-            cursor={{ fill: "hsl(var(--border) / 0.1)" }}
+            cursor={false}
             content={renderTooltip}
+            wrapperStyle={{ outline: "none" }}
+            contentStyle={{ background: "transparent", border: "none", padding: 0, boxShadow: "none" }}
           />
-          {topTools.map((toolName) => (
-            <Bar
-              key={toolName}
-              dataKey={(row: ChartRow) => row.values[toolName] ?? 0}
-              fill="currentColor"
-              className={getToolColor(toolName, topTools)}
-              name={toolName}
-            />
-          ))}
-        </BarChart>
+          <Area
+            type="natural"
+            dataKey="avg"
+            name="avg"
+            fill="url(#fillAvg)"
+            stroke="hsl(var(--chart-1))"
+            stackId="a"
+          />
+          <Area
+            type="natural"
+            dataKey="p50"
+            name="p50"
+            fill="url(#fillP50)"
+            stroke="hsl(var(--chart-2))"
+            stackId="a"
+          />
+          <Area
+            type="natural"
+            dataKey="p95"
+            name="p95"
+            fill="url(#fillP95)"
+            stroke="hsl(var(--chart-3))"
+            stackId="a"
+          />
+        </AreaChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />
       <div className="mt-4 text-xs text-muted-foreground">
         <p>
-          Shows the average execution latency (ms) of the top{" "}
-          {MAX_TOOLS_DISPLAYED} slowest tools for each agent version. Hover over
-          bars to see avg, p50 (median), and p95 latency values.
+          Shows avg, p50 (median), and p95 latency (ms) of the top{" "}
+          {MAX_TOOLS_DISPLAYED} slowest tools for the selected version.
         </p>
       </div>
     </ChartContainer>

--- a/front/components/agent_builder/observability/ToolLatencyChart.tsx
+++ b/front/components/agent_builder/observability/ToolLatencyChart.tsx
@@ -27,6 +27,8 @@ type ChartRow = { version: string; values: Record<string, number> };
 interface ToolLatencyChartProps {
   workspaceId: string;
   agentConfigurationId: string;
+  period: ObservabilityTimeRangeType;
+  onPeriodChange: (p: ObservabilityTimeRangeType) => void;
 }
 
 function AreaLatencyTooltip({
@@ -59,9 +61,9 @@ function AreaLatencyTooltip({
 export function ToolLatencyChart({
   workspaceId,
   agentConfigurationId,
+  period,
+  onPeriodChange,
 }: ToolLatencyChartProps) {
-  const [period, setPeriod] =
-    useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
   const [selectedTool, setSelectedTool] = useState<string | null>(null);
 
   const { toolLatencyByVersion, isToolLatencyLoading, isToolLatencyError } =
@@ -122,8 +124,9 @@ export function ToolLatencyChart({
     <ChartContainer
       title="Average Tool Latency by Version"
       period={period}
-      onPeriodChange={setPeriod}
+      onPeriodChange={onPeriodChange}
       isLoading={isToolLatencyLoading}
+      showPeriodSelector={false}
       additionalControls={
         <select
           className="bg-card rounded border border-border px-2 py-1 text-xs"
@@ -213,7 +216,12 @@ export function ToolLatencyChart({
             cursor={false}
             content={renderTooltip}
             wrapperStyle={{ outline: "none" }}
-            contentStyle={{ background: "transparent", border: "none", padding: 0, boxShadow: "none" }}
+            contentStyle={{
+              background: "transparent",
+              border: "none",
+              padding: 0,
+              boxShadow: "none",
+            }}
           />
           <Area
             type="natural"

--- a/front/components/agent_builder/observability/ToolLatencyChart.tsx
+++ b/front/components/agent_builder/observability/ToolLatencyChart.tsx
@@ -13,12 +13,11 @@ import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 import { ChartContainer } from "@app/components/agent_builder/observability/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/ChartTooltip";
-import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import {
   CHART_HEIGHT,
-  DEFAULT_PERIOD_DAYS,
   MAX_TOOLS_DISPLAYED,
 } from "@app/components/agent_builder/observability/constants";
+import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { calculateTopTools } from "@app/components/agent_builder/observability/utils";
 import { useAgentToolLatency } from "@app/lib/swr/assistants";
 
@@ -27,8 +26,6 @@ type ChartRow = { version: string; values: Record<string, number> };
 interface ToolLatencyChartProps {
   workspaceId: string;
   agentConfigurationId: string;
-  period: ObservabilityTimeRangeType;
-  onPeriodChange: (p: ObservabilityTimeRangeType) => void;
 }
 
 function AreaLatencyTooltip({
@@ -61,9 +58,8 @@ function AreaLatencyTooltip({
 export function ToolLatencyChart({
   workspaceId,
   agentConfigurationId,
-  period,
-  onPeriodChange,
 }: ToolLatencyChartProps) {
+  const { period, setPeriod } = useObservability();
   const [selectedTool, setSelectedTool] = useState<string | null>(null);
 
   const { toolLatencyByVersion, isToolLatencyLoading, isToolLatencyError } =
@@ -123,10 +119,7 @@ export function ToolLatencyChart({
   return (
     <ChartContainer
       title="Average Tool Latency by Version"
-      period={period}
-      onPeriodChange={onPeriodChange}
       isLoading={isToolLatencyLoading}
-      showPeriodSelector={false}
       additionalControls={
         <select
           className="bg-card rounded border border-border px-2 py-1 text-xs"

--- a/front/components/agent_builder/observability/ToolLatencyChart.tsx
+++ b/front/components/agent_builder/observability/ToolLatencyChart.tsx
@@ -38,12 +38,19 @@ function AreaLatencyTooltip({
     return null;
   }
 
+  const colorMap: Record<string, string> = {
+    avg: "text-[hsl(var(--chart-1))]",
+    p50: "text-[hsl(var(--chart-2))]",
+    p95: "text-[hsl(var(--chart-3))]",
+  };
+
   const rows = payload
     .filter((p) => typeof p.value === "number")
     .sort((a, b) => (b.name || "").localeCompare(a.name || ""))
     .map((p) => ({
       label: String(p.name),
       value: `${p.value}ms`,
+      colorClassName: colorMap[String(p.name)] ?? undefined,
     }));
 
   return <ChartTooltipCard title={String(label)} rows={rows} />;

--- a/front/components/agent_builder/observability/ToolLatencyChart.tsx
+++ b/front/components/agent_builder/observability/ToolLatencyChart.tsx
@@ -93,7 +93,6 @@ export function ToolLatencyChart({
       MAX_TOOLS_DISPLAYED
     );
 
-    const versions = toolLatencyByVersion.map((v) => v.version);
     const toolToUse = selectedTool ?? top[0];
     const areaData = toolLatencyByVersion.map((v) => ({
       version: `v${v.version}`,
@@ -102,7 +101,7 @@ export function ToolLatencyChart({
       p95: v.tools[toolToUse]?.p95LatencyMs ?? 0,
     }));
 
-    return { versions, topTools: top, areaData };
+    return { topTools: top, areaData };
   }, [toolLatencyByVersion, selectedTool]);
 
   const renderTooltip = useCallback(

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -128,7 +128,7 @@ export function UsageMetricsChart({
   workspaceId: string;
   agentConfigurationId: string;
 }) {
-  const { period, setPeriod } = useObservability();
+  const { period } = useObservability();
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     useAgentUsageMetrics({
       workspaceId,

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   Bar,
   BarChart,
@@ -15,14 +15,13 @@ import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 import { ChartContainer } from "@app/components/agent_builder/observability/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/ChartTooltip";
-import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import {
   CHART_HEIGHT,
-  DEFAULT_PERIOD_DAYS,
   USAGE_METRICS_LEGEND,
   USAGE_METRICS_PALETTE,
   VERSION_MARKER_STYLE,
 } from "@app/components/agent_builder/observability/constants";
+import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import {
   useAgentUsageMetrics,
   useAgentVersionMarkers,
@@ -125,14 +124,11 @@ function UsageMetricsTooltip(
 export function UsageMetricsChart({
   workspaceId,
   agentConfigurationId,
-  period,
-  onPeriodChange,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
-  period: ObservabilityTimeRangeType;
-  onPeriodChange: (p: ObservabilityTimeRangeType) => void;
 }) {
+  const { period, setPeriod } = useObservability();
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     useAgentUsageMetrics({
       workspaceId,
@@ -172,10 +168,7 @@ export function UsageMetricsChart({
   return (
     <ChartContainer
       title="Usage Metrics"
-      period={period}
-      onPeriodChange={onPeriodChange}
       isLoading={isLoading}
-      showPeriodSelector={false}
       errorMessage={isError ? "Failed to load observability data." : undefined}
     >
       <ResponsiveContainer width="100%" height={CHART_HEIGHT}>

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 import {
   Bar,
@@ -16,14 +15,10 @@ import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 import { ChartContainer } from "@app/components/agent_builder/observability/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/ChartTooltip";
-import type {
-  ObservabilityIntervalType,
-  ObservabilityTimeRangeType,
-} from "@app/components/agent_builder/observability/constants";
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import {
   CHART_HEIGHT,
   DEFAULT_PERIOD_DAYS,
-  OBSERVABILITY_INTERVALS,
   USAGE_METRICS_LEGEND,
   USAGE_METRICS_PALETTE,
   VERSION_MARKER_STYLE,
@@ -130,20 +125,20 @@ function UsageMetricsTooltip(
 export function UsageMetricsChart({
   workspaceId,
   agentConfigurationId,
+  period,
+  onPeriodChange,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
+  period: ObservabilityTimeRangeType;
+  onPeriodChange: (p: ObservabilityTimeRangeType) => void;
 }) {
-  const [period, setPeriod] =
-    useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
-  const [interval, setInterval] = useState<ObservabilityIntervalType>("day");
-
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     useAgentUsageMetrics({
       workspaceId,
       agentConfigurationId,
       days: period,
-      interval,
+      interval: "day",
       disabled: !workspaceId || !agentConfigurationId,
     });
 
@@ -174,33 +169,14 @@ export function UsageMetricsChart({
     };
   }, [usageMetrics?.points, versionMarkers]);
 
-  const intervalControls = (
-    <div className="flex items-center gap-2">
-      {OBSERVABILITY_INTERVALS.map((i) => (
-        <button
-          key={i}
-          onClick={() => setInterval(i)}
-          className={cn(
-            "rounded px-2 py-1 text-xs",
-            interval === i
-              ? "bg-foreground text-background"
-              : "text-muted-foreground hover:text-foreground"
-          )}
-        >
-          {i}
-        </button>
-      ))}
-    </div>
-  );
-
   return (
     <ChartContainer
       title="Usage Metrics"
       period={period}
-      onPeriodChange={setPeriod}
+      onPeriodChange={onPeriodChange}
       isLoading={isLoading}
+      showPeriodSelector={false}
       errorMessage={isError ? "Failed to load observability data." : undefined}
-      additionalControls={intervalControls}
     >
       <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
         <BarChart
@@ -226,7 +202,12 @@ export function UsageMetricsChart({
             cursor={false}
             content={UsageMetricsTooltip}
             wrapperStyle={{ outline: "none" }}
-            contentStyle={{ background: "transparent", border: "none", padding: 0, boxShadow: "none" }}
+            contentStyle={{
+              background: "transparent",
+              border: "none",
+              padding: 0,
+              boxShadow: "none",
+            }}
           />
           {USAGE_METRICS_LEGEND.map(({ key, label }) => (
             <Bar

--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -207,12 +207,26 @@ export function UsageMetricsChart({
           data={data}
           margin={{ top: 10, right: 30, left: 10, bottom: 0 }}
         >
-          <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-          <XAxis dataKey="date" className="text-xs text-muted-foreground" />
-          <YAxis className="text-xs text-muted-foreground" />
+          <CartesianGrid vertical={false} className="stroke-border" />
+          <XAxis
+            dataKey="date"
+            className="text-xs text-muted-foreground"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            minTickGap={16}
+          />
+          <YAxis
+            className="text-xs text-muted-foreground"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+          />
           <Tooltip
-            cursor={{ fill: "hsl(var(--border) / 0.1)" }}
+            cursor={false}
             content={UsageMetricsTooltip}
+            wrapperStyle={{ outline: "none" }}
+            contentStyle={{ background: "transparent", border: "none", padding: 0, boxShadow: "none" }}
           />
           {USAGE_METRICS_LEGEND.map(({ key, label }) => (
             <Bar
@@ -221,6 +235,7 @@ export function UsageMetricsChart({
               name={label}
               fill="currentColor"
               className={USAGE_METRICS_PALETTE[key]}
+              radius={[4, 4, 0, 0]}
             />
           ))}
           {snappedMarkers.map((m, index) => (

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -4,9 +4,6 @@ export type ObservabilityTimeRangeType =
 
 export const DEFAULT_PERIOD_DAYS = 14;
 
-// Use shadcn UI chart color tokens to align with design system.
-// We apply them via text-[color] so components using fill="currentColor"
-// and LegendDot with bg-current pick up the same series color.
 export const USAGE_METRICS_PALETTE = {
   messages: "text-[hsl(var(--chart-1))]",
   conversations: "text-[hsl(var(--chart-2))]",
@@ -30,14 +27,8 @@ export const VERSION_MARKER_STYLE = {
   labelOffsetIncrement: 15,
 } as const;
 
-// Map tool series to shadcn chart tokens. We cycle 1..5 to keep
-// parity with the default shadcn palette depth.
+// TODO: find a way to display more tools
 export const TOOL_COLORS = [
-  "text-[hsl(var(--chart-1))]",
-  "text-[hsl(var(--chart-2))]",
-  "text-[hsl(var(--chart-3))]",
-  "text-[hsl(var(--chart-4))]",
-  "text-[hsl(var(--chart-5))]",
   "text-[hsl(var(--chart-1))]",
   "text-[hsl(var(--chart-2))]",
   "text-[hsl(var(--chart-3))]",
@@ -45,5 +36,5 @@ export const TOOL_COLORS = [
   "text-[hsl(var(--chart-5))]",
 ] as const;
 
-export const MAX_TOOLS_DISPLAYED = 10;
+export const MAX_TOOLS_DISPLAYED = 5;
 export const PERCENTAGE_MULTIPLIER = 100;

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -4,10 +4,6 @@ export type ObservabilityTimeRangeType =
 
 export const DEFAULT_PERIOD_DAYS = 14;
 
-export const OBSERVABILITY_INTERVALS = ["day", "week"] as const;
-export type ObservabilityIntervalType =
-  (typeof OBSERVABILITY_INTERVALS)[number];
-
 // Use shadcn UI chart color tokens to align with design system.
 // We apply them via text-[color] so components using fill="currentColor"
 // and LegendDot with bg-current pick up the same series color.

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -8,10 +8,13 @@ export const OBSERVABILITY_INTERVALS = ["day", "week"] as const;
 export type ObservabilityIntervalType =
   (typeof OBSERVABILITY_INTERVALS)[number];
 
+// Use shadcn UI chart color tokens to align with design system.
+// We apply them via text-[color] so components using fill="currentColor"
+// and LegendDot with bg-current pick up the same series color.
 export const USAGE_METRICS_PALETTE = {
-  messages: "text-blue-500",
-  conversations: "text-amber-500",
-  activeUsers: "text-emerald-500",
+  messages: "text-[hsl(var(--chart-1))]",
+  conversations: "text-[hsl(var(--chart-2))]",
+  activeUsers: "text-[hsl(var(--chart-3))]",
 } as const;
 
 export const USAGE_METRICS_LEGEND = [
@@ -23,7 +26,7 @@ export const USAGE_METRICS_LEGEND = [
 export const CHART_HEIGHT = 260;
 
 export const VERSION_MARKER_STYLE = {
-  stroke: "#f59e0b",
+  stroke: "hsl(var(--primary))",
   strokeWidth: 2,
   strokeDasharray: "5 5",
   labelFontSize: 12,
@@ -31,17 +34,19 @@ export const VERSION_MARKER_STYLE = {
   labelOffsetIncrement: 15,
 } as const;
 
+// Map tool series to shadcn chart tokens. We cycle 1..5 to keep
+// parity with the default shadcn palette depth.
 export const TOOL_COLORS = [
-  "text-blue-500",
-  "text-emerald-500",
-  "text-amber-500",
-  "text-purple-500",
-  "text-pink-500",
-  "text-cyan-500",
-  "text-orange-500",
-  "text-teal-500",
-  "text-indigo-500",
-  "text-rose-500",
+  "text-[hsl(var(--chart-1))]",
+  "text-[hsl(var(--chart-2))]",
+  "text-[hsl(var(--chart-3))]",
+  "text-[hsl(var(--chart-4))]",
+  "text-[hsl(var(--chart-5))]",
+  "text-[hsl(var(--chart-1))]",
+  "text-[hsl(var(--chart-2))]",
+  "text-[hsl(var(--chart-3))]",
+  "text-[hsl(var(--chart-4))]",
+  "text-[hsl(var(--chart-5))]",
 ] as const;
 
 export const MAX_TOOLS_DISPLAYED = 10;

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -22,6 +22,66 @@
       font-synthesis-weight: none;
     }
   }
+
+  /* shadcn-style CSS variables (background, border, chart colors, etc.) */
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 221.2 83.2% 53.3%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 221.2 83.2% 53.3%;
+    --radius: 0.65rem;
+
+    /* Chart tokens (light): exact shadcn palette */
+    --chart-1: 211 100% 78%;
+    --chart-2: 216 100% 58%;
+    --chart-3: 221 97% 54%;
+    --chart-4: 225 84% 49%;
+    --chart-5: 227 76% 41%;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 224.3 76.3% 48%;
+
+    /* Chart tokens (dark): exact shadcn palette */
+    --chart-1: 211 100% 78%;
+    --chart-2: 216 100% 58%;
+    --chart-3: 221 97% 54%;
+    --chart-4: 225 84% 49%;
+    --chart-5: 227 76% 41%;
+  }
 }
 
 html,
@@ -139,6 +199,7 @@ main {
   * {
     scrollbar-width: thin;
   }
+
   .dark * {
     scrollbar-color: theme("colors.gray.700") theme("colors.gray.900");
   }

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -23,29 +23,7 @@
     }
   }
 
-  /* shadcn-style CSS variables (background, border, chart colors, etc.) */
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.65rem;
-
     /* Chart tokens (light): exact shadcn palette */
     --chart-1: 211 100% 78%;
     --chart-2: 216 100% 58%;
@@ -55,26 +33,6 @@
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
-
     /* Chart tokens (dark): exact shadcn palette */
     --chart-1: 211 100% 78%;
     --chart-2: 216 100% 58%;


### PR DESCRIPTION
## Description

This PR polishes the observability charts UI to align with the shadcn design system. The changes include migrating to shadcn chart color tokens, improving chart accessibility with proper ARIA attributes, and enhancing the overall visual appearance. The tool latency chart is converted from a bar chart to an area chart for better visualization, and a centralized time period selector is introduced through a new ObservabilityProvider context.

<img width="1391" height="1253" alt="Screenshot 2025-10-21 at 14 35 31" src="https://github.com/user-attachments/assets/6385c277-f2e6-48d9-a422-d9dab29cb1fa" />

## Risk

Low - behind FF

## Deploy Plan

Deploy front
