### PR TITLE
feat: add support for dynamic toolsets

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -32,6 +32,7 @@ import { MCPReasoningActionDetails } from "@app/components/actions/mcp/details/M
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
+import { MCPToolsetsEnableActionDetails } from "@app/components/actions/mcp/details/MCPToolsetsEnableActionDetails";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import {
@@ -248,6 +249,9 @@ export function MCPActionDetails({
   }
 
   if (isInternalMCPServerOfName(mcpServerId, "toolsets")) {
+    if (toolName === "enable") {
+      return <MCPToolsetsEnableActionDetails {...toolOutputDetailsProps} />;
+    }
     return <MCPListToolsActionDetails {...toolOutputDetailsProps} />;
   }
 

--- a/front/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
@@ -1,0 +1,18 @@
+import { BoltIcon } from "@dust-tt/sparkle";
+
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+
+export function MCPToolsetsEnableActionDetails({
+  viewType,
+}: ToolExecutionDetailsProps) {
+  return (
+    <ActionDetailsWrapper
+      viewType={viewType}
+      actionName={viewType === "conversation" ? "Enabled tool" : "Enable tool"}
+      visual={BoltIcon}
+    >
+      <></>
+    </ActionDetailsWrapper>
+  );
+}

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -11,6 +11,7 @@ import {
   _getAgentRouterToolsConfiguration,
   _getDefaultWebActionsForGlobalAgent,
   _getInteractiveContentToolConfiguration,
+  _getToolsetsToolsConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -39,6 +40,7 @@ export function _getDustGlobalAgent(
     agentRouterMCPServerView,
     webSearchBrowseMCPServerView,
     searchMCPServerView,
+    toolsetsMCPServerView,
     deepDiveMCPServerView,
     interactiveContentMCPServerView,
     featureFlags,
@@ -48,6 +50,7 @@ export function _getDustGlobalAgent(
     agentRouterMCPServerView: MCPServerViewResource | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
     searchMCPServerView: MCPServerViewResource | null;
+    toolsetsMCPServerView: MCPServerViewResource | null;
     deepDiveMCPServerView: MCPServerViewResource | null;
     interactiveContentMCPServerView: MCPServerViewResource | null;
     featureFlags: WhitelistableFeature[];
@@ -134,6 +137,12 @@ export function _getDustGlobalAgent(
   let instructions = `<primary_goal>
   You are an AI agent created by Dust to answer questions using your internal knowledge, the public internet and the user's internal company data sources.
   </primary_goal>
+
+  <toolsets_guidelines>
+  The "toolsets" tools allow listing and enabling additional tools.
+  At the start of each conversation or when encountering any request that might benefit from specialized tools, use \`toolsets__list\` to discover available toolsets.
+  Enable relevant toolsets before attempting to fulfill the request. Never assume or reply that you cannot do something before checking the toolsets available.
+  </toolsets_guidelines>
 
   <general_guidelines>
   ${globalAgentGuidelines}
@@ -276,6 +285,10 @@ export function _getDustGlobalAgent(
     ..._getDefaultWebActionsForGlobalAgent({
       agentId: GLOBAL_AGENTS_SID.DUST,
       webSearchBrowseMCPServerView,
+    }),
+    ..._getToolsetsToolsConfiguration({
+      agentId: GLOBAL_AGENTS_SID.DUST,
+      toolsetsMcpServerView: toolsetsMCPServerView,
     }),
     ..._getAgentRouterToolsConfiguration(
       GLOBAL_AGENTS_SID.DUST,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -356,6 +356,7 @@ function getGlobalAgent({
         agentRouterMCPServerView,
         webSearchBrowseMCPServerView,
         searchMCPServerView,
+        toolsetsMCPServerView,
         deepDiveMCPServerView,
         interactiveContentMCPServerView,
         featureFlags,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/tools.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/tools.test.ts
@@ -1,0 +1,109 @@
+import type { RequestMethod } from "node-mocks-http";
+import { assert, describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types";
+
+import handler from "./tools";
+
+async function setupTest(method: RequestMethod = "POST") {
+  const { req, res, workspace } = await createPublicApiMockRequest({
+    systemKey: true,
+    method,
+  });
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    messagesCreatedAt: [new Date()],
+  });
+
+  req.query.wId = workspace.sId;
+  req.query.cId = conversation.sId;
+
+  const systemSpace = await SpaceFactory.system(workspace);
+  const globalSpace = await SpaceFactory.global(workspace);
+
+  return { req, res, workspace, conversation, systemSpace, globalSpace, auth };
+}
+
+describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/tools", () => {
+  it("should add a new tool to conversation with system key", async () => {
+    const { req, res, workspace, auth, conversation, globalSpace } =
+      await setupTest("POST");
+
+    const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        remoteMCPServer.sId
+      );
+    assert(systemView, "MCP server view not found");
+    const mcpServerView = await MCPServerViewResource.create(auth, {
+      systemView,
+      space: globalSpace,
+    });
+
+    req.body = {
+      action: "add",
+      mcp_server_view_id: mcpServerView.sId,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.success).toBe(true);
+
+    const relationship = await ConversationResource.fetchMCPServerViews(
+      auth,
+      conversation
+    );
+    expect(relationship).toHaveLength(1);
+    expect(relationship[0].enabled).toBe(true);
+  });
+
+  it("should return 401 when not using a system key", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: false,
+      method: "POST",
+    });
+
+    req.query.wId = workspace.sId;
+    req.query.cId = "any";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getJSONData().error.type).toBe("not_authenticated");
+  });
+
+  it("should return 404 when MCP server view doesn't exist", async () => {
+    const { req, res } = await setupTest("POST");
+    req.body = {
+      action: "add",
+      mcp_server_view_id: "non-existent-view",
+    };
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it("should return 400 for invalid request body", async () => {
+    const { req, res } = await setupTest("POST");
+    req.body = null;
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it("should return 405 for unsupported methods", async () => {
+    const { req, res } = await setupTest("GET");
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(405);
+  });
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -1,0 +1,135 @@
+import type {
+  GetMCPServerViewsResponseType,
+  PatchConversationResponseType,
+} from "@dust-tt/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+type FetchConversationToolsResponse = GetMCPServerViewsResponseType;
+
+const ConversationToolActionRequestSchema = z.object({
+  action: z.enum(["add", "delete"]),
+  mcp_server_view_id: z.string(),
+});
+
+export type ConversationToolActionRequest = z.infer<
+  typeof ConversationToolActionRequestSchema
+>;
+
+/**
+ * @ignoreswagger
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      FetchConversationToolsResponse | PatchConversationResponseType
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const conversationWithoutContent = conversationRes.value;
+
+  if (!auth.isSystemKey()) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "not_authenticated",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const parseResult = ConversationToolActionRequestSchema.safeParse(
+        req.body
+      );
+
+      if (!parseResult.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: fromError(parseResult.error).toString(),
+          },
+        });
+      }
+
+      const { action, mcp_server_view_id } = parseResult.data;
+
+      const mcpServerViewRes = await MCPServerViewResource.fetchById(
+        auth,
+        mcp_server_view_id
+      );
+
+      if (!mcpServerViewRes) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "mcp_server_view_not_found",
+            message: "MCP server view not found",
+          },
+        });
+      }
+
+      const r = await ConversationResource.upsertMCPServerViews(auth, {
+        conversation: conversationWithoutContent,
+        mcpServerViews: [mcpServerViewRes],
+        enabled: action === "add",
+      });
+      if (r.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to add MCP server view to conversation",
+          },
+        });
+      }
+
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST expected.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(handler);


### PR DESCRIPTION
## Description

Adds a new `enable` tool to the `toolsets` internal tool server.
This tool takes a `toolset_id` and adds the corresponding `MCPServerView` to the conversation.

The main downside of that approach is that it updates the set of available tools, which likely causes a cache miss. But the alternative is adding a tools to dynamically execute a tool by toolsetId and name, which also requires another tool to obtain the JSON schema. This is not trivial to setup properly especially the UI aspect (need to add special cases everywhere to handle the dynamic tool outputs and transform them into the right MCP tool output).

The `toolsets` tool has also been added to `@dust`.

## Tests

Extensively tested

<img width="601" height="1166" alt="Screenshot 2025-10-24 at 16 31 01" src="https://github.com/user-attachments/assets/161ca228-93fb-490d-b4ab-7f9d236cf06c" />


## Risk

Low

## Deploy Plan

Deploy front