### PR TITLE
[front] allow deleting a spreadsheet folder

### DIFF
--- a/front/components/data_source/DocumentOrTableDeleteDialog.tsx
+++ b/front/components/data_source/DocumentOrTableDeleteDialog.tsx
@@ -18,7 +18,11 @@ import type {
   LightContentNode,
   LightWorkspaceType,
 } from "@app/types";
-import { DocumentDeletionKey } from "@app/types";
+import {
+  DocumentDeletionKey,
+  isSpreadsheetFolderContentNode,
+} from "@app/types";
+import { DATA_SOURCE_FOLDER_SPREADSHEET_MIME_TYPE } from "@dust-tt/client";
 
 interface DocumentOrTableDeleteDialogProps {
   dataSourceView: DataSourceViewType | null;
@@ -60,7 +64,10 @@ export const DocumentOrTableDeleteDialog = ({
     if (
       !contentNode ||
       !dataSourceView ||
-      !["table", "document"].includes(contentNode.type)
+      !(
+        isSpreadsheetFolderContentNode(contentNode) ||
+        ["table", "document"].includes(contentNode.type)
+      )
     ) {
       return;
     }

--- a/front/components/data_source/DocumentOrTableDeleteDialog.tsx
+++ b/front/components/data_source/DocumentOrTableDeleteDialog.tsx
@@ -22,7 +22,6 @@ import {
   DocumentDeletionKey,
   isSpreadsheetFolderContentNode,
 } from "@app/types";
-import { DATA_SOURCE_FOLDER_SPREADSHEET_MIME_TYPE } from "@dust-tt/client";
 
 interface DocumentOrTableDeleteDialogProps {
   dataSourceView: DataSourceViewType | null;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
@@ -8,23 +8,17 @@ import type { DataSourceResource } from "@app/lib/resources/data_source_resource
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { CoreAPI } from "@app/types";
-
-export type DeleteFolderResponseType = {
-  folder: {
-    folder_id: string;
-  };
-};
+import { CoreAPI, isString } from "@app/types";
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<DeleteFolderResponseType>>,
+  res: NextApiResponse<WithAPIErrorResponse<void>>,
   auth: Authenticator,
   { dataSource }: { dataSource: DataSourceResource }
 ): Promise<void> {
   const { fId } = req.query;
 
-  if (typeof fId !== "string" || fId === "") {
+  if (!isString(fId) || fId === "") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -66,11 +60,7 @@ async function handler(
         });
       }
 
-      res.status(200).json({
-        folder: {
-          folder_id: fId,
-        },
-      });
+      res.status(204);
       return;
 
     default:

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
@@ -1,0 +1,99 @@
+import type {
+  DeleteFolderResponseType,
+  GetFolderResponseType,
+  UpsertFolderResponseType,
+} from "@dust-tt/client";
+import { UpsertDataSourceFolderRequestSchema } from "@dust-tt/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import apiConfig from "@app/lib/api/config";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { CoreAPI } from "@app/types";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      | GetFolderResponseType
+      | DeleteFolderResponseType
+      | UpsertFolderResponseType
+    >
+  >,
+  auth: Authenticator,
+  { dataSource }: { dataSource: DataSourceResource }
+): Promise<void> {
+  const { fId } = req.query;
+
+  if (typeof fId !== "string" || fId === "") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const coreAPI = new CoreAPI(apiConfig.getCoreAPIConfig(), logger);
+
+  switch (req.method) {
+    case "DELETE":
+      // Check write permissions
+      if (!dataSource.canWrite(auth)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message: "You are not allowed to delete data in this data source.",
+          },
+        });
+      }
+
+      const delRes = await coreAPI.deleteDataSourceFolder({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.dustAPIDataSourceId,
+        folderId: fId,
+      });
+
+      if (delRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "There was an error deleting the folder.",
+            data_source_error: delRes.error,
+          },
+        });
+      }
+
+      res.status(200).json({
+        folder: {
+          folder_id: fId,
+        },
+      });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET, POST, or DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    dataSource: { requireCanReadOrAdministrate: true },
+  })
+);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
@@ -1,9 +1,3 @@
-import type {
-  DeleteFolderResponseType,
-  GetFolderResponseType,
-  UpsertFolderResponseType,
-} from "@dust-tt/client";
-import { UpsertDataSourceFolderRequestSchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -11,21 +5,20 @@ import apiConfig from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { CoreAPI } from "@app/types";
 
+export type DeleteFolderResponseType = {
+  folder: {
+    folder_id: string;
+  };
+};
+
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<
-      | GetFolderResponseType
-      | DeleteFolderResponseType
-      | UpsertFolderResponseType
-    >
-  >,
+  res: NextApiResponse<WithAPIErrorResponse<DeleteFolderResponseType>>,
   auth: Authenticator,
   { dataSource }: { dataSource: DataSourceResource }
 ): Promise<void> {

--- a/front/types/api/public/spaces.ts
+++ b/front/types/api/public/spaces.ts
@@ -29,6 +29,7 @@ export type LightContentNode = {
   sourceUrl: string | null;
   title: string;
   type: ContentNodeType;
+  mimeType?: string | null;
 };
 
 export const DATA_SOURCE_VIEW_CATEGORIES = [
@@ -71,4 +72,13 @@ export function isWebsiteOrFolderCategory(
   category: unknown
 ): category is Extract<DataSourceViewCategory, "website" | "folder"> {
   return category === "website" || category === "folder";
+}
+
+export function isSpreadsheetFolderContentNode(
+  contentNode: LightContentNode
+): boolean {
+  return (
+    contentNode.type === "folder" &&
+    contentNode.mimeType === "application/vnd.dust.folder.spreadsheet"
+  );
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/4753

When we upload an excel spreadsheet in a folder, we actually create a folder inside the folder, with all the sheets within that folder.

This folder in folder had the mimetype "application/vnd.dust.folder.spreadsheet", and the contentNode was of type "folder". We were returning at the very top of the function when the contentNode was not a "table" or "document" => we were not allowing to delete the spreadsheets.

This PR adds the ability to delete a spreasheet.

It was required to add an actual endpoint for deletion, because we only had endpoints for table and document types.

- EXISTING : front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[fId]/index.ts
- EXISTING : front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[fId]/index.ts
- NEW : front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts

The new endpoint was heavily inspired by the api/v1 brother-endpoint front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts, that was allowing to delete a folder via API.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, able to delete a folder.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.