### PR TITLE
[security] fix conversation metadata enforcement in file API

### DIFF
--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -16,7 +16,10 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { getSecureFileAction } from "@app/pages/api/w/[wId]/files/[fileId]";
 import type { WithAPIErrorResponse } from "@app/types";
-import { isPubliclySupportedUseCase } from "@app/types";
+import {
+  isConversationFileUseCase,
+  isPubliclySupportedUseCase,
+} from "@app/types";
 
 export const config = {
   api: {
@@ -70,7 +73,10 @@ async function handler(
   }
 
   // Check if the user has access to the file based on its useCase and useCaseMetadata
-  if (file.useCase === "conversation" && file.useCaseMetadata?.conversationId) {
+  if (
+    isConversationFileUseCase(file.useCase) &&
+    file.useCaseMetadata?.conversationId
+  ) {
     // For conversation files, check if the user has access to the conversation
     const conversation = await ConversationResource.fetchById(
       auth,
@@ -88,10 +94,8 @@ async function handler(
         },
       });
     }
-  } else if (
-    file.useCase === "folders_document" &&
-    file.useCaseMetadata?.spaceId
-  ) {
+  }
+  if (file.useCase === "folders_document" && file.useCaseMetadata?.spaceId) {
     // For folder documents, check if the user has access to the space
     const space = await SpaceResource.fetchById(
       auth,

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -15,6 +15,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { FileType, WithAPIErrorResponse } from "@app/types";
+import { isConversationFileUseCase } from "@app/types";
 
 export interface FileUploadedRequestResponseBody {
   file: FileType;
@@ -117,7 +118,10 @@ async function handler(
   }
 
   // Check permissions based on useCase and useCaseMetadata
-  if (file.useCase === "conversation" && file.useCaseMetadata?.conversationId) {
+  if (
+    isConversationFileUseCase(file.useCase) &&
+    file.useCaseMetadata?.conversationId
+  ) {
     const conversation = await ConversationResource.fetchById(
       auth,
       file.useCaseMetadata.conversationId

--- a/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
@@ -6,10 +6,8 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type {FileType, WithAPIErrorResponse} from "@app/types";
-import {
-  isConversationFileUseCase
-} from "@app/types";
+import type { FileType, WithAPIErrorResponse } from "@app/types";
+import { isConversationFileUseCase } from "@app/types";
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
@@ -6,7 +6,10 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { FileType, WithAPIErrorResponse } from "@app/types";
+import type {FileType, WithAPIErrorResponse} from "@app/types";
+import {
+  isConversationFileUseCase
+} from "@app/types";
 
 async function handler(
   req: NextApiRequest,
@@ -62,7 +65,7 @@ async function handler(
   }
 
   // Check permissions based on useCase and useCaseMetadata.
-  if (useCase === "conversation" && useCaseMetadata?.conversationId) {
+  if (isConversationFileUseCase(useCase) && useCaseMetadata?.conversationId) {
     const conversation = await ConversationResource.fetchById(
       auth,
       useCaseMetadata.conversationId

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -7,7 +7,11 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { FileShareScope, WithAPIErrorResponse } from "@app/types";
-import { fileShareScopeSchema, frameContentType } from "@app/types";
+import {
+  fileShareScopeSchema,
+  frameContentType,
+  isConversationFileUseCase,
+} from "@app/types";
 
 const ShareFileRequestBodySchema = z.object({
   shareScope: fileShareScopeSchema,
@@ -46,7 +50,10 @@ async function handler(
     });
   }
 
-  if (file.useCase === "conversation" && file.useCaseMetadata?.conversationId) {
+  if (
+    isConversationFileUseCase(file.useCase) &&
+    file.useCaseMetadata?.conversationId
+  ) {
     // For conversation files, check if the user has access to the conversation.
     const conversation = await ConversationResource.fetchById(
       auth,

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -31,6 +31,12 @@ export type FileUseCaseMetadata = {
   lastEditedByAgentConfigurationId?: string;
 };
 
+export function isConversationFileUseCase(
+  useCase: string
+): useCase is "conversation" {
+  return ["conversation", "tool_output"].includes(useCase);
+}
+
 export const fileShareScopeSchema = z.enum(["workspace", "public"]);
 
 export type FileShareScope = z.infer<typeof fileShareScopeSchema>;

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -33,7 +33,7 @@ export type FileUseCaseMetadata = {
 
 export function isConversationFileUseCase(
   useCase: string
-): useCase is "conversation" {
+): useCase is "conversation" | "tool_output" {
   return ["conversation", "tool_output"].includes(useCase);
 }
 


### PR DESCRIPTION
## Description

Detected by http://dev-0.or1g1n.tech:1337/experiments/15/publications/100

Allows a user within a workspace to access tool_output files from conversations even if conversations rely on a space that the user does not have access to.

## Tests

Tested locally. Table query tool_output file still downloadable.

## Risk

Low

## Deploy Plan

- deploy `front`