### PR TITLE
Free ended workspaces: add log comment to sanity check before launching

### DIFF
--- a/front/temporal/scrub_workspace/admin/cli.ts
+++ b/front/temporal/scrub_workspace/admin/cli.ts
@@ -1,5 +1,6 @@
 import parseArgs from "minimist";
 
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import {
   launchDowngradeFreeEndedWorkspacesWorkflow,
   stopDowngradeFreeEndedWorkspacesWorkflow,
@@ -11,6 +12,12 @@ const main = async () => {
   const [command] = argv._;
 
   switch (command) {
+    case "log-free-ended-workspaces":
+      const { workspaces } =
+        await SubscriptionResource.internalFetchWorkspacesWithFreeEndedSubscriptions();
+      console.log(`Found ${workspaces.length} free ended workspaces:`);
+      console.log(workspaces.map((w) => w.sId));
+      return;
     case "lauch-workflow-to-downgrade-free-ended-workspaces":
       await launchDowngradeFreeEndedWorkspacesWorkflow();
       return;


### PR DESCRIPTION
## Description

Adds a command to logs the workspaces that will be impacted by the new workflow to end free workspace with an end date < now()

## Tests

Tested locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 