### PR TITLE
[front] fix(webhooks): simplify error handling in webhook endpoints

### DIFF
--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
@@ -118,10 +118,7 @@ describe("DELETE /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
     expect(res._getStatusCode()).toBe(500);
 
     const responseData = res._getJSONData();
-    expect(responseData.error).toEqual({
-      type: "internal_server_error",
-      message: "Failed to delete webhook source.",
-    });
+    expect(responseData.error.type).toEqual("internal_server_error");
 
     // Restore the original method
     deleteSpy.mockRestore();

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
@@ -4,7 +4,6 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
@@ -54,89 +53,68 @@ async function handler(
     case "PATCH": {
       const { remoteMetadata, oauthConnectionId } = req.body;
 
-      try {
-        const webhookSourceResource = await WebhookSourceResource.fetchById(
-          auth,
-          webhookSourceId
-        );
+      const webhookSourceResource = await WebhookSourceResource.fetchById(
+        auth,
+        webhookSourceId
+      );
 
-        if (!webhookSourceResource) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "webhook_source_not_found",
-              message:
-                "The webhook source you're trying to update was not found.",
-            },
-          });
-        }
-
-        // Build updates object with only provided fields
-        const updates: {
-          remoteMetadata?: Record<string, any>;
-          oauthConnectionId?: string;
-        } = {};
-
-        if (remoteMetadata && typeof remoteMetadata === "object") {
-          updates.remoteMetadata = remoteMetadata;
-        }
-        if (oauthConnectionId && typeof oauthConnectionId === "string") {
-          updates.oauthConnectionId = oauthConnectionId;
-        }
-
-        // Update the webhook source with the provided fields
-        await webhookSourceResource.updateRemoteMetadata(updates);
-
-        return res.status(200).json({
-          success: true,
-        });
-      } catch (error) {
+      if (!webhookSourceResource) {
         return apiError(req, res, {
-          status_code: 500,
+          status_code: 404,
           api_error: {
-            type: "internal_server_error",
-            message: "Failed to update webhook source.",
+            type: "webhook_source_not_found",
+            message:
+              "The webhook source you're trying to update was not found.",
           },
         });
       }
+
+      // Build updates object with only provided fields
+      const updates: {
+        remoteMetadata?: Record<string, any>;
+        oauthConnectionId?: string;
+      } = {};
+
+      if (remoteMetadata && typeof remoteMetadata === "object") {
+        updates.remoteMetadata = remoteMetadata;
+      }
+      if (oauthConnectionId && typeof oauthConnectionId === "string") {
+        updates.oauthConnectionId = oauthConnectionId;
+      }
+
+      // Update the webhook source with the provided fields
+      await webhookSourceResource.updateRemoteMetadata(updates);
+
+      return res.status(200).json({
+        success: true,
+      });
     }
 
     case "DELETE": {
-      try {
-        const webhookSourceResource = await WebhookSourceResource.fetchById(
-          auth,
-          webhookSourceId
-        );
+      const webhookSourceResource = await WebhookSourceResource.fetchById(
+        auth,
+        webhookSourceId
+      );
 
-        if (!webhookSourceResource) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "webhook_source_not_found",
-              message:
-                "The webhook source you're trying to delete was not found.",
-            },
-          });
-        }
-
-        const deleteResult = await webhookSourceResource.delete(auth);
-        if (deleteResult.isErr()) {
-          throw deleteResult.error;
-        }
-
-        return res.status(200).json({
-          success: true,
-        });
-      } catch (error) {
-        logger.warn({ error }, "Failed to delete webhook source.");
+      if (!webhookSourceResource) {
         return apiError(req, res, {
-          status_code: 500,
+          status_code: 404,
           api_error: {
-            type: "internal_server_error",
-            message: "Failed to delete webhook source.",
+            type: "webhook_source_not_found",
+            message:
+              "The webhook source you're trying to delete was not found.",
           },
         });
       }
+
+      const deleteResult = await webhookSourceResource.delete(auth);
+      if (deleteResult.isErr()) {
+        throw deleteResult.error;
+      }
+
+      return res.status(200).json({
+        success: true,
+      });
     }
 
     default: {

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.test.ts
@@ -154,10 +154,7 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
     expect(res._getStatusCode()).toBe(500);
 
     const responseData = res._getJSONData();
-    expect(responseData.error).toEqual({
-      type: "internal_server_error",
-      message: "Failed to fetch webhook source views.",
-    });
+    expect(responseData.error.type).toEqual("internal_server_error");
 
     // Restore the original method
     listSpy.mockRestore();

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
@@ -33,43 +33,33 @@ async function handler(
 
   switch (method) {
     case "GET": {
-      try {
-        const webhookSourceResource = await WebhookSourceResource.fetchById(
-          auth,
-          webhookSourceId
-        );
+      const webhookSourceResource = await WebhookSourceResource.fetchById(
+        auth,
+        webhookSourceId
+      );
 
-        if (!webhookSourceResource) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "webhook_source_not_found",
-              message: "The webhook source was not found.",
-            },
-          });
-        }
-
-        const viewResources =
-          await WebhookSourcesViewResource.listByWebhookSource(
-            auth,
-            webhookSourceResource.id
-          );
-
-        const views = viewResources.map((view) => view.toJSON());
-
-        return res.status(200).json({
-          success: true,
-          views,
-        });
-      } catch (error) {
+      if (!webhookSourceResource) {
         return apiError(req, res, {
-          status_code: 500,
+          status_code: 404,
           api_error: {
-            type: "internal_server_error",
-            message: "Failed to fetch webhook source views.",
+            type: "webhook_source_not_found",
+            message: "The webhook source was not found.",
           },
         });
       }
+
+      const viewResources =
+        await WebhookSourcesViewResource.listByWebhookSource(
+          auth,
+          webhookSourceResource.id
+        );
+
+      const views = viewResources.map((view) => view.toJSON());
+
+      return res.status(200).json({
+        success: true,
+        views,
+      });
     }
 
     default: {

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -151,8 +151,6 @@ async function handler(
         subscribedEvents,
       });
 
