### PR TITLE
[connectors] fix(teams): Handle file upload with different drives

### DIFF
--- a/connectors/src/api/webhooks/teams/content_fragments.ts
+++ b/connectors/src/api/webhooks/teams/content_fragments.ts
@@ -143,11 +143,12 @@ export async function processFileAttachments(
         continue;
       }
 
-      const { itemId, mimeType, siteId } = sharepointFileInfoRes.value;
+      const { itemId, mimeType, siteId, driveId } = sharepointFileInfoRes.value;
 
       const downloadResult = await downloadSharepointFile(
         itemId,
         siteId,
+        driveId,
         microsoftGraphClient,
         logger
       );

--- a/connectors/src/connectors/microsoft/lib/files.ts
+++ b/connectors/src/connectors/microsoft/lib/files.ts
@@ -1,6 +1,7 @@
 import type { LoggerInterface, Result } from "@dust-tt/client";
 import { Err, normalizeError, Ok } from "@dust-tt/client";
 import type { Client } from "@microsoft/microsoft-graph-client";
+import type { DriveItem } from "@microsoft/microsoft-graph-types";
 
 import { clientApiGet } from "@connectors/connectors/microsoft/lib/graph_api";
 
@@ -9,7 +10,10 @@ export async function getSharepointFileInfo(
   microsoftGraphClient: Client,
   logger: LoggerInterface
 ): Promise<
-  Result<{ itemId: string; mimeType: string; siteId: string }, Error>
+  Result<
+    { itemId: string; mimeType: string; siteId: string; driveId: string },
+    Error
+  >
 > {
   // Parse the SharePoint URL to extract the file path
   // Expected format: https://tenant.sharepoint.com/sites/site/library/path/to/file
@@ -43,29 +47,74 @@ export async function getSharepointFileInfo(
     return new Err(new Error("Could not get site ID from SharePoint URL"));
   }
 
-  // Handle "Shared Documents" which is the default library name for Teams
-  let filePath: string;
-  if (remainingPath.startsWith("Shared Documents/")) {
-    // Remove "Shared Documents/" prefix for default drive
-    filePath = remainingPath.replace("Shared Documents/", "");
-  } else {
-    // For other document libraries, keep the full path
-    filePath = remainingPath;
-  }
-
-  // URL decode the file path to handle spaces and special characters
-  filePath = decodeURIComponent(filePath);
+  // Parse the path to identify document library and file path
+  const pathParts = remainingPath.split("/");
+  const driveName = decodeURIComponent(pathParts[0] ?? "Shared Documents");
+  const filePath = decodeURIComponent(pathParts.slice(1).join("/"));
 
   logger.info(
-    { siteId, filePath, siteName },
-    "Attempting Graph API download with parsed SharePoint path"
+    { siteId, driveName, filePath, siteName, tenant },
+    "Parsing SharePoint path for document library access"
   );
 
-  // Get file metadata using the file path
+  // Get all drives for the site to find the correct drive ID
+  let driveId: string;
+
+  if (driveName === "Shared Documents") {
+    // Use default drive for "Shared Documents"
+    driveId = "default";
+  } else {
+    if (!driveName) {
+      return new Err(
+        new Error("Could not extract library name from SharePoint URL")
+      );
+    }
+    // Find the specific drive for other document libraries
+    const drivesResponse = await clientApiGet(
+      logger,
+      microsoftGraphClient,
+      `/sites/${siteId}/drives`
+    );
+
+    const targetDrive = drivesResponse.value.find(
+      (drive: DriveItem) => drive.name === driveName
+    );
+
+    if (!targetDrive) {
+      return new Err(
+        new Error(`Document library '${driveName}' not found in site drives`)
+      );
+    }
+
+    driveId = targetDrive.id;
+
+    logger.info(
+      { libraryName: driveName, driveId, filePath },
+      "Found matching drive for document library"
+    );
+  }
+
+  // URL decode and re-encode the file path properly
+  const encodedPath = filePath
+    .split("/")
+    .map((component) => encodeURIComponent(component))
+    .join("/");
+
+  // Access the file using the correct drive ID
+  const endpoint =
+    driveId === "default"
+      ? `/sites/${siteId}/drive/root:/${encodedPath}`
+      : `/sites/${siteId}/drives/${driveId}/root:/${encodedPath}`;
+
+  logger.info(
+    { endpoint, driveId, encodedPath },
+    "Attempting to access file with correct drive ID"
+  );
+
   const fileItemResponse = await clientApiGet(
     logger,
     microsoftGraphClient,
-    `/sites/${siteId}/drive/root:/${filePath}`
+    endpoint
   );
   const itemId = fileItemResponse?.id;
 
@@ -76,31 +125,74 @@ export async function getSharepointFileInfo(
   const mimeType =
     fileItemResponse.file?.mimeType || "application/octet-stream";
 
-  return new Ok({ itemId, mimeType, siteId });
+  return new Ok({ itemId, mimeType, siteId, driveId });
 }
 
 // Helper function to download a file from SharePoint/Teams URL using Microsoft Graph API
 export async function downloadSharepointFile(
   itemId: string,
   siteId: string,
+  driveId: string,
   microsoftGraphClient: Client,
   logger: LoggerInterface
 ): Promise<Result<Buffer, Error>> {
   // Download the file content using the item ID
   try {
+    // Use the correct drive endpoint - default vs specific drive
+    const endpoint =
+      driveId === "default"
+        ? `/sites/${siteId}/drive/items/${itemId}/content`
+        : `/sites/${siteId}/drives/${driveId}/items/${itemId}/content`;
+
+    logger.info(
+      { endpoint, itemId, driveId },
+      "Downloading file content from SharePoint"
+    );
+
     // Get file content and handle Blob response
     const fileContentResponse = await clientApiGet(
       logger,
       microsoftGraphClient,
-      `/sites/${siteId}/drive/items/${itemId}/content`
+      endpoint
     );
-    // Convert Blob to Buffer
+    // Convert response to Buffer - handle different response types
     let fileContent: Buffer;
     if (fileContentResponse instanceof Blob) {
       const arrayBuffer = await fileContentResponse.arrayBuffer();
       fileContent = Buffer.from(arrayBuffer);
+    } else if (fileContentResponse instanceof ReadableStream) {
+      // Handle ReadableStream response
+      const reader = fileContentResponse.getReader();
+      const chunks: Uint8Array[] = [];
+
+      try {
+        let result = await reader.read();
+        while (!result.done) {
+          chunks.push(result.value);
+          result = await reader.read();
+        }
+
+        // Combine all chunks into a single buffer
+        const totalLength = chunks.reduce(
+          (sum, chunk) => sum + chunk.length,
+          0
+        );
+        const combinedArray = new Uint8Array(totalLength);
+        let offset = 0;
+
+        for (const chunk of chunks) {
+          combinedArray.set(chunk, offset);
+          offset += chunk.length;
+        }
+
+        fileContent = Buffer.from(combinedArray);
+      } finally {
+        reader.releaseLock();
+      }
+    } else if (Buffer.isBuffer(fileContentResponse)) {
+      fileContent = fileContentResponse;
     } else {
-      // Fallback for other response types
+      // Last resort: try to convert to Buffer
       fileContent = Buffer.from(fileContentResponse);
     }
 


### PR DESCRIPTION
## Description

This handle file upload when they are not in default drive. In that case we have to look up available drives and find the one that matches the url.
Also fix the download when we get ReadableStream (happens when we download from sharepoint cloud)


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
