### PR TITLE
[front] Fix view filter in `find` tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -369,7 +369,7 @@ function createServer(
         } else if (rootNodeId) {
           viewFilter = viewFilter.map((view) => ({
             ...view,
-            view_filter: [rootNodeId],
+            filter: [rootNodeId],
           }));
         }
 


### PR DESCRIPTION
## Description

- This PR overrides the filter instead of the view filter in the find tool (code path where we have a root node id) in order to ensure that we preserve the view filter.
- This is an unreachable path because it is not possible to configure a data source outside of its data source view.
- No expected change in behavior, the two filters are actually redundant and the most restrictive filter of all will always be the one on `[rootNodeId]`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