-
-
       if (includeGlobal) {
         const systemView =
           await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -63,43 +63,34 @@ async function handler(
       const webhookSourceResources =
         await WebhookSourceResource.listByWorkspace(auth);
 
-      try {
-        const usageBySourceId = await getWebhookSourcesUsage({ auth });
-        const webhookSourcesWithViews = await concurrentExecutor(
-          webhookSourceResources,
-          async (webhookSourceResource) => {
-            const webhookSource = webhookSourceResource.toJSONForAdmin();
-            const webhookSourceViewResources =
-              await WebhookSourcesViewResource.listByWebhookSource(
-                auth,
-                webhookSource.id
-              );
-            const views = webhookSourceViewResources.map((view) =>
-              view.toJSONForAdmin()
+      const usageBySourceId = await getWebhookSourcesUsage({ auth });
+      const webhookSourcesWithViews = await concurrentExecutor(
+        webhookSourceResources,
+        async (webhookSourceResource) => {
+          const webhookSource = webhookSourceResource.toJSONForAdmin();
+          const webhookSourceViewResources =
+            await WebhookSourcesViewResource.listByWebhookSource(
+              auth,
+              webhookSource.id
             );
+          const views = webhookSourceViewResources.map((view) =>
+            view.toJSONForAdmin()
+          );
 
-            return { ...webhookSource, views };
-          },
-          {
-            concurrency: 10,
-          }
-        );
+          return { ...webhookSource, views };
+        },
+        {
+          concurrency: 10,
+        }
+      );
 
-        return res.status(200).json({
-          success: true,
-          webhookSourcesWithViews: webhookSourcesWithViews.map((source) => ({
-            ...source,
-            usage: usageBySourceId[source.id] ?? { count: 0, agents: [] },
-          })),
-        });
-      } catch (error) {
-        return res.status(500).json({
-          error: {
-            type: "internal_server_error",
-            message: "Failed to load webhook source views.",
-          },
-        });
-      }
+      return res.status(200).json({
+        success: true,
+        webhookSourcesWithViews: webhookSourcesWithViews.map((source) => ({
+          ...source,
+          usage: usageBySourceId[source.id] ?? { count: 0, agents: [] },
+        })),
+      });
     }
 
     case "POST": {
@@ -143,103 +134,94 @@ async function handler(
 
       const trimmedSignatureHeader = signatureHeader.trim();
 
-      try {
-        const webhookSource = await WebhookSourceResource.makeNew(auth, {
-          workspaceId: workspace.id,
-          name,
-          secret:
-            trimmedSignatureHeader.length === 0
-              ? null
-              : secret && secret.length > 0
-                ? secret
-                : generateSecureSecret(64),
-          urlSecret: generateSecureSecret(64),
-          provider,
-          signatureHeader:
-            trimmedSignatureHeader.length > 0 ? trimmedSignatureHeader : null,
-          signatureAlgorithm,
-          subscribedEvents,
-        });
+      const webhookSource = await WebhookSourceResource.makeNew(auth, {
+        workspaceId: workspace.id,
+        name,
+        secret:
+          trimmedSignatureHeader.length === 0
+            ? null
+            : secret && secret.length > 0
+              ? secret
+              : generateSecureSecret(64),
+        urlSecret: generateSecureSecret(64),
+        provider,
+        signatureHeader:
+          trimmedSignatureHeader.length > 0 ? trimmedSignatureHeader : null,
+        signatureAlgorithm,
+        subscribedEvents,
+      });
 
-        if (includeGlobal) {
-          const systemView =
-            await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
-              auth,
-              webhookSource.sId()
-            );
 
-          if (systemView === null) {
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message:
-                  "Missing system view for webhook source, it should have been created when creating the webhook source.",
-              },
-            });
-          }
 
-          const globalSpace =
-            await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-
-          await WebhookSourcesViewResource.create(auth, {
-            systemView,
-            space: globalSpace,
-          });
-        }
-
-        if (provider && connectionId && remoteMetadata) {
-          // Allow redirection to public URL in local dev for webhook registrations.
-          const baseUrl =
-            process.env.DUST_WEBHOOKS_PUBLIC_URL ?? config.getClientFacingUrl();
-          const webhookUrl = buildWebhookUrl({
-            apiBaseUrl: baseUrl,
-            workspaceId: workspace.sId,
-            webhookSource: webhookSource.toJSONForAdmin(),
-          });
-          const service = WEBHOOK_PRESETS[provider].webhookService;
-          const result = await service.createWebhooks({
+      if (includeGlobal) {
+        const systemView =
+          await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
             auth,
-            connectionId,
-            remoteMetadata,
-            webhookUrl,
-            events: subscribedEvents,
-            secret: webhookSource.getSecretPotentiallyRedacted() ?? undefined,
-          });
+            webhookSource.sId()
+          );
 
-          if (result.isErr()) {
-            // If remote webhook creation fails, we still keep the webhook source
-            // but return an error message so the user knows
-            return apiError(req, res, {
-              status_code: 500,
-              api_error: {
-                type: "internal_server_error",
-                message: `Webhook source created but failed to create remote webhook: ${result.error.message}`,
-              },
-            });
-          }
-
-          // Update the webhook source with the id of the webhook
-          const updatedRemoteMetadata = result.value.updatedRemoteMetadata;
-          await webhookSource.updateRemoteMetadata({
-            remoteMetadata: updatedRemoteMetadata,
-            oauthConnectionId: connectionId,
+        if (systemView === null) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Missing system view for webhook source, it should have been created when creating the webhook source.",
+            },
           });
         }
 
