### PR TITLE
Chrisjow/tool validation in teams

### DIFF
--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -318,6 +318,7 @@ export function createToolApprovalAdaptiveCard({
   actionId,
   workspaceId,
   microsoftBotMessageId,
+  teamsMessageLink,
 }: {
   agentName: string;
   toolName: string;
@@ -326,6 +327,7 @@ export function createToolApprovalAdaptiveCard({
   actionId: string;
   workspaceId: string;
   microsoftBotMessageId: number;
+  teamsMessageLink: string | null;
 }): Partial<Activity> {
   const card: AdaptiveCard = {
     type: "AdaptiveCard",
@@ -351,6 +353,22 @@ export function createToolApprovalAdaptiveCard({
           },
         ],
       },
+      ...(teamsMessageLink
+        ? [{
+        type: "Container",
+        spacing: "Medium",
+        separator: true,
+        items: [
+          {
+            type: "TextBlock",
+            text: `[View message in Teams](${teamsMessageLink})`,
+            wrap: true,
+            spacing: "Small",
+            size: "Small",
+            color: "Accent",
+          },
+        ],
+      }] : [])
     ],
     actions: [
       {

--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -307,6 +307,94 @@ export function createErrorAdaptiveCard({
   };
 }
 
+/**
+ * Creates an Adaptive Card for tool execution approval
+ */
+export function createToolApprovalAdaptiveCard({
+  agentName,
+  toolName,
+  conversationId,
+  messageId,
+  actionId,
+  workspaceId,
+  microsoftBotMessageId,
+}: {
+  agentName: string;
+  toolName: string;
+  conversationId: string;
+  messageId: string;
+  actionId: string;
+  workspaceId: string;
+  microsoftBotMessageId: number;
+}): Partial<Activity> {
+  const card: AdaptiveCard = {
+    type: "AdaptiveCard",
+    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+    version: "1.4",
+    body: [
+      {
+        type: "TextBlock",
+        text: "Tool validation Required",
+        weight: "Bolder",
+        size: "Large",
+        spacing: "Medium",
+      },
+      {
+        type: "Container",
+        spacing: "Medium",
+        items: [
+          {
+            type: "TextBlock",
+            text: `Agent **@${agentName}** is requesting permission to use tool **${toolName}**`,
+            wrap: true,
+            spacing: "Small",
+          },
+        ],
+      },
+    ],
+    actions: [
+      {
+        type: "Action.Execute",
+        title: "Approve",
+        verb: "approve_tool",
+        data: {
+          conversationId,
+          messageId,
+          actionId,
+          workspaceId,
+          microsoftBotMessageId,
+          agentName,
+          toolName,
+        },
+      },
+      {
+        type: "Action.Execute",
+        title: "Reject",
+        verb: "reject_tool",
+        data: {
+          conversationId,
+          messageId,
+          actionId,
+          workspaceId,
+          microsoftBotMessageId,
+          agentName,
+          toolName,
+        },
+      },
+    ],
+  };
+
+  return {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: card,
+      },
+    ],
+  };
+}
+
 function createFooterText({
   assistantName,
   conversationUrl,

--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -347,7 +347,7 @@ export function createBasicToolApprovalAdaptiveCard({
           actionId,
           workspaceId,
           microsoftBotMessageId,
-        }
+        },
       },
       userIds: [userAadObjectId],
     },
@@ -413,7 +413,7 @@ export function createInteractiveToolApprovalAdaptiveCard({
   actionId: string;
   workspaceId: string;
   microsoftBotMessageId: number;
-}): AdaptiveCard  {
+}): AdaptiveCard {
   // Interactive card with buttons (for the original user after refresh)
   return {
     type: "AdaptiveCard",

--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -308,18 +308,9 @@ export function createErrorAdaptiveCard({
 }
 
 /**
- * Creates an Adaptive Card for tool execution approval
+ * Creates the basic Adaptive Card for tool execution approval for everyone (read-only, no actions)
  */
-export function createBasicToolApprovalAdaptiveCard({
-  agentName,
-  toolName,
-  conversationId,
-  messageId,
-  actionId,
-  workspaceId,
-  microsoftBotMessageId,
-  userAadObjectId,
-}: {
+export function createBasicToolApprovalAdaptiveCard(data: {
   agentName: string;
   toolName: string;
   conversationId: string;
@@ -329,7 +320,6 @@ export function createBasicToolApprovalAdaptiveCard({
   microsoftBotMessageId: number;
   userAadObjectId: string;
 }): Partial<Activity> {
-  // Basic card for everyone else (read-only, no actions)
   const basicCard: AdaptiveCard = {
     type: "AdaptiveCard",
     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
@@ -339,17 +329,9 @@ export function createBasicToolApprovalAdaptiveCard({
         type: "Action.Execute",
         title: "Tool execution approval",
         verb: "toolExecutionApproval",
-        data: {
-          agentName,
-          toolName,
-          conversationId,
-          messageId,
-          actionId,
-          workspaceId,
-          microsoftBotMessageId,
-        },
+        data,
       },
-      userIds: [userAadObjectId],
+      userIds: [data.userAadObjectId],
     },
     body: [
       {
@@ -365,7 +347,7 @@ export function createBasicToolApprovalAdaptiveCard({
         items: [
           {
             type: "TextBlock",
-            text: `Agent **@${agentName}** is requesting permission to use tool **${toolName}**`,
+            text: `Agent **@${data.agentName}** is requesting permission to use tool **${data.toolName}**`,
             wrap: true,
             spacing: "Small",
           },
@@ -383,7 +365,6 @@ export function createBasicToolApprovalAdaptiveCard({
     ],
   };
 
-  // Use helper to create activity with user-specific refresh
   return {
     type: "message",
     attachments: [
@@ -397,15 +378,10 @@ export function createBasicToolApprovalAdaptiveCard({
   };
 }
 
-export function createInteractiveToolApprovalAdaptiveCard({
-  agentName,
-  toolName,
-  conversationId,
-  messageId,
-  actionId,
-  workspaceId,
-  microsoftBotMessageId,
-}: {
+/**
+ * Creates an interactive Adaptive Card for tool execution approval for the original sender (with buttons)
+ */
+export function createInteractiveToolApprovalAdaptiveCard(data: {
   agentName: string;
   toolName: string;
   conversationId: string;
@@ -414,7 +390,6 @@ export function createInteractiveToolApprovalAdaptiveCard({
   workspaceId: string;
   microsoftBotMessageId: number;
 }): AdaptiveCard {
-  // Interactive card with buttons (for the original user after refresh)
   return {
     type: "AdaptiveCard",
     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
@@ -433,7 +408,7 @@ export function createInteractiveToolApprovalAdaptiveCard({
         items: [
           {
             type: "TextBlock",
-            text: `Agent **@${agentName}** is requesting permission to use tool **${toolName}**`,
+            text: `Agent **@${data.agentName}** is requesting permission to use tool **${data.toolName}**`,
             wrap: true,
             spacing: "Small",
           },
@@ -445,128 +420,13 @@ export function createInteractiveToolApprovalAdaptiveCard({
         type: "Action.Execute",
         title: "Approve",
         verb: "approve_tool",
-        data: {
-          conversationId,
-          messageId,
-          actionId,
-          workspaceId,
-          microsoftBotMessageId,
-          agentName,
-          toolName,
-        },
+        data,
       },
       {
         type: "Action.Execute",
         title: "Reject",
         verb: "reject_tool",
-        data: {
-          conversationId,
-          messageId,
-          actionId,
-          workspaceId,
-          microsoftBotMessageId,
-          agentName,
-          toolName,
-        },
-      },
-    ],
-  };
-}
-
-/**
- * Returns the interactive card for user-specific view (called during refresh)
- */
-export function getInteractiveToolApprovalCard({
-  agentName,
-  toolName,
-  conversationId,
-  messageId,
-  actionId,
-  workspaceId,
-  microsoftBotMessageId,
-  teamsMessageLink,
-}: {
-  agentName: string;
-  toolName: string;
-  conversationId: string;
-  messageId: string;
-  actionId: string;
-  workspaceId: string;
-  microsoftBotMessageId: number;
-  teamsMessageLink: string | null;
-}) {
-  return {
-    type: "AdaptiveCard",
-    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-    version: "1.4",
-    body: [
-      {
-        type: "TextBlock",
-        text: "Tool validation Required",
-        weight: "Bolder",
-        size: "Large",
-        spacing: "Medium",
-      },
-      {
-        type: "Container",
-        spacing: "Medium",
-        items: [
-          {
-            type: "TextBlock",
-            text: `Agent **@${agentName}** is requesting permission to use tool **${toolName}**`,
-            wrap: true,
-            spacing: "Small",
-          },
-        ],
-      },
-      ...(teamsMessageLink
-        ? [
-            {
-              type: "Container",
-              spacing: "Medium",
-              separator: true,
-              items: [
-                {
-                  type: "TextBlock",
-                  text: `[View message in Teams](${teamsMessageLink})`,
-                  wrap: true,
-                  spacing: "Small",
-                  size: "Small",
-                  color: "Accent",
-                },
-              ],
-            },
-          ]
-        : []),
-    ],
-    actions: [
-      {
-        type: "Action.Execute",
-        title: "Approve",
-        verb: "approve_tool",
-        data: {
-          conversationId,
-          messageId,
-          actionId,
-          workspaceId,
-          microsoftBotMessageId,
-          agentName,
-          toolName,
-        },
-      },
-      {
-        type: "Action.Execute",
-        title: "Reject",
-        verb: "reject_tool",
-        data: {
-          conversationId,
-          messageId,
-          actionId,
-          workspaceId,
-          microsoftBotMessageId,
-          agentName,
-          toolName,
-        },
+        data,
       },
     ],
   };

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -908,30 +908,17 @@ export async function botValidateToolExecution({
     }
   }
 
-  // Send confirmation message to user
-  const confirmationText = `Agent **${agentName}**'s request to use tool **${toolName}** was ${
-    approved === "approved" ? "✅ approved" : "❌ rejected"
-  }`;
-
-  try {
-    await sendActivity(context, { type: "message", text: confirmationText });
-    localLogger.info(
-      {
-        conversationId,
-        messageId,
-        actionId,
-        approved,
-        agentName,
-        toolName,
-      },
-      "Tool validation completed and confirmation sent"
-    );
-  } catch (error) {
-    localLogger.error(
-      { error },
-      "Failed to send tool validation confirmation message"
-    );
-  }
+  localLogger.info(
+    {
+      conversationId,
+      messageId,
+      actionId,
+      approved,
+      agentName,
+      toolName,
+    },
+    "Tool validation completed"
+  );
 
   return new Ok(undefined);
 }

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -30,7 +30,11 @@ import {
   createStreamingAdaptiveCard,
   createToolApprovalAdaptiveCard,
 } from "./adaptive_cards";
-import { sendActivity, updateActivity } from "./bot_messaging_utils";
+import {
+  generateTeamsMessageLink,
+  sendActivity,
+  updateActivity,
+} from "./bot_messaging_utils";
 import { validateTeamsUser } from "./user_validation";
 
 export async function botAnswerMessage(
@@ -471,6 +475,12 @@ async function streamAgentResponse({
           break;
         }
 
+        // Generate Teams message link
+        const teamsMessageLink = generateTeamsMessageLink(
+          context,
+          microsoftBotMessage.agentActivityId
+        );
+
         // Send DM to user with approval card
         const approvalCard = createToolApprovalAdaptiveCard({
           agentName: event.metadata.agentName,
@@ -480,6 +490,7 @@ async function streamAgentResponse({
           actionId: event.actionId,
           workspaceId: connector.workspaceId,
           microsoftBotMessageId: microsoftBotMessage.id,
+          teamsMessageLink,
         });
 
         try {

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -30,10 +30,7 @@ import {
   createResponseAdaptiveCard,
   createStreamingAdaptiveCard,
 } from "./adaptive_cards";
-import {
-  sendActivity,
-  updateActivity,
-} from "./bot_messaging_utils";
+import { sendActivity, updateActivity } from "./bot_messaging_utils";
 import { validateTeamsUser } from "./user_validation";
 
 export async function botAnswerMessage(
@@ -503,7 +500,10 @@ async function streamAgentResponse({
         });
 
         try {
-          await updateActivity(context, {id: agentActivityId, ...approvalCard});
+          await updateActivity(context, {
+            id: agentActivityId,
+            ...approvalCard,
+          });
           localLogger.info(
             {
               connectorId: connector.id,

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -503,12 +503,13 @@ async function streamAgentResponse({
         });
 
         try {
-          await sendActivity(context, approvalCard);
+          await updateActivity(context, {id: agentActivityId, ...approvalCard});
           localLogger.info(
             {
               connectorId: connector.id,
               conversationId: conversation.sId,
               toolName: event.metadata.toolName,
+              agentActivityId,
             },
             "Sent tool approval card to user"
           );

--- a/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
+++ b/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
@@ -117,3 +117,33 @@ export async function sendTextMessage(
     text,
   });
 }
+
+/**
+ * Generates a Teams deep link to a specific message
+ * @param context - The TurnContext containing conversation information
+ * @param messageActivityId - The activity ID of the message to link to
+ * @returns A Teams deep link URL or null if it cannot be generated
+ */
+export function generateTeamsMessageLink(
+  context: TurnContext,
+  messageActivityId: string
+): string | null {
+  const conversationId = context.activity.conversation?.id;
+  const channelId = context.activity.channelData?.channel?.id;
+
+  if (!conversationId || !messageActivityId) {
+    return null;
+  }
+
+  // Encode IDs for URL
+  const encodedConversationId = encodeURIComponent(conversationId);
+  const encodedMessageId = encodeURIComponent(messageActivityId);
+
+  if (channelId) {
+    // Channel message: https://teams.microsoft.com/l/message/<channelId>/<messageId>
+    return `https://teams.microsoft.com/l/message/${encodeURIComponent(channelId)}/${encodedMessageId}`;
+  } else {
+    // Chat message (1:1 or group chat): Use conversation ID with context parameter
+    return `https://teams.microsoft.com/l/message/${encodedConversationId}/${encodedMessageId}?context=${encodeURIComponent('{"contextType":"chat"}')}`;
+  }
+}

--- a/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
+++ b/connectors/src/api/webhooks/teams/bot_messaging_utils.ts
@@ -117,33 +117,3 @@ export async function sendTextMessage(
     text,
   });
 }
-
-/**
- * Generates a Teams deep link to a specific message
- * @param context - The TurnContext containing conversation information
- * @param messageActivityId - The activity ID of the message to link to
- * @returns A Teams deep link URL or null if it cannot be generated
- */
-export function generateTeamsMessageLink(
-  context: TurnContext,
-  messageActivityId: string
-): string | null {
-  const conversationId = context.activity.conversation?.id;
-  const channelId = context.activity.channelData?.channel?.id;
-
-  if (!conversationId || !messageActivityId) {
-    return null;
-  }
-
-  // Encode IDs for URL
-  const encodedConversationId = encodeURIComponent(conversationId);
-  const encodedMessageId = encodeURIComponent(messageActivityId);
-
-  if (channelId) {
-    // Channel message: https://teams.microsoft.com/l/message/<channelId>/<messageId>
-    return `https://teams.microsoft.com/l/message/${encodeURIComponent(channelId)}/${encodedMessageId}`;
-  } else {
-    // Chat message (1:1 or group chat): Use conversation ID with context parameter
-    return `https://teams.microsoft.com/l/message/${encodedConversationId}/${encodedMessageId}?context=${encodeURIComponent('{"contextType":"chat"}')}`;
-  }
-}

--- a/connectors/src/api/webhooks/teams/utils.ts
+++ b/connectors/src/api/webhooks/teams/utils.ts
@@ -1,9 +1,29 @@
 import type { TurnContext } from "botbuilder";
+import { z } from "zod";
 
 import { sendTextMessage } from "@connectors/api/webhooks/teams/bot_messaging_utils";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_bot_resources";
+
+/**
+ * Zod schema for validating tool approval data from Teams adaptive cards
+ * This ensures all fields are present, non-empty, and of the correct type
+ */
+export const ToolApprovalDataSchema = z.object({
+  agentName: z.string().min(1, "Agent name is required"),
+  toolName: z.string().min(1, "Tool name is required"),
+  conversationId: z.string().min(1, "Conversation ID is required"),
+  messageId: z.string().min(1, "Message ID is required"),
+  actionId: z.string().min(1, "Action ID is required"),
+  workspaceId: z.string().min(1, "Workspace ID is required"),
+  microsoftBotMessageId: z.number().int().positive("Invalid message ID"),
+});
+
+/**
+ * Type definition for tool approval data (inferred from schema)
+ */
+export type ToolApprovalData = z.infer<typeof ToolApprovalDataSchema>;
 
 export async function getConnector(context: TurnContext) {
   // Extract tenant ID from Teams context
@@ -65,4 +85,28 @@ export async function getConnector(context: TurnContext) {
   );
 
   return connector;
+}
+
+/**
+ * Validates and parses tool approval data from untrusted user input
+ * @param data - Raw data from Teams adaptive card action
+ * @returns Parsed and validated ToolApprovalData or null if invalid
+ */
+export function validateToolApprovalData(
+  data: unknown
+): ToolApprovalData | null {
+  const result = ToolApprovalDataSchema.safeParse(data);
+
+  if (!result.success) {
+    logger.warn(
+      {
+        error: result.error.flatten(),
+        receivedData: data,
+      },
+      "Invalid tool approval data received from Teams"
+    );
+    return null;
+  }
+
+  return result.data;
 }

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -390,20 +390,18 @@ async function handleToolApproval(
     );
 
     // Update the card with error message
-    if (replyToId) {
-      try {
-        await updateActivity(context, {
-          id: replyToId,
-          type: "message",
-          text: "❌ Failed to validate tool execution. Please try again.",
-          attachments: [], // Remove the adaptive card
-        });
-      } catch (updateError) {
-        localLogger.error(
-          { error: updateError, replyToId },
-          "Failed to update approval card with error"
-        );
-      }
+    try {
+      await updateActivity(context, {
+        id: replyToId,
+        type: "message",
+        text: "❌ Failed to validate tool execution. Please try again.",
+        attachments: [],
+      });
+    } catch (updateError) {
+      localLogger.error(
+        { error: updateError, replyToId },
+        "Failed to update approval card with error"
+      );
     }
   } else {
     // Update the card with success message, removing the buttons
@@ -411,33 +409,29 @@ async function handleToolApproval(
       approved === "approved" ? "✅ approved" : "❌ rejected"
     }`;
 
-    if (replyToId) {
-      try {
-        await updateActivity(context, {
-          id: replyToId,
-          type: "message",
-          text: resultText,
-          attachments: [], // Remove the adaptive card and buttons
-        });
+    try {
+      await updateActivity(context, {
+        id: replyToId,
+        type: "message",
+        text: resultText,
+        attachments: [],
+      });
 
-        localLogger.info(
-          {
-            conversationId,
-            messageId,
-            actionId,
-            approved,
-            replyToId,
-          },
-          "Tool approval completed and card disabled"
-        );
-      } catch (updateError) {
-        localLogger.error(
-          { error: updateError, replyToId },
-          "Failed to update approval card with result"
-        );
-      }
-    } else {
-      localLogger.warn("No replyToId found, cannot disable approval card");
+      localLogger.info(
+        {
+          conversationId,
+          messageId,
+          actionId,
+          approved,
+          replyToId,
+        },
+        "Tool approval completed and card disabled"
+      );
+    } catch (updateError) {
+      localLogger.error(
+        { error: updateError, replyToId },
+        "Failed to update approval card with result"
+      );
     }
   }
 }

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -336,7 +336,7 @@ async function handleInteraction(
 async function handleToolApproval(
   context: TurnContext,
   connector: ConnectorResource,
-  localLogger: Logger,
+  localLogger: Logger
 ) {
   const { verb } = context.activity.value.action;
   const approved = verb === "approve_tool" ? "approved" : "rejected";
@@ -437,9 +437,7 @@ async function handleToolApproval(
         );
       }
     } else {
-      localLogger.warn(
-        "No replyToId found, cannot disable approval card"
-      );
+      localLogger.warn("No replyToId found, cannot disable approval card");
     }
   }
 }

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -209,8 +209,10 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
           if (context.activity.value.action.verb === "toolExecutionApproval") {
             res.status(200).json({
               type: "application/vnd.microsoft.card.adaptive",
-              value: createInteractiveToolApprovalAdaptiveCard(context.activity.value.action.data)
-            })
+              value: createInteractiveToolApprovalAdaptiveCard(
+                context.activity.value.action.data
+              ),
+            });
           } else {
             await handleToolApproval(context, connector, localLogger);
           }

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -206,6 +206,7 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
           }
           break;
         case "invoke":
+          // Handle tool execution approval card refresh
           if (context.activity.value.action.verb === "toolExecutionApproval") {
             res.status(200).json({
               type: "application/vnd.microsoft.card.adaptive",

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -370,6 +370,20 @@ async function handleToolApproval(
   const { verb } = context.activity.value.action;
   const approved = verb === "approve_tool" ? "approved" : "rejected";
 
+  // Validate the data before using it
+  const validatedData = validateToolApprovalData(
+    context.activity.value.action.data
+  );
+  if (!validatedData) {
+    localLogger.error(
+      {
+        connectorId: connector.id,
+        receivedData: context.activity.value.action.data,
+      },
+      "Invalid tool approval data received"
+    );
+    return;
+  }
   const {
     conversationId,
     messageId,
@@ -377,7 +391,7 @@ async function handleToolApproval(
     microsoftBotMessageId,
     agentName,
     toolName,
-  } = context.activity.value.action.data;
+  } = validatedData;
 
   localLogger.info(
     {

--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -7,6 +7,7 @@ import type { Request, Response } from "express";
 
 import {
   createErrorAdaptiveCard,
+  createInteractiveToolApprovalAdaptiveCard,
   createThinkingAdaptiveCard,
 } from "@connectors/api/webhooks/teams/adaptive_cards";
 import {
@@ -205,7 +206,14 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
           }
           break;
         case "invoke":
-          await handleToolApproval(context, connector, localLogger);
+          if (context.activity.value.action.verb === "toolExecutionApproval") {
+            res.status(200).json({
+              type: "application/vnd.microsoft.card.adaptive",
+              value: createInteractiveToolApprovalAdaptiveCard(context.activity.value.action.data)
+            })
+          } else {
+            await handleToolApproval(context, connector, localLogger);
+          }
           break;
 
         default:


### PR DESCRIPTION
## Description

This PR implements tool validation functionality for Microsoft Teams by adding adaptive card-based approval workflows. When an agent requests permission to use a tool in Teams, it displays an interactive approval card to the user with approve/reject buttons. The implementation includes user-specific views where the original requestor sees interactive buttons while others see a read-only status message.

## Tests

Call an agent who uses a high/low stake tool and check that a validation card shows up in Teams

## Risk

Low

## Deploy Plan

Deploy connectors
