### PR TITLE
Initiate user oauth if no discord email found

### DIFF
--- a/connectors/migrations/db/migration_102.sql
+++ b/connectors/migrations/db/migration_102.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "discord_user_oauth_connections" (
+  "id" BIGSERIAL,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "discordUserId" VARCHAR(255) NOT NULL,
+  "connectionId" VARCHAR(255) NOT NULL,
+  "workspaceId" VARCHAR(255) NOT NULL,
+  UNIQUE("discordUserId", "workspaceId")
+);
+
+CREATE INDEX "discord_user_oauth_connections_discord_user_id" ON "discord_user_oauth_connections" ("discordUserId");
+CREATE INDEX "discord_user_oauth_connections_connection_id" ON "discord_user_oauth_connections" ("connectionId");
+

--- a/connectors/scripts/register-discord-commands.ts
+++ b/connectors/scripts/register-discord-commands.ts
@@ -1,3 +1,3 @@
 import { initializeDiscordCommands } from "@connectors/api/webhooks/discord/startup";
 
-await initializeDiscordCommands();
+void initializeDiscordCommands();

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -8,6 +8,7 @@ import {
   ConfluenceSpace,
 } from "@connectors/lib/models/confluence";
 import { DiscordConfigurationModel } from "@connectors/lib/models/discord";
