### PR TITLE
Add files:write scope on Slack in EU

### DIFF
--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -7,6 +7,7 @@ import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
+import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -89,6 +90,12 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
           // TODO: This is temporary until our Slack app scope is approved.
           if (extraConfig?.slack_bot_mcp_feature_flag) {
             scopes.push("reactions:read", "reactions:write");
+          }
+
+          // TODO: This is temporary until our Slack app scope is approved.
+          const currentRegion = regionsConfig.getCurrentRegion();
+          if (currentRegion === "europe-west1") {
+            scopes.push("files:write");
           }
 
           return {


### PR DESCRIPTION
## Description

Adds the files:write scope to Slack OAuth bot permissions specifically for the EU region (europe-west1). This is a temporary workaround until the Slack app scope gets officially approved.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front
