### PR TITLE
[Google Drive] Add poke plugin to sync single file

### DIFF
--- a/connectors/src/api/admin.ts
+++ b/connectors/src/api/admin.ts
@@ -77,6 +77,10 @@ const whitelistedCommands = [
     majorCommand: "confluence",
     command: "check-page-exists",
   },
+  {
+    majorCommand: "google_drive",
+    command: "upsert-file",
+  },
 ];
 
 const _adminAPIHandler = async (

--- a/front/lib/api/poke/plugins/data_sources/google_drive_sync_file.ts
+++ b/front/lib/api/poke/plugins/data_sources/google_drive_sync_file.ts
@@ -1,0 +1,70 @@
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import logger from "@app/logger/logger";
+import { ConnectorsAPI, Err, Ok } from "@app/types";
+
+export const googleDriveSyncFilePlugin = createPlugin({
+  manifest: {
+    id: "google-drive-sync-file",
+    name: "Sync Google Drive File",
+    description:
+      "Force sync a single Google Drive file by its file ID. This will upsert the file and all its parent folders if needed.",
+    resourceTypes: ["data_sources"],
+    args: {
+      fileId: {
+        type: "string",
+        label: "File ID",
+        description:
+          "Google Drive file ID (e.g., 1a2b3c4d5e6f7g8h9i0j or the full URL)",
+      },
+    },
+  },
+  isApplicableTo: (auth, resource) => {
+    if (!resource) {
+      return false;
+    }
+
+    return resource.connectorProvider === "google_drive";
+  },
+  execute: async (auth, dataSource, args) => {
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    const { connectorId } = dataSource;
+    if (!connectorId) {
+      return new Err(new Error("No connector on datasource."));
+    }
+
+    const { fileId } = args;
+    if (!fileId.trim()) {
+      return new Err(new Error("fileId is required"));
+    }
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    const res = await connectorsAPI.admin({
+      majorCommand: "google_drive",
+      command: "upsert-file",
+      args: {
+        wId: workspace.sId,
+        connectorId: connectorId.toString(),
+        fileId: fileId.trim(),
+      },
+    });
+
+    if (res.isErr()) {
+      return new Err(new Error(`Failed to sync file: ${res.error.message}`));
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Successfully synced Google Drive file: ${fileId}`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -4,6 +4,7 @@ export * from "./compute_statistics";
 export * from "./confluence_page_checker";
 export * from "./delete_data_source";
 export * from "./garbage_collect_google_drive_document";
+export * from "./google_drive_sync_file";
 export * from "./mark_connector_as_error";
 export * from "./notion_unstuck_syncing_nodes";
 export * from "./notion_update_orphaned_resources_parents";


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/4727

Add a poke plugin for Google Drive that allows syncing a single file by its file ID, similar to the existing `upsert-file` CLI command in `connectors/src/connectors/google_drive/lib/cli.ts`.

This plugin:
- Takes a Google Drive file ID as input
- Syncs the file and all its parent folders if needed
- Useful for debugging sync issues and manually triggering file updates

## Risks

Blast radius: Google Drive data sources poke operations only
Risk: low

## Deploy Plan

- deploy front