### PR TITLE
[front] fix(webhooks): enhance icon handling with provider-based preset

### DIFF
--- a/front/components/triggers/AddTriggerMenu.tsx
+++ b/front/components/triggers/AddTriggerMenu.tsx
@@ -7,6 +7,7 @@ import {
   PlusIcon,
 } from "@dust-tt/sparkle";
 
+import { getIcon } from "@app/components/resources/resources_icons";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { WorkspaceType } from "@app/types";
@@ -56,7 +57,7 @@ export const AddTriggerMenu = ({
             <DropdownMenuItem
               key={kind}
               label={WEBHOOK_PRESETS[kind].name + " Webhook"}
-              icon={WEBHOOK_PRESETS[kind].icon}
+              icon={getIcon(WEBHOOK_PRESETS[kind].icon)}
               onClick={() => createWebhook(kind)}
             />
           ))}

--- a/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
@@ -1,6 +1,7 @@
 import { Button, ExternalLinkIcon, Label, Spinner } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+import { getIcon } from "@app/components/resources/resources_icons";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { LightWorkspaceType, OAuthConnectionType } from "@app/types";
 import { setupOAuthConnection } from "@app/types";
@@ -91,7 +92,7 @@ export function CreateWebhookSourceWithProviderForm({
             label={
               connection ? `Connected to ${kindName}` : `Connect to ${kindName}`
             }
-            icon={preset.icon}
+            icon={getIcon(preset.icon)}
             onClick={handleConnectToProvider}
             disabled={isConnectingProvider || !!connection}
           />

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -26,11 +26,7 @@ import type { WebhookSourceFormValues } from "@app/components/triggers/forms/web
 import { WebhookEndpointUsageInfo } from "@app/components/triggers/WebhookEndpointUsageInfo";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
-import {
-  buildWebhookUrl,
-  DEFAULT_WEBHOOK_ICON,
-  normalizeWebhookIcon,
-} from "@app/lib/webhookSource";
+import { buildWebhookUrl, normalizeWebhookIcon } from "@app/lib/webhookSource";
 import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewForAdminType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
@@ -150,7 +146,7 @@ export function WebhookSourceDetailsInfo({
                 >
                   <IconPicker
                     icons={ActionIcons}
-                    selectedIcon={selectedIcon ?? DEFAULT_WEBHOOK_ICON}
+                    selectedIcon={normalizeWebhookIcon(selectedIcon)}
                     onIconSelect={(iconName: string) => {
                       form.setValue("icon", iconName, { shouldDirty: true });
                       setIsPopoverOpen(false);

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -42,7 +42,7 @@ import {
   useDeleteWebhookSource,
   useWebhookSourcesWithViews,
 } from "@app/lib/swr/webhook_source";
-import { DEFAULT_WEBHOOK_ICON } from "@app/lib/webhookSource";
+import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { LightWorkspaceType, RequireAtLeastOne } from "@app/types";
 import type {
@@ -251,9 +251,9 @@ function WebhookSourceSheetContent({
         includeGlobal: true,
         ...(remoteMetadata ? { remoteMetadata } : {}),
         ...(connectionId ? { connectionId } : {}),
-        icon: data.provider
-          ? WEBHOOK_PRESETS[data.provider].icon
-          : DEFAULT_WEBHOOK_ICON,
+        icon: normalizeWebhookIcon(
+          data.provider ? WEBHOOK_PRESETS[data.provider].icon : null
+        ),
       };
 
       await createWebhookSource(apiData);
@@ -552,9 +552,9 @@ function WebhookSourceSheetContent({
         title: `Create ${mode.provider ? WEBHOOK_PRESETS[mode.provider].name : "Custom"} Webhook Source`,
         description: "",
         icon: getIcon(
-          mode.provider
-            ? WEBHOOK_PRESETS[mode.provider].icon
-            : DEFAULT_WEBHOOK_ICON
+          normalizeWebhookIcon(
+            mode.provider ? WEBHOOK_PRESETS[mode.provider].icon : null
+          )
         ),
         content: (
           <FormProvider {...createForm}>
@@ -582,9 +582,9 @@ function WebhookSourceSheetContent({
         icon: systemView
           ? () => <WebhookSourceViewIcon webhookSourceView={systemView} />
           : getIcon(
-              mode.provider
-                ? WEBHOOK_PRESETS[mode.provider].icon
-                : DEFAULT_WEBHOOK_ICON
+              normalizeWebhookIcon(
+                mode.provider ? WEBHOOK_PRESETS[mode.provider].icon : null
+              )
             ),
         content:
           systemView && webhookSource ? (

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -251,6 +251,9 @@ function WebhookSourceSheetContent({
         includeGlobal: true,
         ...(remoteMetadata ? { remoteMetadata } : {}),
         ...(connectionId ? { connectionId } : {}),
+        icon: data.provider
+          ? WEBHOOK_PRESETS[data.provider].icon
+          : DEFAULT_WEBHOOK_ICON,
       };
 
       await createWebhookSource(apiData);

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -548,9 +548,11 @@ function WebhookSourceSheetContent({
         id: "create",
         title: `Create ${mode.provider ? WEBHOOK_PRESETS[mode.provider].name : "Custom"} Webhook Source`,
         description: "",
-        icon: mode.provider
-          ? WEBHOOK_PRESETS[mode.provider].icon
-          : getIcon(DEFAULT_WEBHOOK_ICON),
+        icon: getIcon(
+          mode.provider
+            ? WEBHOOK_PRESETS[mode.provider].icon
+            : DEFAULT_WEBHOOK_ICON
+        ),
         content: (
           <FormProvider {...createForm}>
             <div className="space-y-4">
@@ -576,9 +578,11 @@ function WebhookSourceSheetContent({
         description: "Webhook source for triggering assistants.",
         icon: systemView
           ? () => <WebhookSourceViewIcon webhookSourceView={systemView} />
-          : mode.provider
-            ? WEBHOOK_PRESETS[mode.provider].icon
-            : getIcon(DEFAULT_WEBHOOK_ICON),
+          : getIcon(
+              mode.provider
+                ? WEBHOOK_PRESETS[mode.provider].icon
+                : DEFAULT_WEBHOOK_ICON
+            ),
         content:
           systemView && webhookSource ? (
             <FormProvider {...editForm}>

--- a/front/components/triggers/WebhookSourceViewIcon.tsx
+++ b/front/components/triggers/WebhookSourceViewIcon.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from "react";
 
 import {
   getAvatarFromIcon,
+  getIcon,
   ResourceAvatar,
 } from "@app/components/resources/resources_icons";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
@@ -18,7 +19,12 @@ export const WebhookSourceViewIcon = ({
   const { provider } = webhookSourceView;
 
   if (provider) {
-    return <ResourceAvatar icon={WEBHOOK_PRESETS[provider].icon} size={size} />;
+    return (
+      <ResourceAvatar
+        icon={getIcon(WEBHOOK_PRESETS[provider].icon)}
+        size={size}
+      />
+    );
   }
 
   return getAvatarFromIcon(webhookSourceView.icon, size);

--- a/front/components/triggers/forms/webhookSourceFormSchema.ts
+++ b/front/components/triggers/forms/webhookSourceFormSchema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { DEFAULT_WEBHOOK_ICON } from "@app/lib/webhookSource";
+import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 export type WebhookSourceFormValues = {
@@ -43,7 +43,7 @@ export function getWebhookSourceFormDefaults(
   return {
     name,
     description: view.description ?? "",
-    icon: view.icon ?? DEFAULT_WEBHOOK_ICON,
+    icon: normalizeWebhookIcon(view.icon),
     sharingSettings,
   };
 }

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -15,7 +15,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import { DEFAULT_WEBHOOK_ICON } from "@app/lib/webhookSource";
+import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok, redactString } from "@app/types";
@@ -46,7 +46,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
   static async makeNew(
     auth: Authenticator,
     blob: CreationAttributes<WebhookSourceModel>,
-    { transaction }: { transaction?: Transaction } = {}
+    { transaction, icon }: { transaction?: Transaction; icon?: string } = {}
   ): Promise<WebhookSourceResource> {
     assert(
       await SpaceResource.canAdministrateSystemSpace(auth),
@@ -69,7 +69,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
         webhookSourceId: webhookSource.id,
         // on creation there is no custom icon or description
         description: "",
-        icon: DEFAULT_WEBHOOK_ICON,
+        icon: normalizeWebhookIcon(icon),
       },
       {
         transaction,

--- a/front/lib/triggers/built-in-webhooks/github/github_webhook_source_presets.ts
+++ b/front/lib/triggers/built-in-webhooks/github/github_webhook_source_presets.ts
@@ -1,5 +1,3 @@
-import { GithubLogo } from "@dust-tt/sparkle";
-
 import { CreateWebhookGithubConnection } from "@app/lib/triggers/built-in-webhooks/github/components/CreateWebhookGithubConnection";
 import { WebhookSourceGithubDetails } from "@app/lib/triggers/built-in-webhooks/github/components/WebhookSourceGithubDetails";
 import { GitHubWebhookService } from "@app/lib/triggers/built-in-webhooks/github/github_webhook_service";
@@ -33,7 +31,7 @@ export const GITHUB_WEBHOOK_PRESET: PresetWebhook<"github"> = {
     field: "X-GitHub-Event",
   },
   events: [GITHUB_PULL_REQUEST_EVENT, GITHUB_ISSUES_EVENT],
-  icon: GithubLogo,
+  icon: "GithubLogo",
   description:
     "Receive events from GitHub such as creation or edition of issues or pull requests.",
   webhookPageUrl: `https://github.com/settings/connections/applications/${process.env.NEXT_PUBLIC_OAUTH_GITHUB_APP_WEBHOOKS_CLIENT_ID}`,

--- a/front/lib/triggers/built-in-webhooks/test/test_webhook_source_presets.ts
+++ b/front/lib/triggers/built-in-webhooks/test/test_webhook_source_presets.ts
@@ -1,5 +1,3 @@
-import { RocketIcon } from "@dust-tt/sparkle";
-
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
@@ -103,7 +101,7 @@ export const TEST_WEBHOOK_PRESET: PresetWebhook<"test"> = {
     field: "event-type",
   },
   events: [TEST_EVENT],
-  icon: RocketIcon,
+  icon: "ActionRocketIcon",
   description: "A test webhook preset with a simple event structure.",
   // Used for dev tests only, it should always be hidden behind the flag
   featureFlag: "hootl_dev_webhooks",

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -118,6 +118,7 @@ async function handler(
         provider,
         connectionId,
         remoteMetadata,
+        icon,
       } = bodyValidation.data;
 
       if (provider && subscribedEvents.length === 0) {
@@ -146,22 +147,26 @@ async function handler(
         });
       }
 
-      const webhookSource = await WebhookSourceResource.makeNew(auth, {
-        workspaceId: workspace.id,
-        name,
-        secret:
-          trimmedSignatureHeader.length === 0
-            ? null
-            : secret && secret.length > 0
-              ? secret
-              : generateSecureSecret(64),
-        urlSecret: generateSecureSecret(64),
-        provider,
-        signatureHeader:
-          trimmedSignatureHeader.length > 0 ? trimmedSignatureHeader : null,
-        signatureAlgorithm,
-        subscribedEvents,
-      });
+      const webhookSource = await WebhookSourceResource.makeNew(
+        auth,
+        {
+          workspaceId: workspace.id,
+          name,
+          secret:
+            trimmedSignatureHeader.length === 0
+              ? null
+              : secret && secret.length > 0
+                ? secret
+                : generateSecureSecret(64),
+          urlSecret: generateSecureSecret(64),
+          provider,
+          signatureHeader:
+            trimmedSignatureHeader.length > 0 ? trimmedSignatureHeader : null,
+          signatureAlgorithm,
+          subscribedEvents,
+        },
+        { icon }
+      );
 
       if (includeGlobal) {
         const systemView =

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -117,4 +117,5 @@ export const WebhookSourcesSchema = z.object({
   // Optional fields for creating remote webhooks
   connectionId: z.string().optional(),
   remoteMetadata: z.record(z.any()).optional(),
+  icon: z.string().optional(),
 });

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -1,8 +1,10 @@
-import type { Icon } from "@dust-tt/sparkle";
-import { GithubLogo, JiraLogo } from "@dust-tt/sparkle";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type React from "react";
 
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
 import type {
   WebhookCreateFormComponentProps,
   WebhookDetailsComponentProps,
@@ -23,19 +25,11 @@ export type WebhookEvent = {
   schema: JSONSchema;
 };
 
-const WebhookPresetIcons = {
-  GithubLogo,
-  JiraLogo,
-} as const;
-
-export type WebhookPresetIcon =
-  (typeof WebhookPresetIcons)[keyof typeof WebhookPresetIcons];
-
 export type PresetWebhook<P extends WebhookProvider = WebhookProvider> = {
   name: string;
   eventCheck: EventCheck;
   events: WebhookEvent[];
-  icon: typeof Icon;
+  icon: InternalAllowedIconType | CustomResourceIconType;
   description: string;
   webhookPageUrl?: string;
   featureFlag?: WhitelistableFeature;


### PR DESCRIPTION
## Description

- This PR changes the way icons are handled: the default for webhooks is now the one from the preset (dynamically loaded), and the one in db will be treated as an override only.
- We are currently in a broken state where every row in db has the globe icon.
- This PR also normalize webhook icons using `normalizeWebhookIcon`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
