### PR TITLE
refactor(front): centralized handling of mentions

### DIFF
--- a/front/lib/mentions/editor/suggestion.ts
+++ b/front/lib/mentions/editor/suggestion.ts
@@ -1,0 +1,127 @@
+import { compareForFuzzySort, subFilter } from "@app/lib/utils";
+import { GLOBAL_AGENTS_SID } from "@app/types";
+
+import type { RichAgentMention, RichMention } from "../types";
+import { isRichAgentMention } from "../types";
+
+/**
+ * Maximum number of suggestions to display in the autocomplete dropdown.
+ */
+const SUGGESTION_DISPLAY_LIMIT = 7;
+
+/**
+ * Priority order for specific agent suggestions.
+ * Lower numbers appear first in the list when within the display limit.
+ */
+const SUGGESTION_PRIORITY: Record<string, number> = {
+  [GLOBAL_AGENTS_SID.DUST]: 1,
+  [GLOBAL_AGENTS_SID.DEEP_DIVE]: 2,
+};
+
+/**
+ * Filters and sorts agent mention suggestions based on a query string.
+ */
+function filterAndSortAgentSuggestions(
+  lowerCaseQuery: string,
+  suggestions: RichAgentMention[]
+): RichAgentMention[] {
+  return suggestions
+    .filter((item) => subFilter(lowerCaseQuery, item.label.toLowerCase()))
+    .sort((a, b) =>
+      compareForFuzzySort(
+        lowerCaseQuery,
+        a.label.toLocaleLowerCase(),
+        b.label.toLocaleLowerCase()
+      )
+    )
+    .sort((a, b) => {
+      // If within SUGGESTION_DISPLAY_LIMIT there's one from SUGGESTION_PRIORITY,
+      // we move it to the top.
+      const aPriority = SUGGESTION_PRIORITY[a.id] ?? Number.MAX_SAFE_INTEGER;
+      const bPriority = SUGGESTION_PRIORITY[b.id] ?? Number.MAX_SAFE_INTEGER;
+      return aPriority - bPriority;
+    });
+}
+
+/**
+ * Filters agent suggestions based on a query, with fallback support.
+ *
+ * When the query is empty, returns suggestions in their pre-defined order.
+ * When the query is non-empty, filters and sorts both primary and fallback
+ * suggestions, prioritizing results from the user's list.
+ *
+ * @param query - The search query string
+ * @param suggestions - Primary suggestions (e.g., user's favorite agents)
+ * @param fallbackSuggestions - Fallback suggestions (e.g., all available agents)
+ * @returns Filtered and sorted suggestions, up to SUGGESTION_DISPLAY_LIMIT
+ */
+export function filterAgentSuggestions(
+  query: string,
+  suggestions: RichAgentMention[],
+  fallbackSuggestions: RichAgentMention[]
+): RichAgentMention[] {
+  // When queried without content, keep the pre-defined order.
+  if (query === "") {
+    return suggestions.slice(0, SUGGESTION_DISPLAY_LIMIT);
+  }
+
+  const lowerCaseQuery = query.toLowerCase();
+
+  const inListSuggestions = filterAndSortAgentSuggestions(
+    lowerCaseQuery,
+    suggestions
+  ).slice(0, SUGGESTION_DISPLAY_LIMIT);
+
+  // If there are enough suggestions from the user's list, use them.
+  if (inListSuggestions.length >= SUGGESTION_DISPLAY_LIMIT) {
+    return inListSuggestions;
+  }
+
+  // Otherwise, fallback to all suggestions.
+  const allSuggestionsNoDuplicates = filterAndSortAgentSuggestions(
+    lowerCaseQuery,
+    fallbackSuggestions
+  ).filter((item) => !inListSuggestions.find((i) => i.id === item.id));
+
+  // Sorts user's list suggestions alphabetically first, then appends and
+  // sorts remaining suggestions alphabetically, without sorting the combined
+  // list again.
+  return [...inListSuggestions, ...allSuggestionsNoDuplicates].slice(
+    0,
+    SUGGESTION_DISPLAY_LIMIT
+  );
+}
+
+/**
+ * Filters all mention suggestions (agents and users) based on a query.
+ *
+ * Currently only supports agent suggestions, but structured to support
+ * user mentions in the future.
+ */
+export function filterMentionSuggestions(
+  query: string,
+  suggestions: RichMention[],
+  fallbackSuggestions: RichMention[]
+): RichMention[] {
+  // Separate agent and user suggestions.
+  const agentSuggestions = suggestions.filter(isRichAgentMention);
+  const fallbackAgentSuggestions =
+    fallbackSuggestions.filter(isRichAgentMention);
+
+  // For now, only filter agents.
+  return filterAgentSuggestions(
+    query,
+    agentSuggestions,
+    fallbackAgentSuggestions
+  );
+}
+
+/**
+ * Utilities for mention suggestion filtering and sorting.
+ */
+export const mentionSuggestions = {
+  filter: filterMentionSuggestions,
+  filterAgents: filterAgentSuggestions,
+  displayLimit: SUGGESTION_DISPLAY_LIMIT,
+  priorities: SUGGESTION_PRIORITY,
+};

