### PR TITLE
Upload file from conversations to Microsoft Drive

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1081,6 +1081,7 @@ The directive should be used to display a clickable version of the agent name in
       search_drive_items: "never_ask",
       update_word_document: "high",
       get_file_content: "never_ask",
+      upload_file: "high",
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,


### PR DESCRIPTION
## Description
Adds an `upload_file` tool to the Microsoft Drive MCP server that enables uploading files from Dust conversation attachments to SharePoint or OneDrive. The tool supports files up to 250MB using Microsoft Graph's simple upload API, automatically creates folder paths if they don't exist, and works with both driveId and siteId endpoints.

## Risk
Low risk. 

## Deploy Plan
Deploy front