### PR TITLE
[connectors] enh(gong): skip full sync of users of incremental sync

### DIFF
--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -267,6 +267,15 @@ export async function gongListAndSaveUsersActivity({
   connectorId: ModelId;
 }) {
   const connector = await fetchGongConnector({ connectorId });
+  const configuration = await fetchGongConfiguration(connector);
+
+  // Skip the full sync of users if we are not on the initial full sync.
+  // The call to /users is costly (many users usually) and heavily rate-limited:
+  // we have seen retry-after of ~20 minutes.
+  if (configuration.lastSyncTimestamp !== null) {
+    return;
+  }
+
   const gongClient = await getGongClient(connector);
 
   let pageCursor = null;

--- a/connectors/src/connectors/gong/temporal/workflows.ts
+++ b/connectors/src/connectors/gong/temporal/workflows.ts
@@ -25,7 +25,6 @@ const {
 
 export async function gongSyncWorkflow({
   connectorId,
-  fromTs,
   forceResync,
 }: {
   connectorId: ModelId;
@@ -34,11 +33,9 @@ export async function gongSyncWorkflow({
 }) {
   await gongSaveStartSyncActivity({ connectorId });
 
-  // Only run the users sync if we are not resuming from a previous sync. New users will be added
-  // through the transcripts incremental sync.
-  if (!fromTs) {
-    await gongListAndSaveUsersActivity({ connectorId });
-  }
+  // Only syncs the users if we are not resuming from a previous sync.
+  // New users will be added through the transcript incremental sync.
+  await gongListAndSaveUsersActivity({ connectorId });
 
   const {
     workflowId,


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/4866.
- We currently always resync the users on incremental syncs (example [here](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/gong-sync-20546-workflow-2025-10-29T07%3A00%3A00Z/019a2ece-f280-7530-8ea9-05978292c727/history)).
- This operation is costly as there are usually many users in an organization.
- We did not differentiate incremental syncs from full syncs correctly, it was based on a `fromTs` that was always null because set when defining the schedule.

## Tests

- Tested locally. No more users resync on incremental syncs.

## Risk

- Low.

## Deploy Plan

- Check if there running workflows.
- Deploy connectors.
- The schedule will keep passing a value for `fromTs` that won't be read.
