### PR TITLE
[front] Add categorization on OpenAI error messages

### DIFF
--- a/front/lib/api/assistant/errors.ts
+++ b/front/lib/api/assistant/errors.ts
@@ -60,7 +60,10 @@ export const categorizeAgentErrorMessage = (error: {
             "Anthropic (Claude's provider) encountered an error. Please try again.",
         };
       }
-    } else if (error.message.includes("OpenAIError")) {
+    } else if (
+      error.message.includes("OpenAIError") ||
+      error.message.includes("OpenAI: Response failed")
+    ) {
       if (error.message.includes("maximum context length")) {
         return {
           category: "context_window_exceeded",
@@ -80,6 +83,19 @@ export const categorizeAgentErrorMessage = (error: {
       } else if (error.message.includes("server_error")) {
         return {
           category: "provider_internal_error",
+          errorTitle: "OpenAI server error",
+          publicMessage: "OpenAI encountered an error. Please try again.",
+        };
+      } else if (
+        error.message.includes(
+          "An error occurred while processing your request."
+        ) &&
+        error.message.includes(
+          "contact us through our help center at help.openai.com if the error persists"
+        )
+      ) {
+        return {
+          category: "retryable_model_error",
           errorTitle: "OpenAI server error",
           publicMessage: "OpenAI encountered an error. Please try again.",
         };

--- a/front/lib/api/assistant/errors.ts
+++ b/front/lib/api/assistant/errors.ts
@@ -30,7 +30,7 @@ export const categorizeAgentErrorMessage = (error: {
   errorTitle: string;
   publicMessage: string;
 } => {
-  if (error.code == "multi_actions_error") {
+  if (error.code === "multi_actions_error") {
     if (error.message.includes("AnthropicError")) {
       if (
         error.message.includes("overloaded_error") ||


### PR DESCRIPTION
## Description

- We are observing a surge in errors from OpenAI in EU ([logs](https://app.datadoghq.eu/logs?query=%40action%3Aassistant-v2-multi-actions-agent%20status%3Aerror%20%40error%3A%2AOpenAI%5C%3A%5C%20Response%5C%20failed%5C%3A%5C%20An%5C%20error%5C%20occurred%5C%20while%5C%20processing%5C%20your%5C%20request.%2A&agg_m=count&agg_m_source=base&agg_q=%40model.model_id&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2C%40model.model_id%2C%40workspace.sId%2C%40error&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1760865893059&to_ts=1761470693059&live=true)).
- As a first step, this PR categorizes these errors for a nicer display in `ErrorMessage`.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
