### PR TITLE
Add code execution sandbox tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -71,6 +71,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "agent_management",
   AGENT_MEMORY_SERVER_NAME,
   "agent_router",
+  "sandbox",
   "confluence",
   "conversation_files",
   "data_sources_file_system",
@@ -1150,6 +1151,29 @@ The directive should be used to display a clickable version of the agent name in
       description: "Create music tracks and sound effects",
       authorization: null,
       icon: "ActionMegaphoneIcon",
+      documentationUrl: null,
+      instructions: null,
+    },
+  },
+  sandbox: {
+    id: 39,
+    availability: "manual",
+    allowMultipleInstances: false,
+    isPreview: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("sandbox_tool");
+    },
+    tools_stakes: {
+      execute_code: "low",
+    },
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "sandbox",
+      version: "1.0.0",
+      description: "Execute code snippets in a sandboxed environment.",
+      authorization: null,
+      icon: "CommandLineIcon",
       documentationUrl: null,
       instructions: null,
     },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -41,6 +41,7 @@ import { default as reasoningServer } from "@app/lib/actions/mcp_internal_action
 import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/run_agent";
 import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
+import { default as sandboxServer } from "@app/lib/actions/mcp_internal_actions/servers/sandbox";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
 import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack";
 import { default as slackBotServer } from "@app/lib/actions/mcp_internal_actions/servers/slack_bot";
@@ -190,6 +191,8 @@ export async function getInternalMCPServer(
       return valtownServer(auth, agentLoopContext);
     case "deep_dive":
       return deepDiveServer(auth, agentLoopContext);
+    case "sandbox":
+      return sandboxServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/sandbox.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/sandbox.ts
@@ -1,0 +1,119 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { DaytonaSandboxProvider } from "@app/lib/actions/mcp_internal_actions/servers/sandbox/daytona_provider";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { Err, normalizeError, Ok } from "@app/types";
+
+const INSTRUCTIONS = `
+## Sandbox Tool
+
+You have access to a sandboxed environment that allows you to execute code snippets and return the output.
+Each conversation gets its own persistent sandbox.
+
+If another tool already exists to perform a task, use it instead of the sandbox. This is your decision framework for using this tool:
+    1. Does this require computation I cannot reliably do mentally?
+    2. Would showing code + output be more trustworthy than just stating an answer?
+    3. Is the data complex enough to benefit from Pandas/NumPy? (multiple columns, transformations, aggregations)
+
+    If the answer is yes to any of these questions, use the sandbox.
+
+- When to use the sandbox:
+    - Mathematical calculations and simulations
+    - Data analysis or transformations with Pandas, NumPy
+    - Algorithms
+    - Formula evaluation
+
+- Do NOT use the sandbox for:
+    - API calls
+    - Simple calculations and simulations
+    - Questions answerable from search or your knowledge
+    - Interactive visualizations and charts
+
+The sandbox has no public internet access.
+
+The sandbox includes common packages, including but not limited to: beautifulsoup4, numpy, llama-index, opencv-python, pandas, scikit-learn, scipy
+
+The output of the execution is the standard output of the code. It will be helpful to print or log the output in the code snippet so it can be returned to the user.
+`;
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("sandbox", {
+    augmentedInstructions: INSTRUCTIONS,
+  });
+
+  server.tool(
+    "execute_code",
+    "Execute code in a sandboxed environment. Use this to run code snippets and return the output.",
+    {
+      language: z
+        .enum(["python", "javascript", "typescript"])
+        .describe("The programming language of the code to execute"),
+      code: z.string().describe("The code to execute"),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: "execute_code",
+        agentLoopContext,
+        enableAlerting: true,
+      },
+      async ({ language, code }) => {
+        const daytonaAPIKey = config.getDaytonaAPIKey();
+
+        if (!agentLoopContext?.runContext) {
+          return new Err(
+            new MCPError("No conversation context available", {
+              tracked: false,
+            })
+          );
+        }
+        const { conversation } = agentLoopContext.runContext;
+
+        const provider = new DaytonaSandboxProvider(daytonaAPIKey);
+        const sandboxName = `${conversation.sId}-${language}`;
+
+        try {
+          // Sandbox lifecycle management is not expected to be handle inside the MCP tool.
+          const sandbox = await provider.getOrCreateSandbox(
+            sandboxName,
+            language
+          );
+          const result = await sandbox.executeCode(code);
+
+          const outputText = result.error
+            ? `Exit code: ${result.exitCode}\n\nError:\n${result.error}\n\nOutput:\n${result.result}`
+            : `Exit code: ${result.exitCode}\n\nOutput:\n${result.result}`;
+
+          return new Ok([
+            {
+              type: "text" as const,
+              text: outputText,
+            },
+          ]);
+        } catch (error) {
+          return new Err(
+            new MCPError(
+              `Failed to execute code: ${normalizeError(error).message}`,
+              {
+                tracked: true,
+              }
+            )
+          );
+        }
+      }
+    )
+  );
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/sandbox/daytona_provider.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/sandbox/daytona_provider.ts
@@ -1,0 +1,56 @@
+import { Daytona } from "@daytonaio/sdk";
+import { DaytonaNotFoundError } from "@daytonaio/sdk/src/errors/DaytonaError";
+
+import type {
+  CodeExecutionResult,
+  SandboxInstance,
+  SandboxLanguage,
+  SandboxProvider,
+} from "./types";
+
+export class DaytonaSandboxProvider implements SandboxProvider {
+  private client: Daytona;
+
+  constructor(apiKey: string) {
+    this.client = new Daytona({
+      apiKey,
+    });
+  }
+
+  async getOrCreateSandbox(
+    name: string,
+    language: SandboxLanguage
+  ): Promise<SandboxInstance> {
+    let sandbox;
+    try {
+      sandbox = await this.client.get(name);
+    } catch (error) {
+      if (error instanceof DaytonaNotFoundError) {
+        sandbox = await this.client.create({
+          language,
+          networkBlockAll: true,
+          name,
+          autoDeleteInterval: 60 * 60 * 24 * 30, // 30 days
+        });
+      } else {
+        throw error;
+      }
+    }
+
+    return new DaytonaSandboxInstance(sandbox);
+  }
+}
+
+class DaytonaSandboxInstance implements SandboxInstance {
+  constructor(private sandbox: any) {}
+
+  async executeCode(code: string): Promise<CodeExecutionResult> {
+    const response = await this.sandbox.process.codeRun(code);
+
+    return {
+      exitCode: response.exitCode,
+      result: response.result || "",
+      error: response.error,
+    };
+  }
+}

