### PR TITLE
[front] enh: extract `WebbrowseInputSchema` and typeguard inputs in `MCPActionDetails`

### DIFF
--- a/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -8,6 +8,7 @@ import {
   isBrowseResultResourceType,
   isToolGeneratedFile,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { isWebbrowseInputType } from "@app/lib/actions/mcp_internal_actions/types";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
 
 export function MCPBrowseActionDetails({
@@ -16,7 +17,8 @@ export function MCPBrowseActionDetails({
   viewType,
   owner,
 }: ToolExecutionDetailsProps) {
-  const urls = toolParams.urls as string[];
+  const urls = isWebbrowseInputType(toolParams) ? toolParams.urls : null;
+
   const browseResults =
     toolOutput?.filter(isBrowseResultResourceType).map((o) => o.resource) ?? [];
   const generatedFiles =

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -14,7 +14,6 @@ import {
   WEBBROWSER_TOOL_NAME,
   WEBSEARCH_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   BrowseResultResourceType,
   WebsearchResultResourceType,
@@ -116,33 +115,7 @@ function createServer(
   server.tool(
     WEBBROWSER_TOOL_NAME,
     "A tool to browse websites, you can provide a list of urls to browse all at once.",
-    {
-      urls: z.string().array().describe("List of urls to browse"),
-      format: z
-        .enum(["markdown", "html"])
-        .optional()
-        .describe("Format to return content: 'markdown' (default) or 'html'."),
-      screenshotMode: z
-        .enum(["none", "viewport", "fullPage"])
-        .optional()
-        .describe(
-          "Screenshot mode: 'none' (default), 'viewport', or 'fullPage'."
-        ),
-      links: z
-        .boolean()
-        .optional()
-        .describe("If true, also retrieve outgoing links from the page."),
-      useSummary: ConfigurableToolInputSchemas[
-        INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
-      ]
-        .describe(
-          "Summarize web pages using an AI agent before returning content. When enabled, provides concise summaries instead of full page content."
-        )
-        .default({
-          value: false,
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
-        }),
-    },
+    WebbrowseInputSchema.shape,
     withToolLogging(
       auth,
       {

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -1,7 +1,6 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { z } from "zod";
 
 import {
   generatePlainTextFile,
@@ -18,7 +17,10 @@ import type {
   BrowseResultResourceType,
   WebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { WebsearchInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
+import {
+  WebbrowseInputSchema,
+  WebsearchInputSchema,
+} from "@app/lib/actions/mcp_internal_actions/types";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { summarizeWithAgent } from "@app/lib/actions/mcp_internal_actions/utils/web_summarization";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -135,7 +135,7 @@ export const WebbrowseInputSchema = z.object({
     .describe("If true, also retrieve outgoing links from the page."),
   useSummary: ConfigurableToolInputSchemas[
     INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
-    ]
+  ]
     .describe(
       "Summarize web pages using an AI agent before returning content. When enabled, provides concise summaries instead of full page content."
     )

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -119,6 +119,40 @@ export function isWebsearchInputType(
   return WebsearchInputSchema.safeParse(input).success;
 }
 
+export const WebbrowseInputSchema = z.object({
+  urls: z.string().array().describe("List of urls to browse"),
+  format: z
+    .enum(["markdown", "html"])
+    .optional()
+    .describe("Format to return content: 'markdown' (default) or 'html'."),
+  screenshotMode: z
+    .enum(["none", "viewport", "fullPage"])
+    .optional()
+    .describe("Screenshot mode: 'none' (default), 'viewport', or 'fullPage'."),
+  links: z
+    .boolean()
+    .optional()
+    .describe("If true, also retrieve outgoing links from the page."),
+  useSummary: ConfigurableToolInputSchemas[
+    INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
+    ]
+    .describe(
+      "Summarize web pages using an AI agent before returning content. When enabled, provides concise summaries instead of full page content."
+    )
+    .default({
+      value: false,
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
+    }),
+});
+
+export type WebbrowseInputType = z.infer<typeof WebbrowseInputSchema>;
+
+export function isWebbrowseInputType(
+  input: Record<string, unknown>
+): input is WebbrowseInputType {
+  return WebbrowseInputSchema.safeParse(input).success;
+}
+
 export const DataSourceFilesystemFindInputSchema = z.object({
   query: z
     .string()


### PR DESCRIPTION
## Description

- This PR extracts the zod schema for the parameters of the web browse tool and reuses this schema to check the tool inputs received in the front end.
- The next step is to do the same for the search, include, fs tools, websearch. This change will remove the need to send in the output of some tools (e.g. search) something that contains the input (`TOOL_OUTPUT.DATA_SOURCE_SEARCH_QUERY`).

## Tests

- Checked locally.

## Risk

- Mostly a refactoring but does affect a widely used tool.

## Deploy Plan

- Deploy front.
