### PR TITLE
[LLM Router] Narrow LLM parameters type

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -6,11 +6,11 @@ import { z } from "zod";
 import type { DataSourceViewContentNode, DataSourceViewType } from "@app/types";
 import { MODEL_IDS } from "@app/types/assistant/models/models";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
-import { REASONING_EFFORT_IDS } from "@app/types/assistant/models/reasoning";
+import { REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 
 const modelIdSchema = z.enum(MODEL_IDS);
 const providerIdSchema = z.enum(MODEL_PROVIDER_IDS);
-const reasoningEffortSchema = z.enum(REASONING_EFFORT_IDS);
+const reasoningEffortSchema = z.enum(REASONING_EFFORTS);
 
 const supportedModelSchema = z.object({
   modelId: modelIdSchema,

--- a/front/components/assistant_builder/instructions/ReasoningEffortSubmenu.tsx
+++ b/front/components/assistant_builder/instructions/ReasoningEffortSubmenu.tsx
@@ -9,7 +9,7 @@ import { useEffect, useMemo } from "react";
 
 import type { AgentBuilderState } from "@app/components/assistant_builder/types";
 import { getSupportedModelConfig } from "@app/lib/assistant";
-import { asDisplayName, REASONING_EFFORT_IDS } from "@app/types";
+import { asDisplayName, REASONING_EFFORTS } from "@app/types";
 
 interface ReasoningEffortSubmenuProps {
   generationSettings: AgentBuilderState["generationSettings"];
@@ -33,12 +33,11 @@ export function ReasoningEffortSubmenu({
 
   useEffect(() => {
     if (modelConfig && reasoningEffort) {
-      const reasoningEffortIndex =
-        REASONING_EFFORT_IDS.indexOf(reasoningEffort);
-      const minIndex = REASONING_EFFORT_IDS.indexOf(
+      const reasoningEffortIndex = REASONING_EFFORTS.indexOf(reasoningEffort);
+      const minIndex = REASONING_EFFORTS.indexOf(
         modelConfig.minimumReasoningEffort
       );
-      const maxIndex = REASONING_EFFORT_IDS.indexOf(
+      const maxIndex = REASONING_EFFORTS.indexOf(
         modelConfig.maximumReasoningEffort
       );
 
@@ -55,13 +54,13 @@ export function ReasoningEffortSubmenu({
     return null;
   }
 
-  const minIndex = REASONING_EFFORT_IDS.indexOf(
+  const minIndex = REASONING_EFFORTS.indexOf(
     modelConfig.minimumReasoningEffort
   );
-  const maxIndex = REASONING_EFFORT_IDS.indexOf(
+  const maxIndex = REASONING_EFFORTS.indexOf(
     modelConfig.maximumReasoningEffort
   );
-  const availableOptions = REASONING_EFFORT_IDS.slice(minIndex, maxIndex + 1);
+  const availableOptions = REASONING_EFFORTS.slice(minIndex, maxIndex + 1);
 
   if (availableOptions.length <= 1) {
     return null;

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -31,7 +31,7 @@ import {
   isModelId,
   isModelProviderId,
   isProviderWhitelisted,
-  isReasoningEffortId,
+  isReasoningEffort,
   Ok,
 } from "@app/types";
 
@@ -69,7 +69,7 @@ function createServer(
         if (
           !isModelId(modelId) ||
           !isModelProviderId(providerId) ||
-          (reasoningEffort !== null && !isReasoningEffortId(reasoningEffort))
+          (reasoningEffort !== null && !isReasoningEffort(reasoningEffort))
         ) {
           return new Err(new MCPError("Invalid model ID."));
         }

--- a/front/lib/agent_yaml_converter/schemas.ts
+++ b/front/lib/agent_yaml_converter/schemas.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { additionalConfigurationSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { MODEL_IDS } from "@app/types/assistant/models/models";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
-import { REASONING_EFFORT_IDS } from "@app/types/assistant/models/reasoning";
+import { REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 
 export const agentYAMLBasicInfoSchema = z.object({
   handle: z.string().min(1, "Handle is required"),
@@ -18,7 +18,7 @@ export const agentYAMLGenerationSettingsSchema = z.object({
   model_id: z.enum(MODEL_IDS),
   provider_id: z.enum(MODEL_PROVIDER_IDS),
   temperature: z.number().min(0).max(1, "Temperature must be between 0 and 1"),
-  reasoning_effort: z.enum(REASONING_EFFORT_IDS),
+  reasoning_effort: z.enum(REASONING_EFFORTS),
   response_format: z.string().optional(),
 });
 
@@ -81,7 +81,7 @@ export const agentYAMLReasoningModelSchema = z
     model_id: z.enum(MODEL_IDS),
     provider_id: z.enum(MODEL_PROVIDER_IDS),
     temperature: z.number().min(0).max(1).nullable().optional(),
-    reasoning_effort: z.enum(REASONING_EFFORT_IDS).nullable().optional(),
+    reasoning_effort: z.enum(REASONING_EFFORTS).nullable().optional(),
   })
   .nullable();
 

--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -100,7 +100,7 @@ export async function getBuilderNameSuggestions(
     getConversationContext(inputs);
   const llm = await getLLM(auth, {
     modelId: "mistral-small-latest",
-    options: { bypassFeatureFlag: true },
+    bypassFeatureFlag: true,
   });
 
   if (llm === null) {

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -25,13 +25,13 @@ export class GoogleLLM extends LLM {
   constructor({
     modelId,
     temperature,
-    reasoningEffortId,
+    reasoningEffort,
     bypassFeatureFlag,
   }: LLMParameters & { modelId: GoogleAIStudioWhitelistedModelId }) {
     super({
       modelId,
       temperature,
-      reasoningEffortId,
+      reasoningEffort,
       bypassFeatureFlag,
     });
     const { GOOGLE_AI_STUDIO_API_KEY } = dustManagedCredentials();

--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -1,0 +1,4 @@
+export const GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS = ["gemini-2.5-pro"];
+
+export type GoogleAIStudioWhitelistedModelId =
+  (typeof GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS)[number];

--- a/front/lib/api/llm/clients/google/utils/google_to_events.ts
+++ b/front/lib/api/llm/clients/google/utils/google_to_events.ts
@@ -4,7 +4,8 @@ import assert from "assert";
 import { hash as blake3 } from "blake3";
 import crypto from "crypto";
 
-import type { LLMEvent, ProviderMetadata } from "@app/lib/api/llm/types/events";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 
 function newId(): string {
   const uuid = crypto.randomUUID();
@@ -16,7 +17,7 @@ export async function* streamLLMEvents({
   metadata,
 }: {
   generateContentResponses: AsyncIterable<GenerateContentResponse>;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }): AsyncGenerator<LLMEvent> {
   // Google does not send a "report" with concatenated text chunks
   // So we have to aggregate it ourselves as we receive text chunks
@@ -106,7 +107,7 @@ function textPartToEvent({
   metadata,
 }: {
   part: { text: string; thought?: boolean };
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }): LLMEvent {
   const { text, thought } = part;
 
@@ -130,7 +131,7 @@ function partToLLMEvent({
   metadata,
 }: {
   part: Part;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }): LLMEvent {
   // Exactly one "structuring" field within a Part should be set
   if (part.text) {

--- a/front/lib/api/llm/clients/google/utils/test/google_to_events.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/google_to_events.test.ts
@@ -145,9 +145,9 @@ const modelOutputFunctionCallEvents: PartialGenerateContentResponse[] = [
 ];
 
 const metadata = {
-  providerId: "google_ai_studio" as const,
-  modelId: "gemini-pro",
-};
+  clientId: "google_ai_studio",
+  modelId: "gemini-2.5-pro",
+} as const;
 
 const finishStopLLMEvents = [
   {

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -25,13 +25,13 @@ export class MistralLLM extends LLM {
   constructor({
     modelId,
     temperature,
-    reasoningEffortId,
+    reasoningEffort,
     bypassFeatureFlag,
   }: LLMParameters & { modelId: MistralWhitelistedModelId }) {
     super({
       modelId,
       temperature,
-      reasoningEffortId,
+      reasoningEffort,
       bypassFeatureFlag,
     });
     const { MISTRAL_API_KEY } = dustManagedCredentials();

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -1,38 +1,39 @@
 import { Mistral } from "@mistralai/mistralai";
 
-import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/components/agent_builder/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import type { MistralWhitelistedModelId } from "@app/lib/api/llm/clients/mistral/types";
 import {
   toMessage,
   toTool,
 } from "@app/lib/api/llm/clients/mistral/utils/conversation_to_mistral";
 import { streamLLMEvents } from "@app/lib/api/llm/clients/mistral/utils/mistral_to_events";
 import { LLM } from "@app/lib/api/llm/llm";
-import type { LLMEvent, ProviderMetadata } from "@app/lib/api/llm/types/events";
-import type { LLMOptions } from "@app/lib/api/llm/types/options";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
-  ModelConfigurationType,
-  ModelConversationTypeMultiActions,
-} from "@app/types";
+  LLMClientMetadata,
+  LLMParameters,
+} from "@app/lib/api/llm/types/options";
+import type { ModelConversationTypeMultiActions } from "@app/types";
 import { dustManagedCredentials } from "@app/types";
 
 export class MistralLLM extends LLM {
   private client: Mistral;
-  private metadata: ProviderMetadata = {
-    providerId: "mistral",
-    modelId: this.model.modelId,
+  private metadata: LLMClientMetadata = {
+    clientId: "mistral",
+    modelId: this.modelId,
   };
-  private temperature: number;
   constructor({
-    model,
-    options,
-  }: {
-    model: ModelConfigurationType;
-    options?: LLMOptions;
-  }) {
-    super({ model, options });
-    this.temperature =
-      options?.temperature ?? AGENT_CREATIVITY_LEVEL_TEMPERATURES.balanced;
+    modelId,
+    temperature,
+    reasoningEffortId,
+    bypassFeatureFlag,
+  }: LLMParameters & { modelId: MistralWhitelistedModelId }) {
+    super({
+      modelId,
+      temperature,
+      reasoningEffortId,
+      bypassFeatureFlag,
+    });
     const { MISTRAL_API_KEY } = dustManagedCredentials();
     if (!MISTRAL_API_KEY) {
       throw new Error("MISTRAL_API_KEY environment variable is required");
@@ -60,7 +61,7 @@ export class MistralLLM extends LLM {
     ];
 
     const completionEvents = await this.client.chat.stream({
-      model: this.model.modelId,
+      model: this.modelId,
       messages,
       temperature: this.temperature,
       stream: true,

--- a/front/lib/api/llm/clients/mistral/types.ts
+++ b/front/lib/api/llm/clients/mistral/types.ts
@@ -1,0 +1,7 @@
+export const MISTRAL_WHITELISTED_MODEL_IDS = [
+  "mistral-large-latest",
+  "mistral-small-latest",
+];
+
+export type MistralWhitelistedModelId =
+  (typeof MISTRAL_WHITELISTED_MODEL_IDS)[number];

--- a/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
+++ b/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
@@ -6,11 +6,8 @@ import type {
 import { CompletionResponseStreamChoiceFinishReason } from "@mistralai/mistralai/models/components";
 import compact from "lodash/compact";
 
-import type {
-  LLMEvent,
-  ProviderMetadata,
-  ToolCallEvent,
-} from "@app/lib/api/llm/types/events";
+import type { LLMEvent, ToolCallEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import type { ExpectedDeltaMessage } from "@app/lib/api/llm/types/predicates";
 import {
   isCorrectCompletionEvent,
@@ -25,7 +22,7 @@ export async function* streamLLMEvents({
   metadata,
 }: {
   completionEvents: AsyncIterable<CompletionEvent>;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }): AsyncGenerator<LLMEvent> {
   // Mistral does not send a "report" with concatenated text chunks
   // So we have to aggregate it ourselves as we receive text chunks
@@ -126,7 +123,7 @@ export function toLLMEvents({
   metadata,
 }: {
   delta: ExpectedDeltaMessage;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }): LLMEvent[] {
   const { content, toolCalls } = delta;
 
@@ -149,7 +146,7 @@ function toToolEvent({
   metadata,
 }: {
   toolCall: ToolCall;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }): ToolCallEvent | null {
   if (!isCorrectToolCall(toolCall)) {
     return null;
@@ -173,7 +170,7 @@ function toStreamEvents({
   metadata,
 }: {
   content: string | Array<ContentChunk>;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }): LLMEvent[] {
   if (isString(content)) {
     return [
@@ -200,7 +197,7 @@ function contentChunkToLLMEvent({
   metadata,
 }: {
   chunk: ContentChunk;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }): LLMEvent | null {
   switch (chunk.type) {
     case "text": {

--- a/front/lib/api/llm/clients/mistral/utils/test/mistral_to_events.test.ts
+++ b/front/lib/api/llm/clients/mistral/utils/test/mistral_to_events.test.ts
@@ -146,9 +146,9 @@ const modelOutputFinishToolCallEvents: CompletionEvent[] = [
 ];
 
 const metadata = {
-  providerId: "mistral" as const,
+  clientId: "mistral",
   modelId: "mistral-large-latest",
-};
+} as const;
 
 const finishStopLLMEvents = [
   {

--- a/front/lib/api/llm/clients/noop/index.ts
+++ b/front/lib/api/llm/clients/noop/index.ts
@@ -1,28 +1,17 @@
 import { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
-import type { LLMOptions } from "@app/lib/api/llm/types/options";
-import type {
-  ModelConfigurationType,
-  ModelConversationTypeMultiActions,
-} from "@app/types";
+import type { LLMParameters } from "@app/lib/api/llm/types/options";
+import type { ModelConversationTypeMultiActions } from "@app/types";
 
 // NoopLLM is a dummy LLM that simply returns "Soupinou!".
 export class NoopLLM extends LLM {
-  constructor({
-    model,
-    options,
-  }: {
-    model: ModelConfigurationType;
-    options?: LLMOptions;
-  }) {
-    super({ model, options });
+  constructor(args: LLMParameters & { modelId: "noop" }) {
+    super(args);
   }
 
   async *stream({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    conversation,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    prompt,
+    conversation: _conversation,
+    prompt: _prompt,
   }: {
     conversation: ModelConversationTypeMultiActions;
     prompt: string;
@@ -33,21 +22,9 @@ export class NoopLLM extends LLM {
         delta: "Soupinou!",
       },
       metadata: {
-        providerId: "noop",
-        modelId: "dummy_model",
+        clientId: "noop",
+        modelId: "noop",
       },
     };
-  }
-
-  async *modelStream({
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    conversation,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    prompt,
-  }: {
-    conversation: ModelConversationTypeMultiActions;
-    prompt?: string;
-  }): AsyncGenerator<string> {
-    yield "Soupinou!";
   }
 }

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -10,7 +10,7 @@ import { SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 export async function getLLM(
   auth: Authenticator,
-  { modelId, temperature, reasoningEffortId, bypassFeatureFlag }: LLMParameters
+  { modelId, temperature, reasoningEffort, bypassFeatureFlag }: LLMParameters
 ): Promise<LLM | null> {
   const modelConfiguration = SUPPORTED_MODEL_CONFIGS.find(
     (config) => config.modelId === modelId
@@ -31,7 +31,7 @@ export async function getLLM(
     return new MistralLLM({
       modelId,
       temperature,
-      reasoningEffortId,
+      reasoningEffort,
       bypassFeatureFlag,
     });
   }
@@ -40,7 +40,7 @@ export async function getLLM(
     return new GoogleLLM({
       modelId,
       temperature,
-      reasoningEffortId,
+      reasoningEffort,
       bypassFeatureFlag,
     });
   }

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -1,33 +1,17 @@
 import { GoogleLLM } from "@app/lib/api/llm/clients/google";
+import { GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS } from "@app/lib/api/llm/clients/google/types";
 import { MistralLLM } from "@app/lib/api/llm/clients/mistral";
+import { MISTRAL_WHITELISTED_MODEL_IDS } from "@app/lib/api/llm/clients/mistral/types";
 import type { LLM } from "@app/lib/api/llm/llm";
-import type { LLMOptions } from "@app/lib/api/llm/types/options";
+import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types";
-import type { ModelIdType } from "@app/types/assistant/models/types";
-
-// Keep this until the list includes all the supported model IDs (cf SUPPORTED_MODEL_CONFIGS)
-const WHITELISTED_MODEL_IDS: ModelIdType[] = [
-  "mistral-large-latest",
-  "mistral-small-latest",
-  "gemini-2.5-pro",
-];
 
 export async function getLLM(
   auth: Authenticator,
-  {
-    modelId,
-    options,
-  }: {
-    modelId: ModelIdType;
-    options?: LLMOptions;
-  }
+  { modelId, temperature, reasoningEffortId, bypassFeatureFlag }: LLMParameters
 ): Promise<LLM | null> {
-  if (!WHITELISTED_MODEL_IDS.includes(modelId)) {
-    return null;
-  }
-
   const modelConfiguration = SUPPORTED_MODEL_CONFIGS.find(
     (config) => config.modelId === modelId
   );
@@ -37,18 +21,29 @@ export async function getLLM(
 
   const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
   const hasFeature =
-    options?.bypassFeatureFlag ??
-    featureFlags.includes("llm_router_direct_requests");
+    bypassFeatureFlag ?? featureFlags.includes("llm_router_direct_requests");
 
-  switch (modelId) {
-    case "mistral-large-latest":
-    case "mistral-small-latest":
-      return hasFeature ? new MistralLLM({ model: modelConfiguration }) : null;
-    case "gemini-2.5-pro":
-      return hasFeature
-        ? new GoogleLLM({ model: modelConfiguration, options })
-        : null;
-    default:
-      return null;
+  if (!hasFeature) {
+    return null;
   }
+
+  if (MISTRAL_WHITELISTED_MODEL_IDS.includes(modelId)) {
+    return new MistralLLM({
+      modelId,
+      temperature,
+      reasoningEffortId,
+      bypassFeatureFlag,
+    });
+  }
+
+  if (GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS.includes(modelId)) {
+    return new GoogleLLM({
+      modelId,
+      temperature,
+      reasoningEffortId,
+      bypassFeatureFlag,
+    });
+  }
+
+  return null;
 }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -5,13 +5,13 @@ import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import type {
   ModelConversationTypeMultiActions,
   ModelIdType,
-  ReasoningEffortIdType,
+  ReasoningEffort,
 } from "@app/types";
 
 export abstract class LLM {
   protected modelId: ModelIdType;
   protected temperature: number;
-  protected reasoningEffortId: ReasoningEffortIdType;
+  protected reasoningEffortId: ReasoningEffort;
   protected bypassFeatureFlag: boolean;
 
   constructor({

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -1,24 +1,30 @@
+import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/components/agent_builder/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
-import type { LLMOptions } from "@app/lib/api/llm/types/options";
+import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import type {
-  ModelConfigurationType,
   ModelConversationTypeMultiActions,
+  ModelIdType,
+  ReasoningEffortIdType,
 } from "@app/types";
 
 export abstract class LLM {
-  protected model: ModelConfigurationType;
-  protected options: LLMOptions | undefined;
+  protected modelId: ModelIdType;
+  protected temperature: number;
+  protected reasoningEffortId: ReasoningEffortIdType;
+  protected bypassFeatureFlag: boolean;
 
   constructor({
-    model,
-    options,
-  }: {
-    model: ModelConfigurationType;
-    options?: LLMOptions;
-  }) {
-    this.model = model;
-    this.options = options;
+    modelId,
+    temperature,
+    reasoningEffortId,
+    bypassFeatureFlag = false,
+  }: LLMParameters) {
+    this.modelId = modelId;
+    this.temperature =
+      temperature ?? AGENT_CREATIVITY_LEVEL_TEMPERATURES.balanced;
+    this.reasoningEffortId = reasoningEffortId ?? "none";
+    this.bypassFeatureFlag = bypassFeatureFlag;
   }
 
   abstract stream({

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -11,19 +11,19 @@ import type {
 export abstract class LLM {
   protected modelId: ModelIdType;
   protected temperature: number;
-  protected reasoningEffortId: ReasoningEffort;
+  protected reasoningEffort: ReasoningEffort;
   protected bypassFeatureFlag: boolean;
 
   constructor({
     modelId,
     temperature,
-    reasoningEffortId,
+    reasoningEffort,
     bypassFeatureFlag = false,
   }: LLMParameters) {
     this.modelId = modelId;
     this.temperature =
       temperature ?? AGENT_CREATIVITY_LEVEL_TEMPERATURES.balanced;
-    this.reasoningEffortId = reasoningEffortId ?? "none";
+    this.reasoningEffort = reasoningEffort ?? "none";
     this.bypassFeatureFlag = bypassFeatureFlag;
   }
 

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -1,9 +1,4 @@
-import type { ModelProviderIdType } from "@app/types";
-
-export type ProviderMetadata = Record<string, any> & {
-  providerId: ModelProviderIdType;
-  modelId: string;
-};
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 
 export type Delta = {
   delta: string;
@@ -17,13 +12,13 @@ export type Text = {
 export interface TextDeltaEvent {
   type: "text_delta";
   content: Delta;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }
 
 export interface ReasoningDeltaEvent {
   type: "reasoning_delta";
   content: Delta;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }
 
 // Output items
@@ -36,19 +31,19 @@ export interface ToolCall {
 export interface ToolCallEvent {
   type: "tool_call";
   content: ToolCall;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }
 
 export interface TextGeneratedEvent {
   type: "text_generated";
   content: Text;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }
 
 export interface ReasoningGeneratedEvent {
   type: "reasoning_generated";
   content: Text;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }
 
 export type LLMOutputItem =
@@ -69,13 +64,13 @@ export interface TokenUsage {
 export interface TokenUsageEvent {
   type: "token_usage";
   content: TokenUsage;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }
 
 export interface SuccessCompletionEvent {
   type: "success";
   content: LLMOutputItem[];
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }
 
 export interface CompletionError {
@@ -86,7 +81,7 @@ export interface CompletionError {
 export interface ErrorCompletionEvent {
   type: "error";
   content: CompletionError;
-  metadata: ProviderMetadata;
+  metadata: LLMClientMetadata;
 }
 
 export type LLMEvent =

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -1,7 +1,13 @@
-import type { AgentReasoningEffort } from "@app/types";
+import type { ModelIdType, ReasoningEffortIdType } from "@app/types";
 
-export type LLMOptions = {
-  reasoningEffort?: AgentReasoningEffort;
+export type LLMParameters = {
+  modelId: ModelIdType;
+  reasoningEffortId?: ReasoningEffortIdType;
   temperature?: number;
   bypassFeatureFlag?: boolean;
+};
+
+export type LLMClientMetadata = {
+  clientId: string;
+  modelId: ModelIdType;
 };

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -1,8 +1,8 @@
-import type { ModelIdType, ReasoningEffortIdType } from "@app/types";
+import type { ModelIdType, ReasoningEffort } from "@app/types";
 
 export type LLMParameters = {
   modelId: ModelIdType;
-  reasoningEffortId?: ReasoningEffortIdType;
+  reasoningEffortId?: ReasoningEffort;
   temperature?: number;
   bypassFeatureFlag?: boolean;
 };

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -2,7 +2,7 @@ import type { ModelIdType, ReasoningEffort } from "@app/types";
 
 export type LLMParameters = {
   modelId: ModelIdType;
-  reasoningEffortId?: ReasoningEffort;
+  reasoningEffort?: ReasoningEffort;
   temperature?: number;
   bypassFeatureFlag?: boolean;
 };

--- a/front/types/assistant/models/reasoning.ts
+++ b/front/types/assistant/models/reasoning.ts
@@ -1,17 +1,12 @@
-import type { ReasoningEffortIdType } from "@app/types/assistant/models/types";
+import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { ioTsEnum } from "@app/types/shared/utils/iots_utils";
 
-export const REASONING_EFFORT_IDS = [
-  "none",
-  "light",
-  "medium",
-  "high",
-] as const;
+export const REASONING_EFFORTS = ["none", "light", "medium", "high"] as const;
 
-export const isReasoningEffortId = (
-  reasoningEffortId: string
-): reasoningEffortId is ReasoningEffortIdType =>
-  REASONING_EFFORT_IDS.includes(reasoningEffortId as ReasoningEffortIdType);
+export const isReasoningEffort = (
+  reasoningEffort: string
+): reasoningEffort is ReasoningEffort =>
+  REASONING_EFFORTS.includes(reasoningEffort as ReasoningEffort);
 
 export const ReasoningEffortCodec =
-  ioTsEnum<(typeof REASONING_EFFORT_IDS)[number]>(REASONING_EFFORT_IDS);
+  ioTsEnum<(typeof REASONING_EFFORTS)[number]>(REASONING_EFFORTS);

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -4,7 +4,7 @@ import type {
   ExtractSpecificKeys,
   MODEL_IDS,
   MODEL_PROVIDER_IDS,
-  REASONING_EFFORT_IDS,
+  REASONING_EFFORTS,
   SUPPORTED_MODEL_CONFIGS,
   WhitelistableFeature,
 } from "@app/types";
@@ -64,11 +64,11 @@ export type SupportedModel = ExtractSpecificKeys<
   (typeof SUPPORTED_MODEL_CONFIGS)[number],
   "providerId" | "modelId"
 >;
-export type ReasoningEffortIdType = (typeof REASONING_EFFORT_IDS)[number];
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
 export type ReasoningModelConfigurationType = {
   modelId: ModelIdType;
   providerId: ModelProviderIdType;
-  reasoningEffort: ReasoningEffortIdType | null;
+  reasoningEffort: ReasoningEffort | null;
   temperature: number | null;
 };
 export type EmbeddingProviderIdType = (typeof EMBEDDING_PROVIDER_IDS)[number];


### PR DESCRIPTION
## Description

LLM were accepting a full model configuration type + options
We want to rely only on modelId, temperature, reasoningEffort and later specific provider parameters (e.g. promptCaching for Anthropic)

## Tests

Tested that name suggestion still works 

## Risk

low - feature flagged

## Deploy Plan

front
