### PR TITLE
[hootl] Add zendesk webhook preset

### DIFF
--- a/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
@@ -52,7 +52,7 @@ export function CreateWebhookSourceWithProviderForm({
         owner,
         provider,
         useCase: "webhooks",
-        extraConfig: extraConfig,
+        extraConfig,
       });
 
       if (connectionRes.isErr()) {

--- a/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
@@ -33,9 +33,12 @@ export function CreateWebhookSourceWithProviderForm({
     null
   );
   const [isConnectingProvider, setIsConnectingToProvider] = useState(false);
+  const [extraConfig, setExtraConfig] = useState<Record<string, string>>({});
+  const [isExtraConfigValid, setIsExtraConfigValid] = useState(false);
 
   const preset = WEBHOOK_PRESETS[provider];
   const kindName = preset.name;
+  const OAuthExtraConfigInput = preset.components.oauthExtraConfigInput;
 
   const handleConnectToProvider = async () => {
     if (!owner) {
@@ -49,7 +52,7 @@ export function CreateWebhookSourceWithProviderForm({
         owner,
         provider,
         useCase: "webhooks",
-        extraConfig: {},
+        extraConfig: extraConfig,
       });
 
       if (connectionRes.isErr()) {
@@ -85,6 +88,16 @@ export function CreateWebhookSourceWithProviderForm({
           Connect your {kindName} account to select repositories and
           organizations to follow.
         </p>
+        {OAuthExtraConfigInput && (
+          <div className="mt-4">
+            <OAuthExtraConfigInput
+              extraConfig={extraConfig}
+              setExtraConfig={setExtraConfig}
+              setIsExtraConfigValid={setIsExtraConfigValid}
+            />
+          </div>
+        )}
+
         <div className="mt-2 flex items-center gap-2">
           <Button
             variant={"outline"}
@@ -93,7 +106,11 @@ export function CreateWebhookSourceWithProviderForm({
             }
             icon={preset.icon}
             onClick={handleConnectToProvider}
-            disabled={isConnectingProvider || !!connection}
+            disabled={
+              isConnectingProvider ||
+              !!connection ||
+              (OAuthExtraConfigInput ? !isExtraConfigValid : false)
+            }
           />
           {connection && preset.webhookPageUrl && (
             <a

--- a/front/lib/api/oauth/providers/zendesk.ts
+++ b/front/lib/api/oauth/providers/zendesk.ts
@@ -13,11 +13,13 @@ import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
   setupUri({
     connection,
+    useCase,
   }: {
     connection: OAuthConnectionType;
     useCase: OAuthUseCase;
   }) {
-    const scopes = ["read"];
+    // Webhooks require write scope to create/manage webhooks
+    const scopes = useCase === "webhooks" ? ["webhooks:write"] : ["read"];
     if (!isValidZendeskSubdomain(connection.metadata.zendesk_subdomain)) {
       throw "Invalid Zendesk subdomain";
     }

--- a/front/lib/triggers/built-in-webhooks/zendesk/components/CreateWebhookZendeskConnection.tsx
+++ b/front/lib/triggers/built-in-webhooks/zendesk/components/CreateWebhookZendeskConnection.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+import type { WebhookCreateFormComponentProps } from "@app/components/triggers/webhook_preset_components";
+
+export function CreateWebhookZendeskConnection({
+  connectionId,
+  onDataToCreateWebhookChange,
+  onReadyToSubmitChange,
+}: WebhookCreateFormComponentProps) {
+  // Notify parent component that we're ready to submit
+  // The connection is already established by the parent component and there is nothing else to do
+  useEffect(() => {
+    if (onDataToCreateWebhookChange) {
+      onDataToCreateWebhookChange({
+        connectionId,
+        remoteMetadata: {},
+      });
+    }
+
+    if (onReadyToSubmitChange) {
+      onReadyToSubmitChange(true);
+    }
+  }, [connectionId, onDataToCreateWebhookChange, onReadyToSubmitChange]);
+  return null;
+}

--- a/front/lib/triggers/built-in-webhooks/zendesk/components/WebhookSourceZendeskDetails.tsx
+++ b/front/lib/triggers/built-in-webhooks/zendesk/components/WebhookSourceZendeskDetails.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon, Page } from "@dust-tt/sparkle";
+import { ExternalLinkIcon, IconButton, Page } from "@dust-tt/sparkle";
 
 import type { WebhookDetailsComponentProps } from "@app/components/triggers/webhook_preset_components";
 import { ZendeskWebhookStoredMetadataSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types";
@@ -27,8 +27,8 @@ export function WebhookSourceZendeskDetails({
     <div className="space-y-4">
       <div>
         <Page.H variant="h6">Zendesk Instance</Page.H>
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-sm text-foreground dark:text-foreground-night">
+        <div className="flex items-center space-x-2">
+          <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono">
             {zendeskSubdomain}.zendesk.com
           </span>
           {webhookId && (
@@ -38,8 +38,11 @@ export function WebhookSourceZendeskDetails({
               rel="noopener noreferrer"
               className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-xs"
             >
-              View webhook
-              <ExternalLinkIcon className="h-3 w-3" />
+              <IconButton
+                icon={ExternalLinkIcon}
+                size="xs"
+                tooltip="See webhook"
+              />{" "}
             </a>
           )}
         </div>

--- a/front/lib/triggers/built-in-webhooks/zendesk/components/WebhookSourceZendeskDetails.tsx
+++ b/front/lib/triggers/built-in-webhooks/zendesk/components/WebhookSourceZendeskDetails.tsx
@@ -1,0 +1,43 @@
+import { ExternalLinkIcon, Page } from "@dust-tt/sparkle";
+
+import type { WebhookDetailsComponentProps } from "@app/components/triggers/webhook_preset_components";
+
+export function WebhookSourceZendeskDetails({
+  webhookSource,
+}: WebhookDetailsComponentProps) {
+  if (webhookSource.provider !== "zendesk" || !webhookSource.remoteMetadata) {
+    return null;
+  }
+
+  const metadata = webhookSource.remoteMetadata;
+  const zendeskSubdomain = metadata.zendeskSubdomain as string | undefined;
+  const webhookId = metadata.webhookId as string | undefined;
+
+  if (!zendeskSubdomain) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Page.H variant="h6">Zendesk Instance</Page.H>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm text-foreground dark:text-foreground-night">
+            {zendeskSubdomain}.zendesk.com
+          </span>
+          {webhookId && (
+            <a
+              href={`https://${zendeskSubdomain}.zendesk.com/admin/apps-integrations/webhooks/webhooks/${webhookId}/details`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-xs"
+            >
+              View webhook
+              <ExternalLinkIcon className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/lib/triggers/built-in-webhooks/zendesk/components/WebhookSourceZendeskDetails.tsx
+++ b/front/lib/triggers/built-in-webhooks/zendesk/components/WebhookSourceZendeskDetails.tsx
@@ -1,6 +1,7 @@
 import { ExternalLinkIcon, Page } from "@dust-tt/sparkle";
 
 import type { WebhookDetailsComponentProps } from "@app/components/triggers/webhook_preset_components";
+import { ZendeskWebhookStoredMetadataSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types";
 
 export function WebhookSourceZendeskDetails({
   webhookSource,
@@ -9,9 +10,14 @@ export function WebhookSourceZendeskDetails({
     return null;
   }
 
-  const metadata = webhookSource.remoteMetadata;
-  const zendeskSubdomain = metadata.zendeskSubdomain as string | undefined;
-  const webhookId = metadata.webhookId as string | undefined;
+  const parsed = ZendeskWebhookStoredMetadataSchema.safeParse(
+    webhookSource.remoteMetadata
+  );
+
+  const zendeskSubdomain = parsed.success
+    ? parsed.data.zendeskSubdomain
+    : undefined;
+  const webhookId = parsed.success ? parsed.data.webhookId : undefined;
 
   if (!zendeskSubdomain) {
     return null;

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_organization_created.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_organization_created.ts
@@ -1,0 +1,77 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+export const organizationCreatedSchema: JSONSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      description: "The event type",
+      const: "zen:event-type:organization.created",
+    },
+    account_id: {
+      type: "integer",
+      description: "The Zendesk account ID",
+    },
+    id: {
+      type: "string",
+      description: "The unique event ID",
+    },
+    time: {
+      type: "string",
+      description: "The time the event occurred in ISO 8601 format",
+    },
+    zendesk_event_version: {
+      type: "string",
+      description: "The version of the Zendesk event schema",
+    },
+    subject: {
+      type: "string",
+      description: "The subject of the event",
+    },
+    event: {
+      type: "object",
+      description:
+        "Event-specific data (empty for organization.created events)",
+      properties: {},
+    },
+    detail: {
+      type: "object",
+      description: "Details about the organization",
+      properties: {
+        created_at: {
+          type: "string",
+          description: "When the organization was created",
+        },
+        external_id: {
+          type: "string",
+          description: "The external ID of the organization",
+        },
+        group_id: {
+          type: "string",
+          description: "The group ID (returned as string)",
+        },
+        id: {
+          type: "string",
+          description: "The organization ID (returned as string)",
+        },
+        name: {
+          type: "string",
+          description: "The organization name",
+        },
+        shared_comments: {
+          type: "boolean",
+          description: "Whether comments are shared within the organization",
+        },
+        shared_tickets: {
+          type: "boolean",
+          description: "Whether tickets are shared within the organization",
+        },
+        updated_at: {
+          type: "string",
+          description: "When the organization was last updated",
+        },
+      },
+    },
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_agent_assignment_changed.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_agent_assignment_changed.ts
@@ -34,11 +34,11 @@ export const ticketAgentAssignmentChangedSchema: JSONSchema = {
       description: "Event-specific data about the agent assignment change",
       properties: {
         current: {
-          type: "integer",
+          type: "string",
           description: "The user ID of the current assignee",
         },
         previous: {
-          type: "integer",
+          type: "string",
           description: "The user ID of the previous assignee",
         },
       },
@@ -48,12 +48,61 @@ export const ticketAgentAssignmentChangedSchema: JSONSchema = {
       description: "Details about the ticket",
       properties: {
         actor_id: {
-          type: "integer",
+          type: "string",
           description: "The ID of the user who performed the action",
         },
+        assignee_id: {
+          type: "string",
+          description: "The assignee ID",
+        },
+        brand_id: {
+          type: "string",
+          description: "The brand ID",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        custom_status: {
+          type: "string",
+          description: "The custom status ID",
+        },
+        description: {
+          type: "string",
+          description: "The ticket description",
+        },
+        external_id: {
+          type: ["string", "null"],
+          description: "The external ID",
+        },
+        form_id: {
+          type: "string",
+          description: "The form ID",
+        },
+        group_id: {
+          type: "string",
+          description: "The group ID",
+        },
         id: {
-          type: "integer",
+          type: "string",
           description: "The ticket ID",
+        },
+        is_public: {
+          type: "boolean",
+          description: "Whether the ticket is public",
+        },
+        organization_id: {
+          type: ["string", "null"],
+          description: "The organization ID",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["LOW", "NORMAL", "HIGH", "URGENT"],
+        },
+        requester_id: {
+          type: "string",
+          description: "The requester ID",
         },
         status: {
           type: "string",
@@ -74,27 +123,9 @@ export const ticketAgentAssignmentChangedSchema: JSONSchema = {
           type: "string",
           description: "The ticket subject",
         },
-        description: {
+        submitter_id: {
           type: "string",
-          description: "The ticket description",
-        },
-        created_at: {
-          type: "string",
-          description: "When the ticket was created",
-        },
-        updated_at: {
-          type: "string",
-          description: "When the ticket was last updated",
-        },
-        priority: {
-          type: "string",
-          description: "The ticket priority",
-          enum: ["low", "normal", "high", "urgent"],
-        },
-        type: {
-          type: "string",
-          description: "The ticket type",
-          enum: ["problem", "incident", "question", "task"],
+          description: "The submitter ID",
         },
         tags: {
           type: "array",
@@ -103,21 +134,24 @@ export const ticketAgentAssignmentChangedSchema: JSONSchema = {
             type: "string",
           },
         },
-        organization_id: {
-          type: "integer",
-          description: "The organization ID",
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["PROBLEM", "INCIDENT", "QUESTION", "TASK"],
         },
-        assignee_id: {
-          type: "integer",
-          description: "The assignee ID",
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
         },
-        group_id: {
-          type: "integer",
-          description: "The group ID",
-        },
-        requester_id: {
-          type: "integer",
-          description: "The requester ID",
+        via: {
+          type: "object",
+          description: "Information about how the ticket was submitted",
+          properties: {
+            channel: {
+              type: "string",
+              description: "The channel through which the ticket was submitted",
+            },
+          },
         },
       },
     },

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_agent_assignment_changed.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_agent_assignment_changed.ts
@@ -1,0 +1,125 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+export const ticketAgentAssignmentChangedSchema: JSONSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      description: "The event type",
+      const: "zen:event-type:ticket.agent_assignment_changed",
+    },
+    account_id: {
+      type: "integer",
+      description: "The Zendesk account ID",
+    },
+    id: {
+      type: "string",
+      description: "The unique event ID",
+    },
+    time: {
+      type: "string",
+      description: "The time the event occurred in ISO 8601 format",
+    },
+    zendesk_event_version: {
+      type: "string",
+      description: "The version of the Zendesk event schema",
+    },
+    subject: {
+      type: "string",
+      description: "The subject of the event",
+    },
+    event: {
+      type: "object",
+      description: "Event-specific data about the agent assignment change",
+      properties: {
+        current: {
+          type: "integer",
+          description: "The user ID of the current assignee",
+        },
+        previous: {
+          type: "integer",
+          description: "The user ID of the previous assignee",
+        },
+      },
+    },
+    detail: {
+      type: "object",
+      description: "Details about the ticket",
+      properties: {
+        actor_id: {
+          type: "integer",
+          description: "The ID of the user who performed the action",
+        },
+        id: {
+          type: "integer",
+          description: "The ticket ID",
+        },
+        status: {
+          type: "string",
+          description: "The ticket status",
+          enum: [
+            "NEW",
+            "OPEN",
+            "PENDING",
+            "HOLD",
+            "SOLVED",
+            "CLOSED",
+            "DELETED",
+            "ARCHIVED",
+            "SCRUBBED",
+          ],
+        },
+        subject: {
+          type: "string",
+          description: "The ticket subject",
+        },
+        description: {
+          type: "string",
+          description: "The ticket description",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["low", "normal", "high", "urgent"],
+        },
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["problem", "incident", "question", "task"],
+        },
+        tags: {
+          type: "array",
+          description: "Tags associated with the ticket",
+          items: {
+            type: "string",
+          },
+        },
+        organization_id: {
+          type: "integer",
+          description: "The organization ID",
+        },
+        assignee_id: {
+          type: "integer",
+          description: "The assignee ID",
+        },
+        group_id: {
+          type: "integer",
+          description: "The group ID",
+        },
+        requester_id: {
+          type: "integer",
+          description: "The requester ID",
+        },
+      },
+    },
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_comment_added.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_comment_added.ts
@@ -38,7 +38,7 @@ export const ticketCommentAddedSchema: JSONSchema = {
           description: "The comment that was added",
           properties: {
             id: {
-              type: "integer",
+              type: "string",
               description: "The comment ID",
             },
             body: {
@@ -54,7 +54,7 @@ export const ticketCommentAddedSchema: JSONSchema = {
               description: "The author of the comment",
               properties: {
                 id: {
-                  type: "integer",
+                  type: "string",
                   description: "The author's user ID",
                 },
                 is_staff: {
@@ -76,12 +76,61 @@ export const ticketCommentAddedSchema: JSONSchema = {
       description: "Details about the ticket",
       properties: {
         actor_id: {
-          type: "integer",
+          type: "string",
           description: "The ID of the user who performed the action",
         },
+        assignee_id: {
+          type: "string",
+          description: "The assignee ID",
+        },
+        brand_id: {
+          type: "string",
+          description: "The brand ID",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        custom_status: {
+          type: "string",
+          description: "The custom status ID",
+        },
+        description: {
+          type: "string",
+          description: "The ticket description",
+        },
+        external_id: {
+          type: ["string", "null"],
+          description: "The external ID",
+        },
+        form_id: {
+          type: "string",
+          description: "The form ID",
+        },
+        group_id: {
+          type: "string",
+          description: "The group ID",
+        },
         id: {
-          type: "integer",
+          type: "string",
           description: "The ticket ID",
+        },
+        is_public: {
+          type: "boolean",
+          description: "Whether the ticket is public",
+        },
+        organization_id: {
+          type: ["string", "null"],
+          description: "The organization ID",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["LOW", "NORMAL", "HIGH", "URGENT"],
+        },
+        requester_id: {
+          type: "string",
+          description: "The requester ID",
         },
         status: {
           type: "string",
@@ -102,23 +151,9 @@ export const ticketCommentAddedSchema: JSONSchema = {
           type: "string",
           description: "The ticket subject",
         },
-        created_at: {
+        submitter_id: {
           type: "string",
-          description: "When the ticket was created",
-        },
-        updated_at: {
-          type: "string",
-          description: "When the ticket was last updated",
-        },
-        priority: {
-          type: "string",
-          description: "The ticket priority",
-          enum: ["low", "normal", "high", "urgent"],
-        },
-        type: {
-          type: "string",
-          description: "The ticket type",
-          enum: ["problem", "incident", "question", "task"],
+          description: "The submitter ID",
         },
         tags: {
           type: "array",
@@ -127,21 +162,24 @@ export const ticketCommentAddedSchema: JSONSchema = {
             type: "string",
           },
         },
-        organization_id: {
-          type: "integer",
-          description: "The organization ID",
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["PROBLEM", "INCIDENT", "QUESTION", "TASK"],
         },
-        assignee_id: {
-          type: "integer",
-          description: "The assignee ID",
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
         },
-        group_id: {
-          type: "integer",
-          description: "The group ID",
-        },
-        requester_id: {
-          type: "integer",
-          description: "The requester ID",
+        via: {
+          type: "object",
+          description: "Information about how the ticket was submitted",
+          properties: {
+            channel: {
+              type: "string",
+              description: "The channel through which the ticket was submitted",
+            },
+          },
         },
       },
     },

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_comment_added.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_comment_added.ts
@@ -1,0 +1,149 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+export const ticketCommentAddedSchema: JSONSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      description: "The event type",
+      const: "zen:event-type:ticket.comment_added",
+    },
+    account_id: {
+      type: "integer",
+      description: "The Zendesk account ID",
+    },
+    id: {
+      type: "string",
+      description: "The unique event ID",
+    },
+    time: {
+      type: "string",
+      description: "The time the event occurred in ISO 8601 format",
+    },
+    zendesk_event_version: {
+      type: "string",
+      description: "The version of the Zendesk event schema",
+    },
+    subject: {
+      type: "string",
+      description: "The subject of the event",
+    },
+    event: {
+      type: "object",
+      description: "Event-specific data about the comment",
+      properties: {
+        comment: {
+          type: "object",
+          description: "The comment that was added",
+          properties: {
+            id: {
+              type: "integer",
+              description: "The comment ID",
+            },
+            body: {
+              type: "string",
+              description: "The comment body text",
+            },
+            is_public: {
+              type: "boolean",
+              description: "Whether the comment is public or private",
+            },
+            author: {
+              type: "object",
+              description: "The author of the comment",
+              properties: {
+                id: {
+                  type: "integer",
+                  description: "The author's user ID",
+                },
+                is_staff: {
+                  type: "boolean",
+                  description: "Whether the author is a staff member",
+                },
+                name: {
+                  type: "string",
+                  description: "The author's name",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    detail: {
+      type: "object",
+      description: "Details about the ticket",
+      properties: {
+        actor_id: {
+          type: "integer",
+          description: "The ID of the user who performed the action",
+        },
+        id: {
+          type: "integer",
+          description: "The ticket ID",
+        },
+        status: {
+          type: "string",
+          description: "The ticket status",
+          enum: [
+            "NEW",
+            "OPEN",
+            "PENDING",
+            "HOLD",
+            "SOLVED",
+            "CLOSED",
+            "DELETED",
+            "ARCHIVED",
+            "SCRUBBED",
+          ],
+        },
+        subject: {
+          type: "string",
+          description: "The ticket subject",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["low", "normal", "high", "urgent"],
+        },
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["problem", "incident", "question", "task"],
+        },
+        tags: {
+          type: "array",
+          description: "Tags associated with the ticket",
+          items: {
+            type: "string",
+          },
+        },
+        organization_id: {
+          type: "integer",
+          description: "The organization ID",
+        },
+        assignee_id: {
+          type: "integer",
+          description: "The assignee ID",
+        },
+        group_id: {
+          type: "integer",
+          description: "The group ID",
+        },
+        requester_id: {
+          type: "integer",
+          description: "The requester ID",
+        },
+      },
+    },
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_created.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_created.ts
@@ -39,12 +39,61 @@ export const ticketCreatedSchema: JSONSchema = {
       description: "Details about the ticket",
       properties: {
         actor_id: {
-          type: "integer",
+          type: "string",
           description: "The ID of the user who performed the action",
         },
+        assignee_id: {
+          type: "string",
+          description: "The assignee ID",
+        },
+        brand_id: {
+          type: "string",
+          description: "The brand ID",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        custom_status: {
+          type: "string",
+          description: "The custom status ID",
+        },
+        description: {
+          type: "string",
+          description: "The ticket description",
+        },
+        external_id: {
+          type: ["string", "null"],
+          description: "The external ID",
+        },
+        form_id: {
+          type: "string",
+          description: "The form ID",
+        },
+        group_id: {
+          type: "string",
+          description: "The group ID",
+        },
         id: {
-          type: "integer",
+          type: "string",
           description: "The ticket ID",
+        },
+        is_public: {
+          type: "boolean",
+          description: "Whether the ticket is public",
+        },
+        organization_id: {
+          type: ["string", "null"],
+          description: "The organization ID",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["LOW", "NORMAL", "HIGH", "URGENT"],
+        },
+        requester_id: {
+          type: "string",
+          description: "The requester ID",
         },
         status: {
           type: "string",
@@ -65,23 +114,9 @@ export const ticketCreatedSchema: JSONSchema = {
           type: "string",
           description: "The ticket subject",
         },
-        created_at: {
+        submitter_id: {
           type: "string",
-          description: "When the ticket was created",
-        },
-        updated_at: {
-          type: "string",
-          description: "When the ticket was last updated",
-        },
-        priority: {
-          type: "string",
-          description: "The ticket priority",
-          enum: ["low", "normal", "high", "urgent"],
-        },
-        type: {
-          type: "string",
-          description: "The ticket type",
-          enum: ["problem", "incident", "question", "task"],
+          description: "The submitter ID",
         },
         tags: {
           type: "array",
@@ -90,21 +125,24 @@ export const ticketCreatedSchema: JSONSchema = {
             type: "string",
           },
         },
-        organization_id: {
-          type: "integer",
-          description: "The organization ID",
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["PROBLEM", "INCIDENT", "QUESTION", "TASK"],
         },
-        assignee_id: {
-          type: "integer",
-          description: "The assignee ID",
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
         },
-        group_id: {
-          type: "integer",
-          description: "The group ID",
-        },
-        requester_id: {
-          type: "integer",
-          description: "The requester ID",
+        via: {
+          type: "object",
+          description: "Information about how the ticket was submitted",
+          properties: {
+            channel: {
+              type: "string",
+              description: "The channel through which the ticket was submitted",
+            },
+          },
         },
       },
     },

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_created.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_created.ts
@@ -1,0 +1,112 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+export const ticketCreatedSchema: JSONSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      description: "The event type",
+      const: "zen:event-type:ticket.created",
+    },
+    account_id: {
+      type: "integer",
+      description: "The Zendesk account ID",
+    },
+    id: {
+      type: "string",
+      description: "The unique event ID",
+    },
+    time: {
+      type: "string",
+      description: "The time the event occurred in ISO 8601 format",
+    },
+    zendesk_event_version: {
+      type: "string",
+      description: "The version of the Zendesk event schema",
+    },
+    subject: {
+      type: "string",
+      description: "The subject of the event",
+    },
+    event: {
+      type: "object",
+      description: "Event-specific data (empty for ticket.created)",
+      properties: {},
+    },
+    detail: {
+      type: "object",
+      description: "Details about the ticket",
+      properties: {
+        actor_id: {
+          type: "integer",
+          description: "The ID of the user who performed the action",
+        },
+        id: {
+          type: "integer",
+          description: "The ticket ID",
+        },
+        status: {
+          type: "string",
+          description: "The ticket status",
+          enum: [
+            "NEW",
+            "OPEN",
+            "PENDING",
+            "HOLD",
+            "SOLVED",
+            "CLOSED",
+            "DELETED",
+            "ARCHIVED",
+            "SCRUBBED",
+          ],
+        },
+        subject: {
+          type: "string",
+          description: "The ticket subject",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["low", "normal", "high", "urgent"],
+        },
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["problem", "incident", "question", "task"],
+        },
+        tags: {
+          type: "array",
+          description: "Tags associated with the ticket",
+          items: {
+            type: "string",
+          },
+        },
+        organization_id: {
+          type: "integer",
+          description: "The organization ID",
+        },
+        assignee_id: {
+          type: "integer",
+          description: "The assignee ID",
+        },
+        group_id: {
+          type: "integer",
+          description: "The group ID",
+        },
+        requester_id: {
+          type: "integer",
+          description: "The requester ID",
+        },
+      },
+    },
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_priority_changed.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_priority_changed.ts
@@ -1,0 +1,127 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+export const ticketPriorityChangedSchema: JSONSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      description: "The event type",
+      const: "zen:event-type:ticket.priority_changed",
+    },
+    account_id: {
+      type: "integer",
+      description: "The Zendesk account ID",
+    },
+    id: {
+      type: "string",
+      description: "The unique event ID",
+    },
+    time: {
+      type: "string",
+      description: "The time the event occurred in ISO 8601 format",
+    },
+    zendesk_event_version: {
+      type: "string",
+      description: "The version of the Zendesk event schema",
+    },
+    subject: {
+      type: "string",
+      description: "The subject of the event",
+    },
+    event: {
+      type: "object",
+      description: "Event-specific data about the priority change",
+      properties: {
+        current: {
+          type: "string",
+          description: "The current priority",
+          enum: ["LOW", "NORMAL", "HIGH", "URGENT"],
+        },
+        previous: {
+          type: "string",
+          description: "The previous priority",
+          enum: ["LOW", "NORMAL", "HIGH", "URGENT"],
+        },
+      },
+    },
+    detail: {
+      type: "object",
+      description: "Details about the ticket",
+      properties: {
+        actor_id: {
+          type: "integer",
+          description: "The ID of the user who performed the action",
+        },
+        id: {
+          type: "integer",
+          description: "The ticket ID",
+        },
+        status: {
+          type: "string",
+          description: "The ticket status",
+          enum: [
+            "NEW",
+            "OPEN",
+            "PENDING",
+            "HOLD",
+            "SOLVED",
+            "CLOSED",
+            "DELETED",
+            "ARCHIVED",
+            "SCRUBBED",
+          ],
+        },
+        subject: {
+          type: "string",
+          description: "The ticket subject",
+        },
+        description: {
+          type: "string",
+          description: "The ticket description",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["low", "normal", "high", "urgent"],
+        },
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["problem", "incident", "question", "task"],
+        },
+        tags: {
+          type: "array",
+          description: "Tags associated with the ticket",
+          items: {
+            type: "string",
+          },
+        },
+        organization_id: {
+          type: "integer",
+          description: "The organization ID",
+        },
+        assignee_id: {
+          type: "integer",
+          description: "The assignee ID",
+        },
+        group_id: {
+          type: "integer",
+          description: "The group ID",
+        },
+        requester_id: {
+          type: "integer",
+          description: "The requester ID",
+        },
+      },
+    },
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_priority_changed.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_priority_changed.ts
@@ -50,12 +50,61 @@ export const ticketPriorityChangedSchema: JSONSchema = {
       description: "Details about the ticket",
       properties: {
         actor_id: {
-          type: "integer",
+          type: "string",
           description: "The ID of the user who performed the action",
         },
+        assignee_id: {
+          type: "string",
+          description: "The assignee ID",
+        },
+        brand_id: {
+          type: "string",
+          description: "The brand ID",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        custom_status: {
+          type: "string",
+          description: "The custom status ID",
+        },
+        description: {
+          type: "string",
+          description: "The ticket description",
+        },
+        external_id: {
+          type: ["string", "null"],
+          description: "The external ID",
+        },
+        form_id: {
+          type: "string",
+          description: "The form ID",
+        },
+        group_id: {
+          type: "string",
+          description: "The group ID",
+        },
         id: {
-          type: "integer",
+          type: "string",
           description: "The ticket ID",
+        },
+        is_public: {
+          type: "boolean",
+          description: "Whether the ticket is public",
+        },
+        organization_id: {
+          type: ["string", "null"],
+          description: "The organization ID",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["LOW", "NORMAL", "HIGH", "URGENT"],
+        },
+        requester_id: {
+          type: "string",
+          description: "The requester ID",
         },
         status: {
           type: "string",
@@ -76,27 +125,9 @@ export const ticketPriorityChangedSchema: JSONSchema = {
           type: "string",
           description: "The ticket subject",
         },
-        description: {
+        submitter_id: {
           type: "string",
-          description: "The ticket description",
-        },
-        created_at: {
-          type: "string",
-          description: "When the ticket was created",
-        },
-        updated_at: {
-          type: "string",
-          description: "When the ticket was last updated",
-        },
-        priority: {
-          type: "string",
-          description: "The ticket priority",
-          enum: ["low", "normal", "high", "urgent"],
-        },
-        type: {
-          type: "string",
-          description: "The ticket type",
-          enum: ["problem", "incident", "question", "task"],
+          description: "The submitter ID",
         },
         tags: {
           type: "array",
@@ -105,21 +136,24 @@ export const ticketPriorityChangedSchema: JSONSchema = {
             type: "string",
           },
         },
-        organization_id: {
-          type: "integer",
-          description: "The organization ID",
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["PROBLEM", "INCIDENT", "QUESTION", "TASK"],
         },
-        assignee_id: {
-          type: "integer",
-          description: "The assignee ID",
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
         },
-        group_id: {
-          type: "integer",
-          description: "The group ID",
-        },
-        requester_id: {
-          type: "integer",
-          description: "The requester ID",
+        via: {
+          type: "object",
+          description: "Information about how the ticket was submitted",
+          properties: {
+            channel: {
+              type: "string",
+              description: "The channel through which the ticket was submitted",
+            },
+          },
         },
       },
     },

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_status_changed.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_status_changed.ts
@@ -1,0 +1,143 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+export const ticketStatusChangedSchema: JSONSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      description: "The event type",
+      const: "zen:event-type:ticket.status_changed",
+    },
+    account_id: {
+      type: "integer",
+      description: "The Zendesk account ID",
+    },
+    id: {
+      type: "string",
+      description: "The unique event ID",
+    },
+    time: {
+      type: "string",
+      description: "The time the event occurred in ISO 8601 format",
+    },
+    zendesk_event_version: {
+      type: "string",
+      description: "The version of the Zendesk event schema",
+    },
+    subject: {
+      type: "string",
+      description: "The subject of the event",
+    },
+    event: {
+      type: "object",
+      description: "Event-specific data about the status change",
+      properties: {
+        current: {
+          type: "string",
+          description: "The current status of the ticket",
+          enum: [
+            "NEW",
+            "OPEN",
+            "PENDING",
+            "HOLD",
+            "SOLVED",
+            "CLOSED",
+            "DELETED",
+            "ARCHIVED",
+            "SCRUBBED",
+          ],
+        },
+        previous: {
+          type: "string",
+          description: "The previous status of the ticket",
+          enum: [
+            "NEW",
+            "OPEN",
+            "PENDING",
+            "HOLD",
+            "SOLVED",
+            "CLOSED",
+            "DELETED",
+            "ARCHIVED",
+            "SCRUBBED",
+          ],
+        },
+      },
+    },
+    detail: {
+      type: "object",
+      description: "Details about the ticket",
+      properties: {
+        actor_id: {
+          type: "integer",
+          description: "The ID of the user who performed the action",
+        },
+        id: {
+          type: "integer",
+          description: "The ticket ID",
+        },
+        status: {
+          type: "string",
+          description: "The ticket status",
+          enum: [
+            "NEW",
+            "OPEN",
+            "PENDING",
+            "HOLD",
+            "SOLVED",
+            "CLOSED",
+            "DELETED",
+            "ARCHIVED",
+            "SCRUBBED",
+          ],
+        },
+        subject: {
+          type: "string",
+          description: "The ticket subject",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["low", "normal", "high", "urgent"],
+        },
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["problem", "incident", "question", "task"],
+        },
+        tags: {
+          type: "array",
+          description: "Tags associated with the ticket",
+          items: {
+            type: "string",
+          },
+        },
+        organization_id: {
+          type: "integer",
+          description: "The organization ID",
+        },
+        assignee_id: {
+          type: "integer",
+          description: "The assignee ID",
+        },
+        group_id: {
+          type: "integer",
+          description: "The group ID",
+        },
+        requester_id: {
+          type: "integer",
+          description: "The requester ID",
+        },
+      },
+    },
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_status_changed.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_status_changed.ts
@@ -70,12 +70,61 @@ export const ticketStatusChangedSchema: JSONSchema = {
       description: "Details about the ticket",
       properties: {
         actor_id: {
-          type: "integer",
+          type: "string",
           description: "The ID of the user who performed the action",
         },
+        assignee_id: {
+          type: "string",
+          description: "The assignee ID",
+        },
+        brand_id: {
+          type: "string",
+          description: "The brand ID",
+        },
+        created_at: {
+          type: "string",
+          description: "When the ticket was created",
+        },
+        custom_status: {
+          type: "string",
+          description: "The custom status ID",
+        },
+        description: {
+          type: "string",
+          description: "The ticket description",
+        },
+        external_id: {
+          type: ["string", "null"],
+          description: "The external ID",
+        },
+        form_id: {
+          type: "string",
+          description: "The form ID",
+        },
+        group_id: {
+          type: "string",
+          description: "The group ID",
+        },
         id: {
-          type: "integer",
+          type: "string",
           description: "The ticket ID",
+        },
+        is_public: {
+          type: "boolean",
+          description: "Whether the ticket is public",
+        },
+        organization_id: {
+          type: ["string", "null"],
+          description: "The organization ID",
+        },
+        priority: {
+          type: "string",
+          description: "The ticket priority",
+          enum: ["LOW", "NORMAL", "HIGH", "URGENT"],
+        },
+        requester_id: {
+          type: "string",
+          description: "The requester ID",
         },
         status: {
           type: "string",
@@ -96,23 +145,9 @@ export const ticketStatusChangedSchema: JSONSchema = {
           type: "string",
           description: "The ticket subject",
         },
-        created_at: {
+        submitter_id: {
           type: "string",
-          description: "When the ticket was created",
-        },
-        updated_at: {
-          type: "string",
-          description: "When the ticket was last updated",
-        },
-        priority: {
-          type: "string",
-          description: "The ticket priority",
-          enum: ["low", "normal", "high", "urgent"],
-        },
-        type: {
-          type: "string",
-          description: "The ticket type",
-          enum: ["problem", "incident", "question", "task"],
+          description: "The submitter ID",
         },
         tags: {
           type: "array",
@@ -121,21 +156,24 @@ export const ticketStatusChangedSchema: JSONSchema = {
             type: "string",
           },
         },
-        organization_id: {
-          type: "integer",
-          description: "The organization ID",
+        type: {
+          type: "string",
+          description: "The ticket type",
+          enum: ["PROBLEM", "INCIDENT", "QUESTION", "TASK"],
         },
-        assignee_id: {
-          type: "integer",
-          description: "The assignee ID",
+        updated_at: {
+          type: "string",
+          description: "When the ticket was last updated",
         },
-        group_id: {
-          type: "integer",
-          description: "The group ID",
-        },
-        requester_id: {
-          type: "integer",
-          description: "The requester ID",
+        via: {
+          type: "object",
+          description: "Information about how the ticket was submitted",
+          properties: {
+            channel: {
+              type: "string",
+              description: "The channel through which the ticket was submitted",
+            },
+          },
         },
       },
     },

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_user_created.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_user_created.ts
@@ -1,0 +1,76 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+export const userCreatedSchema: JSONSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      description: "The event type",
+      const: "zen:event-type:user.created",
+    },
+    account_id: {
+      type: "integer",
+      description: "The Zendesk account ID",
+    },
+    id: {
+      type: "string",
+      description: "The unique event ID",
+    },
+    time: {
+      type: "string",
+      description: "The time the event occurred in ISO 8601 format",
+    },
+    zendesk_event_version: {
+      type: "string",
+      description: "The version of the Zendesk event schema",
+    },
+    subject: {
+      type: "string",
+      description: "The subject of the event",
+    },
+    event: {
+      type: "object",
+      description: "Event-specific data (empty for user.created events)",
+      properties: {},
+    },
+    detail: {
+      type: "object",
+      description: "Details about the user",
+      properties: {
+        created_at: {
+          type: "string",
+          description: "When the user was created",
+        },
+        email: {
+          type: "string",
+          description: "The user's email address",
+        },
+        external_id: {
+          type: "string",
+          description: "The external ID of the user",
+        },
+        default_group_id: {
+          type: "string",
+          description: "The default group ID (returned as string)",
+        },
+        id: {
+          type: "string",
+          description: "The user ID (returned as string)",
+        },
+        organization_id: {
+          type: "string",
+          description: "The organization ID (returned as string)",
+        },
+        role: {
+          type: "string",
+          description: "The user's role",
+        },
+        updated_at: {
+          type: "string",
+          description: "When the user was last updated",
+        },
+      },
+    },
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const ZendeskAdditionalDataSchema = z.object({});
+
+export type ZendeskAdditionalData = z.infer<typeof ZendeskAdditionalDataSchema>;

--- a/front/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
-export const ZendeskAdditionalDataSchema = z.object({});
+export const ZendeskWebhookStoredMetadataSchema = z.object({
+  zendeskSubdomain: z.string().describe("The Zendesk subdomain"),
+  webhookId: z.string().describe("The ID of the created Zendesk webhook"),
+});
 
-export type ZendeskAdditionalData = z.infer<typeof ZendeskAdditionalDataSchema>;
+export type ZendeskWebhookStoredMetadata = z.infer<
+  typeof ZendeskWebhookStoredMetadataSchema
+>;

--- a/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_events.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_events.ts
@@ -1,0 +1,67 @@
+import { organizationCreatedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_organization_created";
+import { ticketAgentAssignmentChangedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_agent_assignment_changed";
+import { ticketCommentAddedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_comment_added";
+import { ticketCreatedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_created";
+import { ticketPriorityChangedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_priority_changed";
+import { ticketStatusChangedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_status_changed";
+import { userCreatedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_user_created";
+import type { WebhookEvent } from "@app/types/triggers/webhooks_source_preset";
+
+export const ZENDESK_TICKET_CREATED_EVENT: WebhookEvent = {
+  name: "ticket.created",
+  value: "zen:event-type:ticket.created",
+  description: "A ticket was created",
+  schema: ticketCreatedSchema,
+};
+
+export const ZENDESK_TICKET_COMMENT_ADDED_EVENT: WebhookEvent = {
+  name: "ticket.comment_added",
+  value: "zen:event-type:ticket.comment_added",
+  description: "A comment was added to a ticket",
+  schema: ticketCommentAddedSchema,
+};
+
+export const ZENDESK_TICKET_STATUS_CHANGED_EVENT: WebhookEvent = {
+  name: "ticket.status_changed",
+  value: "zen:event-type:ticket.status_changed",
+  description: "A ticket's status changed",
+  schema: ticketStatusChangedSchema,
+};
+
+export const ZENDESK_TICKET_PRIORITY_CHANGED_EVENT: WebhookEvent = {
+  name: "ticket.priority_changed",
+  value: "zen:event-type:ticket.priority_changed",
+  description: "A ticket's priority changed",
+  schema: ticketPriorityChangedSchema,
+};
+
+export const ZENDESK_TICKET_AGENT_ASSIGNMENT_CHANGED_EVENT: WebhookEvent = {
+  name: "ticket.agent_assignment_changed",
+  value: "zen:event-type:ticket.agent_assignment_changed",
+  description: "A ticket was reassigned to another agent",
+  schema: ticketAgentAssignmentChangedSchema,
+};
+
+export const ZENDESK_USER_CREATED_EVENT: WebhookEvent = {
+  name: "user.created",
+  value: "zen:event-type:user.created",
+  description: "A user was created",
+  schema: userCreatedSchema,
+};
+
+export const ZENDESK_ORGANIZATION_CREATED_EVENT: WebhookEvent = {
+  name: "organization.created",
+  value: "zen:event-type:organization.created",
+  description: "An organization was created",
+  schema: organizationCreatedSchema,
+};
+
+export const ZENDESK_WEBHOOK_EVENTS = [
+  ZENDESK_TICKET_CREATED_EVENT,
+  ZENDESK_TICKET_STATUS_CHANGED_EVENT,
+  ZENDESK_TICKET_COMMENT_ADDED_EVENT,
+  ZENDESK_TICKET_AGENT_ASSIGNMENT_CHANGED_EVENT,
+  ZENDESK_TICKET_PRIORITY_CHANGED_EVENT,
+  ZENDESK_USER_CREATED_EVENT,
+  ZENDESK_ORGANIZATION_CREATED_EVENT,
+];

--- a/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_service.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_service.ts
@@ -1,0 +1,217 @@
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import type { ZendeskAdditionalData } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types";
+import { ZENDESK_WEBHOOK_EVENTS } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_events";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, OAuthAPI, Ok } from "@app/types";
+import type { RemoteWebhookService } from "@app/types/triggers/remote_webhook_service";
+
+export class ZendeskWebhookService implements RemoteWebhookService<"zendesk"> {
+  async getServiceData(
+    _oauthToken: string
+  ): Promise<Result<ZendeskAdditionalData, Error>> {
+    // No additional data needed for Zendesk webhooks
+    return new Ok({});
+  }
+
+  async createWebhooks({
+    auth,
+    connectionId,
+    remoteMetadata,
+    webhookUrl,
+    events,
+    secret,
+  }: {
+    auth: Authenticator;
+    connectionId: string;
+    remoteMetadata: ZendeskAdditionalData;
+    webhookUrl: string;
+    events: string[];
+    secret?: string;
+  }): Promise<
+    Result<
+      {
+        updatedRemoteMetadata: Record<string, any>;
+        errors?: string[];
+      },
+      Error
+    >
+  > {
+    try {
+      const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), console);
+
+      // Verify the connection belongs to this workspace
+      const metadataRes = await oauthAPI.getConnectionMetadata({
+        connectionId,
+      });
+
+      if (metadataRes.isErr()) {
+        return new Err(new Error("Zendesk connection not found"));
+      }
+
+      const workspace = auth.getNonNullableWorkspace();
+
+      const workspaceId = metadataRes.value.connection.metadata.workspace_id;
+      if (!workspaceId || workspaceId !== workspace.sId) {
+        return new Err(
+          new Error("Connection does not belong to this workspace")
+        );
+      }
+
+      const zendeskSubdomain =
+        metadataRes.value.connection.metadata.zendesk_subdomain;
+      if (!zendeskSubdomain || typeof zendeskSubdomain !== "string") {
+        return new Err(new Error("Zendesk subdomain not found in connection"));
+      }
+
+      const tokenRes = await oauthAPI.getAccessToken({ connectionId });
+
+      if (tokenRes.isErr()) {
+        return new Err(new Error("Failed to get Zendesk access token"));
+      }
+
+      const accessToken = tokenRes.value.access_token;
+
+      // Map event names to Zendesk event type format using the preset
+      const eventMapping = Object.fromEntries(
+        ZENDESK_WEBHOOK_EVENTS.map((e) => [e.name, e.value])
+      );
+      const subscriptions = events.map((event) => eventMapping[event] || event);
+
+      // Create the webhook in Zendesk
+      const webhookPayload = {
+        webhook: {
+          name: `Dust Webhook - ${workspace.name}`,
+          endpoint: webhookUrl,
+          http_method: "POST",
+          request_format: "json",
+          status: "active",
+          subscriptions,
+          ...(secret && { signing_secret: { secret } }),
+        },
+      };
+
+      const response = await fetch(
+        `https://${zendeskSubdomain}.zendesk.com/api/v2/webhooks`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(webhookPayload),
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return new Err(
+          new Error(
+            `Failed to create Zendesk webhook: ${response.status} ${response.statusText} - ${errorText}`
+          )
+        );
+      }
+
+      const data = await response.json();
+      const webhookId = data.webhook?.id;
+
+      if (!webhookId) {
+        return new Err(
+          new Error("Webhook created but no ID returned from Zendesk")
+        );
+      }
+
+      return new Ok({
+        updatedRemoteMetadata: {
+          ...remoteMetadata,
+          webhookId: String(webhookId),
+          zendeskSubdomain,
+        },
+      });
+    } catch (error: any) {
+      return new Err(
+        new Error(error.message || "Failed to create Zendesk webhook")
+      );
+    }
+  }
+
+  async deleteWebhooks({
+    auth,
+    connectionId,
+    remoteMetadata,
+  }: {
+    auth: Authenticator;
+    connectionId: string;
+    remoteMetadata: Record<string, any>;
+  }): Promise<Result<void, Error>> {
+    try {
+      const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), console);
+
+      // Verify the connection belongs to this workspace
+      const metadataRes = await oauthAPI.getConnectionMetadata({
+        connectionId,
+      });
+
+      if (metadataRes.isErr()) {
+        return new Err(new Error("Zendesk connection not found"));
+      }
+
+      const workspace = auth.getNonNullableWorkspace();
+
+      const workspaceId = metadataRes.value.connection.metadata.workspace_id;
+      if (!workspaceId || workspaceId !== workspace.sId) {
+        return new Err(
+          new Error("Connection does not belong to this workspace")
+        );
+      }
+
+      const tokenRes = await oauthAPI.getAccessToken({
+        connectionId,
+      });
+
+      if (tokenRes.isErr()) {
+        return new Err(new Error("Failed to get Zendesk access token"));
+      }
+
+      const accessToken = tokenRes.value.access_token;
+
+      const webhookId = remoteMetadata.webhookId;
+      const zendeskSubdomain = remoteMetadata.zendeskSubdomain;
+
+      if (!webhookId) {
+        return new Err(new Error("Webhook ID not found in remote metadata"));
+      }
+
+      if (!zendeskSubdomain) {
+        return new Err(
+          new Error("Zendesk subdomain not found in remote metadata")
+        );
+      }
+
+      const response = await fetch(
+        `https://${zendeskSubdomain}.zendesk.com/api/v2/webhooks/${webhookId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        logger.warn(
+          `Failed to delete Zendesk webhook: ${response.status} ${response.statusText} - ${errorText}`
+        );
+      }
+
+      return new Ok(undefined);
+    } catch (error: any) {
+      return new Err(
+        new Error(error.message || "Failed to delete webhook from Zendesk")
+      );
+    }
+  }
+}

--- a/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_service.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_service.ts
@@ -1,17 +1,17 @@
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import type { ZendeskAdditionalData } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types";
+import type { ZendeskWebhookStoredMetadata } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types";
 import { ZENDESK_WEBHOOK_EVENTS } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_events";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, OAuthAPI, Ok } from "@app/types";
 import type { RemoteWebhookService } from "@app/types/triggers/remote_webhook_service";
+import type { NoAdditionalData } from "@app/types/triggers/webhooks";
 
 export class ZendeskWebhookService implements RemoteWebhookService<"zendesk"> {
   async getServiceData(
     _oauthToken: string
-  ): Promise<Result<ZendeskAdditionalData, Error>> {
-    // No additional data needed for Zendesk webhooks
+  ): Promise<Result<NoAdditionalData, Error>> {
     return new Ok({});
   }
 
@@ -25,115 +25,107 @@ export class ZendeskWebhookService implements RemoteWebhookService<"zendesk"> {
   }: {
     auth: Authenticator;
     connectionId: string;
-    remoteMetadata: ZendeskAdditionalData;
+    remoteMetadata: NoAdditionalData;
     webhookUrl: string;
     events: string[];
     secret?: string;
   }): Promise<
     Result<
       {
-        updatedRemoteMetadata: Record<string, any>;
+        updatedRemoteMetadata: ZendeskWebhookStoredMetadata;
         errors?: string[];
       },
       Error
     >
   > {
-    try {
-      const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), console);
+    const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
-      // Verify the connection belongs to this workspace
-      const metadataRes = await oauthAPI.getConnectionMetadata({
-        connectionId,
-      });
+    // Verify the connection belongs to this workspace
+    const metadataRes = await oauthAPI.getConnectionMetadata({
+      connectionId,
+    });
 
-      if (metadataRes.isErr()) {
-        return new Err(new Error("Zendesk connection not found"));
-      }
+    if (metadataRes.isErr()) {
+      return new Err(new Error("Zendesk connection not found"));
+    }
 
-      const workspace = auth.getNonNullableWorkspace();
+    const workspace = auth.getNonNullableWorkspace();
 
-      const workspaceId = metadataRes.value.connection.metadata.workspace_id;
-      if (!workspaceId || workspaceId !== workspace.sId) {
-        return new Err(
-          new Error("Connection does not belong to this workspace")
-        );
-      }
+    const workspaceId = metadataRes.value.connection.metadata.workspace_id;
+    if (!workspaceId || workspaceId !== workspace.sId) {
+      return new Err(new Error("Connection does not belong to this workspace"));
+    }
 
-      const zendeskSubdomain =
-        metadataRes.value.connection.metadata.zendesk_subdomain;
-      if (!zendeskSubdomain || typeof zendeskSubdomain !== "string") {
-        return new Err(new Error("Zendesk subdomain not found in connection"));
-      }
+    const zendeskSubdomain =
+      metadataRes.value.connection.metadata.zendesk_subdomain;
+    if (!zendeskSubdomain || typeof zendeskSubdomain !== "string") {
+      return new Err(new Error("Zendesk subdomain not found in connection"));
+    }
 
-      const tokenRes = await oauthAPI.getAccessToken({ connectionId });
+    const tokenRes = await oauthAPI.getAccessToken({ connectionId });
 
-      if (tokenRes.isErr()) {
-        return new Err(new Error("Failed to get Zendesk access token"));
-      }
+    if (tokenRes.isErr()) {
+      return new Err(new Error("Failed to get Zendesk access token"));
+    }
 
-      const accessToken = tokenRes.value.access_token;
+    const accessToken = tokenRes.value.access_token;
 
-      // Map event names to Zendesk event type format using the preset
-      const eventMapping = Object.fromEntries(
-        ZENDESK_WEBHOOK_EVENTS.map((e) => [e.name, e.value])
-      );
-      const subscriptions = events.map((event) => eventMapping[event] || event);
+    // Map event names to Zendesk event type format using the preset
+    const eventMapping = Object.fromEntries(
+      ZENDESK_WEBHOOK_EVENTS.map((e) => [e.name, e.value])
+    );
+    const subscriptions = events.map((event) => eventMapping[event] || event);
 
-      // Create the webhook in Zendesk
-      const webhookPayload = {
-        webhook: {
-          name: `Dust Webhook - ${workspace.name}`,
-          endpoint: webhookUrl,
-          http_method: "POST",
-          request_format: "json",
-          status: "active",
-          subscriptions,
-          ...(secret && { signing_secret: { secret } }),
+    // Create the webhook in Zendesk
+    const webhookPayload = {
+      webhook: {
+        name: `Dust Webhook - ${workspace.name}`,
+        endpoint: webhookUrl,
+        http_method: "POST",
+        request_format: "json",
+        status: "active",
+        subscriptions,
+        ...(secret && { signing_secret: { secret } }),
+      },
+    };
+
+    const response = await fetch(
+      `https://${zendeskSubdomain}.zendesk.com/api/v2/webhooks`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
         },
-      };
-
-      const response = await fetch(
-        `https://${zendeskSubdomain}.zendesk.com/api/v2/webhooks`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(webhookPayload),
-        }
-      );
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        return new Err(
-          new Error(
-            `Failed to create Zendesk webhook: ${response.status} ${response.statusText} - ${errorText}`
-          )
-        );
+        body: JSON.stringify(webhookPayload),
       }
+    );
 
-      const data = await response.json();
-      const webhookId = data.webhook?.id;
-
-      if (!webhookId) {
-        return new Err(
-          new Error("Webhook created but no ID returned from Zendesk")
-        );
-      }
-
-      return new Ok({
-        updatedRemoteMetadata: {
-          ...remoteMetadata,
-          webhookId: String(webhookId),
-          zendeskSubdomain,
-        },
-      });
-    } catch (error: any) {
+    if (!response.ok) {
+      const errorText = await response.text();
       return new Err(
-        new Error(error.message || "Failed to create Zendesk webhook")
+        new Error(
+          `Failed to create Zendesk webhook: ${response.status} ${response.statusText} - ${errorText}`
+        )
       );
     }
+
+    const data = await response.json();
+    const webhookId = data.webhook?.id;
+
+    if (!webhookId) {
+      return new Err(
+        new Error("Webhook created but no ID returned from Zendesk")
+      );
+    }
+
+    return new Ok({
+      updatedRemoteMetadata: {
+        ...remoteMetadata,
+        webhookId: String(webhookId),
+        zendeskSubdomain,
+      },
+    });
   }
 
   async deleteWebhooks({
@@ -143,75 +135,67 @@ export class ZendeskWebhookService implements RemoteWebhookService<"zendesk"> {
   }: {
     auth: Authenticator;
     connectionId: string;
-    remoteMetadata: Record<string, any>;
+    remoteMetadata: ZendeskWebhookStoredMetadata;
   }): Promise<Result<void, Error>> {
-    try {
-      const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), console);
+    const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
-      // Verify the connection belongs to this workspace
-      const metadataRes = await oauthAPI.getConnectionMetadata({
-        connectionId,
-      });
+    // Verify the connection belongs to this workspace
+    const metadataRes = await oauthAPI.getConnectionMetadata({
+      connectionId,
+    });
 
-      if (metadataRes.isErr()) {
-        return new Err(new Error("Zendesk connection not found"));
-      }
+    if (metadataRes.isErr()) {
+      return new Err(new Error("Zendesk connection not found"));
+    }
 
-      const workspace = auth.getNonNullableWorkspace();
+    const workspace = auth.getNonNullableWorkspace();
 
-      const workspaceId = metadataRes.value.connection.metadata.workspace_id;
-      if (!workspaceId || workspaceId !== workspace.sId) {
-        return new Err(
-          new Error("Connection does not belong to this workspace")
-        );
-      }
+    const workspaceId = metadataRes.value.connection.metadata.workspace_id;
+    if (!workspaceId || workspaceId !== workspace.sId) {
+      return new Err(new Error("Connection does not belong to this workspace"));
+    }
 
-      const tokenRes = await oauthAPI.getAccessToken({
-        connectionId,
-      });
+    const tokenRes = await oauthAPI.getAccessToken({
+      connectionId,
+    });
 
-      if (tokenRes.isErr()) {
-        return new Err(new Error("Failed to get Zendesk access token"));
-      }
+    if (tokenRes.isErr()) {
+      return new Err(new Error("Failed to get Zendesk access token"));
+    }
 
-      const accessToken = tokenRes.value.access_token;
+    const accessToken = tokenRes.value.access_token;
 
-      const webhookId = remoteMetadata.webhookId;
-      const zendeskSubdomain = remoteMetadata.zendeskSubdomain;
+    const webhookId = remoteMetadata.webhookId;
+    const zendeskSubdomain = remoteMetadata.zendeskSubdomain;
 
-      if (!webhookId) {
-        return new Err(new Error("Webhook ID not found in remote metadata"));
-      }
+    if (!webhookId) {
+      return new Err(new Error("Webhook ID not found in remote metadata"));
+    }
 
-      if (!zendeskSubdomain) {
-        return new Err(
-          new Error("Zendesk subdomain not found in remote metadata")
-        );
-      }
-
-      const response = await fetch(
-        `https://${zendeskSubdomain}.zendesk.com/api/v2/webhooks/${webhookId}`,
-        {
-          method: "DELETE",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/json",
-          },
-        }
-      );
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        logger.warn(
-          `Failed to delete Zendesk webhook: ${response.status} ${response.statusText} - ${errorText}`
-        );
-      }
-
-      return new Ok(undefined);
-    } catch (error: any) {
+    if (!zendeskSubdomain) {
       return new Err(
-        new Error(error.message || "Failed to delete webhook from Zendesk")
+        new Error("Zendesk subdomain not found in remote metadata")
       );
     }
+
+    const response = await fetch(
+      `https://${zendeskSubdomain}.zendesk.com/api/v2/webhooks/${webhookId}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.warn(
+        `Failed to delete Zendesk webhook: ${response.status} ${response.statusText} - ${errorText}`
+      );
+    }
+
+    return new Ok(undefined);
   }
 }

--- a/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_source_presets.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_source_presets.ts
@@ -1,0 +1,27 @@
+import { ZendeskLogo } from "@dust-tt/sparkle";
+
+import { ZendeskOAuthExtraConfig } from "@app/components/data_source/ZendeskOAuthExtraConfig";
+import { CreateWebhookZendeskConnection } from "@app/lib/triggers/built-in-webhooks/zendesk/components/CreateWebhookZendeskConnection";
+import { WebhookSourceZendeskDetails } from "@app/lib/triggers/built-in-webhooks/zendesk/components/WebhookSourceZendeskDetails";
+import { ZENDESK_WEBHOOK_EVENTS } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_events";
+import { ZendeskWebhookService } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_service";
+import type { PresetWebhook } from "@app/types/triggers/webhooks_source_preset";
+
+export const ZENDESK_WEBHOOK_PRESET: PresetWebhook<"zendesk"> = {
+  name: "Zendesk",
+  eventCheck: {
+    type: "body",
+    field: "type",
+  },
+  events: ZENDESK_WEBHOOK_EVENTS,
+  icon: ZendeskLogo,
+  description:
+    "Receive events from Zendesk such as ticket creation or modification",
+  featureFlag: "hootl_dev_webhooks",
+  webhookService: new ZendeskWebhookService(),
+  components: {
+    detailsComponent: WebhookSourceZendeskDetails,
+    createFormComponent: CreateWebhookZendeskConnection,
+    oauthExtraConfigInput: ZendeskOAuthExtraConfig,
+  },
+};

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -8,7 +8,6 @@ import type { GithubAdditionalData } from "@app/lib/triggers/built-in-webhooks/g
 import { GITHUB_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/github/github_webhook_source_presets";
 import type { TestServiceData } from "@app/lib/triggers/built-in-webhooks/test/test_webhook_source_presets";
 import { TEST_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/test/test_webhook_source_presets";
-import type { ZendeskAdditionalData } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types";
 import { ZENDESK_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_source_presets";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -34,10 +33,13 @@ export function isWebhookProvider(
   return WEBHOOK_PROVIDERS.includes(provider as WebhookProvider);
 }
 
+export const NoAdditionalDataSchema = z.object({});
+export type NoAdditionalData = z.infer<typeof NoAdditionalDataSchema>;
+
 type WebhookProviderServiceDataMap = {
   github: GithubAdditionalData;
   test: TestServiceData;
-  zendesk: ZendeskAdditionalData;
+  zendesk: NoAdditionalData;
 };
 
 export type WebhookServiceDataForProvider<P extends WebhookProvider> =

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -8,6 +8,8 @@ import type { GithubAdditionalData } from "@app/lib/triggers/built-in-webhooks/g
 import { GITHUB_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/github/github_webhook_source_presets";
 import type { TestServiceData } from "@app/lib/triggers/built-in-webhooks/test/test_webhook_source_presets";
 import { TEST_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/test/test_webhook_source_presets";
+import type { ZendeskAdditionalData } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_service_types";
+import { ZENDESK_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_source_presets";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { PresetWebhook } from "@app/types/triggers/webhooks_source_preset";
@@ -22,7 +24,7 @@ export const WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS = [
 export type WebhookSourceSignatureAlgorithm =
   (typeof WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS)[number];
 
-export const WEBHOOK_PROVIDERS = ["test", "github"] as const;
+export const WEBHOOK_PROVIDERS = ["test", "github", "zendesk"] as const;
 
 export type WebhookProvider = (typeof WEBHOOK_PROVIDERS)[number];
 
@@ -35,6 +37,7 @@ export function isWebhookProvider(
 type WebhookProviderServiceDataMap = {
   github: GithubAdditionalData;
   test: TestServiceData;
+  zendesk: ZendeskAdditionalData;
 };
 
 export type WebhookServiceDataForProvider<P extends WebhookProvider> =
@@ -43,6 +46,7 @@ export type WebhookServiceDataForProvider<P extends WebhookProvider> =
 export const WEBHOOK_PRESETS = {
   github: GITHUB_WEBHOOK_PRESET,
   test: TEST_WEBHOOK_PRESET,
+  zendesk: ZENDESK_WEBHOOK_PRESET,
 } satisfies {
   [P in WebhookProvider]: PresetWebhook<P>;
 };

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -7,6 +7,7 @@ import type {
   WebhookCreateFormComponentProps,
   WebhookDetailsComponentProps,
 } from "@app/components/triggers/webhook_preset_components";
+import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { RemoteWebhookService } from "@app/types/triggers/remote_webhook_service";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";
@@ -43,5 +44,6 @@ export type PresetWebhook<P extends WebhookProvider = WebhookProvider> = {
   components: {
     detailsComponent: React.ComponentType<WebhookDetailsComponentProps>;
     createFormComponent: React.ComponentType<WebhookCreateFormComponentProps>;
+    oauthExtraConfigInput?: React.ComponentType<ConnectorOauthExtraConfigProps>;
   };
 };


### PR DESCRIPTION
## Description

Add the webhook preset for zendesk
It requires to support extra config for oauth

I have asked dust+god to analyse all the events and give me the one which are the more interesting for dust users
Other events can easily be added on request later on

The PR looks big but is it mostly the schemas of the events

## Tests

manual test to register webhook and receive event

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front