### PR TITLE
[front] fix(webhooks): remove incorrect loading spinner

### DIFF
--- a/front/lib/swr/useWebhookServiceData.ts
+++ b/front/lib/swr/useWebhookServiceData.ts
@@ -26,7 +26,7 @@ export function useWebhookServiceData({
 
   return {
     serviceData: data?.serviceData ?? null,
-    isServiceDataLoading: !error && !data,
+    isServiceDataLoading: !error && !data && connectionId,
     isTagsError: !!error,
     mutateServiceData: mutate,
   };

--- a/front/lib/swr/useWebhookServiceData.ts
+++ b/front/lib/swr/useWebhookServiceData.ts
@@ -27,7 +27,7 @@ export function useWebhookServiceData({
   return {
     serviceData: data?.serviceData ?? null,
     isServiceDataLoading: !error && !data && connectionId,
-    isTagsError: !!error,
+    isServiceDataError: !!error,
     mutateServiceData: mutate,
   };
 }


### PR DESCRIPTION
## Description

- We currently have a loading spinner in `CreateWebhookGithubConnection` even if we haven't setup the connection yet.
- This PR fixes that.
- Also fixes a minor naming issue.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