--- a/front/lib/mentions/editor/utils.ts
+++ b/front/lib/mentions/editor/utils.ts
@@ -1,0 +1,98 @@
+/**
+ * TipTap editor integration utilities for mentions.
+ *
+ * This module provides utilities for working with mentions in the TipTap
+ * editor, including insertion, extraction, and text serialization.
+ */
+
+import type { Content, Editor } from "@tiptap/react";
+
+import { extractFromEditorJSON } from "../format";
+import type { RichMention } from "../types";
+
+/**
+ * Inserts a mention into the editor at the current cursor position.
+ *
+ * Automatically adds spacing before the mention if needed, and always adds
+ * a space after the mention for better UX.
+ */
+export function insertMention(editor: Editor, mention: RichMention): void {
+  const shouldAddSpace =
+    !editor.isEmpty && editor.getText()[editor.getText().length - 1] !== " ";
+
+  editor
+    .chain()
+    .focus()
+    .insertContent(shouldAddSpace ? " " : "")
+    .insertContent({
+      type: "mention",
+      attrs: {
+        type: mention.type,
+        id: mention.id,
+        label: mention.label,
+        description: mention.description,
+        pictureUrl: mention.pictureUrl,
+      },
+    })
+    .insertContent(" ")
+    .run();
+}
+
+/**
+ * Extracts all mentions from the editor's current content.
+ *
+ * @returns Array of rich mention objects
+ */
+export function getMentions(editor: Editor): RichMention[] {
+  return extractFromEditorJSON(editor.getJSON()).mentions;
+}
+
+/**
+ * Gets the text content from the editor with mentions serialized.
+ *
+ * Mentions are converted to the format: :mention[name]{sId=xxx}
+ *
+ * @returns Serialized text with mentions
+ */
+export function getTextWithMentions(editor: Editor): string {
+  return extractFromEditorJSON(editor.getJSON()).text;
+}
+
+/**
+ * Resets the editor content with mentions.
+ *
+ * Useful for pre-populating the editor with specific mentions,
+ * such as when replying to a message or continuing a conversation.
+ */
+export function resetWithMentions(
+  editor: Editor,
+  mentions: RichMention[],
+  addSpaceAfter = true
+): void {
+  const content: Content[] = mentions.map((mention) => ({
+    type: "mention",
+    attrs: {
+      type: mention.type,
+      id: mention.id,
+      label: mention.label,
+      description: mention.description,
+      pictureUrl: mention.pictureUrl,
+    },
+  }));
+
+  if (addSpaceAfter) {
+    content.push({ type: "text", text: " " });
+  }
+
+  editor.commands.setContent(content);
+}
+
+/**
+ * Editor utilities for mention handling.
+ */
+export const editorMentionUtils = {
+  insertMention,
+  getMentions,
+  getTextWithMentions,
+  resetWithMentions,
+};

--- a/front/lib/mentions/format.test.ts
+++ b/front/lib/mentions/format.test.ts
@@ -1,26 +1,26 @@
 import { describe, expect, it } from "vitest";
 
-import { mentionAgent, replaceMentionsByAt } from "@app/lib/mentions";
+import { replaceMentionsWithAt, serializeMention } from "./format";
 
