### PR TITLE
[front] - fix(temporal): extend heartbeat timeout for check activities

### DIFF
--- a/front/temporal/production_checks/workflows.ts
+++ b/front/temporal/production_checks/workflows.ts
@@ -4,7 +4,7 @@ import type * as activities from "@app/temporal/production_checks/activities";
 
 const { runAllChecksActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "1 hour",
-  heartbeatTimeout: "5 minutes",
+  heartbeatTimeout: "10 minutes",
 });
 
 export async function runAllChecksWorkflow() {


### PR DESCRIPTION
## Description

This PR increases the heartbeat timeout for the `runAllChecksActivity` from 5 to 10 minutes to prevent premature temporal workflow failures. The `production_checks` workflow was experiencing heartbeat timeouts specifically during the execution of the `managed_data_source_gdrive_gc` check, which processes Google Drive data sources by fetching documents in batches and can take longer than the previous 5-minute heartbeat timeout to complete for workspaces with large numbers of documents.

The timeout occurred when processing multiple Google Drive data sources sequentially, where the combined time for database queries, document retrieval, and garbage collection checks exceeded the heartbeat threshold, causing the workflow to fail with `TIMEOUT_TYPE_HEARTBEAT` errors.

## Risk

Low risk change that only affects the heartbeat timeout configuration.

## Tests

N/A

## Deploy Plan

Deploy front