### PR TITLE
[front] - feat(obs): add global feedback analyzer agent

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/feedback_analyzer.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/feedback_analyzer.ts
@@ -1,0 +1,83 @@
+import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
+import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
+import { _getInteractiveContentToolConfiguration } from "@app/lib/api/assistant/global_agents/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { AgentConfigurationType } from "@app/types";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+  GLOBAL_AGENTS_SID,
+  MAX_STEPS_USE_PER_RUN_LIMIT,
+} from "@app/types";
+
+export function _getFeedbackAnalyzerGlobalAgent({
+  auth,
+  settings,
+  interactiveContentMCPServerView,
+}: {
+  auth: Authenticator;
+  settings: GlobalAgentSettings | null;
+  interactiveContentMCPServerView: MCPServerViewResource | null;
+}): AgentConfigurationType | null {
+  const sId = GLOBAL_AGENTS_SID.FEEDBACK_ANALYZER;
+  const metadata = getGlobalAgentMetadata(sId);
+
+  const instructions = `<primary_goal>
+You analyze agent feedback comments, identify themes, outliers, and trends over time, and propose actionable improvements.
+</primary_goal>
+
+<guidelines>
+${globalAgentGuidelines}
+- Be objective and specific; quantify where possible.
+- Group insights by agent, user segment, and time period when relevant.
+- Highlight regressions, recurring issues, and high-impact opportunities.
+- When a visual or structured summary aids comprehension, create an Interactive Content frame.
+</guidelines>`;
+
+  const owner = auth.getNonNullableWorkspace();
+  const modelConfiguration = auth.isUpgraded()
+    ? getLargeWhitelistedModel(owner)
+    : getSmallWhitelistedModel(owner);
+
+  if (!modelConfiguration) {
+    return null;
+  }
+
+  const model = {
+    providerId: modelConfiguration.providerId,
+    modelId: modelConfiguration.modelId,
+    temperature: 0.5,
+    reasoningEffort: modelConfiguration.defaultReasoningEffort,
+  };
+
+  return {
+    id: -1,
+    sId,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: metadata.name,
+    description: metadata.description,
+    instructions,
+    pictureUrl: metadata.pictureUrl,
+    status: settings?.status ?? "active",
+    scope: "global",
+    userFavorite: false,
+    model,
+    actions: [
+      ..._getInteractiveContentToolConfiguration({
+        agentId: sId,
+        interactiveContentMCPServerView,
+      }),
+    ],
+    maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    templateId: null,
+    requestedGroupIds: [],
+    requestedSpaceIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+}

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -37,6 +37,14 @@ type AgentMetadata = {
 
 export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
   switch (sId) {
+    case GLOBAL_AGENTS_SID.FEEDBACK_ANALYZER:
+      return {
+        sId: GLOBAL_AGENTS_SID.FEEDBACK_ANALYZER,
+        name: "Fred",
+        description:
+          "Analyze agent feedback to surface trends, themes, and actionable improvements.",
+        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+      };
     case GLOBAL_AGENTS_SID.HELPER:
       return {
         sId: GLOBAL_AGENTS_SID.HELPER,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -19,6 +19,7 @@ import {
 } from "@app/lib/api/assistant/global_agents/configurations/dust/deep-dive";
 import { _getDustGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import { _getNoopAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/noop";
+import { _getFeedbackAnalyzerGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/feedback_analyzer";
 import { _getGeminiProGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/google";
 import {
   _getHelperGlobalAgent,
@@ -61,9 +62,9 @@ import type {
   GlobalAgentStatus,
   WhitelistableFeature,
 } from "@app/types";
-import { isDevelopment } from "@app/types";
 import {
   GLOBAL_AGENTS_SID,
+  isDevelopment,
   isGlobalAgentId,
   isProviderWhitelisted,
 } from "@app/types";
@@ -398,6 +399,13 @@ function getGlobalAgent({
         settings,
       });
       break;
+    case GLOBAL_AGENTS_SID.FEEDBACK_ANALYZER:
+      agentConfiguration = _getFeedbackAnalyzerGlobalAgent({
+        auth,
+        settings,
+        interactiveContentMCPServerView,
+      });
+      break;
     case GLOBAL_AGENTS_SID.NOOP:
       // we want only to have it in development
       if (isDevelopment()) {
@@ -581,6 +589,12 @@ export async function getGlobalAgents(
   if (!flags.includes("deepseek_r1_global_agent_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.DEEPSEEK_R1
+    );
+  }
+
+  if (!flags.includes("agent_builder_observability")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.FEEDBACK_ANALYZER
     );
   }
 

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -106,6 +106,7 @@ export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
   DEEP_DIVE = "deep-dive",
+  FEEDBACK_ANALYZER = "feedback-analyzer",
   DUST_TASK = "dust-task",
   DUST_BROWSER_SUMMARY = "dust-browser-summary",
   DUST_PLANNING = "dust-planning",


### PR DESCRIPTION
## Description

This PR introduces a new global agent called "Fred" (Feedback Analyzer) designed to analyze agent feedback comments and surface actionable insights. The agent is configured with specialized instructions to identify themes, outliers, and trends in feedback data, helping improve agent performance through data-driven insights. The implementation follows the standard global agent pattern and is gated behind the `agent_builder_observability` feature flag.

**References:**
- https://github.com/dust-tt/tasks/issues/4895

## Risk

Low

## Tests

Locally

## Deploy Plan

- Deploy front
