### PR TITLE
Merge `TextContent` and `TextContentType`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -167,7 +167,7 @@ function createServer(
           );
         }
 
-        let text = content.text;
+        let text = content.value;
 
         // Returning early with a custom message if the text is empty.
         if (text.length === 0) {
@@ -288,8 +288,8 @@ export async function getFileFromConversation(
       fileId,
       title: attachment.title,
       content: {
-        type: "text",
-        text: CONTENT_OUTDATED_MSG,
+        type: "text_content",
+        value: CONTENT_OUTDATED_MSG,
       },
     });
   }

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -24,8 +24,8 @@ describe("renderUserMessage", () => {
     const res = renderUserMessage(m);
 
     expect(res.role).toBe("user");
-    expect(res.content[0].type).toBe("text");
-    const text = (res.content[0] as TextContent).text;
+    expect(res.content[0].type).toBe("text_content");
+    const text = (res.content[0] as TextContent).value;
 
     expect(text).toContain("@John Doe");
     expect(text).not.toContain(":mention[John Doe]{user_123}");
@@ -42,8 +42,8 @@ describe("renderUserMessage", () => {
     });
 
     const res = renderUserMessage(m);
-    expect(res.content[0].type).toBe("text");
-    const text = (res.content[0] as TextContent).text;
+    expect(res.content[0].type).toBe("text_content");
+    const text = (res.content[0] as TextContent).value;
 
     // Should include a dust system block and a Sender line.
     expect(text.startsWith("<dust_system>\n")).toBe(true);
@@ -64,8 +64,8 @@ describe("renderUserMessage", () => {
     const res = renderUserMessage(m);
 
     expect(res.name).toBe("jdoe");
-    expect(res.content[0].type).toBe("text");
-    const text = (res.content[0] as TextContent).text;
+    expect(res.content[0].type).toBe("text_content");
+    const text = (res.content[0] as TextContent).value;
     expect(text).toContain("- Sender: @jdoe");
   });
 
@@ -77,8 +77,8 @@ describe("renderUserMessage", () => {
     });
 
     const res = renderUserMessage(m);
-    expect(res.content[0].type).toBe("text");
-    const text = (res.content[0] as TextContent).text;
+    expect(res.content[0].type).toBe("text_content");
+    const text = (res.content[0] as TextContent).value;
 
     // We do not assert exact date formatting (locale-dependent). We only check
     // that the line is present and not empty.
@@ -103,8 +103,8 @@ describe("renderUserMessage", () => {
     });
 
     const res = renderUserMessage(m);
-    expect(res.content[0].type).toBe("text");
-    const text = (res.content[0] as TextContent).text;
+    expect(res.content[0].type).toBe("text_content");
+    const text = (res.content[0] as TextContent).value;
 
     expect(text).toContain("- Source: Scheduled trigger");
 
@@ -124,8 +124,8 @@ describe("renderUserMessage", () => {
     });
 
     const res = renderUserMessage(m);
-    expect(res.content[0].type).toBe("text");
-    const text = (res.content[0] as TextContent).text;
+    expect(res.content[0].type).toBe("text_content");
+    const text = (res.content[0] as TextContent).value;
 
     expect(text).toContain("- Source: email");
   });
