### PR TITLE
Disable tags management in exploratory search mode

### DIFF
--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -33,9 +33,8 @@ export function DataSourceViewTagsFilterDropdown() {
   >({
     name: "configuration.additionalConfiguration",
   });
-  const isExploratorySearchEnabled = Boolean(
-    additionalConfiguration[ADVANCED_SEARCH_SWITCH]
-  );
+  const isExploratorySearchEnabled = 
+    additionalConfiguration[ADVANCED_SEARCH_SWITCH] === true;
 
   const dataSourceViews = sources.in.reduce((acc, source) => {
     if (source.type === "data_source") {

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -33,7 +33,7 @@ export function DataSourceViewTagsFilterDropdown() {
   >({
     name: "configuration.additionalConfiguration",
   });
-  const isExploratorySearchEnabled = 
+  const isExploratorySearchEnabled =
     additionalConfiguration[ADVANCED_SEARCH_SWITCH] === true;
 
   const dataSourceViews = sources.in.reduce((acc, source) => {

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -10,9 +10,11 @@ import { useCallback, useMemo } from "react";
 import { useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { TagSearchSection } from "@app/components/assistant_builder/tags/TagSearchSection";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
+import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   DataSourceTag,
   DataSourceViewType,
@@ -25,6 +27,15 @@ export function DataSourceViewTagsFilterDropdown() {
   const { updateSourcesTags, toggleInConversationFiltering } =
     useDataSourceBuilderContext();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
+  const additionalConfiguration = useWatch<
+    MCPFormData,
+    "configuration.additionalConfiguration"
+  >({
+    name: "configuration.additionalConfiguration",
+  });
+  const isExploratorySearchEnabled = Boolean(
+    additionalConfiguration[ADVANCED_SEARCH_SWITCH]
+  );
 
   const dataSourceViews = sources.in.reduce((acc, source) => {
     if (source.type === "data_source") {
@@ -178,7 +189,17 @@ export function DataSourceViewTagsFilterDropdown() {
   return (
     <PopoverRoot>
       <PopoverTrigger asChild>
-        <Button label="Filters" variant="outline" isSelect />
+        <Button
+          label="Filters"
+          variant="outline"
+          isSelect
+          disabled={isExploratorySearchEnabled}
+          tooltip={
+            isExploratorySearchEnabled
+              ? "Exploratory search mode doesn't support filtering data sources yet"
+              : undefined
+          }
+        />
       </PopoverTrigger>
 
       <PopoverContent


### PR DESCRIPTION
## Description

[Task](https://github.com/dust-tt/tasks/issues/4939)
Disable tags filtering when exploratory search mode is enabled with a tooltip explaining why

## Tests

Tested locally on agent builder

## Risk

Low

## Deploy Plan

Deploy front
