### PR TITLE
[hootl] UI: Align the buttons and remove the useless namle display

### DIFF
--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -197,11 +197,6 @@ export function WebhookSourceDetailsInfo({
               />
             );
           })()}
-
-        <div>
-          <Page.H variant="h6">Source Name</Page.H>
-          <Page.P>{webhookSourceView.webhookSource.name}</Page.P>
-        </div>
         {provider && WEBHOOK_PRESETS[provider].events.length > 0 && (
           <div className="space-y-3">
             <Page.H variant="h6">Subscribed events</Page.H>

--- a/front/lib/triggers/built-in-webhooks/github/components/WebhookSourceGithubDetails.tsx
+++ b/front/lib/triggers/built-in-webhooks/github/components/WebhookSourceGithubDetails.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon, IconButton, Page } from "@dust-tt/sparkle";
+import { Chip, ExternalLinkIcon, Page } from "@dust-tt/sparkle";
 
 import type { WebhookDetailsComponentProps } from "@app/components/triggers/webhook_preset_components";
 import { GithubAdditionalDataSchema } from "@app/lib/triggers/built-in-webhooks/github/github_service_types";
@@ -33,62 +33,33 @@ export function WebhookSourceGithubDetails({
 
   return (
     <div className="space-y-4">
-      {hasRepositories && (
-        <div>
-          <Page.H variant="h6">
-            GitHub {repositories.length === 1 ? "Repository" : "Repositories"}
-          </Page.H>
-          <div className="space-y-2">
-            {repositories.map((repository) => (
-              <div
-                key={repository.fullName}
-                className="flex items-center space-x-2"
-              >
-                <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono">
-                  {repository.fullName}
-                </span>
-                <a
-                  href={`https://github.com/${repository.fullName}/settings/hooks`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-xs"
-                >
-                  <IconButton icon={ExternalLinkIcon} size="xs" />
-                </a>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {hasOrganizations && (
-        <div>
-          <Page.H variant="h6">
-            GitHub{" "}
-            {organizations.length === 1 ? "Organization" : "Organizations"}
-          </Page.H>
-          <div className="space-y-2">
-            {organizations.map((organization) => (
-              <div
-                key={organization.name}
-                className="flex items-center space-x-2"
-              >
-                <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono">
-                  {organization.name}
-                </span>
-                <a
-                  href={`https://github.com/organizations/${organization.name}/settings/hooks`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-xs"
-                >
-                  <IconButton icon={ExternalLinkIcon} size="xs" />
-                </a>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+      <div>
+        <Page.H variant="h6">Connected Sources</Page.H>
+      </div>
+      <div>
+        {[
+          ...organizations.map((org) => [
+            org.name,
+            `https://github.com/organizations/${org.name}/settings/hooks`,
+          ]),
+          ...repositories.map((repo) => [
+            repo.fullName,
+            `https://github.com/${repo.fullName}/settings/hooks`,
+          ]),
+        ].map(([item, link]) => (
+          <Chip
+            key={item}
+            label={item}
+            icon={ExternalLinkIcon}
+            size="xs"
+            color="primary"
+            className="m-0.5"
+            onClick={() => {
+              window.open(link, "_blank");
+            }}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/front/lib/triggers/built-in-webhooks/github/components/WebhookSourceGithubDetails.tsx
+++ b/front/lib/triggers/built-in-webhooks/github/components/WebhookSourceGithubDetails.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon, Page } from "@dust-tt/sparkle";
+import { ExternalLinkIcon, IconButton, Page } from "@dust-tt/sparkle";
 
 import type { WebhookDetailsComponentProps } from "@app/components/triggers/webhook_preset_components";
 import { GithubAdditionalDataSchema } from "@app/lib/triggers/built-in-webhooks/github/github_service_types";
@@ -42,9 +42,9 @@ export function WebhookSourceGithubDetails({
             {repositories.map((repository) => (
               <div
                 key={repository.fullName}
-                className="flex items-center gap-2"
+                className="flex items-center space-x-2"
               >
-                <span className="font-mono text-sm text-foreground dark:text-foreground-night">
+                <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono">
                   {repository.fullName}
                 </span>
                 <a
@@ -53,8 +53,7 @@ export function WebhookSourceGithubDetails({
                   rel="noopener noreferrer"
                   className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-xs"
                 >
-                  View webhooks
-                  <ExternalLinkIcon className="h-3 w-3" />
+                  <IconButton icon={ExternalLinkIcon} size="xs" />
                 </a>
               </div>
             ))}
@@ -70,8 +69,11 @@ export function WebhookSourceGithubDetails({
           </Page.H>
           <div className="space-y-2">
             {organizations.map((organization) => (
-              <div key={organization.name} className="flex items-center gap-2">
-                <span className="font-mono text-sm text-foreground dark:text-foreground-night">
+              <div
+                key={organization.name}
+                className="flex items-center space-x-2"
+              >
+                <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono">
                   {organization.name}
                 </span>
                 <a
@@ -80,8 +82,7 @@ export function WebhookSourceGithubDetails({
                   rel="noopener noreferrer"
                   className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-xs"
                 >
-                  View webhooks
-                  <ExternalLinkIcon className="h-3 w-3" />
+                  <IconButton icon={ExternalLinkIcon} size="xs" />
                 </a>
               </div>
             ))}


### PR DESCRIPTION
## Description

- Align the buttons to the right
- remove the useless name of the webhook

<img width="2404" height="1754" alt="image" src="https://github.com/user-attachments/assets/d4b030ba-bd72-4c22-9670-7a1bb8c147fb" />


## Tests


## Risk

no

## Deploy Plan

deploy front
