### PR TITLE
[front] Revamp design for adding triggers in Agent Builder

### DIFF
--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -16,21 +16,13 @@ import type {
 import { AgentBuilderSectionContainer } from "@app/components/agent_builder/AgentBuilderSectionContainer";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { TriggerCard } from "@app/components/agent_builder/triggers/TriggerCard";
+import type { SheetMode } from "@app/components/agent_builder/triggers/TriggerViewsSheet";
 import { TriggerViewsSheet } from "@app/components/agent_builder/triggers/TriggerViewsSheet";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useWebhookSourceViewsFromSpaces } from "@app/lib/swr/webhook_source";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
-
-type SheetMode =
-  | { type: "add" }
-  | {
-      type: "edit";
-      trigger: AgentBuilderTriggerType;
-      index: number;
-      webhookSourceView: WebhookSourceViewType | null;
-    };
 
 interface AgentBuilderTriggersBlockProps {
   owner: LightWorkspaceType;

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -24,7 +24,7 @@ import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 type SheetMode =
-  | { type: "selection" }
+  | { type: "add" }
   | {
       type: "edit";
       trigger: AgentBuilderTriggerType;
@@ -45,17 +45,17 @@ export function AgentBuilderTriggersBlock({
 }: AgentBuilderTriggersBlockProps) {
   const { getValues, setValue } = useFormContext<AgentBuilderFormData>();
 
-  const {
-    fields: triggersToCreate,
-    remove: removeFromCreate,
-  } = useFieldArray<AgentBuilderFormData, "triggersToCreate">({
+  const { fields: triggersToCreate, remove: removeFromCreate } = useFieldArray<
+    AgentBuilderFormData,
+    "triggersToCreate"
+  >({
     name: "triggersToCreate",
   });
 
-  const {
-    fields: triggersToUpdate,
-    remove: removeFromUpdate,
-  } = useFieldArray<AgentBuilderFormData, "triggersToUpdate">({
+  const { fields: triggersToUpdate, remove: removeFromUpdate } = useFieldArray<
+    AgentBuilderFormData,
+    "triggersToUpdate"
+  >({
     name: "triggersToUpdate",
   });
 
@@ -97,7 +97,7 @@ export function AgentBuilderTriggersBlock({
   ];
 
   const handleAddTriggersClick = () => {
-    setSheetMode({ type: "selection" });
+    setSheetMode({ type: "add" });
   };
 
   const handleTriggerEdit = (

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -33,6 +33,7 @@ export function TriggerSelectionPage({
     });
   }, [searchTerm, webhookSourceViews]);
 
+  // Adding a few useful shortcut keywords for schedules.
   const showSchedule = useMemo(() => {
     if (!searchTerm.trim()) {
       return true;

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -61,9 +61,7 @@ export function TriggerSelectionPage({
 
         {showSchedule && (
           <div className="flex flex-col gap-3">
-            <span className="text-element-900 text-lg font-semibold">
-              Top triggers
-            </span>
+            <span className="text-lg font-semibold">Top triggers</span>
             <div className="grid grid-cols-2 gap-3">
               <ToolCard
                 icon={TimeIcon}
@@ -80,9 +78,7 @@ export function TriggerSelectionPage({
 
         {filteredWebhookSourceViews.length > 0 && (
           <div className="flex flex-col gap-3">
-            <span className="text-element-900 text-lg font-semibold">
-              Webhooks
-            </span>
+            <span className="text-lg font-semibold">Webhooks</span>
             <div className="grid grid-cols-2 gap-3">
               {filteredWebhookSourceViews.map((view) => {
                 const icon = isCustomResourceIconType(view.icon)
@@ -107,7 +103,7 @@ export function TriggerSelectionPage({
         )}
 
         {!showSchedule && filteredWebhookSourceViews.length === 0 && (
-          <div className="text-element-600 flex h-32 items-center justify-center text-sm">
+          <div className="flex h-32 items-center justify-center text-sm">
             No triggers found matching your search
           </div>
         )}

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -87,7 +87,7 @@ export function TriggerSelectionPage({
                     label="Schedule"
                     description="Trigger this agent on a schedule"
                     isSelected={false}
-                    canAdd={true}
+                    canAdd
                     onClick={onScheduleSelect}
                     cardContainerClassName="h-36"
                   />
@@ -109,9 +109,12 @@ export function TriggerSelectionPage({
                         key={view.sId}
                         icon={icon}
                         label={view.customName}
-                        description={view.description ?? `Trigger this agent with ${view.customname}.`}
+                        description={
+                          view.description ??
+                          `Trigger this agent with ${view.customName}.`
+                        }
                         isSelected={false}
-                        canAdd={true}
+                        canAdd
                         onClick={() => onWebhookSelect(view)}
                         cardContainerClassName="h-36"
                       />

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -1,0 +1,122 @@
+import {
+  ActionIcons,
+  Input,
+  Page,
+  TimeIcon,
+  ToolCard,
+} from "@dust-tt/sparkle";
+import React, { useMemo, useState } from "react";
+
+import {
+  InternalActionIcons,
+  isCustomResourceIconType,
+} from "@app/components/resources/resources_icons";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+
+interface TriggerSelectionPageProps {
+  onScheduleSelect: () => void;
+  onWebhookSelect: (webhookSourceView: WebhookSourceViewType) => void;
+  webhookSourceViews: WebhookSourceViewType[];
+}
+
+export function TriggerSelectionPage({
+  onScheduleSelect,
+  onWebhookSelect,
+  webhookSourceViews,
+}: TriggerSelectionPageProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredWebhookSourceViews = useMemo(() => {
+    if (!searchTerm.trim()) {
+      return webhookSourceViews;
+    }
+
+    const term = searchTerm.toLowerCase();
+    return webhookSourceViews.filter((view) => {
+      return [view.customName, view.description].some((field) =>
+        field?.toLowerCase().includes(term)
+      );
+    });
+  }, [searchTerm, webhookSourceViews]);
+
+  const showSchedule = useMemo(() => {
+    if (!searchTerm.trim()) {
+      return true;
+    }
+
+    const term = searchTerm.toLowerCase();
+    return (
+      "schedule".includes(term) ||
+      "time".includes(term) ||
+      "cron".includes(term)
+    );
+  }, [searchTerm]);
+
+  return (
+    <Page.Vertical sizing="grow">
+      <div className="flex flex-col gap-4 px-6 py-4">
+        <Input
+          placeholder="Search triggers..."
+          value={searchTerm}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setSearchTerm(e.target.value)
+          }
+          name="triggerSearch"
+        />
+
+        {showSchedule && (
+          <div className="flex flex-col gap-3">
+            <span className="text-lg font-semibold text-element-900">
+              Top triggers
+            </span>
+            <div className="grid grid-cols-2 gap-3">
+              <ToolCard
+                icon={TimeIcon}
+                label="Schedule"
+                description="Trigger this agent on a schedule"
+                isSelected={false}
+                canAdd={true}
+                onClick={onScheduleSelect}
+                cardContainerClassName="h-36"
+              />
+            </div>
+          </div>
+        )}
+
+        {filteredWebhookSourceViews.length > 0 && (
+          <div className="flex flex-col gap-3">
+            <span className="text-lg font-semibold text-element-900">
+              Webhooks
+            </span>
+            <div className="grid grid-cols-2 gap-3">
+              {filteredWebhookSourceViews.map((view) => {
+                const icon = isCustomResourceIconType(view.icon)
+                  ? ActionIcons[view.icon]
+                  : InternalActionIcons[view.icon];
+
+                return (
+                  <ToolCard
+                    key={view.sId}
+                    icon={icon}
+                    label={view.customName}
+                    description={view.description}
+                    isSelected={false}
+                    canAdd={true}
+                    onClick={() => onWebhookSelect(view)}
+                    cardContainerClassName="h-36"
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {!showSchedule && filteredWebhookSourceViews.length === 0 && (
+          <div className="flex h-32 items-center justify-center text-sm text-element-700">
+            No triggers found matching your search
+          </div>
+        )}
+      </div>
+    </Page.Vertical>
+  );
+}

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -1,8 +1,8 @@
 import {
   ActionIcons,
-  Page,
   SearchInput,
   Sheet,
+  SheetContainer,
   SheetContent,
   SheetFooter,
   SheetHeader,
@@ -68,65 +68,63 @@ export function TriggerSelectionPage({
         <SheetHeader>
           <SheetTitle>Add triggers</SheetTitle>
         </SheetHeader>
-        <Page.Vertical sizing="grow">
-          <div className="flex flex-col gap-4 px-6 py-4">
-            <SearchInput
-              placeholder="Search triggers..."
-              value={searchTerm}
-              onChange={setSearchTerm}
-              name="triggerSearch"
-            />
+        <SheetContainer>
+          <SearchInput
+            placeholder="Search triggers..."
+            value={searchTerm}
+            onChange={setSearchTerm}
+            name="triggerSearch"
+          />
 
-            {showSchedule && (
-              <div className="flex flex-col gap-3">
-                <span className="text-lg font-semibold">Top triggers</span>
-                <div className="grid grid-cols-2 gap-3">
-                  <ToolCard
-                    icon={TimeIcon}
-                    label="Schedule"
-                    description="Trigger this agent on a schedule"
-                    isSelected={false}
-                    canAdd={true}
-                    onClick={onScheduleSelect}
-                    cardContainerClassName="h-36"
-                  />
-                </div>
+          {showSchedule && (
+            <div className="flex flex-col gap-3">
+              <span className="text-lg font-semibold">Top triggers</span>
+              <div className="grid grid-cols-2 gap-3">
+                <ToolCard
+                  icon={TimeIcon}
+                  label="Schedule"
+                  description="Trigger this agent on a schedule"
+                  isSelected={false}
+                  canAdd={true}
+                  onClick={onScheduleSelect}
+                  cardContainerClassName="h-36"
+                />
               </div>
-            )}
+            </div>
+          )}
 
-            {filteredWebhookSourceViews.length > 0 && (
-              <div className="flex flex-col gap-3">
-                <span className="text-lg font-semibold">Webhooks</span>
-                <div className="grid grid-cols-2 gap-3">
-                  {filteredWebhookSourceViews.map((view) => {
-                    const icon = isCustomResourceIconType(view.icon)
-                      ? ActionIcons[view.icon]
-                      : InternalActionIcons[view.icon];
+          {filteredWebhookSourceViews.length > 0 && (
+            <div className="flex flex-col gap-3">
+              <span className="text-lg font-semibold">Webhooks</span>
+              <div className="grid grid-cols-2 gap-3">
+                {filteredWebhookSourceViews.map((view) => {
+                  const icon = isCustomResourceIconType(view.icon)
+                    ? ActionIcons[view.icon]
+                    : InternalActionIcons[view.icon];
 
-                    return (
-                      <ToolCard
-                        key={view.sId}
-                        icon={icon}
-                        label={view.customName}
-                        description={view.description}
-                        isSelected={false}
-                        canAdd={true}
-                        onClick={() => onWebhookSelect(view)}
-                        cardContainerClassName="h-36"
-                      />
-                    );
-                  })}
-                </div>
+                  return (
+                    <ToolCard
+                      key={view.sId}
+                      icon={icon}
+                      label={view.customName}
+                      description={view.description}
+                      isSelected={false}
+                      canAdd={true}
+                      onClick={() => onWebhookSelect(view)}
+                      cardContainerClassName="h-36"
+                    />
+                  );
+                })}
               </div>
-            )}
+            </div>
+          )}
 
-            {!showSchedule && filteredWebhookSourceViews.length === 0 && (
-              <div className="flex h-32 items-center justify-center text-sm">
-                No triggers found matching your search
-              </div>
-            )}
-          </div>
-        </Page.Vertical>
+          {!showSchedule && filteredWebhookSourceViews.length === 0 && (
+            <div className="flex h-32 items-center justify-center text-sm">
+              No triggers found matching your search
+            </div>
+          )}
+        </SheetContainer>
         <SheetFooter
           leftButtonProps={{
             label: "Close",

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -2,6 +2,11 @@ import {
   ActionIcons,
   Page,
   SearchInput,
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
   TimeIcon,
   ToolCard,
 } from "@dust-tt/sparkle";
@@ -14,12 +19,16 @@ import {
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 interface TriggerSelectionPageProps {
+  isOpen: boolean;
+  onClose: () => void;
   onScheduleSelect: () => void;
   onWebhookSelect: (webhookSourceView: WebhookSourceViewType) => void;
   webhookSourceViews: WebhookSourceViewType[];
 }
 
 export function TriggerSelectionPage({
+  isOpen,
+  onClose,
   onScheduleSelect,
   onWebhookSelect,
   webhookSourceViews,
@@ -54,64 +63,78 @@ export function TriggerSelectionPage({
   }, [searchTerm]);
 
   return (
-    <Page.Vertical sizing="grow">
-      <div className="flex flex-col gap-4 px-6 py-4">
-        <SearchInput
-          placeholder="Search triggers..."
-          value={searchTerm}
-          onChange={setSearchTerm}
-          name="triggerSearch"
-        />
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent size="lg">
+        <SheetHeader>
+          <SheetTitle>Add triggers</SheetTitle>
+        </SheetHeader>
+        <Page.Vertical sizing="grow">
+          <div className="flex flex-col gap-4 px-6 py-4">
+            <SearchInput
+              placeholder="Search triggers..."
+              value={searchTerm}
+              onChange={setSearchTerm}
+              name="triggerSearch"
+            />
 
-        {showSchedule && (
-          <div className="flex flex-col gap-3">
-            <span className="text-lg font-semibold">Top triggers</span>
-            <div className="grid grid-cols-2 gap-3">
-              <ToolCard
-                icon={TimeIcon}
-                label="Schedule"
-                description="Trigger this agent on a schedule"
-                isSelected={false}
-                canAdd={true}
-                onClick={onScheduleSelect}
-                cardContainerClassName="h-36"
-              />
-            </div>
-          </div>
-        )}
-
-        {filteredWebhookSourceViews.length > 0 && (
-          <div className="flex flex-col gap-3">
-            <span className="text-lg font-semibold">Webhooks</span>
-            <div className="grid grid-cols-2 gap-3">
-              {filteredWebhookSourceViews.map((view) => {
-                const icon = isCustomResourceIconType(view.icon)
-                  ? ActionIcons[view.icon]
-                  : InternalActionIcons[view.icon];
-
-                return (
+            {showSchedule && (
+              <div className="flex flex-col gap-3">
+                <span className="text-lg font-semibold">Top triggers</span>
+                <div className="grid grid-cols-2 gap-3">
                   <ToolCard
-                    key={view.sId}
-                    icon={icon}
-                    label={view.customName}
-                    description={view.description}
+                    icon={TimeIcon}
+                    label="Schedule"
+                    description="Trigger this agent on a schedule"
                     isSelected={false}
                     canAdd={true}
-                    onClick={() => onWebhookSelect(view)}
+                    onClick={onScheduleSelect}
                     cardContainerClassName="h-36"
                   />
-                );
-              })}
-            </div>
-          </div>
-        )}
+                </div>
+              </div>
+            )}
 
-        {!showSchedule && filteredWebhookSourceViews.length === 0 && (
-          <div className="flex h-32 items-center justify-center text-sm">
-            No triggers found matching your search
+            {filteredWebhookSourceViews.length > 0 && (
+              <div className="flex flex-col gap-3">
+                <span className="text-lg font-semibold">Webhooks</span>
+                <div className="grid grid-cols-2 gap-3">
+                  {filteredWebhookSourceViews.map((view) => {
+                    const icon = isCustomResourceIconType(view.icon)
+                      ? ActionIcons[view.icon]
+                      : InternalActionIcons[view.icon];
+
+                    return (
+                      <ToolCard
+                        key={view.sId}
+                        icon={icon}
+                        label={view.customName}
+                        description={view.description}
+                        isSelected={false}
+                        canAdd={true}
+                        onClick={() => onWebhookSelect(view)}
+                        cardContainerClassName="h-36"
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {!showSchedule && filteredWebhookSourceViews.length === 0 && (
+              <div className="flex h-32 items-center justify-center text-sm">
+                No triggers found matching your search
+              </div>
+            )}
           </div>
-        )}
-      </div>
-    </Page.Vertical>
+        </Page.Vertical>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Close",
+            variant: "outline",
+            onClick: onClose,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -1,10 +1,4 @@
-import {
-  ActionIcons,
-  Input,
-  Page,
-  TimeIcon,
-  ToolCard,
-} from "@dust-tt/sparkle";
+import { ActionIcons, Input, Page, TimeIcon, ToolCard } from "@dust-tt/sparkle";
 import React, { useMemo, useState } from "react";
 
 import {
@@ -66,7 +60,7 @@ export function TriggerSelectionPage({
 
         {showSchedule && (
           <div className="flex flex-col gap-3">
-            <span className="text-lg font-semibold text-element-900">
+            <span className="text-element-900 text-lg font-semibold">
               Top triggers
             </span>
             <div className="grid grid-cols-2 gap-3">
@@ -85,7 +79,7 @@ export function TriggerSelectionPage({
 
         {filteredWebhookSourceViews.length > 0 && (
           <div className="flex flex-col gap-3">
-            <span className="text-lg font-semibold text-element-900">
+            <span className="text-element-900 text-lg font-semibold">
               Webhooks
             </span>
             <div className="grid grid-cols-2 gap-3">
@@ -112,7 +106,7 @@ export function TriggerSelectionPage({
         )}
 
         {!showSchedule && filteredWebhookSourceViews.length === 0 && (
-          <div className="flex h-32 items-center justify-center text-sm text-element-700">
+          <div className="text-element-600 flex h-32 items-center justify-center text-sm">
             No triggers found matching your search
           </div>
         )}

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -64,7 +64,7 @@ export function TriggerSelectionPage({
 
   return (
     <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent size="lg">
+      <SheetContent size="xl">
         <SheetHeader>
           <SheetTitle>Add triggers</SheetTitle>
         </SheetHeader>
@@ -74,10 +74,11 @@ export function TriggerSelectionPage({
             value={searchTerm}
             onChange={setSearchTerm}
             name="triggerSearch"
+            className="mt-4"
           />
 
           {showSchedule && (
-            <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-4 py-2">
               <span className="text-lg font-semibold">Top triggers</span>
               <div className="grid grid-cols-2 gap-3">
                 <ToolCard
@@ -94,8 +95,8 @@ export function TriggerSelectionPage({
           )}
 
           {filteredWebhookSourceViews.length > 0 && (
-            <div className="flex flex-col gap-3">
-              <span className="text-lg font-semibold">Webhooks</span>
+            <div className="flex flex-col gap-4">
+              <span className="text-lg font-semibold">Other triggers</span>
               <div className="grid grid-cols-2 gap-3">
                 {filteredWebhookSourceViews.map((view) => {
                   const icon = isCustomResourceIconType(view.icon)

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -77,48 +77,50 @@ export function TriggerSelectionPage({
             className="mt-4"
           />
 
-          {showSchedule && (
-            <div className="flex flex-col gap-4 py-2">
-              <span className="text-lg font-semibold">Top triggers</span>
-              <div className="grid grid-cols-2 gap-3">
-                <ToolCard
-                  icon={TimeIcon}
-                  label="Schedule"
-                  description="Trigger this agent on a schedule"
-                  isSelected={false}
-                  canAdd={true}
-                  onClick={onScheduleSelect}
-                  cardContainerClassName="h-36"
-                />
-              </div>
-            </div>
-          )}
+          <div className="flex flex-col gap-4 py-2">
+            {showSchedule && (
+              <>
+                <span className="text-lg font-semibold">Top triggers</span>
+                <div className="grid grid-cols-2 gap-3">
+                  <ToolCard
+                    icon={TimeIcon}
+                    label="Schedule"
+                    description="Trigger this agent on a schedule"
+                    isSelected={false}
+                    canAdd={true}
+                    onClick={onScheduleSelect}
+                    cardContainerClassName="h-36"
+                  />
+                </div>
+              </>
+            )}
 
-          {filteredWebhookSourceViews.length > 0 && (
-            <div className="flex flex-col gap-4">
-              <span className="text-lg font-semibold">Other triggers</span>
-              <div className="grid grid-cols-2 gap-3">
-                {filteredWebhookSourceViews.map((view) => {
-                  const icon = isCustomResourceIconType(view.icon)
-                    ? ActionIcons[view.icon]
-                    : InternalActionIcons[view.icon];
+            {filteredWebhookSourceViews.length > 0 && (
+              <div className="flex flex-col gap-4">
+                <span className="text-lg font-semibold">Other triggers</span>
+                <div className="grid grid-cols-2 gap-3">
+                  {filteredWebhookSourceViews.map((view) => {
+                    const icon = isCustomResourceIconType(view.icon)
+                      ? ActionIcons[view.icon]
+                      : InternalActionIcons[view.icon];
 
-                  return (
-                    <ToolCard
-                      key={view.sId}
-                      icon={icon}
-                      label={view.customName}
-                      description={view.description}
-                      isSelected={false}
-                      canAdd={true}
-                      onClick={() => onWebhookSelect(view)}
-                      cardContainerClassName="h-36"
-                    />
-                  );
-                })}
+                    return (
+                      <ToolCard
+                        key={view.sId}
+                        icon={icon}
+                        label={view.customName}
+                        description={view.description}
+                        isSelected={false}
+                        canAdd={true}
+                        onClick={() => onWebhookSelect(view)}
+                        cardContainerClassName="h-36"
+                      />
+                    );
+                  })}
+                </div>
               </div>
-            </div>
-          )}
+            )}
+          </div>
 
           {!showSchedule && filteredWebhookSourceViews.length === 0 && (
             <div className="flex h-32 items-center justify-center text-sm">

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -109,7 +109,7 @@ export function TriggerSelectionPage({
                         key={view.sId}
                         icon={icon}
                         label={view.customName}
-                        description={view.description}
+                        description={view.description ?? `Trigger this agent with ${view.customname}.`}
                         isSelected={false}
                         canAdd={true}
                         onClick={() => onWebhookSelect(view)}

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -1,4 +1,10 @@
-import { ActionIcons, Input, Page, TimeIcon, ToolCard } from "@dust-tt/sparkle";
+import {
+  ActionIcons,
+  Page,
+  SearchInput,
+  TimeIcon,
+  ToolCard,
+} from "@dust-tt/sparkle";
 import React, { useMemo, useState } from "react";
 
 import {
@@ -50,12 +56,10 @@ export function TriggerSelectionPage({
   return (
     <Page.Vertical sizing="grow">
       <div className="flex flex-col gap-4 px-6 py-4">
-        <Input
+        <SearchInput
           placeholder="Search triggers..."
           value={searchTerm}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setSearchTerm(e.target.value)
-          }
+          onChange={setSearchTerm}
           name="triggerSearch"
         />
 

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -64,7 +64,7 @@ export function TriggerSelectionPage({
 
   return (
     <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent size="xl">
+      <SheetContent size="lg">
         <SheetHeader>
           <SheetTitle>Add triggers</SheetTitle>
         </SheetHeader>

--- a/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
+++ b/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
@@ -1,9 +1,4 @@
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@dust-tt/sparkle";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@dust-tt/sparkle";
 import React, { useCallback, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
@@ -20,7 +15,7 @@ import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 type SheetMode =
-  | { type: "selection" }
+  | { type: "add" }
   | {
       type: "edit";
       trigger: AgentBuilderTriggerType;
@@ -67,7 +62,7 @@ export function TriggerViewsSheet({
     webhookSourceView: WebhookSourceViewType | null;
   } | null>(null);
 
-  const isSelectionSheetOpen = mode?.type === "selection";
+  const isSelectionSheetOpen = mode?.type === "add";
 
   const handleSelectionSheetClose = useCallback(() => {
     onModeChange(null);

--- a/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
+++ b/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
@@ -1,0 +1,209 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
+import React, { useCallback, useState } from "react";
+import { useFieldArray, useFormContext } from "react-hook-form";
+
+import type {
+  AgentBuilderFormData,
+  AgentBuilderScheduleTriggerType,
+  AgentBuilderTriggerType,
+  AgentBuilderWebhookTriggerType,
+} from "@app/components/agent_builder/AgentBuilderFormContext";
+import { ScheduleEdition } from "@app/components/agent_builder/triggers/schedule/ScheduleEdition";
+import { TriggerSelectionPage } from "@app/components/agent_builder/triggers/TriggerSelectionPage";
+import { WebhookEdition } from "@app/components/agent_builder/triggers/webhook/WebhookEdition";
+import type { LightWorkspaceType } from "@app/types";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+
+type SheetMode =
+  | { type: "selection" }
+  | {
+      type: "edit";
+      trigger: AgentBuilderTriggerType;
+      index: number;
+      webhookSourceView: WebhookSourceViewType | null;
+    };
+
+interface TriggerViewsSheetProps {
+  owner: LightWorkspaceType;
+  mode: SheetMode | null;
+  onModeChange: (mode: SheetMode | null) => void;
+  webhookSourceViews: WebhookSourceViewType[];
+  agentConfigurationId: string | null;
+}
+
+export function TriggerViewsSheet({
+  owner,
+  mode,
+  onModeChange,
+  webhookSourceViews,
+  agentConfigurationId,
+}: TriggerViewsSheetProps) {
+  const { control } = useFormContext<AgentBuilderFormData>();
+
+  const { append: appendTriggerToCreate, update: updateTriggerToCreate } =
+    useFieldArray({
+      control,
+      name: "triggersToCreate",
+    });
+
+  const { append: appendTriggerToUpdate } = useFieldArray({
+    control,
+    name: "triggersToUpdate",
+  });
+
+  const [scheduleEditionState, setScheduleEditionState] = useState<{
+    trigger: AgentBuilderScheduleTriggerType | null;
+    index: number | null;
+  } | null>(null);
+
+  const [webhookEditionState, setWebhookEditionState] = useState<{
+    trigger: AgentBuilderWebhookTriggerType | null;
+    index: number | null;
+    webhookSourceView: WebhookSourceViewType | null;
+  } | null>(null);
+
+  const isSelectionSheetOpen = mode?.type === "selection";
+
+  const handleSelectionSheetClose = useCallback(() => {
+    onModeChange(null);
+  }, [onModeChange]);
+
+  const handleScheduleSelect = useCallback(() => {
+    setScheduleEditionState({ trigger: null, index: null });
+    onModeChange(null);
+  }, [onModeChange]);
+
+  const handleWebhookSelect = useCallback(
+    (webhookSourceView: WebhookSourceViewType) => {
+      setWebhookEditionState({
+        trigger: null,
+        index: null,
+        webhookSourceView,
+      });
+      onModeChange(null);
+    },
+    [onModeChange]
+  );
+
+  const handleScheduleSave = useCallback(
+    (trigger: AgentBuilderScheduleTriggerType) => {
+      if (
+        scheduleEditionState &&
+        scheduleEditionState.index !== null &&
+        scheduleEditionState.index !== undefined
+      ) {
+        if (scheduleEditionState.trigger?.sId) {
+          appendTriggerToUpdate(trigger);
+        } else {
+          updateTriggerToCreate(scheduleEditionState.index, trigger);
+        }
+      } else {
+        appendTriggerToCreate(trigger);
+      }
+      setScheduleEditionState(null);
+    },
+    [
+      scheduleEditionState,
+      appendTriggerToCreate,
+      appendTriggerToUpdate,
+      updateTriggerToCreate,
+    ]
+  );
+
+  const handleWebhookSave = useCallback(
+    (trigger: AgentBuilderWebhookTriggerType) => {
+      if (
+        webhookEditionState &&
+        webhookEditionState.index !== null &&
+        webhookEditionState.index !== undefined
+      ) {
+        if (webhookEditionState.trigger?.sId) {
+          appendTriggerToUpdate(trigger);
+        } else {
+          updateTriggerToCreate(webhookEditionState.index, trigger);
+        }
+      } else {
+        appendTriggerToCreate(trigger);
+      }
+      setWebhookEditionState(null);
+    },
+    [
+      webhookEditionState,
+      appendTriggerToCreate,
+      appendTriggerToUpdate,
+      updateTriggerToCreate,
+    ]
+  );
+
+  const handleScheduleClose = useCallback(() => {
+    setScheduleEditionState(null);
+  }, []);
+
+  const handleWebhookClose = useCallback(() => {
+    setWebhookEditionState(null);
+  }, []);
+
+  if (mode?.type === "edit") {
+    if (mode.trigger.kind === "schedule") {
+      if (scheduleEditionState === null) {
+        setScheduleEditionState({
+          trigger: mode.trigger,
+          index: mode.index,
+        });
+        onModeChange(null);
+      }
+    } else if (mode.trigger.kind === "webhook") {
+      if (webhookEditionState === null) {
+        setWebhookEditionState({
+          trigger: mode.trigger,
+          index: mode.index,
+          webhookSourceView: mode.webhookSourceView,
+        });
+        onModeChange(null);
+      }
+    }
+  }
+
+  return (
+    <>
+      <Sheet
+        open={isSelectionSheetOpen}
+        onOpenChange={(open) => !open && handleSelectionSheetClose()}
+      >
+        <SheetContent size="lg">
+          <SheetHeader>
+            <SheetTitle>Add triggers</SheetTitle>
+          </SheetHeader>
+          <TriggerSelectionPage
+            onScheduleSelect={handleScheduleSelect}
+            onWebhookSelect={handleWebhookSelect}
+            webhookSourceViews={webhookSourceViews}
+          />
+        </SheetContent>
+      </Sheet>
+
+      <ScheduleEdition
+        owner={owner}
+        trigger={scheduleEditionState?.trigger ?? null}
+        isOpen={scheduleEditionState !== null}
+        onClose={handleScheduleClose}
+        onSave={handleScheduleSave}
+      />
+
+      <WebhookEdition
+        owner={owner}
+        trigger={webhookEditionState?.trigger ?? null}
+        isOpen={webhookEditionState !== null}
+        onClose={handleWebhookClose}
+        onSave={handleWebhookSave}
+        agentConfigurationId={agentConfigurationId}
+        webhookSourceView={webhookEditionState?.webhookSourceView ?? null}
+      />
+    </>
+  );
+}

--- a/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
+++ b/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
@@ -1,4 +1,3 @@
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@dust-tt/sparkle";
 import React, { useCallback, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
@@ -158,21 +157,13 @@ export function TriggerViewsSheet({
 
   return (
     <>
-      <Sheet
-        open={isSelectionSheetOpen}
-        onOpenChange={(open) => !open && handleSelectionSheetClose()}
-      >
-        <SheetContent size="lg">
-          <SheetHeader>
-            <SheetTitle>Add triggers</SheetTitle>
-          </SheetHeader>
-          <TriggerSelectionPage
-            onScheduleSelect={handleScheduleSelect}
-            onWebhookSelect={handleWebhookSelect}
-            webhookSourceViews={webhookSourceViews}
-          />
-        </SheetContent>
-      </Sheet>
+      <TriggerSelectionPage
+        isOpen={isSelectionSheetOpen}
+        onClose={handleSelectionSheetClose}
+        onScheduleSelect={handleScheduleSelect}
+        onWebhookSelect={handleWebhookSelect}
+        webhookSourceViews={webhookSourceViews}
+      />
 
       <ScheduleEdition
         owner={owner}

--- a/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
+++ b/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
@@ -87,11 +87,7 @@ export function TriggerViewsSheet({
 
   const handleScheduleSave = useCallback(
     (trigger: AgentBuilderScheduleTriggerType) => {
-      if (
-        scheduleEditionState &&
-        scheduleEditionState.index !== null &&
-        scheduleEditionState.index !== undefined
-      ) {
+      if (scheduleEditionState?.index) {
         if (scheduleEditionState.trigger?.sId) {
           appendTriggerToUpdate(trigger);
         } else {
@@ -112,11 +108,7 @@ export function TriggerViewsSheet({
 
   const handleWebhookSave = useCallback(
     (trigger: AgentBuilderWebhookTriggerType) => {
-      if (
-        webhookEditionState &&
-        webhookEditionState.index !== null &&
-        webhookEditionState.index !== undefined
-      ) {
+      if (webhookEditionState?.index) {
         if (webhookEditionState.trigger?.sId) {
           appendTriggerToUpdate(trigger);
         } else {

--- a/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
+++ b/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
@@ -14,7 +14,7 @@ import { WebhookEdition } from "@app/components/agent_builder/triggers/webhook/W
 import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
-type SheetMode =
+export type SheetMode =
   | { type: "add" }
   | {
       type: "edit";


### PR DESCRIPTION
## Description

- This PR updates the design for adding triggers to an agent in Agent Builder.
- It replaces the existing dropdown list with a pattern similar to adding tools:
  - There's an "Add triggers" button
  - Clicking on it opens a sheet with 1 card per type of trigger (what we had in the dropdown list)
  - Clicking on a card opens the sheet from where the trigger can be configured
  - Saving on this last sheet closes both sheets

<img width="421" height="1031" alt="Screenshot 2025-10-26 at 10 59 17 PM" src="https://github.com/user-attachments/assets/0f180be5-f8c1-4a7d-873d-fe6370d04fcd" />

- The descriptions are empty; the flow of webhook source creation in `Spaces > Triggers` should include inputting a description earlier on (currently you have to create the source and then edit it to add a description).

## Tests

- Checked locally.

## Risk

- Low, mostly UI.

## Deploy Plan

- Deploy front.
