### PR TITLE
[front] refactor(webhooks): convert `sId` to getter in `WebhookSourceResource`

### DIFF
--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -258,7 +258,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     });
   }
 
-  sId(): string {
+  get sId(): string {
     return WebhookSourceResource.modelIdToSId({
       id: this.id,
       workspaceId: this.workspaceId,
@@ -284,7 +284,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
   toJSON(): WebhookSourceType {
     return {
       id: this.id,
-      sId: this.sId(),
+      sId: this.sId,
       name: this.name,
       provider: this.provider,
       createdAt: this.createdAt.getTime(),

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -496,7 +496,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
   }
 
   get webhookSourceSId(): string {
-    return this.getWebhookSourceResource().sId();
+    return this.getWebhookSourceResource().sId;
   }
 
   static modelIdToSId({

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -54,7 +54,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     req.query = {
       wId: workspace.sId,
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
       webhookSourceUrlSecret: webhookSource.urlSecret,
     };
     req.body = { any: "payload" };
@@ -153,7 +153,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     req.query = {
       wId: workspace.sId,
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
       webhookSourceUrlSecret: "invalid-secret", // Using wrong secret
     };
     req.body = { any: "payload" };
@@ -186,7 +186,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     req.query = {
       wId: workspace.sId,
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
       // Missing webhookSourceUrlSecret parameter (it will be undefined)
     };
     req.body = { any: "payload" };
@@ -223,7 +223,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     req.query = {
       wId: workspace.sId,
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
       webhookSourceUrlSecret: customUrlSecret, // Using the correct secret
     };
     req.body = { any: "payload" };
@@ -281,7 +281,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     req.query = {
       wId: workspace.sId,
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
       webhookSourceUrlSecret: webhookSource.urlSecret,
     };
     req.body = {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
@@ -84,7 +84,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
 
     // Set request body
     req.body = {
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
     };
 
     // Create regular space for the test
@@ -102,7 +102,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
         sId: expect.any(String),
         spaceId: regularSpace.sId,
         webhookSource: expect.objectContaining({
-          sId: webhookSource.sId(),
+          sId: webhookSource.sId,
         }),
       }),
     });
@@ -120,7 +120,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
 
     // Set request body
     req.body = {
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
     };
 
     req.query.spaceId = globalSpace.sId;
@@ -136,7 +136,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
         sId: expect.any(String),
         spaceId: globalSpace.sId,
         webhookSource: expect.objectContaining({
-          sId: webhookSource.sId(),
+          sId: webhookSource.sId,
         }),
       }),
     });
@@ -151,7 +151,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
 
     // Set request body
     req.body = {
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
     };
 
     await handler(req, res);
@@ -191,7 +191,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
 
     // Set request body
     req.body = {
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
     };
 
     // Get the system space from defaults (don't create a new one)

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
@@ -45,7 +45,7 @@ describe("DELETE /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
       workspace,
       "Test Webhook Source"
     );
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     await handler(req, res);
 
@@ -59,7 +59,7 @@ describe("DELETE /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
     // Verify the webhook source was actually deleted
     const deletedWebhookSource = await WebhookSourceResource.fetchById(
       authenticator,
-      webhookSource.sId()
+      webhookSource.sId
     );
     expect(deletedWebhookSource).toBeNull();
   });
@@ -104,7 +104,7 @@ describe("DELETE /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
       workspace,
       "Test Webhook Source"
     );
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     // Mock the delete method to simulate failure
     const deleteSpy = vi
@@ -136,7 +136,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
       workspace,
       "Test Webhook Source"
     );
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
     req.body = {
       remoteMetadata: { id: "remote-webhook-123", repo: "owner/repo" },
     };
@@ -153,7 +153,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
     // Verify the webhook source was actually updated
     const updatedWebhookSource = await WebhookSourceResource.fetchById(
       authenticator,
-      webhookSource.sId()
+      webhookSource.sId
     );
     expect(updatedWebhookSource?.remoteMetadata).toEqual({
       id: "remote-webhook-123",
@@ -171,7 +171,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
       workspace,
       "Test Webhook Source"
     );
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
     req.body = {
       oauthConnectionId: "connection-456",
     };
@@ -188,7 +188,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
     // Verify the webhook source was actually updated
     const updatedWebhookSource = await WebhookSourceResource.fetchById(
       authenticator,
-      webhookSource.sId()
+      webhookSource.sId
     );
     expect(updatedWebhookSource?.oauthConnectionId).toBe("connection-456");
   });
