### PR TITLE
Fix and add more info in to panic log revoke membership

### DIFF
--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -73,7 +73,12 @@ async function handler(
           switch (revokeResult.error.type) {
             case "not_found":
               logger.error(
-                { panic: true, revokeResult },
+                {
+                  panic: true,
+                  revokeResult,
+                  userId: user.sId,
+                  workspaceId: owner.sId,
+                },
                 "Failed to revoke membership and track usage."
               );
               return apiError(req, res, {
@@ -85,10 +90,6 @@ async function handler(
               });
             case "already_revoked":
             case "invalid_end_at":
-              logger.error(
-                { panic: true, revokeResult },
-                "Failed to revoke membership and track usage."
-              );
               break;
             default:
               assertNever(revokeResult.error.type);


### PR DESCRIPTION
## Description

- Adds the user and workspace ids to the panic log. 
- Do not panic if the member was already revoked or who was not revoked because of invalid end date. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 