-describe("mentionAgent", () => {
+describe("serializeMention", () => {
   it("mentions an agent", () => {
-    const res = mentionAgent({ name: "agent", sId: "youpi" });
+    const res = serializeMention({ name: "agent", sId: "youpi" });
     expect(res).toBe(":mention[agent]{sId=youpi}");
   });
 });
 
-describe("replaceMentionsByAt", () => {
-  describe("idempotency with mentionAgent", () => {
+describe("replaceMentionsWithAt", () => {
+  describe("idempotency with serializeMention", () => {
     it("should replace mentions", () => {
-      const res = replaceMentionsByAt(
-        mentionAgent({ name: "agent", sId: "youpi" })
+      const res = replaceMentionsWithAt(
+        serializeMention({ name: "agent", sId: "youpi" })
       );
       expect(res).toBe("@agent");
     });
 
     it("should replace mentions", () => {
-      const res = replaceMentionsByAt(
-        mentionAgent({ name: "agent", sId: "youpi" }) + " text"
+      const res = replaceMentionsWithAt(
+        serializeMention({ name: "agent", sId: "youpi" }) + " text"
       );
       expect(res).toBe("@agent text");
     });
@@ -28,21 +28,21 @@ describe("replaceMentionsByAt", () => {
 
   describe("mentions", () => {
     it("should replace mentions", () => {
-      const res = replaceMentionsByAt(
+      const res = replaceMentionsWithAt(
         ":mention[soupinou]{sId=youpi} :mention[pistache]{sId=youpi2} hello both"
       );
       expect(res).toBe("@soupinou @pistache hello both");
     });
 
     it("should replace mentions with text", () => {
-      const res = replaceMentionsByAt(
+      const res = replaceMentionsWithAt(
         ":mention[soupinou]{sId=youpi} hello :mention[pistache]{sId=youpi2} both"
       );
       expect(res).toBe("@soupinou hello @pistache both");
     });
 
     it("should replace mentions with spaces", () => {
-      const res = replaceMentionsByAt(
+      const res = replaceMentionsWithAt(
         "Hello :mention[John Doe]{user_123}, how are you?"
       );
       expect(res).toBe("Hello @John Doe, how are you?");
@@ -51,12 +51,12 @@ describe("replaceMentionsByAt", () => {
 
   describe("non-mentions", () => {
     it("should not extract pure text", () => {
-      const res = replaceMentionsByAt("youpi est en vacances");
+      const res = replaceMentionsWithAt("youpi est en vacances");
       expect(res).toBe("youpi est en vacances");
     });
 
     it("should not extract almost a mention", () => {
-      const res = replaceMentionsByAt(":mention[agent]");
+      const res = replaceMentionsWithAt(":mention[agent]");
       expect(res).toBe(":mention[agent]");
     });
   });

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -1,0 +1,131 @@
+/**
+ * Mention serialization and parsing utilities.
+ *
+ * This module handles conversion between different mention representations:
+ * - String format: :mention[name]{sId=xxx}
+ * - TipTap JSON format
+ * - Plain text with @ symbols
+ */
+
+import type { JSONContent } from "@tiptap/react";
+
+import type { RichMention } from "./types";
+
+/**
+ * Regular expression for parsing mention strings.
+ * Format: `:mention[name]{sId=xxx}`
+ */
+const MENTION_REGEX = /:mention\[([^\]]+)\]\{[^}]+\}/g;
+
+/**
+ * Serializes a mention to the standard string format.
+ * Format: :mention[name]{sId=xxx}
+ */
+export function serializeMention(
+  mention: RichMention | { name: string; sId: string }
+): string {
+  if ("name" in mention && "sId" in mention) {
+    // Legacy format support
+    return `:mention[${mention.name}]{sId=${mention.sId}}`;
+  }
+  return `:mention[${mention.label}]{sId=${mention.id}}`;
+}
+
+/**
+ * Parses mention strings from text.
+ * Returns an array of matches with name and sId.
+ */
+export function parseMentions(text: string): Array<{
+  name: string;
+  sId: string;
+  fullMatch: string;
+}> {
+  const matches = [...text.matchAll(MENTION_REGEX)];
+  return matches.map((match) => ({
+    name: match[1],
+    sId: match[2],
+    fullMatch: match[0],
+  }));
+}
+
+/**
+ * Replaces all mention strings with @-style mentions.
+ * :mention[Agent Name]{sId=xxx} -> @Agent Name
+ */
+export function replaceMentionsWithAt(text: string): string {
+  return text.replaceAll(MENTION_REGEX, (_, name) => `@${name}`);
+}
+
+/**
+ * Extracts text and mentions from a TipTap JSON node structure.
+ * Recursively processes the node tree and returns concatenated text with
+ * serialized mentions, plus an array of rich mention objects.
+ */
+export function extractFromEditorJSON(node?: JSONContent): {
+  text: string;
+  mentions: RichMention[];
+} {
+  let textContent = "";
+  let mentions: RichMention[] = [];
+
+  if (!node) {
+    return { text: textContent, mentions };
+  }
+
+  // Check if the node is of type 'text' and concatenate its text.
+  if (node.type === "text") {
+    textContent += node.text;
+  }
+
+  // If the node is a 'mention', serialize it and add to mentions array.
+  if (node.type === "mention") {
+    const mentionData: RichMention = {
+      id: node.attrs?.id,
+      label: node.attrs?.label,
+      type: node.attrs?.type,
+      pictureUrl: node.attrs?.pictureUrl ?? "",
+      description: node.attrs?.description ?? "",
+    };
+
+    textContent += serializeMention({
+      name: mentionData.label,
+      sId: mentionData.id,
+    });
+
+    mentions.push(mentionData);
+  }
+
+  // If the node is a 'hardBreak' or a 'paragraph', add a newline character.
+  if (node.type && ["hardBreak", "paragraph"].includes(node.type)) {
+    textContent += "\n";
+  }
+
+  // Handle pasted attachments.
+  if (node.type === "pastedAttachment") {
+    const title = node.attrs?.title ?? "";
+    const fileId = node.attrs?.fileId ?? "";
+    textContent += `:pasted_attachment[${title}]{fileId=${fileId}}`;
+  }
+
+  // If the node has content, recursively extract from each child node.
+  if (node.content) {
+    node.content.forEach((childNode) => {
+      const childResult = extractFromEditorJSON(childNode);
+      textContent += childResult.text;
+      mentions = mentions.concat(childResult.mentions);
+    });
+  }
+
+  return { text: textContent, mentions };
+}
+
+/**
+ * Utilities for working with mention formats.
+ */
+export const mentionFormat = {
+  serialize: serializeMention,
+  parse: parseMentions,
+  replaceWithAt: replaceMentionsWithAt,
+  extractFromEditorJSON,
+  regex: MENTION_REGEX,
+};

--- a/front/lib/mentions/index.ts
+++ b/front/lib/mentions/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Centralized mention handling module.
+ *
+ * This module provides a unified API for working with mentions across
+ * the Dust application, including types, formatting, UI components,
+ * editor integration, and markdown rendering.
+ *
+ * Usage:
+ *   import { RichMention, mentionFormat, MentionDisplay } from "@app/lib/mentions";
+ */
+
+// Types
+export type {
+  AgentMention,
+  MentionType,
+  RichAgentMention,
+  RichMention,
+  RichUserMention,
+  UserMention,
+} from "./types";
+export {
+  isAgentMention,
+  isRichAgentMention,
+  isRichUserMention,
+  toMentionType,
+  toRichMention,
+} from "./types";
+
+// Format utilities
+export {
+  extractFromEditorJSON,
+  mentionFormat,
+  parseMentions,
+  replaceMentionsWithAt,
+  serializeMention,
+} from "./format";
+
+// UI components
+export { MentionDisplay } from "./ui/MentionDisplay";
+export { MentionDropdown } from "./ui/MentionDropdown";
+
+// Editor utilities
+export {
+  filterAgentSuggestions,
+  mentionSuggestions,
+} from "./editor/suggestion";
+export { editorMentionUtils } from "./editor/utils";
+
+// Markdown plugins
+export {
+  agentMentionDirective,
+  getAgentMentionPlugin,
+} from "./markdown/plugin";

--- a/front/lib/mentions/markdown/plugin.tsx
+++ b/front/lib/mentions/markdown/plugin.tsx
@@ -1,0 +1,72 @@
+/**
+ * Markdown directive plugin for mentions.
+ *
+ * This module provides remark-directive plugins for parsing and rendering
+ * mentions in markdown content, enabling the :mention[name]{sId=xxx} syntax.
+ */
+
+import { visit } from "unist-util-visit";
+
+import type { WorkspaceType } from "@app/types";
+
+import { MentionDisplay } from "../ui/MentionDisplay";
+
+/**
+ * Remark directive plugin for parsing mention directives.
+ *
+ * Transforms `:mention[name]{sId=xxx}` into a custom HTML element
+ * that can be rendered by the mention component.
+ *
+ * Note: We cannot easily rename "mention" to "agent_mention" because
+ * the messages stored in the database use this name.
+ */
+export function agentMentionDirective() {
+  return (tree: any) => {
+    visit(tree, ["textDirective"], (node) => {
+      if (node.name === "mention" && node.children[0]) {
+        const data = node.data || (node.data = {});
+        data.hName = "mention";
+        data.hProperties = {
+          agentSId: node.attributes.sId,
+          agentName: node.children[0].value,
+        };
+      }
+    });
+  };
+}
+
+/**
+ * Creates a React component plugin for rendering mentions in markdown.
+ *
+ * This function returns a component that can be used as a custom component
+ * in ReactMarkdown to render the mention HTML elements.
+ *
+ * @param owner - The workspace context for mention interactions
+ * @returns A React component for rendering mentions
+ */
+export function getAgentMentionPlugin(owner: WorkspaceType) {
+  const AgentMentionPlugin = ({
+    agentName,
+    agentSId,
+  }: {
+    agentName: string;
+    agentSId: string;
+  }) => {
+    return (
+      <MentionDisplay
+        mention={{
+          id: agentSId,
+          label: agentName,
+          type: "agent",
+          pictureUrl: "",
+          description: "",
+        }}
+        interactive
+        owner={owner}
+        showTooltip={false}
+      />
+    );
+  };
+
+  return AgentMentionPlugin;
+}

--- a/front/lib/mentions/types.ts
+++ b/front/lib/mentions/types.ts
@@ -1,0 +1,123 @@
+/**
+ * Centralized mention types and utilities.
+ *
+ * This module provides a unified type system for handling mentions across
+ * the application, including API formats, UI representations, and type guards.
+ */
+
+/**
+ * Base mention structure used in API requests and database storage.
+ * This is the minimal representation of an agent mention.
+ */
+export type AgentMention = {
+  configurationId: string;
+};
+
+/**
+ * User mention type for future support of mentioning users in conversations.
+ */
+export type UserMention = {
+  type: "user";
+  userId: string;
+};
+
+/**
+ * Union type of all supported mention types.
+ * Currently only agent mentions are supported in the API layer.
+ */
+export type MentionType = AgentMention;
+
+/**
+ * Rich mention type with full display metadata.
+ * Used in UI components and the editor where we need display information.
+ */
+export interface RichMention {
+  id: string; // configurationId for agents, userId for users
+  type: "agent" | "user";
+  label: string; // Display name
+  pictureUrl: string;
+  description: string;
+  userFavorite?: boolean;
+}
+
+/**
+ * Agent-specific rich mention with additional metadata.
+ */
+export interface RichAgentMention extends RichMention {
+  type: "agent";
+  userFavorite?: boolean;
+}
+
+/**
+ * User-specific rich mention.
+ */
+export interface RichUserMention extends RichMention {
+  type: "user";
+}
+
+/**
+ * Type guard to check if a mention is an agent mention.
+ */
+export function isAgentMention(mention: MentionType): mention is AgentMention {
+  return (mention as AgentMention).configurationId !== undefined;
+}
+
+/**
+ * Type guard to check if a rich mention is an agent mention.
+ */
+export function isRichAgentMention(
+  mention: RichMention
+): mention is RichAgentMention {
+  return mention.type === "agent";
+}
+
+/**
+ * Type guard to check if a rich mention is a user mention.
+ */
+export function isRichUserMention(
+  mention: RichMention
+): mention is RichUserMention {
+  return mention.type === "user";
+}
+
+/**
+ * Converts a rich mention to the API MentionType format.
+ * Used when sending data to the API.
+ */
+export function toMentionType(rich: RichMention): MentionType {
+  if (rich.type === "agent") {
+    return {
+      configurationId: rich.id,
+    };
+  }
+
+  // Future: handle user mentions
+  throw new Error(`Unsupported mention type: ${rich.type}`);
+}
+
+/**
+ * Converts an API MentionType to a rich mention with display metadata.
+ * Requires additional metadata to be provided.
+ */
+export function toRichMention(
+  mention: MentionType,
+  metadata: {
+    label: string;
+    pictureUrl: string;
+    description: string;
+    userFavorite?: boolean;
+  }
+): RichMention {
+  if (isAgentMention(mention)) {
+    return {
+      id: mention.configurationId,
+      type: "agent",
+      label: metadata.label,
+      pictureUrl: metadata.pictureUrl,
+      description: metadata.description,
+      userFavorite: metadata.userFavorite,
+    } satisfies RichAgentMention;
+  }
+
+  throw new Error("Unsupported mention type");
+}

--- a/front/lib/mentions/ui/MentionDisplay.tsx
+++ b/front/lib/mentions/ui/MentionDisplay.tsx
@@ -1,0 +1,84 @@
+/**
+ * Display component for mentions.
+ *
+ * This component provides a consistent visual representation of mentions
+ * across the application. It can be used in both interactive (with dropdown)
+ * and non-interactive modes.
+ */
+
+import {
+  TooltipContent,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+} from "@dust-tt/sparkle";
+import React from "react";
+
+import type { WorkspaceType } from "@app/types";
+
+import type { RichMention } from "../types";
+import { MentionDropdown } from "./MentionDropdown";
+
+interface MentionDisplayProps {
+  mention: RichMention;
+  interactive?: boolean;
+  owner?: WorkspaceType;
+  showTooltip?: boolean;
+}
+
+/**
+ * Displays a mention as a styled badge with optional tooltip and dropdown.
+ *
+ * When interactive=true and owner is provided, clicking the mention will
+ * show a dropdown menu with actions. When showTooltip=true and description
+ * is available, hovering will show a tooltip.
+ */
+export function MentionDisplay({
+  mention,
+  interactive = false,
+  owner,
+  showTooltip = true,
+}: MentionDisplayProps) {
+  const trigger = (
+    <span className="inline-block cursor-pointer font-medium text-highlight-500">
+      @{mention.label}
+    </span>
+  );
+
+  // If interactive and owner is provided, wrap with dropdown.
+  if (interactive && owner) {
+    // If tooltip is requested and description exists, wrap with tooltip.
+    if (showTooltip && mention.description) {
+      return (
+        <TooltipProvider>
+          <MentionDropdown mention={mention} owner={owner}>
+            <TooltipRoot>
+              <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+              <TooltipContent>{mention.description}</TooltipContent>
+            </TooltipRoot>
+          </MentionDropdown>
+        </TooltipProvider>
+      );
+    }
+
+    return (
+      <MentionDropdown mention={mention} owner={owner}>
+        {trigger}
+      </MentionDropdown>
+    );
+  }
+
+  // Non-interactive display, optionally with tooltip.
+  if (showTooltip && mention.description) {
+    return (
+      <TooltipProvider>
+        <TooltipRoot>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent>{mention.description}</TooltipContent>
+        </TooltipRoot>
+      </TooltipProvider>
+    );
+  }
+
+  return trigger;
+}

--- a/front/lib/mentions/ui/MentionDropdown.tsx
+++ b/front/lib/mentions/ui/MentionDropdown.tsx
@@ -1,0 +1,77 @@
+/**
+ * Shared dropdown component for mention interactions.
+ *
+ * This component provides a consistent dropdown menu for mentions across
+ * the application, including actions like starting a new conversation or
+ * viewing agent details.
+ */
+
+import {
+  ChatBubbleBottomCenterTextIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  EyeIcon,
+} from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+import React from "react";
+
+import { useURLSheet } from "@app/hooks/useURLSheet";
+import { getConversationRoute, setQueryParam } from "@app/lib/utils/router";
+import type { WorkspaceType } from "@app/types";
+
+import type { RichMention } from "../types";
+
+interface MentionDropdownProps {
+  mention: RichMention;
+  owner: WorkspaceType;
+  children: React.ReactNode;
+}
+
+/**
+ * Dropdown menu component for agent mentions.
+ * Provides actions to start a new conversation or view agent details.
+ */
+export function MentionDropdown({
+  mention,
+  owner,
+  children,
+}: MentionDropdownProps) {
+  const router = useRouter();
+  const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");
+
+  // Only support agent mentions for now.
+  if (mention.type !== "agent") {
+    return <>{children}</>;
+  }
+
+  const handleStartConversation = async () => {
+    await router.push(
+      getConversationRoute(owner.sId, "new", `agent=${mention.id}`)
+    );
+  };
+
+  const handleSeeDetails = () => {
+    onOpenChangeAgentModal(true);
+    setQueryParam(router, "agentDetails", mention.id);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+      <DropdownMenuContent side="bottom" align="start">
+        <DropdownMenuItem
+          onClick={handleStartConversation}
+          icon={ChatBubbleBottomCenterTextIcon}
+          label={`New conversation with @${mention.label}`}
+        />
+        <DropdownMenuItem
+          onClick={handleSeeDetails}
+          icon={EyeIcon}
+          label={`About @${mention.label}`}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Description

This PR moves all mention related code in one place for the front-end. It contains:
* display in past messages
* input bar
* mention autocomplete

⚠️ this just puts the code in the same place, the next PR will refactor to use this

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
