### PR TITLE
[front] - chore: implement dynamic search placeholders

### DIFF
--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -36,6 +36,7 @@ import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { useDataSourceViews } from "@app/lib/swr/data_source_views";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import type {
@@ -48,7 +49,10 @@ import type {
   LightWorkspaceType,
   SpaceType,
 } from "@app/types";
-import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
+import {
+  DATA_SOURCE_VIEW_CATEGORIES_DISPLAY_NAMES,
+  MIN_SEARCH_QUERY_SIZE,
+} from "@app/types";
 
 const DEFAULT_VIEW_TYPE = "all";
 
@@ -79,6 +83,19 @@ function isBackendSearch(
   props: SpaceSearchInputProps
 ): props is BackendSearchProps {
   return props.useBackendSearch === true;
+}
+
+function getSearchInputPlaceholder(
+  space: SpaceType,
+  category?: DataSourceViewCategory,
+  dataSourceView?: DataSourceViewType
+) {
+  if (dataSourceView) {
+    return `Search in ${getDisplayNameForDataSource(dataSourceView.dataSource)}`;
+  } else if (category) {
+    return `Search in ${DATA_SOURCE_VIEW_CATEGORIES_DISPLAY_NAMES[category]}`;
+  }
+  return `Search in ${space.name}`;
 }
 
 export function SpaceSearchInput(props: SpaceSearchInputProps) {
@@ -383,11 +400,12 @@ function BackendSearch({
       setSearchHitCount(searchResults.length);
     }
   }, [isLoading, isSearchValidating, searchResults]);
+
   return (
     <SpaceSearchContext.Provider value={searchContextValue}>
       <SearchInput
         name="search"
-        placeholder={`Search in ${space.name}`}
+        placeholder={getSearchInputPlaceholder(space, category, dataSourceView)}
         value={searchTerm}
         onChange={handleSearchChange}
         disabled={isSearchDisabled}
@@ -488,7 +506,7 @@ function FrontendSearch({
     <SpaceSearchContext.Provider value={searchContextValue}>
       <SearchInput
         name="search"
-        placeholder={`Search in ${space.name}`}
+        placeholder={getSearchInputPlaceholder(space, category, dataSourceView)}
         value={searchTerm}
         onChange={searchParam.setParam}
         disabled={isSearchDisabled}

--- a/front/types/api/public/spaces.ts
+++ b/front/types/api/public/spaces.ts
@@ -52,6 +52,18 @@ export function isValidDataSourceViewCategory(
   );
 }
 
+export const DATA_SOURCE_VIEW_CATEGORIES_DISPLAY_NAMES: Record<
+  DataSourceViewCategory,
+  string
+> = {
+  managed: "Connections",
+  folder: "Folders",
+  website: "Websites",
+  apps: "Apps",
+  actions: "Tools",
+  triggers: "Triggers",
+};
+
 export type DataSourceViewCategoryWithoutApps = Exclude<
   DataSourceViewCategory,
   "apps" | "actions"


### PR DESCRIPTION
## Description

This PR adds dynamic search placeholders to the `SpaceSearchLayout` component that contextually display what the user is searching within. Instead of always showing "Search in [space name]", the placeholder now adapts based on the current context:

- When searching within a specific data source: "Search in [data source name]"
- When filtering by category: "Search in [category display name]" (e.g., "Search in Connections", "Search in Folders")
- When in general space view: "Search in [space name]"

The implementation introduces a mapping of data source view categories to human-readable display names and leverages existing data source display name utilities.

**References:**
- https://github.com/dust-tt/tasks/issues/4886

## Risk

Low

## Tests

Locally

## Deploy plan

- Deploy front