### PR TITLE
update scopes

### DIFF
--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -30,9 +30,13 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
         case "personal_actions":
           return {
             user_scopes: [
+              "channels:history",
               "channels:read",
               "chat:write",
+              "groups:history",
               "groups:read",
+              "im:history",
+              "mpim:history",
               "reactions:read",
               "reactions:write",
               "search:read.private",


### PR DESCRIPTION
## Description
This PR adds missing OAuth scopes to the Slack `personal_actions` use case to enable thread reading functionality. The added scopes (`channels:history`, `groups:history`, `im:history`, `mpim:history`) are required for the Slack MCP personal server to read thread messages from public channels, private channels, direct messages, and group messages respectively. This resolves the "missing_scope" errors that occur when using the `read_thread_messages` tool.

## Risk
Low risk. These are standard Slack OAuth scopes that only grant read access to message history, matching the existing permissions pattern for the connection use case. No database schema changes or breaking modifications.

## Tests
Manual testing required to verify thread reading functionality works after OAuth re-authorization with the new scopes.

## Deploy Plan
