### PR TITLE
enh(snowflake): support more keypair setups + resync on update

### DIFF
--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -44,6 +44,7 @@ function handleTestConnectionError(
 ): "INVALID_CONFIGURATION" {
   switch (e.code) {
     case "INVALID_CREDENTIALS":
+    case "INVALID_ACCOUNT":
     case "NOT_READONLY":
     case "NO_TABLES":
       return "INVALID_CONFIGURATION";

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -161,7 +161,8 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
       },
       { where: { connectorId: c.id } }
     );
-    // We launch the workflow again so it syncs immediately.
+
+    // We launch the workflow, so it syncs immediately.
     await launchSnowflakeSyncWorkflow(c.id);
 
     return new Ok(c.id.toString());

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -27,6 +27,7 @@ import {
 import logger from "@connectors/logger/logger";
 import type { SnowflakeCredentials } from "@connectors/types";
 import { EXCLUDE_DATABASES, EXCLUDE_SCHEMAS } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SnowflakeRow = Record<string, any>;
@@ -296,7 +297,7 @@ export async function connectToSnowflake(
 
     return new Ok(connection);
   } catch (error) {
-    return new Err(error instanceof Error ? error : new Error(String(error)));
+    return new Err(normalizeError(error));
   }
 }
 
@@ -693,7 +694,7 @@ async function _closeConnection(
     await new Promise<void>((resolve, reject) => {
       conn.destroy((err: SnowflakeError | undefined) => {
         if (err) {
-          console.error("Error closing connection:", err);
+          logger.error({ error: err }, "Error closing Snowflake connection");
           reject(err);
         } else {
           resolve();
@@ -702,7 +703,7 @@ async function _closeConnection(
     });
     return new Ok(undefined);
   } catch (error) {
-    return new Err(error instanceof Error ? error : new Error(String(error)));
+    return new Err(normalizeError(error));
   }
 }
 
@@ -734,6 +735,6 @@ async function _executeQuery(
     );
     return new Ok(r);
   } catch (error) {
-    return new Err(error instanceof Error ? error : new Error(String(error)));
+    return new Err(normalizeError(error));
   }
 }

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -590,11 +590,7 @@ async function _checkRoleGrants(
         "TASK",
       ].includes(grantOn)
     ) {
-      if (
-        ["MODIFY PROGRAMMATIC AUTHENTICATION METHODS", "MONITOR"].includes(
-          g.privilege
-        )
-      ) {
+      if (["MONITOR"].includes(g.privilege)) {
         continue;
       }
       return new Err(

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1386,6 +1386,7 @@ dependencies = [
  "jsonwebtoken 9.3.1",
  "lazy_static",
  "once_cell",
+ "openssl",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
@@ -2942,6 +2943,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.4+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,6 +2959,7 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -137,6 +137,7 @@ hyper = { version = "1.3.1", features = ["full"] }
 init-tracing-opentelemetry =  { version = "0.29.0", features = ["tracing_subscriber_ext"] }
 itertools = "0.10"
 jsonwebtoken = "9.3.0"
+openssl = { version = "0.10", features = ["vendored"] }
 lazy_static = "1.4"
 once_cell = "1.18"
 opentelemetry = "0.30.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -183,3 +183,4 @@ unicode-normalization = "0.1.24"
 url = "2.5"
 urlencoding = "2.1"
 uuid = { version = "1.8", features = ["v4"] }
+zeroize = "1"

--- a/core/src/databases/remote_databases/snowflake/api/auth.rs
+++ b/core/src/databases/remote_databases/snowflake/api/auth.rs
@@ -20,12 +20,10 @@ pub async fn login(
     auth: &SnowflakeAuthMethod,
     config: &SnowflakeClientConfig,
 ) -> Result<String> {
-    debug!("login() called");
     let url = format!(
         "https://{account}.snowflakecomputing.com/session/v1/login-request",
         account = config.account
     );
-    debug!("Login URL: {}", url);
 
     let mut queries = vec![];
     if let Some(warehouse) = &config.warehouse {
@@ -42,8 +40,6 @@ pub async fn login(
     }
 
     let login_data = login_request_data(username, auth, config)?;
-    debug!("Sending login request...");
-    debug!("Query params: {:?}", queries);
 
     let start_time = std::time::Instant::now();
     let response = match http
@@ -55,18 +51,13 @@ pub async fn login(
         .send()
         .await
     {
-        Ok(resp) => {
-            debug!("Got response after {:?}", start_time.elapsed());
-            resp
-        }
+        Ok(resp) => resp,
         Err(e) => {
-            debug!("Request failed after {:?}: {:?}", start_time.elapsed(), e);
             return Err(e.into());
         }
     };
 
     let status = response.status();
-    debug!("Response status: {}", status);
     let body = response.text().await?;
     if !status.is_success() {
         debug!("Login failed with status {}: {}", status, body);
@@ -148,30 +139,130 @@ fn generate_jwt_from_key_pair(
         &payload,
         &key,
     )?;
+
     Ok(jwt)
 }
 
 fn try_parse_private_key(pem: &str, password: Option<&[u8]>) -> Result<RsaPrivateKey> {
-    if let Some(password) = password {
-        if !password.is_empty() {
-            if let Ok(private) = RsaPrivateKey::from_pkcs8_encrypted_pem(pem, password) {
-                return Ok(private);
+    let trimmed = pem.trim();
+
+    // Detect the PEM label, if any, to provide targeted guidance.
+    let pem_label = trimmed
+        .lines()
+        .find_map(|l| l.strip_prefix("-----BEGIN "))
+        .and_then(|rest| rest.strip_suffix("-----"))
+        .map(|s| s.trim().to_string());
+
+    if let Some(label) = pem_label.as_deref() {
+        // Common misconfigurations: PUBLIC KEY and ENCRYPTED PRIVATE KEY
+        if label.eq_ignore_ascii_case("PUBLIC KEY") {
+            return Err(Error::Decode(
+                "A public key was provided. Please supply a private key PEM (-----BEGIN PRIVATE KEY----- or -----BEGIN RSA PRIVATE KEY-----). \
+If you copied the Snowflake RSA_PUBLIC_KEY into this field, replace it with the corresponding private key.".to_string(),
+            ));
+        }
+
+        if label.eq_ignore_ascii_case("ENCRYPTED PRIVATE KEY") {
+            // If password is missing or empty, fail fast with a clear hint.
+            let needs_pass = match password {
+                Some(p) => p.is_empty(),
+                None => true,
+            };
+            if needs_pass {
+                return Err(Error::Decode(
+                    "An encrypted private key was provided but no passphrase is set. Provide 'private_key_passphrase' or use an unencrypted PKCS#8 private key.".to_string(),
+                ));
+            }
+
+            // Try native PKCS#8 decrypt first; if it fails, we will fallback to OpenSSL below
+            match RsaPrivateKey::from_pkcs8_encrypted_pem(trimmed, password.unwrap()) {
+                Ok(k) => return Ok(k),
+                Err(_) => {
+                    // continue to OpenSSL fallback
+                }
             }
         }
     }
 
-    if let Ok(private) = RsaPrivateKey::from_pkcs8_encrypted_pem(pem, b"") {
+    // Try the encrypted (empty passphrase) case (some keys are intentionally empty-passphrase).
+    if let Ok(private) = RsaPrivateKey::from_pkcs8_encrypted_pem(trimmed, b"") {
         return Ok(private);
     }
 
-    RsaPrivateKey::from_pkcs8_pem(pem).or_else(|pkcs8_err| {
-        RsaPrivateKey::from_pkcs1_pem(pem).map_err(|pkcs1_err| {
-            Error::Decode(format!(
-                "Failed to parse private key. PKCS8 error: {}, PKCS1 error: {}",
-                pkcs8_err, pkcs1_err
-            ))
-        })
-    })
+    // Try unencrypted PKCS#8, then PKCS#1
+    match RsaPrivateKey::from_pkcs8_pem(trimmed) {
+        Ok(k) => return Ok(k),
+        Err(pkcs8_err) => match RsaPrivateKey::from_pkcs1_pem(trimmed) {
+            Ok(k) => return Ok(k),
+            Err(pkcs1_err) => {
+                // OpenSSL fallback: handle legacy encrypted formats and broader algs.
+                use openssl::pkey::PKey;
+                let maybe_pkey = if let Some(pass) = password {
+                    let mut pw = pass.to_vec();
+                    PKey::private_key_from_pem_passphrase(trimmed.as_bytes(), &mut pw)
+                } else {
+                    PKey::private_key_from_pem(trimmed.as_bytes())
+                };
+
+                // If OpenSSL successfully parsed, convert to a form rsa crate understands.
+                {
+                    use openssl::pkey::Id;
+                    if let Ok(pkey) = maybe_pkey {
+                        if pkey.id() != Id::RSA {
+                            return Err(Error::UnsupportedFormat(format!(
+                                "Unsupported private key algorithm: {:?}",
+                                pkey.id()
+                            )));
+                        }
+                        // Export to unencrypted PKCS#8 PEM and parse with rsa.
+                        match pkey.private_key_to_pem_pkcs8() {
+                            Ok(pkcs8_pem) => {
+                                if let Ok(rsa_key) = RsaPrivateKey::from_pkcs8_pem(
+                                    std::str::from_utf8(&pkcs8_pem).unwrap_or_default(),
+                                ) {
+                                    return Ok(rsa_key);
+                                }
+                            }
+                            Err(_) => {
+                                // Continue to the next fallback.
+                            }
+                        }
+                        // Fallback: export PKCS#1 DER and parse
+                        match pkey.rsa() {
+                            Ok(r) => match r.private_key_to_der() {
+                                Ok(der) => match RsaPrivateKey::from_pkcs1_der(&der) {
+                                    Ok(rsa_key) => return Ok(rsa_key),
+                                    Err(e) => {
+                                        return Err(Error::Decode(format!(
+                                            "Failed to parse OpenSSL-exported RSA DER: {}",
+                                            e
+                                        )))
+                                    }
+                                },
+                                Err(e) => {
+                                    return Err(Error::Decode(format!(
+                                        "OpenSSL failed exporting PKCS#1 DER: {}",
+                                        e
+                                    )))
+                                }
+                            },
+                            Err(e) => {
+                                return Err(Error::Decode(format!(
+                                    "OpenSSL failed extracting RSA key: {}",
+                                    e
+                                )))
+                            }
+                        }
+                    }
+                }
+
+                Err(Error::Decode(format!(
+                    "Failed to parse private key. PKCS8 error: {}, PKCS1 error: {}",
+                    pkcs8_err, pkcs1_err
+                )))
+            }
+        },
+    }
 }
 
 #[derive(serde::Deserialize)]

--- a/core/src/databases/remote_databases/snowflake/api/auth.rs
+++ b/core/src/databases/remote_databases/snowflake/api/auth.rs
@@ -162,7 +162,7 @@ fn try_parse_private_key(pem: &str, password: Option<&[u8]>) -> Result<RsaPrivat
         }
     }
 
-    // Try formats in a simple, ordered sequence. Log detailed failures; return generic errors.
+    // Try formats in ordered sequence.
     if let Some(pass) = password {
         if let Ok(k) = RsaPrivateKey::from_pkcs8_encrypted_pem(trimmed, pass) {
             return Ok(k);


### PR DESCRIPTION
## Description

- adds support for more type of private keys
- fix support for private keys with empty passphrase
- immediately resync snowflake connnector on credentials update (skip timer)

fixes https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=123744697&issue=dust-tt%7Ctasks%7C3787

## Tests

Extensive local tests with multiple type of key pair setups

## Risk

Blast radius: snowflake connections

## Deploy Plan

Deploy `core` and `connectors`