### PR TITLE
feat(front): re add the scrub_workspace_queue_v1

### DIFF
--- a/front/temporal/scrub_workspace/worker.ts
+++ b/front/temporal/scrub_workspace/worker.ts
@@ -30,3 +30,26 @@ export async function runScrubWorkspaceQueueWorker() {
 
   await worker.run();
 }
+
+export async function runScrubWorkspaceQueueWorkerV1() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    workflowsPath: require.resolve("./workflows"),
+    activities,
+    maxConcurrentActivityTaskExecutions: 2,
+    taskQueue: "scrub-workspace-queue-v1",
+    connection,
+    namespace,
+    interceptors: {
+      activity: [
+        (ctx: Context) => {
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -11,7 +11,10 @@ import { runPermissionsWorker } from "@app/temporal/permissions_queue/worker";
 import { runProductionChecksWorker } from "@app/temporal/production_checks/worker";
 import { runRelocationWorker } from "@app/temporal/relocation/worker";
 import { runRemoteToolsSyncWorker } from "@app/temporal/remote_tools/worker";
-import { runScrubWorkspaceQueueWorker } from "@app/temporal/scrub_workspace/worker";
+import {
+  runScrubWorkspaceQueueWorker,
+  runScrubWorkspaceQueueWorkerV1,
+} from "@app/temporal/scrub_workspace/worker";
 import {
   runTrackerNotificationWorker,
   runTrackerWorker,
@@ -37,6 +40,7 @@ export type WorkerName =
   | "relocation"
   | "remote_tools_sync"
   | "scrub_workspace_queue"
+  | "scrub_workspace_queue_v1"
   | "tracker_notification"
   | "update_workspace_usage"
   | "upsert_queue"
@@ -59,6 +63,8 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   relocation: runRelocationWorker,
   remote_tools_sync: runRemoteToolsSyncWorker,
   scrub_workspace_queue: runScrubWorkspaceQueueWorker,
+  // TODO(rcs): remove this after all workflows on the v1 are done, ETA 2025-11-15
+  scrub_workspace_queue_v1: runScrubWorkspaceQueueWorkerV1,
   tracker_notification: runTrackerNotificationWorker,
   update_workspace_usage: runUpdateWorkspaceUsageWorker,
   upsert_queue: runUpsertQueueWorker,


### PR DESCRIPTION
## Description

When I updated the workflow version for `scrub_workspace`, I missed the queue was the same as the workflow name. 

That means the old workflows are not running because we don't have any workers for it. 

So this PR adds back the workers so we can consume the messages 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
