### PR TITLE
Do not track interactive content file hallucination

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
@@ -440,9 +440,12 @@ function createServer(
       },
       async ({ file_id }) => {
         const result = await getClientExecutableFileContent(auth, file_id);
-
         if (result.isErr()) {
-          return new Err(new MCPError(result.error.message));
+          return new Err(
+            new MCPError(result.error.message, {
+              tracked: result.error.tracked,
+            })
+          );
         }
 
         const { fileResource, content } = result.value;

--- a/front/lib/actions/mcp_internal_actions/servers/slideshow/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slideshow/index.ts
@@ -293,9 +293,12 @@ function createServer(
       },
       async ({ file_id }) => {
         const result = await getClientExecutableFileContent(auth, file_id);
-
         if (result.isErr()) {
-          return new Err(new MCPError(result.error.message));
+          return new Err(
+            new MCPError(result.error.message, {
+              tracked: result.error.tracked,
+            })
+          );
         }
 
         const { fileResource, content } = result.value;

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -230,7 +230,7 @@ export async function editClientExecutableFile(
   if (fileContentResult.isErr()) {
     return new Err({
       message: fileContentResult.error.message,
-      tracked: true,
+      tracked: fileContentResult.error.tracked,
     });
   }
   const { fileResource, content: currentContent } = fileContentResult.value;
@@ -332,44 +332,60 @@ export async function renameClientExecutableFile(
 export async function getClientExecutableFileContent(
   auth: Authenticator,
   fileId: string
-): Promise<Result<{ fileResource: FileResource; content: string }, Error>> {
+): Promise<
+  Result<
+    { fileResource: FileResource; content: string },
+    {
+      message: string;
+      tracked: boolean;
+    }
+  >
+> {
   try {
     // Sometimes the model makes up a random file id that doesn't exist,
     // so we check if this is actually a valid id or not.
     const resourceId = getResourceIdFromSId(fileId);
 
     if (resourceId === null) {
-      return new Err(new Error(`The id ${fileId} is not a valid file id`));
+      return new Err({
+        message: `The id ${fileId} is not a valid file id`,
+        tracked: false,
+      });
     }
 
     const fileResource = await FileResource.fetchById(auth, fileId);
     if (!fileResource) {
-      return new Err(new Error(`File not found: ${fileId}`));
+      return new Err({
+        message: `File not found: ${fileId}`,
+        tracked: false,
+      });
     }
 
     // Check if it's an Interactive Content file.
     if (!isInteractiveContentFileContentType(fileResource.contentType)) {
-      return new Err(
-        new Error(
+      return new Err({
+        message:
           `File '${fileId}' is not an Interactive Content file ` +
-            `(content type: ${fileResource.contentType})`
-        )
-      );
+          `(content type: ${fileResource.contentType})`,
+        tracked: false,
+      });
     }
 
     // Get the file content.
     const content = await getFileContent(auth, fileResource, "original");
     if (!content) {
-      return new Err(new Error(`Failed to read content from file '${fileId}'`));
+      return new Err({
+        message: `Failed to read content from file '${fileId}'`,
+        tracked: true,
+      });
     }
 
     return new Ok({ fileResource, content });
   } catch (error) {
-    return new Err(
-      new Error(
-        `Failed to retrieve file content for '${fileId}': ${normalizeError(error)}`
-      )
-    );
+    return new Err({
+      message: `Failed to retrieve file content for '${fileId}': ${normalizeError(error)}`,
+      tracked: true,
+    });
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR slightly relax the tracking of the interactive content server retrieve file content tool, LLMs seem to sometimes hallucinate a bit. Those errors are properly handled today and does not require any actions from the on-call engineer.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
