### PR TITLE
[front] fix(triggers): add proper handling for duplicate subscribers

### DIFF
--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
@@ -67,9 +67,6 @@ export function AssistantToolsSection({
     ),
   ];
 
-  // TODO(20250626, aubin): Add model used for reasoning in details following
-  // regression when moving reasoning to MCP.
-
   const filteredModels = removeNulls(models);
   return (
     <div className="flex flex-col gap-5">

--- a/front/components/triggers/AddTriggerMenu.tsx
+++ b/front/components/triggers/AddTriggerMenu.tsx
@@ -14,8 +14,8 @@ import { DEFAULT_WEBHOOK_ICON } from "@app/lib/webhookSource";
 import type { WorkspaceType } from "@app/types";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";
 import {
+  isWebhookProvider,
   WEBHOOK_PRESETS,
-  WEBHOOK_PROVIDERS,
 } from "@app/types/triggers/webhooks";
 
 type AddTriggerMenuProps = {
@@ -42,24 +42,21 @@ export const AddTriggerMenu = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        {/* TODO(HOOTL): use the object directly instead */}
-        {WEBHOOK_PROVIDERS.filter((provider) => {
-          const preset = WEBHOOK_PRESETS[provider];
-          return (
-            preset.featureFlag === undefined || hasFeature(preset.featureFlag)
-          );
-        })
-          .sort((kindA, kindB) =>
-            WEBHOOK_PRESETS[kindA].name.localeCompare(
-              WEBHOOK_PRESETS[kindB].name
-            )
+        {Object.entries(WEBHOOK_PRESETS)
+          .filter(([_, { featureFlag }]) => {
+            return featureFlag === undefined || hasFeature(featureFlag);
+          })
+          .sort(([_, { name: nameA }], [__, { name: nameB }]) =>
+            nameA.localeCompare(nameB)
           )
-          .map((kind) => (
+          .map(([provider, preset]) => (
             <DropdownMenuItem
-              key={kind}
-              label={WEBHOOK_PRESETS[kind].name + " Webhook"}
-              icon={getIcon(WEBHOOK_PRESETS[kind].icon)}
-              onClick={() => createWebhook(kind)}
+              key={`trigger-${provider}`}
+              label={preset.name + " Webhook"}
+              icon={getIcon(preset.icon)}
+              onClick={() =>
+                isWebhookProvider(provider) && createWebhook(provider)
+              }
             />
           ))}
         <DropdownMenuItem

--- a/front/components/triggers/AddTriggerMenu.tsx
+++ b/front/components/triggers/AddTriggerMenu.tsx
@@ -46,9 +46,6 @@ export const AddTriggerMenu = ({
           .filter(([_, { featureFlag }]) => {
             return featureFlag === undefined || hasFeature(featureFlag);
           })
-          .sort(([_, { name: nameA }], [__, { name: nameB }]) =>
-            nameA.localeCompare(nameB)
-          )
           .map(([provider, preset]) => (
             <DropdownMenuItem
               key={`trigger-${provider}`}

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -52,8 +52,6 @@ export function registerCatTool(
   auth: Authenticator,
   server: McpServer,
   agentLoopContext: AgentLoopContextType | undefined,
-  // TODO(2025-08-28 aubin): determine whether we want to allow an extra description or instead
-  //  encourage putting extra details in the server instructions, which are passed to the instructions.
   { name, extraDescription }: { name: string; extraDescription?: string }
 ) {
   const baseDescription =

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -170,7 +170,7 @@ describe("TriggerResource", () => {
         expect(result.error).toBeInstanceOf(DustError);
         expect(result.error.code).toBe("unauthorized");
         expect(result.error.message).toBe(
-          "User do not have access to this trigger"
+          "User does not have access to this trigger"
         );
       }
     });
@@ -425,7 +425,7 @@ describe("TriggerResource", () => {
         expect(result.error).toBeInstanceOf(DustError);
         expect(result.error.code).toBe("unauthorized");
         expect(result.error.message).toBe(
-          "User do not have access to this trigger"
+          "User does not have access to this trigger"
         );
       }
     });

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -175,69 +175,6 @@ describe("TriggerResource", () => {
       }
     });
 
-    it("should handle database errors gracefully", async () => {
-      const {
-        workspace,
-        authenticator: editorAuth,
-        user: editorUser,
-      } = await createResourceTest({
-        role: "admin",
-      });
-
-      // Create a second user who will be the subscriber
-      const subscriberUser = await UserFactory.basic();
-      const subscriberAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        subscriberUser.sId,
-        workspace.sId
-      );
-
-      // Create an agent configuration for the trigger
-      const agentConfig = await AgentConfigurationFactory.createTestAgent(
-        editorAuth,
-        { name: "Test Agent" }
-      );
-
-      // Create a trigger
-      const triggerResult = await TriggerResource.makeNew(editorAuth, {
-        id: 123,
-        workspaceId: workspace.id,
-        name: "Test Trigger",
-        kind: "schedule",
-        agentConfigurationId: agentConfig.sId,
-        editor: editorUser.id,
-        customPrompt: null,
-        enabled: true,
-        configuration: {
-          cron: "0 9 * * 1",
-          timezone: "UTC",
-        },
-      });
-
-      expect(triggerResult.isOk()).toBe(true);
-      if (triggerResult.isErr()) {
-        throw triggerResult.error;
-      }
-
-      const trigger = triggerResult.value;
-
-      // Mock TriggerSubscriberModel.create to throw an error
-      const mockCreate = vi
-        .spyOn(TriggerSubscriberModel, "create")
-        .mockRejectedValue(new Error("Database connection failed"));
-
-      const result = await trigger.addToSubscribers(subscriberAuth);
-
-      expect(result.isErr()).toBe(true);
-      if (result.isErr()) {
-        expect(result.error).toBeInstanceOf(DustError);
-        expect(result.error.code).toBe("internal_error");
-        expect(result.error.message).toBe("Database connection failed");
-      }
-
-      // Restore the original method
-      mockCreate.mockRestore();
-    });
-
     it("should handle duplicate subscription attempts", async () => {
       const {
         workspace,

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -542,12 +542,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
 
   async addToSubscribers(
     auth: Authenticator
-  ): Promise<
-    Result<
-      undefined,
-      DustError<"unauthorized" | "internal_error" | "internal_error">
-    >
-  > {
+  ): Promise<Result<undefined, DustError<"unauthorized" | "internal_error">>> {
     if (auth.getNonNullableWorkspace().id !== this.workspaceId) {
       return new Err(
         new DustError("unauthorized", "User do not have access to this trigger")

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -545,7 +545,10 @@ export class TriggerResource extends BaseResource<TriggerModel> {
   ): Promise<Result<undefined, DustError<"unauthorized" | "internal_error">>> {
     if (auth.getNonNullableWorkspace().id !== this.workspaceId) {
       return new Err(
-        new DustError("unauthorized", "User do not have access to this trigger")
+        new DustError(
+          "unauthorized",
+          "User does not have access to this trigger"
+        )
       );
     }
 

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -572,7 +572,10 @@ export class TriggerResource extends BaseResource<TriggerModel> {
   ): Promise<Result<undefined, DustError<"unauthorized" | "internal_error">>> {
     if (auth.getNonNullableWorkspace().id !== this.workspaceId) {
       return new Err(
-        new DustError("unauthorized", "User do not have access to this trigger")
+        new DustError(
+          "unauthorized",
+          "User does not have access to this trigger"
+        )
       );
     }
 
@@ -598,7 +601,10 @@ export class TriggerResource extends BaseResource<TriggerModel> {
   > {
     if (auth.getNonNullableWorkspace().id !== this.workspaceId) {
       return new Err(
-        new DustError("unauthorized", "User do not have access to this trigger")
+        new DustError(
+          "unauthorized",
+          "User does not have access to this trigger"
+        )
       );
     }
 

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -555,17 +555,13 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       );
     }
 
-    try {
-      await TriggerSubscriberModel.create({
-        workspaceId: auth.getNonNullableWorkspace().id,
-        triggerId: this.id,
-        userId: auth.getNonNullableUser().id,
-      });
+    await TriggerSubscriberModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      triggerId: this.id,
+      userId: auth.getNonNullableUser().id,
+    });
 
-      return new Ok(undefined);
-    } catch (error) {
-      return new Err(new DustError("internal_error", errorToString(error)));
-    }
+    return new Ok(undefined);
   }
 
   async removeFromSubscribers(

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -558,6 +558,19 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       );
     }
 
+    const existing = await TriggerSubscriberModel.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        triggerId: this.id,
+        userId: auth.getNonNullableUser().id,
+      },
+    });
+    if (existing) {
+      return new Err(
+        new DustError("internal_error", "User is already a subscriber")
+      );
+    }
+
     await TriggerSubscriberModel.create({
       workspaceId: auth.getNonNullableWorkspace().id,
       triggerId: this.id,

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -114,8 +114,6 @@ async function handler(
         presetProviderId: model.providerId,
         // Not configurable in the template, keeping the column for now since some templates do
         // have a custom temperature.
-        // TODO(2025-09-29 aubin): update old templates to remove temperature setting.
-        //  Dependent on fixing it in Agent Builder.
         presetTemperature: "balanced",
         tags: body.tags,
         visibility: body.visibility,


### PR DESCRIPTION
## Description

- This PR fixes how duplicate attempts to subscribe to the same trigger with the same user are handled: instead of try-catching the DB call we check beforehand.
- This PR also handles the few remaining TODOs left in a code for triggers.

## Tests

- Tested manually.

## Risk

- Low.

## Deploy Plan

- Deploy front.
