### PR TITLE
Fix secret component height

### DIFF
--- a/front/components/agent_builder/capabilities/shared/SecretSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/SecretSection.tsx
@@ -25,11 +25,11 @@ function SecretSelectionTable({
   columns,
 }: SecretSelectionTableProps) {
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex flex-col">
       <DataTable
         data={tableData}
         columns={columns}
-        className="h-full"
+        className="max-h-80 overflow-auto"
         filterColumn="name"
       />
     </div>
@@ -154,9 +154,7 @@ export function SecretSection({
                 </div>
               </div>
             ) : (
-              <div className="flex h-64 flex-col">
-                <SecretSelectionTable tableData={tableData} columns={columns} />
-              </div>
+              <SecretSelectionTable tableData={tableData} columns={columns} />
             )}
           </>
         )}


### PR DESCRIPTION
## Description

* "Additional configuration" was overlapping with the secret selection. Fixing max height.

## Tests

<img width="383" height="486" alt="Screenshot 2025-10-28 at 12 18 36 PM" src="https://github.com/user-attachments/assets/e2e88c77-1674-49fa-a788-1748f13a5c6d" />


## Risk

* None

## Deploy Plan

* Deploy front