### PR TITLE
[front] hootl: blacklist events per provider

### DIFF
--- a/front/lib/triggers/built-in-webhooks/github/github_webhook_source_presets.ts
+++ b/front/lib/triggers/built-in-webhooks/github/github_webhook_source_presets.ts
@@ -31,6 +31,7 @@ export const GITHUB_WEBHOOK_PRESET: PresetWebhook<"github"> = {
     field: "X-GitHub-Event",
   },
   events: [GITHUB_PULL_REQUEST_EVENT, GITHUB_ISSUES_EVENT],
+  event_blacklist: ["ping"],
   icon: "GithubLogo",
   description:
     "Receive events from GitHub such as creation or edition of issues or pull requests.",

--- a/front/lib/triggers/temporal/webhook/activities.ts
+++ b/front/lib/triggers/temporal/webhook/activities.ts
@@ -169,11 +169,8 @@ export async function runTriggerWebhookActivity({
       throw new TriggerNonRetryableError(errorMessage);
     }
 
-    if (
-      WEBHOOK_PRESETS[webhookSource.provider].event_blacklist?.includes(
-        receivedEventValue!
-      )
-    ) {
+    const blacklist = WEBHOOK_PRESETS[webhookSource.provider].event_blacklist;
+    if (blacklist && blacklist.includes(receivedEventValue)) {
       // Silently ignore blacklisted events
       await webhookRequest.markAsProcessed();
       logger.info(
@@ -183,7 +180,7 @@ export async function runTriggerWebhookActivity({
           provider: webhookSource.provider,
           eventValue: receivedEventValue,
         },
-        "Webhook event is blacklist, ignoring."
+        "Webhook event is blacklisted, ignoring."
       );
       return;
     }

--- a/front/lib/triggers/temporal/webhook/activities.ts
+++ b/front/lib/triggers/temporal/webhook/activities.ts
@@ -168,6 +168,25 @@ export async function runTriggerWebhookActivity({
       );
       throw new TriggerNonRetryableError(errorMessage);
     }
+
+    if (
+      WEBHOOK_PRESETS[webhookSource.provider].event_blacklist?.includes(
+        receivedEventValue!
+      )
+    ) {
+      // Silently ignore blacklisted events
+      await webhookRequest.markAsProcessed();
+      logger.info(
+        {
+          workspaceId,
+          webhookRequestId,
+          provider: webhookSource.provider,
+          eventValue: receivedEventValue,
+        },
+        "Webhook event is blacklist, ignoring."
+      );
+      return;
+    }
   }
 
   // Fetch all triggers based on the webhook source id.

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -20,24 +20,45 @@ export type EventCheck = {
 };
 
 export type WebhookEvent = {
+  // A human-readable name for the event.
   name: string;
+
+  // The value sent by the webhook provider to identify this event.
   value: string;
   description: string;
+
+  // The JSON schema describing the payload sent by the webhook for this event.
   schema: JSONSchema;
 };
 
 export type PresetWebhook<P extends WebhookProvider = WebhookProvider> = {
   name: string;
+  description: string;
+  icon: InternalAllowedIconType | CustomResourceIconType;
+
+  // How to check incoming webhook requests to determine which event they correspond to.
+  // It's made of a type (headers or body) and a field (header name or body property name)
+  // to match against the event values defined below.
+  // For example, GitHub uses a specific header "X-GitHub-Event" to indicate the event type.
   eventCheck: EventCheck;
   events: WebhookEvent[];
-  icon: InternalAllowedIconType | CustomResourceIconType;
-  description: string;
+  // List of event values to ignore. For example, GitHub sends a "ping" event when a webhook is created.
+  // We will not want to implement it, and don't want to throw errors when receiving it.
+  event_blacklist?: string[];
+
+  // Optional URL to the webhook provider's webhook management page.
   webhookPageUrl?: string;
-  featureFlag?: WhitelistableFeature;
+
+  // The service that will handle creating the webhooks for a given provider.
+  // Likely implements OAuth flow to manage webhooks on behalf of users.
   webhookService: RemoteWebhookService<P>;
+
+  // React components to render the webhook details and creation form.
   components: {
     detailsComponent: React.ComponentType<WebhookDetailsComponentProps>;
     createFormComponent: React.ComponentType<WebhookCreateFormComponentProps>;
     oauthExtraConfigInput?: React.ComponentType<ConnectorOauthExtraConfigProps>;
   };
+
+  featureFlag?: WhitelistableFeature;
 };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

closing https://github.com/dust-tt/tasks/issues/4790

adding a event_blacklist per webhook provider allowing to not act on certain events
e.g, github sends a ping event when establishing connection, this should not trigger issues 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

not tested

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

deploy front