### PR TITLE
[front] fix(webhooks): simplify `WebhookSourceResource.makeNew` method

### DIFF
--- a/front/lib/resources/webhook_request_resource.test.ts
+++ b/front/lib/resources/webhook_request_resource.test.ts
@@ -30,24 +30,18 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
 
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
-
       // Create 4 webhook requests (exceeds custom limit of 3)
-      const requests: Array<{
+      const requests: {
         workspaceId: number;
         webhookSourceId: number;
         status: WebhookRequestStatus;
         createdAt: Date;
         updatedAt: Date;
-      }> = [];
+      }[] = [];
       for (let i = 0; i < 4; i++) {
         requests.push({
           workspaceId: workspace.id,
@@ -75,24 +69,18 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
 
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
-
       // Create 4 webhook requests
-      const requests: Array<{
+      const requests: {
         workspaceId: number;
         webhookSourceId: number;
         status: WebhookRequestStatus;
         createdAt: Date;
         updatedAt: Date;
-      }> = [];
+      }[] = [];
       for (let i = 0; i < 4; i++) {
         requests.push({
           workspaceId: workspace.id,
@@ -121,15 +109,9 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
-
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
 
       // Create a webhook request from 40 days ago (beyond 30 day TTL)
       const oldDate = new Date();
@@ -159,15 +141,9 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
-
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
 
       // Create a webhook request from 20 days ago (within 30 day TTL)
       const recentDate = new Date();
@@ -208,36 +184,24 @@ describe("WebhookRequestResource", () => {
       const factory2 = new WebhookSourceFactory(workspace2);
       const factory3 = new WebhookSourceFactory(workspace3);
 
-      const source1Result = await factory1.create({
+      const webhookSource1 = await factory1.create({
         name: "Test Webhook Source 1",
       });
-      const source2Result = await factory2.create({
+      const webhookSource2 = await factory2.create({
         name: "Test Webhook Source 2",
       });
-      const source3Result = await factory3.create({
+      const webhookSource3 = await factory3.create({
         name: "Test Webhook Source 3",
       });
 
-      if (
-        source1Result.isErr() ||
-        source2Result.isErr() ||
-        source3Result.isErr()
-      ) {
-        throw new Error("Failed to create webhook sources");
-      }
-
-      const webhookSource1 = source1Result.value;
-      const webhookSource2 = source2Result.value;
-      const webhookSource3 = source3Result.value;
-
       // Workspace 1: Create 4 requests (exceeds limit of 3)
-      const requests1: Array<{
+      const requests1: {
         workspaceId: number;
         webhookSourceId: number;
         status: WebhookRequestStatus;
         createdAt: Date;
         updatedAt: Date;
-      }> = [];
+      }[] = [];
       for (let i = 0; i < 4; i++) {
         requests1.push({
           workspaceId: workspace1.id,
@@ -250,13 +214,13 @@ describe("WebhookRequestResource", () => {
       await WebhookRequestModel.bulkCreate(requests1);
 
       // Workspace 2: Create 2 requests (within limit of 3)
-      const requests2: Array<{
+      const requests2: {
         workspaceId: number;
         webhookSourceId: number;
         status: WebhookRequestStatus;
         createdAt: Date;
         updatedAt: Date;
-      }> = [];
+      }[] = [];
       for (let i = 0; i < 2; i++) {
         requests2.push({
           workspaceId: workspace2.id,
@@ -304,19 +268,12 @@ describe("WebhookRequestResource", () => {
       const factory1 = new WebhookSourceFactory(workspace1);
       const factory2 = new WebhookSourceFactory(workspace2);
 
-      const source1Result = await factory1.create({
+      const webhookSource1 = await factory1.create({
         name: "Test Webhook Source 1",
       });
-      const source2Result = await factory2.create({
+      const webhookSource2 = await factory2.create({
         name: "Test Webhook Source 2",
       });
-
-      if (source1Result.isErr() || source2Result.isErr()) {
-        throw new Error("Failed to create webhook sources");
-      }
-
-      const webhookSource1 = source1Result.value;
-      const webhookSource2 = source2Result.value;
 
       // Create old requests in both workspaces
       const oldDate = new Date();
@@ -364,15 +321,9 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
-
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
 
       // Create requests with different statuses
       const statuses: WebhookRequestStatus[] = [
@@ -380,13 +331,13 @@ describe("WebhookRequestResource", () => {
         "processed",
         "failed",
       ];
-      const requests: Array<{
+      const requests: {
         workspaceId: number;
         webhookSourceId: number;
         status: WebhookRequestStatus;
         createdAt: Date;
         updatedAt: Date;
-      }> = [];
+      }[] = [];
       // Create 2 requests
       for (let i = 0; i < 2; i++) {
         requests.push({
@@ -427,24 +378,18 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
 
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
-
       // Create 4 requests
-      const requests: Array<{
+      const requests: {
         workspaceId: number;
         webhookSourceId: number;
         status: WebhookRequestStatus;
         createdAt: Date;
         updatedAt: Date;
-      }> = [];
+      }[] = [];
       for (let i = 0; i < 4; i++) {
         requests.push({
           workspaceId: workspace.id,
@@ -472,24 +417,18 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
 
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
-
       // Create exactly 3 requests (at the limit, should NOT be returned)
-      const requests: Array<{
+      const requests: {
         workspaceId: number;
         webhookSourceId: number;
         status: WebhookRequestStatus;
         createdAt: Date;
         updatedAt: Date;
-      }> = [];
+      }[] = [];
       for (let i = 0; i < 3; i++) {
         requests.push({
           workspaceId: workspace.id,
@@ -537,15 +476,9 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
-
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
 
       // Create a recent request (should NOT be deleted)
       const recentRequest = await WebhookRequestModel.create({
@@ -594,15 +527,9 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
-
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
 
       // Create 5 recent requests with distinct timestamps
       for (let i = 0; i < 5; i++) {
@@ -643,15 +570,9 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
-
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
 
       // Create 3 old requests
       const oldDate = new Date();
@@ -667,16 +588,14 @@ describe("WebhookRequestResource", () => {
       }
 
       // Create 5 recent requests
-      const recentIds: number[] = [];
       for (let i = 0; i < 5; i++) {
-        const request = await WebhookRequestModel.create({
+        await WebhookRequestModel.create({
           workspaceId: workspace.id,
           webhookSourceId: webhookSource.id,
           status: "received",
           createdAt: new Date(),
           updatedAt: new Date(),
         });
-        recentIds.push(request.id);
       }
 
       // Verify all 8 requests exist
@@ -705,15 +624,9 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
-
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
 
       // Create 2 recent requests (within default max of 1000)
       const requestIds: number[] = [];
@@ -755,15 +668,9 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
-
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
 
       // Create 2 recent requests
       for (let i = 0; i < 2; i++) {
@@ -806,19 +713,12 @@ describe("WebhookRequestResource", () => {
       const factory1 = new WebhookSourceFactory(workspace1);
       const factory2 = new WebhookSourceFactory(workspace2);
 
-      const source1Result = await factory1.create({
+      const webhookSource1 = await factory1.create({
         name: "Test Webhook Source 1",
       });
-      const source2Result = await factory2.create({
+      const webhookSource2 = await factory2.create({
         name: "Test Webhook Source 2",
       });
-
-      if (source1Result.isErr() || source2Result.isErr()) {
-        throw new Error("Failed to create webhook sources");
-      }
-
-      const webhookSource1 = source1Result.value;
-      const webhookSource2 = source2Result.value;
 
       // Create 3 old requests in workspace 1
       const oldDate = new Date();
@@ -902,15 +802,9 @@ describe("WebhookRequestResource", () => {
 
       // Create a webhook source
       const webhookSourceFactory = new WebhookSourceFactory(workspace);
-      const webhookSourceResult = await webhookSourceFactory.create({
+      const webhookSource = await webhookSourceFactory.create({
         name: "Test Webhook Source",
       });
-
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-
-      const webhookSource = webhookSourceResult.value;
 
       // Create 5 requests with distinct timestamps in the past
       const creationTimes: Date[] = [];

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -258,7 +258,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     });
   }
 
-  sId(): string {
+  get sId(): string {
     return WebhookSourceResource.modelIdToSId({
       id: this.id,
       workspaceId: this.workspaceId,
@@ -284,7 +284,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
   toJSON(): WebhookSourceType {
     return {
       id: this.id,
-      sId: this.sId(),
+      sId: this.sId,
       name: this.name,
       provider: this.provider,
       createdAt: this.createdAt.getTime(),

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -258,7 +258,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     });
   }
 
-  get sId(): string {
+  sId(): string {
     return WebhookSourceResource.modelIdToSId({
       id: this.id,
       workspaceId: this.workspaceId,
@@ -284,7 +284,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
   toJSON(): WebhookSourceType {
     return {
       id: this.id,
-      sId: this.sId,
+      sId: this.sId(),
       name: this.name,
       provider: this.provider,
       createdAt: this.createdAt.getTime(),

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -496,7 +496,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
   }
 
   get webhookSourceSId(): string {
-    return this.getWebhookSourceResource().sId;
+    return this.getWebhookSourceResource().sId();
   }
 
   static modelIdToSId({

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -496,7 +496,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
   }
 
   get webhookSourceSId(): string {
-    return this.getWebhookSourceResource().sId();
+    return this.getWebhookSourceResource().sId;
   }
 
   static modelIdToSId({

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -48,17 +48,9 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     // Create a webhook source
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const webhookSourceResult = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
-
-    if (webhookSourceResult.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${webhookSourceResult.error.message}`
-      );
-    }
-
-    const webhookSource = webhookSourceResult.value;
 
     req.query = {
       wId: workspace.sId,
@@ -155,17 +147,9 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     // Create a webhook source
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const webhookSourceResult = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
-
-    if (webhookSourceResult.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${webhookSourceResult.error.message}`
-      );
-    }
-
-    const webhookSource = webhookSourceResult.value;
 
     req.query = {
       wId: workspace.sId,
@@ -196,17 +180,9 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     // Create a webhook source
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const webhookSourceResult = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
-
-    if (webhookSourceResult.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${webhookSourceResult.error.message}`
-      );
-    }
-
-    const webhookSource = webhookSourceResult.value;
 
     req.query = {
       wId: workspace.sId,
@@ -240,18 +216,10 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
     // Create a webhook source with a custom URL secret
     const customUrlSecret = "my-custom-url-secret-123";
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const webhookSourceResult = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source with URL Secret",
       urlSecret: customUrlSecret,
     });
-
-    if (webhookSourceResult.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${webhookSourceResult.error.message}`
-      );
-    }
-
-    const webhookSource = webhookSourceResult.value;
 
     req.query = {
       wId: workspace.sId,
@@ -305,19 +273,11 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     // Create a GitHub webhook source that doesn't subscribe to pull_request events
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const webhookSourceResult = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test GitHub Webhook Source",
       provider: "github",
       subscribedEvents: ["issues"], // Subscribe to issues but not pull_request
     });
-
-    if (webhookSourceResult.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${webhookSourceResult.error.message}`
-      );
-    }
-
-    const webhookSource = webhookSourceResult.value;
 
     req.query = {
       wId: workspace.sId,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
@@ -80,11 +80,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
 
     // Create a webhook source first
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const webhookSourceResult = await webhookSourceFactory.create();
-    if (webhookSourceResult.isErr()) {
-      throw webhookSourceResult.error;
-    }
-    const webhookSource = webhookSourceResult.value;
+    const webhookSource = await webhookSourceFactory.create();
 
     // Set request body
     req.body = {
@@ -120,11 +116,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
 
     // Create a webhook source first
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const webhookSourceResult = await webhookSourceFactory.create();
-    if (webhookSourceResult.isErr()) {
-      throw webhookSourceResult.error;
-    }
-    const webhookSource = webhookSourceResult.value;
+    const webhookSource = await webhookSourceFactory.create();
 
     // Set request body
     req.body = {
@@ -155,11 +147,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
     const { req, res, workspace } = await setupTest("builder", "POST");
 
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const webhookSourceResult = await webhookSourceFactory.create();
-    if (webhookSourceResult.isErr()) {
-      throw webhookSourceResult.error;
-    }
-    const webhookSource = webhookSourceResult.value;
+    const webhookSource = await webhookSourceFactory.create();
 
     // Set request body
     req.body = {
@@ -199,11 +187,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
 
     // Create a webhook source first
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const webhookSourceResult = await webhookSourceFactory.create();
-    if (webhookSourceResult.isErr()) {
-      throw webhookSourceResult.error;
-    }
-    const webhookSource = webhookSourceResult.value;
+    const webhookSource = await webhookSourceFactory.create();
 
     // Set request body
     req.body = {

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
@@ -6,6 +6,7 @@ import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resourc
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WebhookSourceFactory } from "@app/tests/utils/WebhookSourceFactory";
+import type { WorkspaceType } from "@app/types";
 
 import handler from "./index";
 
@@ -28,15 +29,9 @@ async function setupTest(
   return { req, res, workspace, authenticator };
 }
 
-async function createWebhookSource(workspace: any, name: string) {
+async function createWebhookSource(workspace: WorkspaceType, name: string) {
   const webhookSourceFactory = new WebhookSourceFactory(workspace);
-  const result = await webhookSourceFactory.create({ name });
-
-  if (result.isErr()) {
-    throw new Error(`Failed to create webhook source: ${result.error.message}`);
-  }
-
-  return result.value;
+  return webhookSourceFactory.create({ name });
 }
 
 describe("DELETE /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.test.ts
@@ -41,17 +41,10 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
     );
 
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
 
-    if (result.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${result.error.message}`
-      );
-    }
-
-    const webhookSource = result.value;
     req.query.webhookSourceId = webhookSource.sId();
 
     // Create additional views for the webhook source
@@ -85,17 +78,10 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
     const { req, res, workspace } = await setupTest("admin", "GET");
 
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
 
-    if (result.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${result.error.message}`
-      );
-    }
-
-    const webhookSource = result.value;
     req.query.webhookSourceId = webhookSource.sId();
 
     await handler(req, res);
@@ -150,17 +136,10 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
     const { req, res, workspace } = await setupTest("admin", "GET");
 
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
 
-    if (result.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${result.error.message}`
-      );
-    }
-
-    const webhookSource = result.value;
     req.query.webhookSourceId = webhookSource.sId();
 
     // Mock the listByWebhookSource method to simulate failure
@@ -188,17 +167,10 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
     const { req, res, workspace } = await setupTest("user", "GET");
 
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
 
-    if (result.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${result.error.message}`
-      );
-    }
-
-    const webhookSource = result.value;
     req.query.webhookSourceId = webhookSource.sId();
 
     await handler(req, res);
@@ -216,17 +188,10 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
     const { req, res, workspace } = await setupTest("builder", "GET");
 
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
 
-    if (result.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${result.error.message}`
-      );
-    }
-
-    const webhookSource = result.value;
     req.query.webhookSourceId = webhookSource.sId();
 
     await handler(req, res);
@@ -254,17 +219,10 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
 
     // Create a webhook source in the other workspace
     const webhookSourceFactory = new WebhookSourceFactory(otherWorkspace);
-    const result = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source in Other Workspace",
     });
 
-    if (result.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${result.error.message}`
-      );
-    }
-
-    const webhookSource = result.value;
     req.query.webhookSourceId = webhookSource.sId();
 
     await handler(req, res);
@@ -284,17 +242,10 @@ describe("Method Support /api/w/[wId]/webhook_sources/[webhookSourceId]/views", 
     const { req, res, workspace } = await setupTest("admin", "POST");
 
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
 
-    if (result.isErr()) {
-      throw new Error(
-        `Failed to create webhook source: ${result.error.message}`
-      );
-    }
-
-    const webhookSource = result.value;
     req.query.webhookSourceId = webhookSource.sId();
 
     await handler(req, res);

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -144,7 +144,7 @@ async function handler(
       const trimmedSignatureHeader = signatureHeader.trim();
 
       try {
-        const webhookSourceRes = await WebhookSourceResource.makeNew(auth, {
+        const webhookSource = await WebhookSourceResource.makeNew(auth, {
           workspaceId: workspace.id,
           name,
           secret:
@@ -160,12 +160,6 @@ async function handler(
           signatureAlgorithm,
           subscribedEvents,
         });
-
-        if (webhookSourceRes.isErr()) {
-          throw new Error(webhookSourceRes.error.message);
-        }
-
-        const webhookSource = webhookSourceRes.value;
 
         if (includeGlobal) {
           const systemView =

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.test.ts
@@ -40,19 +40,12 @@ describe("GET /api/w/[wId]/webhook_sources/views", () => {
 
     // Create webhook sources and views
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result1 = await webhookSourceFactory.create({
+    const webhookSource1 = await webhookSourceFactory.create({
       name: "Test Webhook Source 1",
     });
-    const result2 = await webhookSourceFactory.create({
+    const webhookSource2 = await webhookSourceFactory.create({
       name: "Test Webhook Source 2",
     });
-
-    if (result1.isErr() || result2.isErr()) {
-      throw new Error("Failed to create webhook sources");
-    }
-
-    const webhookSource1 = result1.value;
-    const webhookSource2 = result2.value;
 
     // Get the existing spaces
     const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
@@ -108,15 +101,9 @@ describe("GET /api/w/[wId]/webhook_sources/views", () => {
 
     // Create webhook source
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
-
-    if (result.isErr()) {
-      throw new Error("Failed to create webhook source");
-    }
-
-    const webhookSource = result.value;
 
     // Get existing spaces
     const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
@@ -205,13 +192,9 @@ describe("GET /api/w/[wId]/webhook_sources/views", () => {
     );
 
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
-
-    if (result.isErr()) {
-      throw new Error("Failed to create webhook source");
-    }
 
     const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
     const globalSpace = spaces.find((s) => s.kind === "global");
@@ -239,13 +222,9 @@ describe("GET /api/w/[wId]/webhook_sources/views", () => {
     );
 
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
-
-    if (result.isErr()) {
-      throw new Error("Failed to create webhook source");
-    }
 
     const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);
     const globalSpace = spaces.find((s) => s.kind === "global");
@@ -274,15 +253,9 @@ describe("GET /api/w/[wId]/webhook_sources/views", () => {
 
     // Create webhook source
     const webhookSourceFactory = new WebhookSourceFactory(workspace);
-    const result = await webhookSourceFactory.create({
+    const webhookSource = await webhookSourceFactory.create({
       name: "Test Webhook Source",
     });
-
-    if (result.isErr()) {
-      throw new Error("Failed to create webhook source");
-    }
-
-    const webhookSource = result.value;
 
     // Get spaces
     const spaces = await SpaceResource.listWorkspaceSpaces(authenticator);

--- a/front/tests/utils/WebhookSourceFactory.ts
+++ b/front/tests/utils/WebhookSourceFactory.ts
@@ -33,7 +33,7 @@ export class WebhookSourceFactory {
       this.workspace.sId
     );
 
-    const result = await WebhookSourceResource.makeNew(auth, {
+    return WebhookSourceResource.makeNew(auth, {
       workspaceId: this.workspace.id,
       name: cachedName,
       urlSecret: options.urlSecret ?? faker.string.alphanumeric(64),
@@ -43,7 +43,5 @@ export class WebhookSourceFactory {
       provider: options.provider ?? null,
       subscribedEvents: options.subscribedEvents ?? [],
     });
-
-    return result;
   }
 }

--- a/front/tests/utils/WebhookSourceViewFactory.ts
+++ b/front/tests/utils/WebhookSourceViewFactory.ts
@@ -27,11 +27,9 @@ export class WebhookSourceViewFactory {
     let webhookSourceId = options.webhookSourceId;
     if (!webhookSourceId) {
       const webhookSourceFactory = new WebhookSourceFactory(this.workspace);
-      const webhookSourceResult = await webhookSourceFactory.create();
-      if (webhookSourceResult.isErr()) {
-        throw webhookSourceResult.error;
-      }
-      webhookSourceId = webhookSourceResult.value.sId();
+      const webhookSource = await webhookSourceFactory.create();
+
+      webhookSourceId = webhookSource.sId();
     }
 
     const systemView =


### PR DESCRIPTION
## Description

- This PR aligns the implementation of `WebhookSourceResource .makeNew` with existing resources by having it return an instance of the resource rather than a Result.
- Returning a `Result` here actually hides in turn the actual error when the creation fails.

## Tests

- Tested locally, updated the tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
