### PR TITLE
Dust: load memories in system prompt

### DIFF
--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -610,9 +610,12 @@ export async function getGlobalAgents(
     auth.user() &&
     agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST)
   ) {
-    memories = await AgentMemoryResource.findByAgentConfigurationId(auth, {
-      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-    });
+    memories = await AgentMemoryResource.findByAgentConfigurationIdAndUser(
+      auth,
+      {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      }
+    );
   }
 
   // For now we retrieve them all

--- a/front/lib/resources/agent_memory_resource.ts
+++ b/front/lib/resources/agent_memory_resource.ts
@@ -133,6 +133,34 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
     );
   }
 
+  static async findByAgentConfigurationId(
+    auth: Authenticator,
+    {
+      agentConfigurationId,
+    }: {
+      agentConfigurationId: string;
+    },
+    transaction?: Transaction
+  ): Promise<AgentMemoryResource[]> {
+    const userId = auth.user()?.id ?? null;
+    if (!userId) {
+      return [];
+    }
+
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          agentConfigurationId,
+          userId,
+        },
+        order: [["updatedAt", "DESC"]],
+      },
+      transaction
+    );
+  }
+
   async updateContent(auth: Authenticator, content: string) {
     return this.update({ content });
   }

--- a/front/lib/resources/agent_memory_resource.ts
+++ b/front/lib/resources/agent_memory_resource.ts
@@ -133,7 +133,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
     );
   }
 
-  static async findByAgentConfigurationId(
+  static async findByAgentConfigurationIdAndUser(
     auth: Authenticator,
     {
       agentConfigurationId,


### PR DESCRIPTION
## Description

Load Dust memory by default in prompt and not enforce tool usage. 
Activated to Dust only. 
It's one more DB query :/ 

<kbd>
<img width="1783" height="506" alt="Screenshot 2025-10-30 at 16 05 36" src="https://github.com/user-attachments/assets/d438342d-d049-4e39-8e9a-5f8646aae0ac" />
</kbd>


In my memory is "I love chocolate" 🍫 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 