### PR TITLE
Fix personal auth required flow

### DIFF
--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -1,6 +1,7 @@
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import { markAgentMessageAsFailed } from "@app/temporal/agent_loop/activities/common";
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { assertNever } from "@app/types";
 
@@ -59,6 +60,8 @@ export async function publishDeferredEventsActivity(
           },
           isLastBlockingEventForStep: isLastEvent,
         };
+
+        await markAgentMessageAsFailed(agentMessageRow, eventToPublish.error);
         break;
 
       case "tool_approve_execution":

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -170,7 +170,7 @@ export async function runToolActivity(
 
       case "tool_personal_auth_required":
       case "tool_approve_execution":
-        // Note from seb to pr: is it still possible to reach that place now that we block on approval https://github.com/dust-tt/dust/blob/15fac5beeb615f37c90bc81871699ee0b6466721/front/temporal/agent_loop/workflows.ts#L277 ?
+        // Update and publish deferred events for these types.
         // Defer personal auth events to be sent after all tools complete.
         deferredEvents.push({
           event,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Currently if a personal tool requires an authentication, we broadcast a tool error with the proper error code. However, this remains ephemeral as the agent message status isn't updated. In today's code the message content alert is displayed based on those conditions:
https://github.com/dust-tt/dust/blob/053a0938827a590ec7dd46db75e5c9645dbe0894/front/components/assistant/conversation/AgentMessage.tsx#L636-L639

This PR ensures that the agent message row gets updated if the agent message failed because of personal auth error.

<img width="1072" height="508" alt="image" src="https://github.com/user-attachments/assets/b3bd83d5-bee7-4a74-81fb-fdda850250f0" />
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
I'll spend a day adding some tests around this part as it have been getting a lot of changes recently, pretty hard to ensure we never introduce any regression!

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
