### PR TITLE
clean env var, don't send responses if not found

### DIFF
--- a/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
+++ b/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
@@ -15,22 +15,12 @@ import { cacheWithRedis } from "@connectors/types/shared/cache";
  * Raw token acquisition function (for caching)
  */
 async function acquireTenantSpecificToken(): Promise<string> {
-  if (
-    !apiConfig.getMicrosoftBotTenantId() ||
-    !apiConfig.getMicrosoftBotId() ||
-    !apiConfig.getMicrosoftBotPassword()
-  ) {
-    throw new Error(
-      "Missing required environment variables: MICROSOFT_BOT_TENANT_ID, MICROSOFT_BOT_ID, MICROSOFT_BOT_PASSWORD"
-    );
-  }
-
   const tokenResponse = await axios.post(
     `https://login.microsoftonline.com/${apiConfig.getMicrosoftBotTenantId()}/oauth2/v2.0/token`,
     new URLSearchParams({
       grant_type: "client_credentials",
-      client_id: apiConfig.getMicrosoftBotId()!,
-      client_secret: apiConfig.getMicrosoftBotPassword()!,
+      client_id: apiConfig.getMicrosoftBotId(),
+      client_secret: apiConfig.getMicrosoftBotPassword(),
       scope: "https://api.botframework.com/.default",
     }),
     {

--- a/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
+++ b/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
@@ -3,6 +3,7 @@ import { Err, Ok } from "@dust-tt/client";
 import axios from "axios";
 import type { Activity, TurnContext } from "botbuilder";
 
+import { apiConfig } from "@connectors/lib/api/config";
 import { cacheWithRedis } from "@connectors/types/shared/cache";
 
 /**
@@ -15,21 +16,21 @@ import { cacheWithRedis } from "@connectors/types/shared/cache";
  */
 async function acquireTenantSpecificToken(): Promise<string> {
   if (
-    !process.env.MICROSOFT_BOT_TENANT_ID ||
-    !process.env.MICROSOFT_BOT_ID ||
-    !process.env.MICROSOFT_BOT_PASSWORD
+    !apiConfig.getMicrosoftBotTenantId() ||
+    !apiConfig.getMicrosoftBotId() ||
+    !apiConfig.getMicrosoftBotPassword()
   ) {
     throw new Error(
-      "Missing required environment variables: BOT_TENANT_ID, BOT_ID, BOT_PASSWORD"
+      "Missing required environment variables: MICROSOFT_BOT_TENANT_ID, MICROSOFT_BOT_ID, MICROSOFT_BOT_PASSWORD"
     );
   }
 
   const tokenResponse = await axios.post(
-    `https://login.microsoftonline.com/${process.env.MICROSOFT_BOT_TENANT_ID}/oauth2/v2.0/token`,
+    `https://login.microsoftonline.com/${apiConfig.getMicrosoftBotTenantId()}/oauth2/v2.0/token`,
     new URLSearchParams({
       grant_type: "client_credentials",
-      client_id: process.env.MICROSOFT_BOT_ID!,
-      client_secret: process.env.MICROSOFT_BOT_PASSWORD!,
+      client_id: apiConfig.getMicrosoftBotId()!,
+      client_secret: apiConfig.getMicrosoftBotPassword()!,
       scope: "https://api.botframework.com/.default",
     }),
     {
@@ -49,7 +50,7 @@ async function acquireTenantSpecificToken(): Promise<string> {
 export const getTenantSpecificToken: () => Promise<string> = cacheWithRedis(
   acquireTenantSpecificToken,
   () =>
-    `teams-bot-token-${process.env.MICROSOFT_BOT_ID}-${process.env.MICROSOFT_BOT_TENANT_ID}`,
+    `teams-bot-token-${apiConfig.getMicrosoftBotId()}-${apiConfig.getMicrosoftBotTenantId()}`,
   {
     ttlMs: 50 * 60 * 1000, // 50 minutes
   }

--- a/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
+++ b/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
@@ -39,8 +39,7 @@ async function acquireTenantSpecificToken(): Promise<string> {
  */
 export const getTenantSpecificToken: () => Promise<string> = cacheWithRedis(
   acquireTenantSpecificToken,
-  () =>
-    `teams-bot-token-${apiConfig.getMicrosoftBotId()}-${apiConfig.getMicrosoftBotTenantId()}`,
+  () => `teams-bot-token`,
   {
     ttlMs: 50 * 60 * 1000, // 50 minutes
   }

--- a/connectors/src/api/webhooks/teams/utils.ts
+++ b/connectors/src/api/webhooks/teams/utils.ts
@@ -20,10 +20,6 @@ export async function getConnector(context: TurnContext) {
 
   if (!tenantId) {
     logger.error("No tenant ID found in Teams context");
-    await sendTextMessage(
-      context,
-      "❌ Unable to identify tenant for this Teams message"
-    );
     return;
   }
 
@@ -37,10 +33,6 @@ export async function getConnector(context: TurnContext) {
     logger.error(
       { tenantId },
       "No Microsoft Bot configuration found for tenant"
-    );
-    await sendTextMessage(
-      context,
-      "❌ Microsoft Teams Integration is not enabled for your Organization."
     );
     return;
   }

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -46,7 +46,6 @@ adapter.onTurnError = async (context, error) => {
       error: error.message,
       stack: error.stack,
       botId: apiConfig.getMicrosoftBotId(),
-      hasPassword: !!apiConfig.getMicrosoftBotPassword(),
     },
     "Bot Framework adapter error"
   );
@@ -245,11 +244,6 @@ async function handleMessage(
     {
       serviceUrl: context.activity.serviceUrl,
       conversationId: context.activity.conversation?.id,
-      cardType: "ThinkingCard",
-      credentials: {
-        hasAppId: !!apiConfig.getMicrosoftBotId(),
-        hasAppPassword: !!apiConfig.getMicrosoftBotPassword(),
-      },
     },
     "About to send thinking card to Bot Framework"
   );

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -22,6 +22,7 @@ import {
   validateBotFrameworkToken,
 } from "@connectors/api/webhooks/teams/jwt_validation";
 import { getConnector } from "@connectors/api/webhooks/teams/utils";
+import { apiConfig } from "@connectors/lib/api/config";
 import type { Logger } from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
 import { apiError } from "@connectors/logger/withlogging";
@@ -29,10 +30,10 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 
 // CloudAdapter configuration - simplified for incoming message validation only
 const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication({
-  MicrosoftAppId: process.env.MICROSOFT_BOT_ID,
-  MicrosoftAppPassword: process.env.MICROSOFT_BOT_PASSWORD,
+  MicrosoftAppId: apiConfig.getMicrosoftBotId(),
+  MicrosoftAppPassword: apiConfig.getMicrosoftBotPassword(),
   MicrosoftAppType: "MultiTenant",
-  MicrosoftAppTenantId: process.env.MICROSOFT_BOT_TENANT_ID,
+  MicrosoftAppTenantId: apiConfig.getMicrosoftBotTenantId(),
 });
 
 const adapter = new CloudAdapter(botFrameworkAuthentication);
@@ -44,8 +45,8 @@ adapter.onTurnError = async (context, error) => {
       connectorProvider: "microsoft_bot",
       error: error.message,
       stack: error.stack,
-      botId: process.env.MICROSOFT_BOT_ID,
-      hasPassword: !!process.env.MICROSOFT_BOT_PASSWORD,
+      botId: apiConfig.getMicrosoftBotId(),
+      hasPassword: !!apiConfig.getMicrosoftBotPassword(),
     },
     "Bot Framework adapter error"
   );
@@ -100,7 +101,7 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
     });
   }
 
-  const microsoftAppId = process.env.MICROSOFT_BOT_ID;
+  const microsoftAppId = apiConfig.getMicrosoftBotId();
   if (!microsoftAppId) {
     logger.error(
       { connectorProvider: "microsoft_bot" },
@@ -183,6 +184,7 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
 
       const connector = await getConnector(context);
       if (!connector) {
+        res.status(400).json({ error: "Connector not found" });
         return;
       }
 
@@ -245,8 +247,8 @@ async function handleMessage(
       conversationId: context.activity.conversation?.id,
       cardType: "ThinkingCard",
       credentials: {
-        hasAppId: !!process.env.MICROSOFT_BOT_ID,
-        hasAppPassword: !!process.env.MICROSOFT_BOT_PASSWORD,
+        hasAppId: !!apiConfig.getMicrosoftBotId(),
+        hasAppPassword: !!apiConfig.getMicrosoftBotPassword(),
       },
     },
     "About to send thinking card to Bot Framework"

--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -40,6 +40,15 @@ export const apiConfig = {
   getConnectorsPublicURL: (): string => {
     return EnvironmentConfig.getEnvVariable("CONNECTORS_PUBLIC_URL");
   },
+  getMicrosoftBotId: (): string => {
+    return EnvironmentConfig.getEnvVariable("MICROSOFT_BOT_ID");
+  },
+  getMicrosoftBotPassword: (): string => {
+    return EnvironmentConfig.getEnvVariable("MICROSOFT_BOT_PASSWORD");
+  },
+  getMicrosoftBotTenantId: (): string => {
+    return EnvironmentConfig.getEnvVariable("MICROSOFT_BOT_TENANT_ID");
+  },
   getDiscordAppPublicKey: (): string => {
     return EnvironmentConfig.getEnvVariable("DISCORD_APP_PUBLIC_KEY");
   },


### PR DESCRIPTION
## Description

Stop sending messages if tenant is not found on the current instance. In multiple region setup, if tenant is registered on one region, the other one should not answer.

Also cleanup env vars

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
