### PR TITLE
[hootl] UI: event chips + remove webhook wording

### DIFF
--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -102,7 +102,7 @@ export function CreateWebhookSourceFormContent({
               {...field}
               id="trigger-description"
               rows={3}
-              placeholder="Enter a description for this trigger"
+              placeholder="Help your team understand when to use this trigger."
             />
           </div>
         )}
@@ -139,7 +139,8 @@ export function CreateWebhookSourceFormContent({
 
             return (
               <div className="flex flex-col gap-2">
-                <Label htmlFor="subscribedEvents">Subscribed events</Label>
+                <Label htmlFor="subscribedEvents">Events to watch</Label>
+                <p>Choose which events will activate this trigger</p>
                 <div>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
@@ -1,7 +1,11 @@
-import { Button, Label, Spinner } from "@dust-tt/sparkle";
+import {
+  Button,
+  CloudArrowLeftRightIcon,
+  Label,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 
-import { getIcon } from "@app/components/resources/resources_icons";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { LightWorkspaceType, OAuthConnectionType } from "@app/types";
 import { setupOAuthConnection } from "@app/types";
@@ -67,7 +71,6 @@ export function CreateWebhookSourceWithProviderForm({
         sendNotification({
           type: "success",
           title: `Connected to ${kindName}`,
-          description: "Fetching your repositories and organizations...",
         });
       }
     } catch (error) {
@@ -84,16 +87,15 @@ export function CreateWebhookSourceWithProviderForm({
   const buttonLabel = connection
     ? hasConnectionPage
       ? `Edit connection`
-      : `Connected to ${kindName}`
-    : `Connect to ${kindName}`;
+      : `Connected`
+    : `Connect`;
 
   return (
     <div className="flex flex-col space-y-4">
       <div>
         <Label>{kindName} Connection</Label>
         <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Connect your {kindName} account to select repositories and
-          organizations to follow.
+          {kindName} connection is required
         </p>
         {OAuthExtraConfigInput && (
           <div className="mt-4">
@@ -109,7 +111,7 @@ export function CreateWebhookSourceWithProviderForm({
           <Button
             variant={"outline"}
             label={buttonLabel}
-            icon={getIcon(preset.icon)}
+            icon={CloudArrowLeftRightIcon}
             // if we are not connected, click starts the OAuth flow
             // if we are connected with a connection page URL, click opens that page
             // otherwise button is disabled

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -1,7 +1,7 @@
 import {
   ActionIcons,
   Button,
-  Checkbox,
+  Chip,
   ClipboardIcon,
   cn,
   EyeIcon,
@@ -200,33 +200,26 @@ export function WebhookSourceDetailsInfo({
         {provider && WEBHOOK_PRESETS[provider].events.length > 0 && (
           <div className="space-y-3">
             <Page.H variant="h6">Subscribed events</Page.H>
-            <div className="space-y-2">
-              {WEBHOOK_PRESETS[provider].events.map((event) => {
-                const isSubscribed =
-                  webhookSourceView.webhookSource.subscribedEvents.includes(
-                    event.value
+            <div>
+              {webhookSourceView.webhookSource.subscribedEvents
+                .map((eventValue) => {
+                  const event = WEBHOOK_PRESETS[provider].events.find(
+                    (e) => e.value === eventValue
                   );
-                return (
-                  <div
-                    key={event.value}
-                    className="flex items-center space-x-3"
-                  >
-                    <Checkbox
-                      id={`${provider}-event-${event.value}`}
-                      checked={isSubscribed}
-                      disabled
-                    />
-                    <div className="grid gap-1.5 leading-none">
-                      <label
-                        htmlFor={`${provider}-event-${event.value}`}
-                        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                      >
-                        {event.name}
-                      </label>
-                    </div>
-                  </div>
-                );
-              })}
+                  return event ? event.name : eventValue;
+                })
+                .map((event) => {
+                  return (
+                    <Chip
+                      key={event}
+                      size="xs"
+                      color="primary"
+                      className="m-0.5"
+                    >
+                      {event}
+                    </Chip>
+                  );
+                })}
             </div>
           </div>
         )}

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -164,7 +164,7 @@ export function WebhookSourceDetailsInfo({
             {...descriptionField}
             id="trigger-description"
             rows={3}
-            placeholder="Enter a description for this trigger"
+            placeholder="Help your team understand when to use this trigger."
           />
         </div>
       </div>

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -550,7 +550,7 @@ function WebhookSourceSheetContent({
     () => [
       {
         id: "create",
-        title: `Create ${mode.provider ? WEBHOOK_PRESETS[mode.provider].name : "Custom"} Webhook Source`,
+        title: `New ${mode.provider ? WEBHOOK_PRESETS[mode.provider].name : "Custom"} Webhook`,
         description: "",
         icon: getIcon(
           normalizeWebhookIcon(

--- a/front/lib/triggers/built-in-webhooks/github/components/CreateWebhookGithubConnection.tsx
+++ b/front/lib/triggers/built-in-webhooks/github/components/CreateWebhookGithubConnection.tsx
@@ -155,7 +155,7 @@ export function CreateWebhookGithubConnection({
                 )}
             </Label>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Select repositories to monitor for events
+              Choose which repositories can activate this trigger
             </p>
             <div className="mt-2 flex flex-col gap-2">
               <div className="flex flex-wrap items-center gap-1">
@@ -223,7 +223,7 @@ export function CreateWebhookGithubConnection({
                 )}
             </Label>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Select organizations to monitor all their repositories
+              Choose which organizations can activate this trigger
             </p>
             <div className="mt-2 flex flex-col gap-2">
               <div className="flex flex-wrap items-center gap-1">


### PR DESCRIPTION
## Description

 - Move the selected events as chips as they are not editable at the moment.
 - Update the modal wording when creating webhook source

<img width="500" height="800" alt="image" src="https://github.com/user-attachments/assets/beb3eca6-d947-4976-a892-b34cf52d0844" />

<img width="500" height="800" alt="image" src="https://github.com/user-attachments/assets/bded34dd-e94f-4e8d-9cc3-616e653a6cd8" />


## Tests

manual

## Risk

no

## Deploy Plan

deploy front