### PR TITLE
[front] refactor(webhooks): move body validation schemas in endpoints 

### DIFF
--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -19,17 +19,22 @@ import { CreateWebhookSourceWithProviderForm } from "@app/components/triggers/Cr
 import type { LightWorkspaceType } from "@app/types";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";
 import {
-  basePostWebhookSourcesSchema,
-  refineSubscribedEvents,
   WEBHOOK_PRESETS,
   WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS,
+  WebhookSourcesSchema,
 } from "@app/types/triggers/webhooks";
 
-export const CreateWebhookSourceSchema = basePostWebhookSourcesSchema
-  .extend({
-    autoGenerate: z.boolean().default(true),
-  })
-  .refine(...refineSubscribedEvents)
+export const CreateWebhookSourceSchema = WebhookSourcesSchema.extend({
+  autoGenerate: z.boolean().default(true),
+})
+  .refine(
+    ({ provider, subscribedEvents }) =>
+      !provider || subscribedEvents.length > 0,
+    {
+      message: "Subscribed events must not be empty.",
+      path: ["subscribedEvents"],
+    }
+  )
   .refine(
     (data) => data.autoGenerate || (data.secret ?? "").trim().length > 0,
     {

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -5,16 +5,18 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetWebhookRequestsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/webhook_requests";
 import type { GetWebhookSourceViewsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views";
-import type { GetWebhookSourcesResponseBody } from "@app/pages/api/w/[wId]/webhook_sources";
+import type {
+  GetWebhookSourcesResponseBody,
+  PostWebhookSourcesBody,
+} from "@app/pages/api/w/[wId]/webhook_sources";
 import type { DeleteWebhookSourceResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/[webhookSourceId]";
 import type { GetWebhookSourceViewsResponseBody as GetSpecificWebhookSourceViewsResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views";
 import type { GetWebhookSourceViewsListResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/views";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type {
-  PostWebhookSourcesBody,
   WebhookSourceForAdminType,
   WebhookSourceViewForAdminType,
+  WebhookSourceViewType,
 } from "@app/types/triggers/webhooks";
 
 export function useWebhookSourceViews({

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 import type {
   CustomResourceIconType,
@@ -14,7 +15,15 @@ import { apiError } from "@app/logger/withlogging";
 import type { Result, WithAPIErrorResponse } from "@app/types";
 import { assertNever, Err, Ok } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
-import { patchWebhookSourceViewBodySchema } from "@app/types/triggers/webhooks";
+
+const PatchWebhookSourceViewBodySchema = z.object({
+  name: z.string().min(1, "Name is required."),
+  description: z
+    .string()
+    .max(4000, "Description must be at most 4000 characters.")
+    .optional(),
+  icon: z.string().optional(),
+});
 
 export type GetWebhookSourceViewResponseBody = {
   webhookSourceView: WebhookSourceViewType;
@@ -96,7 +105,7 @@ async function handler(
           },
         });
       }
-      const bodyValidation = patchWebhookSourceViewBodySchema.safeParse(
+      const bodyValidation = PatchWebhookSourceViewBodySchema.safeParse(
         req.body
       );
       if (!bodyValidation.success) {

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -112,7 +112,7 @@ export type WebhookSourceWithSystemViewAndUsageType =
     usage: AgentsUsageType | null;
   };
 
-export const basePostWebhookSourcesSchema = z.object({
+export const WebhookSourcesSchema = z.object({
   name: z.string().min(1, "Name is required"),
   // Secret can be omitted or empty when auto-generated server-side.
   secret: z.string().nullable(),
@@ -124,46 +124,4 @@ export const basePostWebhookSourcesSchema = z.object({
   // Optional fields for creating remote webhooks
   connectionId: z.string().optional(),
   remoteMetadata: z.record(z.any()).optional(),
-});
-
-export const refineSubscribedEvents: [
-  (data: {
-    provider: WebhookProvider | null;
-    subscribedEvents: string[];
-  }) => boolean,
-  {
-    message: string;
-    path: string[];
-  },
-] = [
-  ({
-    provider,
-    subscribedEvents,
-  }: {
-    provider: WebhookProvider | null;
-    subscribedEvents: string[];
-  }) => !provider || subscribedEvents.length > 0,
-  {
-    message: "Subscribed events must not be empty.",
-    path: ["subscribedEvents"],
-  },
-];
-
-export const postWebhookSourcesSchema = basePostWebhookSourcesSchema.refine(
-  ...refineSubscribedEvents
-);
-
-export type PostWebhookSourcesBody = z.infer<typeof postWebhookSourcesSchema>;
-
-export type PatchWebhookSourceViewBody = z.infer<
-  typeof patchWebhookSourceViewBodySchema
->;
-
-export const patchWebhookSourceViewBodySchema = z.object({
-  name: z.string().min(1, "Name is required."),
-  description: z
-    .string()
-    .max(4000, "Description must be at most 4000 characters.")
-    .optional(),
-  icon: z.string().optional(),
 });

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -1,4 +1,3 @@
-import type { Icon } from "@dust-tt/sparkle";
 import { z } from "zod";
 
 import type {
@@ -10,7 +9,6 @@ import { GITHUB_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/githu
 import type { TestServiceData } from "@app/lib/triggers/built-in-webhooks/test/test_webhook_source_presets";
 import { TEST_WEBHOOK_PRESET } from "@app/lib/triggers/built-in-webhooks/test/test_webhook_source_presets";
 import type { AgentsUsageType } from "@app/types/data_source";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { PresetWebhook } from "@app/types/triggers/webhooks_source_preset";
 import type { EditedByUser } from "@app/types/user";
@@ -33,12 +31,6 @@ export function isWebhookProvider(
 ): provider is WebhookProvider {
   return WEBHOOK_PROVIDERS.includes(provider as WebhookProvider);
 }
-
-export type CustomPresetType = {
-  name: string;
-  icon: typeof Icon;
-  featureFlag?: WhitelistableFeature;
-};
 
 type WebhookProviderServiceDataMap = {
   github: GithubAdditionalData;
@@ -87,6 +79,7 @@ type BaseWebhookSourceViewType = {
   spaceId: string;
   editedByUser: EditedByUser | null;
 };
+
 export type WebhookSourceViewType = BaseWebhookSourceViewType & {
   webhookSource: WebhookSourceType;
 };


### PR DESCRIPTION
## Description

- This PR moves the Zod schemas used to validate bodies of endpoints in the corresponding handlers instead of having them in `app/types`.
- The `refineSubscribedEvents` schema refinement is also moved: inlined in the hook form in `CreateWebhookSourceForm` and replaced with a runtime check in the endpoint.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
