### PR TITLE
Bump sdk to version 1.1.18

### DIFF
--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.1.17",
+      "version": "1.1.18",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Bumping the sdk to get my latest change: https://github.com/dust-tt/dust/pull/17143
I thought the publish would be like sparkle where the github action would bump the package file, apparently it does not 😄 
(https://github.com/dust-tt/dust/actions/runs/18683460727/job/53269848518)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish SDK
