### PR TITLE
[front] - chore(obs): add loading blocks

### DIFF
--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -1,14 +1,19 @@
 import {
   Button,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   Label,
+  LoadingBlock,
 } from "@dust-tt/sparkle";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import { OBSERVABILITY_TIME_RANGE } from "@app/components/agent_builder/observability/constants";
+import {
+  CHART_CONTAINER_HEIGHT_CLASS,
+  OBSERVABILITY_TIME_RANGE,
+} from "@app/components/agent_builder/observability/constants";
 import {
   ObservabilityProvider,
   useObservability,
@@ -27,10 +32,11 @@ export function AgentBuilderObservability({
 }: AgentBuilderObservabilityProps) {
   const { owner } = useAgentBuilderContext();
 
-  const { agentConfiguration } = useAgentConfiguration({
-    workspaceId: owner.sId,
-    agentConfigurationId: agentConfigurationSId,
-  });
+  const { agentConfiguration, isAgentConfigurationLoading } =
+    useAgentConfiguration({
+      workspaceId: owner.sId,
+      agentConfigurationId: agentConfigurationSId,
+    });
 
   if (!agentConfiguration) {
     return null;
@@ -52,18 +58,28 @@ export function AgentBuilderObservability({
         </div>
 
         <div className="grid grid-cols-1 gap-6">
-          <UsageMetricsChart
-            workspaceId={owner.sId}
-            agentConfigurationId={agentConfiguration.sId}
-          />
-          <ToolExecutionChart
-            workspaceId={owner.sId}
-            agentConfigurationId={agentConfiguration.sId}
-          />
-          <ToolLatencyChart
-            workspaceId={owner.sId}
-            agentConfigurationId={agentConfiguration.sId}
-          />
+          {isAgentConfigurationLoading ? (
+            <>
+              <ChartContainerSkeleton />
+              <ChartContainerSkeleton />
+              <ChartContainerSkeleton />
+            </>
+          ) : (
+            <>
+              <UsageMetricsChart
+                workspaceId={owner.sId}
+                agentConfigurationId={agentConfiguration.sId}
+              />
+              <ToolExecutionChart
+                workspaceId={owner.sId}
+                agentConfigurationId={agentConfiguration.sId}
+              />
+              <ToolLatencyChart
+                workspaceId={owner.sId}
+                agentConfigurationId={agentConfiguration.sId}
+              />
+            </>
+          )}
         </div>
       </div>
     </ObservabilityProvider>
@@ -89,6 +105,24 @@ function HeaderPeriodDropdown() {
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
+    </div>
+  );
+}
+
+function ChartContainerSkeleton() {
+  return (
+    <div
+      className={cn(
+        "bg-card flex flex-col rounded-lg border border-border p-4",
+        CHART_CONTAINER_HEIGHT_CLASS
+      )}
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <LoadingBlock className="h-6 w-40 rounded-md" />
+      </div>
+      <div className="flex-1">
+        <LoadingBlock className="h-full w-full rounded-xl" />
+      </div>
     </div>
   );
 }

--- a/front/components/agent_builder/observability/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/ChartContainer.tsx
@@ -1,7 +1,10 @@
-import { Spinner } from "@dust-tt/sparkle";
+import { cn, Spinner } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
-import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
+import {
+  CHART_CONTAINER_HEIGHT_CLASS,
+  CHART_HEIGHT,
+} from "@app/components/agent_builder/observability/constants";
 
 interface ChartContainerProps {
   title: string;
@@ -23,7 +26,12 @@ export function ChartContainer({
   const message = isLoading ? null : errorMessage ?? emptyMessage;
 
   return (
-    <div className="bg-card rounded-lg border border-border p-4">
+    <div
+      className={cn(
+        "bg-card rounded-lg border border-border p-4",
+        CHART_CONTAINER_HEIGHT_CLASS
+      )}
+    >
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-lg font-medium text-foreground">{title}</h3>
         <div className="flex items-center gap-3">{additionalControls}</div>

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -17,6 +17,7 @@ export const USAGE_METRICS_LEGEND = [
 ] as const;
 
 export const CHART_HEIGHT = 260;
+export const CHART_CONTAINER_HEIGHT_CLASS = "h-100";
 
 export const VERSION_MARKER_STYLE = {
   stroke: "hsl(var(--primary))",


### PR DESCRIPTION
## Description

This PR adds loading skeleton states to the agent observability charts while the agent configuration is being fetched. The implementation displays three `ChartContainerSkeleton` components with proper height constraints and loading blocks that match the final chart containers' visual structure.

## Risk

Low

## Deploy Plan

Deploy front