### PR TITLE
front: enforce agent editor group invariant (safe draft cleanup, backfill, diagnostics)

### DIFF
--- a/front/migrations/20251021_repair_missing_agent_editor_groups.ts
+++ b/front/migrations/20251021_repair_missing_agent_editor_groups.ts
@@ -1,0 +1,203 @@
+import assert from "assert";
+import _ from "lodash";
+import type { Logger } from "pino";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { GroupAgentModel } from "@app/lib/models/assistant/group_agent";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types";
+import { AGENT_GROUP_PREFIX } from "@app/types";
+
+async function repairMissingEditorGroupForAgentSId(
+  auth: Authenticator,
+  workspace: LightWorkspaceType,
+  agentConfigs: AgentConfiguration[],
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  // agentConfigs contain all non-draft versions for a single sId
+  const sId = agentConfigs[0].sId;
+  logger.info({ sId }, "Checking agent for missing editor group");
+
+  const links = await GroupAgentModel.findAll({
+    where: {
+      agentConfigurationId: agentConfigs.map((a) => a.id),
+      workspaceId: workspace.id,
+    },
+    attributes: ["groupId", "agentConfigurationId"],
+  });
+
+  const groupIds = Array.from(new Set(links.map((l) => l.groupId)));
+  const editorGroups = groupIds.length
+    ? await GroupModel.findAll({
+        where: {
+          id: { [Op.in]: groupIds },
+          workspaceId: workspace.id,
+          kind: "agent_editors",
+        },
+        attributes: ["id", "name", "kind"],
+      })
+    : [];
+
+  if (editorGroups.length > 0) {
+    logger.info({ sId }, "Editor group already exists, skipping");
+    return;
+  }
+
+  // No editor group across any non-draft versions: create one and associate.
+  logger.info({ sId }, "Creating missing agent_editors group");
+  if (!execute) {
+    return;
+  }
+
+  // Create group
+  const editorGroup = await GroupResource.makeNew({
+    workspaceId: workspace.id,
+    name: `${AGENT_GROUP_PREFIX} ${agentConfigs[0].name} (${sId})`,
+    kind: "agent_editors",
+  });
+  assert(editorGroup, "Failed to create editor group");
+
+  // Associate to all non-draft versions for this sId that lack the link
+  const existingLinkedAgentIds = new Set(links.map((l) => l.agentConfigurationId));
+  const toLink = agentConfigs
+    .filter((c) => !existingLinkedAgentIds.has(c.id))
+    .map((c) => ({
+      groupId: editorGroup.id,
+      agentConfigurationId: c.id,
+      workspaceId: workspace.id,
+    }));
+  if (toLink.length > 0) {
+    await GroupAgentModel.bulkCreate(toLink);
+  }
+
+  // Seed members = authors of all versions who are active in workspace
+  const authorIds = Array.from(new Set(agentConfigs.map((a) => a.authorId)));
+  const users = await UserResource.fetchByModelIds(authorIds);
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users,
+    workspace,
+  });
+  const authorsInWorkspace = users.filter((u) =>
+    memberships.some((m) => m.userId === u.id)
+  );
+
+  const setMembersRes = await editorGroup.setMembers(
+    auth,
+    authorsInWorkspace.map((u) => u.toJSON())
+  );
+  if (setMembersRes.isErr()) {
+    throw setMembersRes.error;
+  }
+}
+
+const repairWorkspace = async (
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+) => {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // Get all non-draft agents for workspace
+  const agents = await AgentConfiguration.findAll({
+    where: {
+      workspaceId: workspace.id,
+      status: { [Op.ne]: "draft" },
+    },
+    attributes: [
+      "id",
+      "sId",
+      "name",
+      "status",
+      "version",
+      "authorId",
+      "workspaceId",
+    ],
+  });
+
+  if (agents.length === 0) {
+    logger.info({ workspaceId: workspace.sId }, "No agents found");
+    return;
+  }
+
+  // Filter to only sIds with zero agent_editors groups across their versions
+  const bySId = _.groupBy(agents, (a) => a.sId);
+
+  const candidates: AgentConfiguration[][] = [];
+  for (const sId of Object.keys(bySId)) {
+    const cfgs = bySId[sId]!;
+    const links = await GroupAgentModel.findAll({
+      where: {
+        agentConfigurationId: cfgs.map((c) => c.id),
+        workspaceId: workspace.id,
+      },
+      attributes: ["groupId"],
+    });
+    const groupIds = Array.from(new Set(links.map((l) => l.groupId)));
+    if (groupIds.length === 0) {
+      candidates.push(cfgs);
+      continue;
+    }
+    const editorGroups = await GroupModel.count({
+      where: {
+        id: { [Op.in]: groupIds },
+        workspaceId: workspace.id,
+        kind: "agent_editors",
+      },
+    });
+    if (editorGroups === 0) {
+      candidates.push(cfgs);
+    }
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      candidates: candidates.length,
+    },
+    "Agents missing editor groups to repair"
+  );
+
+  await concurrentExecutor(
+    candidates,
+    (cfgs) => repairMissingEditorGroupForAgentSId(auth, workspace, cfgs, execute, logger),
+    { concurrency: 4 }
+  );
+};
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting repair of missing agent editor groups");
+
+    if (wId) {
+      const ws = await WorkspaceModel.findOne({ where: { sId: wId } });
+      if (!ws) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+      await repairWorkspace(execute, logger, renderLightWorkspaceType({ workspace: ws }));
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await repairWorkspace(execute, logger, workspace);
+        },
+        { concurrency: 4 }
+      );
+    }
+
+    logger.info("Repair completed");
+  }
+);
+


