### PR TITLE
Migrate from next lint to eslint directly

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
     "next/core-web-vitals",
     "prettier",
     "eslint:recommended",
+    "plugin:@next/next/recommended",
     "plugin:@typescript-eslint/recommended",
   ],
   plugins: [
@@ -11,6 +12,7 @@ module.exports = {
     "dust",
     "eslint-plugin-unused-imports",
   ],
+  ignorePatterns: ["migrations/**/*.ts", "mailing/**/*.ts"],
   rules: {
     // Intentionally discourage direct global fetch; prefer explicit egress helpers.
     // For now set to "warn" so we can migrate incrementally.
@@ -89,7 +91,6 @@ module.exports = {
   overrides: [
     {
       files: ["*.jsx", "*.js", "*.ts", "*.tsx", "**/*.jsx"],
-      excludedFiles: ["migrations/**/*.ts", "mailings/**/*.ts"],
     },
     {
       // Force the setting of a swagger description on each public api endpoint

--- a/front/admin/relocate_users.ts
+++ b/front/admin/relocate_users.ts
@@ -37,6 +37,7 @@ function makeWorkOSThrottler<T>(logger: Logger) {
         const waitTime = (err.retryAfter + 1) * 1000;
         logger.info({ waitTime }, "Waiting");
         await new Promise((resolve) => setTimeout(resolve, waitTime));
+        // eslint-disable-next-line @typescript-eslint/return-await
         return await fn();
       } else {
         throw normalizeError(err);

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -852,6 +852,7 @@ export default async function createServer(
             if (agentMessage && agentMessage.status === "succeeded") {
               const { finalText, cot, refsFromAgent, files } =
                 getFinishedContent(agentMessage);
+              /* eslint-disable-next-line @typescript-eslint/return-await */
               return await finalizeAndReturn(
                 new Ok(
                   buildSuccessContent({
@@ -869,6 +870,7 @@ export default async function createServer(
           const normalizedError = normalizeError(streamError);
           const isNotConnected = normalizedError.message === "Not connected";
           const errorMessage = `Error processing agent stream: ${normalizedError.message}`;
+          /* eslint-disable-next-line @typescript-eslint/return-await */
           return await finalizeAndReturn(
             new Err(
               new MCPError(errorMessage, {

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -258,27 +258,8 @@ const config = {
     }
     return config;
   },
-  eslint: {
-    // By default, `next lint` only runs on pages/, app/, components/, lib/, and src/
-    // directories. We want to run it in all directories
-    dirs: [
-      "admin",
-      "components",
-      "config",
-      "hooks",
-      "lib",
-      "logger",
-      // "mailing", Not putting migrations as it generates a lot of noise in linter, especially raw SQL
-      // "migrations", Not putting migrations as it generates a lot of noise in linter, especially raw SQL
-      "pages",
-      "poke",
-      "prompt",
-      "scripts",
-      "temporal",
-      "tests",
-      "types",
-    ],
-  },
+  // We don't use next lint anymore, it's removed in next 16. So we disable it here.
+  // eslint: false
 };
 
 module.exports = withBundleAnalyzer(config);

--- a/front/package.json
+++ b/front/package.json
@@ -8,7 +8,7 @@
     "start:worker": "tsx ./start_worker.ts",
     "dev:worker": "./admin/dev_worker.sh",
     "lint:test-filenames": "BAD_FILES=$(find pages -type f -name '*.test.ts' | grep -E '/[^/]*(\\[|\\])[^/]*$'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: Found .test.ts files in 'pages' directory with brackets [] in their names (this can break endpoints):\"; echo \"$BAD_FILES\"; exit 1; else echo \"Filename check: OK. No .test.ts files with brackets found in 'pages'.\"; exit 0; fi",
-    "lint": "npm run lint:test-filenames && next lint",
+    "lint": "npm run lint:test-filenames && eslint .",
     "docs": "npx next-swagger-doc-cli swagger.json 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "docs:check": "npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "format": "prettier --write .",


### PR DESCRIPTION
## Description

Replace `next lint` with `eslint .` in the lint script to use ESLint directly instead of Next.js's wrapper. The configuration remains unchanged, using the existing .eslintrc.js and eslint-config-next package.

`next lint` is removed in next 16: https://nextjs.org/docs/app/guides/upgrading/version-16#next-lint-command

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
