### PR TITLE
[Google Drive] Add file metadata logging to track sync delay

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -189,7 +189,17 @@ export async function incrementalSync(
           `Invalid file. File is: ${JSON.stringify(change.file)}`
         );
       }
-      localLogger.info({ fileId: change.file.id }, "will sync file");
+      localLogger.info(
+        {
+          fileId: change.file.id,
+          createdTime: change.file.createdTime,
+          modifiedTime: change.file.modifiedTime,
+          trashed: change.file.trashed,
+          mimeType: change.file.mimeType,
+          size: change.file.size,
+        },
+        "will sync file"
+      );
 
       const dataSourceConfig = dataSourceConfigFromConnector(connector);
 


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/4727

Add detailed file metadata (createdTime, modifiedTime, trashed, mimeType, size) to the incremental sync logs to help investigate and measure the delay between when changes are made to files in Google Drive and when we actually sync those changes.

By logging `modifiedTime` alongside the sync timestamp, we can calculate the sync delay and identify potential issues with our incremental sync process.

## Risks

Blast radius: Google Drive incremental sync logging only
Risk: none

## Deploy Plan

- deploy connectors