### PR TITLE
[front] - refactor(obs): switch usage to AreaChart

### DIFF
--- a/front/components/agent_builder/observability/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/UsageMetricsChart.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
 import {
-  Bar,
-  BarChart,
+  Area,
+  AreaChart,
   CartesianGrid,
-  Label,
-  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -19,54 +17,9 @@ import {
   CHART_HEIGHT,
   USAGE_METRICS_LEGEND,
   USAGE_METRICS_PALETTE,
-  VERSION_MARKER_STYLE,
 } from "@app/components/agent_builder/observability/constants";
 import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
-import {
-  useAgentUsageMetrics,
-  useAgentVersionMarkers,
-} from "@app/lib/swr/assistants";
-
-function parseUTCDate(s: string): number {
-  const parts = s.split("-");
-  if (parts.length === 3) {
-    const yy = Number(parts[0]);
-    const mm = Number(parts[1]);
-    const dd = Number(parts[2]);
-    if (Number.isFinite(yy) && Number.isFinite(mm) && Number.isFinite(dd)) {
-      return Date.UTC(yy, mm - 1, dd);
-    }
-  }
-  const d = new Date(s);
-  return Number.isNaN(d.getTime()) ? 0 : d.getTime();
-}
-
-function snapVersionMarkersToLabels(
-  markers: Array<{ version: string; timestamp: string }>,
-  labels: string[]
-): Array<{ version: string; x: string }> {
-  if (!labels.length || !markers.length) {
-    return [];
-  }
-
-  const labelTimes = labels.map((s) => ({ s, t: parseUTCDate(s) }));
-
-  const snapToLabel = (ts: string): string => {
-    const markerT = parseUTCDate(ts);
-    let best: { s: string; t: number } | null = null;
-    for (const lt of labelTimes) {
-      if (lt.t <= markerT && (!best || lt.t > best.t)) {
-        best = lt;
-      }
-    }
-    return best ? best.s : labels[0];
-  };
-
-  return markers.map((m) => ({
-    version: m.version,
-    x: snapToLabel(m.timestamp),
-  }));
-}
+import { useAgentUsageMetrics } from "@app/lib/swr/assistants";
 
 interface UsageMetricsData {
   messages: number;
@@ -138,47 +91,74 @@ export function UsageMetricsChart({
       disabled: !workspaceId || !agentConfigurationId,
     });
 
-  const { versionMarkers, isVersionMarkersLoading, isVersionMarkersError } =
-    useAgentVersionMarkers({
-      workspaceId,
-      agentConfigurationId,
-      days: period,
-      disabled: !workspaceId || !agentConfigurationId,
-    });
-
-  const isLoading = isUsageMetricsLoading || isVersionMarkersLoading;
-  const isError = isUsageMetricsError || isVersionMarkersError;
-
   const legendItems = USAGE_METRICS_LEGEND.map(({ key, label }) => ({
     key,
     label,
     colorClassName: USAGE_METRICS_PALETTE[key],
   }));
 
-  const { data, snappedMarkers } = useMemo(() => {
-    const dataPoints = usageMetrics?.points ?? [];
-    const markers = versionMarkers ?? [];
-    const labels = dataPoints.map((d) => d.date);
-    return {
-      data: dataPoints,
-      snappedMarkers: snapVersionMarkersToLabels(markers, labels),
-    };
-  }, [usageMetrics?.points, versionMarkers]);
+  const data = useMemo(
+    () => usageMetrics?.points ?? [],
+    [usageMetrics?.points]
+  );
 
   return (
     <ChartContainer
       title="Usage Metrics"
-      isLoading={isLoading}
-      errorMessage={isError ? "Failed to load observability data." : undefined}
+      isLoading={isUsageMetricsLoading}
+      errorMessage={
+        isUsageMetricsError ? "Failed to load observability data." : undefined
+      }
     >
       <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-        <BarChart
+        <AreaChart
           data={data}
-          margin={{ top: 10, right: 30, left: 10, bottom: 0 }}
+          margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
         >
+          <defs>
+            <linearGradient id="fillMessages" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="hsl(var(--chart-1))"
+                stopOpacity={0.8}
+              />
+              <stop
+                offset="95%"
+                stopColor="hsl(var(--chart-1))"
+                stopOpacity={0.1}
+              />
+            </linearGradient>
+            <linearGradient id="fillConversations" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="hsl(var(--chart-2))"
+                stopOpacity={0.8}
+              />
+              <stop
+                offset="95%"
+                stopColor="hsl(var(--chart-2))"
+                stopOpacity={0.1}
+              />
+            </linearGradient>
+            <linearGradient id="fillActiveUsers" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="hsl(var(--chart-3))"
+                stopOpacity={0.8}
+              />
+              <stop
+                offset="95%"
+                stopColor="hsl(var(--chart-3))"
+                stopOpacity={0.1}
+              />
+            </linearGradient>
+          </defs>
           <CartesianGrid vertical={false} className="stroke-border" />
           <XAxis
             dataKey="date"
+            type="category"
+            scale="point"
+            allowDuplicatedCategory={false}
             className="text-xs text-muted-foreground"
             tickLine={false}
             axisLine={false}
@@ -192,8 +172,8 @@ export function UsageMetricsChart({
             tickMargin={8}
           />
           <Tooltip
-            cursor={false}
             content={UsageMetricsTooltip}
+            cursor={false}
             wrapperStyle={{ outline: "none" }}
             contentStyle={{
               background: "transparent",
@@ -202,38 +182,29 @@ export function UsageMetricsChart({
               boxShadow: "none",
             }}
           />
-          {USAGE_METRICS_LEGEND.map(({ key, label }) => (
-            <Bar
-              key={key}
-              dataKey={key}
-              name={label}
-              fill="currentColor"
-              className={USAGE_METRICS_PALETTE[key]}
-              radius={[4, 4, 0, 0]}
-            />
-          ))}
-          {snappedMarkers.map((m, index) => (
-            <ReferenceLine
-              key={`${m.version}-${m.x}`}
-              x={m.x}
-              stroke={VERSION_MARKER_STYLE.stroke}
-              strokeWidth={VERSION_MARKER_STYLE.strokeWidth}
-              strokeDasharray={VERSION_MARKER_STYLE.strokeDasharray}
-              ifOverflow="extendDomain"
-            >
-              <Label
-                value={`v${m.version}`}
-                position="top"
-                fill={VERSION_MARKER_STYLE.stroke}
-                fontSize={VERSION_MARKER_STYLE.labelFontSize}
-                offset={
-                  VERSION_MARKER_STYLE.labelOffsetBase +
-                  index * VERSION_MARKER_STYLE.labelOffsetIncrement
-                }
-              />
-            </ReferenceLine>
-          ))}
-        </BarChart>
+          {/* Areas for each usage metric */}
+          <Area
+            type="natural"
+            dataKey="messages"
+            name="Messages"
+            fill="url(#fillMessages)"
+            stroke="hsl(var(--chart-1))"
+          />
+          <Area
+            type="natural"
+            dataKey="conversations"
+            name="Conversations"
+            fill="url(#fillConversations)"
+            stroke="hsl(var(--chart-2))"
+          />
+          <Area
+            type="natural"
+            dataKey="activeUsers"
+            name="Active users"
+            fill="url(#fillActiveUsers)"
+            stroke="hsl(var(--chart-3))"
+          />
+        </AreaChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />
     </ChartContainer>


### PR DESCRIPTION
## Description

This PR refactors the `UsageMetricsChart` component to use `AreaChart` instead of `BarChart` for displaying usage metrics over time. The change provides a better visual representation of usage trends and aligns with the ongoing observability UI improvements. The refactoring also removes version marker logic that was specific to the bar chart implementation and simplifies the tooltip handling.


<img width="795" height="354" alt="Screenshot 2025-10-22 at 16 26 38" src="https://github.com/user-attachments/assets/6c3a2bcf-ade2-4484-9f99-62f7b4ad453d" />

PS: I have very few data locally, so the chart doesn't look great

**References:**
- https://ui.shadcn.com/charts/area

## Risk

Low behind FF

## Deploy plan

Deploy front