### PR TITLE
[front] Fix icon definition on Zendesk webhook preset

### DIFF
--- a/front/components/resources/resources_icons.tsx
+++ b/front/components/resources/resources_icons.tsx
@@ -45,6 +45,7 @@ import {
   SlackLogo,
   StripeLogo,
   ValTownLogo,
+  ZendeskLogo,
 } from "@dust-tt/sparkle";
 import type { ComponentProps, ComponentType } from "react";
 
@@ -117,6 +118,7 @@ export const InternalActionIcons = {
   StripeLogo,
   DriveLogo,
   ValTownLogo,
+  ZendeskLogo,
 };
 
 export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);

--- a/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_source_presets.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_source_presets.ts
@@ -1,5 +1,3 @@
-import { ZendeskLogo } from "@dust-tt/sparkle";
-
 import { ZendeskOAuthExtraConfig } from "@app/components/data_source/ZendeskOAuthExtraConfig";
 import { CreateWebhookZendeskConnection } from "@app/lib/triggers/built-in-webhooks/zendesk/components/CreateWebhookZendeskConnection";
 import { WebhookSourceZendeskDetails } from "@app/lib/triggers/built-in-webhooks/zendesk/components/WebhookSourceZendeskDetails";
@@ -14,7 +12,7 @@ export const ZENDESK_WEBHOOK_PRESET: PresetWebhook<"zendesk"> = {
     field: "type",
   },
   events: ZENDESK_WEBHOOK_EVENTS,
-  icon: ZendeskLogo,
+  icon: "ZendeskLogo",
   description:
     "Receive events from Zendesk such as ticket creation or modification",
   featureFlag: "hootl_dev_webhooks",

--- a/sdks/js/src/mcp_icon_types.ts
+++ b/sdks/js/src/mcp_icon_types.ts
@@ -40,6 +40,7 @@ export const MCPInternalActionIconSchema = z.enum([
   "StripeLogo",
   "OpenaiLogo",
   "ValTownLogo",
+  "ZendeskLogo",
 ]);
 
 export const MCPExternalActionIconSchema = z.enum([

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2843,6 +2843,7 @@ const InternalAllowedIconSchema = FlexibleEnumSchema<
   | "StripeLogo"
   | "OpenaiLogo"
   | "ValTownLogo"
+  | "ZendeskLogo"
 >();
 
 const CustomServerIconSchema = FlexibleEnumSchema<


### PR DESCRIPTION
## Description

The way we define icons for webhook presets was changed here: https://github.com/dust-tt/dust/pull/17322.
This PR aligns the Zendesk preset to this new pattern.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
