### PR TITLE
Data Retention workflow: optimize to reduce high CPU load

### DIFF
--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -397,7 +397,11 @@ AgentMessage.init(
   {
     modelName: "agent_message",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["workspaceId"], concurrently: true }],
+    indexes: [
+      { fields: ["workspaceId"], concurrently: true },
+      // Index for agent-based data retention queries.
+      { fields: ["workspaceId", "agentConfigurationId"], concurrently: true },
+    ],
   }
 );
 
@@ -590,6 +594,11 @@ Message.init(
       },
       {
         fields: ["workspaceId", "conversationId", "sId"],
+      },
+      // Index for data retention workflow - optimizes GROUP BY with MAX(createdAt).
+      {
+        fields: ["workspaceId", "conversationId", "createdAt"],
+        concurrently: true,
       },
     ],
     hooks: {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -390,6 +390,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           required: true,
           attributes: [],
           where: {
+            workspaceId,
             agentConfigurationId,
           },
         },

--- a/front/migrations/db/migration_395.sql
+++ b/front/migrations/db/migration_395.sql
@@ -1,0 +1,3 @@
+-- Migration created on Oct 29, 2025
+CREATE INDEX CONCURRENTLY "agent_messages_workspace_id_agent_configuration_id" ON "agent_messages" ("workspaceId", "agentConfigurationId");
+CREATE INDEX CONCURRENTLY "messages_workspace_id_conversation_id_created_at" ON "messages" ("workspaceId", "conversationId", "createdAt");

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -112,7 +112,7 @@ export async function purgeConversationsBatchActivity({
           }
         },
         {
-          concurrency: 4,
+          concurrency: 2,
         }
       );
 
@@ -211,7 +211,7 @@ export async function purgeAgentConversationsBatchActivity({
       }
     },
     {
-      concurrency: 4,
+      concurrency: 2,
     }
   );
 

--- a/front/temporal/data_retention/worker.ts
+++ b/front/temporal/data_retention/worker.ts
@@ -14,7 +14,7 @@ export async function runDataRetentionWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 8,
+    maxConcurrentActivityTaskExecutions: 4,
     connection,
     namespace,
     interceptors: {


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/4827
Everyday at 4pm there is spike in CPU load and looks like data retention is the culprit. 

Done here: 
- Added some indexes. 
- Reduced concurrency of workflows and concurrency of deleteConversation execution. 

I think it's okay, currently this daily workflow is executing in 15min to 1hour.

## Tests

Nothing to really test but I'll monitor if it makes a diff on the next execution.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run migration.
Deploy front. 
No need to reset the workflows or to bump the queue. 