### PR TITLE
Delete invalid conversations

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -208,6 +208,7 @@ export async function destroyConversation(
   const c = await ConversationResource.fetchById(auth, conversation.sId, {
     includeDeleted: true,
     includeTest: true,
+    dangerouslySkipPermissionFiltering: true,
   });
   if (c) {
     await c.delete(auth);

--- a/front/migrations/20251027_delete_conversations_with_invalid_groups.ts
+++ b/front/migrations/20251027_delete_conversations_with_invalid_groups.ts
@@ -4,7 +4,7 @@ import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
 
@@ -71,11 +71,7 @@ makeScript({}, async ({ execute }, logger) => {
   await concurrentExecutor(
     Array.from(conversationsPerWorkspace.entries()),
     async ([workspaceId, conversationIds]) => {
-      const workspace = await WorkspaceModel.findOne({
-        where: {
-          id: workspaceId,
-        },
-      });
+      const workspace = await WorkspaceResource.fetchByModelId(workspaceId);
 
       if (!workspace) {
         logger.error({ workspaceId }, "Workspace not found for conversation");

--- a/front/migrations/20251027_delete_conversations_with_invalid_groups.ts
+++ b/front/migrations/20251027_delete_conversations_with_invalid_groups.ts
@@ -1,0 +1,147 @@
+import { QueryTypes } from "sequelize";
+
+import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+
+interface InvalidConversation {
+  id: number;
+  sId: string;
+  workspaceId: number;
+  missing_group_id: number;
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  // Get all conversations with non-existing groups in requestedGroupIds
+  // eslint-disable-next-line dust/no-raw-sql
+  const invalidConversations = await frontSequelize.query<InvalidConversation>(
+    `
+    SELECT 
+      ac.id,
+      ac."sId",
+      ac."workspaceId",
+      requested_group_id as missing_group_id
+    FROM conversations ac
+    CROSS JOIN UNNEST(ac."requestedGroupIds") as requested_group_id
+    WHERE NOT EXISTS (
+      SELECT 1 
+      FROM groups g 
+      WHERE g.id = requested_group_id 
+      AND g."workspaceId" = ac."workspaceId"
+    ) 
+    ORDER BY ac.id, requested_group_id
+    `,
+    { type: QueryTypes.SELECT }
+  );
+
+  logger.info(
+    { count: invalidConversations.length },
+    `Found ${invalidConversations.length} conversations with invalid groups`
+  );
+
+  if (invalidConversations.length === 0) {
+    logger.info("No conversations with invalid groups found. Nothing to do.");
+    return;
+  }
+
+  // Group by conversation id to avoid duplicate processing
+  const conversationsPerWorkspace = new Map<number, Set<string>>();
+
+  for (const conv of invalidConversations) {
+    const existing = conversationsPerWorkspace.get(conv.workspaceId);
+    if (!existing) {
+      conversationsPerWorkspace.set(
+        conv.workspaceId,
+        new Set<string>([conv.sId])
+      );
+    } else {
+      existing.add(conv.sId);
+    }
+  }
+
+  logger.info(
+    { count: conversationsPerWorkspace.size },
+    `Found ${conversationsPerWorkspace.size} workspaces with invalid conversations`
+  );
+
+  await concurrentExecutor(
+    Array.from(conversationsPerWorkspace.entries()),
+    async ([workspaceId, conversationIds]) => {
+      const workspace = await WorkspaceModel.findOne({
+        where: {
+          id: workspaceId,
+        },
+      });
+
+      if (!workspace) {
+        logger.error({ workspaceId }, "Workspace not found for conversation");
+        return;
+      }
+
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const conversations = await ConversationResource.fetchByIds(
+        auth,
+        Array.from(conversationIds),
+        { dangerouslySkipPermissionFiltering: true }
+      );
+
+      if (conversations.length !== conversationIds.size) {
+        logger.warn(
+          {
+            workspaceId: workspaceId,
+            missingConversationIds: Array.from(conversationIds).filter(
+              (id) => !conversations.some((c) => c.sId === id)
+            ),
+          },
+          "Missing conversations"
+        );
+      }
+
+      for (const conversation of conversations) {
+        logger.info(
+          {
+            sId: conversation.sId,
+            workspaceId: workspaceId,
+          },
+          execute
+            ? "Deleting conversation with all messages"
+            : "Would delete conversation with all messages (dry run)"
+        );
+
+        if (execute) {
+          const result = await destroyConversation(auth, {
+            conversationId: conversation.sId,
+          });
+          if (result.isErr()) {
+            logger.error(
+              {
+                sId: conversation.sId,
+                workspaceId: workspaceId,
+                error: result.error,
+              },
+              "Failed to delete conversation"
+            );
+          } else {
+            logger.info(
+              {
+                sId: conversation.sId,
+                workspaceId: workspaceId,
+              },
+              "Successfully deleted conversation with all messages"
+            );
+          }
+        }
+      }
+    },
+    {
+      concurrency: 4,
+    }
+  );
+
+  logger.info("Migration completed");
+});


### PR DESCRIPTION
## Description

Handle the "dangerouslySkipPermissionFiltering" in conversation_resource, as it was passed in destroyConversation but ignored. Also added the option at the end of destroyConversations (to be consistent with line 146 )

Script is getting all conversations with inexistent requestedGroupIds and destoy them. These conversations are not accessible by anybody right now but would become visible if we switch to the requestedSpaceIds (which remained empty after backfill, as the spaces were removed)

## Tests

Tested locally 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

run script (dry run first)
