### PR TITLE
Change Microsoft feature flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -197,11 +197,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   microsoft_drive_mcp_server: {
     description: "Microsoft Drive MCP server",
-    stage: "dust_only",
+    stage: "on_demand",
   },
   microsoft_teams_mcp_server: {
     description: "Microsoft Teams MCP server",
-    stage: "dust_only",
+    stage: "on_demand",
   },
   agent_builder_observability: {
     description:


### PR DESCRIPTION
## Description
Changes the availability stage of Microsoft Drive and Microsoft Teams MCP servers from "dust_only" to "on_demand". This makes these Microsoft MCP tools available to customers upon request rather than being restricted to internal Dust usage only.

## Risk
None

## Deploy Plan
Deploy front