### PR TITLE
[Slack MCP] update - access to private channels and DMs and list channel tool update

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -14,6 +14,13 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types";
 
+// Constants for Slack API limits and pagination
+export const SLACK_API_PAGE_SIZE = 100;
+export const MAX_CHANNELS_LIMIT = 500;
+export const MAX_THREAD_MESSAGES = 200;
+export const DEFAULT_THREAD_MESSAGES = 20;
+export const CHANNEL_CACHE_TTL_MS = 60 * 10 * 1000; // 10 minutes
+
 export const getSlackClient = async (accessToken?: string) => {
   if (!accessToken) {
     throw new Error("No access token provided");
@@ -34,6 +41,13 @@ type GetPublicChannelsArgs = {
   slackClient: WebClient;
 };
 
+type GetChannelsArgs = {
+  mcpServerId: string;
+  slackClient: WebClient;
+  types?: string;
+  memberOnly?: boolean;
+};
+
 type ChannelWithIdAndName = Omit<Channel, "id" | "name"> & {
   id: string;
   name: string;
@@ -48,7 +62,7 @@ const _getPublicChannels = async ({
   do {
     const response = await slackClient.conversations.list({
       cursor,
-      limit: 100,
+      limit: SLACK_API_PAGE_SIZE,
       exclude_archived: true,
       types: "public_channel",
     });
@@ -59,9 +73,11 @@ const _getPublicChannels = async ({
     cursor = response.response_metadata?.next_cursor;
 
     // We can't handle a huge list of channels, and even if we could, it would be unusable
-    // in the UI. So we arbitrarily cap it to 500 channels.
-    if (channels.length >= 500) {
-      logger.warn("Channel list truncated after reaching over 500 channels.");
+    // in the UI. So we arbitrarily cap it to MAX_CHANNELS_LIMIT channels.
+    if (channels.length >= MAX_CHANNELS_LIMIT) {
+      logger.warn(
+        `Channel list truncated after reaching over ${MAX_CHANNELS_LIMIT} channels.`
+      );
       break;
     }
   } while (cursor);
@@ -76,13 +92,115 @@ const _getPublicChannels = async ({
     .sort((a, b) => a.name.localeCompare(b.name));
 };
 
+const _getChannels = async ({
+  slackClient,
+  types = "public_channel",
+  memberOnly = false,
+}: GetChannelsArgs): Promise<ChannelWithIdAndName[]> => {
+  const channels: Channel[] = [];
+
+  let cursor: string | undefined = undefined;
+  do {
+    const response = await slackClient.conversations.list({
+      cursor,
+      limit: SLACK_API_PAGE_SIZE,
+      exclude_archived: true,
+      types,
+    });
+    if (!response.ok) {
+      throw new Error(response.error);
+    }
+    channels.push(...(response.channels ?? []));
+    cursor = response.response_metadata?.next_cursor;
+
+    // We can't handle a huge list of channels, and even if we could, it would be unusable
+    // in the UI. So we arbitrarily cap it to MAX_CHANNELS_LIMIT channels.
+    if (channels.length >= MAX_CHANNELS_LIMIT) {
+      logger.warn(
+        `Channel list truncated after reaching over ${MAX_CHANNELS_LIMIT} channels.`
+      );
+      break;
+    }
+  } while (cursor);
+
+  let filteredChannels = channels.filter((c) => !!c.id && !!c.name);
+
+  // Filter by membership if requested
+  if (memberOnly) {
+    filteredChannels = filteredChannels.filter((c) => c.is_member);
+  }
+
+  return filteredChannels
+    .map((c) => ({
+      ...c,
+      id: c.id!,
+      name: c.name!,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
 export const getCachedPublicChannels = cacheWithRedis(
   _getPublicChannels,
   ({ mcpServerId }: GetPublicChannelsArgs) => mcpServerId,
   {
-    ttlMs: 60 * 10 * 1000, // 10 minutes
+    ttlMs: CHANNEL_CACHE_TTL_MS,
   }
 );
+
+export const getCachedChannels = cacheWithRedis(
+  _getChannels,
+  ({ mcpServerId, types, memberOnly }: GetChannelsArgs) =>
+    `${mcpServerId}-${types}-${memberOnly}`,
+  {
+    ttlMs: CHANNEL_CACHE_TTL_MS,
+  }
+);
+
+// Helper function to build filtered list responses
+function buildFilteredListResponse<T>(
+  items: T[],
+  nameFilter: string | undefined,
+  filterFn: (item: T, normalizedFilter: string) => boolean,
+  contextMessage: (
+    count: number,
+    hasFilter: boolean,
+    filterText?: string
+  ) => string
+): Ok<Array<{ type: "text"; text: string }>> {
+  if (!nameFilter) {
+    return new Ok([
+      { type: "text" as const, text: contextMessage(items.length, false) },
+      { type: "text" as const, text: JSON.stringify(items, null, 2) },
+    ]);
+  }
+
+  const normalizedNameFilter = removeDiacritics(nameFilter.toLowerCase());
+  const filteredItems = items.filter((item) =>
+    filterFn(item, normalizedNameFilter)
+  );
+
+  if (filteredItems.length > 0) {
+    return new Ok([
+      {
+        type: "text" as const,
+        text: contextMessage(filteredItems.length, true, nameFilter),
+      },
+      {
+        type: "text" as const,
+        text: JSON.stringify(filteredItems, null, 2),
+      },
+    ]);
+  }
+
+  return new Ok([
+    {
+      type: "text" as const,
+      text:
+        contextMessage(items.length, true, nameFilter) + " but none matching",
+    },
+    { type: "text" as const, text: JSON.stringify(items, null, 2) },
+  ]);
+}
 
 // Post message function
 export async function executePostMessage(
@@ -126,28 +244,47 @@ export async function executePostMessage(
       );
     }
 
-    // Resolve channel id
-    const conversationsList = await getCachedPublicChannels({
-      mcpServerId,
-      slackClient,
-    });
-    const searchString = to.trim().replace(/^#/, "").toLowerCase();
-    const channel = conversationsList.find(
-      (c) =>
-        c.name?.toLowerCase() === searchString ||
-        c.id?.toLowerCase() === searchString
-    );
-    if (!channel) {
-      return new Err(
-        new MCPError(
-          `Unable to resolve channel id for "${to}". Please use a channel id or a valid channel name.`,
-          {
-            tracked: false,
-          }
-        )
-      );
+    // Resolve channel id - optimize by trying conversations.info first if it looks like an ID
+    const searchString = to.trim().replace(/^#/, "");
+    let channelId: string | undefined;
+
+    // If searchString looks like a Slack channel ID (starts with C or G), try direct lookup first
+    if (searchString.match(/^[CG][A-Z0-9]+$/)) {
+      try {
+        const infoResp = await slackClient.conversations.info({
+          channel: searchString,
+        });
+        if (infoResp.ok && infoResp.channel?.id) {
+          channelId = infoResp.channel.id;
+        }
+      } catch (error) {
+        // Fall through to list-based search
+      }
     }
-    const channelId = channel.id;
+
+    // If not found via direct lookup, search through cached channels list
+    if (!channelId) {
+      const conversationsList = await getCachedPublicChannels({
+        mcpServerId,
+        slackClient,
+      });
+      const channel = conversationsList.find(
+        (c) =>
+          c.name?.toLowerCase() === searchString.toLowerCase() ||
+          c.id?.toLowerCase() === searchString.toLowerCase()
+      );
+      if (!channel) {
+        return new Err(
+          new MCPError(
+            `Unable to resolve channel id for "${to}". Please use a channel id or a valid channel name.`,
+            {
+              tracked: false,
+            }
+          )
+        );
+      }
+      channelId = channel.id;
+    }
 
     const signedUrl = await file.getSignedUrlForDownload(auth, "original");
     const fileResp = await fetch(signedUrl);
@@ -212,7 +349,7 @@ export async function executeListUsers(
   do {
     const response = await slackClient.users.list({
       cursor,
-      limit: 100,
+      limit: SLACK_API_PAGE_SIZE,
     });
     if (!response.ok) {
       return new Err(new MCPError(response.error ?? "Unknown error"));
@@ -220,6 +357,7 @@ export async function executeListUsers(
     users.push(...(response.members ?? []).filter((member) => !member.is_bot));
     cursor = response.response_metadata?.next_cursor;
 
+    // Early return optimization: if we found matching users and have a filter, return immediately
     if (nameFilter) {
       const normalizedNameFilter = removeDiacritics(nameFilter.toLowerCase());
       const filteredUsers = users.filter(
@@ -232,36 +370,42 @@ export async function executeListUsers(
           )
       );
 
-      // Early return if we found a user
       if (filteredUsers.length > 0) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `The workspace has ${filteredUsers.length} users containing "${nameFilter}"`,
-          },
-          {
-            type: "text" as const,
-            text: JSON.stringify(filteredUsers, null, 2),
-          },
-        ]);
+        return buildFilteredListResponse<Member>(
+          users,
+          nameFilter,
+          (user, normalizedFilter) =>
+            removeDiacritics(user.name?.toLowerCase() ?? "").includes(
+              normalizedFilter
+            ) ||
+            removeDiacritics(user.real_name?.toLowerCase() ?? "").includes(
+              normalizedFilter
+            ),
+          (count, hasFilter, filterText) =>
+            hasFilter
+              ? `The workspace has ${count} users containing "${filterText}"`
+              : `The workspace has ${count} users`
+        );
       }
     }
   } while (cursor);
 
-  if (nameFilter) {
-    return new Ok([
-      {
-        type: "text" as const,
-        text: `The workspace has ${users.length} users but none containing "${nameFilter}"`,
-      },
-      { type: "text" as const, text: JSON.stringify(users, null, 2) },
-    ]);
-  }
-
-  return new Ok([
-    { type: "text" as const, text: `The workspace has ${users.length} users` },
-    { type: "text" as const, text: JSON.stringify(users, null, 2) },
-  ]);
+  // No filter or no matches found after checking all pages
+  return buildFilteredListResponse<Member>(
+    users,
+    nameFilter,
+    (user, normalizedFilter) =>
+      removeDiacritics(user.name?.toLowerCase() ?? "").includes(
+        normalizedFilter
+      ) ||
+      removeDiacritics(user.real_name?.toLowerCase() ?? "").includes(
+        normalizedFilter
+      ),
+    (count, hasFilter, filterText) =>
+      hasFilter
+        ? `The workspace has ${count} users containing "${filterText}"`
+        : `The workspace has ${count} users`
+  );
 }
 
 export async function executeGetUser(userId: string, accessToken: string) {
@@ -331,4 +475,149 @@ export async function executeListPublicChannels(
     },
     { type: "text" as const, text: JSON.stringify(channels, null, 2) },
   ]);
+}
+
+export async function executeListChannels(
+  nameFilter: string | undefined,
+  accessToken: string,
+  mcpServerId: string
+) {
+  const slackClient = await getSlackClient(accessToken);
+  const channels = await getCachedChannels({
+    mcpServerId,
+    slackClient,
+    types: "public_channel,private_channel",
+    memberOnly: false,
+  });
+
+  return buildFilteredListResponse<ChannelWithIdAndName>(
+    channels,
+    nameFilter,
+    (channel, normalizedFilter) =>
+      removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
+        normalizedFilter
+      ) ||
+      removeDiacritics(channel.topic?.value?.toLowerCase() ?? "").includes(
+        normalizedFilter
+      ),
+    (count, hasFilter, filterText) =>
+      hasFilter
+        ? `The workspace has ${count} channels containing "${filterText}"`
+        : `The workspace has ${count} channels`
+  );
+}
+
+export async function executeListJoinedChannels(
+  nameFilter: string | undefined,
+  accessToken: string,
+  mcpServerId: string
+) {
+  const slackClient = await getSlackClient(accessToken);
+  const channels = await getCachedChannels({
+    mcpServerId,
+    slackClient,
+    types: "public_channel,private_channel",
+    memberOnly: true,
+  });
+
+  return buildFilteredListResponse<ChannelWithIdAndName>(
+    channels,
+    nameFilter,
+    (channel, normalizedFilter) =>
+      removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
+        normalizedFilter
+      ) ||
+      removeDiacritics(channel.topic?.value?.toLowerCase() ?? "").includes(
+        normalizedFilter
+      ),
+    (count, hasFilter, filterText) =>
+      hasFilter
+        ? `You are a member of ${count} channels containing "${filterText}"`
+        : `You are a member of ${count} channels`
+  );
+}
+
+export async function executeReadThreadMessages(
+  channel: string,
+  threadTs: string,
+  limit: number | undefined,
+  cursor: string | undefined,
+  oldest: string | undefined,
+  latest: string | undefined,
+  accessToken: string
+) {
+  const slackClient = await getSlackClient(accessToken);
+
+  try {
+    const response = await slackClient.conversations.replies({
+      channel: channel,
+      ts: threadTs,
+      limit: limit
+        ? Math.min(limit, MAX_THREAD_MESSAGES)
+        : DEFAULT_THREAD_MESSAGES,
+      cursor: cursor,
+      oldest: oldest,
+      latest: latest,
+    });
+
+    if (!response.ok) {
+      return new Err(
+        new MCPError(
+          response.error === "channel_not_found"
+            ? "Channel not found or you are not a member of this channel"
+            : response.error === "thread_not_found"
+              ? "Thread not found or has been deleted"
+              : response.error ?? "Unknown error reading thread"
+        )
+      );
+    }
+
+    const messages = response.messages ?? [];
+    if (messages.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "No messages found in this thread.",
+        },
+      ]);
+    }
+
+    // First message is the parent, rest are replies
+    const parentMessage = messages[0];
+    const threadReplies = messages.slice(1);
+
+    const formattedOutput = {
+      parent_message: {
+        text: parentMessage?.text ?? "",
+        user: parentMessage?.user ?? "",
+        ts: parentMessage?.ts ?? "",
+        reply_count: parentMessage?.reply_count ?? 0,
+      },
+      thread_replies: threadReplies.map((msg) => ({
+        text: msg.text ?? "",
+        user: msg.user ?? "",
+        ts: msg.ts ?? "",
+      })),
+      total_messages: messages.length,
+      has_more: response.has_more ?? false,
+      next_cursor: response.response_metadata?.next_cursor ?? null,
+      pagination_info: {
+        current_page_size: messages.length,
+        replies_in_this_page: threadReplies.length,
+      },
+    };
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Thread contains ${formattedOutput.total_messages} message(s) (1 parent + ${formattedOutput.thread_replies.length} replies)`,
+      },
+      {
+        type: "text" as const,
+        text: JSON.stringify(formattedOutput, null, 2),
+      },
+    ]);
+  } catch (error) {
+    return new Err(new MCPError(`Error reading thread messages: ${error}`));
+  }
 }

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -12,9 +12,11 @@ import type {
 import { renderRelativeTimeFrameForToolOutput } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
   executeGetUser,
-  executeListPublicChannels,
+  executeListChannels,
+  executeListJoinedChannels,
   executeListUsers,
   executePostMessage,
+  executeReadThreadMessages,
   getSlackClient,
 } from "@app/lib/actions/mcp_internal_actions/servers/slack/helpers";
 import {
@@ -53,53 +55,125 @@ export const slackSearch = async (
   query: string,
   accessToken: string
 ): Promise<SlackSearchMatch[]> => {
-  // The slack client library does not support the assistant.search.context endpoint,
-  // so we use the raw fetch API to call it (GET with query params).
-  const params = new URLSearchParams({
-    query,
-    sort: "score",
-    sort_dir: "desc",
-    limit: SLACK_SEARCH_ACTION_NUM_RESULTS.toString(),
-  });
+  // Try assistant.search.context first (requires special token and Slack AI enabled)
+  try {
+    const params = new URLSearchParams({
+      query,
+      sort: "score",
+      sort_dir: "desc",
+      limit: SLACK_SEARCH_ACTION_NUM_RESULTS.toString(),
+    });
 
-  const resp = await fetch(
-    `https://slack.com/api/assistant.search.context?${params.toString()}`,
-    {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
+    const resp = await fetch(
+      `https://slack.com/api/assistant.search.context?${params.toString()}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
+
+    if (!resp.ok) {
+      throw new Error(`HTTP ${resp.status}`);
     }
-  );
 
-  if (!resp.ok) {
-    throw new Error(`HTTP ${resp.status}`);
-  }
-
-  type SlackSearchResponse = {
-    ok: boolean;
-    error?: string;
-    results: {
-      messages: SlackSearchMatch[];
+    type SlackSearchResponse = {
+      ok: boolean;
+      error?: string;
+      results: {
+        messages: SlackSearchMatch[];
+      };
     };
-  };
 
-  const data: SlackSearchResponse = (await resp.json()) as SlackSearchResponse;
-  if (!data.ok) {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    throw new Error(data.error || "unknown_error");
+    const data: SlackSearchResponse =
+      (await resp.json()) as SlackSearchResponse;
+    if (!data.ok) {
+      // If invalid_action_token or other errors, throw to trigger fallback
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      throw new Error(data.error || "unknown_error");
+    }
+
+    const rawMatches: SlackSearchMatch[] = data.results.messages;
+
+    // Filter out matches that don't have a text.
+    const matchesWithText = rawMatches.filter((match) => !!match.content);
+
+    // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
+    const matches = matchesWithText.slice(0, SLACK_SEARCH_ACTION_NUM_RESULTS);
+
+    return matches;
+  } catch (error) {
+    // Fallback to standard search.messages API if assistant.search.context fails
+    logger.info(
+      { error },
+      "Failed to use assistant.search.context, falling back to search.messages"
+    );
+
+    const slackClient = await getSlackClient(accessToken);
+
+    const response = await slackClient.search.messages({
+      query,
+      sort: "score",
+      sort_dir: "desc",
+      count: SLACK_SEARCH_ACTION_NUM_RESULTS,
+    });
+
+    if (!response.ok) {
+      throw new Error(response.error ?? "unknown_error");
+    }
+
+    const rawMatches = response.messages?.matches ?? [];
+
+    // Transform to match expected format
+    const matches: SlackSearchMatch[] = rawMatches.map((match) => ({
+      author_name: match.username,
+      channel_name: match.channel?.name,
+      message_ts: match.ts,
+      content: match.text,
+      permalink: match.permalink,
+    }));
+
+    // Filter out matches that don't have text
+    const matchesWithText = matches.filter((match) => !!match.content);
+
+    // Keep only the top results
+    return matchesWithText.slice(0, SLACK_SEARCH_ACTION_NUM_RESULTS);
   }
-
-  const rawMatches: SlackSearchMatch[] = data.results.messages;
-
-  // Filter out matches that don't have a text.
-  const matchesWithText = rawMatches.filter((match) => !!match.content);
-
-  // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
-  const matches = matchesWithText.slice(0, SLACK_SEARCH_ACTION_NUM_RESULTS);
-
-  return matches;
 };
+
+// Helper function to format date as YYYY-MM-DD with zero-padding
+function formatDateForSlackQuery(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+// Helper function to build search results from matches
+function buildSearchResults<T>(
+  matches: T[],
+  refs: string[],
+  extractors: {
+    permalink: (match: T) => string | undefined;
+    text: (match: T) => string;
+    id: (match: T) => string;
+    content: (match: T) => string;
+  }
+): SearchResultResourceType[] {
+  return matches.map(
+    (match, index): SearchResultResourceType => ({
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+      uri: extractors.permalink(match) ?? "",
+      text: extractors.text(match),
+      id: extractors.id(match),
+      source: { provider: "slack" },
+      tags: [],
+      ref: refs[index] ?? "",
+      chunks: [stripNullBytes(extractors.content(match))],
+    })
+  );
+}
 
 function makeQueryResource(
   keywords: string[],
@@ -195,7 +269,7 @@ function buildSlackSearchQuery(
   if (timeFrame) {
     const timestampInMs = timeFrameFromNow(timeFrame);
     const date = new Date(timestampInMs);
-    query = `${query} after:${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+    query = `${query} after:${formatDateForSlackQuery(date)}`;
   }
   if (channels && channels.length > 0) {
     query = `${query} ${channels
@@ -303,7 +377,7 @@ async function createServer(
   if (slackAIStatus === "disabled" || slackAIStatus === "disconnected") {
     server.tool(
       "search_messages",
-      "Search messages across all channels and dms for the current user",
+      "Search messages across all channels and DMs for the current user",
       {
         keywords: z
           .string()
@@ -412,22 +486,15 @@ async function createServer(
                 citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
               );
 
-              const results: SearchResultResourceType[] = matches.map(
-                (match): SearchResultResourceType => {
-                  return {
-                    mimeType:
-                      INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-                    uri: match.permalink ?? "",
-                    text: `#${match.channel_name ?? "Unknown"}, ${match.content ?? ""}`,
-
-                    id: match.message_ts ?? "",
-                    source: {
-                      provider: "slack",
-                    },
-                    tags: [],
-                    ref: refs.shift() as string,
-                    chunks: [stripNullBytes(match.content ?? "")],
-                  };
+              const results = buildSearchResults<SlackSearchMatch>(
+                matches,
+                refs,
+                {
+                  permalink: (match) => match.permalink,
+                  text: (match) =>
+                    `#${match.channel_name ?? "Unknown"}, ${match.content ?? ""}`,
+                  id: (match) => match.message_ts ?? "",
+                  content: (match) => match.content ?? "",
                 }
               );
 
@@ -559,19 +626,14 @@ async function createServer(
                 return `From ${author} in #${channel}: ${content}`;
               };
 
-              const results: SearchResultResourceType[] = matches.map(
-                (match): SearchResultResourceType => {
-                  return {
-                    mimeType:
-                      INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-                    uri: match.permalink ?? "",
-                    text: getTextFromMatch(match),
-                    id: match.message_ts ?? "",
-                    source: { provider: "slack" },
-                    tags: [],
-                    ref: refs.shift() as string,
-                    chunks: [stripNullBytes(match.content ?? "")],
-                  };
+              const results = buildSearchResults<SlackSearchMatch>(
+                matches,
+                refs,
+                {
+                  permalink: (match) => match.permalink,
+                  text: (match) => getTextFromMatch(match),
+                  id: (match) => match.message_ts ?? "",
+                  content: (match) => match.content ?? "",
                 }
               );
 
@@ -605,141 +667,8 @@ async function createServer(
   }
 
   server.tool(
-    "list_threads",
-    "List threads for a given channel",
-    {
-      channel: z.string().describe("The channel name to list threads for."),
-      relativeTimeFrame: z
-        .string()
-        .regex(/^(all|\d+[hdwmy])$/)
-        .describe(
-          "The time frame (relative to LOCAL_TIME) to restrict the search based" +
-            " on the user request and past conversation context." +
-            " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
-            " where {k} is a number. Be strict, do not invent invalid values."
-        ),
-    },
-    withToolLogging(
-      auth,
-      {
-        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
-        agentLoopContext,
-      },
-      async ({ channel, relativeTimeFrame }, { authInfo }) => {
-        if (!agentLoopContext?.runContext) {
-          return new Err(
-            new MCPError("Unreachable: missing agentLoopRunContext.")
-          );
-        }
-
-        const accessToken = authInfo?.token;
-        const slackClient = await getSlackClient(accessToken);
-
-        const timeFrame = parseTimeFrame(relativeTimeFrame);
-
-        try {
-          let query = `-threads:replies in:${channel.charAt(0) === "#" ? channel : `#${channel}`}`;
-
-          if (timeFrame) {
-            const timestampInMs = timeFrameFromNow(timeFrame);
-            const date = new Date(timestampInMs);
-            query = `${query} after:${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
-          }
-
-          const r = await slackClient.search.messages({
-            query,
-            sort: "timestamp",
-            sort_dir: "desc",
-            highlight: false,
-            count: SLACK_SEARCH_ACTION_NUM_RESULTS,
-            page: 1,
-          });
-
-          if (!r.ok) {
-            return new Err(new MCPError(r.error ?? "Unknown error"));
-          }
-
-          const rawMatches = r.messages?.matches ?? [];
-
-          // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
-          const matches = rawMatches.slice(0, SLACK_SEARCH_ACTION_NUM_RESULTS);
-
-          if (matches.length === 0) {
-            return new Ok([
-              {
-                type: "text" as const,
-                text: `No threads found.`,
-              },
-              {
-                type: "resource" as const,
-                resource: makeQueryResource(
-                  [],
-                  timeFrame,
-                  [channel],
-                  [],
-                  [],
-                  []
-                ),
-              },
-            ]);
-          } else {
-            const { citationsOffset } = agentLoopContext.runContext.stepContext;
-
-            const refs = getRefs().slice(
-              citationsOffset,
-              citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
-            );
-
-            const results: SearchResultResourceType[] = matches.map(
-              (match): SearchResultResourceType => {
-                return {
-                  mimeType:
-                    INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-                  uri: match.permalink ?? "",
-                  text: `#${match.channel?.name ?? "Unknown"}, ${match.text ?? ""}`,
-
-                  id: match.ts ?? "",
-                  source: {
-                    provider: "slack",
-                  },
-                  tags: [],
-                  ref: refs.shift() as string,
-                  chunks: [stripNullBytes(match.text ?? "")],
-                };
-              }
-            );
-
-            return new Ok([
-              ...results.map((result) => ({
-                type: "resource" as const,
-                resource: result,
-              })),
-              {
-                type: "resource" as const,
-                resource: makeQueryResource(
-                  [],
-                  timeFrame,
-                  [channel],
-                  [],
-                  [],
-                  []
-                ),
-              },
-            ]);
-          }
-        } catch (error) {
-          if (isSlackTokenRevoked(error)) {
-            return new Ok(makePersonalAuthenticationError("slack").content);
-          }
-          return new Err(new MCPError(`Error listing threads: ${error}`));
-        }
-      }
-    )
-  );
-
-  server.tool(
     "post_message",
-    "Post a message to a channel or a direct message",
+    "Post a message to a public channel, private channel, or DM",
     {
       to: z
         .string()
@@ -870,8 +799,8 @@ async function createServer(
   );
 
   server.tool(
-    "list_public_channels",
-    "List all public channels in the workspace",
+    "list_channels",
+    "List all public channels of the workspace and only the private channels where you are currently a member",
     {
       nameFilter: z
         .string()
@@ -891,17 +820,242 @@ async function createServer(
         }
 
         try {
-          return await executeListPublicChannels(
+          return await executeListChannels(
             nameFilter,
             accessToken,
             mcpServerId
           );
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
-            return new Err(new MCPError("slack"));
+            return new Ok(makePersonalAuthenticationError("slack").content);
           }
           return new Err(new MCPError(`Error listing channels: ${error}`));
         }
+      }
+    )
+  );
+
+  server.tool(
+    "list_joined_channels",
+    "List only public and private channels where you are currently a member",
+    {
+      nameFilter: z
+        .string()
+        .optional()
+        .describe("The name of the channel to filter by (optional)"),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+      },
+      async ({ nameFilter }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Access token not found"));
+        }
+
+        try {
+          return await executeListJoinedChannels(
+            nameFilter,
+            accessToken,
+            mcpServerId
+          );
+        } catch (error) {
+          if (isSlackTokenRevoked(error)) {
+            return new Ok(makePersonalAuthenticationError("slack").content);
+          }
+          return new Err(new MCPError(`Error listing channels: ${error}`));
+        }
+      }
+    )
+  );
+
+  server.tool(
+    "list_threads",
+    "List threads for a given channel. Returns thread headers with timestamps (ts field). Use read_thread_messages with the ts field to read the full thread content.",
+    {
+      channel: z.string().describe("The channel name to list threads for."),
+      relativeTimeFrame: z
+        .string()
+        .regex(/^(all|\d+[hdwmy])$/)
+        .describe(
+          "The time frame (relative to LOCAL_TIME) to restrict the search based" +
+            " on the user request and past conversation context." +
+            " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
+            " where {k} is a number. Be strict, do not invent invalid values."
+        ),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+      },
+      async ({ channel, relativeTimeFrame }, { authInfo }) => {
+        if (!agentLoopContext?.runContext) {
+          return new Err(
+            new MCPError("Unreachable: missing agentLoopRunContext.")
+          );
+        }
+
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Access token not found"));
+        }
+
+        const slackClient = await getSlackClient(accessToken);
+
+        const timeFrame = parseTimeFrame(relativeTimeFrame);
+
+        try {
+          let query = `-threads:replies in:${channel.charAt(0) === "#" ? channel : `#${channel}`}`;
+
+          if (timeFrame) {
+            const timestampInMs = timeFrameFromNow(timeFrame);
+            const date = new Date(timestampInMs);
+            query = `${query} after:${formatDateForSlackQuery(date)}`;
+          }
+
+          const r = await slackClient.search.messages({
+            query,
+            sort: "timestamp",
+            sort_dir: "desc",
+            highlight: false,
+            count: SLACK_SEARCH_ACTION_NUM_RESULTS,
+            page: 1,
+          });
+
+          if (!r.ok) {
+            return new Err(new MCPError(r.error ?? "Unknown error"));
+          }
+
+          const rawMatches = r.messages?.matches ?? [];
+
+          // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
+          const matches = rawMatches.slice(0, SLACK_SEARCH_ACTION_NUM_RESULTS);
+
+          if (matches.length === 0) {
+            return new Ok([
+              {
+                type: "text" as const,
+                text: `No threads found.`,
+              },
+              {
+                type: "resource" as const,
+                resource: makeQueryResource(
+                  [],
+                  timeFrame,
+                  [channel],
+                  [],
+                  [],
+                  []
+                ),
+              },
+            ]);
+          } else {
+            const { citationsOffset } = agentLoopContext.runContext.stepContext;
+
+            const refs = getRefs().slice(
+              citationsOffset,
+              citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+            );
+
+            const results = buildSearchResults<{
+              permalink?: string;
+              channel?: { name?: string };
+              text?: string;
+              ts?: string;
+            }>(matches, refs, {
+              permalink: (match) => match.permalink,
+              text: (match) =>
+                `#${match.channel?.name ?? "Unknown"}, ${match.text ?? ""}`,
+              id: (match) => match.ts ?? "",
+              content: (match) => match.text ?? "",
+            });
+
+            return new Ok([
+              ...results.map((result) => ({
+                type: "resource" as const,
+                resource: result,
+              })),
+              {
+                type: "resource" as const,
+                resource: makeQueryResource(
+                  [],
+                  timeFrame,
+                  [channel],
+                  [],
+                  [],
+                  []
+                ),
+              },
+            ]);
+          }
+        } catch (error) {
+          if (isSlackTokenRevoked(error)) {
+            return new Ok(makePersonalAuthenticationError("slack").content);
+          }
+          return new Err(new MCPError(`Error listing threads: ${error}`));
+        }
+      }
+    )
+  );
+
+  server.tool(
+    "read_thread_messages",
+    "Read all messages in a specific thread. Use list_threads first to find thread timestamps (ts field).",
+    {
+      channel: z
+        .string()
+        .describe("Channel name or ID where the thread is located"),
+      threadTs: z
+        .string()
+        .describe(
+          "Thread timestamp (ts field from list_threads results, identifies the parent message)"
+        ),
+      limit: z
+        .number()
+        .optional()
+        .describe("Number of messages to retrieve (default: 20, max: 200)"),
+      cursor: z
+        .string()
+        .optional()
+        .describe("Pagination cursor from previous call to get next page"),
+      oldest: z
+        .string()
+        .optional()
+        .describe("Only messages after this timestamp (Unix timestamp)"),
+      latest: z
+        .string()
+        .optional()
+        .describe("Only messages before this timestamp (Unix timestamp)"),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: SLACK_TOOL_LOG_NAME,
+        agentLoopContext,
+      },
+      async (
+        { channel, threadTs, limit, cursor, oldest, latest },
+        { authInfo }
+      ) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(new MCPError("Access token not found"));
+        }
+
+        return executeReadThreadMessages(
+          channel,
+          threadTs,
+          limit,
+          cursor,
+          oldest,
+          latest,
+          accessToken
+        );
       }
     )
   );


### PR DESCRIPTION
## Description
This PR enhances the Slack MCP personal server to provide better access to private channels and DMs while adding new thread reading capabilities. The changes replace the limited `list_public_channels` tool with more comprehensive channel listing tools and introduce a new thread messages reader.

[Issue link - FDE Board](https://github.com/dust-tt/tasks/issues/4660)
[Design Doc](notion.so/dust-tt/Slack-MCP-update-28828599d94180c99d4bc48c7e6a0151?source=copy_link)

Key improvements include:
- Added `list_channels` tool that returns all public channels plus private channels where the user is a member
- Added `list_joined_channels` tool that returns only channels where the user is currently a member
- Added `read_thread_messages` tool to read full thread content with pagination support
- Enhanced search fallback mechanism using standard Slack API when assistant search context fails
- Optimized channel resolution with direct lookup for channel IDs
- Extracted common constants and helper functions for better code organization

## Risk
Low risk changes focused on expanding existing functionality. The changes maintain backward compatibility while adding new capabilities. No database schema changes or breaking API modifications.

## Tests
Manual testing required for Slack integration functionality. Added helper functions are unit-testable and follow existing patterns in the codebase.

## Deploy Plan
Run front
