### PR TITLE
[front] fix: exclude `discord_bot` from `checkConnectorsLastSyncSuccess`

### DIFF
--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -507,6 +507,16 @@ export function isWebhookBasedProvider(provider: ConnectorProvider): boolean {
   return WEBHOOK_BASED_CONNECTORS.includes(provider);
 }
 
+const BOT_TYPE_CONNECTORS: ConnectorProvider[] = [
+  "slack_bot",
+  "microsoft_bot",
+  "discord_bot",
+];
+
+export function isBotTypeProvider(provider: ConnectorProvider): boolean {
+  return BOT_TYPE_CONNECTORS.includes(provider);
+}
+
 export const REMOTE_DATABASE_CONNECTOR_PROVIDERS: ConnectorProvider[] = [
   "snowflake",
   "bigquery",

--- a/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
+++ b/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
@@ -1,6 +1,9 @@
 import { QueryTypes } from "sequelize";
 
-import { isWebhookBasedProvider } from "@app/lib/connector_providers";
+import {
+  isBotTypeProvider,
+  isWebhookBasedProvider,
+} from "@app/lib/connector_providers";
 import type { CheckFunction } from "@app/lib/production_checks/types";
 import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/utils";
 import type { ConnectorProvider } from "@app/types";
@@ -65,12 +68,10 @@ export const checkConnectorsLastSyncSuccess: CheckFunction = async (
   const stalledLastSyncConnectors: any[] = [];
   const connectors = (await listAllConnectors()).filter(
     (connector) =>
-      // Ignore webhook-based connectors and webcrawlers
+      // Ignore webhook-based connectors, webcrawlers, and bot-type connectors
       !isWebhookBasedProvider(connector.type) &&
-      connector.type !== "webcrawler" &&
-      connector.type !== "slack_bot" &&
-      connector.type !== "microsoft_bot" &&
-      connector.type !== "discord_bot"
+      !isBotTypeProvider(connector.type) &&
+      connector.type !== "webcrawler"
   );
   heartbeat();
 

--- a/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
+++ b/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
@@ -69,7 +69,8 @@ export const checkConnectorsLastSyncSuccess: CheckFunction = async (
       !isWebhookBasedProvider(connector.type) &&
       connector.type !== "webcrawler" &&
       connector.type !== "slack_bot" &&
-      connector.type !== "microsoft_bot"
+      connector.type !== "microsoft_bot" &&
+      connector.type !== "discord_bot"
   );
   heartbeat();
 


### PR DESCRIPTION
## Description

- This PR ignores the `discord_bot` connector from the production check on connectors syncing at least every week, since this connector doesn't really sync.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
