### PR TITLE
feat(core): support tag filtering in search node method

### DIFF
--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -253,6 +253,10 @@ export const CoreAPINodesSearchFilterSchema = t.intersection([
       in: t.union([t.readonlyArray(t.string), t.null]),
       not: t.union([t.readonlyArray(t.string), t.null]),
     }),
+    tags: t.partial({
+      in: t.union([t.readonlyArray(t.string), t.null]),
+      not: t.union([t.readonlyArray(t.string), t.null]),
+    }),
   }),
 ]);
 


### PR DESCRIPTION
## Description

Step #1 to support tag filtering in exploratory search mode
- Add support to tags filters in core API
- There should be no change of behaviour

## Tests

Tested with front locally

## Risk

Low

## Deploy Plan

Deploy Core & Front
