### PR TITLE
deactivate gitlab server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -140,6 +140,8 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
       asana_list_workspaces: "never_ask",
     },
   },
+  //Removed temporaly gitlab server
+  /*
   {
     id: 10003,
     name: "gitlab",
@@ -167,6 +169,7 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
       semantic_code_search: "never_ask",
     },
   },
+  */
   //Removed temporaly see https://dust4ai.slack.com/archives/C050SM8NSPK/p1754397289272209
   /*
   {


### PR DESCRIPTION
## Description

Deactivate gitlab server

## Tests

local

## Risk

low/none : existing agents with the gitlab tool will stop working. Mitigation is to add it as a remote tool. But since Gitlab is currently down, this does not change behavior

## Deploy Plan

Front only
