### PR TITLE
[front] hootl: move email to name in trigger card

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -198,7 +198,7 @@ const webhookTriggerSchema = z.object({
   configuration: webhookConfigSchema,
   editor: z.number().nullable(),
   webhookSourceViewSId: z.string().nullable().optional(),
-  editorEmail: z.string().optional(),
+  editorName: z.string().optional(),
 });
 
 const scheduleTriggerSchema = z.object({
@@ -210,7 +210,7 @@ const scheduleTriggerSchema = z.object({
   naturalLanguageDescription: z.string().nullable(),
   configuration: scheduleConfigSchema,
   editor: z.number().nullable(),
-  editorEmail: z.string().optional(),
+  editorName: z.string().optional(),
 });
 
 const triggerSchema = z.discriminatedUnion("kind", [

--- a/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
@@ -203,7 +203,7 @@ export function ScheduleEditionModal({
       editor: trigger?.editor ?? user?.id ?? null,
       naturalLanguageDescription: data.naturalLanguageDescription ?? null,
       customPrompt: data.customPrompt.trim() ?? null,
-      editorEmail: trigger?.editorEmail ?? user?.email,
+      editorName: trigger?.editorName ?? user?.email,
     };
 
     onSave(triggerData);
@@ -229,7 +229,7 @@ export function ScheduleEditionModal({
               You cannot edit this schedule. It is managed by{" "}
               <span className="font-semibold">
                 {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-                {trigger.editorEmail || "another user"}
+                {trigger.editorName || "another user"}
               </span>
               .
             </ContentMessage>

--- a/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
@@ -203,7 +203,7 @@ export function ScheduleEditionModal({
       editor: trigger?.editor ?? user?.id ?? null,
       naturalLanguageDescription: data.naturalLanguageDescription ?? null,
       customPrompt: data.customPrompt.trim() ?? null,
-      editorName: trigger?.editorName ?? user?.email,
+      editorName: trigger?.editorName ?? user?.fullName,
     };
 
     onSave(triggerData);

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -88,11 +88,11 @@ export const TriggerCard = ({
         <span className="text-muted-foreground dark:text-muted-foreground-night">
           <span className="line-clamp-2 break-words">{description}</span>
         </span>
-        {trigger.editorEmail && (
+        {trigger.editorName && (
           <span className="mt-auto text-xs text-muted-foreground dark:text-muted-foreground-night">
             Managed by{" "}
             <span className="font-semibold">
-              {trigger.editorEmail ?? "another user"}
+              {trigger.editorName ?? "another user"}
             </span>
             .
           </span>

--- a/front/components/agent_builder/triggers/WebhookEditionModal.tsx
+++ b/front/components/agent_builder/triggers/WebhookEditionModal.tsx
@@ -248,7 +248,7 @@ export function WebhookEditionModal({
     }
 
     const editor = trigger?.editor ?? user.id ?? null;
-    const editorName = trigger?.editorName ?? user.email ?? undefined;
+    const editorName = trigger?.editorName ?? user.fullName ?? undefined;
 
     const triggerData: AgentBuilderWebhookTriggerType = {
       sId: trigger?.sId,

--- a/front/components/agent_builder/triggers/WebhookEditionModal.tsx
+++ b/front/components/agent_builder/triggers/WebhookEditionModal.tsx
@@ -248,7 +248,7 @@ export function WebhookEditionModal({
     }
 
     const editor = trigger?.editor ?? user.id ?? null;
-    const editorEmail = trigger?.editorEmail ?? user.email ?? undefined;
+    const editorName = trigger?.editorName ?? user.email ?? undefined;
 
     const triggerData: AgentBuilderWebhookTriggerType = {
       sId: trigger?.sId,
@@ -267,7 +267,7 @@ export function WebhookEditionModal({
       },
       webhookSourceViewSId: data.webhookSourceViewSId ?? undefined,
       editor,
-      editorEmail,
+      editorName,
     };
 
     onSave(triggerData);
@@ -330,7 +330,7 @@ export function WebhookEditionModal({
             <ContentMessage variant="info">
               You cannot edit this trigger. It is managed by{" "}
               <span className="font-semibold">
-                {trigger.editorEmail ?? "another user"}
+                {trigger.editorName ?? "another user"}
               </span>
               .
             </ContentMessage>

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -19,7 +19,7 @@ export interface GetTriggersResponseBody {
   triggers: (TriggerType & {
     isSubscriber: boolean;
     isEditor: boolean;
-    editorEmail?: string;
+    editorName?: string;
   })[];
 }
 
@@ -103,8 +103,8 @@ async function handler(
         ...new Set(allTriggers.map((trigger) => trigger.editor)),
       ];
       const editorUsers = await UserResource.fetchByModelIds(editorIds);
-      const editorEmailMap = new Map(
-        editorUsers.map((user) => [user.id, user.email])
+      const editorNamesMap = new Map(
+        editorUsers.map((user) => [user.id, user.username])
       );
 
       const triggersWithIsSubscriber = await Promise.all(
@@ -112,7 +112,7 @@ async function handler(
           ...trigger.toJSON(),
           isSubscriber: await trigger.isSubscriber(auth),
           isEditor: trigger.editor === auth.getNonNullableUser().id,
-          editorEmail: editorEmailMap.get(trigger.editor),
+          editorName: editorNamesMap.get(trigger.editor),
         }))
       );
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -104,7 +104,7 @@ async function handler(
       ];
       const editorUsers = await UserResource.fetchByModelIds(editorIds);
       const editorNamesMap = new Map(
-        editorUsers.map((user) => [user.id, user.username])
+        editorUsers.map((user) => [user.id, user.fullName()])
       );
 
       const triggersWithIsSubscriber = await Promise.all(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Close https://github.com/dust-tt/tasks/issues/4787

Moves the email to name on the trigger cards.
<img width="662" height="282" alt="image" src="https://github.com/user-attachments/assets/69157d96-d9ad-4d1d-bbe6-20afec0470c0" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front