### PR TITLE
Be more explicit about slack content fragments

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1380,9 +1380,10 @@ async function makeContentFragments(
   }
 
   // Prepend $url to the content to make it available to the model.
+  const sectionHeader = `This only shows user-generated messages since ${startingAtTs} in #${channelName}. Look at the conversation history for the full thread.\n`;
   const section = document
-    ? `$url: ${url}\n${sectionFullText(document)}`
-    : `$url: ${url}\n`;
+    ? `$url: ${url}\n${sectionHeader}${sectionFullText(document)}`
+    : `$url: ${url}\n${sectionHeader}`;
 
   const contentType = "text/vnd.dust.attachment.slack.thread";
   const fileName = `slack_thread-${channelName}-${threadTs}.txt`;


### PR DESCRIPTION
## Description

* Wasn't explicit enough the first time around. Seeing it is now consistently picking up the entire message history:

<img width="827" height="941" alt="Screenshot 2025-10-21 at 3 33 28 PM" src="https://github.com/user-attachments/assets/3cab819b-5c2c-46c2-924f-ef1e7c71cdc1" />

