### PR TITLE
[assistant] chore: Track tool picker opened

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -23,6 +23,11 @@ import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils"
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import { useSpaces } from "@app/lib/swr/spaces";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+} from "@app/lib/tracking";
 import type { WorkspaceType } from "@app/types";
 
 function ToolsPickerLoading({ count = 5 }: { count?: number }) {
@@ -109,6 +114,11 @@ export function ToolsPicker({
       onOpenChange={(open) => {
         setIsOpen(open);
         if (open) {
+          trackEvent({
+            area: TRACKING_AREAS.TOOLS,
+            object: "tool_picker",
+            action: TRACKING_ACTIONS.OPEN,
+          });
           setSearchText("");
         }
       }}


### PR DESCRIPTION
## Description

Adds tracking for when users open the tool picker dropdown in the assistant interface.

Related to https://github.com/dust-tt/tasks/issues/4900

## Tests

Manual testing that the event is fired

## Risk

Low - only adds a non-blocking analytics tracking call without modifying existing functionality.

## Deploy Plan

Deploy in production