-        return res.status(201).json({
-          success: true,
-          webhookSource: webhookSource.toJSONForAdmin(),
-        });
-      } catch (error) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to create webhook source.",
-          },
+        const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+
+        await WebhookSourcesViewResource.create(auth, {
+          systemView,
+          space: globalSpace,
         });
       }
+
+      if (provider && connectionId && remoteMetadata) {
+        // Allow redirection to public URL in local dev for webhook registrations.
+        const baseUrl =
+          process.env.DUST_WEBHOOKS_PUBLIC_URL ?? config.getClientFacingUrl();
+        const webhookUrl = buildWebhookUrl({
+          apiBaseUrl: baseUrl,
+          workspaceId: workspace.sId,
+          webhookSource: webhookSource.toJSONForAdmin(),
+        });
+        const service = WEBHOOK_PRESETS[provider].webhookService;
+        const result = await service.createWebhooks({
+          auth,
+          connectionId,
+          remoteMetadata,
+          webhookUrl,
+          events: subscribedEvents,
+          secret: webhookSource.getSecretPotentiallyRedacted() ?? undefined,
+        });
+
+        if (result.isErr()) {
+          // If remote webhook creation fails, we still keep the webhook source
+          // but return an error message so the user knows
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Webhook source created but failed to create remote webhook: ${result.error.message}`,
+            },
+          });
+        }
+
+        // Update the webhook source with the id of the webhook
+        const updatedRemoteMetadata = result.value.updatedRemoteMetadata;
+        await webhookSource.updateRemoteMetadata({
+          remoteMetadata: updatedRemoteMetadata,
+          oauthConnectionId: connectionId,
+        });
+      }
+
+      return res.status(201).json({
+        success: true,
+        webhookSource: webhookSource.toJSONForAdmin(),
+      });
     }
 
     default: {


### PR DESCRIPTION
## Description

- A few endpoint handlers relative to webhooks relied on wide try-catches to return 500 on any error.
- This behavior is already handled via the `withLogging` wrapper.
- This PR removes these try-catches, which actually hides the error from the logs.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