### PR DESCRIPTION
Context
- We saw intermittent "Unexpected: agent should have exactly one editor group." on active/archived agents. DB checks revealed a small set of agents with zero editor groups, violating the invariant and causing the error when code resolves the editor group.
- Root causes:
  - Draft cleanup script deleted groups associated with drafts even when the same group was linked to non‑draft versions (orphaning active/archived versions).
  - Historical/backfill gaps left some sIds without an `agent_editors` group.
  - Creation path had limited visibility when group resolution failed; opted for diagnostics instead of silently creating groups to keep surface clear for real data issues.

Changes
- Migration script safety (front/migrations/20250505_delete_group_draft_agents.ts):
  - Only delete a group if it has no non‑draft associations. Skip with a log if it does.
- One‑time repair backfill (front/migrations/20251021_repair_missing_agent_editor_groups.ts):
  - For each workspace, finds agent sIds (active/archived) with zero `agent_editors` groups across their versions.
  - Creates a single `agent_editors` group, links it to all non‑draft versions for the sId, and seeds members from authors who are still workspace members.
  - Supports `--wId` to scope and `--execute` gating to apply changes.
- Diagnostics in creation path (front/lib/api/assistant/configuration/agent.ts):
  - Before resolving the group of an existing agent version, logs:
    - existing version (sId, id, version, scope, status)
    - counts of total group links and `agent_editors` links
  - Emits an explicit error log when resolution returns null.

How to run (safe by default)
- Dry run all workspaces:
  - yarn ts-node front/migrations/20251021_repair_missing_agent_editor_groups.ts
- Dry run single workspace:
  - yarn ts-node front/migrations/20251021_repair_missing_agent_editor_groups.ts --wId <workspace_sId>
- Apply (all workspaces):
  - yarn ts-node front/migrations/20251021_repair_missing_agent_editor_groups.ts --execute
- Apply (single workspace):
  - yarn ts-node front/migrations/20251021_repair_missing_agent_editor_groups.ts --wId <workspace_sId> --execute

Risk/impact
- Draft cleanup now avoids deleting shared editor groups, preventing new orphaning.
- Backfill is idempotent per sId and gated by `--execute`.
- Creation path behavior unchanged; logs added for observability only.

Validation plan
- Before backfill: run a query to list non‑draft agents with 0 editor groups.
- After backfill: rerun the query; expect zero results.
- Exercise the agent creation flow for an updated agent to confirm no errors and see diagnostic logs in case of issues.

Follow‑ups (optional)
- Consider adding a DB constraint to enforce at most one `agent_editors` group per `agent_configuration_id` and/or per `sId`.
