### PR TITLE
[front] Template Webhooks preset service data typing

### DIFF
--- a/front/lib/swr/useWebhookServiceData.ts
+++ b/front/lib/swr/useWebhookServiceData.ts
@@ -1,24 +1,23 @@
-import type { Fetcher } from "swr";
-
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetServiceDataResponseType } from "@app/pages/api/w/[wId]/webhook_sources/service-data";
 import type { LightWorkspaceType } from "@app/types";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";
 
-export function useWebhookServiceData({
+export function useWebhookServiceData<P extends WebhookProvider>({
   owner,
   connectionId,
   provider,
 }: {
   owner: LightWorkspaceType;
   connectionId: string | null;
-  provider: WebhookProvider;
+  provider: P;
 }) {
-  const serviceDataFetcher: Fetcher<GetServiceDataResponseType> = fetcher;
-
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error, mutate } = useSWRWithDefaults<
+    string,
+    GetServiceDataResponseType<P>
+  >(
     `/api/w/${owner.sId}/webhook_sources/service-data?connectionId=${connectionId}&provider=${provider}`,
-    serviceDataFetcher,
+    fetcher,
     {
       disabled: !connectionId,
     }

--- a/front/lib/triggers/built-in-webhooks/github/components/CreateWebhookGithubConnection.tsx
+++ b/front/lib/triggers/built-in-webhooks/github/components/CreateWebhookGithubConnection.tsx
@@ -15,22 +15,9 @@ import { useEffect, useMemo, useState } from "react";
 import type { WebhookCreateFormComponentProps } from "@app/components/triggers/webhook_preset_components";
 import { useWebhookServiceData } from "@app/lib/swr/useWebhookServiceData";
 import type {
-  GithubAdditionalData,
   GithubOrganization,
   GithubRepository,
 } from "@app/lib/triggers/built-in-webhooks/github/github_service_types";
-import { GithubAdditionalDataSchema } from "@app/lib/triggers/built-in-webhooks/github/github_service_types";
-
-function isGithubAdditionalData(
-  data: Record<string, unknown> | null
-): data is GithubAdditionalData {
-  if (!data) {
-    return false;
-  }
-
-  const result = GithubAdditionalDataSchema.safeParse(data);
-  return result.success;
-}
 
 export function CreateWebhookGithubConnection({
   owner,
@@ -46,13 +33,12 @@ export function CreateWebhookGithubConnection({
   >([]);
   const [repoSearchQuery, setRepoSearchQuery] = useState("");
 
-  const { serviceData, isServiceDataLoading } = useWebhookServiceData({
-    owner,
-    connectionId,
-    provider: "github",
-  });
-
-  const githubData = isGithubAdditionalData(serviceData) ? serviceData : null;
+  const { serviceData: githubData, isServiceDataLoading } =
+    useWebhookServiceData({
+      owner,
+      connectionId,
+      provider: "github",
+    });
   const [orgSearchQuery, setOrgSearchQuery] = useState("");
   const [showRepoDropdown, setShowRepoDropdown] = useState(false);
   const [showOrgDropdown, setShowOrgDropdown] = useState(false);

--- a/front/lib/triggers/built-in-webhooks/github/github_webhook_service.ts
+++ b/front/lib/triggers/built-in-webhooks/github/github_webhook_service.ts
@@ -10,7 +10,7 @@ import type { Result } from "@app/types";
 import { Err, isString, OAuthAPI, Ok } from "@app/types";
 import type { RemoteWebhookService } from "@app/types/triggers/remote_webhook_service";
 
-export class GitHubWebhookService implements RemoteWebhookService {
+export class GitHubWebhookService implements RemoteWebhookService<"github"> {
   async getServiceData(
     oauthToken: string
   ): Promise<Result<GithubAdditionalData, Error>> {

--- a/front/lib/triggers/built-in-webhooks/github/github_webhook_source_presets.ts
+++ b/front/lib/triggers/built-in-webhooks/github/github_webhook_source_presets.ts
@@ -26,7 +26,7 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
   schema: issuesSchema,
 };
 
-export const GITHUB_WEBHOOK_PRESET: PresetWebhook = {
+export const GITHUB_WEBHOOK_PRESET: PresetWebhook<"github"> = {
   name: "GitHub",
   eventCheck: {
     type: "headers",

--- a/front/lib/triggers/built-in-webhooks/test/test_webhook_source_presets.ts
+++ b/front/lib/triggers/built-in-webhooks/test/test_webhook_source_presets.ts
@@ -10,6 +10,8 @@ import type {
   WebhookEvent,
 } from "@app/types/triggers/webhooks_source_preset";
 
+export type TestServiceData = Record<string, unknown>;
+
 const TEST_EVENT: WebhookEvent = {
   name: "Test event",
   value: "test_event",
@@ -31,10 +33,10 @@ const TEST_EVENT: WebhookEvent = {
   },
 };
 
-class TestWebhookService implements RemoteWebhookService {
+class TestWebhookService implements RemoteWebhookService<"test"> {
   async getServiceData(
     oauthToken: string
-  ): Promise<Result<Record<string, unknown>, Error>> {
+  ): Promise<Result<TestServiceData, Error>> {
     logger.info("Fetching service data with oauthToken:", oauthToken);
     return new Ok({
       info: "This is test service data",
@@ -94,7 +96,7 @@ class TestWebhookService implements RemoteWebhookService {
   }
 }
 
-export const TEST_WEBHOOK_PRESET: PresetWebhook = {
+export const TEST_WEBHOOK_PRESET: PresetWebhook<"test"> = {
   name: "Test",
   eventCheck: {
     type: "headers",

--- a/front/pages/api/w/[wId]/webhook_sources/service-data.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/service-data.ts
@@ -8,19 +8,19 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isString, OAuthAPI } from "@app/types";
+import type {
+  WebhookProvider,
+  WebhookServiceDataForProvider,
+} from "@app/types/triggers/webhooks";
 import {
   isWebhookProvider,
   WEBHOOK_PRESETS,
-} from "@app/types/triggers/webhooks";
-import type {
-  ServiceDataForProvider,
-  WebhookProvider,
 } from "@app/types/triggers/webhooks";
 
 export type GetServiceDataResponseType<
   P extends WebhookProvider = WebhookProvider,
 > = {
-  serviceData: ServiceDataForProvider<P>;
+  serviceData: WebhookServiceDataForProvider<P>;
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/webhook_sources/service-data.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/service-data.ts
@@ -12,9 +12,15 @@ import {
   isWebhookProvider,
   WEBHOOK_PRESETS,
 } from "@app/types/triggers/webhooks";
+import type {
+  ServiceDataForProvider,
+  WebhookProvider,
+} from "@app/types/triggers/webhooks";
 
-export type GetServiceDataResponseType = {
-  serviceData: Record<string, unknown>;
+export type GetServiceDataResponseType<
+  P extends WebhookProvider = WebhookProvider,
+> = {
+  serviceData: ServiceDataForProvider<P>;
 };
 
 async function handler(

--- a/front/types/triggers/remote_webhook_service.ts
+++ b/front/types/triggers/remote_webhook_service.ts
@@ -1,10 +1,16 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
+import type {
+  ServiceDataForProvider,
+  WebhookProvider,
+} from "@app/types/triggers/webhooks";
 
-export interface RemoteWebhookService {
+export interface RemoteWebhookService<
+  P extends WebhookProvider = WebhookProvider,
+> {
   getServiceData(
     oauthToken: string
-  ): Promise<Result<Record<string, unknown>, Error>>;
+  ): Promise<Result<ServiceDataForProvider<P>, Error>>;
 
   /**
    * Creates webhooks on the remote service (e.g., GitHub, Jira)

--- a/front/types/triggers/remote_webhook_service.ts
+++ b/front/types/triggers/remote_webhook_service.ts
@@ -1,8 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
 import type {
-  ServiceDataForProvider,
   WebhookProvider,
+  WebhookServiceDataForProvider,
 } from "@app/types/triggers/webhooks";
 
 export interface RemoteWebhookService<
@@ -10,7 +10,7 @@ export interface RemoteWebhookService<
 > {
   getServiceData(
     oauthToken: string
-  ): Promise<Result<ServiceDataForProvider<P>, Error>>;
+  ): Promise<Result<WebhookServiceDataForProvider<P>, Error>>;
 
   /**
    * Creates webhooks on the remote service (e.g., GitHub, Jira)

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -5,7 +5,9 @@ import type {
   CustomResourceIconType,
   InternalAllowedIconType,
 } from "@app/components/resources/resources_icons";
+import type { GithubAdditionalData } from "@app/lib/triggers/built-in-webhooks/github/github_service_types";
 import { GITHUB_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/github/github_webhook_source_presets";
+import type { TestServiceData } from "@app/lib/triggers/built-in-webhooks/test/test_webhook_source_presets";
 import { TEST_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/test/test_webhook_source_presets";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
@@ -38,10 +40,20 @@ export type CustomPresetType = {
   featureFlag?: WhitelistableFeature;
 };
 
-export const WEBHOOK_PRESETS: Record<WebhookProvider, PresetWebhook> = {
+export type WebhookProviderServiceDataMap = {
+  github: GithubAdditionalData;
+  test: TestServiceData;
+};
+
+export type ServiceDataForProvider<P extends WebhookProvider> =
+  WebhookProviderServiceDataMap[P];
+
+export const WEBHOOK_PRESETS: {
+  [P in WebhookProvider]: PresetWebhook<P>;
+} = {
   github: GITHUB_WEBHOOK_PRESET,
   test: TEST_WEBHOOK_PRESET,
-} as const;
+};
 
 export type WebhookSourceType = {
   id: ModelId;

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -40,19 +40,19 @@ export type CustomPresetType = {
   featureFlag?: WhitelistableFeature;
 };
 
-export type WebhookProviderServiceDataMap = {
+type WebhookProviderServiceDataMap = {
   github: GithubAdditionalData;
   test: TestServiceData;
 };
 
-export type ServiceDataForProvider<P extends WebhookProvider> =
+export type WebhookServiceDataForProvider<P extends WebhookProvider> =
   WebhookProviderServiceDataMap[P];
 
-export const WEBHOOK_PRESETS: {
-  [P in WebhookProvider]: PresetWebhook<P>;
-} = {
+export const WEBHOOK_PRESETS = {
   github: GITHUB_WEBHOOK_PRESET,
   test: TEST_WEBHOOK_PRESET,
+} satisfies {
+  [P in WebhookProvider]: PresetWebhook<P>;
 };
 
 export type WebhookSourceType = {

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -9,6 +9,7 @@ import type {
 } from "@app/components/triggers/webhook_preset_components";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { RemoteWebhookService } from "@app/types/triggers/remote_webhook_service";
+import type { WebhookProvider } from "@app/types/triggers/webhooks";
 
 export type EventCheck = {
   type: "headers" | "body";
@@ -30,7 +31,7 @@ const WebhookPresetIcons = {
 export type WebhookPresetIcon =
   (typeof WebhookPresetIcons)[keyof typeof WebhookPresetIcons];
 
-export type PresetWebhook = {
+export type PresetWebhook<P extends WebhookProvider = WebhookProvider> = {
   name: string;
   eventCheck: EventCheck;
   events: WebhookEvent[];
@@ -38,7 +39,7 @@ export type PresetWebhook = {
   description: string;
   webhookPageUrl?: string;
   featureFlag?: WhitelistableFeature;
-  webhookService: RemoteWebhookService;
+  webhookService: RemoteWebhookService<P>;
   components: {
     detailsComponent: React.ComponentType<WebhookDetailsComponentProps>;
     createFormComponent: React.ComponentType<WebhookCreateFormComponentProps>;


### PR DESCRIPTION
## Description

- This PR templates the type for the service data relative to a webhook provider so that when fetching the service data for github you get it already with the correct type.
- Next steps are to 1. refactor the types a bit to remove the need for updating various mapping object or types when adding a new provider 2. do a similar templating on the `remoteMetadata`.

## Tests

- Tested locally.

## Risk

- Low, close to 0 runtime change.

## Deploy Plan

- Deploy front.
