### PR TITLE
[front] chore: extract Zod schemas for tool inputs

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -2,7 +2,6 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
-import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
@@ -10,7 +9,6 @@ import {
   INCLUDE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   IncludeQueryResourceType,
   IncludeResultResourceType,
@@ -23,6 +21,10 @@ import {
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import {
+  IncludeInputSchema,
+  TagsInputSchema,
+} from "@app/lib/actions/mcp_internal_actions/types";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -51,32 +53,6 @@ function createServer(
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
   const server = makeInternalMCPServer("include_data");
-
-  const commonInputsSchema = {
-    timeFrame:
-      ConfigurableToolInputSchemas[
-        INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
-      ].optional(),
-    dataSources:
-      ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
-  };
-
-  const tagsInputSchema = {
-    tagsIn: z
-      .array(z.string())
-      .describe(
-        "A list of labels (also called tags) to restrict the search based on the user request and past conversation context." +
-          "If multiple labels are provided, the search will return documents that have at least one of the labels." +
-          "You can't check that all labels are present, only that at least one is present." +
-          "If no labels are provided, the search will return all documents regardless of their labels."
-      ),
-    tagsNot: z
-      .array(z.string())
-      .describe(
-        "A list of labels (also called tags) to exclude from the search based on the user request and past conversation context." +
-          "Any document having one of these labels will be excluded from the search."
-      ),
-  };
 
   const areTagsDynamic = agentLoopContext
     ? shouldAutoGenerateTags(agentLoopContext)
@@ -262,7 +238,7 @@ function createServer(
     server.tool(
       INCLUDE_TOOL_NAME,
       "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
-      commonInputsSchema,
+      IncludeInputSchema.shape,
       withToolLogging(
         auth,
         { toolNameForMonitoring: "include", agentLoopContext },
@@ -274,8 +250,8 @@ function createServer(
       INCLUDE_TOOL_NAME,
       "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
       {
-        ...commonInputsSchema,
-        ...tagsInputSchema,
+        ...IncludeInputSchema.shape,
+        ...TagsInputSchema.shape,
       },
       withToolLogging(
         auth,

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -19,6 +19,7 @@ import type {
   BrowseResultResourceType,
   WebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { WebsearchInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { summarizeWithAgent } from "@app/lib/actions/mcp_internal_actions/utils/web_summarization";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -45,23 +46,7 @@ function createServer(
   server.tool(
     WEBSEARCH_TOOL_NAME,
     "A tool that performs a Google web search based on a string query.",
-    {
-      query: z
-        .string()
-        .describe(
-          "The query used to perform the Google search. If requested by the " +
-            "user, use the Google syntax `site:` to restrict the search " +
-            "to a particular website or domain."
-        ),
-      page: z
-        .number()
-        .optional()
-        .describe(
-          "A 1-indexed page number used to paginate through the search results." +
-            " Should only be provided if the page is strictly greater than 1 in order" +
-            " to go deeper into the search results for a specific query."
-        ),
-    },
+    WebsearchInputSchema.shape,
     withToolLogging(
       auth,
       {

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -1,10 +1,7 @@
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { FILESYSTEM_LIST_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
-import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { renderSearchResults } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
   extractDataSourceIdFromNodeId,
@@ -15,6 +12,7 @@ import {
   getAgentDataSourceConfigurations,
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { DataSourceFilesystemListInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -28,49 +26,6 @@ import type {
   Result,
 } from "@app/types";
 import { CoreAPI, Err, Ok } from "@app/types";
-
-const ListToolInputSchema = {
-  nodeId: z
-    .string()
-    .nullable()
-    .describe(
-      "The exact ID of the node to list the contents of. " +
-        "This ID can be found from previous search results in the 'nodeId' field. " +
-        "If not provided, the content at the root of the filesystem will be shown."
-    ),
-  mimeTypes: z
-    .array(z.string())
-    .optional()
-    .describe(
-      "The mime types to search for. If provided, only nodes with one of these mime types " +
-        "will be returned. If not provided, no filter will be applied. The mime types passed " +
-        "here must be one of the mime types found in the 'mimeType' field."
-    ),
-  dataSources:
-    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
-  sortBy: z
-    .enum(["title", "timestamp"])
-    .optional()
-    .describe(
-      "Field to sort the results by. 'title' sorts alphabetically A-Z, 'timestamp' sorts by " +
-        "most recent first. If not specified, results are returned in the default order, which is " +
-        "folders first, then both documents and tables and alphabetically by title."
-    ),
-  limit: z
-    .number()
-    .optional()
-    .describe(
-      "Maximum number of results to return. Initial searches should use 10-20."
-    ),
-  nextPageCursor: z
-    .string()
-    .optional()
-    .describe(
-      "Cursor for fetching the next page of results. This parameter should only be used to fetch " +
-        "the next page of a previous search. The value should be exactly the 'nextPageCursor' from " +
-        "the previous search result."
-    ),
-};
 
 export function registerListTool(
   auth: Authenticator,
@@ -91,7 +46,7 @@ export function registerListTool(
   server.tool(
     name,
     toolDescription,
-    ListToolInputSchema,
+    DataSourceFilesystemListInputSchema.shape,
     withToolLogging(
       auth,
       {

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -59,20 +59,6 @@ export const TagsInputSchema = z.object({
     ),
 });
 
-type TagsInputType = z.infer<typeof TagsInputSchema>;
-
-export type SearchInputTypeWithTags = SearchWithNodesInputType & TagsInputType;
-
-export function isSearchInputType(
-  input: Record<string, unknown>
-): input is SearchInputTypeWithTags {
-  return (
-    SearchWithNodesInputSchema.safeParse(input).success ||
-    SearchWithNodesInputSchema.extend(TagsInputSchema.shape).safeParse(input)
-      .success
-  );
-}
-
 export const IncludeInputSchema = z.object({
   timeFrame:
     ConfigurableToolInputSchemas[
@@ -81,17 +67,6 @@ export const IncludeInputSchema = z.object({
   dataSources:
     ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
 });
-
-export type IncludeInputType = z.infer<typeof IncludeInputSchema>;
-
-export function isIncludeInputType(
-  input: Record<string, unknown>
-): input is IncludeInputType {
-  return (
-    IncludeInputSchema.safeParse(input).success ||
-    IncludeInputSchema.extend(TagsInputSchema.shape).safeParse(input).success
-  );
-}
 
 export const WebsearchInputSchema = z.object({
   query: z
@@ -110,48 +85,6 @@ export const WebsearchInputSchema = z.object({
         " to go deeper into the search results for a specific query."
     ),
 });
-
-export type WebsearchInputType = z.infer<typeof WebsearchInputSchema>;
-
-export function isWebsearchInputType(
-  input: Record<string, unknown>
-): input is WebsearchInputType {
-  return WebsearchInputSchema.safeParse(input).success;
-}
-
-export const WebbrowseInputSchema = z.object({
-  urls: z.string().array().describe("List of urls to browse"),
-  format: z
-    .enum(["markdown", "html"])
-    .optional()
-    .describe("Format to return content: 'markdown' (default) or 'html'."),
-  screenshotMode: z
-    .enum(["none", "viewport", "fullPage"])
-    .optional()
-    .describe("Screenshot mode: 'none' (default), 'viewport', or 'fullPage'."),
-  links: z
-    .boolean()
-    .optional()
-    .describe("If true, also retrieve outgoing links from the page."),
-  useSummary: ConfigurableToolInputSchemas[
-    INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
-  ]
-    .describe(
-      "Summarize web pages using an AI agent before returning content. When enabled, provides concise summaries instead of full page content."
-    )
-    .default({
-      value: false,
-      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
-    }),
-});
-
-export type WebbrowseInputType = z.infer<typeof WebbrowseInputSchema>;
-
-export function isWebbrowseInputType(
-  input: Record<string, unknown>
-): input is WebbrowseInputType {
-  return WebbrowseInputSchema.safeParse(input).success;
-}
 
 export const DataSourceFilesystemFindInputSchema = z.object({
   query: z
@@ -198,16 +131,6 @@ export const DataSourceFilesystemFindInputSchema = z.object({
     ),
 });
 
-export type DataSourceFilesystemFindInputType = z.infer<
-  typeof DataSourceFilesystemFindInputSchema
->;
-
-export function isDataSourceFilesystemFindInputType(
-  input: Record<string, unknown>
-): input is DataSourceFilesystemFindInputType {
-  return DataSourceFilesystemFindInputSchema.safeParse(input).success;
-}
-
 export const DataSourceFilesystemListInputSchema = z.object({
   nodeId: z
     .string()
@@ -250,13 +173,3 @@ export const DataSourceFilesystemListInputSchema = z.object({
         "the previous search result."
     ),
 });
-
-export type DataSourceFilesystemListInputType = z.infer<
-  typeof DataSourceFilesystemListInputSchema
->;
-
-export function isDataSourceFilesystemListInputType(
-  input: Record<string, unknown>
-): input is DataSourceFilesystemListInputType {
-  return DataSourceFilesystemListInputSchema.safeParse(input).success;
-}

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -1,0 +1,262 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { z } from "zod";
+
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+
+export const SearchInputSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      "The string used to retrieve relevant chunks of information using semantic similarity" +
+        " based on the user request and conversation context." +
+        " Include as much semantic signal based on the entire conversation history," +
+        " paraphrasing if necessary. longer queries are generally better."
+    ),
+  relativeTimeFrame: z
+    .string()
+    .regex(/^(all|\d+[hdwmy])$/)
+    .describe(
+      "The time frame (relative to LOCAL_TIME) to restrict the search based" +
+        " on the user request and past conversation context." +
+        " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
+        " where {k} is a number. Be strict, do not invent invalid values."
+    ),
+  dataSources:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+});
+
+export const SearchWithNodesInputSchema = SearchInputSchema.extend({
+  nodeIds: z
+    .array(z.string())
+    .describe(
+      "Array of exact content node IDs to search within. These are the 'nodeId' values from " +
+        "previous search results, which can be folders or files. All children of the designated " +
+        "nodes will be searched. If not provided, all available files and folders will be searched."
+    )
+    .optional(),
+});
+
+export type SearchWithNodesInputType = z.infer<
+  typeof SearchWithNodesInputSchema
+>;
+
+export const TagsInputSchema = z.object({
+  tagsIn: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "A list of labels (also called tags) to restrict the search based on the user request and past conversation context." +
+        "If multiple labels are provided, the search will return documents that have at least one of the labels." +
+        "You can't check that all labels are present, only that at least one is present." +
+        "If no labels are provided, the search will return all documents regardless of their labels."
+    ),
+  tagsNot: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "A list of labels (also called tags) to exclude from the search based on the user request and past conversation context." +
+        "Any document having one of these labels will be excluded from the search."
+    ),
+});
+
+type TagsInputType = z.infer<typeof TagsInputSchema>;
+
+export type SearchInputTypeWithTags = SearchWithNodesInputType & TagsInputType;
+
+export function isSearchInputType(
+  input: Record<string, unknown>
+): input is SearchInputTypeWithTags {
+  return (
+    SearchWithNodesInputSchema.safeParse(input).success ||
+    SearchWithNodesInputSchema.extend(TagsInputSchema.shape).safeParse(input)
+      .success
+  );
+}
+
+export const IncludeInputSchema = z.object({
+  timeFrame:
+    ConfigurableToolInputSchemas[
+      INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
+    ].optional(),
+  dataSources:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+});
+
+export type IncludeInputType = z.infer<typeof IncludeInputSchema>;
+
+export function isIncludeInputType(
+  input: Record<string, unknown>
+): input is IncludeInputType {
+  return (
+    IncludeInputSchema.safeParse(input).success ||
+    IncludeInputSchema.extend(TagsInputSchema.shape).safeParse(input).success
+  );
+}
+
+export const WebsearchInputSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      "The query used to perform the Google search. If requested by the " +
+        "user, use the Google syntax `site:` to restrict the search " +
+        "to a particular website or domain."
+    ),
+  page: z
+    .number()
+    .optional()
+    .describe(
+      "A 1-indexed page number used to paginate through the search results." +
+        " Should only be provided if the page is strictly greater than 1 in order" +
+        " to go deeper into the search results for a specific query."
+    ),
+});
+
+export type WebsearchInputType = z.infer<typeof WebsearchInputSchema>;
+
+export function isWebsearchInputType(
+  input: Record<string, unknown>
+): input is WebsearchInputType {
+  return WebsearchInputSchema.safeParse(input).success;
+}
+
+export const WebbrowseInputSchema = z.object({
+  urls: z.string().array().describe("List of urls to browse"),
+  format: z
+    .enum(["markdown", "html"])
+    .optional()
+    .describe("Format to return content: 'markdown' (default) or 'html'."),
+  screenshotMode: z
+    .enum(["none", "viewport", "fullPage"])
+    .optional()
+    .describe("Screenshot mode: 'none' (default), 'viewport', or 'fullPage'."),
+  links: z
+    .boolean()
+    .optional()
+    .describe("If true, also retrieve outgoing links from the page."),
+  useSummary: ConfigurableToolInputSchemas[
+    INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
+  ]
+    .describe(
+      "Summarize web pages using an AI agent before returning content. When enabled, provides concise summaries instead of full page content."
+    )
+    .default({
+      value: false,
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
+    }),
+});
+
+export type WebbrowseInputType = z.infer<typeof WebbrowseInputSchema>;
+
+export function isWebbrowseInputType(
+  input: Record<string, unknown>
+): input is WebbrowseInputType {
+  return WebbrowseInputSchema.safeParse(input).success;
+}
+
+export const DataSourceFilesystemFindInputSchema = z.object({
+  query: z
+    .string()
+    .optional()
+    .describe(
+      "The title to search for. This supports partial matching and does not require the " +
+        "exact title. For example, searching for 'budget' will find 'Budget 2024.xlsx', " +
+        "'Q1 Budget Report', etc..."
+    ),
+  rootNodeId: z
+    .string()
+    .optional()
+    .describe(
+      "The node ID of the node to start the search from. If not provided, the search will " +
+        "start from the root of the filesystem. This ID can be found from previous search " +
+        "results in the 'nodeId' field. This parameter restricts the search to the children " +
+        "and descendant of a specific node. If a node output by this tool or the list tool" +
+        "has children (hasChildren: true), it means that it can be passed as a rootNodeId."
+    ),
+  mimeTypes: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "The mime types to search for. If provided, only nodes with one of these mime types " +
+        "will be returned. If not provided, no filter will be applied. The mime types passed " +
+        "here must be one of the mime types found in the 'mimeType' field."
+    ),
+  dataSources:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+  limit: z
+    .number()
+    .optional()
+    .describe(
+      "Maximum number of results to return. Initial searches should use 10-20."
+    ),
+  nextPageCursor: z
+    .string()
+    .optional()
+    .describe(
+      "Cursor for fetching the next page of results. This parameter should only be used to fetch " +
+        "the next page of a previous search. The value should be exactly the 'nextPageCursor' from " +
+        "the previous search result."
+    ),
+});
+
+export type DataSourceFilesystemFindInputType = z.infer<
+  typeof DataSourceFilesystemFindInputSchema
+>;
+
+export function isDataSourceFilesystemFindInputType(
+  input: Record<string, unknown>
+): input is DataSourceFilesystemFindInputType {
+  return DataSourceFilesystemFindInputSchema.safeParse(input).success;
+}
+
+export const DataSourceFilesystemListInputSchema = z.object({
+  nodeId: z
+    .string()
+    .nullable()
+    .describe(
+      "The exact ID of the node to list the contents of. " +
+        "This ID can be found from previous search results in the 'nodeId' field. " +
+        "If not provided, the content at the root of the filesystem will be shown."
+    ),
+  mimeTypes: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "The mime types to search for. If provided, only nodes with one of these mime types " +
+        "will be returned. If not provided, no filter will be applied. The mime types passed " +
+        "here must be one of the mime types found in the 'mimeType' field."
+    ),
+  dataSources:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+  sortBy: z
+    .enum(["title", "timestamp"])
+    .optional()
+    .describe(
+      "Field to sort the results by. 'title' sorts alphabetically A-Z, 'timestamp' sorts by " +
+        "most recent first. If not specified, results are returned in the default order, which is " +
+        "folders first, then both documents and tables and alphabetically by title."
+    ),
+  limit: z
+    .number()
+    .optional()
+    .describe(
+      "Maximum number of results to return. Initial searches should use 10-20."
+    ),
+  nextPageCursor: z
+    .string()
+    .optional()
+    .describe(
+      "Cursor for fetching the next page of results. This parameter should only be used to fetch " +
+        "the next page of a previous search. The value should be exactly the 'nextPageCursor' from " +
+        "the previous search result."
+    ),
+});
+
+export type DataSourceFilesystemListInputType = z.infer<
+  typeof DataSourceFilesystemListInputSchema
+>;
+
+export function isDataSourceFilesystemListInputType(
+  input: Record<string, unknown>
+): input is DataSourceFilesystemListInputType {
+  return DataSourceFilesystemListInputSchema.safeParse(input).success;
+}


### PR DESCRIPTION
## Description

- This PR extracts the Zod schemas for the inputs of the search, FS tools, websearch, include to a dedicated file.
- The goal is to then use these schemas to typeguard the inputs received in the front-end, which will allow using the inputs instead of some magic resource we send in the tool output to describe what the inputs are.

## Tests

## Risk

- Affects some widely used tools.

## Deploy Plan

- Deploy front.
