### PR TITLE
[front] fix(`find`): add check that root node ID is accessible

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -367,6 +367,32 @@ function createServer(
             (view) => view.data_source_id === dataSourceNodeId
           );
         } else if (rootNodeId) {
+          // Checking that we do have access to the root node.
+          const rootNodeSearchResult = await coreAPI.searchNodes({
+            filter: {
+              data_source_views: viewFilter,
+              node_ids: [rootNodeId],
+            },
+          });
+          if (rootNodeSearchResult.isErr()) {
+            return new Err(
+              new MCPError(
+                `Failed to search content: ${rootNodeSearchResult.error.message}`
+              )
+            );
+          }
+          // If we could not access the root node, we return an error early here.
+          if (
+            rootNodeSearchResult.value.nodes.length === 0 ||
+            rootNodeSearchResult.value.nodes[0].node_id !== rootNodeId
+          ) {
+            return new Err(
+              new MCPError(`Could not find node: ${rootNodeId}`, {
+                tracked: false,
+              })
+            );
+          }
+
           viewFilter = viewFilter.map((view) => ({
             ...view,
             filter: [rootNodeId],


### PR DESCRIPTION
## Description

- Following discussion in [this thread](https://dust4ai.slack.com/archives/C09GELMTTRT/p1761559123979309).
- This PR adds a check in the `find` tool to check that a root node id passed is accessible based on the data source view + the agent configuration.

## Tests

- Tested locally, no change in behavior observed but I could not repro the theoretical issue I had in mind in the first place

## Risk

## Deploy Plan

- Deploy front.
