### PR TITLE
[front] fix: slack/discord/teams integration buttons 

### DIFF
--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -269,7 +269,9 @@ export default function WorkspaceAdmin({
             <VoiceTranscriptionToggle owner={owner} />
           </ContextItem.List>
         </Page.Vertical>
-        {(!isSlackDataSourceBotEnabled || isDiscordBotEnabled) && (
+        {(!isSlackDataSourceBotEnabled ||
+          isDiscordBotEnabled ||
+          isMicrosoftTeamsBotEnabled) && (
           <Page.Vertical align="stretch" gap="md">
             <Page.H variant="h4">Integrations</Page.H>
             {!isSlackDataSourceBotEnabled && (

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -38,7 +38,6 @@ import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { useConnectorConfig, useToggleChatBot } from "@app/lib/swr/connectors";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import logger from "@app/logger/logger";
 import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type {
@@ -56,7 +55,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   isSlackDataSourceBotEnabled: boolean;
-  isDiscordBotEnabled: boolean;
+  isMicrosoftTeamsBotAvailable: boolean;
+  isDiscordBotAvailable: boolean;
   slackBotDataSource: DataSourceType | null;
   microsoftBotDataSource: DataSourceType | null;
   discordBotDataSource: DataSourceType | null;
@@ -98,7 +98,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const featureFlags = await getFeatureFlags(owner);
-  const isDiscordBotEnabled = featureFlags.includes("discord_bot");
+  const isMicrosoftTeamsBotAvailable = featureFlags.includes(
+    "microsoft_teams_bot"
+  );
+  const isDiscordBotAvailable = featureFlags.includes("discord_bot");
 
   const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
 
@@ -107,7 +110,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       owner,
       subscription,
       isSlackDataSourceBotEnabled,
-      isDiscordBotEnabled,
+      isMicrosoftTeamsBotAvailable,
+      isDiscordBotAvailable,
       slackBotDataSource: slackBotDataSource?.toJSON() ?? null,
       microsoftBotDataSource: microsoftBotDataSource?.toJSON() ?? null,
       discordBotDataSource: discordBotDataSource?.toJSON() ?? null,
@@ -120,7 +124,8 @@ export default function WorkspaceAdmin({
   owner,
   subscription,
   isSlackDataSourceBotEnabled,
-  isDiscordBotEnabled,
+  isMicrosoftTeamsBotAvailable,
+  isDiscordBotAvailable,
   slackBotDataSource,
   microsoftBotDataSource,
   discordBotDataSource,
@@ -133,11 +138,6 @@ export default function WorkspaceAdmin({
   const [workspaceNameError, setWorkspaceNameError] = useState<string>("");
 
   const [isSheetOpen, setIsSheetOpen] = useState(false);
-
-  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
-  const isMicrosoftTeamsBotEnabled = featureFlags.includes(
-    "microsoft_teams_bot"
-  );
 
   const formValidation = useCallback(() => {
     if (workspaceName === owner.name) {
@@ -270,13 +270,13 @@ export default function WorkspaceAdmin({
           </ContextItem.List>
         </Page.Vertical>
         {(!isSlackDataSourceBotEnabled ||
-          isDiscordBotEnabled ||
-          isMicrosoftTeamsBotEnabled) && (
+          isMicrosoftTeamsBotAvailable ||
+          isDiscordBotAvailable) && (
           <Page.Vertical align="stretch" gap="md">
             <Page.H variant="h4">Integrations</Page.H>
-            {!isSlackDataSourceBotEnabled && (
-              <ContextItem.List>
-                <div className="h-full border-b border-border dark:border-border-night" />
+            <ContextItem.List>
+              <div className="h-full border-b border-border dark:border-border-night" />
+              {!isSlackDataSourceBotEnabled && (
                 <BotToggle
                   owner={owner}
                   botDataSource={slackBotDataSource}
@@ -287,40 +287,40 @@ export default function WorkspaceAdmin({
                   description="Use Dust Agents in Slack with the Dust Slack app"
                   visual={<SlackLogo className="h-6 w-6" />}
                 />
-                {isMicrosoftTeamsBotEnabled && (
-                  <BotToggle
-                    owner={owner}
-                    botDataSource={microsoftBotDataSource}
-                    systemSpace={systemSpace}
-                    oauth={{
-                      provider: "microsoft_tools",
-                      useCase: "bot",
-                      extraConfig: {},
-                    }}
-                    connectorProvider="microsoft_bot"
-                    name="Microsoft Teams Bot"
-                    description="Use Dust Agents in Teams with the Dust Microsoft Teams Bot"
-                    visual={<MicrosoftLogo className="h-6 w-6" />}
-                  />
-                )}
-                {isDiscordBotEnabled && (
-                  <BotToggle
-                    owner={owner}
-                    botDataSource={discordBotDataSource}
-                    systemSpace={systemSpace}
-                    oauth={{
-                      provider: "discord",
-                      useCase: "bot",
-                      extraConfig: {},
-                    }}
-                    connectorProvider="discord_bot"
-                    name="Discord Bot"
-                    description="Use Dust Agents in Discord with the Dust Discord app"
-                    visual={<DiscordLogo className="h-6 w-6" />}
-                  />
-                )}
-              </ContextItem.List>
-            )}
+              )}
+              {isMicrosoftTeamsBotAvailable && (
+                <BotToggle
+                  owner={owner}
+                  botDataSource={microsoftBotDataSource}
+                  systemSpace={systemSpace}
+                  oauth={{
+                    provider: "microsoft_tools",
+                    useCase: "bot",
+                    extraConfig: {},
+                  }}
+                  connectorProvider="microsoft_bot"
+                  name="Microsoft Teams Bot"
+                  description="Use Dust Agents in Teams with the Dust Microsoft Teams Bot"
+                  visual={<MicrosoftLogo className="h-6 w-6" />}
+                />
+              )}
+              {isDiscordBotAvailable && (
+                <BotToggle
+                  owner={owner}
+                  botDataSource={discordBotDataSource}
+                  systemSpace={systemSpace}
+                  oauth={{
+                    provider: "discord",
+                    useCase: "bot",
+                    extraConfig: {},
+                  }}
+                  connectorProvider="discord_bot"
+                  name="Discord Bot"
+                  description="Use Dust Agents in Discord with the Dust Discord app"
+                  visual={<DiscordLogo className="h-6 w-6" />}
+                />
+              )}
+            </ContextItem.List>
           </Page.Vertical>
         )}
       </Page.Vertical>


### PR DESCRIPTION
## Description

Fixed the logic :  
- microsoft and discrod are available depending on their feature flag.
- slack is available if legacy bot has not been enabled on the datasource.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
deploy front
