### PR TITLE
Re-use getCachedPublicChannels in the post_message tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -782,13 +782,18 @@ async function createServer(
         }
 
         try {
-          return await executePostMessage(auth, agentLoopContext, {
-            to,
-            message,
-            threadTs,
-            fileId,
-            accessToken,
-          });
+          return await executePostMessage(
+            auth,
+            agentLoopContext,
+            {
+              to,
+              message,
+              threadTs,
+              fileId,
+              accessToken,
+            },
+            mcpServerId
+          );
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
             return new Ok(makePersonalAuthenticationError("slack").content);

--- a/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack_bot/index.ts
@@ -69,13 +69,18 @@ async function createServer(
         }
 
         try {
-          return await executePostMessage(auth, agentLoopContext, {
-            to,
-            message,
-            threadTs,
-            fileId,
-            accessToken,
-          });
+          return await executePostMessage(
+            auth,
+            agentLoopContext,
+            {
+              to,
+              message,
+              threadTs,
+              fileId,
+              accessToken,
+            },
+            mcpServerId
+          );
         } catch (error) {
           return new Err(
             new MCPError(`Error posting message: ${normalizeError(error)}`)

--- a/front/lib/actions/mcp_internal_actions/servers/slack_bot/slack_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack_bot/slack_api_helper.ts
@@ -100,7 +100,8 @@ export async function executePostMessage(
     message: string;
     threadTs: string | undefined;
     fileId: string | undefined;
-  }
+  },
+  mcpServerId: string
 ) {
   const slackClient = await getSlackClient(accessToken);
   const originalMessage = message;
@@ -125,16 +126,12 @@ export async function executePostMessage(
     }
 
     // Resolve channel id
-    const conversationsList = await slackClient.conversations.list({
-      exclude_archived: true,
+    const conversationsList = await getCachedPublicChannels({
+      mcpServerId,
+      slackClient,
     });
-    if (!conversationsList.ok) {
-      return new Err(
-        new MCPError(conversationsList.error ?? "Failed to list conversations")
-      );
-    }
     const searchString = to.trim().replace(/^#/, "").toLowerCase();
-    const channel = conversationsList.channels?.find(
+    const channel = conversationsList.find(
       (c) =>
         c.name?.toLowerCase() === searchString ||
         c.id?.toLowerCase() === searchString


### PR DESCRIPTION
## Description

This PR optimizes the `post_message` tool in both Slack MCP servers by re-using the existing cached `getCachedPublicChannels` function instead of making direct API calls to conversations.list.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
