### PR TITLE
[obs] Ingest Agent message content

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
@@ -28,7 +28,8 @@
       "type": "integer"
     },
     "content": {
-      "type": "text"
+      "type": "text",
+      "index": "false"
     },
     "tokens": {
       "type": "object",

--- a/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_1.mappings.json
@@ -27,6 +27,9 @@
     "latency_ms": {
       "type": "integer"
     },
+    "content": {
+      "type": "text"
+    },
     "tokens": {
       "type": "object",
       "properties": {

--- a/front/lib/analytics/migrations/20251031_add_content_to_agent_message_analytics_1.http
+++ b/front/lib/analytics/migrations/20251031_add_content_to_agent_message_analytics_1.http
@@ -1,0 +1,9 @@
+PUT /front.agent_message_analytics_1/_mapping
+{
+  "properties": {
+    "content": {
+      "type": "text",
+      "index": "false"
+    }
+  }
+}

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -83,6 +83,7 @@ export async function storeAgentAnalyticsActivity(
     user_id: userMessage.user?.sId ?? "unknown",
     workspace_id: workspace.sId,
     feedbacks: [],
+    content: agentMessage.content,
   };
 
   await storeToElasticsearch(document);

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -45,4 +45,5 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   feedbacks: AgentMessageAnalyticsFeedback[];
   user_id: string;
   workspace_id: string;
+  content: string | null;
 }


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/tasks/issues/4948
- Store agent message content in Elasticsearch

## Tests

Locally

## Risk

Low

## Deploy Plan

1. Update ES index in US
2. Update ES index in EU
3. Deploy front