### PR TITLE
Prevent accessing frames from (soft) deleted conversations

### DIFF
--- a/front/lib/api/files/client_executable.test.ts
+++ b/front/lib/api/files/client_executable.test.ts
@@ -14,16 +14,9 @@ import {
 import type { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
 import { AgentMCPActionOutputItem } from "@app/lib/models/assistant/actions/mcp";
 
-// Mock the AgentMCPActionOutputItem.findAll method
-vi.mock("@app/lib/models/assistant/actions/mcp", () => ({
-  AgentMCPActionOutputItem: {
-    findAll: vi.fn(),
-  },
-}));
-
-const mockAgentMCPActionOutputItemFindAll = vi.mocked(
-  AgentMCPActionOutputItem.findAll
-);
+const mockAgentMCPActionOutputItemFindAll = vi
+  .spyOn(AgentMCPActionOutputItem, "findAll")
+  .mockImplementation(() => Promise.resolve([]));
 
 const createEditAction = (
   id: string,

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -1,0 +1,111 @@
+import { Readable } from "stream";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { GLOBAL_AGENTS_SID } from "@app/types";
+import { frameContentType } from "@app/types/files";
+
+describe("FileResource", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("fetchByShareTokenWithContent", () => {
+    const expectedContent = "<html>Frame content</html>";
+
+    beforeEach(() => {
+      vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+        new Readable({
+          read() {
+            this.push(expectedContent);
+            this.push(null); // End the stream.
+          },
+        })
+      );
+    });
+
+    it("should return file and content for active conversation", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      // Create conversation.
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      // Create frame file linked to conversation.
+      const frameFile = await FileFactory.create(workspace, null, {
+        contentType: frameContentType,
+        fileName: "frame.html",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      await frameFile.markAsReady();
+      await frameFile.markAsReady();
+
+      const frameShareInfo = await frameFile.getShareInfo();
+
+      const token = frameShareInfo?.shareUrl.split("/").at(-1);
+      assert(token, "Share token should be defined");
+
+      // Should successfully fetch file.
+      const result = await FileResource.fetchByShareTokenWithContent(token);
+
+      expect(result).not.toBeNull();
+      expect(result?.file.id).toBe(frameFile.id);
+      expect(result?.content).toEqual(expectedContent);
+    });
+
+    it("should return null for soft-deleted conversation", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      // Create conversation.
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      // Create frame file linked to conversation.
+      const frameFile = await FileFactory.create(workspace, null, {
+        contentType: frameContentType,
+        fileName: "frame.html",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      await frameFile.markAsReady();
+      await frameFile.markAsReady();
+
+      const frameShareInfo = await frameFile.getShareInfo();
+
+      const token = frameShareInfo?.shareUrl.split("/").at(-1);
+      assert(token, "Share token should be defined");
+
+      // Soft-delete the conversation.
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      assert(conversationResource, "Conversation resource should be defined");
+      await conversationResource.updateVisibilityToDeleted();
+
+      // Should successfully fetch file.
+      const result = await FileResource.fetchByShareTokenWithContent(token);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -50,7 +50,6 @@ describe("FileResource", () => {
       });
 
       await frameFile.markAsReady();
-      await frameFile.markAsReady();
 
       const frameShareInfo = await frameFile.getShareInfo();
 
@@ -86,7 +85,6 @@ describe("FileResource", () => {
         useCaseMetadata: { conversationId: conversation.sId },
       });
 
-      await frameFile.markAsReady();
       await frameFile.markAsReady();
 
       const frameShareInfo = await frameFile.getShareInfo();

--- a/front/pages/share/frame/[token].tsx
+++ b/front/pages/share/frame/[token].tsx
@@ -50,7 +50,6 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 
   // Note: We don't protect workspace sharing here - protection happens at the API level.
   // This allows the page to load but the content API call will fail if unauthorized.
-
   const shareUrl = `${config.getClientFacingUrl()}${context.req.url}`;
 
   return {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR ensures Frames from a (soft) deleted conversation can't be accessed anymore.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
