### PR TITLE
Improve throttle in connectors

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -531,7 +531,7 @@ async function processErrorResult(
       await throttleWithRedis(
         RATE_LIMITS["chat.update"],
         `${connector.id}-chat-update`,
-        false,
+        { canBeIgnored: false },
         async () =>
           slackClient.chat.update({
             ...errorPost,

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -131,7 +131,10 @@ async function streamAgentAnswerToSlack(
 
   let answer = "";
   const actions: AgentActionPublicType[] = [];
-  const throttledPostSlackMessageUpdate = throttle(postSlackMessageUpdate, 500);
+  const throttledPostSlackMessageUpdate = throttle(
+    postSlackMessageUpdate,
+    1_000
+  );
   for await (const event of streamRes.value.eventStream) {
     switch (event.type) {
       case "tool_params":
@@ -575,7 +578,7 @@ async function postSlackMessageUpdate({
   const response = await throttleWithRedis(
     RATE_LIMITS["chat.update"],
     `${connector.id}-chat-update`,
-    canBeIgnored,
+    { canBeIgnored },
     async () =>
       slackClient.chat.update({
         ...makeMessageUpdateBlocksAndText(

--- a/connectors/src/connectors/slack/feedback_api.ts
+++ b/connectors/src/connectors/slack/feedback_api.ts
@@ -210,7 +210,7 @@ export async function submitFeedbackToAPI({
           await throttleWithRedis(
             RATE_LIMITS["chat.update"],
             `${connector.id}-chat-update`,
-            false,
+            { canBeIgnored: false },
             async () =>
               slackClient.chat.update({
                 channel: slackChannelId,

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -184,7 +184,7 @@ async function _getSlackUserInfo(
     const res = await throttleWithRedis(
       RATE_LIMITS["users.info"],
       `${connectorId}-users-info`,
-      false,
+      { canBeIgnored: false },
       () => slackClient.users.info({ user: userId }),
       { source: "getSlackUserInfo" }
     );

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -191,7 +191,7 @@ export class ZendeskClient {
       return await throttleWithRedis(
         rateLimitConfig,
         `zendesk:${this.connectorId}`,
-        false,
+        { canBeIgnored: false },
         runFetch,
         { subdomain, endpoint }
       );

--- a/connectors/src/lib/throttle.test.ts
+++ b/connectors/src/lib/throttle.test.ts
@@ -784,10 +784,12 @@ describe("throttle", () => {
         addTimestamp: vi.fn(async (timestamp: number) => {
           timestamps.push(timestamp);
         }),
-        removeTimestampsBatch: vi.fn(async (timestamp: number) => {
-          const index = timestamps.indexOf(timestamp);
-          if (index > -1) {
-            timestamps.splice(index, 1);
+        removeTimestampsBatch: vi.fn(async (timestamps: number[]) => {
+          for (const timestamp of timestamps) {
+            const index = timestamps.indexOf(timestamp);
+            if (index > -1) {
+              timestamps.splice(index, 1);
+            }
           }
         }),
         acquireLock: vi.fn(async () => {}),

--- a/connectors/src/lib/throttle.ts
+++ b/connectors/src/lib/throttle.ts
@@ -10,10 +10,7 @@ export type RateLimit = {
   windowInMs: number;
 };
 
-// Increased timeout to handle lock contention during high-traffic periods.
-// The throttle logic itself (Redis operations for timestamp management) can take several seconds
-// under load, requiring a longer timeout than the default 3 seconds.
-const ACQUIRE_LOCK_TIMEOUT_MS = 10_000;
+const ACQUIRE_LOCK_TIMEOUT_MS = 3_000;
 
 export async function throttleWithRedis<T>(
   rateLimit: RateLimit,

--- a/connectors/src/lib/throttle.ts
+++ b/connectors/src/lib/throttle.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 
+import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import { distributedLock, distributedUnlock } from "@connectors/lib/lock";
 import logger from "@connectors/logger/logger";
 import { redisClient } from "@connectors/types/shared/redis_client";
@@ -9,10 +10,15 @@ export type RateLimit = {
   windowInMs: number;
 };
 
+// Increased timeout to handle lock contention during high-traffic periods.
+// The throttle logic itself (Redis operations for timestamp management) can take several seconds
+// under load, requiring a longer timeout than the default 3 seconds.
+const ACQUIRE_LOCK_TIMEOUT_MS = 10_000;
+
 export async function throttleWithRedis<T>(
   rateLimit: RateLimit,
   key: string,
-  canBeIgnored: boolean,
+  { canBeIgnored }: { canBeIgnored: boolean },
   func: () => Promise<T>,
   extraLogs: Record<string, string>
 ): Promise<T | undefined> {
@@ -27,21 +33,32 @@ export async function throttleWithRedis<T>(
   const addTimestamp = async (timestamp: number) => {
     await client.rPush(redisKey, timestamp.toString());
   };
-  const removeTimestamp = async (timestamp: number) => {
-    await client.lRem(redisKey, 1, timestamp.toString());
+  const removeTimestampsBatch = async (timestamps: number[]) => {
+    if (timestamps.length === 0) {
+      return;
+    }
+
+    // Use Redis multi() to batch all removals into a single operation.
+    // This significantly reduces lock hold time compared to sequential lRem calls,
+    // helping prevent "Failed to acquire lock for throttling" errors under high load.
+    const multi = client.multi();
+    for (const timestamp of timestamps) {
+      multi.lRem(redisKey, 1, timestamp.toString());
+    }
+    await multi.exec();
   };
 
   const acquireLock = async () => {
-    const acquiredLockTimeout = 3000;
     const start = Date.now();
 
-    while (Date.now() - start < acquiredLockTimeout) {
+    while (Date.now() - start < ACQUIRE_LOCK_TIMEOUT_MS) {
       lockValue = await distributedLock(client, redisKey);
       if (lockValue) {
         break;
       }
-      // Sleep for 100ms before retrying
-      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Sleep for 100ms before retrying.
+      await setTimeoutAsync(100);
     }
     if (!lockValue) {
       throw new Error("Failed to acquire lock for throttling");
@@ -62,17 +79,17 @@ export async function throttleWithRedis<T>(
     releaseLock,
     getTimestamps,
     addTimestamp,
-    removeTimestamp,
+    removeTimestampsBatch,
   });
 
   if (throttleRes.skip) {
-    // Ignore the request
+    // Ignore the request.
     return;
   } else if (throttleRes.delay && throttleRes.delay > 0) {
     logger.info({ delay: throttleRes, ...extraLogs }, "Delaying api request");
-    await new Promise((resolve) => setTimeout(resolve, throttleRes.delay));
+    await setTimeoutAsync(throttleRes.delay);
   } else if (throttleRes.delay === 0) {
-    // Do nothing and just call the function
+    // Do nothing and just call the function.
   } else {
     throw new Error("Invalid delay");
   }
@@ -88,7 +105,7 @@ export async function throttle({
   releaseLock,
   getTimestamps,
   addTimestamp,
-  removeTimestamp,
+  removeTimestampsBatch,
 }: {
   rateLimit: RateLimit;
   canBeIgnored: boolean;
@@ -97,7 +114,7 @@ export async function throttle({
   releaseLock: () => Promise<void>;
   getTimestamps: () => Promise<number[]>;
   addTimestamp: (timestamp: number) => Promise<void>;
-  removeTimestamp: (timestamp: number) => Promise<void>;
+  removeTimestampsBatch: (timestamps: number[]) => Promise<void>;
 }): Promise<{ delay: number | undefined; skip: boolean }> {
   await acquireLock();
 
@@ -111,11 +128,9 @@ export async function throttle({
       return timestamp > windowStart;
     });
 
-    // Remove the expired timestamps entries.
+    // Remove the expired timestamps entries using batch operation.
     const diff = _.difference(rawTimestamps, timestamps);
-    for (const timestamp of diff) {
-      await removeTimestamp(timestamp);
-    }
+    await removeTimestampsBatch(diff);
 
     // Check if the list of timestamps is less than the rate limit.
     if (timestamps.length < rateLimit.limit) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/4829.

 Fixes "Failed to acquire lock for throttling" errors by batching Redis timestamp removal operations. The throttle function was holding locks for too long when cleaning up expired timestamps due to sequential Redis calls. We now use Redis `multi()` to batch all removals into a single operation, reducing lock contention time during high-traffic periods with multiple concurrent Slack message updates.
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
