### PR TITLE
Markdown directive for Images renders for any file

### DIFF
--- a/front/components/markdown/Image.tsx
+++ b/front/components/markdown/Image.tsx
@@ -7,6 +7,15 @@ import {
   getProcessedFileDownloadUrl,
 } from "@app/lib/swr/files";
 import type { LightWorkspaceType } from "@app/types";
+import { FILE_FORMATS } from "@app/types/files";
+
+const IMAGE_EXTENSIONS = Array.from(
+  new Set(
+    Object.values(FILE_FORMATS)
+      .filter((format) => format.cat === "image")
+      .flatMap((format) => format.exts)
+  )
+);
 
 interface ImgProps {
   src: string;
@@ -21,6 +30,16 @@ export function Img({ src, alt, owner }: ImgProps) {
   const matches = src.match(/\bfil_[A-Za-z0-9]{10,}\b/g);
   if (!matches || matches.length !== 1) {
     return null;
+  }
+
+  // Check if this is actually an image file by checking the extension in the alt text.
+  // Default is true for backward compatibility when no alt text is provided.
+  if (alt) {
+    const altLower = alt.toLowerCase();
+    const isImageFile = IMAGE_EXTENSIONS.some((ext) => altLower.endsWith(ext));
+    if (!isImageFile) {
+      return null;
+    }
   }
 
   const baseUrl = process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL;


### PR DESCRIPTION
## Description

**Problem:**
When an agent decides to use the markdown syntax `![filename.mp3](fil_xxx)` it is processed by the image rendering component, attempting to display audio files as images.

Looks like agents tend to use this directive also for mp3, cc eng runner card https://github.com/dust-tt/tasks/issues/4921

I'm not sure why we expected any item following this directive to be an image but I did not question that and opted for a quick fix: if we know it's not an image looking at the file name, we don't render it as an image. 

**Done:** 

Updated the Image.tsx component to filter out non-image files based on their file extension. The component now:
- Only renders files with image extensions (.jpg, .jpeg, .png, .gif, .webp)
- Returns null for non-image files (like .mp3), preventing them from being processed through the image rendering pipeline
- Maintains backward compatibility by assuming files without alt text are images

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front