### PR TITLE
allow agent to include more fields in getDeal and getCompany responses

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
@@ -1109,13 +1109,22 @@ export const getContact = async (
 
 export const getCompany = async (
   accessToken: string,
-  companyId: string
+  companyId: string,
+  extraProperties?: string[]
 ): Promise<SimplePublicObject | null> => {
   const hubspotClient = new Client({ accessToken });
   try {
+    const defaultProperties = [
+      "createdate",
+      "domain",
+      "name",
+      "hubspot_owner_id",
+    ];
     const company = await hubspotClient.crm.companies.basicApi.getById(
       companyId,
-      ["createdate", "domain", "name", "hubspot_owner_id"]
+      extraProperties
+        ? [...defaultProperties, ...extraProperties]
+        : defaultProperties
     );
     return company;
   } catch (error: any) {
@@ -1132,11 +1141,12 @@ export const getCompany = async (
 
 export const getDeal = async (
   accessToken: string,
-  dealId: string
+  dealId: string,
+  extraProperties?: string[]
 ): Promise<SimplePublicObject | null> => {
   const hubspotClient = new Client({ accessToken });
   try {
-    const deal = await hubspotClient.crm.deals.basicApi.getById(dealId, [
+    const defaultProperties = [
       "amount",
       "hubspot_owner_id",
       "closedate",
@@ -1146,7 +1156,13 @@ export const getDeal = async (
       "hs_lastmodifieddate",
       "hs_object_id",
       "pipeline",
-    ]);
+    ];
+    const deal = await hubspotClient.crm.deals.basicApi.getById(
+      dealId,
+      extraProperties
+        ? [...defaultProperties, ...extraProperties]
+        : defaultProperties
+    );
     return deal;
   } catch (error: any) {
     if (error.code === 404) {

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/index.ts
@@ -701,14 +701,24 @@ function createServer(): McpServer {
   // Definition for getCompany tool
   server.tool(
     "get_company",
-    "Retrieves a Hubspot company by its ID.",
+    "Retrieves a Hubspot company by its ID. Returns default properties plus any additional properties specified.",
     {
       companyId: z.string().describe("The ID of the company to retrieve."),
+      extraProperties: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Optional additional properties to retrieve beyond the default set (createdate, domain, name, hubspot_owner_id)."
+        ),
     },
-    async ({ companyId }, { authInfo }) => {
+    async ({ companyId, extraProperties }, { authInfo }) => {
       return withAuth({
         action: async (accessToken) => {
-          const result = await getCompany(accessToken, companyId);
+          const result = await getCompany(
+            accessToken,
+            companyId,
+            extraProperties
+          );
           if (!result) {
             return {
               isError: true,
@@ -734,14 +744,20 @@ function createServer(): McpServer {
   // Definition for getDeal tool
   server.tool(
     "get_deal",
-    "Retrieves a Hubspot deal by its ID.",
+    "Retrieves a Hubspot deal by its ID. Returns default properties plus any additional properties specified.",
     {
       dealId: z.string().describe("The ID of the deal to retrieve."),
+      extraProperties: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Optional additional properties to retrieve beyond the default set (amount, hubspot_owner_id, closedate, createdate, dealname, dealstage, hs_lastmodifieddate, hs_object_id, pipeline)."
+        ),
     },
-    async ({ dealId }, { authInfo }) => {
+    async ({ dealId, extraProperties }, { authInfo }) => {
       return withAuth({
         action: async (accessToken) => {
-          const result = await getDeal(accessToken, dealId);
+          const result = await getDeal(accessToken, dealId, extraProperties);
           if (!result) {
             return {
               isError: true,


### PR DESCRIPTION
## Description

we include a few default properties to minimize context window space consumption, but the agent can now add extra properties to return

## Tests

local with hubspot instance

## Risk

N/A

## Deploy Plan

front only
