### PR TITLE
[front] Handle renaming of `ToolCard` into `ActionCard`

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.18",
-        "@dust-tt/sparkle": "^0.3.18",
+        "@dust-tt/sparkle": "^0.3.20",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.18.tgz",
-      "integrity": "sha512-RQFwImMLA0XhtiN2ocbPyxj5BPKLFFFSa1p6Qr/R15X7qoFQCDh9JA9xm/Te+YQbzxE0UEFcNCjw8XrYwOLYSw==",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.20.tgz",
+      "integrity": "sha512-z4eA3LmfuvB7IzLS4n7HFn+HJ9QJvRTqjDSfXip/YvvyHjGWrmyHFu+nCUrPPNqYoPjlSfsgVuLA05RPqPdZqQ==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.18",
-    "@dust-tt/sparkle": "^0.3.18",
+    "@dust-tt/sparkle": "^0.3.20",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -75,7 +75,7 @@ function MCPServerCard({
         mountPortal
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         mountPortalContainer={containerRef.current || undefined}
-        toolInfo={{
+        footer={{
           label: "More info",
           onClick: onToolInfoClick,
         }}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -1,8 +1,8 @@
 import {
+  ActionCard,
   ActionIcons,
   BookOpenIcon,
   Hoverable,
-  ToolCard,
 } from "@dust-tt/sparkle";
 import React, { useMemo } from "react";
 
@@ -64,7 +64,7 @@ function MCPServerCard({
 
   return (
     <div ref={containerRef}>
-      <ToolCard
+      <ActionCard
         icon={icon}
         label={view.label}
         description={description}

--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -1,4 +1,4 @@
-import { SearchInput, TimeIcon, ToolCard } from "@dust-tt/sparkle";
+import { ActionCard, SearchInput, TimeIcon } from "@dust-tt/sparkle";
 import React, { useMemo, useState } from "react";
 
 import { getIcon } from "@app/components/resources/resources_icons";
@@ -60,7 +60,7 @@ export function TriggerSelectionPageContent({
           <>
             <span className="text-lg font-semibold">Top triggers</span>
             <div className="grid grid-cols-2 gap-3">
-              <ToolCard
+              <ActionCard
                 icon={TimeIcon}
                 label="Schedule"
                 description="Trigger this agent on a schedule"
@@ -79,7 +79,7 @@ export function TriggerSelectionPageContent({
             <div className="grid grid-cols-2 gap-3">
               {filteredWebhookSourceViews.map((view) => {
                 return (
-                  <ToolCard
+                  <ActionCard
                     key={view.sId}
                     icon={getIcon(normalizeWebhookIcon(view.icon))}
                     label={view.customName}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.3.18",
+        "@dust-tt/sparkle": "^0.3.20",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1164,9 +1164,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.18.tgz",
-      "integrity": "sha512-RQFwImMLA0XhtiN2ocbPyxj5BPKLFFFSa1p6Qr/R15X7qoFQCDh9JA9xm/Te+YQbzxE0UEFcNCjw8XrYwOLYSw==",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.20.tgz",
+      "integrity": "sha512-z4eA3LmfuvB7IzLS4n7HFn+HJ9QJvRTqjDSfXip/YvvyHjGWrmyHFu+nCUrPPNqYoPjlSfsgVuLA05RPqPdZqQ==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.3.18",
+    "@dust-tt/sparkle": "^0.3.20",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

- In sparkle, the component `ToolCard` was renamed into `ActionCard` in https://github.com/dust-tt/dust/pull/17365 since it's now used for representing triggers as well.
- This PR handles the renaming in front.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
