### PR TITLE
[front] feat(webhooks): Add cli command to replay failed webhooks

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -23,8 +23,10 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { tokenCountForTexts } from "@app/lib/tokenization";
+import { launchAgentTriggerWebhookWorkflow } from "@app/lib/triggers/temporal/webhook/client";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import {
@@ -623,6 +625,111 @@ async function apikeys(command: string, args: parseArgs.ParsedArgs) {
   }
 }
 
+async function trigger(command: string, args: parseArgs.ParsedArgs) {
+  switch (command) {
+    case "replay-failed-webhooks": {
+      if (!args.wId) {
+        throw new Error("Missing --wId argument");
+      }
+
+      const limit = args.limit ? parseInt(args.limit, 10) : 100;
+      const execute = !!args.execute;
+
+      if (!execute) {
+        logger.info(
+          "[DRY RUN] Use --execute to actually replay the webhooks. Running in dry-run mode."
+        );
+      }
+
+      const auth = await Authenticator.internalAdminForWorkspace(args.wId);
+      const workspace = await WorkspaceResource.fetchById(args.wId);
+      if (!workspace) {
+        throw new Error(`Workspace not found: wId='${args.wId}'`);
+      }
+
+      logger.info(
+        { workspaceId: args.wId, limit },
+        "Fetching failed webhook requests..."
+      );
+
+      const failedWebhooks = await WebhookRequestResource.listByStatus({
+        workspaceId: workspace.id,
+        status: "failed",
+        limit,
+      });
+
+      if (failedWebhooks.length === 0) {
+        logger.info("No failed webhook requests found.");
+        return;
+      }
+
+      logger.info(
+        { count: failedWebhooks.length },
+        `Found ${failedWebhooks.length} failed webhook requests.`
+      );
+
+      let successCount = 0;
+      let errorCount = 0;
+
+      for (const webhookRequest of failedWebhooks) {
+        try {
+          logger.info(
+            {
+              webhookRequestId: webhookRequest.id,
+              webhookSourceId: webhookRequest.webhookSourceId,
+              errorMessage: webhookRequest.errorMessage,
+              createdAt: webhookRequest.createdAt,
+            },
+            `Processing webhook request ${webhookRequest.id}...`
+          );
+
+          if (execute) {
+            await launchAgentTriggerWebhookWorkflow({
+              auth,
+              webhookRequest,
+            });
+            successCount++;
+            logger.info(
+              { webhookRequestId: webhookRequest.id },
+              "Webhook workflow launched successfully."
+            );
+          } else {
+            logger.info(
+              { webhookRequestId: webhookRequest.id },
+              "[DRY RUN] Would launch workflow for this webhook request."
+            );
+            successCount++;
+          }
+        } catch (error) {
+          errorCount++;
+          logger.error(
+            {
+              webhookRequestId: webhookRequest.id,
+              error,
+            },
+            "Failed to launch webhook workflow."
+          );
+        }
+      }
+
+      logger.info(
+        {
+          total: failedWebhooks.length,
+          successful: successCount,
+          errors: errorCount,
+          dryRun: !execute,
+        },
+        "Webhook replay completed."
+      );
+
+      return;
+    }
+
+    default:
+      console.log(`Unknown trigger command: ${command}`);
+  }
+}
+
 export const CLI_OBJECT_TYPES = [
   "workspace",
   "user",
@@ -632,6 +739,7 @@ export const CLI_OBJECT_TYPES = [
   "registry",
   "production-check",
   "api-key",
+  "trigger",
 ] as const;
 
 export type CliObjectType = (typeof CLI_OBJECT_TYPES)[number];
@@ -679,6 +787,8 @@ const main = async () => {
       return productionCheck(command, argv);
     case "api-key":
       return apikeys(command, argv);
+    case "trigger":
+      return trigger(command, argv);
     default:
       assertNever(objectType);
   }

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -632,7 +632,6 @@ async function trigger(command: string, args: parseArgs.ParsedArgs) {
         throw new Error("Missing --wId argument");
       }
 
-      const limit = args.limit ? parseInt(args.limit, 10) : 100;
       const execute = !!args.execute;
 
       if (!execute) {
@@ -645,7 +644,6 @@ async function trigger(command: string, args: parseArgs.ParsedArgs) {
 
       const failedWebhooks = await WebhookRequestResource.listByStatus(auth, {
         status: "failed",
-        limit,
       });
 
       if (failedWebhooks.length === 0) {

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -642,18 +642,8 @@ async function trigger(command: string, args: parseArgs.ParsedArgs) {
       }
 
       const auth = await Authenticator.internalAdminForWorkspace(args.wId);
-      const workspace = await WorkspaceResource.fetchById(args.wId);
-      if (!workspace) {
-        throw new Error(`Workspace not found: wId='${args.wId}'`);
-      }
 
-      logger.info(
-        { workspaceId: args.wId, limit },
-        "Fetching failed webhook requests..."
-      );
-
-      const failedWebhooks = await WebhookRequestResource.listByStatus({
-        workspaceId: workspace.id,
+      const failedWebhooks = await WebhookRequestResource.listByStatus(auth, {
         status: "failed",
         limit,
       });

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -688,7 +688,6 @@ async function trigger(command: string, args: parseArgs.ParsedArgs) {
               auth,
               webhookRequest,
             });
-            successCount++;
             logger.info(
               { webhookRequestId: webhookRequest.id },
               "Webhook workflow launched successfully."
@@ -698,8 +697,8 @@ async function trigger(command: string, args: parseArgs.ParsedArgs) {
               { webhookRequestId: webhookRequest.id },
               "[DRY RUN] Would launch workflow for this webhook request."
             );
-            successCount++;
           }
+          successCount++;
         } catch (error) {
           errorCount++;
           logger.error(

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -130,36 +130,31 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     webhookSourceId: ModelId,
     options: ResourceFindOptions<WebhookRequestModel> = {}
   ): Promise<WebhookRequestResource[]> {
-    const resources = await this.baseFetch(auth, {
+    return this.baseFetch(auth, {
       ...options,
       where: {
         ...options.where,
         webhookSourceId,
       },
     });
-
-    return resources;
   }
 
-  static async listByStatus({
-    workspaceId,
-    status,
-    limit = 100,
-  }: {
-    workspaceId: ModelId;
-    status: "received" | "processed" | "failed";
-    limit?: number;
-  }): Promise<WebhookRequestResource[]> {
-    const res = await this.model.findAll({
+  static async listByStatus(
+    auth: Authenticator,
+    {
+      status,
+      limit = 100,
+    }: {
+      status: "received" | "processed" | "failed";
+      limit?: number;
+    }
+  ): Promise<WebhookRequestResource[]> {
+    return this.baseFetch(auth, {
       where: {
-        workspaceId,
         status,
       },
       limit,
-      order: [["createdAt", "DESC"]],
     });
-
-    return res.map((c) => new this(this.model, c.get()));
   }
 
   static async getWorkspaceIdsWithTooManyRequests({

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -7,6 +7,7 @@ import type {
 import { literal, Op, QueryTypes } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
+import type { WebhookRequestStatus } from "@app/lib/models/assistant/triggers/webhook_request";
 import { WebhookRequestModel } from "@app/lib/models/assistant/triggers/webhook_request";
 import type { WebhookRequestTriggerStatus } from "@app/lib/models/assistant/triggers/webhook_request_trigger";
 import { WebhookRequestTriggerModel } from "@app/lib/models/assistant/triggers/webhook_request_trigger";
@@ -144,7 +145,7 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     {
       status,
     }: {
-      status: "received" | "processed" | "failed";
+      status: WebhookRequestStatus;
     }
   ): Promise<WebhookRequestResource[]> {
     return this.baseFetch(auth, {

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -151,7 +151,6 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
       where: {
         status,
       },
-      limit,
     });
   }
 

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -141,6 +141,27 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     return resources;
   }
 
+  static async listByStatus({
+    workspaceId,
+    status,
+    limit = 100,
+  }: {
+    workspaceId: ModelId;
+    status: "received" | "processed" | "failed";
+    limit?: number;
+  }): Promise<WebhookRequestResource[]> {
+    const res = await this.model.findAll({
+      where: {
+        workspaceId,
+        status,
+      },
+      limit,
+      order: [["createdAt", "DESC"]],
+    });
+
+    return res.map((c) => new this(this.model, c.get()));
+  }
+
   static async getWorkspaceIdsWithTooManyRequests({
     webhookRequestTtl = WEBHOOK_REQUEST_TTL,
     maxWebhookRequestsToKeep = MAX_WEBHOOK_REQUESTS_TO_KEEP,

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -143,10 +143,8 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     auth: Authenticator,
     {
       status,
-      limit = 100,
     }: {
       status: "received" | "processed" | "failed";
-      limit?: number;
     }
   ): Promise<WebhookRequestResource[]> {
     return this.baseFetch(auth, {


### PR DESCRIPTION
## Description

- This PR adds a CLI command to retry failed webhooks.
- Mostly useful for debugging locally, but could also be used after pushing a fix that would fix failed webhooks.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
