### PR TITLE
Don't use attachment when sending large paste to LLM

### DIFF
--- a/extension/ui/components/input_bar/editor/useCustomEditor.tsx
+++ b/extension/ui/components/input_bar/editor/useCustomEditor.tsx
@@ -95,7 +95,7 @@ function getTextAndMentionsFromNode(node?: JSONContent) {
   if (node.type === "pastedAttachment") {
     const title = node.attrs?.title ?? "";
     const fileId = node.attrs?.fileId ?? "";
-    textContent += `:pasted_attachment[${title}]{fileId=${fileId}}`;
+    textContent += `:pasted_content[${title}]{pastedId=${fileId}}`;
   }
 
   // If the node has content, recursively get text and mentions from each child node

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -175,7 +175,7 @@ const InputBarContainer = ({
         {
           type: "pastedAttachment",
           attrs: { fileId, title, textContent },
-          text: `:pasted_attachment[${title}]{fileId=${fileId}}`,
+          text: `:pasted_content[${title}]{pastedId=${fileId}}`,
         },
         { type: "text", text: " " },
       ];

--- a/front/components/assistant/conversation/input_bar/editor/markdownSerializer.ts
+++ b/front/components/assistant/conversation/input_bar/editor/markdownSerializer.ts
@@ -53,7 +53,7 @@ function buildNodeSerializers(schema: Schema) {
     node: ProseMirrorNode
   ) => {
     state.write(
-      `:pasted_attachment[${node.attrs.title}]{fileId=${node.attrs.fileId}}`
+      `:pasted_content[${node.attrs.title}]{pastedId=${node.attrs.fileId}}`
     );
   };
 

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -81,7 +81,7 @@ function getTextAndMentionsFromNode(node?: JSONContent) {
   if (node.type === "pastedAttachment") {
     const title = node.attrs?.title ?? "";
     const fileId = node.attrs?.fileId ?? "";
-    textContent += `:pasted_attachment[${title}]{fileId=${fileId}}`;
+    textContent += `:pasted_content[${title}]{pastedId=${fileId}}`;
   }
 
   // If the node has content, recursively get text and mentions from each child node

--- a/front/components/markdown/PastedAttachmentBlock.tsx
+++ b/front/components/markdown/PastedAttachmentBlock.tsx
@@ -10,7 +10,11 @@ export function PastedAttachmentBlock({ title }: { title: string }) {
 export function pastedAttachmentDirective() {
   return (tree: any) => {
     visit(tree, ["textDirective"], (node) => {
-      if (node.name === "pasted_attachment" && node.children[0]) {
+      // Support both old "pasted_attachment" and new "pasted_content" for backward compatibility
+      if (
+        (node.name === "pasted_content" || node.name === "pasted_attachment") &&
+        node.children[0]
+      ) {
         const data = node.data || (node.data = {});
         data.hName = "pasted_attachment";
         data.hProperties = {

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -48,6 +48,11 @@ export type ContentNodeAttachmentType = BaseConversationAttachmentType & {
   sourceUrl: string | null;
 };
 
+export type LargePasteType = {
+  fileId: string;
+  title: string;
+};
+
 export type ConversationAttachmentType =
   | FileAttachmentType
   | ContentNodeAttachmentType;
@@ -210,6 +215,16 @@ export function getAttachmentFromToolOutput({
     isQueryable,
     isSearchable,
   };
+}
+
+export function renderLargePasteXml({
+  largePaste,
+  content,
+}: {
+  largePaste: LargePasteType;
+  content: string;
+}): string {
+  return `<pastedContent name="${largePaste.title}">${content}</pastedContent>`;
 }
 
 export function renderAttachmentXml({

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -155,6 +155,11 @@ export async function constructPromptMultiActions(
     `// searchable: content can be searched alongside other searchable files' content using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`\n` +
     "Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files mime types to decide which tool to use on which file.\n";
 
+  const pastedContentSection =
+    "# PASTED CONTENT\n" +
+    "The conversation history may contain large pasted contents, indicated by <pastedContent> tags. " +
+    "These tags contain the full content of the pasted content, so don't try to retrieve it with tools.\n";
+
   // GUIDELINES section
   let guidelinesSection = "# GUIDELINES\n";
   const canRetrieveDocuments = agentConfiguration.actions.some(
@@ -217,7 +222,7 @@ export async function constructPromptMultiActions(
     );
   }
 
-  const prompt = `${context}\n${toolsSection}\n${attachmentsSection}\n${guidelinesSection}\n${instructions}`;
+  const prompt = `${context}\n${toolsSection}\n${attachmentsSection}\n${pastedContentSection}\n${guidelinesSection}\n${instructions}`;
 
   return prompt;
 }

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -74,10 +74,7 @@ export async function generateSnippet(
     }
 
     if (isPastedFile(file.contentType)) {
-      // Include up to 2^16 characters in pasted text snippet
-      if (content.length > 65536) {
-        return new Ok(content.slice(0, 65536) + "... (truncated)");
-      }
+      // Include all the text content, as if they were pasted directly in the conversation.
       return new Ok(content);
     }
 

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -136,7 +136,7 @@ export function extractFromEditorJSON(node?: JSONContent): {
   if (node.type === "pastedAttachment") {
     const title = node.attrs?.title ?? "";
     const fileId = node.attrs?.fileId ?? "";
-    textContent += `:pasted_attachment[${title}]{fileId=${fileId}}`;
+    textContent += `:pasted_content[${title}]{pastedId=${fileId}}`;
   }
 
   // If the node has content, recursively extract from each child node.


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/4541

Add the content of the large paste as "pasteContent" instead of attachment so:
 - they are fully included in the conversation
 - the LLM does not try to download it like a normal attachement
 - it does not contain other useless tags

Update dust prompt to make it more aware of this, but it is not really necessary as dust knew to use the pasted content as is.

There is no longer a limit of the size of pasted data included in the conversation.
This means included pasted data can take a looot of context.
But this matches the behaviour of a normal copy/paste, shich seems to be what the user want: a pure UI trick

## Tests

Manual test

Conv message looks like this:

<img width="1690" height="974" alt="image" src="https://github.com/user-attachments/assets/450f7822-a486-4c2e-98d6-58e42b5d704b" />


## Risk

There is no longer a limit of the size of pasted data included in the conversation

## Deploy Plan

deploy front