--- a/front/lib/actions/mcp_internal_actions/servers/sandbox/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/sandbox/types.ts
@@ -1,0 +1,24 @@
+export type SandboxLanguage = "python" | "javascript" | "typescript";
+
+export interface CodeExecutionResult {
+  exitCode: number;
+  result: string;
+  error?: string;
+}
+
+export interface SandboxProvider {
+  /**
+   * Get or create a sandbox with the given name and language
+   */
+  getOrCreateSandbox(
+    name: string,
+    language: SandboxLanguage
+  ): Promise<SandboxInstance>;
+}
+
+export interface SandboxInstance {
+  /**
+   * Execute code in the sandbox
+   */
+  executeCode(code: string): Promise<CodeExecutionResult>;
+}

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -294,6 +294,9 @@ const config = {
       password: EnvironmentConfig.getEnvVariable("ELASTICSEARCH_PASSWORD"),
     };
   },
+  getDaytonaAPIKey: (): string => {
+    return EnvironmentConfig.getEnvVariable("DAYTONA_API_KEY");
+  },
 };
 
 export default config;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
+        "@daytonaio/sdk": "^0.111.1",
         "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.3.17",
         "@elastic/elasticsearch": "^8.15.0",
@@ -531,6 +532,880 @@
       "dev": true,
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.914.0.tgz",
+      "integrity": "sha512-ZW0ALyys+pTpPvDyKp1InkfUGqttezH9c4TNxwuRKE1M78fwFf/Fnwrdmxzgc9SXReyANB4zpLHtbrTk4mj4Rg==",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/credential-provider-node": "3.914.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.914.0",
+        "@aws-sdk/middleware-expect-continue": "3.914.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.914.0",
+        "@aws-sdk/middleware-host-header": "3.914.0",
+        "@aws-sdk/middleware-location-constraint": "3.914.0",
+        "@aws-sdk/middleware-logger": "3.914.0",
+        "@aws-sdk/middleware-recursion-detection": "3.914.0",
+        "@aws-sdk/middleware-sdk-s3": "3.914.0",
+        "@aws-sdk/middleware-ssec": "3.914.0",
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/region-config-resolver": "3.914.0",
+        "@aws-sdk/signature-v4-multi-region": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@aws-sdk/util-user-agent-browser": "3.914.0",
+        "@aws-sdk/util-user-agent-node": "3.914.0",
+        "@aws-sdk/xml-builder": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/eventstream-serde-browser": "^4.2.3",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.3",
+        "@smithy/eventstream-serde-node": "^4.2.3",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/hash-blob-browser": "^4.2.4",
+        "@smithy/hash-node": "^4.2.3",
+        "@smithy/hash-stream-node": "^4.2.3",
+        "@smithy/invalid-dependency": "^4.2.3",
+        "@smithy/md5-js": "^4.2.3",
+        "@smithy/middleware-content-length": "^4.2.3",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-retry": "^4.4.4",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.3",
+        "@smithy/util-defaults-mode-node": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/util-stream": "^4.5.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.3",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.914.0.tgz",
+      "integrity": "sha512-83Xp8Wl7RDWg/iIYL8dmrN9DN7qu7fcUzDC9LyMhDN8cAEACykN/i4Fk45UHRCejL9Sjxu4wsQzxRYp1smQ95g==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/middleware-host-header": "3.914.0",
+        "@aws-sdk/middleware-logger": "3.914.0",
+        "@aws-sdk/middleware-recursion-detection": "3.914.0",
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/region-config-resolver": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@aws-sdk/util-user-agent-browser": "3.914.0",
+        "@aws-sdk/util-user-agent-node": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/hash-node": "^4.2.3",
+        "@smithy/invalid-dependency": "^4.2.3",
+        "@smithy/middleware-content-length": "^4.2.3",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-retry": "^4.4.4",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.3",
+        "@smithy/util-defaults-mode-node": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.914.0.tgz",
+      "integrity": "sha512-QMnWdW7PwxVfi5WBV2a6apM1fIizgBf1UHYbqd3e1sXk8B0d3tpysmLZdIx30OY066zhEo6FyAKLAeTSsGrALg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/xml-builder": "3.914.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/signature-v4": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.914.0.tgz",
+      "integrity": "sha512-v7zeMsLkTB0/ZK6DGbM6QUNIeeEtNBd+4DHihXjsHKBKxBESKIJlWF5Bcj+pgCSWcFGClxmqL6NfWCFQ0WdtjQ==",
+      "dependencies": {
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.914.0.tgz",
+      "integrity": "sha512-NXS5nBD0Tbk5ltjOAucdcx8EQQcFdVpCGrly56AIbznl0yhuG5Sxq4q2tUSJj9006eEXBK5rt52CdDixCcv3xg==",
+      "dependencies": {
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-stream": "^4.5.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.914.0.tgz",
+      "integrity": "sha512-RcL02V3EE8DRuu8qb5zoV+aVWbUIKZRA3NeHsWKWCD25nxQUYF4CrbQizWQ91vda5+e6PysGGLYROOzapX3Xmw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/credential-provider-env": "3.914.0",
+        "@aws-sdk/credential-provider-http": "3.914.0",
+        "@aws-sdk/credential-provider-process": "3.914.0",
+        "@aws-sdk/credential-provider-sso": "3.914.0",
+        "@aws-sdk/credential-provider-web-identity": "3.914.0",
+        "@aws-sdk/nested-clients": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/credential-provider-imds": "^4.2.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.914.0.tgz",
+      "integrity": "sha512-SDUvDKqsJ5UPDkem0rq7/bdZtXKKTnoBeWvRlI20Zuv4CLdYkyIGXU9sSA2mrhsZ/7bt1cduTHpGd1n/UdBQEg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.914.0",
+        "@aws-sdk/credential-provider-http": "3.914.0",
+        "@aws-sdk/credential-provider-ini": "3.914.0",
+        "@aws-sdk/credential-provider-process": "3.914.0",
+        "@aws-sdk/credential-provider-sso": "3.914.0",
+        "@aws-sdk/credential-provider-web-identity": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/credential-provider-imds": "^4.2.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.914.0.tgz",
+      "integrity": "sha512-34C3CYM3iAVcSg3cX4UfOwabWeTeowjZkqJbWgDZ+I/HNZ8+9YbVuJcOZL5fVhw242UclxlVlddNPNprluZKGg==",
+      "dependencies": {
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.914.0.tgz",
+      "integrity": "sha512-LfuSyhwvb1qOWN+oN3zyq5D899RZVA0nUrx6czKpDJYarYG0FCTZPO5aPcyoNGAjUu8l+CYUvXcd9ZdZiwv3/A==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.914.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/token-providers": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.914.0.tgz",
+      "integrity": "sha512-49zJm5x48eG4kiu7/lUGYicwpOPA3lzkuxZ8tdegKKB9Imya6yxdATx4V5UcapFfX79xgpZr750zYHHqSX53Sw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/nested-clients": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.914.0.tgz",
+      "integrity": "sha512-woPS2ut/64pTB/IIZC5eH5hLDZ41++6cVUBXvlu0x0QwjJBE2axRoq1o/ZNFfrYAOSQXB+0X2QrEhPfF9bYOVw==",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.3",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/smithy-client": "^4.9.0",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.914.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.914.0.tgz",
+      "integrity": "sha512-mHLsVnPPp4iq3gL2oEBamfpeETFV0qzxRHmcnCfEP3hualV8YF8jbXGmwPCPopUPQDpbYDBHYtXaoClZikCWPQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.914.0.tgz",
+      "integrity": "sha512-whZZIb5y+WpPzP3xOxDRwk+EVEnYB5PIXmbvT8FQmhFc4ljM+oUGcbpEOGQICvwBt74N5RYQwsIUdeR2wEOHlA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.914.0.tgz",
+      "integrity": "sha512-e9xuIftfciowzrIJmI3bXCtsVdB6P9YqHsq7zO+dkcBR4jkjmUWlQAylSBlM16cnC5EsbOK1KsU3RKELFA8TyQ==",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-stream": "^4.5.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.914.0.tgz",
+      "integrity": "sha512-7r9ToySQ15+iIgXMF/h616PcQStByylVkCshmQqcdeynD/lCn2l667ynckxW4+ql0Q+Bo/URljuhJRxVJzydNA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.914.0.tgz",
+      "integrity": "sha512-Mpd0Sm9+GN7TBqGnZg1+dO5QZ/EOYEcDTo7KfvoyrXScMlxvYm9fdrUVMmLdPn/lntweZGV3uNrs+huasGOOTA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.914.0.tgz",
+      "integrity": "sha512-/gaW2VENS5vKvJbcE1umV4Ag3NuiVzpsANxtrqISxT3ovyro29o1RezW/Avz/6oJqjnmgz8soe9J1t65jJdiNg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.914.0.tgz",
+      "integrity": "sha512-yiAjQKs5S2JKYc+GrkvGMwkUvhepXDigEXpSJqUseR/IrqHhvGNuOxDxq+8LbDhM4ajEW81wkiBbU+Jl9G82yQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.914.0.tgz",
+      "integrity": "sha512-jcbOc0FxW6p4KRJE/7LFA05cRAeLK4eZK4k4ZaWZOqbkH48WihKaDlxYsppbWa2WnIvVcjPye4kSTncBEFZrPg==",
+      "dependencies": {
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/signature-v4": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-stream": "^4.5.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.914.0.tgz",
+      "integrity": "sha512-V1Oae/oLVbpNb9uWs+v80GKylZCdsbqs2c2Xb1FsAUPtYeSnxFuAWsF3/2AEMSSpFe0dTC5KyWr/eKl2aim9VQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.914.0.tgz",
+      "integrity": "sha512-+grKWKg+htCpkileNOqm7LO9OrE9nVPv49CYbF7dXefQIdIhfQ0pvm+hdSUnh8GFLx86FKoJs2DZSBCYqgjQFw==",
+      "dependencies": {
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.914.0.tgz",
+      "integrity": "sha512-cktvDU5qsvtv9HqJ0uoPgqQ87pttRMZe33fdZ3NQmnkaT6O6AI7x9wQNW5bDH3E6rou/jYle9CBSea1Xum69rQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/middleware-host-header": "3.914.0",
+        "@aws-sdk/middleware-logger": "3.914.0",
+        "@aws-sdk/middleware-recursion-detection": "3.914.0",
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/region-config-resolver": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@aws-sdk/util-endpoints": "3.914.0",
+        "@aws-sdk/util-user-agent-browser": "3.914.0",
+        "@aws-sdk/util-user-agent-node": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/core": "^3.17.0",
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/hash-node": "^4.2.3",
+        "@smithy/invalid-dependency": "^4.2.3",
+        "@smithy/middleware-content-length": "^4.2.3",
+        "@smithy/middleware-endpoint": "^4.3.4",
+        "@smithy/middleware-retry": "^4.4.4",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/node-http-handler": "^4.4.2",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/smithy-client": "^4.9.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.3",
+        "@smithy/util-defaults-mode-node": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.914.0.tgz",
+      "integrity": "sha512-KlmHhRbn1qdwXUdsdrJ7S/MAkkC1jLpQ11n+XvxUUUCGAJd1gjC7AjxPZUM7ieQ2zcb8bfEzIU7al+Q3ZT0u7Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.914.0.tgz",
+      "integrity": "sha512-EOQ/ObGwaRXfK54GnxVRdHFiUvCZ4IJYAHMoQWfF9ZrV/4g0B4eBgJAal+DRO5g1sye32EtaGwFiQ6sULJb/Pw==",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/signature-v4": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.914.0.tgz",
+      "integrity": "sha512-wX8lL5OnCk/54eUPP1L/dCH+Gp/f3MjnHR6rNp+dbGs7+omUAub4dEbM/JMBE4Jsn5coiVgmgqx97Q5cRxh/EA==",
+      "dependencies": {
+        "@aws-sdk/core": "3.914.0",
+        "@aws-sdk/nested-clients": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.914.0.tgz",
+      "integrity": "sha512-kQWPsRDmom4yvAfyG6L1lMmlwnTzm1XwMHOU+G5IFlsP4YEaMtXidDzW/wiivY0QFrhfCz/4TVmu0a2aPU57ug==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.914.0.tgz",
+      "integrity": "sha512-POUBUTjD7WQ/BVoUGluukCIkIDO12IPdwRAvUgFshfbaUdyXFuBllM/6DmdyeR3rJhXnBqe3Uy5e2eXbz/MBTw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-endpoints": "^3.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
+      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.914.0.tgz",
+      "integrity": "sha512-rMQUrM1ECH4kmIwlGl9UB0BtbHy6ZuKdWFrIknu8yGTRI/saAucqNTh5EI1vWBxZ0ElhK5+g7zOnUuhSmVQYUA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/types": "^4.8.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.914.0.tgz",
+      "integrity": "sha512-gTkLFUZiNPgJmeFCX8VJRmQWXKfF3Imm5IquFIR5c0sCBfhtMjTXZF0dHDW5BlceZ4tFPwfF9sCqWJ52wbFSBg==",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.914.0",
+        "@aws-sdk/types": "3.914.0",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.914.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.914.0.tgz",
+      "integrity": "sha512-k75evsBD5TcIjedycYS7QXQ98AmOtbnxRJOPtCo0IwYRmy7UvqgS/gBL5SmrIqeV6FDSYRQMgdBxSMp6MLmdew==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+      "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1134,6 +2009,35 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@daytonaio/api-client": {
+      "version": "0.111.1",
+      "resolved": "https://registry.npmjs.org/@daytonaio/api-client/-/api-client-0.111.1.tgz",
+      "integrity": "sha512-8DBvsLjOetuNX2xllIbN1IqXf9dyvGn3a3ts24kpF9JJyu7sjaiBEQdsBKFs6zLitH60YrzXEAUSBIyKuhLMYA==",
+      "dependencies": {
+        "axios": "^1.6.1"
+      }
+    },
+    "node_modules/@daytonaio/sdk": {
+      "version": "0.111.1",
+      "resolved": "https://registry.npmjs.org/@daytonaio/sdk/-/sdk-0.111.1.tgz",
+      "integrity": "sha512-BHoGnYUVwTBO/YqF/FJ3YUqClihVu/mioY90byb6pM8NdN6IwLWKkhEiRUHHGZ/hGm8tX35I2Okj6EzYAMfkSA==",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.787.0",
+        "@aws-sdk/lib-storage": "^3.798.0",
+        "@daytonaio/api-client": "0.111.1",
+        "@iarna/toml": "^2.2.5",
+        "axios": "^1.11.0",
+        "busboy": "^1.0.0",
+        "dotenv": "^17.0.1",
+        "expand-tilde": "^2.0.2",
+        "fast-glob": "^3.3.0",
+        "form-data": "^4.0.4",
+        "isomorphic-ws": "^5.0.0",
+        "pathe": "^2.0.3",
+        "shell-quote": "^1.8.2",
+        "tar": "^6.2.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2530,6 +3434,11 @@
       "version": "2.0.3",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
@@ -8615,6 +9524,687 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
+      "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.0.tgz",
+      "integrity": "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.1.tgz",
+      "integrity": "sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.0.tgz",
+      "integrity": "sha512-Kkmz3Mup2PGp/HNJxhCWkLNdlajJORLSjwkcfrj0E7nu6STAEdcMR1ir5P9/xOmncx8xXfru0fbUYLlZog/cFg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.1.tgz",
+      "integrity": "sha512-V4Qc2CIb5McABYfaGiIYLTmo/vwNIK7WXI5aGveBd9UcdhbOMwcvIMxIw/DJj1S9QgOMa/7FBkarMdIC0EOTEQ==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-stream": "^4.5.4",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.3.tgz",
+      "integrity": "sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.3.tgz",
+      "integrity": "sha512-rcr0VH0uNoMrtgKuY7sMfyKqbHc4GQaQ6Yp4vwgm+Z6psPuOgL+i/Eo/QWdXRmMinL3EgFM0Z1vkfyPyfzLmjw==",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.3.tgz",
+      "integrity": "sha512-EcS0kydOr2qJ3vV45y7nWnTlrPmVIMbUFOZbMG80+e2+xePQISX9DrcbRpVRFTS5Nqz3FiEbDcTCAV0or7bqdw==",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.3.tgz",
+      "integrity": "sha512-GewKGZ6lIJ9APjHFqR2cUW+Efp98xLu1KmN0jOWxQ1TN/gx3HTUPVbLciFD8CfScBj2IiKifqh9vYFRRXrYqXA==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.3.tgz",
+      "integrity": "sha512-uQobOTQq2FapuSOlmGLUeGTpvcBLE5Fc7XjERUSk4dxEi4AhTwuyHYZNAvL4EMUp7lzxxkKDFaJ1GY0ovrj0Kg==",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.3.tgz",
+      "integrity": "sha512-QIvH/CKOk1BZPz/iwfgbh1SQD5Y0lpaw2kLA8zpLRRtYMPXeYUEWh+moTaJyqDaKlbrB174kB7FSRFiZ735tWw==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
+      "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.4.tgz",
+      "integrity": "sha512-W7eIxD+rTNsLB/2ynjmbdeP7TgxRXprfvqQxKFEfy9HW2HeD7t+g+KCIrY0pIn/GFjA6/fIpH+JQnfg5TTk76Q==",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.0",
+        "@smithy/chunked-blob-reader-native": "^4.2.1",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.3.tgz",
+      "integrity": "sha512-6+NOdZDbfuU6s1ISp3UOk5Rg953RJ2aBLNLLBEcamLjHAg1Po9Ha7QIB5ZWhdRUVuOUrT8BVFR+O2KIPmw027g==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.3.tgz",
+      "integrity": "sha512-EXMSa2yiStVII3x/+BIynyOAZlS7dGvI7RFrzXa/XssBgck/7TXJIvnjnCu328GY/VwHDC4VeDyP1S4rqwpYag==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.3.tgz",
+      "integrity": "sha512-Cc9W5DwDuebXEDMpOpl4iERo8I0KFjTnomK2RMdhhR87GwrSmUmwMxS4P5JdRf+LsjOdIqumcerwRgYMr/tZ9Q==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.3.tgz",
+      "integrity": "sha512-5+4bUEJQi/NRgzdA5SVXvAwyvEnD0ZAiKzV3yLO6dN5BG8ScKBweZ8mxXXUtdxq+Dx5k6EshKk0XJ7vgvIPSnA==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.3.tgz",
+      "integrity": "sha512-/atXLsT88GwKtfp5Jr0Ks1CSa4+lB+IgRnkNrrYP0h1wL4swHNb0YONEvTceNKNdZGJsye+W2HH8W7olbcPUeA==",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.5.tgz",
+      "integrity": "sha512-SIzKVTvEudFWJbxAaq7f2GvP3jh2FHDpIFI6/VAf4FOWGFZy0vnYMPSRj8PGYI8Hjt29mvmwSRgKuO3bK4ixDw==",
+      "dependencies": {
+        "@smithy/core": "^3.17.1",
+        "@smithy/middleware-serde": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/url-parser": "^4.2.3",
+        "@smithy/util-middleware": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.5.tgz",
+      "integrity": "sha512-DCaXbQqcZ4tONMvvdz+zccDE21sLcbwWoNqzPLFlZaxt1lDtOE2tlVpRSwcTOJrjJSUThdgEYn7HrX5oLGlK9A==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/service-error-classification": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.1",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-retry": "^4.2.3",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
+      "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
+      "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
+      "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/shared-ini-file-loader": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.3.tgz",
+      "integrity": "sha512-MAwltrDB0lZB/H6/2M5PIsISSwdI5yIh6DaBB9r0Flo9nx3y0dzl/qTMJPd7tJvPdsx6Ks/cwVzheGNYzXyNbQ==",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/querystring-builder": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
+      "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
+      "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
+      "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
+      "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.3.tgz",
+      "integrity": "sha512-NkxsAxFWwsPsQiwFG2MzJ/T7uIR6AQNh1SzcxSUnmmIqIQMlLRQDKhc17M7IYjiuBXhrQRjQTo3CxX+DobS93g==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
+      "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
+      "integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.1.tgz",
+      "integrity": "sha512-Ngb95ryR5A9xqvQFT5mAmYkCwbXvoLavLFwmi7zVg/IowFPCfiqRfkOKnbc/ZRL8ZKJ4f+Tp6kSu6wjDQb8L/g==",
+      "dependencies": {
+        "@smithy/core": "^3.17.1",
+        "@smithy/middleware-endpoint": "^4.3.5",
+        "@smithy/middleware-stack": "^4.2.3",
+        "@smithy/protocol-http": "^5.3.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-stream": "^4.5.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
+      "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.4.tgz",
+      "integrity": "sha512-qI5PJSW52rnutos8Bln8nwQZRpyoSRN6k2ajyoUHNMUzmWqHnOJCnDELJuV6m5PML0VkHI+XcXzdB+6awiqYUw==",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.1",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.6.tgz",
+      "integrity": "sha512-c6M/ceBTm31YdcFpgfgQAJaw3KbaLuRKnAz91iMWFLSrgxRpYm03c3bu5cpYojNMfkV9arCUelelKA7XQT36SQ==",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.0",
+        "@smithy/credential-provider-imds": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/property-provider": "^4.2.3",
+        "@smithy/smithy-client": "^4.9.1",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
+      "integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
+      "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
+      "dependencies": {
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.3.tgz",
+      "integrity": "sha512-lLPWnakjC0q9z+OtiXk+9RPQiYPNAovt2IXD3CP4LkOnd9NpUsxOjMx1SnoUVB7Orb7fZp67cQMtTBKMFDvOGg==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.4.tgz",
+      "integrity": "sha512-+qDxSkiErejw1BAIXUFBSfM5xh3arbz1MmxlbMCKanDDZtVEQ7PSKW9FQS0Vud1eI/kYn0oCTVKyNzRlq+9MUw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.4",
+        "@smithy/node-http-handler": "^4.4.3",
+        "@smithy/types": "^4.8.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.3.tgz",
+      "integrity": "sha512-5+nU///E5sAdD7t3hs4uwvCTWQtTR8JwKwOCSJtBRx0bY1isDo1QwH87vRK86vlFLBTISqoDA2V6xvP6nF1isQ==",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.3",
+        "@smithy/types": "^4.8.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -12210,6 +13800,11 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
+    "node_modules/bowser": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -14590,6 +16185,17 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dottie": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.6.tgz",
@@ -16155,6 +17761,17 @@
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -18621,6 +20238,17 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/hot-shots": {
       "version": "10.0.0",
       "license": "MIT",
@@ -19606,6 +21234,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -23691,6 +25327,14 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
       "license": "ISC"
     },
+    "node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
@@ -26858,8 +28502,12 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "license": "MIT",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -27831,6 +29479,15 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
       "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
       "dev": true
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -30724,7 +32381,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-      "devOptional": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/front/package.json
+++ b/front/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
+    "@daytonaio/sdk": "^0.111.1",
     "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.3.17",
     "@elastic/elasticsearch": "^8.15.0",
@@ -115,6 +116,7 @@
     "luxon": "^3.4.4",
     "marked": "^14.1.3",
     "marklassian": "^1.0.4",
+    "mathjs": "^15.0.0",
     "minimist": "^1.2.8",
     "moment-timezone": "^0.5.43",
     "motion": "^12.7.3",
@@ -164,8 +166,7 @@
     "yargs": "^17.7.2",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.24.5",
-    "zod-validation-error": "^3.4.0",
-    "mathjs": "^15.0.0"
+    "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.3.0",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -28,6 +28,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Collaborative editing features",
     stage: "dust_only",
   },
+  sandbox_tool: {
+    description: "Sandbox MCP tool for running code in sandboxed environments",
+    stage: "dust_only",
+  },
   confluence_tool: {
     description: "Confluence MCP tool",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -698,6 +698,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "legacy_dust_apps"
   | "dust_default_haiku_feature"
   | "llm_router_direct_requests"
+  | "sandbox_tool"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

* Adding sandbox tool that executes agent-generated code. Currently using daytona.io as sandbox. A new sandbox will be created/retained for each conversation. Daytona.io references intentionally abstracted in order to be able to swap in other sandbox providers.
* This is a starting point for internal only testing. It just scratches the surface of the sandbox capabilities we can add, but starting simple.
* Sandbox will by default stop after 15 minutes, archive after 7 days, delete after 30 days.
* Network calls blocked for now

## Tests

<img width="552" height="621" alt="Screenshot 2025-10-23 at 5 15 44 PM" src="https://github.com/user-attachments/assets/d00a1e85-2d3e-4e02-adcb-822920bc1246" />

## Risk

* Internal only

## Deploy Plan

1. Add env variable
2. Deploy front