### PR TITLE
add a buffer when retrieving transcript list from modjo

### DIFF
--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -41,7 +41,7 @@ function getScheduleOptions(
       overlap: ScheduleOverlapPolicy.SKIP,
     },
     spec: {
-      cronExpressions: ["*/10 * * * *"],
+      cronExpressions: ["*/5 * * * *"],
     },
     memo: {
       transcriptsConfigurationId: transcriptsConfiguration.id,

--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -41,7 +41,7 @@ function getScheduleOptions(
       overlap: ScheduleOverlapPolicy.SKIP,
     },
     spec: {
-      cronExpressions: ["*/5 * * * *"],
+      cronExpressions: ["*/10 * * * *"],
     },
     memo: {
       transcriptsConfigurationId: transcriptsConfiguration.id,


### PR DESCRIPTION
## Description

- Adds a buffer of 2 hours when getting the transcript list from modjo (other providers get the list from the last day)

https://github.com/dust-tt/tasks/issues/4806
This solves the case where multiple calls are started in the same period, but span until multiple time periods. Adding a buffer will simply list all calls started in the last 2 hours before, rather than listing calls started after the last successful sync


## Risk

low - the logs will be more verbose

## Deploy Plan

front only
