### PR TITLE
[front] chore(AB): add `Top tools` header in `Add tools` sheet

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -135,10 +135,10 @@ export function MCPServerSelectionPage({
 
   return (
     <div className="flex flex-col gap-4 py-2">
+      {topMCPServerViews.length ? (
+        <span className="text-lg font-semibold">Top tools</span>
+      ) : null}
       <div className="grid grid-cols-2 gap-3">
-        {topMCPServerViews.length ? (
-          <span className="text-lg font-semibold">Top tools</span>
-        ) : null}
         {topMCPServerViews.map((view) => (
           <MCPServerCard
             key={view.id}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -137,6 +137,9 @@ export function MCPServerSelectionPage({
     <>
       <div className="flex flex-col gap-4 py-2">
         <div className="grid grid-cols-2 gap-3">
+          {topMCPServerViews.length ? (
+            <span className="text-lg font-semibold">Top tools</span>
+          ) : null}
           {topMCPServerViews.map((view) => (
             <MCPServerCard
               key={view.id}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -59,7 +59,7 @@ function MCPServerCard({
       </>
     );
   } else {
-    description = <>{getMcpServerViewDescription(view)}</>;
+    description = getMcpServerViewDescription(view);
   }
 
   return (
@@ -134,47 +134,45 @@ export function MCPServerSelectionPage({
   }
 
   return (
-    <>
-      <div className="flex flex-col gap-4 py-2">
-        <div className="grid grid-cols-2 gap-3">
-          {topMCPServerViews.length ? (
-            <span className="text-lg font-semibold">Top tools</span>
-          ) : null}
-          {topMCPServerViews.map((view) => (
-            <MCPServerCard
-              key={view.id}
-              view={view}
-              isSelected={selectedMCPIds.has(view.sId)}
-              onClick={() => onItemClick(view)}
-              onToolInfoClick={() => {
-                if (onToolDetailsClick) {
-                  onToolDetailsClick({ type: "MCP", view });
-                }
-              }}
-              featureFlags={featureFlags}
-            />
-          ))}
-        </div>
-        {nonTopMCPServerViews.length ? (
-          <span className="text-lg font-semibold">Other tools</span>
+    <div className="flex flex-col gap-4 py-2">
+      <div className="grid grid-cols-2 gap-3">
+        {topMCPServerViews.length ? (
+          <span className="text-lg font-semibold">Top tools</span>
         ) : null}
-        <div className="grid grid-cols-2 gap-3">
-          {nonTopMCPServerViews.map((view) => (
-            <MCPServerCard
-              key={view.id}
-              view={view}
-              isSelected={selectedMCPIds.has(view.sId)}
-              onClick={() => onItemClick(view)}
-              onToolInfoClick={() => {
-                if (onToolDetailsClick) {
-                  onToolDetailsClick({ type: "MCP", view });
-                }
-              }}
-              featureFlags={featureFlags}
-            />
-          ))}
-        </div>
+        {topMCPServerViews.map((view) => (
+          <MCPServerCard
+            key={view.id}
+            view={view}
+            isSelected={selectedMCPIds.has(view.sId)}
+            onClick={() => onItemClick(view)}
+            onToolInfoClick={() => {
+              if (onToolDetailsClick) {
+                onToolDetailsClick({ type: "MCP", view });
+              }
+            }}
+            featureFlags={featureFlags}
+          />
+        ))}
       </div>
-    </>
+      {nonTopMCPServerViews.length ? (
+        <span className="text-lg font-semibold">Other tools</span>
+      ) : null}
+      <div className="grid grid-cols-2 gap-3">
+        {nonTopMCPServerViews.map((view) => (
+          <MCPServerCard
+            key={view.id}
+            view={view}
+            isSelected={selectedMCPIds.has(view.sId)}
+            onClick={() => onItemClick(view)}
+            onToolInfoClick={() => {
+              if (onToolDetailsClick) {
+                onToolDetailsClick({ type: "MCP", view });
+              }
+            }}
+            featureFlags={featureFlags}
+          />
+        ))}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Description

- This PR adds a header `Top tools` at the top of `MCPServerSelectionPage`.
- This change is in preparation of a rework on the Triggers sheet, which will have the same pattern (Top triggers, other triggers).

Before
<img width="599" height="495" alt="Screenshot 2025-10-22 at 10 06 56 AM" src="https://github.com/user-attachments/assets/cd24af22-3078-4594-b77b-6dbc84a45b7c" />

After
<img width="599" height="517" alt="Screenshot 2025-10-22 at 10 02 15 AM" src="https://github.com/user-attachments/assets/e8bc5672-349c-4058-be75-06e4dc38b48d" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
