### PR TITLE
[front] fix(find): fix root node ID selection

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -369,7 +369,7 @@ function createServer(
         } else if (rootNodeId) {
           viewFilter = viewFilter.map((view) => ({
             ...view,
-            filter: view.filter ? [...view.filter, rootNodeId] : [rootNodeId],
+            filter: [rootNodeId],
           }));
         }
 


### PR DESCRIPTION
## Description

- This PR follows discussion in [this thread](https://dust4ai.slack.com/archives/C09GELMTTRT/p1761559123979309).
- Ultimately we probably want to implement some way of adding an additional filter, here we may want to add an item in the `viewFilter` array to add an AND condition on having the `rootNodeId` as parent, but finding which data source the `rootNodeId` belongs to is not straightforward.

## Tests

## Risk

- Low (revert).

## Deploy Plan

- Deploy front.
