### PR TITLE
Close tool picker if last unselected item is picked

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -123,7 +123,12 @@ export function ToolsPicker({
 
     const selectionIncreased = selectedCount > prevSelectedCount;
 
-    if (selectionIncreased && prevUnselectedCount > 0 && unselectedCount === 0) {
+    // if we have selected one more item and there are no unselected items left, close the picker
+    if (
+      selectionIncreased &&
+      prevUnselectedCount > 0 &&
+      unselectedCount === 0
+    ) {
       setIsOpen(false);
       setSearchText("");
     }

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -109,6 +109,8 @@ export function ToolsPicker({
   const prevSelectedCountRef = useRef(selectedMCPServerViewIds.length);
   const prevUnselectedCountRef = useRef(filteredServerViewsUnselected.length);
 
+  // Compare the previous and current selected and unselected tool counts
+  // to determine if the picker should be closed.
   useEffect(() => {
     const prevSelectedCount = prevSelectedCountRef.current;
     const prevUnselectedCount = prevUnselectedCountRef.current;
@@ -136,8 +138,8 @@ export function ToolsPicker({
     prevSelectedCountRef.current = selectedCount;
     prevUnselectedCountRef.current = unselectedCount;
   }, [
-    filteredServerViewsUnselected.length,
     isOpen,
+    filteredServerViewsUnselected.length,
     selectedMCPServerViewIds.length,
   ]);
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -1177,14 +1177,18 @@ function useMCPServerViewsFromSpacesBase(
   const availabilitiesParam = availabilities.join(",");
 
   const url = `/api/w/${owner.sId}/mcp/views?spaceIds=${spaceIds}&availabilities=${availabilitiesParam}`;
-  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
-    ...swrOptions,
-    ...(!spaces.length ? { disabled: true } : {}),
-  });
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    url,
+    configFetcher,
+    {
+      ...swrOptions,
+      ...(!spaces.length ? { disabled: true } : {}),
+    }
+  );
 
   return {
     serverViews: data?.serverViews ?? emptyArray(),
-    isLoading: !error && !data && spaces.length !== 0,
+    isLoading: isLoading && !error && !data && spaces.length !== 0,
     isError: error,
     mutateServerViews: mutate,
   };

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -1177,18 +1177,14 @@ function useMCPServerViewsFromSpacesBase(
   const availabilitiesParam = availabilities.join(",");
 
   const url = `/api/w/${owner.sId}/mcp/views?spaceIds=${spaceIds}&availabilities=${availabilitiesParam}`;
-  const { data, error, mutate, isLoading } = useSWRWithDefaults(
-    url,
-    configFetcher,
-    {
-      ...swrOptions,
-      ...(!spaces.length ? { disabled: true } : {}),
-    }
-  );
+  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
+    ...swrOptions,
+    ...(!spaces.length ? { disabled: true } : {}),
+  });
 
   return {
     serverViews: data?.serverViews ?? emptyArray(),
-    isLoading: isLoading && !error && !data && spaces.length !== 0,
+    isLoading: !error && !data && spaces.length !== 0,
     isError: error,
     mutateServerViews: mutate,
   };


### PR DESCRIPTION
## Description

- Fix for https://github.com/dust-tt/tasks/issues/4482
- Closes the tool dropdown picker if the last selectable element was selected

### Summary of changes

- Track the previous selected/unselected counts with refs so we know the current selection on every render
- The effect only triggers an action if there were a new item selected and there's no more items left
- If that's the case we automatically close the modal 

This makes sure that user can still selected several items at once, discover our list of tools while not being stuck if there's no items to select left

## Tests

Checked for:

- No regression: ✅ 
- Picker opens instantly: ✅ 
- When doing a search and no results appear picker don't close: ✅ 
- When selecting the last available item the picker closes: ✅ 
- When all items are selected, if we open the picker it's not auto closing: ✅ 

https://github.com/user-attachments/assets/fe33a332-973c-422b-a650-da3addae9b65

## Risk

Low

## Deploy Plan

Deploy front