### PR TITLE
[front] fix(triggers): fix icon in `TriggerCard`

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -7,6 +7,7 @@ import type { DataSourceViewContentNode, DataSourceViewType } from "@app/types";
 import { MODEL_IDS } from "@app/types/assistant/models/models";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import { REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
+import { WEBHOOK_PROVIDERS } from "@app/types/triggers/webhooks";
 
 const modelIdSchema = z.enum(MODEL_IDS);
 const providerIdSchema = z.enum(MODEL_PROVIDER_IDS);
@@ -193,6 +194,7 @@ const webhookTriggerSchema = z.object({
   enabled: z.boolean().default(true),
   name: z.string(),
   kind: z.enum(["webhook"]),
+  provider: z.enum(WEBHOOK_PROVIDERS).nullable(),
   customPrompt: z.string().nullable(),
   naturalLanguageDescription: z.string().nullable(),
   configuration: webhookConfigSchema,

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -225,18 +225,6 @@ export type AgentBuilderScheduleTriggerType = z.infer<
   typeof scheduleTriggerSchema
 >;
 
-export function isAgentBuilderWebhookTriggerType(
-  trigger: AgentBuilderTriggerType
-): trigger is AgentBuilderWebhookTriggerType {
-  return trigger.kind === "webhook";
-}
-
-export function isAgentBuilderScheduleTriggerType(
-  trigger: AgentBuilderTriggerType
-): trigger is AgentBuilderScheduleTriggerType {
-  return trigger.kind === "schedule";
-}
-
 export const agentBuilderFormSchema = z.object({
   agentSettings: agentSettingsSchema,
   instructions: z.string().min(1, "Instructions are required"),

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -1,6 +1,5 @@
 import {
   Avatar,
-  BellIcon,
   Card,
   CardActionButton,
   Chip,
@@ -11,19 +10,18 @@ import cronstrue from "cronstrue";
 import { useMemo } from "react";
 
 import type { AgentBuilderTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { getIcon } from "@app/components/resources/resources_icons";
 import { useUser } from "@app/lib/swr/user";
-import type { TriggerKind } from "@app/types/assistant/triggers";
+import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 
-function getIcon(kind: TriggerKind) {
-  switch (kind) {
+function getTriggerIcon(trigger: AgentBuilderTriggerType) {
+  switch (trigger.kind) {
     case "schedule":
-      return (
-        <TimeIcon className="h-4 w-4 text-foreground dark:text-foreground-night" />
-      );
+      // There's actually no dark mode here since we're in an Avatar (fixed background).
+      return <TimeIcon className="h-4 w-4 text-foreground" />;
     case "webhook":
-      return (
-        <BellIcon className="h-4 w-4 text-foreground dark:text-foreground-night" />
-      );
+      const IconComponent = getIcon(normalizeWebhookIcon(trigger.provider));
+      return <IconComponent className="h-4 w-4 text-foreground" />;
     default:
       return null;
   }
@@ -79,7 +77,7 @@ export const TriggerCard = ({
     >
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
-          <Avatar visual={getIcon(trigger.kind)} size="xs" />
+          <Avatar visual={getTriggerIcon(trigger)} size="xs" />
           <span className="truncate">{trigger.name}</span>
           {!trigger.enabled && (
             <Chip size="mini" color="rose" label="Disabled" />

--- a/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
+++ b/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
@@ -193,12 +193,11 @@ export function TriggerViewsSheet({
     },
     [
       user,
-      editTrigger,
-      editWebhookSourceView,
-      selectedWebhookSourceView,
-      onAppendTriggerToCreate,
-      onAppendTriggerToUpdate,
       handleSheetClose,
+      editTrigger,
+      onAppendTriggerToUpdate,
+      onAppendTriggerToCreate,
+      webhookSourceView,
       form,
     ]
   );

--- a/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
@@ -62,6 +62,7 @@ export function formValuesToWebhookTriggerData({
       ? webhook.naturalDescription?.trim() ?? null
       : null,
     kind: "webhook",
+    provider: webhookSourceView?.provider ?? null,
     configuration: {
       includePayload: webhook.includePayload,
       event: webhook.event,


### PR DESCRIPTION
## Description

- In Agent Builder we show a grid with the triggers that are already configured for the agent.
- The icons on each card rae currently hardcoded based on whether the trigger is a schedule or a webhook.
- This PR reads the icon the same way as for any trigger elsewhere.
- This PR also fixes the icons for the dark mode (they were barely visible).

Before
<img width="733" height="155" alt="Screenshot 2025-10-28 at 3 27 46 PM" src="https://github.com/user-attachments/assets/8b213326-a040-4ea6-b099-b1c3ceec845b" />

After
<img width="733" height="155" alt="Screenshot 2025-10-28 at 3 18 17 PM" src="https://github.com/user-attachments/assets/82a0e3dd-d767-4544-89ac-21f4a1cb8c4c" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
