### PR TITLE
[front] enh(triggers): merge schedule and webhooks buttons in AgentBuilder

### DIFF
--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -198,9 +198,9 @@ export function AgentBuilderTriggersBlock({
             <DropdownMenuTrigger asChild>
               <Button
                 label="Add Trigger"
-                variant="primary"
                 isSelect
                 type="button"
+                icon={BoltIcon}
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent>

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -23,6 +23,7 @@ import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { ScheduleEditionModal } from "@app/components/agent_builder/triggers/ScheduleEditionModal";
 import { TriggerCard } from "@app/components/agent_builder/triggers/TriggerCard";
 import { WebhookEditionModal } from "@app/components/agent_builder/triggers/WebhookEditionModal";
+import { getIcon } from "@app/components/resources/resources_icons";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useWebhookSourceViewsFromSpaces } from "@app/lib/swr/webhook_source";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -238,7 +239,7 @@ export function AgentBuilderTriggersBlock({
                   <DropdownMenuItem
                     key={view.sId}
                     label={view.customName}
-                    icon={view.icon}
+                    icon={getIcon(view.icon)}
                     onClick={() => handleCreateTrigger("webhook", view)}
                   />
                 ))}
@@ -276,7 +277,7 @@ export function AgentBuilderTriggersBlock({
                       <DropdownMenuItem
                         key={view.sId}
                         label={view.customName}
-                        icon={view.icon}
+                        icon={getIcon(view.icon)}
                         onClick={() => handleCreateTrigger("webhook", view)}
                       />
                     ))}

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -214,12 +214,12 @@ export function AgentBuilderTriggersBlock({
                   <DropdownMenuItem
                     key={view.sId}
                     label={view.customName}
-                    icon={(props) => (
+                    icon={
                       <WebhookSourceViewIcon
                         webhookSourceView={view}
                         size="sm"
                       />
-                    )}
+                    }
                     onClick={() => handleCreateTrigger("webhook", view.sId)}
                   />
                 ))}
