### PR TITLE
[front] - chore(ES): add "dismiss" to feedbacks

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
@@ -86,6 +86,9 @@
         "is_conversation_shared": {
           "type": "boolean"
         },
+        "dismissed": {
+          "type": "boolean"
+        },
         "created_at": {
           "type": "date"
         }

--- a/front/lib/analytics/migrations/20250317_add_dismissed_to_feedbacks.http
+++ b/front/lib/analytics/migrations/20250317_add_dismissed_to_feedbacks.http
@@ -1,0 +1,10 @@
+PUT /front.agent_message_analytics_1/_mapping
+{
+  "properties": {
+    "feedbacks": {
+      "properties": {
+        "dismissed": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -28,6 +28,7 @@ export interface AgentMessageAnalyticsFeedback {
   thumb_direction: ThumbReaction;
   content?: string;
   is_conversation_shared: boolean;
+  dismissed: boolean;
   created_at: string; // ISO date string.
 }
 


### PR DESCRIPTION
## Description
Adds a `dismissed` boolean field to the agent message analytics Elasticsearch mapping and TypeScript interface. This extends the feedback tracking system to capture when users dismiss agent message feedback, enabling better analytics on feedback engagement patterns.

## Risk
Minor Elasticsearch schema change. The new field is optional and backward compatible, so existing documents will continue to work normally.

## Tests

Locally

## Deploy Plan
- Apply Elasticsearch mapping migration using the included HTTP script to add the `dismissed` field to the feedbacks nested object
- Deploy front
