### PR TITLE
[front] refactor: rename Modals to Sheets for schedule and webhook edition components

### DIFF
--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -20,9 +20,9 @@ import type {
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { AgentBuilderSectionContainer } from "@app/components/agent_builder/AgentBuilderSectionContainer";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
-import { ScheduleEditionModal } from "@app/components/agent_builder/triggers/ScheduleEditionModal";
+import { ScheduleEditionSheet } from "@app/components/agent_builder/triggers/ScheduleEditionSheet";
 import { TriggerCard } from "@app/components/agent_builder/triggers/TriggerCard";
-import { WebhookEditionModal } from "@app/components/agent_builder/triggers/WebhookEditionModal";
+import { WebhookEditionSheet } from "@app/components/agent_builder/triggers/WebhookEditionSheet";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useWebhookSourceViewsFromSpaces } from "@app/lib/swr/webhook_source";
@@ -296,7 +296,7 @@ export function AgentBuilderTriggersBlock({
       </div>
 
       {/* Create/Edit Schedule Modal */}
-      <ScheduleEditionModal
+      <ScheduleEditionSheet
         owner={owner}
         trigger={
           dialogMode?.type === "edit" && dialogMode.trigger.kind === "schedule"
@@ -313,7 +313,7 @@ export function AgentBuilderTriggersBlock({
       />
 
       {/* Create/Edit Webhook Modal */}
-      <WebhookEditionModal
+      <WebhookEditionSheet
         owner={owner}
         trigger={
           dialogMode?.type === "edit" && dialogMode.trigger.kind === "webhook"

--- a/front/components/agent_builder/triggers/ScheduleEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionSheet.tsx
@@ -83,7 +83,7 @@ interface ScheduleEditionModalProps {
   onSave: (trigger: AgentBuilderTriggerType) => void;
 }
 
-export function ScheduleEditionModal({
+export function ScheduleEditionSheet({
   owner,
   trigger,
   isOpen,

--- a/front/components/agent_builder/triggers/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/WebhookEditionSheet.tsx
@@ -58,7 +58,7 @@ interface WebhookEditionModalProps {
   webhookSourceView: WebhookSourceViewType | null;
 }
 
-export function WebhookEditionModal({
+export function WebhookEditionSheet({
   owner,
   trigger,
   isOpen,


### PR DESCRIPTION
## Description

- This PR renames the two components `Webhook/ScheduleEditionModal` into `Webhook/ScheduleEditionSheet` (the files are renamed as well).
- The goal of this PR is to prevent mixing the file renaming with other bigger changes and creating a diff too big.

## Tests

- Checked locally.

## Risk

## Deploy Plan

- Deploy front.
