### PR TITLE
Bump @modelcontextprotocol/sdk fork to 1.20.1

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,7 +18,7 @@
         "@mendable/firecrawl-js": "^1.29.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@mistralai/mistralai": "^1.10.0",
-        "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#628ebe48388549faae7e35504611af9ac2c6f5e4",
+        "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#4a3d6b942e3982c818acd529de9b574c92776a2e",
         "@notionhq/client": "^2.3.0",
         "@octokit/core": "^6.1.5",
         "@radix-ui/react-dialog": "^1.0.5",
@@ -3206,9 +3206,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.1",
-      "resolved": "git+ssh://git@github.com/dust-tt/typescript-sdk.git#628ebe48388549faae7e35504611af9ac2c6f5e4",
-      "integrity": "sha512-+B3C9NuEh3TqkbwOECcDmZUfLEnoLGpl5y78GcuVZ3kf9ygCNP3W+AVoT13geezuFjIJKuSjtt6b4hg1xgTFqw==",
+      "version": "1.20.1",
+      "resolved": "git+ssh://git@github.com/dust-tt/typescript-sdk.git#4a3d6b942e3982c818acd529de9b574c92776a2e",
+      "integrity": "sha512-VH2xjzEUtvyjE16Oni07beE1InChx5EZOAgSO3USqUroVs0LVvm9FMl/To4doW4ZF3a58EEg/tXxiMtCRkU5aQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/front/package.json
+++ b/front/package.json
@@ -39,7 +39,7 @@
     "@mendable/firecrawl-js": "^1.29.1",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@mistralai/mistralai": "^1.10.0",
-    "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#628ebe48388549faae7e35504611af9ac2c6f5e4",
+    "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#4a3d6b942e3982c818acd529de9b574c92776a2e",
     "@notionhq/client": "^2.3.0",
     "@octokit/core": "^6.1.5",
     "@radix-ui/react-dialog": "^1.0.5",


### PR DESCRIPTION
## Description

Front now installs a new version of the forked @modelcontextprotocol/sdk
Needed to install last version of @google/genai needed in the context of LLM Router initiative

## Tests

Tested locally with Prisma MCP (OAuth)

## Risk

Low

## Deploy Plan

Front
