### PR TITLE
Fix: tools approval modal not showing up immediately

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -170,7 +170,7 @@ export function useAgentMessageStream({
           // end of the stream to the client. So we just return.
           return;
         case "tool_approve_execution":
-          return;
+          break;
 
         case "generation_tokens":
           if (


### PR DESCRIPTION
## Description

Early return was skipping the tool approval event (mistake during the transition to virtuoso)

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front