### PR TITLE
enh(token_pricing): properly account cache reads in cost computation

### DIFF
--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -4,25 +4,29 @@ import type { ModelIdType as BaseModelIdType } from "@app/types";
 type PricingEntry = {
   input: number;
   output: number;
+  // Optional cached-token pricing (USD per million tokens). For now unused.
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
 };
 
 // Pricing (in USD) per million of tokens for current models.
 // This record must contain all BaseModelIdType values.
 const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
-  // https://platform.openai.com/docs/models/gpt-5
+  // https://openai.com/api/pricing
   "gpt-5": {
     input: 1.25,
     output: 10.0,
+    cache_read_input_tokens: 0.125,
   },
-  // https://platform.openai.com/docs/models/gpt-5-mini
   "gpt-5-mini": {
     input: 0.25,
     output: 2.0,
+    cache_read_input_tokens: 0.025,
   },
-  // https://platform.openai.com/docs/models/gpt-5-nano
   "gpt-5-nano": {
     input: 0.05,
     output: 0.4,
+    cache_read_input_tokens: 0.005,
   },
   "gpt-4-turbo": {
     input: 10.0,
@@ -43,6 +47,7 @@ const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
   "gpt-4o-2024-08-06": {
     input: 2.5,
     output: 10.0,
+    cache_read_input_tokens: 1.25,
   },
   o1: {
     input: 15.0,
@@ -51,6 +56,7 @@ const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
   "o1-mini": {
     input: 3.0,
     output: 12.0,
+    cache_read_input_tokens: 1.5,
   },
   o3: {
     input: 15.0,
@@ -75,42 +81,62 @@ const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
   "claude-4-opus-20250514": {
     input: 15.0,
     output: 75.0,
+    cache_creation_input_tokens: 18.75,
+    cache_read_input_tokens: 1.5,
   },
   "claude-4-sonnet-20250514": {
     input: 3.0,
     output: 15.0,
+    cache_creation_input_tokens: 3.75,
+    cache_read_input_tokens: 0.3,
   },
   "claude-sonnet-4-5-20250929": {
     input: 3.0,
     output: 15.0,
+    cache_creation_input_tokens: 3.75,
+    cache_read_input_tokens: 0.3,
   },
   "claude-3-opus-20240229": {
     input: 15.0,
     output: 75.0,
+    cache_creation_input_tokens: 18.75,
+    cache_read_input_tokens: 1.5,
   },
   "claude-3-5-sonnet-20240620": {
     input: 3.0,
     output: 15.0,
+    cache_creation_input_tokens: 3.75,
+    cache_read_input_tokens: 0.3,
   },
   "claude-3-5-sonnet-20241022": {
     input: 3.0,
     output: 15.0,
+    cache_creation_input_tokens: 3.75,
+    cache_read_input_tokens: 0.3,
   },
   "claude-3-7-sonnet-20250219": {
     input: 3.0,
     output: 15.0,
+    cache_creation_input_tokens: 3.75,
+    cache_read_input_tokens: 0.3,
   },
   "claude-3-haiku-20240307": {
     input: 0.25,
     output: 1.25,
+    cache_creation_input_tokens: 0.3,
+    cache_read_input_tokens: 0.03,
   },
   "claude-3-5-haiku-20241022": {
     input: 1.0,
     output: 5.0,
+    cache_creation_input_tokens: 1.25,
+    cache_read_input_tokens: 0.1,
   },
   "claude-haiku-4-5-20251001": {
     input: 1.0,
     output: 5.0,
+    cache_creation_input_tokens: 1.25,
+    cache_read_input_tokens: 0.1,
   },
   "claude-2.1": {
     input: 8.0,
@@ -425,8 +451,14 @@ const DEFAULT_PRICING = MODEL_PRICING[DEFAULT_PRICING_MODEL_ID];
 function calculateTokenUsageCostForUsage(usage: RunUsageType): number {
   const pricing = MODEL_PRICING[usage.modelId] ?? DEFAULT_PRICING;
 
+  const cachedTokens = usage.cachedTokens ?? 0;
+  const uncachedPromptTokens = Math.max(usage.promptTokens - cachedTokens, 0);
+
+  const cachedInputRate = pricing.cache_read_input_tokens ?? pricing.input;
+
   return (
-    (usage.promptTokens / 1_000_000) * pricing.input +
+    (uncachedPromptTokens / 1_000_000) * pricing.input +
+    (cachedTokens / 1_000_000) * cachedInputRate +
     (usage.completionTokens / 1_000_000) * pricing.output
   );
 }


### PR DESCRIPTION
## Description

- Add optional pricing fields to PricingEntry for cached tokens:
          - cache_read_input_tokens
          - cache_creation_input_tokens
- Populate only for models explicitly documented by providers (legacy untouched):
- Bill cached reads in cost computation
         
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
