### PR TITLE
Improve conversation resource permission

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -137,7 +137,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     // Create space-to-groups mapping once for efficient permission checks.
     const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
 
-    const accessibleConversations = validConversations.filter((c) =>
+    const newSpaceBasedAccessible = validConversations.filter((c) =>
       auth.canRead(
         createResourcePermissionsFromSpacesWithMap(
           spaceIdToGroupsMap,
@@ -147,11 +147,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       )
     );
 
-    if (accessibleConversations.length !== validConversations.length) {
+    if (newSpaceBasedAccessible.length !== validConversations.length) {
       // If the feature flag is enabled, only return the accessible conversations.
       // TODO(2025-10-23 REQUESTED_SPACE_IDS): Remove this FF check.
       if (hasRequestedSpaceIdsFF) {
-        return accessibleConversations;
+        return newSpaceBasedAccessible;
       }
 
       // Compare new space-based permissions with legacy group-based permissions.
@@ -160,14 +160,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       );
 
       if (
-        accessibleConversations.length !== legacyGroupBasedAccessible.length
+        newSpaceBasedAccessible.length !== legacyGroupBasedAccessible.length
       ) {
         // Otherwise, log a warning showing the difference between new and legacy permissions.
         logger.warn(
           {
             workspaceId: workspace.sId,
             validConversations: validConversations.map((c) => c.sId),
-            newSpaceBasedAccessible: accessibleConversations.map((c) => c.sId),
+            newSpaceBasedAccessible: newSpaceBasedAccessible.map((c) => c.sId),
             legacyGroupBasedAccessible: legacyGroupBasedAccessible.map(
               (c) => c.sId
             ),

--- a/front/lib/resources/permission_utils.ts
+++ b/front/lib/resources/permission_utils.ts
@@ -54,7 +54,10 @@ export function createResourcePermissionsFromSpacesWithMap(
 
   for (const spaceId of requestedSpaceIds) {
     const groupIds = spaceIdToGroupsMap.get(spaceId);
+
+    // This should never happen since conversations are pre-filtered to only include valid spaces.
     assert(groupIds, `No group IDs found for space ID ${spaceId}`);
+
     resolvedGroupIds.push(groupIds);
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/17246.

The previously shipped PR surfaced a bunch of errors and logs. Most of them coming from conversations being accessed whereas one of the underlying space has been deleted. FWIW those conversations were already not accessible today as they were getting evicted by the `canAccessConversation` , this is now done earlier. This PR updates the logic to account for it. It's pretty verbose but will get way simpler once remove the previous group ids code path.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Added some tests.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
