### PR TITLE
feat(front): better error management for voice2text

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -359,6 +359,13 @@ const InputBarContainer = ({
         }
       }
     },
+    onError: (error) => {
+      sendNotification({
+        type: "error",
+        title: "Failed to transcribe voice",
+        description: normalizeError(error).message,
+      });
+    },
   });
 
   // Update the editor ref when the editor is created.

--- a/front/pages/api/w/[wId]/services/transcribe/index.ts
+++ b/front/pages/api/w/[wId]/services/transcribe/index.ts
@@ -92,14 +92,22 @@ async function handler(
           break;
 
         case "fullTranscript":
-          const fullTranscript = await findAgentsInMessage(
-            auth,
-            chunk.fullTranscript
-          );
+          const transcript = chunk.fullTranscript;
 
-          res.write(
-            `data: ${JSON.stringify({ type: "fullTranscript", fullTranscript })}\n\n`
-          );
+          if (!transcript) {
+            res.write(
+              `data: ${JSON.stringify({ type: "error", error: "the audio was silent, please check your microphone" })}\n\n`
+            );
+            res.end();
+            return;
+          } else {
+            const fullTranscript = await findAgentsInMessage(auth, transcript);
+
+            res.write(
+              `data: ${JSON.stringify({ type: "fullTranscript", fullTranscript })}\n\n`
+            );
+          }
+
           stop = true;
           break;
 


### PR DESCRIPTION
## Description

When the transcription is empty, we still give it to the "find agent" agent that will try to do something and output something like "The output of a speech to text AI model".

This means 2 things:
* handling of errors was not great
* and we used tokens to find nothing in an empty text

This PR does 4 things:
1. allow the `transcribe` endpoint to return an error
2. send an error when the transcription is an empty text
3. don't call find agent when the transcription is empty
4. display the error in the UI

## Tests


https://github.com/user-attachments/assets/9cc70bd3-3073-422c-a30e-0bdef7ed4343



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
