### PR TITLE
[front] - feat(obs): ES feedback update

### DIFF
--- a/front/lib/analytics/feedback.ts
+++ b/front/lib/analytics/feedback.ts
@@ -1,0 +1,41 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import type { WorkspaceType } from "@app/types";
+import type { AgentMessageAnalyticsFeedback } from "@app/types/assistant/analytics";
+import type { AgentMessageType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+
+function constructDocumentId(
+  workspace: WorkspaceType,
+  message: AgentMessageType
+): string {
+  const timestamp = new Date(message.created).toISOString();
+  return `${workspace.sId}_${message.sId}_${timestamp}`;
+}
+
+/**
+ * Updates the feedbacks array for an analytics document.
+ */
+export async function updateAnalyticsFeedback({
+  auth,
+  message,
+  feedbacks,
+}: {
+  auth: Authenticator;
+  message: AgentMessageType;
+  feedbacks: AgentMessageAnalyticsFeedback[];
+}): Promise<Result<estypes.UpdateResponse, ElasticsearchError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const documentId = constructDocumentId(workspace, message);
+
+  return withEs(async (client) => {
+    return client.update({
+      index: ANALYTICS_ALIAS_NAME,
+      id: documentId,
+      doc: { feedbacks },
+    });
+  });
+}

--- a/front/lib/analytics/feedback.ts
+++ b/front/lib/analytics/feedback.ts
@@ -16,9 +16,6 @@ function constructDocumentId(
   return `${workspace.sId}_${message.sId}_${timestamp}`;
 }
 