+import { DiscordUserOAuthConnectionModel } from "@connectors/lib/models/discord_user_oauth_connection";
 import {
   GithubCodeDirectory,
   GithubCodeFile,
@@ -100,6 +101,7 @@ async function main(): Promise<void> {
   await ConfluencePage.sync({ alter: true });
   await ConfluenceSpace.sync({ alter: true });
   await DiscordConfigurationModel.sync({ alter: true });
+  await DiscordUserOAuthConnectionModel.sync({ alter: true });
   await SlackConfigurationModel.sync({ alter: true });
   await SlackMessages.sync({ alter: true });
   await SlackChannel.sync({ alter: true });

--- a/connectors/src/api/webhooks/discord/bot.ts
+++ b/connectors/src/api/webhooks/discord/bot.ts
@@ -58,7 +58,11 @@ export async function sendMessageToAgent(
 
   const messageWithMention = `:mention[${agentConfiguration.name}]{sId=${agentConfiguration.sId}} ${message}`;
 
-  const userEmail = await getUserEmail(discordUserId, logger);
+  const userEmail = await getUserEmail(
+    discordUserId,
+    connector.workspaceId,
+    logger
+  );
 
   if (!userEmail) {
     // No OAuth connection exists, tell user to run /connect-user-to-dust command
@@ -472,10 +476,11 @@ function isPersonalAuthenticationActionError(
 
 async function getUserEmail(
   discordUserId: string,
+  workspaceId: string,
   logger: Logger
 ): Promise<string | null> {
   const userConnection = await DiscordUserOAuthConnectionModel.findOne({
-    where: { discordUserId },
+    where: { discordUserId, workspaceId },
   });
   if (!userConnection) {
     return null;

--- a/connectors/src/api/webhooks/discord/startup.ts
+++ b/connectors/src/api/webhooks/discord/startup.ts
@@ -87,6 +87,11 @@ function getDesiredCommands(): DiscordSlashCommand[] {
         },
       ],
     },
+    {
+      name: "connect-user-to-dust",
+      description: "Connect your Discord account to use Dust agents",
+      type: 1,
+    },
   ];
 }
 
@@ -181,7 +186,7 @@ export function initializeDiscordCommands(): void {
       await bulkOverwriteCommands(desiredCommands);
       logger.info("Discord commands registered successfully");
     } catch (error) {
-      logger.error(
+      logger.warn(
         { error: normalizeError(error) },
         "Failed to initialize Discord commands"
       );

--- a/connectors/src/lib/models/discord_user_oauth_connection.ts
+++ b/connectors/src/lib/models/discord_user_oauth_connection.ts
@@ -1,0 +1,51 @@
+import type {
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+} from "sequelize";
+import { DataTypes, Model } from "sequelize";
+
+import { connectorsSequelize } from "@connectors/resources/storage";
+
+export class DiscordUserOAuthConnectionModel extends Model<
+  InferAttributes<DiscordUserOAuthConnectionModel>,
+  InferCreationAttributes<DiscordUserOAuthConnectionModel>
+> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare discordUserId: string;
+  declare connectionId: string;
+  declare workspaceId: string;
+}
+
+DiscordUserOAuthConnectionModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+    },
+    discordUserId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    connectionId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    workspaceId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: connectorsSequelize,
+    modelName: "discord_user_oauth_connections",
+    indexes: [
+      { fields: ["discordUserId"] },
+      { fields: ["connectionId"] },
+      { fields: ["discordUserId", "workspaceId"], unique: true },
+    ],
+  }
+);

--- a/core/src/oauth/providers/discord.rs
+++ b/core/src/oauth/providers/discord.rs
@@ -84,7 +84,11 @@ impl Provider for DiscordConnectionProvider {
         let _use_case = match connection.metadata()["use_case"].as_str() {
             Some(use_case) => match use_case {
                 "bot" | "personal_actions" => DiscordUseCase::Bot,
-                _ => return Err(ProviderError::from(anyhow!("Discord use_case format invalid"))),
+                _ => {
+                    return Err(ProviderError::from(anyhow!(
+                        "Discord use_case format invalid"
+                    )))
+                }
             },
             None => return Err(ProviderError::from(anyhow!("Discord use_case missing"))),
         };

--- a/core/src/oauth/providers/discord.rs
+++ b/core/src/oauth/providers/discord.rs
@@ -83,10 +83,10 @@ impl Provider for DiscordConnectionProvider {
     ) -> Result<FinalizeResult, ProviderError> {
         let _use_case = match connection.metadata()["use_case"].as_str() {
             Some(use_case) => match use_case {
-                "bot" => DiscordUseCase::Bot,
-                _ => Err(anyhow!("Discord use_case format invalid"))?,
+                "bot" | "personal_actions" => DiscordUseCase::Bot,
+                _ => return Err(ProviderError::from(anyhow!("Discord use_case format invalid"))),
             },
-            None => Err(anyhow!("Discord use_case missing"))?,
+            None => return Err(ProviderError::from(anyhow!("Discord use_case missing"))),
         };
 
         let form_data = vec![

--- a/front/lib/api/oauth/providers/discord.ts
+++ b/front/lib/api/oauth/providers/discord.ts
@@ -19,24 +19,35 @@ export class DiscordOAuthProvider implements BaseOAuthStrategyProvider {
     useCase: OAuthUseCase;
     _extraConfig?: ExtraConfigType;
   }) {
-    if (useCase !== "bot") {
-      throw new Error(
-        `Discord OAuth only supports "bot" use case, got: ${useCase}`
+    const clientId = config.getOAuthDiscordClientId();
+
+    if (useCase === "bot") {
+      const bot_scopes = ["bot"];
+
+      return (
+        `https://discord.com/api/oauth2/authorize?` +
+        `client_id=${clientId}` +
+        `&scope=${encodeURIComponent(bot_scopes.join("+"))}` +
+        `&permissions=83968` + // Allows the bot to read message history, embed links, and send messages
+        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("discord"))}` +
+        `&response_type=code` +
+        `&state=${connection.connection_id}`
+      );
+    } else if (useCase === "personal_actions") {
+      const personal_scopes = ["identify", "email"];
+
+      return (
+        `https://discord.com/api/oauth2/authorize?` +
+        `client_id=${clientId}` +
+        `&scope=${encodeURIComponent(personal_scopes.join(" "))}` +
+        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("discord"))}` +
+        `&response_type=code` +
+        `&state=${connection.connection_id}`
       );
     }
 
-    const bot_scopes = ["bot"];
-
-    const clientId = config.getOAuthDiscordClientId();
-
-    return (
-      `https://discord.com/api/oauth2/authorize?` +
-      `client_id=${clientId}` +
-      `&scope=${encodeURIComponent(bot_scopes.join("+"))}` +
-      `&permissions=83968` + // Allows the bot to read message history, embed links, and send messages
-      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("discord"))}` +
-      `&response_type=code` +
-      `&state=${connection.connection_id}`
+    throw new Error(
+      `Discord OAuth only supports "bot" and "personal_actions" use cases, got: ${useCase}`
     );
   }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -215,7 +215,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   discord_bot: {
     description:
       "Discord bot integration for workspace-level Discord integration",
-    stage: "dust_only",
+    stage: "on_demand",
   },
   dust_default_haiku_feature: {
     description:


### PR DESCRIPTION
## Description

* We require each individual Discord user to oauth in order to acquire their email. Currently taking the following approach: (1) Create oauth connection and send link from connector service (2) Use normal oauth flow to complete personal_actions use case flow
* This is a workflow we have not needed to do up to this point. Curious on feedback on if this is the correct approach.

## Tests

<img width="901" height="505" alt="Screenshot 2025-10-21 at 2 55 15 PM" src="https://github.com/user-attachments/assets/efd66ead-ca91-472f-8043-14c20603cace" />


## Risk

* Not customer facing yet

## Deploy Plan

1. Run connector migration
2. Deploy oauth
3. Deploy front
4. Deploy connectors