### PR TITLE
[front] enh(webhooks): validate name unicity on creation

### DIFF
--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -134,6 +134,18 @@ async function handler(
 
       const trimmedSignatureHeader = signatureHeader.trim();
 
+      const existingWebhookSourceWithSameName =
+        await WebhookSourceResource.fetchByName(auth, name);
+      if (existingWebhookSourceWithSameName) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "A webhook source with the same name already exists.",
+          },
+        });
+      }
+
       const webhookSource = await WebhookSourceResource.makeNew(auth, {
         workspaceId: workspace.id,
         name,


### PR DESCRIPTION
## Description

- This PR adds a check in the endpoint to create a new webhook source on the unicity of the name for the workspace.
- The unicity is already enforced by a unique constraint in db, but the error is not surfaced correctly.
- The query is already optimized by an index.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
