### PR TITLE
[front] - fix(ConversationMenu): suppress context menu on ConversationMenu component

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -213,7 +213,10 @@ export function ConversationMenu({
   };
 
   return (
-    <div onClick={(e) => e.stopPropagation()}>
+    <div
+      onClick={(e) => e.stopPropagation()}
+      onContextMenu={(e) => e.stopPropagation()}
+    >
       <DeleteConversationsDialog
         isOpen={showDeleteDialog}
         type="selection"


### PR DESCRIPTION
 ## Description

This PR stops the browser's context menu from triggering on right-click within the ConversationMenu to maintain intended interaction flow.

**References:**
- https://github.com/dust-tt/tasks/issues/4551

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front