### PR TITLE
[extension] Parse tool inputs from params instead of output resources

### DIFF
--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/shared/lib/tool_inputs.ts
+++ b/extension/shared/lib/tool_inputs.ts
@@ -1,4 +1,5 @@
-import { parseTimeFrame, TimeFrame } from "@app/shared/lib/time_frame";
+import type { TimeFrame } from "@app/shared/lib/time_frame";
+import { parseTimeFrame } from "@app/shared/lib/time_frame";
 import { z } from "zod";
 
 export const SearchInputSchema = z

--- a/extension/shared/lib/tool_inputs.ts
+++ b/extension/shared/lib/tool_inputs.ts
@@ -1,0 +1,173 @@
+import type { TimeFrame } from "@app/shared/lib/time_frame";
+import { z } from "zod";
+
+export const SearchInputSchema = z.object({
+  query: z.string(),
+  relativeTimeFrame: z.string().regex(/^(all|\d+[hdwmy])$/),
+  tagsIn: z.array(z.string()).optional(),
+  tagsNot: z.array(z.string()).optional(),
+  nodeIds: z.array(z.string()).optional(),
+});
+
+export function isSearchInputType(
+  input: Record<string, unknown>
+): input is z.infer<typeof SearchInputSchema> {
+  return SearchInputSchema.safeParse(input).success;
+}
+
+function renderMimeType(mimeType: string) {
+  return mimeType
+    .replace("application/vnd.dust.", "")
+    .replace("-", " ")
+    .replace(".", " ");
+}
+
+function renderRelativeTimeFrameForToolOutput(
+  relativeTimeFrame: TimeFrame | null
+): string {
+  return relativeTimeFrame
+    ? "over the last " +
+        (relativeTimeFrame.duration > 1
+          ? `${relativeTimeFrame.duration} ${relativeTimeFrame.unit}s`
+          : `${relativeTimeFrame.unit}`)
+    : "across all time periods";
+}
+
+function renderTagsForToolOutput(
+  tagsIn?: string[],
+  tagsNot?: string[]
+): string {
+  const tagsInAsString =
+    tagsIn && tagsIn.length > 0 ? `, with labels ${tagsIn?.join(", ")}` : "";
+  const tagsNotAsString =
+    tagsNot && tagsNot.length > 0
+      ? `, excluding labels ${tagsNot?.join(", ")}`
+      : "";
+  return `${tagsInAsString}${tagsNotAsString}`;
+}
+
+function renderSearchNodeIds(nodeIds?: string[]): string {
+  return nodeIds && nodeIds.length > 0
+    ? `within ${nodeIds.length} different subtrees `
+    : "";
+}
+
+export function makeQueryTextForDataSourceSearch({
+  query,
+  timeFrame,
+  tagsIn,
+  tagsNot,
+  nodeIds,
+}: {
+  query: string;
+  timeFrame: TimeFrame | null;
+  tagsIn?: string[];
+  tagsNot?: string[];
+  nodeIds?: string[];
+}): string {
+  const timeFrameAsString = renderRelativeTimeFrameForToolOutput(timeFrame);
+  const tagsAsString = renderTagsForToolOutput(tagsIn, tagsNot);
+  const nodeIdsAsString = renderSearchNodeIds(nodeIds);
+
+  return query
+    ? `Searching "${query}" ${nodeIdsAsString}${timeFrameAsString}${tagsAsString}.`
+    : `Searching ${timeFrameAsString}${tagsAsString}.`;
+}
+
+export const IncludeInputSchema = z.object({
+  timeFrame: z.string().optional(),
+});
+
+export function isIncludeInputType(
+  input: Record<string, unknown>
+): input is z.infer<typeof IncludeInputSchema> {
+  return IncludeInputSchema.safeParse(input).success;
+}
+
+export function renderRelativeTimeFrame(
+  relativeTimeFrame: TimeFrame | null
+): string {
+  return renderRelativeTimeFrameForToolOutput(relativeTimeFrame);
+}
+
+export const WebsearchInputSchema = z.object({
+  query: z.string(),
+  page: z.number().optional(),
+});
+
+export type WebsearchInputType = z.infer<typeof WebsearchInputSchema>;
+
+export function isWebsearchInputType(
+  input: Record<string, unknown>
+): input is WebsearchInputType {
+  return WebsearchInputSchema.safeParse(input).success;
+}
+
+export const DataSourceFilesystemFindInputSchema = z.object({
+  query: z.string().optional(),
+  rootNodeId: z.string().optional(),
+  mimeTypes: z.array(z.string()).optional(),
+  limit: z.number().optional(),
+  nextPageCursor: z.string().optional(),
+});
+
+export function isDataSourceFilesystemFindInputType(
+  input: Record<string, unknown>
+): input is z.infer<typeof DataSourceFilesystemFindInputSchema> {
+  return DataSourceFilesystemFindInputSchema.safeParse(input).success;
+}
+
+export function makeQueryTextForFind({
+  query,
+  rootNodeId,
+  mimeTypes,
+  nextPageCursor,
+}: {
+  query?: string;
+  rootNodeId?: string;
+  mimeTypes?: string[];
+  nextPageCursor?: string;
+}): string {
+  const queryText = query ? ` "${query}"` : " all content";
+  const scope = rootNodeId
+    ? ` under ${rootNodeId}`
+    : " across the entire data sources";
+  const types = mimeTypes?.length
+    ? ` (${mimeTypes.map(renderMimeType).join(", ")} files)`
+    : "";
+  const pagination = nextPageCursor ? " - next page" : "";
+
+  return `Searching for${queryText}${scope}${types}${pagination}.`;
+}
+
+export const DataSourceFilesystemListInputSchema = z.object({
+  nodeId: z.string().nullable(),
+  mimeTypes: z.array(z.string()).optional(),
+  sortBy: z.enum(["title", "timestamp"]).optional(),
+  limit: z.number().optional(),
+  nextPageCursor: z.string().optional(),
+});
+
+export function isDataSourceFilesystemListInputType(
+  input: Record<string, unknown>
+): input is z.infer<typeof DataSourceFilesystemListInputSchema> {
+  return DataSourceFilesystemListInputSchema.safeParse(input).success;
+}
+
+export function makeQueryTextForList({
+  nodeId,
+  mimeTypes,
+  nextPageCursor,
+}: {
+  nodeId: string | null;
+  mimeTypes?: string[];
+  nextPageCursor?: string;
+}): string {
+  const location = nodeId ? ` within node "${nodeId}"` : " at the root level";
+  const types = mimeTypes?.length
+    ? ` (${mimeTypes.map(renderMimeType).join(", ")} files)`
+    : "";
+  const pagination = nextPageCursor ? " - next page" : "";
+
+  return `Listing content${location}${types}${pagination}.`;
+}

