### PR TITLE
Ignore Firecrawl webhooks on paused connectors

### DIFF
--- a/connectors/src/api/webhooks/webhook_firecrawl.ts
+++ b/connectors/src/api/webhooks/webhook_firecrawl.ts
@@ -86,7 +86,15 @@ const _webhookFirecrawlAPIHandler = async (
   if (!connector) {
     logger.error({ connectorId: metadata.connectorId }, "Connector not found");
     // We ignore the webhook.
-    return res.status(200);
+    return res.status(200).end();
+  }
+
+  if (connector.isPaused()) {
+    logger.info(
+      { connectorId: connector.id },
+      "Connector is paused, ignoring webhook"
+    );
+    return res.status(200).end();
   }
 
   switch (type) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See Slack thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1761737279490119).

Current implementation of the Firecrawl webcrawler does not account for paused connectors. This PR ensures that we avoid launching new workflows.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
