### PR TITLE
Merged AssistantMessageTypeModel types:

### DIFF
--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -3,8 +3,7 @@ import assert from "assert";
 
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import type {
-  AssistantContentMessageTypeModel,
-  AssistantFunctionCallMessageTypeModel,
+  AssistantMessageTypeModel,
   FunctionMessageTypeModel,
   ImageContent,
   ModelMessageTypeMultiActionsWithoutContentFragment,
@@ -141,9 +140,7 @@ function assistantContentToPart(
 }
 
 async function assistantMessageToParts(
-  message:
-    | AssistantContentMessageTypeModel
-    | AssistantFunctionCallMessageTypeModel
+  message: AssistantMessageTypeModel
 ): Promise<Content> {
   assert(message.contents, "Assistant message is missing contents");
 

--- a/front/lib/api/llm/clients/google/utils/test/conversation_to_google.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/conversation_to_google.test.ts
@@ -33,6 +33,7 @@ const conversationMessages: ModelMessageTypeMultiActionsWithoutContentFragment[]
     },
     {
       role: "assistant",
+      name: "@test",
       function_calls: [
         {
           id: "DdHr7L197",

--- a/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
+++ b/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
@@ -8,8 +8,7 @@ import assert from "assert";
 
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import type {
-  AssistantContentMessageTypeModel,
-  AssistantFunctionCallMessageTypeModel,
+  AssistantMessageTypeModel,
   Content,
   ModelMessageTypeMultiActionsWithoutContentFragment,
 } from "@app/types";
@@ -49,9 +48,7 @@ function toContentChunk(
 }
 
 function toAssistantMessage(
-  message:
-    | AssistantFunctionCallMessageTypeModel
-    | AssistantContentMessageTypeModel
+  message: AssistantMessageTypeModel
 ): AssistantMessage & { role: "assistant" } {
   assert(message.contents, "Assistant message is missing contents");
 

--- a/front/lib/api/llm/clients/mistral/utils/test/conversation_to_mistral.test.ts
+++ b/front/lib/api/llm/clients/mistral/utils/test/conversation_to_mistral.test.ts
@@ -33,6 +33,7 @@ const conversationMessages: ModelMessageTypeMultiActionsWithoutContentFragment[]
     },
     {
       role: "assistant",
+      name: "@test",
       function_calls: [
         {
           id: "DdHr7L197",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "front",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -59,20 +59,13 @@ export interface FunctionCallType {
 }
 
 // Assistant requiring usage of function(s) call(s)
-export interface AssistantFunctionCallMessageTypeModel {
-  role: "assistant";
-  /** @deprecated, use contents instead. */
-  content?: string;
-  /** @deprecated, use contents instead. */
-  function_calls: FunctionCallType[];
-  contents: Array<Exclude<AgentContentItemType, ErrorContentType>>;
-}
-
-export interface AssistantContentMessageTypeModel {
+export interface AssistantMessageTypeModel {
   role: "assistant";
   name: string;
   /** @deprecated, use contents instead. */
   content?: string;
+  /** @deprecated, use contents instead. */
+  function_calls: FunctionCallType[];
   contents: Array<Exclude<AgentContentItemType, ErrorContentType>>;
 }
 
@@ -86,8 +79,7 @@ export interface FunctionMessageTypeModel {
 
 export type ModelMessageTypeMultiActionsWithoutContentFragment =
   | UserMessageTypeModel
-  | AssistantFunctionCallMessageTypeModel
-  | AssistantContentMessageTypeModel
+  | AssistantMessageTypeModel
   | FunctionMessageTypeModel;
 
 export type ModelMessageTypeMultiActions =


### PR DESCRIPTION
## Description


Merging `AssistantFunctionCallMessageTypeModel` and `AssistantContentMessageTypeModel` into a single `AssistantMessageTypeModel`:

### Previous Types

```ts
// Assistant requiring usage of function(s) call(s)
export interface AssistantFunctionCallMessageTypeModel {
  role: "assistant";
  /** @deprecated, use contents instead. */
  content?: string;
  /** @deprecated, use contents instead. */
  function_calls: FunctionCallType[];
  contents: Array<Exclude<AgentContentItemType, ErrorContentType>>;
}

export interface AssistantContentMessageTypeModel {
  role: "assistant";
  name: string;
  /** @deprecated, use contents instead. */
  content?: string;
  contents: Array<Exclude<AgentContentItemType, ErrorContentType>>;
}
```

### New Type

```ts
export interface AssistantMessageTypeModel {
  role: "assistant";
  name: string;
  /** @deprecated, use contents instead. */
  content?: string;
  /** @deprecated, use contents instead. */
  function_calls: FunctionCallType[];
  contents: Array<Exclude<AgentContentItemType, ErrorContentType>>;
}
```

## Tests

Ran all tests.

Checked and was able to talk, think and tool use with dust agent without issues. could also do so in old conversations and regenerate properly.

## Risk

Not much, the code affected isn't very big.

## Deploy Plan

Deploy front.