@@ -203,7 +203,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
       workspace,
       "Test Webhook Source"
     );
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
     req.body = {
       remoteMetadata: { id: "remote-webhook-789", repo: "org/project" },
       oauthConnectionId: "connection-789",
@@ -221,7 +221,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
     // Verify all fields were updated
     const updatedWebhookSource = await WebhookSourceResource.fetchById(
       authenticator,
-      webhookSource.sId()
+      webhookSource.sId
     );
     expect(updatedWebhookSource?.remoteMetadata).toEqual({
       id: "remote-webhook-789",
@@ -240,7 +240,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
       workspace,
       "Test Webhook Source"
     );
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
     req.body = {
       remoteMetadata: "invalid", // Invalid: should be object
       oauthConnectionId: "valid-connection",
@@ -258,7 +258,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
     // Verify only the valid field was updated
     const updatedWebhookSource = await WebhookSourceResource.fetchById(
       authenticator,
-      webhookSource.sId()
+      webhookSource.sId
     );
     expect(updatedWebhookSource?.remoteMetadata).toBeNull();
     expect(updatedWebhookSource?.oauthConnectionId).toBe("valid-connection");
@@ -271,7 +271,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
       workspace,
       "Test Webhook Source"
     );
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
     req.body = {};
 
     await handler(req, res);
@@ -332,7 +332,7 @@ describe("Method Support /api/w/[wId]/webhook_sources/[webhookSourceId]", () => 
       workspace,
       "Test Webhook Source"
     );
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     await handler(req, res);
 
@@ -353,7 +353,7 @@ describe("Method Support /api/w/[wId]/webhook_sources/[webhookSourceId]", () => 
       workspace,
       "Test Webhook Source"
     );
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     await handler(req, res);
 

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.test.ts
@@ -45,7 +45,7 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
       name: "Test Webhook Source",
     });
 
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     // Create additional views for the webhook source
     // Get the existing global space instead of creating a new one
@@ -56,7 +56,7 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
     }
     const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
     await webhookSourceViewFactory.create(globalSpace, {
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
     });
 
     await handler(req, res);
@@ -82,7 +82,7 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
       name: "Test Webhook Source",
     });
 
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     await handler(req, res);
 
@@ -140,7 +140,7 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
       name: "Test Webhook Source",
     });
 
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     // Mock the listByWebhookSource method to simulate failure
     const listSpy = vi
@@ -168,7 +168,7 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
       name: "Test Webhook Source",
     });
 
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     await handler(req, res);
 
@@ -189,7 +189,7 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
       name: "Test Webhook Source",
     });
 
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     await handler(req, res);
 
@@ -220,7 +220,7 @@ describe("GET /api/w/[wId]/webhook_sources/[webhookSourceId]/views", () => {
       name: "Test Webhook Source in Other Workspace",
     });
 
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     await handler(req, res);
 
@@ -243,7 +243,7 @@ describe("Method Support /api/w/[wId]/webhook_sources/[webhookSourceId]/views", 
       name: "Test Webhook Source",
     });
 
-    req.query.webhookSourceId = webhookSource.sId();
+    req.query.webhookSourceId = webhookSource.sId;
 
     await handler(req, res);
 

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -155,7 +155,7 @@ async function handler(
         const systemView =
           await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
             auth,
-            webhookSource.sId()
+            webhookSource.sId
           );
 
         if (systemView === null) {

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.test.ts
@@ -117,7 +117,7 @@ describe("GET /api/w/[wId]/webhook_sources/views", () => {
     // Create views in both spaces
     const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
     await webhookSourceViewFactory.create(globalSpace, {
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
     });
 
     // Query for views in both spaces (comma-separated)
@@ -268,7 +268,7 @@ describe("GET /api/w/[wId]/webhook_sources/views", () => {
     // Create view in global space
     const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
     await webhookSourceViewFactory.create(globalSpace, {
-      webhookSourceId: webhookSource.sId(),
+      webhookSourceId: webhookSource.sId,
     });
 
     // Try to query with both valid and invalid space IDs

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.test.ts
@@ -57,10 +57,10 @@ describe("GET /api/w/[wId]/webhook_sources/views", () => {
     // Create additional views for the webhook sources
     const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
     await webhookSourceViewFactory.create(globalSpace, {
-      webhookSourceId: webhookSource1.sId(),
+      webhookSourceId: webhookSource1.sId,
     });
     await webhookSourceViewFactory.create(globalSpace, {
-      webhookSourceId: webhookSource2.sId(),
+      webhookSourceId: webhookSource2.sId,
     });
 
     // Query for views in the global space

--- a/front/tests/utils/WebhookSourceViewFactory.ts
+++ b/front/tests/utils/WebhookSourceViewFactory.ts
@@ -29,7 +29,7 @@ export class WebhookSourceViewFactory {
       const webhookSourceFactory = new WebhookSourceFactory(this.workspace);
       const webhookSource = await webhookSourceFactory.create();
 
-      webhookSourceId = webhookSource.sId();
+      webhookSourceId = webhookSource.sId;
     }
 
     const systemView =


### PR DESCRIPTION
## Description

- This PR changes the `sId` method on `WebhookSourceResource` to be a getter to match other existing resources.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
