### PR TITLE
Refactor listConversationsForUser to use baseFetchWithAuthorization

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -35,7 +35,6 @@ import logger from "@app/logger/logger";
 import type {
   ConversationMCPServerViewType,
   ConversationType,
-  ConversationVisibility,
   ConversationWithoutContentType,
   LightAgentConfigurationType,
   ParticipantActionType,
@@ -49,15 +48,25 @@ export type FetchConversationOptions = {
   includeTest?: boolean;
 };
 
+interface UserParticipation {
+  actionRequired: boolean;
+  unread: boolean;
+  updated: number;
+}
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
 export interface ConversationResource
   extends ReadonlyAttributesType<ConversationModel> {}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ConversationResource extends BaseResource<ConversationModel> {
   static model: ModelStaticWorkspaceAware<ConversationModel> =
     ConversationModel;
+
+  // User-specific participation fields (populated when conversations are listed for a user).
+  private userParticipation?: UserParticipation;
 
   static async makeNew(
     auth: Authenticator,
@@ -468,70 +477,66 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return new Ok(undefined);
   }
 
-  // TODO(2025-10-22 flav): Use baseFetchWithAuthorization.
   static async listConversationsForUser(
     auth: Authenticator,
     options?: FetchConversationOptions
-  ): Promise<ConversationWithoutContentType[]> {
-    const owner = auth.getNonNullableWorkspace();
+  ): Promise<ConversationResource[]> {
     const user = auth.getNonNullableUser();
 
-    const includedConversationVisibilities: ConversationVisibility[] = [
-      "unlisted",
-    ];
-
-    if (options?.includeDeleted) {
-      includedConversationVisibilities.push("deleted");
-    }
-    if (options?.includeTest) {
-      includedConversationVisibilities.push("test");
-    }
-
+    // First get all participations for the user to get conversation IDs and metadata.
     const participations = await ConversationParticipantModel.findAll({
       attributes: [
-        "userId",
-        "updatedAt",
+        "actionRequired",
         "conversationId",
         "unread",
-        "actionRequired",
+        "updatedAt",
+        "userId",
       ],
       where: {
         userId: user.id,
-        workspaceId: owner.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
-      include: [
-        {
-          model: ConversationModel,
-          required: true,
-          where: {
-            visibility: { [Op.in]: includedConversationVisibilities },
-          },
-        },
-      ],
       order: [["updatedAt", "DESC"]],
     });
 
-    return participations.reduce((acc, p) => {
-      const c = p.conversation;
+    if (participations.length === 0) {
+      return [];
+    }
 
-      if (c) {
-        const resource = new this(this.model, c.get());
-        acc.push({
-          id: c.id,
-          created: c.createdAt.getTime(),
-          updated: p.updatedAt.getTime(),
-          unread: p.unread,
+    const conversationIds = participations.map((p) => p.conversationId);
+
+    // Use baseFetchWithAuthorization to get conversations with proper authorization.
+    const conversations = await this.baseFetchWithAuthorization(auth, options, {
+      where: {
+        id: { [Op.in]: conversationIds },
+      },
+    });
+
+    const participationMap = new Map(
+      participations.map((p) => [
+        p.conversationId,
+        {
           actionRequired: p.actionRequired,
-          hasError: c.hasError,
-          sId: c.sId,
-          title: c.title,
-          requestedGroupIds: resource.getRequestedGroupIdsFromModel(auth),
-          requestedSpaceIds: resource.getRequestedSpaceIdsFromModel(auth),
-        });
-      }
+          unread: p.unread,
+          updated: p.updatedAt.getTime(),
+        },
+      ])
+    );
 
-      return acc;
-    }, [] as ConversationWithoutContentType[]);
+    // Attach participation data to resources.
+    conversations.forEach((c) => {
+      const participation = participationMap.get(c.id);
+      if (participation) {
+        c.userParticipation = participation;
+      }
+    });
+
+    // Sort by participation updated time descending.
+    return conversations.sort(
+      (a, b) =>
+        (b.userParticipation?.updated ?? 0) -
+        (a.userParticipation?.updated ?? 0)
+    );
   }
 
   static async listConversationsForTrigger(
@@ -1078,5 +1083,41 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         workspaceId: workspace.id,
       })
     );
+  }
+
+  toJSON(): ConversationWithoutContentType {
+    // If conversation is fetched for a user, use the participation data.
+    const participation = this.userParticipation ?? {
+      actionRequired: false,
+      unread: false,
+      updated: this.updatedAt.getTime(),
+    };
+
+    return {
+      actionRequired: participation.actionRequired,
+      created: this.createdAt.getTime(),
+      hasError: this.hasError,
+      id: this.id,
+      // TODO(REQUESTED_SPACE_IDS 2025-10-24): Stop exposing this once all logic is centralized
+      // in baseFetchWithAuthorization.
+      requestedGroupIds: this.requestedGroupIds.map((groups) =>
+        groups.map((g) =>
+          GroupResource.modelIdToSId({
+            id: g,
+            workspaceId: this.workspaceId,
+          })
+        )
+      ),
+      requestedSpaceIds: this.requestedSpaceIds.map((id) =>
+        SpaceResource.modelIdToSId({
+          id,
+          workspaceId: this.workspaceId,
+        })
+      ),
+      sId: this.sId,
+      title: this.title,
+      unread: participation.unread,
+      updated: participation.updated,
+    };
   }
 }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -451,7 +451,7 @@ async function handler(
         await ConversationResource.listConversationsForUser(auth);
       res.status(200).json({
         conversations: conversations.map((c) => ({
-          ...c,
+          ...c.toJSON(),
 
           // Theses 2 properties are excluded from the ConversationWithoutContentType used internally (as they are not needed anywhere).
           // They are still returned for the public API to stay backward compatible.

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -52,7 +52,9 @@ async function handler(
     case "GET":
       const conversations =
         await ConversationResource.listConversationsForUser(auth);
-      res.status(200).json({ conversations });
+      res
+        .status(200)
+        .json({ conversations: conversations.map((c) => c.toJSON()) });
       return;
 
     case "POST":


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors `listConversationsForUser` so it i. uses `baseFetchWithAuthorization` and ii. return a `ConversationResource` rather than a type.

As we want the conversation to reflect the user's participation, I ended up introducing a not so good pattern that let you store user's information on the current conversation. It's a private field that can't be altered from outside.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
