### PR TITLE
[front] Show agent spaces in poke

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -329,17 +329,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     sId: string,
     { includeDeleted }: { includeDeleted?: boolean } = {}
   ): Promise<SpaceResource | null> {
-    const spaceModelId = getResourceIdFromSId(sId);
-    if (!spaceModelId) {
-      return null;
-    }
-
-    const [space] = await this.baseFetch(auth, {
-      where: { id: spaceModelId },
-      includeDeleted,
-    });
-
-    return space;
+    const [space] = await this.fetchByIds(auth, [sId], { includeDeleted });
+    return space ?? null;
   }
 
   static async fetchByIds(

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -32,7 +32,7 @@ import type {
   SpaceKind,
   SpaceType,
 } from "@app/types";
-import { Err, GLOBAL_SPACE_NAME, Ok } from "@app/types";
+import { Err, GLOBAL_SPACE_NAME, Ok, removeNulls } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -340,6 +340,19 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
 
     return space;
+  }
+
+  static async fetchByIds(
+    auth: Authenticator,
+    ids: string[],
+    { includeDeleted }: { includeDeleted?: boolean } = {}
+  ): Promise<SpaceResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        id: removeNulls(ids.map(getResourceIdFromSId)),
+      },
+      includeDeleted,
+    });
   }
 
   static async fetchByModelIds(auth: Authenticator, ids: ModelId[]) {

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -22,7 +22,6 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration/agent";
 import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { decodeSqids } from "@app/lib/utils";
 import type {
@@ -55,16 +54,10 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   const lastVersionEditors = await getEditors(auth, agentConfigurations[0]);
   const [latestAgentConfiguration] = agentConfigurations;
 
-  // TODO(2025-10-17 thomas): Use requestedSpaceIds instead of requestedGroupIds.
-  const uniqueGroupIds = Array.from(
-    new Set(latestAgentConfiguration.requestedGroupIds.flat())
+  const spaces = await SpaceResource.fetchByIds(
+    auth,
+    latestAgentConfiguration.requestedSpaceIds
   );
-  const groupRes = await GroupResource.fetchByIds(auth, uniqueGroupIds);
-  if (groupRes.isErr()) {
-    throw new Error(`Failed to fetch groups: ${groupRes.error.message}`);
-  }
-
-  const spaces = await SpaceResource.listForGroups(auth, groupRes.value);
 
   return {
     props: {


### PR DESCRIPTION
## Description

Show the list of requested spaces - previously was showing all spaces related to requested groups, which show inconsistent spaces if the same group is attached to multiple spaces

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front