### PR TITLE
[front] enh(navbar): rearrange padding and margins in navigation sidebar tabs list

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -112,7 +112,7 @@ export const NavigationSidebar = React.forwardRef<
         )}
         {navs.length > 1 && (
           <Tabs value={currentTab?.id ?? "conversations"}>
-            <TabsList className="flex min-h-14 grow items-center justify-center">
+            <TabsList className="flex min-h-14 grow items-center pl-4">
               {navs.map((tab) => (
                 <div key={tab.id} ref={tab.ref ?? undefined}>
                   <TabsTrigger

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -99,7 +99,7 @@ export const NavigationSidebar = React.forwardRef<
 
   return (
     <div ref={ref} className="flex min-w-0 grow flex-col">
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col">
         {appStatus && <AppStatusBanner appStatus={appStatus} />}
         {!hasIncidentBanner && endDate && endDate < in30Days && (
           <SubscriptionEndBanner

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -99,7 +99,7 @@ export const NavigationSidebar = React.forwardRef<
 
   return (
     <div ref={ref} className="flex min-w-0 grow flex-col">
-      <div className="flex flex-col gap-2 pt-3">
+      <div className="flex flex-col gap-2">
         {appStatus && <AppStatusBanner appStatus={appStatus} />}
         {!hasIncidentBanner && endDate && endDate < in30Days && (
           <SubscriptionEndBanner
@@ -112,7 +112,7 @@ export const NavigationSidebar = React.forwardRef<
         )}
         {navs.length > 1 && (
           <Tabs value={currentTab?.id ?? "conversations"}>
-            <TabsList className="px-2">
+            <TabsList className="flex min-h-14 grow items-center justify-center">
               {navs.map((tab) => (
                 <div key={tab.id} ref={tab.ref ?? undefined}>
                   <TabsTrigger


### PR DESCRIPTION
## Description

- The vertical padding on the tabs is a little off, we actually have a situation where we have a lot of top padding that compensates for the inner div ends up being too small.
- This PR centers each div around the content. One other change is that there won't be an extra padding at the top of a banner.

Before

<img width="367" alt="Screenshot 2025-10-28 at 10 44 25 PM" src="https://github.com/user-attachments/assets/80f27609-221a-47f8-ad8a-0cfb14a55a78" />
<img width="367" alt="Screenshot 2025-10-28 at 10 54 06 PM" src="https://github.com/user-attachments/assets/19c12a4e-d85b-4137-aed1-5e3d0d470b6d" />

After

<img width="367" alt="Screenshot 2025-10-28 at 10 44 38 PM" src="https://github.com/user-attachments/assets/6cb68543-63b2-4284-9fa2-b1a9037d8152" />
<img width="367" alt="Screenshot 2025-10-28 at 10 45 03 PM" src="https://github.com/user-attachments/assets/2f79f8e6-90a0-4357-8b00-f4f1df7a07be" />

## Tests

- Checked locally

## Risk

- Low.

## Deploy Plan

- Deploy front.
