### PR TITLE
Do not return test conversation when listing for user

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -527,7 +527,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       {
         where: {
           id: { [Op.in]: conversationIds },
-          visibility: { [Op.notIn]: ["deleted", "test"] },
+          visibility: { [Op.eq]: "unlisted" },
         },
       }
     );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -494,8 +494,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   static async listConversationsForUser(
-    auth: Authenticator,
-    options?: FetchConversationOptions
+    auth: Authenticator
   ): Promise<ConversationResource[]> {
     const user = auth.getNonNullableUser();
 
@@ -522,11 +521,16 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const conversationIds = participations.map((p) => p.conversationId);
 
     // Use baseFetchWithAuthorization to get conversations with proper authorization.
-    const conversations = await this.baseFetchWithAuthorization(auth, options, {
-      where: {
-        id: { [Op.in]: conversationIds },
-      },
-    });
+    const conversations = await this.baseFetchWithAuthorization(
+      auth,
+      {},
+      {
+        where: {
+          id: { [Op.in]: conversationIds },
+          visibility: { [Op.notIn]: ["deleted", "test"] },
+        },
+      }
+    );
 
     const participationMap = new Map(
       participations.map((p) => [

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -10,7 +10,12 @@ import {
 } from "@app/lib/models/assistant/conversation";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import type { ConversationType, ModelId, WorkspaceType } from "@app/types";
+import type {
+  ConversationType,
+  ConversationVisibility,
+  ModelId,
+  WorkspaceType,
+} from "@app/types";
 
 export class ConversationFactory {
   static async create(
@@ -20,12 +25,14 @@ export class ConversationFactory {
       messagesCreatedAt,
       conversationCreatedAt,
       requestedSpaceIds,
+      visibility = "unlisted",
       t,
     }: {
       agentConfigurationId: string;
       messagesCreatedAt: Date[];
       conversationCreatedAt?: Date;
       requestedSpaceIds?: ModelId[];
+      visibility?: ConversationVisibility;
       t?: Transaction;
     }
   ): Promise<ConversationType> {
@@ -34,7 +41,7 @@ export class ConversationFactory {
 
     const conversation = await createConversation(auth, {
       title: "Test Conversation",
-      visibility: "unlisted",
+      visibility,
     });
 
     if (conversationCreatedAt) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See Slack [thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1761656596719209).

Regression was introduced in https://github.com/dust-tt/dust/pull/17300.

This PR ensure we only return conversations with visibility set to `unlisted` when listing conversation for a user. All this part is pretty confusing, I'll refactor a bit more in a follow up PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
