### PR TITLE
Allow provider change in update_assistants_models

### DIFF
--- a/front/scripts/update_agent_models.ts
+++ b/front/scripts/update_agent_models.ts
@@ -12,7 +12,7 @@ async function updateWorkspaceAssistants(
   toModel: SupportedModelIds,
   execute: boolean,
   onlyActive: boolean,
-  forceProviderChange: boolean,
+  forceProviderChange: boolean
 ) {
   const whereClause: any = { workspaceId, modelId: fromModel };
   if (onlyActive) {
@@ -30,7 +30,12 @@ async function updateWorkspaceAssistants(
   );
 
   for (const agent of agentConfigurations) {
-    if (!isSupportedModel({ modelId: toModel, providerId: agent.providerId }, !forceProviderChange)) {
+    if (
+      !isSupportedModel(
+        { modelId: toModel, providerId: agent.providerId },
+        !forceProviderChange
+      )
+    ) {
       throw new Error(
         `Model ${toModel} is not supported for provider ${agent.providerId}.`
       );
@@ -47,7 +52,9 @@ async function updateWorkspaceAssistants(
     const actionWord = execute ? "Updated" : "[DRYRUN] Would update";
     console.log(
       `${actionWord} ${agent.name} (${agent.sId}) from ${fromModel} to ${toModel}` +
-        (providerChanged ? ` (provider: ${agent.providerId} -> ${targetProviderId})` : "") +
+        (providerChanged
+          ? ` (provider: ${agent.providerId} -> ${targetProviderId})`
+          : "") +
         "."
     );
   }
@@ -82,10 +89,18 @@ makeScript(
       type: "boolean",
       demandOption: false,
       default: false,
-      description: "Allow switching provider to match the target model. When false, only models from the same provider are allowed. It is a safety mechanism to avoid unexpected provider changes.",
+      description:
+        "Allow switching provider to match the target model. When false, only models from the same provider are allowed. It is a safety mechanism to avoid unexpected provider changes.",
     },
   },
-  async ({ fromModel, toModel, workspaceIds, execute, onlyActive, forceProviderChange }) => {
+  async ({
+    fromModel,
+    toModel,
+    workspaceIds,
+    execute,
+    onlyActive,
+    forceProviderChange,
+  }) => {
     const whereClause = workspaceIds.length > 0 ? { sId: workspaceIds } : {};
     const workspaces = await WorkspaceModel.findAll({
       attributes: ["id", "name", "sId"],
@@ -99,7 +114,7 @@ makeScript(
         toModel as SupportedModelIds,
         execute,
         onlyActive,
-        forceProviderChange,
+        forceProviderChange
       );
     }
   }

--- a/front/scripts/update_agent_models.ts
+++ b/front/scripts/update_agent_models.ts
@@ -30,7 +30,7 @@ async function updateWorkspaceAssistants(
     }agent configurations with model ${fromModel} in workspace ${workspaceId}`
   );
 
-  const excluded = new Set(excludeAgentsIds ?? []);
+  const excluded = new Set(excludeAgentsIds);
 
   for (const agent of agentConfigurations) {
     if (excluded.has(agent.sId)) {

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -82,12 +82,12 @@ export const DEFAULT_REASONING_MODEL_ID = O4_MINI_MODEL_ID;
 
 export const DEFAULT_TOKEN_COUNT_ADJUSTMENT = 1.15;
 
-export function isSupportedModel(model: unknown): model is SupportedModel {
+export function isSupportedModel(model: unknown, checkProvider: boolean = true): model is SupportedModel {
   const maybeSupportedModel = model as SupportedModel;
   return SUPPORTED_MODEL_CONFIGS.some(
     (m) =>
       m.modelId === maybeSupportedModel.modelId &&
-      m.providerId === maybeSupportedModel.providerId
+      (!checkProvider || m.providerId === maybeSupportedModel.providerId)
   );
 }
 

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -82,7 +82,10 @@ export const DEFAULT_REASONING_MODEL_ID = O4_MINI_MODEL_ID;
 
 export const DEFAULT_TOKEN_COUNT_ADJUSTMENT = 1.15;
 
-export function isSupportedModel(model: unknown, checkProvider: boolean = true): model is SupportedModel {
+export function isSupportedModel(
+  model: unknown,
+  checkProvider: boolean = true
+): model is SupportedModel {
   const maybeSupportedModel = model as SupportedModel;
   return SUPPORTED_MODEL_CONFIGS.some(
     (m) =>


### PR DESCRIPTION
## Description

Adds two options to the update_assistants_models.ts script:
- `forceProviderChange` option to allow switching providers when updating assistant models. Previously, the script only allowed model updates within the same provider. The new flag enables cross-provider model migrations when explicitly requested, while maintaining the default safety behavior.
- `excludeAgentsIds` option to allow excluding agents from the update

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

The safety mechanism remains the default behavior, and the flag requires explicit opt-in.


## Deploy Plan

Deploy front
