### PR TITLE
[connectors] enh(Zendesk): reduce prefix size in tickets

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -348,7 +348,6 @@ export async function syncTicket({
       updatedAt: updatedAtDate,
       additionalPrefixes: {
         metadata: metadata.join(", "),
-        labels: ticket.tags.join(", ") || "none",
       },
     });
 

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -316,7 +316,6 @@ export async function syncTicket({
       ...metadata,
       `updatedAt:${updatedAtDate.getTime()}`,
       `createdAt:${createdAtDate.getTime()}`,
-      `ticketId:${ticket.id}`,
       ...(ticket.group_id ? [`groupId:${ticket.group_id}`] : []),
       ...(ticket.organization_id
         ? [`organizationId:${ticket.organization_id}`]


### PR DESCRIPTION
## Description

- Looking at a few chunks for Zendesk tickets the prefixes are very large (exemple [here](https://eu.dust.tt/poke/I7skOjQX7r/conversation/xNuuFhpgv9) where some chunks have prefixes that are ~150-token long).
- We actually embed quite a lot of non-semantically significant data in there such as ticket/group/organization IDs (the filtering doesn't work, it's based on strict equalities excluding the actual ID).
- This PR also removes the ticket ID from the tags, as it's bound to being unique and therefore not relevant in tags filtering.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
