### PR TITLE
[hootl] UI: Add description in webhook creation modal

### DIFF
--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -10,6 +10,7 @@ import {
   Input,
   Label,
   SliderToggle,
+  TextArea,
 } from "@dust-tt/sparkle";
 import type { useForm } from "react-hook-form";
 import { Controller, useWatch } from "react-hook-form";
@@ -86,6 +87,21 @@ export function CreateWebhookSourceFormContent({
             messageStatus="error"
             autoFocus
           />
+        )}
+      />
+      <Controller
+        control={form.control}
+        name="description"
+        render={({ field }) => (
+          <div className="space-y-2">
+            <Label htmlFor="trigger-description">Description</Label>
+            <TextArea
+              {...field}
+              id="trigger-description"
+              rows={3}
+              placeholder="Enter a description for this trigger"
+            />
+          </div>
         )}
       />
 

--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -94,7 +94,7 @@ export function CreateWebhookSourceFormContent({
         name="description"
         render={({ field }) => (
           <div className="space-y-2">
-            <Label htmlFor="trigger-description">Description</Label>
+            <Label htmlFor="trigger-description">Description (optional)</Label>
             <TextArea
               {...field}
               id="trigger-description"

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -435,6 +435,7 @@ function WebhookSourceSheetContent({
 
     const agents = _.uniq(
       webhookSourcesWithViews
+        .filter((source) => source.sId === webhookSource.sId)
         .map((source) => source.usage?.agents ?? [])
         .flat()
         .map((agent) => `@${agent.name}`)

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -46,7 +46,11 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
   static async makeNew(
     auth: Authenticator,
     blob: CreationAttributes<WebhookSourceModel>,
-    { transaction, icon }: { transaction?: Transaction; icon?: string } = {}
+    {
+      transaction,
+      icon,
+      description,
+    }: { transaction?: Transaction; icon?: string; description?: string } = {}
   ): Promise<WebhookSourceResource> {
     assert(
       await SpaceResource.canAdministrateSystemSpace(auth),
@@ -67,8 +71,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
         editedAt: new Date(),
         editedByUserId: auth.user()?.id,
         webhookSourceId: webhookSource.id,
-        // on creation there is no custom icon or description
-        description: "",
+        description: description ?? "",
         icon: normalizeWebhookIcon(icon),
       },
       {

--- a/front/pages/api/w/[wId]/webhook_sources/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.test.ts
@@ -1,6 +1,7 @@
 import type { RequestMethod } from "node-mocks-http";
 import { describe, expect, it } from "vitest";
 
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WebhookSourceFactory } from "@app/tests/utils/WebhookSourceFactory";
@@ -159,5 +160,43 @@ describe("POST /api/w/[wId]/webhook_sources/", () => {
     expect(data.error).toBeDefined();
     expect(data.error.type).toBe("invalid_request_error");
     expect(data.error.message).toContain("Subscribed events must not be empty");
+  });
+
+  it("should create webhook source with description and retrieve it in system space view", async () => {
+    // Create webhook source with description
+    const {
+      req: postReq,
+      res: postRes,
+      authenticator,
+    } = await setupTest("admin", "POST");
+
+    const testDescription = "This is a test webhook for monitoring events";
+
+    postReq.body = {
+      name: "Webhook With Description",
+      secret: "test-secret-789",
+      signatureHeader: "X-Signature",
+      signatureAlgorithm: "sha256",
+      includeGlobal: true,
+      provider: null,
+      subscribedEvents: [],
+      description: testDescription,
+    };
+
+    await handler(postReq, postRes);
+
+    expect(postRes._getStatusCode()).toBe(201);
+    const postData = postRes._getJSONData();
+    expect(postData.success).toBe(true);
+    expect(postData.webhookSource).toBeDefined();
+    expect(postData.webhookSource.name).toBe("Webhook With Description");
+
+    const systemView =
+      await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
+        authenticator,
+        postData.webhookSource.sId
+      );
+    expect(systemView).not.toBeNull();
+    systemView && expect(systemView.description).toBe(testDescription);
   });
 });

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -119,6 +119,7 @@ async function handler(
         connectionId,
         remoteMetadata,
         icon,
+        description,
       } = bodyValidation.data;
 
       if (provider && subscribedEvents.length === 0) {
@@ -165,7 +166,7 @@ async function handler(
           signatureAlgorithm,
           subscribedEvents,
         },
-        { icon }
+        { icon, description }
       );
 
       if (includeGlobal) {

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -124,4 +124,5 @@ export const WebhookSourcesSchema = z.object({
   connectionId: z.string().optional(),
   remoteMetadata: z.record(z.any()).optional(),
   icon: z.string().optional(),
+  description: z.string().optional(),
 });


### PR DESCRIPTION
## Description

### Add description field to the webhook creation modal

<img width="550" height="550" alt="image" src="https://github.com/user-attachments/assets/25eeece2-db15-4096-aba5-37d12e5c5934" />


### Only display the actual related agents when deleting a trigger

<img width="1500" height="800" alt="image" src="https://github.com/user-attachments/assets/d3344805-afeb-4cc3-b965-e33e5b5d28c7" />


## Tests

manual tests

## Risk

low

## Deploy Plan

deploy front