--- a/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
@@ -1,4 +1,3 @@
-import { asDisplayName } from "@app/shared/lib/utils";
 import {
   isDataSourceFilesystemFindInputType,
   isDataSourceFilesystemListInputType,
@@ -10,6 +9,7 @@ import {
   makeQueryTextForInclude,
   makeQueryTextForList,
 } from "@app/shared/lib/tool_inputs";
+import { asDisplayName } from "@app/shared/lib/utils";
 import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
 import { MCPBrowseActionDetails } from "@app/ui/components/actions/mcp/details/MCPBrowseActionDetails";
 import {

--- a/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
@@ -1,4 +1,3 @@
-import { parseTimeFrame } from "@app/shared/lib/time_frame";
 import { asDisplayName } from "@app/shared/lib/utils";
 import {
   isDataSourceFilesystemFindInputType,
@@ -8,8 +7,8 @@ import {
   isWebsearchInputType,
   makeQueryTextForDataSourceSearch,
   makeQueryTextForFind,
+  makeQueryTextForInclude,
   makeQueryTextForList,
-  renderRelativeTimeFrame,
 } from "@app/shared/lib/tool_inputs";
 import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
 import { MCPBrowseActionDetails } from "@app/ui/components/actions/mcp/details/MCPBrowseActionDetails";
@@ -82,13 +81,7 @@ export function MCPActionDetails(props: MCPActionDetailsProps) {
           visual={MagnifyingGlassIcon}
           query={
             isSearchInputType(params)
-              ? makeQueryTextForDataSourceSearch({
-                  query: params.query,
-                  timeFrame: parseTimeFrame(params.relativeTimeFrame),
-                  tagsIn: params.tagsIn,
-                  tagsNot: params.tagsNot,
-                  nodeIds: params.nodeIds,
-                })
+              ? makeQueryTextForDataSourceSearch(params)
               : null
           }
         />
@@ -138,13 +131,7 @@ export function MCPActionDetails(props: MCPActionDetailsProps) {
           }
           visual={ClockIcon}
           query={
-            isIncludeInputType(params)
-              ? `Requested to include documents ${renderRelativeTimeFrame(
-                  params.timeFrame
-                    ? (parseTimeFrame(params.timeFrame) ?? null)
-                    : null
-                )}.`
-              : null
+            isIncludeInputType(params) ? makeQueryTextForInclude(params) : null
           }
         />
       );

--- a/extension/ui/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -4,16 +4,10 @@ import type {
   ThinkingOutputType,
 } from "@dust-tt/client";
 import {
-  isIncludeQueryResourceType,
-  isSearchQueryResourceType,
-  isWebsearchQueryResourceType,
-} from "@dust-tt/client";
-import {
   ContentMessage,
   InformationCircleIcon,
   Markdown,
 } from "@dust-tt/sparkle";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 interface ThinkingBlockProps {
   resource: ThinkingOutputType;
@@ -77,8 +71,6 @@ export function SearchResultDetails({
   visual,
   viewType,
 }: SearchResultProps) {
-  const displayQuery = query || "No query provided";
-
   return (
     <ActionDetailsWrapper
       viewType={viewType}
@@ -86,7 +78,7 @@ export function SearchResultDetails({
       visual={visual}
     >
       <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-        {displayQuery}
+        {query ?? "No query provided"}
       </div>
     </ActionDetailsWrapper>
   );

--- a/extension/ui/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -66,35 +66,18 @@ export function ReasoningSuccessBlock({
 
 interface SearchResultProps {
   actionName: string;
-  defaultQuery?: string;
+  query: string | null;
   visual: React.ComponentType<{ className?: string }>;
-  actionOutput: CallToolResult["content"] | null;
   viewType: "conversation" | "sidebar";
 }
 
 export function SearchResultDetails({
   actionName,
-  defaultQuery,
+  query,
   visual,
   viewType,
-  actionOutput,
 }: SearchResultProps) {
-  const query =
-    actionOutput
-      ?.map((r) => {
-        if (
-          isSearchQueryResourceType(r) ||
-          isWebsearchQueryResourceType(r) ||
-          isIncludeQueryResourceType(r)
-        ) {
-          return r.resource.text.trim();
-        }
-        return null;
-      })
-      .filter(Boolean)
-      .join("\n") ||
-    defaultQuery ||
-    "No query provided";
+  const displayQuery = query || "No query provided";
 
   return (
     <ActionDetailsWrapper
@@ -103,7 +86,7 @@ export function SearchResultDetails({
       visual={visual}
     >
       <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-        {query}
+        {displayQuery}
       </div>
     </ActionDetailsWrapper>
   );


### PR DESCRIPTION
## Description

- Same as https://github.com/dust-tt/dust/pull/17124 but for the extension.
- Part of ongoing work to stop returning the inputs of a tool in its output, which we do for some tools like the search (we return a `data_source_search_query` output, this came from a time where every `XxxActionDetails` was heavily templated and changing their props was close to impossible).
- This PR starts by reading the data from the tool inputs rather than the output.
- Once published, we'll be able to stop sending the outputs in the tool and do some cleanup.

## Tests

## Risk

## Deploy Plan

- Publish Chrome extension.
