### PR TITLE
[Mentions] Fix sort in mention dropdown (front + extension)

### DIFF
--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -154,8 +154,13 @@ function spreadLength(a: string, b: string) {
   return lastIndex - firstIndex;
 }
 
+export type AgentConfigurationForSort = Pick<
+  LightAgentConfigurationType,
+  "name" | "sId" | "userFavorite" | "scope" | "pictureUrl" | "description"
+>;
+
 export function filterAndSortAgents(
-  agents: LightAgentConfigurationType[],
+  agents: AgentConfigurationForSort[],
   searchText: string
 ) {
   const lowerCaseSearchText = searchText.toLowerCase();
@@ -165,8 +170,10 @@ export function filterAndSortAgents(
   );
 
   if (searchText.length > 0) {
-    filtered.sort((a, b) =>
-      compareForFuzzySort(lowerCaseSearchText, a.name, b.name)
+    filtered.sort(
+      (a, b) =>
+        compareForFuzzySort(lowerCaseSearchText, a.name, b.name) ||
+        compareAgentsForSort(a, b)
     );
   }
 
@@ -183,8 +190,8 @@ export const isEqualNode = (
 // This function implements our general strategy to sort agents to users (input bar, agent list,
 // agent suggestions...).
 export function compareAgentsForSort(
-  a: LightAgentConfigurationType,
-  b: LightAgentConfigurationType
+  a: AgentConfigurationForSort,
+  b: AgentConfigurationForSort
 ) {
   if (a.userFavorite && !b.userFavorite) {
     return -1;

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -1,8 +1,11 @@
 import isEqual from "lodash/isEqual";
 
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
-import type { LightAgentConfigurationType } from "@app/types";
-import { isDevelopment } from "@app/types";
+import type {
+  AgentConfigurationForSort,
+  LightAgentConfigurationType,
+} from "@app/types";
+import { compareAgentsForSort, isDevelopment } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
 export const MODELS_STRING_MAX_LENGTH = 255;
@@ -284,7 +287,7 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
 }
 
 export function filterAndSortAgents(
-  agents: LightAgentConfigurationType[],
+  agents: AgentConfigurationForSort[],
   searchText: string
 ) {
   const lowerCaseSearchText = searchText.toLowerCase();
@@ -294,8 +297,10 @@ export function filterAndSortAgents(
   );
 
   if (searchText.length > 0) {
-    filtered.sort((a, b) =>
-      compareForFuzzySort(lowerCaseSearchText, a.name, b.name)
+    filtered.sort(
+      (a, b) =>
+        compareForFuzzySort(lowerCaseSearchText, a.name, b.name) ||
+        compareAgentsForSort(a, b)
     );
   }
 

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -212,11 +212,16 @@ const CUSTOM_ORDER: string[] = [
   GLOBAL_AGENTS_SID.NOOP,
 ];
 
+export type AgentConfigurationForSort = Pick<
+  LightAgentConfigurationType,
+  "name" | "sId" | "userFavorite" | "scope" | "pictureUrl" | "description"
+>;
+
 // This function implements our general strategy to sort agents to users (input bar, agent list,
 // agent suggestions...).
 export function compareAgentsForSort(
-  a: LightAgentConfigurationType,
-  b: LightAgentConfigurationType
+  a: AgentConfigurationForSort,
+  b: AgentConfigurationForSort
 ) {
   if (a.userFavorite && !b.userFavorite) {
     return -1;


### PR DESCRIPTION
## Description
Unifies mention dropdown sorting across front and extension by reusing the shared sorter:
- Make `compareAgentsForSort` accept EditorSuggestion-like items (id/label/userFavorite) in addition to agents.
- Make `filterAndSortAgents` work with both shapes by using name|label for fuzzy sort.
- Use `filterAndSortAgents` for mention suggestions in both front and extension.

Minimal changes, preserves existing fuzzy ranking and priority tie-breaks.

## Risks
Blast radius: mention dropdown ordering in front and extension.
Risk: low

## Deploy Plan
- deploy front
- publish/update extension
