### PR TITLE
[front] Add back GitLab and Valtown logos

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.18",
-        "@dust-tt/sparkle": "^0.3.20",
+        "@dust-tt/sparkle": "^0.3.21",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.20.tgz",
-      "integrity": "sha512-z4eA3LmfuvB7IzLS4n7HFn+HJ9QJvRTqjDSfXip/YvvyHjGWrmyHFu+nCUrPPNqYoPjlSfsgVuLA05RPqPdZqQ==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.21.tgz",
+      "integrity": "sha512-Z6dge6kTDl4fS43Yn/pdLXxzO6qLgFxvgbsO5NE+fXf3jE+YulMJpM25u/7Tpm4254SCR3A2drvnftbs8ebF6w==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.18",
-    "@dust-tt/sparkle": "^0.3.20",
+    "@dust-tt/sparkle": "^0.3.21",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.3.20",
+        "@dust-tt/sparkle": "^0.3.21",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1164,9 +1164,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.20.tgz",
-      "integrity": "sha512-z4eA3LmfuvB7IzLS4n7HFn+HJ9QJvRTqjDSfXip/YvvyHjGWrmyHFu+nCUrPPNqYoPjlSfsgVuLA05RPqPdZqQ==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.21.tgz",
+      "integrity": "sha512-Z6dge6kTDl4fS43Yn/pdLXxzO6qLgFxvgbsO5NE+fXf3jE+YulMJpM25u/7Tpm4254SCR3A2drvnftbs8ebF6w==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.3.20",
+    "@dust-tt/sparkle": "^0.3.21",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/17450.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
