### PR TITLE
Improve Memory Tool Breakdown

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -18,6 +18,11 @@ import {
   makeQueryTextForList,
 } from "@app/components/actions/mcp/details/input_rendering";
 import { MCPAgentManagementActionDetails } from "@app/components/actions/mcp/details/MCPAgentManagementActionDetails";
+import {
+  MCPAgentMemoryEraseActionDetails,
+  MCPAgentMemoryRecordActionDetails,
+  MCPAgentMemoryRetrieveActionDetails,
+} from "@app/components/actions/mcp/details/MCPAgentMemoryActionDetails";
 import { MCPBrowseActionDetails } from "@app/components/actions/mcp/details/MCPBrowseActionDetails";
 import {
   DataSourceNodeContentDetails,
@@ -253,6 +258,19 @@ export function MCPActionDetails({
     return <MCPDeepDiveActionDetails {...toolOutputDetailsProps} />;
   }
 
+  if (isInternalMCPServerOfName(mcpServerId, "agent_memory")) {
+    if (toolName === "retrieve") {
+      return (
+        <MCPAgentMemoryRetrieveActionDetails {...toolOutputDetailsProps} />
+      );
+    }
+    if (toolName === "record_entries") {
+      return <MCPAgentMemoryRecordActionDetails {...toolOutputDetailsProps} />;
+    }
+    if (toolName === "erase_entries") {
+      return <MCPAgentMemoryEraseActionDetails {...toolOutputDetailsProps} />;
+    }
+  }
   if (isInternalMCPServerOfName(mcpServerId, "toolsets")) {
     if (toolName === "enable") {
       return <MCPToolsetsEnableActionDetails {...toolOutputDetailsProps} />;

--- a/front/components/actions/mcp/details/MCPAgentMemoryActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAgentMemoryActionDetails.tsx
@@ -1,0 +1,166 @@
+import {
+  ActionLightbulbIcon,
+  Card,
+  ContentMessage,
+  Icon,
+  Markdown,
+} from "@dust-tt/sparkle";
+import type {
+  CallToolResult,
+  TextContent,
+} from "@modelcontextprotocol/sdk/types.js";
+import { useMemo } from "react";
+
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+
+export function MCPAgentMemoryRetrieveActionDetails({
+  toolOutput,
+  viewType,
+}: ToolExecutionDetailsProps) {
+  const parsedMemories = useMemo(
+    () => parseMemoriesFromOutput(toolOutput),
+    [toolOutput]
+  );
+
+  return (
+    <ActionDetailsWrapper
+      viewType={viewType}
+      actionName="Retrieve Agent Memory"
+      visual={ActionLightbulbIcon}
+    >
+      <div className="flex flex-col pt-4">
+        <div className="flex flex-col gap-2">
+          <span className="heading-base">Saved memories</span>
+          {parsedMemories.length === 0 ? (
+            <ActionCard actionText={"*No memory was retrieved.*"} />
+          ) : (
+            <MemoriesCardList memories={parsedMemories} />
+          )}
+        </div>
+      </div>
+    </ActionDetailsWrapper>
+  );
+}
+
+export function MCPAgentMemoryRecordActionDetails({
+  toolParams,
+  viewType,
+}: ToolExecutionDetailsProps) {
+  const entries = Array.isArray(toolParams.entries) ? toolParams.entries : [];
+  return (
+    <ActionDetailsWrapper
+      viewType={viewType}
+      actionName="Record Agent Memory"
+      visual={ActionLightbulbIcon}
+    >
+      <div className="flex flex-col pt-4">
+        <div className="flex flex-col gap-2">
+          <span className="heading-base">
+            {entries.length === 1 ? "Recorded memory" : "Recorded memories"}
+          </span>
+          {entries.length === 0 ? (
+            <ActionCard actionText={"*No entries were recorded.*"} />
+          ) : (
+            <MemoriesCardList memories={entries} />
+          )}
+        </div>
+      </div>
+    </ActionDetailsWrapper>
+  );
+}
+
+export function MCPAgentMemoryEraseActionDetails({
+  toolParams,
+  toolOutput,
+  viewType,
+}: ToolExecutionDetailsProps) {
+  const indexes = Array.isArray(toolParams.indexes) ? toolParams.indexes : [];
+  const remainingMemories = useMemo(
+    () => parseMemoriesFromOutput(toolOutput),
+    [toolOutput]
+  );
+  return (
+    <ActionDetailsWrapper
+      viewType={viewType}
+      actionName="Erase Agent Memory"
+      visual={ActionLightbulbIcon}
+    >
+      <div className="flex flex-col gap-4 pt-4">
+        <div className="flex flex-col gap-2">
+          <span className="heading-base">Output</span>
+          <ActionCard
+            actionText={
+              indexes.length === 0
+                ? "*No memory entries were erased.*"
+                : `*Erased ${indexes.length} ${indexes.length === 1 ? "memory" : "memories"}.*`
+            }
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="heading-base">Remaining memories</div>
+          {remainingMemories.length === 0 ? (
+            <ActionCard actionText={"*No memories remaining.*"} />
+          ) : (
+            <MemoriesCardList memories={remainingMemories} />
+          )}
+        </div>
+      </div>
+    </ActionDetailsWrapper>
+  );
+}
+
+/**
+ * Shared components & utils.
+ */
+
+const MemoriesCardList = ({ memories }: { memories: string[] }) => {
+  return (
+    <div className="flex flex-col gap-1">
+      {memories.map((memory, index) => (
+        <Card key={index} size="md" className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <Icon visual={ActionLightbulbIcon} size="xs" />
+            <div className="text-sm">{memory}</div>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+const ActionCard = ({ actionText }: { actionText: string }) => {
+  return (
+    <ContentMessage variant="primary" size="lg">
+      <Markdown content={actionText} forcedTextSize="text-sm" />
+    </ContentMessage>
+  );
+};
+
+function parseMemoriesFromOutput(
+  toolOutput: CallToolResult["content"] | null
+): string[] {
+  const memoryOutputs =
+    toolOutput?.filter(
+      (output): output is TextContent => output.type === "text"
+    ) ?? [];
+
+  const memories: string[] = [];
+
+  memoryOutputs.forEach((output) => {
+    if (output.text === "(memory empty)") {
+      return;
+    }
+    const lines = output.text.split("\n");
+    lines.forEach((line: string) => {
+      const match = line.match(/^\[\d+\]\s*(.+)$/);
+      if (match) {
+        memories.push(match[1].trim());
+      } else if (line.trim()) {
+        memories.push(line.trim());
+      }
+    });
+  });
+
+  return memories;
+}


### PR DESCRIPTION
## Description

A little bit of code to improve the design of memories on the message breakdown modal. 

## Before After: Retrieving memories

**Before:**
<kbd>
<img width="676" height="319" alt="Screenshot 2025-10-29 at 13 29 54" src="https://github.com/user-attachments/assets/d98665c9-8c93-45e9-a064-05e04dfdc282" />
</kbd>
**After:**
<kbd>
<img width="681" height="222" alt="Screenshot 2025-10-29 at 13 25 56" src="https://github.com/user-attachments/assets/6f451abd-d492-4a61-b026-c8b82df52414" />
</kbd>

## Before After: Saving memories
**Before:**
<kbd>
<img width="682" height="362" alt="Screenshot 2025-10-29 at 13 28 26" src="https://github.com/user-attachments/assets/4be0f94d-1178-4d2d-b042-c669c03526ce" />
</kbd>
**After:**
<kbd>
<img width="682" height="165" alt="Screenshot 2025-10-29 at 13 27 23" src="https://github.com/user-attachments/assets/b26e799e-55db-4523-b664-c0d6eef80fe1" />
</kbd>

## Before After: Erasing memories
**Before:**
<kbd>
<img width="682" height="331" alt="Screenshot 2025-10-29 at 13 31 24" src="https://github.com/user-attachments/assets/95c5fead-30e5-47e7-bdab-5b095c93a20a" />
</kbd>
**After:**
<kbd>
<img width="683" height="258" alt="Screenshot 2025-10-29 at 13 26 26" src="https://github.com/user-attachments/assets/3c3ec0da-cf52-4141-ae3b-57b5aae7f39f" />
</kbd>

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 