### PR TITLE
[front] Remove JSONSchema validation in `extractMetadataFromTools`

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -11,7 +11,7 @@ import {
 import { Context, heartbeat } from "@temporalio/activity";
 import assert from "assert";
 import EventEmitter from "events";
-import type { JSONSchema7 } from "json-schema";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import {
   calculateContentSize,
@@ -98,13 +98,13 @@ const MCP_TOOL_DONE_EVENT_NAME = "TOOL_DONE" as const;
 const MCP_TOOL_ERROR_EVENT_NAME = "TOOL_ERROR" as const;
 const MCP_TOOL_HEARTBEAT_EVENT_NAME = "TOOL_HEARTBEAT" as const;
 
-const EMPTY_INPUT_SCHEMA: JSONSchema7 = {
+const EMPTY_INPUT_SCHEMA: JSONSchema = {
   properties: {},
   required: [],
   type: "object",
 };
 
-function isEmptyInputSchema(schema: JSONSchema7): boolean {
+function isEmptyInputSchema(schema: JSONSchema): boolean {
   // By default, empty tools yields an empty input schema.
   const isContentConsideredEmpty =
     schema.properties === undefined &&

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -6,6 +6,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { Implementation, Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { ProxyAgent } from "undici";
 
 import { isInternalAllowedIcon } from "@app/components/resources/resources_icons";
@@ -473,7 +474,9 @@ export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
     return {
       name,
       description: description ?? "",
-      inputSchema,
+      // TODO: the types are slightly incompatible: we have an unknown as the values of `properties`
+      //  whereas JSONSchema expects a JSONSchema7Definition.
+      inputSchema: inputSchema as JSONSchema,
     };
   });
 }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -6,7 +6,6 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { Implementation, Tool } from "@modelcontextprotocol/sdk/types.js";
-import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { ProxyAgent } from "undici";
 
 import { isInternalAllowedIcon } from "@app/components/resources/resources_icons";
@@ -38,7 +37,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { getUntrustedEgressAgent } from "@app/lib/egress";
 import { isWorkspaceUsingStaticIP } from "@app/lib/misc";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
-import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase, OAuthProvider, Result } from "@app/types";
 import {
@@ -472,20 +470,10 @@ export function extractMetadataFromServerVersion(
 
 export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
   return tools.map((tool) => {
-    let inputSchema: JSONSchema | undefined;
-
-    const { isValid, error } = validateJsonSchema(tool.inputSchema);
-    if (isValid) {
-      inputSchema = tool.inputSchema as JSONSchema;
-    } else {
-      logger.error(
-        `[MCP] Invalid input schema for tool: ${tool.name} (${error}).`
-      );
-    }
     return {
       name: tool.name,
       description: tool.description ?? "",
-      inputSchema,
+      inputSchema: tool.inputSchema,
     };
   });
 }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -469,11 +469,11 @@ export function extractMetadataFromServerVersion(
 }
 
 export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
-  return tools.map((tool) => {
+  return tools.map(({ name, description, inputSchema }) => {
     return {
-      name: tool.name,
-      description: tool.description ?? "",
-      inputSchema: tool.inputSchema,
+      name,
+      description: description ?? "",
+      inputSchema,
     };
   });
 }

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -1,4 +1,4 @@
-import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 import type {
   CustomResourceIconType,
@@ -43,7 +43,7 @@ export function getRetryPolicyFromToolConfiguration(
 export type MCPToolType = {
   name: string;
   description: string;
-  inputSchema?: JSONSchema;
+  inputSchema?: Tool["inputSchema"];
 };
 
 export type MCPToolWithAvailabilityType = MCPToolType & {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -1,4 +1,4 @@
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import type {
   CustomResourceIconType,
@@ -43,7 +43,7 @@ export function getRetryPolicyFromToolConfiguration(
 export type MCPToolType = {
   name: string;
   description: string;
-  inputSchema?: Tool["inputSchema"];
+  inputSchema?: JSONSchema;
 };
 
 export type MCPToolWithAvailabilityType = MCPToolType & {


### PR DESCRIPTION
## Description

- This PR removes the JSON schema validation we have on every MCP tool input in the main loop.
- This validation is very expensive (hundreds of ms per call).
- This validation currently does not do anything besides logging if I understand correctly, the error logs generated by it are [here](https://app.datadoghq.eu/logs?query=%22%5BMCP%5D%20Invalid%20input%20schema%20for%20tool%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1761318106492&to_ts=1761577306492&live=true) and all look like things that can probably be handled by models (uint32 being an invalid format, certain keywords being unknown).
- More refined logs [here](https://app.datadoghq.eu/logs?query=%22%5BMCP%5D%20Invalid%20input%20schema%20for%20tool%22%20-%2Auint32%2A%20-%2AschemaVersion%2A%20-%2Adiscriminator%2A%20-%2Aobject%2Cboolean%2A%20-%2Acan%27t%5C%20resolve%5C%20reference%2A%20-%2Aunknown%5C%20keyword%5C%20%5C%22example%5C%22%2A%20-%2Aunknown%5C%20keyword%5C%20%5C%22x-nullable%5C%22%2A%20-%2Ano%5C%20schema%5C%20with%5C%20key%5C%20or%5C%20ref%5C%20%5C%22https%5C%3A%2F%2Fjson-schema.org%2A%20-%2Aunknown%5C%20keyword%5C%20%5C%22prefixItems%5C%22%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760975508680&to_ts=1761580308680&live=true).

## Tests

- Tested locally with websearch and search.

## Risk

- Medium to high: on a critical path.

## Deploy Plan

- Deploy front.