-/**
- * Updates the feedbacks array for an analytics document.
- */
 export async function updateAnalyticsFeedback({
   auth,
   message,

--- a/front/lib/analytics/feedback.ts
+++ b/front/lib/analytics/feedback.ts
@@ -3,30 +3,29 @@ import type { estypes } from "@elastic/elasticsearch";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import type { WorkspaceType } from "@app/types";
+import type { LightWorkspaceType } from "@app/types";
 import type { AgentMessageAnalyticsFeedback } from "@app/types/assistant/analytics";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 
-function constructDocumentId(
-  workspace: WorkspaceType,
+function makeDocumentId(
+  workspace: LightWorkspaceType,
   message: AgentMessageType
 ): string {
   const timestamp = new Date(message.created).toISOString();
   return `${workspace.sId}_${message.sId}_${timestamp}`;
 }
 
-export async function updateAnalyticsFeedback({
-  auth,
-  message,
-  feedbacks,
-}: {
-  auth: Authenticator;
-  message: AgentMessageType;
-  feedbacks: AgentMessageAnalyticsFeedback[];
-}): Promise<Result<estypes.UpdateResponse, ElasticsearchError>> {
+export async function updateAnalyticsFeedback(
+  auth: Authenticator,
+  params: {
+    message: AgentMessageType;
+    feedbacks: AgentMessageAnalyticsFeedback[];
+  }
+): Promise<Result<estypes.UpdateResponse, ElasticsearchError>> {
   const workspace = auth.getNonNullableWorkspace();
-  const documentId = constructDocumentId(workspace, message);
+  const { message, feedbacks } = params;
+  const documentId = makeDocumentId(workspace, message);
 
   return withEs(async (client) => {
     return client.update({

--- a/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
@@ -66,6 +66,29 @@
           "type": "keyword"
         }
       }
+    },
+    "feedbacks": {
+      "type": "nested",
+      "properties": {
+        "feedback_id": {
+          "type": "integer"
+        },
+        "user_id": {
+          "type": "keyword"
+        },
+        "thumb_direction": {
+          "type": "keyword"
+        },
+        "content": {
+          "type": "text"
+        },
+        "is_conversation_shared": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "date"
+        }
+      }
     }
   }
 }

--- a/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
@@ -80,7 +80,8 @@
           "type": "keyword"
         },
         "content": {
-          "type": "text"
+          "type": "text",
+          "index": "false"
         },
         "is_conversation_shared": {
           "type": "boolean"

--- a/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
@@ -71,7 +71,7 @@
       "type": "nested",
       "properties": {
         "feedback_id": {
-          "type": "integer"
+          "type": "keyword"
         },
         "user_id": {
           "type": "keyword"

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -156,14 +156,10 @@ export async function updateAnalyticsDocById({
   id,
   scriptSource,
   params,
-  ifSeqNo,
-  ifPrimaryTerm,
 }: {
   id: string;
   scriptSource: string;
   params?: estypes.Script["params"];
-  ifSeqNo?: number;
-  ifPrimaryTerm?: number;
 }): Promise<Result<estypes.UpdateResponse, ElasticsearchError>> {
   return withEs((client) =>
     client.update({
@@ -174,8 +170,6 @@ export async function updateAnalyticsDocById({
         source: scriptSource,
         params,
       },
-      if_seq_no: ifSeqNo,
-      if_primary_term: ifPrimaryTerm,
     })
   );
 }

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -3,7 +3,6 @@ import { Client, errors as esErrors } from "@elastic/elasticsearch";
 
 import config from "@app/lib/api/config";
 import { normalizeError } from "@app/types";
-import type { AgentMessageAnalyticsFeedback } from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -73,7 +72,7 @@ function toElasticsearchError(err: unknown): ElasticsearchError {
   return new ElasticsearchError("unknown_error", normalizeError(err).message);
 }
 
-async function withEs<T>(
+export async function withEs<T>(
   fn: (client: Client) => Promise<T>
 ): Promise<Result<T, ElasticsearchError>> {
   const client = await getClient();
@@ -161,24 +160,5 @@ export async function searchAnalytics<
     size: options?.size,
     from: options?.from,
     sort: options?.sort,
-  });
-}
-
-/**
- * Updates the feedbacks array for an analytics document.
- */
-export async function appendFeedbackToAnalyticsDoc({
-  id,
-  feedbacks,
-}: {
-  id: string;
-  feedbacks: AgentMessageAnalyticsFeedback[];
-}): Promise<Result<estypes.UpdateResponse, ElasticsearchError>> {
-  return withEs(async (client) => {
-    return client.update({
-      index: ANALYTICS_ALIAS_NAME,
-      id,
-      doc: { feedbacks },
-    });
   });
 }

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -12,6 +12,7 @@ export const ANALYTICS_ALIAS_NAME = "front.agent_message_analytics";
 
 export interface ElasticsearchBaseDocument {
   workspace_id: string;
+
   [key: string]: unknown;
 }
 
@@ -41,6 +42,33 @@ function extractErrorReason(err: esErrors.ResponseError): string {
   return err.message;
 }
 
+function toElasticsearchError(err: unknown): ElasticsearchError {
+  if (err instanceof esErrors.ResponseError) {
+    const statusCode = err.statusCode ?? undefined;
+    const reason = extractErrorReason(err);
+    return { type: "query_error", message: reason, statusCode };
+  }
+  if (err instanceof esErrors.ConnectionError) {
+    return {
+      type: "connection_error",
+      message: "Failed to connect to Elasticsearch",
+    };
+  }
+  return { type: "unknown_error", message: normalizeError(err).message };
+}
+
+async function withEs<T>(
+  fn: (client: Client) => Promise<T>
+): Promise<Result<T, ElasticsearchError>> {
+  const client = await getClient();
+  try {
+    const res = await fn(client);
+    return new Ok(res);
+  } catch (err) {
+    return new Err(toElasticsearchError(err));
+  }
+}
+
 export async function getClient(): Promise<Client> {
   if (esClient) {
     return esClient;
@@ -67,34 +95,11 @@ async function esSearch<
 ): Promise<
   Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
 > {
-  const client = await getClient();
-
-  try {
-    const result = await client.search<TDocument, TAggregations>({
+  return withEs((client) =>
+    client.search<TDocument, TAggregations>({
       ...params,
-    });
-    return new Ok(result);
-  } catch (err) {
-    if (err instanceof esErrors.ResponseError) {
-      const statusCode = err.statusCode ?? undefined;
-      const reason = extractErrorReason(err);
-      return new Err({
-        type: "query_error",
-        message: reason,
-        statusCode,
-      });
-    }
-    if (err instanceof esErrors.ConnectionError) {
-      return new Err({
-        type: "connection_error",
-        message: "Failed to connect to Elasticsearch",
-      });
-    }
-    return new Err({
-      type: "unknown_error",
-      message: normalizeError(err).message,
-    });
-  }
+    })
+  );
 }
 
 export function bucketsToArray<TBucket>(
@@ -141,4 +146,36 @@ export async function searchAnalytics<
     from: options?.from,
     sort: options?.sort,
   });
+}
+
+/**
+ * Update a single analytics document by id using a painless script.
+ * The update targets the analytics alias to ensure writes hit the active index.
+ */
+export async function updateAnalyticsDocById({
+  id,
+  scriptSource,
+  params,
+  ifSeqNo,
+  ifPrimaryTerm,
+}: {
+  id: string;
+  scriptSource: string;
+  params?: estypes.Script["params"];
+  ifSeqNo?: number;
+  ifPrimaryTerm?: number;
+}): Promise<Result<estypes.UpdateResponse, ElasticsearchError>> {
+  return withEs((client) =>
+    client.update({
+      index: ANALYTICS_ALIAS_NAME,
+      id,
+      script: {
+        lang: "painless",
+        source: scriptSource,
+        params,
+      },
+      if_seq_no: ifSeqNo,
+      if_primary_term: ifPrimaryTerm,
+    })
+  );
 }

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -2,6 +2,7 @@ import type { estypes } from "@elastic/elasticsearch";
 import { Client, errors as esErrors } from "@elastic/elasticsearch";
 
 import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
 import { normalizeError } from "@app/types";
 import type { AgentMessageAnalyticsFeedback } from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
@@ -168,14 +169,16 @@ export async function searchAnalytics<
  * Append a feedback entry atomically to the `feedbacks` array.
  */
 export async function appendFeedbackToAnalyticsDoc({
+  auth,
   id,
-  workspaceId,
   feedback,
 }: {
+  auth: Authenticator;
   id: string;
-  workspaceId: string;
   feedback: AgentMessageAnalyticsFeedback;
 }): Promise<Result<estypes.UpdateResponse, ElasticsearchError>> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+
   return withEs(async (client) => {
     const getRes = await client.get<{
       workspace_id?: string;

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -3,6 +3,7 @@ import { Client, errors as esErrors } from "@elastic/elasticsearch";
 
 import config from "@app/lib/api/config";
 import { normalizeError } from "@app/types";
+import type { AgentMessageAnalyticsFeedback } from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -172,4 +173,19 @@ export async function updateAnalyticsDocById({
       },
     })
   );
+}
+
+/**
+ * Convenience: append a feedback entry atomically to the `feedbacks` array.
+ */
+export async function appendFeedbackToAnalyticsDoc({
+  id,
+  feedback,
+}: {
+  id: string;
+  feedback: AgentMessageAnalyticsFeedback;
+}): Promise<Result<estypes.UpdateResponse, ElasticsearchError>> {
+  const scriptSource =
+    "if (ctx._source.feedbacks == null) { ctx._source.feedbacks = []; } ctx._source.feedbacks.add(params.feedback);";
+  return updateAnalyticsDocById({ id, scriptSource, params: { feedback } });
 }

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -71,6 +71,7 @@ export async function storeAgentAnalyticsActivity(
     tools_used: toolsUsed,
     user_id: userMessage.user?.sId ?? "unknown",
     workspace_id: workspace.sId,
+    feedbacks: [],
   };
 
   await storeToElasticsearch(document);

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -1,3 +1,4 @@
+import type { ThumbReaction } from "@app/components/assistant/conversation/FeedbackSelector";
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 import type { AgentMessageType } from "@app/types";
 
@@ -24,7 +25,7 @@ export interface AgentMessageAnalyticsToolUsed {
 export interface AgentMessageAnalyticsFeedback {
   feedback_id: number;
   user_id: string;
-  thumb_direction: "up" | "down";
+  thumb_direction: ThumbReaction;
   content?: string;
   is_conversation_shared: boolean;
   created_at: string; // ISO date string.

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -21,6 +21,15 @@ export interface AgentMessageAnalyticsToolUsed {
   status: string;
 }
 
+export interface AgentMessageAnalyticsFeedback {
+  feedback_id: number;
+  user_id: string;
+  thumb_direction: "up" | "down";
+  content?: string;
+  is_conversation_shared: boolean;
+  created_at: string; // ISO date string.
+}
+
 export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   agent_id: string;
   agent_version: string;
@@ -31,6 +40,7 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   timestamp: string; // ISO date string.
   tokens: AgentMessageAnalyticsTokens;
   tools_used: AgentMessageAnalyticsToolUsed[];
+  feedbacks: AgentMessageAnalyticsFeedback[];
   user_id: string;
   workspace_id: string;
 }


### PR DESCRIPTION
## Description

This PR adds feedback data tracking to the Elasticsearch agent message analytics mapping and implements an update mechanism. This enables updating analytics documents with user feedback information (thumbs up/down, content, sharing status) without requiring full document re-indexing. 

Note: this is not used yet and will by used when ingesting dat

## Risk

Low, behind FF

## Tests

Tested locally

## Deploy Plan

- Update ES index (EU/US)
- Deploy front