@@ -257,12 +257,12 @@ export function AgentBuilderTriggersBlock({
                       <DropdownMenuItem
                         key={view.sId}
                         label={view.customName}
-                        icon={(props) => (
+                        icon={
                           <WebhookSourceViewIcon
                             webhookSourceView={view}
                             size="sm"
                           />
-                        )}
+                        }
                         onClick={() => handleCreateTrigger("webhook", view.sId)}
                       />
                     ))}

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -56,6 +56,7 @@ export function AgentBuilderTriggersBlock({
   agentConfigurationId,
 }: AgentBuilderTriggersBlockProps) {
   const { getValues, setValue } = useFormContext<AgentBuilderFormData>();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const {
     fields: triggersToCreate,
@@ -116,6 +117,7 @@ export function AgentBuilderTriggersBlock({
     kind: TriggerKind,
     webhookSourceView?: WebhookSourceViewType
   ) => {
+    setIsDropdownOpen(false);
     setDialogMode({
       type: "add",
       kind,
@@ -209,7 +211,7 @@ export function AgentBuilderTriggersBlock({
       }
       headerActions={
         allTriggers.length > 0 && (
-          <DropdownMenu>
+          <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
             <DropdownMenuTrigger asChild>
               <Button
                 label="Add Trigger"
@@ -247,7 +249,10 @@ export function AgentBuilderTriggersBlock({
         ) : allTriggers.length === 0 ? (
           <EmptyCTA
             action={
-              <DropdownMenu>
+              <DropdownMenu
+                open={isDropdownOpen}
+                onOpenChange={setIsDropdownOpen}
+              >
                 <DropdownMenuTrigger asChild>
                   <Button
                     label="Add Trigger"

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -260,9 +260,9 @@ export function AgentBuilderTriggersBlock({
                 <DropdownMenuTrigger asChild>
                   <Button
                     label="Add Trigger"
-                    variant="outline"
                     isSelect
                     type="button"
+                    icon={BoltIcon}
                   />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -198,7 +198,7 @@ export function AgentBuilderTriggersBlock({
             <DropdownMenuTrigger asChild>
               <Button
                 label="Add Trigger"
-                variant="outline"
+                variant="primary"
                 isSelect
                 type="button"
               />

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -116,21 +116,11 @@ export function AgentBuilderTriggersBlock({
     kind: TriggerKind,
     webhookSourceView?: WebhookSourceViewType
   ) => {
-    if (kind === "schedule") {
-      setDialogMode({
-        type: "add",
-        kind: "schedule",
-      });
-    } else {
-      if (!webhookSourceView) {
-        throw new Error("webhookSourceView is required for webhook triggers");
-      }
-      setDialogMode({
-        type: "add",
-        kind: "webhook",
-        webhookSourceView,
-      });
-    }
+    setDialogMode({
+      type: "add",
+      kind,
+      webhookSourceView,
+    });
   };
 
   const handleTriggerEdit = (

--- a/front/components/agent_builder/triggers/WebhookEditionModal.tsx
+++ b/front/components/agent_builder/triggers/WebhookEditionModal.tsx
@@ -80,18 +80,17 @@ export function WebhookEditionModal({
 }: WebhookEditionModalProps) {
   const { user } = useUser();
 
-  const defaultValues = useMemo(
-    (): WebhookFormData => ({
-      name: "Webhook Trigger",
-      enabled: true,
-      customPrompt: "",
-      webhookSourceViewSId: preSelectedWebhookSourceViewSId ?? "",
-      event: undefined,
-      filter: "",
-      includePayload: true,
-    }),
-    [preSelectedWebhookSourceViewSId]
-  );
+  const getDefaultValues = (): WebhookFormData => ({
+    name: "Webhook Trigger",
+    enabled: true,
+    customPrompt: "",
+    webhookSourceViewSId: preSelectedWebhookSourceViewSId ?? "",
+    event: undefined,
+    filter: "",
+    includePayload: true,
+  });
+
+  const defaultValues = useMemo(getDefaultValues, [preSelectedWebhookSourceViewSId]);
 
   const form = useForm<WebhookFormData>({
     resolver: zodResolver(webhookFormSchema),
@@ -187,6 +186,7 @@ export function WebhookEditionModal({
     }
   }, [generatedFilter, form]);
 
+  // Reset natural description when modal closes
   useEffect(() => {
     if (!isOpen) {
       form.reset(defaultValues);

--- a/front/components/agent_builder/triggers/WebhookEditionModal.tsx
+++ b/front/components/agent_builder/triggers/WebhookEditionModal.tsx
@@ -22,7 +22,7 @@ import {
   TextArea,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -80,17 +80,20 @@ export function WebhookEditionModal({
 }: WebhookEditionModalProps) {
   const { user } = useUser();
 
-  const getDefaultValues = (): WebhookFormData => ({
-    name: "Webhook Trigger",
-    enabled: true,
-    customPrompt: "",
-    webhookSourceViewSId: preSelectedWebhookSourceViewSId ?? "",
-    event: undefined,
-    filter: "",
-    includePayload: true,
-  });
+  const getDefaultValues = useCallback(
+    (): WebhookFormData => ({
+      name: "Webhook Trigger",
+      enabled: true,
+      customPrompt: "",
+      webhookSourceViewSId: preSelectedWebhookSourceViewSId ?? "",
+      event: undefined,
+      filter: "",
+      includePayload: true,
+    }),
+    [preSelectedWebhookSourceViewSId]
+  );
 
-  const defaultValues = useMemo(getDefaultValues, [preSelectedWebhookSourceViewSId]);
+  const defaultValues = useMemo(getDefaultValues, [getDefaultValues]);
 
   const form = useForm<WebhookFormData>({
     resolver: zodResolver(webhookFormSchema),
@@ -126,7 +129,10 @@ export function WebhookEditionModal({
           label: view.customName,
           kind: view.kind,
           icon: (props) => (
-            <WebhookSourceViewIcon webhookSourceView={view} size={props.className ? undefined : "sm"} />
+            <WebhookSourceViewIcon
+              webhookSourceView={view}
+              size={props.className ? undefined : "sm"}
+            />
           ),
         });
       });
@@ -138,8 +144,8 @@ export function WebhookEditionModal({
     if (!selectedViewSId) {
       return null;
     }
-    const view = webhookSourceViews.find((v) => v.sId === selectedViewSId);
-    return view;
+
+    return webhookSourceViews.find((v) => v.sId === selectedViewSId);
   }, [webhookSourceViews, selectedViewSId]);
 
   const selectedPreset = useMemo((): PresetWebhook | null => {

--- a/front/components/agent_builder/triggers/WebhookEditionModal.tsx
+++ b/front/components/agent_builder/triggers/WebhookEditionModal.tsx
@@ -1,4 +1,3 @@
-import type { Icon } from "@dust-tt/sparkle";
 import {
   Button,
   Checkbox,
@@ -22,21 +21,18 @@ import {
   TextArea,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import type { AgentBuilderWebhookTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { RecentWebhookRequests } from "@app/components/agent_builder/triggers/RecentWebhookRequests";
 import { TriggerFilterRenderer } from "@app/components/agent_builder/triggers/TriggerFilterRenderer";
 import { useWebhookFilterGeneration } from "@app/components/agent_builder/triggers/useWebhookFilterGeneration";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
-import { WebhookSourceViewIcon } from "@app/components/triggers/WebhookSourceViewIcon";
 import { useUser } from "@app/lib/swr/user";
-import { useWebhookSourceViewsFromSpaces } from "@app/lib/swr/webhook_source";
 import type { LightWorkspaceType } from "@app/types";
-import type { WebhookSourceKind } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP } from "@app/types/triggers/webhooks";
 import type { PresetWebhook } from "@app/types/triggers/webhooks_source_preset";
 
@@ -59,15 +55,8 @@ interface WebhookEditionModalProps {
   onClose: () => void;
   onSave: (trigger: AgentBuilderWebhookTriggerType) => void;
   agentConfigurationId: string | null;
-  preSelectedWebhookSourceViewSId?: string;
+  webhookSourceView: WebhookSourceViewType | null;
 }
-
-type WebhookOption = {
-  value: string;
-  label: string;
-  kind: WebhookSourceKind;
-  icon: React.ComponentType<React.ComponentProps<typeof Icon>>;
-};
 
 export function WebhookEditionModal({
   owner,
@@ -76,96 +65,48 @@ export function WebhookEditionModal({
   onClose,
   onSave,
   agentConfigurationId,
-  preSelectedWebhookSourceViewSId,
+  webhookSourceView,
 }: WebhookEditionModalProps) {
   const { user } = useUser();
 
-  const getDefaultValues = useCallback(
+  const defaultValues = useMemo(
     (): WebhookFormData => ({
       name: "Webhook Trigger",
       enabled: true,
       customPrompt: "",
-      webhookSourceViewSId: preSelectedWebhookSourceViewSId ?? "",
+      webhookSourceViewSId: webhookSourceView?.sId ?? "",
       event: undefined,
       filter: "",
       includePayload: true,
     }),
-    [preSelectedWebhookSourceViewSId]
+    [webhookSourceView?.sId]
   );
-
-  const defaultValues = useMemo(getDefaultValues, [getDefaultValues]);
 
   const form = useForm<WebhookFormData>({
     resolver: zodResolver(webhookFormSchema),
     defaultValues,
   });
 
-  const selectedViewSId = form.watch("webhookSourceViewSId") ?? "";
   const selectedEvent = form.watch("event");
   const includePayload = form.watch("includePayload");
 
-  const { spaces } = useSpacesContext();
-  const { webhookSourceViews, isLoading: isWebhookSourceViewsLoading } =
-    useWebhookSourceViewsFromSpaces(owner, spaces, !isOpen);
-
   const isEditor = (trigger?.editor ?? user?.id) === user?.id;
 
-  const spaceById = useMemo(() => {
-    return new Map(spaces.map((space) => [space.sId, space.name]));
-  }, [spaces]);
-
-  const accessibleSpaceIds = useMemo(
-    () => new Set(spaceById.keys()),
-    [spaceById]
-  );
-
-  const webhookOptions = useMemo((): WebhookOption[] => {
-    const options: WebhookOption[] = [];
-    webhookSourceViews
-      .filter((view) => accessibleSpaceIds.has(view.spaceId))
-      .forEach((view) => {
-        options.push({
-          value: view.sId,
-          label: view.customName,
-          kind: view.kind,
-          icon: (props) => (
-            <WebhookSourceViewIcon
-              webhookSourceView={view}
-              size={props.className ? undefined : "sm"}
-            />
-          ),
-        });
-      });
-
-    return options;
-  }, [webhookSourceViews, accessibleSpaceIds]);
-
-  const selectedWebhookSourceView = useMemo(() => {
-    if (!selectedViewSId) {
-      return null;
-    }
-
-    return webhookSourceViews.find((v) => v.sId === selectedViewSId);
-  }, [webhookSourceViews, selectedViewSId]);
-
   const selectedPreset = useMemo((): PresetWebhook | null => {
-    if (
-      !selectedWebhookSourceView ||
-      selectedWebhookSourceView.kind === "custom"
-    ) {
+    if (!webhookSourceView || webhookSourceView.kind === "custom") {
       return null;
     }
-    return WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP[selectedWebhookSourceView.kind];
-  }, [selectedWebhookSourceView]);
+    return WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP[webhookSourceView.kind];
+  }, [webhookSourceView]);
 
   const availableEvents = useMemo(() => {
-    if (!selectedPreset || !selectedWebhookSourceView) {
+    if (!selectedPreset || !webhookSourceView) {
       return [];
     }
     return selectedPreset.events.filter((event) =>
-      selectedWebhookSourceView.subscribedEvents.includes(event.value)
+      webhookSourceView.subscribedEvents.includes(event.value)
     );
-  }, [selectedPreset, selectedWebhookSourceView]);
+  }, [selectedPreset, webhookSourceView]);
 
   const selectedEventSchema = useMemo(() => {
     if (!selectedEvent || !selectedPreset) {
@@ -242,8 +183,8 @@ export function WebhookEditionModal({
 
     // Validate that event is selected for preset webhooks (not custom)
     if (
-      selectedWebhookSourceView &&
-      selectedWebhookSourceView.kind !== "custom" &&
+      webhookSourceView &&
+      webhookSourceView.kind !== "custom" &&
       selectedPreset &&
       availableEvents.length > 0 &&
       !data.event
@@ -264,7 +205,7 @@ export function WebhookEditionModal({
       name: data.name.trim(),
       customPrompt: data.customPrompt.trim(),
       naturalLanguageDescription:
-        selectedWebhookSourceView?.kind !== "custom"
+        webhookSourceView?.kind !== "custom"
           ? naturalDescription || null
           : null,
       kind: "webhook",
@@ -324,11 +265,11 @@ export function WebhookEditionModal({
     if (trigger) {
       return isEditor ? "Edit Webhook" : "View Webhook";
     }
-    if (selectedWebhookSourceView) {
-      return `Create ${selectedWebhookSourceView.customName} Trigger`;
+    if (webhookSourceView) {
+      return `Create ${webhookSourceView.customName} Trigger`;
     }
     return "Create Webhook";
-  }, [trigger, isEditor, selectedWebhookSourceView]);
+  }, [trigger, isEditor, webhookSourceView]);
 
   return (
     <Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
@@ -385,60 +326,6 @@ export function WebhookEditionModal({
                     : "The trigger is currently disabled"}
                 </div>
               </div>
-
-              {/* Webhook Configuration - Only show selector when editing or no pre-selection */}
-              {(!preSelectedWebhookSourceViewSId || trigger) && (
-                <div className="flex flex-col space-y-1">
-                  <Label>Webhook Source</Label>
-                  {isWebhookSourceViewsLoading ? (
-                    <div className="flex items-center gap-2">
-                      <Spinner size="sm" />
-                      <span className="text-sm text-muted-foreground">
-                        Loading webhook sources...
-                      </span>
-                    </div>
-                  ) : (
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          id="webhook-source"
-                          variant="outline"
-                          isSelect
-                          className="w-fit"
-                          disabled={!isEditor}
-                          label={
-                            selectedViewSId
-                              ? webhookOptions.find(
-                                  (opt) => opt.value === selectedViewSId
-                                )?.label
-                              : "Select webhook source"
-                          }
-                        />
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent>
-                        <DropdownMenuLabel label="Select webhook source" />
-                        {webhookOptions.map((option) => (
-                          <DropdownMenuItem
-                            key={option.value}
-                            label={option.label}
-                            disabled={!isEditor}
-                            icon={option.icon}
-                            onClick={() => {
-                              form.setValue(
-                                "webhookSourceViewSId",
-                                option.value,
-                                {
-                                  shouldValidate: true,
-                                }
-                              );
-                            }}
-                          />
-                        ))}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  )}
-                </div>
-              )}
 
               {/* Event selector for non-custom webhooks */}
               {selectedPreset && availableEvents.length > 0 && (
@@ -521,7 +408,7 @@ export function WebhookEditionModal({
                   </>
                 )}
 
-                {selectedWebhookSourceView?.kind === "custom" && (
+                {webhookSourceView?.kind === "custom" && (
                   <>
                     <Label htmlFor="trigger-filter-description">
                       Filter Expression (optional)
@@ -619,8 +506,8 @@ export function WebhookEditionModal({
               ? isEditor
                 ? "Update Webhook"
                 : "Close"
-              : selectedWebhookSourceView
-                ? `Add ${selectedWebhookSourceView.customName} Trigger`
+              : webhookSourceView
+                ? `Add ${webhookSourceView.customName} Trigger`
                 : "Add Webhook",
             variant: "primary",
             onClick: isEditor ? form.handleSubmit(onSubmit) : handleClose,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/4786.
- This PR merges the two buttons to add triggers into one single dropdown that contains the schedule as a first item and then every type of webhook.
- Selecting a webhook loads the sheet with only this webhook source view (no picker anymore).
- The name of the webhook edition sheet is updated from `Create webhook` to `Create ${webhookSource.name} trigger`.

<img width="787" height="252" alt="Screenshot 2025-10-21 at 10 09 00 PM" src="https://github.com/user-attachments/assets/678e14fc-b7dd-4b3c-9d7b-78fe44d80cff" />


## Tests

- Checked locally.

## Risk

- Low, behind FF + mostly UI.

## Deploy Plan

- Deploy front.
