### PR TITLE
[front] - fix(input bar): prefill message input with selected agent

### DIFF
--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -10,10 +10,10 @@ import { useRouter } from "next/router";
 import { useCallback, useContext, useMemo, useState } from "react";
 
 import { AgentPicker } from "@app/components/assistant/AgentPicker";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { mentionAgent } from "@app/lib/mentions";
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import {
   useAgentConfigurations,
   useSuggestedAgentConfigurations,

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -7,12 +7,13 @@ import {
   RobotIcon,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useContext, useMemo, useState } from "react";
 
 import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { mentionAgent } from "@app/lib/mentions";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import {
   useAgentConfigurations,
   useSuggestedAgentConfigurations,
@@ -60,6 +61,7 @@ export function AgentSuggestion({
   const [isLoading, setIsLoading] = useState(false);
 
   const router = useRouter();
+  const { setSelectedAgent } = useContext(InputBarContext);
 
   const { submit: handleSelectSuggestion } = useSubmitFunction(
     async (agent: LightAgentConfigurationType) => {
@@ -147,7 +149,11 @@ export function AgentSuggestion({
               subtitle={agent.lastAuthors?.join(", ") ?? ""}
               title={agent.name}
               pictureUrl={agent.pictureUrl}
-              onClick={() => handleSelectSuggestion(agent)}
+              onClick={async () => {
+                // Immediately prefill next message with selected agent
+                setSelectedAgent({ configurationId: agent.sId });
+                await handleSelectSuggestion(agent);
+              }}
               variant="secondary"
               action={
                 <AssistantCardMore onClick={() => showAgentDetails(agent)} />
@@ -164,6 +170,8 @@ export function AgentSuggestion({
           onItemClick={async (agent) => {
             if (!isLoading) {
               setIsLoading(true);
+              // Immediately prefill next message with selected agent
+              setSelectedAgent({ configurationId: agent.sId });
               await handleSelectSuggestion(agent);
               setIsLoading(false);
             }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -474,7 +474,8 @@ const InputBarContainer = ({
   const { animate } = useContext(InputBarContext);
   useEffect(() => {
     if (animate) {
-      editorService.focusEnd();
+      // Schedule focus to avoid flushing during render lifecycle.
+      queueMicrotask(() => editorService.focusEnd());
     }
   }, [animate, editorService]);
 

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -356,72 +356,77 @@ const useCustomEditor = ({
     }
   }, [suggestions, editor]);
 
-  // setting after as we need the editor to be initialized
-  editor?.setOptions({
-    editorProps: {
-      handleKeyDown: (view, event) => {
-        const submitMessageKey = localStorage.getItem("submitMessageKey");
-        const isCmdEnterForSubmission =
-          isSubmitMessageKey(submitMessageKey) &&
-          submitMessageKey === "cmd+enter";
-        const isEnterForSubmission = !isCmdEnterForSubmission;
-
-        // Check if this is a submission key combination based on user preferences
-        const isSubmissionKey =
-          (isEnterForSubmission &&
-            event.key === "Enter" &&
-            !event.shiftKey &&
-            !event.ctrlKey &&
-            !event.metaKey &&
-            !event.altKey) ||
-          (isCmdEnterForSubmission && event.key === "Enter" && event.metaKey);
-
-        if (isSubmissionKey) {
-          const mentionPluginState = mentionPluginKey.getState(view.state);
-          // Let the mention extension handle the event if its dropdown is currently opened.
-          if (mentionPluginState?.active) {
-            return false;
-          }
-
-          // On mobile, we want to let the user go to the next line and not immediately send
-          if (isMobile(navigator)) {
-            return false;
-          }
-
-          // Prevent the default Enter key behavior
-          event.preventDefault();
-
-          const clearEditor = () => {
-            editor.commands.clearContent();
-          };
-
-          const setLoading = (loading: boolean) => {
-            if (loading) {
-              editor?.view.dom.classList.add("loading-text");
-            } else {
-              editor?.view.dom.classList.remove("loading-text");
-            }
-            return editor?.setEditable(!loading);
-          };
-
-          onEnterKeyDown(
-            editor.isEmpty,
-            editorService.getMarkdownAndMentions(),
-            clearEditor,
-            setLoading
-          );
-
-          // Return true to indicate that this key event has been handled.
-          return true;
-        }
-
-        // Return false to let other keydown handlers or TipTap's default behavior process the event.
-        return false;
-      },
-    },
-  });
-
   const editorService = useEditorService(editor);
+
+  // Set keydown handler after editor is initialized to avoid synchronous updates during render.
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+    editor.setOptions({
+      editorProps: {
+        handleKeyDown: (view, event) => {
+          const submitMessageKey = localStorage.getItem("submitMessageKey");
+          const isCmdEnterForSubmission =
+            isSubmitMessageKey(submitMessageKey) &&
+            submitMessageKey === "cmd+enter";
+          const isEnterForSubmission = !isCmdEnterForSubmission;
+
+          // Check if this is a submission key combination based on user preferences
+          const isSubmissionKey =
+            (isEnterForSubmission &&
+              event.key === "Enter" &&
+              !event.shiftKey &&
+              !event.ctrlKey &&
+              !event.metaKey &&
+              !event.altKey) ||
+            (isCmdEnterForSubmission && event.key === "Enter" && event.metaKey);
+
+          if (isSubmissionKey) {
+            const mentionPluginState = mentionPluginKey.getState(view.state);
+            // Let the mention extension handle the event if its dropdown is currently opened.
+            if (mentionPluginState?.active) {
+              return false;
+            }
+
+            // On mobile, we want to let the user go to the next line and not immediately send
+            if (isMobile(navigator)) {
+              return false;
+            }
+
+            // Prevent the default Enter key behavior
+            event.preventDefault();
+
+            const clearEditor = () => {
+              editor.commands.clearContent();
+            };
+
+            const setLoading = (loading: boolean) => {
+              if (loading) {
+                editor?.view.dom.classList.add("loading-text");
+              } else {
+                editor?.view.dom.classList.remove("loading-text");
+              }
+              return editor?.setEditable(!loading);
+            };
+
+            onEnterKeyDown(
+              editor.isEmpty,
+              editorService.getMarkdownAndMentions(),
+              clearEditor,
+              setLoading
+            );
+
+            // Return true to indicate that this key event has been handled.
+            return true;
+          }
+
+          // Return false to let other keydown handlers or TipTap's default behavior process the event.
+          return false;
+        },
+      },
+    });
+  }, [editor, editorService, onEnterKeyDown]);
 
   // Expose the editor instance and the editor service.
   return {

--- a/front/components/assistant/conversation/input_bar/editor/useHandleAgentMentions.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useHandleAgentMentions.tsx
@@ -79,7 +79,8 @@ const useHandleAgentMentions = (
       };
 
       if (!editorService.hasMention(mention)) {
-        editorService.insertMention(mention);
+        // Schedule insertion to avoid synchronous editor updates during React render/effects.
+        queueMicrotask(() => editorService.insertMention(mention));
       }
     }
   }, [selectedAgent, editorService, disableAutoFocus, agentConfigurations]);


### PR DESCRIPTION
## Description

This PR aims at fixing https://github.com/dust-tt/tasks/issues/4917. It was relatively simple at first but then led to the following console error:
```
  useCustomEditor.tsx:146 Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task. Error Component Stack
```

So I had to fix (with the help of Claude Code) the TipTap editor React render lifecycle conflicts by deferring DOM mutations with `queueMicrotask`. 
Explanation: TipTap commands (insertMention, focus) perform synchronous DOM/editor mutations that can trigger React's `flushSync` when called during render/effect cycles. Using `queueMicrotask` schedules these operations for the next microtask (after current call stack but before next frame), ensuring React isn't mid-render when mutations occur.

**References:**
- https://github.com/dust-tt/tasks/issues/4917

## Tests

- [x] Locally
- [x] Front-edge

## Risk

Low

## Deploy Plan

Deploy front
