### PR TITLE
improve remote mcp server view

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -18,7 +18,7 @@ import {
   getMcpServerDisplayName,
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
-  mcpServersSortingFn,
+  mcpServerOrViewSortingFn,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
@@ -189,7 +189,7 @@ export const AdminActionsList = ({
             },
           };
         })
-        .sort(mcpServersSortingFn),
+        .sort(mcpServerOrViewSortingFn),
     [
       connections,
       mcpServers,
@@ -257,11 +257,8 @@ export const AdminActionsList = ({
             </DataTable.CellContent>
           );
         },
-        sortingFn: (rowA, rowB) => {
-          return rowA.original.mcpServer.name.localeCompare(
-            rowB.original.mcpServer.name
-          );
-        },
+        sortingFn: (rowA, rowB) =>
+          mcpServerOrViewSortingFn(rowA.original, rowB.original),
         meta: {
           className: "hidden w-28 @2xl:w-10 @sm:table-cell",
         },

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -109,6 +109,18 @@ export const mcpServersSortingFn = (
   return a.mcpServer.name.localeCompare(b.mcpServer.name);
 };
 
+export const mcpServerOrViewSortingFn = (
+  a: { mcpServer: MCPServerType; mcpServerView?: MCPServerViewType | null },
+  b: { mcpServer: MCPServerType; mcpServerView?: MCPServerViewType | null }
+) => {
+  const aName = getMcpServerOrViewDisplayName(a.mcpServer, a.mcpServerView);
+  const bName = getMcpServerOrViewDisplayName(b.mcpServer, b.mcpServerView);
+  return aName.localeCompare(bName, undefined, {
+    sensitivity: "base",
+    numeric: true,
+  });
+};
+
 export function isRemoteMCPServerType(
   server: MCPServerType
 ): server is RemoteMCPServerType {
@@ -127,6 +139,15 @@ function getIsPreviewServer(server: MCPServerType): boolean {
 
 export function getMcpServerViewDescription(view: MCPServerViewType): string {
   return view.description ?? view.server.description;
+}
+
+export function getMcpServerOrViewDisplayName(
+  mcpServer: MCPServerType,
+  mcpServerView?: MCPServerViewType | null
+): string {
+  return mcpServerView
+    ? getMcpServerViewDisplayName(mcpServerView)
+    : getMcpServerDisplayName(mcpServer);
 }
 
 export function getMcpServerViewDisplayName(

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -115,10 +115,7 @@ export const mcpServerOrViewSortingFn = (
 ) => {
   const aName = getMcpServerOrViewDisplayName(a.mcpServer, a.mcpServerView);
   const bName = getMcpServerOrViewDisplayName(b.mcpServer, b.mcpServerView);
-  return aName.localeCompare(bName, undefined, {
-    sensitivity: "base",
-    numeric: true,
-  });
+  return aName.localeCompare(bName);
 };
 
 export function isRemoteMCPServerType(

--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -12,6 +12,7 @@ export type DefaultRemoteMCPServerConfig = {
   authMethod: "bearer" | "oauth-dynamic" | null;
   supportedOAuthUseCases?: MCPOAuthUseCase[];
   scope?: string;
+  isPreview?: boolean;
   toolStakes?: Record<string, "high" | "low" | "never_ask">;
 };
 
@@ -26,6 +27,7 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
     connectionInstructions:
       "You will need to provide your Stripe API key as a bearer token. We recommend using restricted API keys to limit access to the functionality your agents require.",
     authMethod: "bearer",
+    isPreview: false,
     toolStakes: {
       search_documentation: "never_ask",
       list_customers: "low",
@@ -61,6 +63,7 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
     icon: "LinearLogo",
     documentationUrl: "https://linear.app/docs",
     authMethod: "oauth-dynamic",
+    isPreview: false,
     toolStakes: {
       search_documentation: "never_ask",
       list_comments: "never_ask",
@@ -95,6 +98,7 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
     documentationUrl:
       "https://developers.asana.com/docs/using-asanas-mcp-server",
     authMethod: "oauth-dynamic",
+    isPreview: false,
     toolStakes: {
       asana_get_attachment: "never_ask",
       asana_get_attachments_for_object: "never_ask",
@@ -144,7 +148,7 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
     id: 10003,
     name: "gitlab",
     description:
-      "GitLab tools for repository management, issue tracking, and CI/CD operations.",
+      "GitLab tools for repository management, issue tracking, and CI/CD operations.\n\n This feature is available for testing, but not ready for production use. See GitLab's documentation for more details.",
     url: "https://gitlab.com/api/v4/mcp",
     icon: "GitlabLogo",
     documentationUrl:
@@ -153,6 +157,7 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
       "GitLab uses OAuth authentication with the 'mcp' scope. The default URL connects to gitlab.com.",
     authMethod: "oauth-dynamic",
     scope: "mcp",
+    isPreview: true,
     toolStakes: {
       get_mcp_server_version: "never_ask",
       create_issue: "low",

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -33,13 +33,20 @@ export function makeInternalMCPServer(
     augmentedInstructions?: string;
   }
 ): McpServer {
-  const { serverInfo } = INTERNAL_MCP_SERVERS[serverName];
+  const mcpServerConfig = INTERNAL_MCP_SERVERS[serverName];
+  const { serverInfo } = mcpServerConfig;
   const instructions =
     options?.augmentedInstructions ?? serverInfo.instructions ?? undefined;
 
-  return new McpServer(serverInfo, {
-    instructions,
-  });
+  return new McpServer(
+    {
+      ...serverInfo,
+      isPreview: mcpServerConfig.isPreview,
+    },
+    {
+      instructions,
+    }
+  );
 }
 
 export function makePersonalAuthenticationError(

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -454,6 +454,7 @@ export function extractMetadataFromServerVersion(
       requiresSecret: isInternalMCPServerDefinition(r)
         ? r.requiresSecret
         : undefined,
+      isPreview: isInternalMCPServerDefinition(r) ? r.isPreview : undefined,
     };
   }
 
@@ -465,6 +466,7 @@ export function extractMetadataFromServerVersion(
     authorization: null,
     documentationUrl: null,
     requiresSecret: undefined,
+    isPreview: undefined,
   };
 }
 

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -80,6 +80,7 @@ export type MCPServerType = {
   allowMultipleInstances: boolean;
   documentationUrl: string | null;
   requiresSecret?: boolean;
+  isPreview?: boolean;
 };
 
 export type RemoteMCPServerType = MCPServerType & {

--- a/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
@@ -73,6 +73,7 @@ export class DefaultRemoteMCPServerInMemoryResource {
       documentationUrl: this.config.documentationUrl || null,
       availability: "manual" as const,
       allowMultipleInstances: true,
+      isPreview: this.config.isPreview,
     };
   }
 }

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -372,7 +372,6 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         : this.sharedSecret
       : null;
 
-    // Check if this is a default remote server to get its isPreview value
     const defaultConfig = getDefaultRemoteMCPServerByURL(this.url);
 
     return {

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -13,6 +13,7 @@ import type {
 } from "@app/components/resources/resources_icons";
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { getDefaultRemoteMCPServerByURL } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPToolType, RemoteMCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -371,6 +372,9 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
         : this.sharedSecret
       : null;
 
+    // Check if this is a default remote server to get its isPreview value
+    const defaultConfig = getDefaultRemoteMCPServerByURL(this.url);
+
     return {
       sId: this.sId,
 
@@ -391,6 +395,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       sharedSecret: secret,
       customHeaders: this.customHeaders,
       documentationUrl: null,
+      isPreview: defaultConfig?.isPreview,
     };
   }
 }


### PR DESCRIPTION
## Description

- Adds isPreview field to remote MCP servers
- Sets isPreview to `true` for the Gitlab tool and adds disclaimer
- Sorts the server views alphabetically (no longer by internal/external type of tool)
- Sorts the "add tool" dropdown list alphabetically (no longer by internal/external type of tool)

## Tests

Locally

## Risk

low

## Deploy Plan

Front only
