### PR TITLE
Remove slack no messages in thread context

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1383,7 +1383,7 @@ async function makeContentFragments(
   // Prepend $url to the content to make it available to the model.
   const section = document
     ? `$url: ${url}\n${sectionFullText(document)}`
-    : `$url: ${url}\nNo messages previously sent in this thread.`;
+    : `$url: ${url}\n`;
 
   const contentType = "text/vnd.dust.attachment.slack.thread";
   const fileName = `slack_thread-${channelName}-${threadTs}.txt`;


### PR DESCRIPTION
## Description

* This message was confusing LLM because it was assuming no messages in conversation based on this attachment (ignoring the conversation history).

## Tests

* Slack bot locally

## Risk

* None

## Deploy Plan

* Deply connectors