### PR TITLE
[front] Replace `Avatar` with `Icon` in `AddToolsMenu` dropdown

### DIFF
--- a/front/components/actions/mcp/AddToolsMenu.tsx
+++ b/front/components/actions/mcp/AddToolsMenu.tsx
@@ -10,8 +10,8 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
+import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
-import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPServerType } from "@app/lib/api/mcp";
@@ -109,7 +109,7 @@ export const AddToolsMenu = ({
             <DropdownMenuItem
               key={mcpServer.sId}
               label={getMcpServerDisplayName(mcpServer)}
-              icon={() => getAvatar(mcpServer, "sm")}
+              icon={getIcon(mcpServer.icon)}
               onClick={withTracking(
                 TRACKING_AREAS.TOOLS,
                 "tool_select",

--- a/front/components/actions/mcp/AddToolsMenu.tsx
+++ b/front/components/actions/mcp/AddToolsMenu.tsx
@@ -109,6 +109,7 @@ export const AddToolsMenu = ({
             <DropdownMenuItem
               key={mcpServer.sId}
               label={getMcpServerDisplayName(mcpServer)}
+              className="m-1"
               icon={getIcon(mcpServer.icon)}
               onClick={withTracking(
                 TRACKING_AREAS.TOOLS,


### PR DESCRIPTION
## Description

- This PR changes the dropdown menu in Add tools to take icons instead of avatars out of consistency with the connections.

Before

<img width="713" height="706" alt="Screenshot 2025-10-23 at 11 16 48 PM" src="https://github.com/user-attachments/assets/48406141-1402-4647-a2b3-b8a491902ce8" />

After

<img width="713" height="706" alt="Screenshot 2025-10-23 at 11 17 18 PM" src="https://github.com/user-attachments/assets/86ea48e9-3150-49ec-9698-1895e6bfaa45" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
