### PR TITLE
Add index on AgentMCPActionOutputItem

### DIFF
--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -357,9 +357,11 @@ AgentMCPActionOutputItem.init(
     sequelize: frontSequelize,
     indexes: [
       {
+        // TODO(2025-10-29 flav) Remove once index below has been created.
         fields: ["workspaceId"],
         concurrently: true,
       },
+      { fields: ["workspaceId", "id"], concurrently: true },
       {
         fields: ["agentMCPActionId"],
         concurrently: true,

--- a/front/migrations/db/migration_394.sql
+++ b/front/migrations/db/migration_394.sql
@@ -1,0 +1,2 @@
+-- Migration created on Oct 29, 2025
+CREATE INDEX CONCURRENTLY "agent_mcp_action_output_items_workspace_id_id" ON "agent_mcp_action_output_items" ("workspaceId", "id");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The relocation process paginates over all rows for a table filtering by `workspaceId` and ordering by `id`.

For the table `AgentMCPActionOutputItem` we currently have btree indexes on `workspaceId` and on `id` (via PK). But:
`ORDER BY id with a WHERE workspaceId = X` needs either:
- a sort on the filtered rows, or
- a composite index that matches the filter and the order (workspaceId, id).

The PK on id alone can provide ordering by id, but it would read across all workspaces, then filter → inefficient and can’t early-stop for LIMIT without extra conditions.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [x] Run SQL migrations
