### PR TITLE
[Agent Loop] Fix: Larger heartbeat timeout for run_tool

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -88,7 +88,6 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
-import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT } from "@app/temporal/agent_loop/workflows";
 import type { ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok, slugify } from "@app/types";
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -397,7 +397,7 @@ export async function* tryCallMCPTool(
         setTimeout(() => {
           heartbeat();
           resolve();
-        }, TOOL_ACTIVITY_HEARTBEAT_TIMEOUT / 2);
+        }, TOOL_ACTIVITY_HEARTBEAT_TIMEOUT / 6);
       });
 
     while (!toolDone) {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -397,7 +397,8 @@ export async function* tryCallMCPTool(
         setTimeout(() => {
           heartbeat();
           resolve();
-        }, TOOL_ACTIVITY_HEARTBEAT_TIMEOUT / 6);
+          // Reasonable delay to react to cancellation under 10s.
+        }, 10_000);
       });
 
     while (!toolDone) {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -29,7 +29,7 @@ import type {
 } from "@app/types/assistant/agent_run";
 
 const toolActivityStartToCloseTimeout = `${DEFAULT_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1} minutes`;
-export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT = 20_000;
+export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT = 60_000;
 
 const { runModelAndCreateActionsActivity } = proxyActivities<
   typeof runModelAndCreateWrapperActivities


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/4830

We observe cases in which it takes more than 20s (the previous heartbeat timeout) to reach the first heartbeat (once trycallmcptool has been called)

This takes a conservative value of 1mn for heartbeat timeout.

It should not happen that booting up run tool before trycallmcptool takes up to 1mn. If it ever does, it will point on an underlying issue that we should then investigate

Risks
---
none

Deploy
---
front