@@ -134,8 +134,8 @@ describe("renderUserMessage", () => {
     const m = buildMessage({ content: "Just text", context: {} });
 
     const res = renderUserMessage(m);
-    expect(res.content[0].type).toBe("text");
-    const text = (res.content[0] as TextContent).text;
+    expect(res.content[0].type).toBe("text_content");
+    const text = (res.content[0] as TextContent).value;
 
     expect(text.startsWith("<dust_system>")).toBe(false);
     expect(text).toBe("Just text");

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -279,8 +279,8 @@ export function renderUserMessage(m: UserMessageType): UserMessageTypeModel {
     name: m.context.fullName || m.context.username,
     content: [
       {
-        type: "text",
-        text: systemContext + content,
+        type: "text_content",
+        value: systemContext + content,
       },
     ],
   };

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -298,7 +298,7 @@ async function countTokensForMessages(
       const textContents: string[] = [];
       for (const c of m.content) {
         if (isTextContent(c)) {
-          textContents.push(c.text);
+          textContents.push(c.value);
         } else if (isImageContent(c)) {
           additionalTokens[i] += IMAGE_CONTENT_TOKEN_COUNT;
         } else {
@@ -327,11 +327,11 @@ async function countTokensForMessages(
     } else if (m.role === "function") {
       const content = Array.isArray(m.content)
         ? m.content
-        : [{ type: "text" as const, text: m.content }];
+        : [{ type: "text_content" as const, value: m.content }];
       const textContents: string[] = [];
       for (const c of content) {
         if (isTextContent(c)) {
-          textContents.push(c.text);
+          textContents.push(c.value);
         } else if (isImageContent(c)) {
           additionalTokens[i] += IMAGE_CONTENT_TOKEN_COUNT;
         } else {

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -17,6 +17,7 @@ import type {
   ConversationType,
   ModelConfigurationType,
   ModelMessageTypeMultiActions,
+  TextContent,
 } from "@app/types";
 import {
   assertNever,
@@ -24,7 +25,6 @@ import {
   isContentFragmentType,
   isUserMessageType,
 } from "@app/types";
-import type { TextContentType } from "@app/types/assistant/agent_message_content";
 
 /**
  * Renders agent message steps into model messages
@@ -44,7 +44,7 @@ export function renderAgentSteps(
     );
     if (stepsWithContent.length) {
       const lastStepWithContent = stepsWithContent[stepsWithContent.length - 1];
-      const textContents: TextContentType[] = [];
+      const textContents: TextContent[] = [];
       for (const content of lastStepWithContent.contents) {
         if (content.type === "text_content") {
           textContents.push(content);
@@ -72,7 +72,7 @@ export function renderAgentSteps(
         );
         continue;
       }
-      const textContents: TextContentType[] = [];
+      const textContents: TextContent[] = [];
       for (const content of step.contents) {
         if (content.type === "text_content") {
           textContents.push(content);

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -33,19 +33,24 @@ import type {
   MessageType,
   ModelId,
   Result,
+  TextContent,
   UserMessageType,
 } from "@app/types";
-import { ConversationError, Err, Ok, removeNulls } from "@app/types";
+import {
+  ConversationError,
+  Err,
+  isTextContent,
+  Ok,
+  removeNulls,
+} from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   AgentContentItemType,
   ReasoningContentType,
-  TextContentType,
 } from "@app/types/assistant/agent_message_content";
 import {
   isFunctionCallContent,
   isReasoningContent,
-  isTextContent,
 } from "@app/types/assistant/agent_message_content";
 import type { ParsedContentItem } from "@app/types/assistant/conversation";
 
@@ -348,8 +353,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         agentStepContents
       );
 
-      const textContents: Array<{ step: number; content: TextContentType }> =
-        [];
+      const textContents: Array<{ step: number; content: TextContent }> = [];
       for (const content of agentStepContents) {
         if (content.content.type === "text_content") {
           textContents.push({ step: content.step, content: content.content });

--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -56,8 +56,8 @@ function getConversationContext(inputs: BuilderSuggestionInputType): {
         role: "user",
         content: [
           {
-            type: "text",
-            text: initialPrompt + descriptionText + instructionsText,
+            type: "text_content",
+            value: initialPrompt + descriptionText + instructionsText,
           },
         ],
         name: "",

--- a/front/lib/api/assistant/utils.ts
+++ b/front/lib/api/assistant/utils.ts
@@ -21,7 +21,7 @@ export function getTextContentFromMessage(
   return content
     ?.map((c) => {
       if (isTextContent(c)) {
-        return c.text;
+        return c.value;
       }
 
       if (isImageContent(c)) {

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -14,7 +14,6 @@ import { assertNever, isRecord, safeParseJSON } from "@app/types";
 import type {
   FunctionCallContentType,
   ReasoningContentType,
-  TextContentType,
 } from "@app/types/assistant/agent_message_content";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 
@@ -30,8 +29,8 @@ async function contentToPart(
   content: TextContent | ImageContent
 ): Promise<Part> {
   switch (content.type) {
-    case "text":
-      return { text: content.text };
+    case "text_content":
+      return { text: content.value };
     case "image_url":
       // Google only accepts images as base64 inline data
       // TODO(LLM-Router 2025-10-27): Handle error properly and send Non retryableError event
@@ -73,9 +72,9 @@ async function functionMessageToResponses(
   const functionResponses = await Promise.all(
     message.content.map(async (c) => {
       switch (c.type) {
-        case "text":
+        case "text_content":
           return {
-            response: { output: c.text },
+            response: { output: c.value },
             name: message.name,
             id: message.function_call_id,
           };
@@ -99,7 +98,7 @@ async function functionMessageToResponses(
 }
 
 function assistantContentToPart(
-  content: ReasoningContentType | TextContentType | FunctionCallContentType
+  content: ReasoningContentType | TextContent | FunctionCallContentType
 ): Part {
   switch (content.type) {
     case "reasoning":

--- a/front/lib/api/llm/clients/google/utils/test/conversation_to_google.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/conversation_to_google.test.ts
@@ -22,12 +22,14 @@ const conversationMessages: ModelMessageTypeMultiActionsWithoutContentFragment[]
       name: "Somebody",
       content: [
         {
-          type: "text",
-          text: '<attachment id="id" type="image/png" title="title.png" version="latest" isIncludable="true" isQueryable="false" isSearchable="false">[Image content interpreted by a vision-enabled model. Description not available in this context.\n</attachment>',
+          type: "text_content",
+          value:
+            '<attachment id="id" type="image/png" title="title.png" version="latest" isIncludable="true" isQueryable="false" isSearchable="false">[Image content interpreted by a vision-enabled model. Description not available in this context.\n</attachment>',
         },
         {
-          type: "text",
-          text: "<dust_system>\n- Sender: Somebody (@somebody) <somebody@dust.tt>\n- Sent at: Oct 22, 2025, 10:53:44 GMT+2\n- Source: web\n</dust_system>\n\n@test hello",
+          type: "text_content",
+          value:
+            "<dust_system>\n- Sender: Somebody (@somebody) <somebody@dust.tt>\n- Sent at: Oct 22, 2025, 10:53:44 GMT+2\n- Source: web\n</dust_system>\n\n@test hello",
         },
       ],
     },

--- a/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
+++ b/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
@@ -12,20 +12,16 @@ import type {
   AssistantFunctionCallMessageTypeModel,
   Content,
   ModelMessageTypeMultiActionsWithoutContentFragment,
+  TextContent,
 } from "@app/types";
 import { assertNever } from "@app/types";
 import type {
   FunctionCallContentType,
   ReasoningContentType,
-  TextContentType,
 } from "@app/types/assistant/agent_message_content";
 
-function toContentChunk(
-  content: Content | TextContentType | ReasoningContentType
-): ContentChunk {
+function toContentChunk(content: Content | ReasoningContentType): ContentChunk {
   switch (content.type) {
-    case "text":
-      return content;
     case "image_url":
       return {
         type: "image_url",
@@ -57,8 +53,7 @@ function toAssistantMessage(
 
   const textContents = message.contents
     .filter(
-      (c): c is TextContentType | ReasoningContentType =>
-        c.type !== "function_call"
+      (c): c is TextContent | ReasoningContentType => c.type !== "function_call"
     )
     .map(toContentChunk);
   const toolCalls = message.contents

--- a/front/lib/api/llm/clients/mistral/utils/test/conversation_to_mistral.test.ts
+++ b/front/lib/api/llm/clients/mistral/utils/test/conversation_to_mistral.test.ts
@@ -22,12 +22,14 @@ const conversationMessages: ModelMessageTypeMultiActionsWithoutContentFragment[]
       name: "Somebody",
       content: [
         {
-          type: "text",
-          text: '<attachment id="id" type="image/png" title="title.png" version="latest" isIncludable="true" isQueryable="false" isSearchable="false">[Image content interpreted by a vision-enabled model. Description not available in this context.\n</attachment>',
+          type: "text_content",
+          value:
+            '<attachment id="id" type="image/png" title="title.png" version="latest" isIncludable="true" isQueryable="false" isSearchable="false">[Image content interpreted by a vision-enabled model. Description not available in this context.\n</attachment>',
         },
         {
-          type: "text",
-          text: "<dust_system>\n- Sender: Somebody (@somebody) <somebody@dust.tt>\n- Sent at: Oct 22, 2025, 10:53:44 GMT+2\n- Source: web\n</dust_system>\n\n@test hello",
+          type: "text_content",
+          value:
+            "<dust_system>\n- Sender: Somebody (@somebody) <somebody@dust.tt>\n- Sent at: Oct 22, 2025, 10:53:44 GMT+2\n- Source: web\n</dust_system>\n\n@test hello",
         },
       ],
     },

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -518,8 +518,8 @@ export async function getContentFragmentFromAttachmentFile(
         name: `inject_${attachment.contentType}`,
         content: [
           {
-            type: "text",
-            text: renderAttachmentXml({ attachment }),
+            type: "text_content",
+            value: renderAttachmentXml({ attachment }),
           },
         ],
       });
@@ -581,8 +581,8 @@ export async function getContentFragmentFromAttachmentFile(
       name: `inject_${attachment.contentType}`,
       content: [
         {
-          type: "text",
-          text: renderAttachmentXml({
+          type: "text_content",
+          value: renderAttachmentXml({
             attachment,
             content: document.document.text ?? null,
           }),
@@ -616,8 +616,8 @@ export async function getContentFragmentFromAttachmentFile(
         name: `inject_pasted_content`,
         content: [
           {
-            type: "text",
-            text: renderLargePasteXml({
+            type: "text_content",
+            value: renderLargePasteXml({
               largePaste,
               content,
             }),
@@ -631,8 +631,8 @@ export async function getContentFragmentFromAttachmentFile(
       name: `inject_${attachment.contentType}`,
       content: [
         {
-          type: "text",
-          text: renderAttachmentXml({
+          type: "text_content",
+          value: renderAttachmentXml({
             attachment,
             content,
           }),
@@ -675,8 +675,8 @@ export async function renderLightContentFragmentForModel(
       name: `attach_${contentType}`,
       content: [
         {
-          type: "text",
-          text: `The content of this file is no longer available. Reason: ${contentFragment.expiredReason}`,
+          type: "text_content",
+          value: `The content of this file is no longer available. Reason: ${contentFragment.expiredReason}`,
         },
       ],
     };
@@ -708,8 +708,8 @@ export async function renderLightContentFragmentForModel(
       name: `attach_pasted_content`,
       content: [
         {
-          type: "text",
-          text: renderLargePasteXml({
+          type: "text_content",
+          value: renderLargePasteXml({
             largePaste,
             content: attachment.snippet ?? "",
           }),
@@ -725,8 +725,8 @@ export async function renderLightContentFragmentForModel(
         name: `inject_${contentType}`,
         content: [
           {
-            type: "text",
-            text: renderAttachmentXml({
+            type: "text_content",
+            value: renderAttachmentXml({
               attachment,
               content:
                 "[Image content interpreted by a vision-enabled model. " +
@@ -750,8 +750,8 @@ export async function renderLightContentFragmentForModel(
           },
         },
         {
-          type: "text",
-          text: renderAttachmentXml({
+          type: "text_content",
+          value: renderAttachmentXml({
             attachment,
           }),
         },
@@ -764,8 +764,8 @@ export async function renderLightContentFragmentForModel(
     name: `attach_${contentType}`,
     content: [
       {
-        type: "text",
-        text: renderAttachmentXml({
+        type: "text_content",
+        value: renderAttachmentXml({
           // Use fileId as contentFragmentId to provide a consistent identifier for the model
           // to reference content fragments across different actions like include_file.
           attachment,

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -9,12 +9,12 @@ import type {
   ModelConversationTypeMultiActions,
   Ok,
   Result,
+  TextContent,
   UserMessageType,
 } from "@app/types";
 import type {
   FunctionCallContentType,
   ReasoningContentType,
-  TextContentType,
 } from "@app/types/assistant/agent_message_content";
 
 export type Output = {
@@ -23,9 +23,7 @@ export type Output = {
     name: string | null;
   }>;
   generation: string | null;
-  contents: Array<
-    TextContentType | FunctionCallContentType | ReasoningContentType
-  >;
+  contents: Array<TextContent | FunctionCallContentType | ReasoningContentType>;
 };
 
 export type GetOutputRequestParams = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -6,12 +6,12 @@ import type {
   ModelIdType,
   ModelProviderIdType,
   OAuthProvider,
+  TextContent,
 } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   FunctionCallContentType,
   ReasoningContentType,
-  TextContentType,
 } from "@app/types/assistant/agent_message_content";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import { isOAuthProvider, isValidScope } from "@app/types/oauth/lib";
@@ -390,5 +390,5 @@ export type AgentStepContentEvent = {
   configurationId: string;
   messageId: string;
   index: number;
-  content: TextContentType | FunctionCallContentType | ReasoningContentType;
+  content: TextContent | FunctionCallContentType | ReasoningContentType;
 };

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -1,10 +1,8 @@
 import type { ModelId, ModelProviderIdType } from "@app/types";
-import type { FunctionCallType } from "@app/types/assistant/generation";
-
-export type TextContentType = {
-  type: "text_content";
-  value: string;
-};
+import type {
+  FunctionCallType,
+  TextContent,
+} from "@app/types/assistant/generation";
 
 export type ReasoningContentType = {
   type: "reasoning";
@@ -32,16 +30,10 @@ export type ErrorContentType = {
 };
 
 export type AgentContentItemType =
-  | TextContentType
+  | TextContent
   | ReasoningContentType
   | FunctionCallContentType
   | ErrorContentType;
-
-export function isTextContent(
-  content: AgentContentItemType
-): content is TextContentType {
-  return content.type === "text_content";
-}
 
 export function isReasoningContent(
   content: AgentContentItemType

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -25,14 +25,14 @@ export interface ImageContent {
 }
 
 export interface TextContent {
-  type: "text";
-  text: string;
+  type: "text_content";
+  value: string;
 }
 
 export type Content = TextContent | ImageContent;
 
 export function isTextContent(content: object): content is TextContent {
-  return "text" in content && "type" in content && content.type === "text";
+  return "value" in content && "type" in content && content.type === "text";
 }
 
 export function isImageContent(content: object): content is ImageContent {

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -32,7 +32,9 @@ export interface TextContent {
 export type Content = TextContent | ImageContent;
 
 export function isTextContent(content: object): content is TextContent {
-  return "value" in content && "type" in content && content.type === "text";
+  return (
+    "value" in content && "type" in content && content.type === "text_content"
+  );
 }
 
 export function isImageContent(content: object): content is ImageContent {


### PR DESCRIPTION
## Description

Currently we use `TextContentType` for assistant messages and `TextContent` for user messages. This creates unnecessary confusion. This PR aims to merge them into a single type.

Note: We opted to merge `TextContent` into `TextContentType` (except for the name) because unlike `UserMessageTypeModel`, the `AssistantMessage...Model` directly writes to DB. (The User messages get turned into `ContentFragment`s and the text parts are just kept in DB as a `content: string` value).

Thus we take these two types:

```ts
export type TextContentType = {
  type: "text_content";
  value: string;
};

export interface TextContent {
  type: "text";
  text: string;
}
```

To merge into:

```ts
export interface TextContent {
  type: "text_content";
  value: string;
}
```


## Tests

Passed all tests.
Checked if I was able to see past conversations, if I was able to talk to an agent, if I could upload documents to it, if it could call tools.

## Risk

Low.

## Deploy Plan

Deploy front.
