### PR TITLE
Update SDK to mention new field parentAgentMessageId

### DIFF
--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -985,6 +985,7 @@ const AgentMessageTypeSchema = z.object({
   visibility: VisibilitySchema,
   version: z.number(),
   parentMessageId: z.string().nullable(),
+  parentAgentMessageId: z.string().nullable(),
   configuration: LightAgentConfigurationSchema,
   status: AgentMessageStatusSchema,
   actions: z.array(AgentActionTypeSchema),


### PR DESCRIPTION
## Description

`parentAgentMessageId` was added a couple of weeks ago for the handoff flow to `BaseAgentMessageType`, it points to the agent message that handed off the current agent message. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish new patch version of the SDK. 
