### PR TITLE
[obs] Show "Others" tool category in tool usage charts

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -39,6 +39,8 @@ export const TOOL_COLORS = [
 
 export const MAX_TOOLS_DISPLAYED = 5;
 
+export const OTHER_TOOLS_LABEL = "Others";
+
 export const FEEDBACK_DISTRIBUTION_PALETTE = {
   positive: "text-[hsl(var(--chart-1))]",
   negative: "text-[hsl(var(--chart-4))]",

--- a/front/components/agent_builder/observability/hooks.ts
+++ b/front/components/agent_builder/observability/hooks.ts
@@ -77,7 +77,8 @@ function createChartData(
     }
 
     if (includeOthers) {
-      const othersCount = Math.max(0, total - topToolsCount);
+      const othersCount = total - topToolsCount;
+
       if (othersCount > 0) {
         values[OTHER_TOOLS_LABEL] = calculatePercentage(othersCount, total);
       }

--- a/front/components/agent_builder/observability/hooks.ts
+++ b/front/components/agent_builder/observability/hooks.ts
@@ -143,8 +143,8 @@ function processToolUsageData(
   }
 
   const counts = aggregateToolCounts(data);
-  const includeOthers = counts.size > MAX_TOOLS_DISPLAYED;
   const selectedTools = selectTopTools(counts, MAX_TOOLS_DISPLAYED);
+  const includeOthers = counts.size > MAX_TOOLS_DISPLAYED;
   const topTools = includeOthers
     ? [...selectedTools, OTHER_TOOLS_LABEL]
     : selectedTools;

--- a/front/components/agent_builder/observability/hooks.ts
+++ b/front/components/agent_builder/observability/hooks.ts
@@ -62,6 +62,7 @@ function createChartData(
       Object.values(item.tools).reduce((acc, tool) => acc + tool.count, 0);
 
     const values: Record<string, number> = {};
+    let topToolsCount = 0;
     for (const toolName of displayTools) {
       if (toolName === OTHER_TOOLS_LABEL) {
         continue;
@@ -71,17 +72,12 @@ function createChartData(
       const count = toolData?.count ?? 0;
       if (count > 0) {
         values[toolName] = calculatePercentage(count, total);
+        topToolsCount += count;
       }
     }
 
     if (includeOthers) {
-      let othersCount = 0;
-      for (const [toolName, toolData] of Object.entries(item.tools)) {
-        if (!displayTools.includes(toolName)) {
-          othersCount += toolData.count;
-        }
-      }
-
+      const othersCount = Math.max(0, total - topToolsCount);
       if (othersCount > 0) {
         values[OTHER_TOOLS_LABEL] = calculatePercentage(othersCount, total);
       }

--- a/front/components/agent_builder/observability/shared/ChartShapes.tsx
+++ b/front/components/agent_builder/observability/shared/ChartShapes.tsx
@@ -1,3 +1,4 @@
+import { OTHER_TOOLS_LABEL } from "@app/components/agent_builder/observability/constants";
 import type { ValuesPayload } from "@app/components/agent_builder/observability/utils";
 
 export function RoundedTopBarShape({
@@ -37,13 +38,29 @@ export function RoundedTopBarShape({
   let topTool: string | undefined;
   for (let idx = stackOrder.length - 1; idx >= 0; idx--) {
     const candidate = stackOrder[idx];
-    if ((payload.values[candidate] ?? 0) > 0) {
+    const value = payload.values[candidate] ?? 0;
+
+    if (value > 0) {
+      // If the candidate is the OTHER_TOOLS_LABEL, check if there is any item above
+      if (candidate === OTHER_TOOLS_LABEL) {
+        const hasItemAbove = stackOrder
+          .slice(idx + 1)
+          .some(
+            (tool) =>
+              tool !== OTHER_TOOLS_LABEL && (payload.values[tool] ?? 0) > 0
+          );
+
+        if (hasItemAbove) {
+          continue;
+        }
+      }
+
       topTool = candidate;
       break;
     }
   }
 
-  if (topTool !== toolName) {
+  if (!topTool || topTool !== toolName) {
     return <rect x={x} y={y} width={width} height={height} fill={fill} />;
   }
 

--- a/front/components/agent_builder/observability/shared/ChartShapes.tsx
+++ b/front/components/agent_builder/observability/shared/ChartShapes.tsx
@@ -1,4 +1,3 @@
-import { OTHER_TOOLS_LABEL } from "@app/components/agent_builder/observability/constants";
 import type { ValuesPayload } from "@app/components/agent_builder/observability/utils";
 
 export function RoundedTopBarShape({
@@ -41,20 +40,6 @@ export function RoundedTopBarShape({
     const value = payload.values[candidate] ?? 0;
 
     if (value > 0) {
-      // If the candidate is the OTHER_TOOLS_LABEL, check if there is any item above
-      if (candidate === OTHER_TOOLS_LABEL) {
-        const hasItemAbove = stackOrder
-          .slice(idx + 1)
-          .some(
-            (tool) =>
-              tool !== OTHER_TOOLS_LABEL && (payload.values[tool] ?? 0) > 0
-          );
-
-        if (hasItemAbove) {
-          continue;
-        }
-      }
-
       topTool = candidate;
       break;
     }

--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -1,8 +1,15 @@
-import { TOOL_COLORS } from "@app/components/agent_builder/observability/constants";
+import {
+  OTHER_TOOLS_LABEL,
+  TOOL_COLORS,
+} from "@app/components/agent_builder/observability/constants";
 
 export type ValuesPayload = { values: Record<string, number> };
 
 export function getToolColor(toolName: string, topTools: string[]): string {
+  if (toolName === OTHER_TOOLS_LABEL) {
+    return "text-muted-foreground";
+  }
+
   const idx = topTools.indexOf(toolName);
   return TOOL_COLORS[(idx >= 0 ? idx : 0) % TOOL_COLORS.length];
 }


### PR DESCRIPTION
## Description

- If there's more than MAX_TOOLS_DISPLAYED tools called for a given step or version we aggregate them as a single "others" category

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front 
