### PR TITLE
[front] hootl: remove trigger on user revoke

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -1,8 +1,11 @@
 import type { Transaction } from "sequelize";
 
+import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
+import logger from "@app/logger/logger";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 import type { LightWorkspaceType } from "@app/types";
 
@@ -18,6 +21,35 @@ export async function revokeAndTrackMembership(
   });
 
   if (revokeResult.isOk()) {
+    // Delete all triggers created by the user
+    try {
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      const deleteTriggerResult =
+        await TriggerResource.deleteAllForUser(userAuth);
+      if (deleteTriggerResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            userId: user.sId,
+            error: deleteTriggerResult.error,
+          },
+          "Failed to delete triggers for revoked user"
+        );
+      }
+    } catch (error) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          userId: user.sId,
+          error,
+        },
+        "Failed to create authenticator or delete triggers for revoked user"
+      );
+    }
+
     await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });
     void ServerSideTracking.trackRevokeMembership({
       user: user.toJSON(),

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -22,31 +22,21 @@ export async function revokeAndTrackMembership(
 
   if (revokeResult.isOk()) {
     // Delete all triggers created by the user
-    try {
-      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        user.sId,
-        workspace.sId
-      );
-      const deleteTriggerResult =
-        await TriggerResource.deleteAllForUser(userAuth);
-      if (deleteTriggerResult.isErr()) {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-            userId: user.sId,
-            error: deleteTriggerResult.error,
-          },
-          "Failed to delete triggers for revoked user"
-        );
-      }
-    } catch (error) {
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const deleteTriggerResult =
+      await TriggerResource.deleteAllForUser(userAuth);
+    if (deleteTriggerResult.isErr()) {
       logger.error(
         {
           workspaceId: workspace.sId,
           userId: user.sId,
-          error,
+          error: deleteTriggerResult.error,
         },
-        "Failed to create authenticator or delete triggers for revoked user"
+        "Failed to delete triggers for revoked user"
       );
     }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

We currently don't delete triggers when revoking a user, which leads to errors because we run a trigger for a user that does not have access to the workspace.

This PR fixes that.
Closes https://github.com/dust-tt/tasks/issues/4598

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front