### PR TITLE
[front] enh(FS tools): refactor filter composition

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -354,7 +354,7 @@ function createServer(
 
         // If rootNodeId is provided and is a data source node ID, search only in
         // the data source. If rootNodeId is provided and is a regular node ID,
-        // reset all view_filters to this node, so only descendents of this node
+        // add this node to all filters so that only descendents of this node
         // are searched. It is not straightforward to guess which data source it
         // belongs to, this is why irrelevant data sources are not directly
         // filtered out.
@@ -369,7 +369,7 @@ function createServer(
         } else if (rootNodeId) {
           viewFilter = viewFilter.map((view) => ({
             ...view,
-            filter: [rootNodeId],
+            filter: view.filter ? [...view.filter, rootNodeId] : [rootNodeId],
           }));
         }
 


### PR DESCRIPTION
## Description

- This PR refactors the way filters are combined in the data source `find` filesystem tool to always append to existing arrays instead of overriding them.
- The idea is that we never want to override an existing value.
- No change in behavior expected since the filters are redundant, but more explicit when reading that all filters are append-only.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
