### PR TITLE
[Run Agent] Fix contentType in refs schema

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -173,7 +173,7 @@ export function MCPRunAgentActionDetails({
         citation.href
       );
       mcpReferenceCitations[key] = {
-        contentType: citation.mimeType as AllSupportedFileContentType,
+        contentType: citation.contentType as AllSupportedFileContentType,
         title: citation.title,
         href: citation.href,
         description: citation.description,

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -585,7 +585,7 @@ export const RunAgentResultResourceSchema = z.object({
         href: z.string().optional(),
         title: z.string(),
         provider: z.string(),
-        mimeType: z.string(),
+        contentType: z.string(),
       })
     )
     .optional(),

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -113,7 +113,7 @@ export function getCitationsFromActions(
           title: citation.title,
           provider: citation.provider,
           ...(faviconUrl && { faviconUrl }),
-          contentType: citation.mimeType as AllSupportedFileContentType,
+          contentType: citation.contentType as AllSupportedFileContentType,
         };
       });
     }


### PR DESCRIPTION
## Description
Fixes issue from this [thread](https://dust4ai.slack.com/archives/C097P501RB9/p1761046282972269) introduced by https://github.com/dust-tt/dust/pull/16760

The `RunAgentResultResourceSchema` was using `mimeType` in the refs object when it should use `contentType` to match the `CitationType` interface.

Reproduced locally, confirmed the PR fixes

## Risks
Blast radius: Run agent tool citations display
Risk: low

## Deploy Plan
- deploy front