### PR TITLE
[hootl] Fix webhook URL issue + webhook redirect in local dev via DUST_WEBHOOKS_PUBLIC_URL

### DIFF
--- a/front/lib/webhookSource.ts
+++ b/front/lib/webhookSource.ts
@@ -8,7 +8,6 @@ import {
   isCustomResourceIconType,
   isInternalAllowedIcon,
 } from "@app/components/resources/resources_icons";
-import type { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import type {
   WebhookSourceForAdminType,
   WebhookSourceSignatureAlgorithm,
@@ -85,7 +84,7 @@ export const buildWebhookUrl = ({
 }: {
   apiBaseUrl: string;
   workspaceId: string;
-  webhookSource: WebhookSourceForAdminType | WebhookSourceResource;
+  webhookSource: WebhookSourceForAdminType;
 }): string => {
   return `${apiBaseUrl}/api/v1/w/${workspaceId}/triggers/hooks/${webhookSource.sId}/${webhookSource.urlSecret}`;
 };

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -180,7 +180,7 @@ async function handler(
         }
 
         if (kind !== "custom" && connectionId && remoteMetadata) {
-          // Allow redirection to public URL in local dev for webhook registrations
+          // Allow redirection to public URL in local dev for webhook registrations.
           const baseUrl =
             process.env.DUST_WEBHOOKS_PUBLIC_URL ?? config.getClientFacingUrl();
           const webhookUrl = buildWebhookUrl({

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -180,12 +180,14 @@ async function handler(
         }
 
         if (kind !== "custom" && connectionId && remoteMetadata) {
+          // Allow redirection to public URL in local dev for webhook registrations
+          const baseUrl =
+            process.env.DUST_WEBHOOKS_PUBLIC_URL ?? config.getClientFacingUrl();
           const webhookUrl = buildWebhookUrl({
-            apiBaseUrl: config.getClientFacingUrl(),
+            apiBaseUrl: baseUrl,
             workspaceId: workspace.sId,
-            webhookSource: webhookSource,
+            webhookSource: webhookSource.toJSONForAdmin(),
           });
-
           const service =
             WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP[kind].webhookService;
           const result = await service.createWebhooks({


### PR DESCRIPTION
## Description

WebhookSourceResource uses a sId method so the URL is not correctly build
WebhookSourceResource use a sId method while the WebhookSourceForAdminType object uses a sId field, so I have switch both calls to always used the WebhookSourceForAdminType.

I have also added a new env variable to use in local to redirect the webhhok to a public url: DUST_WEBHOOKS_PUBLIC_URL
This can be used with ngrok

## Tests

Manual

## Risk

low, still behind internal flag

## Deploy Plan

deploy front
