### PR TITLE
[assistant] perf: Auto-resize avatars on upload

### DIFF
--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -147,15 +147,22 @@ const resizeAndUploadToFileStorage = async (
     ".",
     ""
   );
-  const originalUrl = await file.getSignedUrlForDownload(auth, "original");
   const convertapi = new ConvertAPI(process.env.CONVERTAPI_API_KEY);
 
   let result;
   try {
+    // Upload the original file content directly to ConvertAPI to avoid exposing a signed URL
+    // which could be fetched by the third-party service. This still sends the file contents to
+    // ConvertAPI for conversion but removes the use of a signed download URL.
+    const uploadResult = await convertapi.upload(
+      file.getReadStream({ auth, version: "original" }),
+      `${file.fileName}.${originalFormat}`
+    );
+
     result = await convertapi.convert(
       originalFormat,
       {
-        File: originalUrl,
+        File: uploadResult,
         ScaleProportions: true,
         ImageResolution: "72",
         ScaleImage: "true",

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -50,7 +50,7 @@ const resizeAndUploadToPublicBucket: ProcessingFunction = async (
   auth: Authenticator,
   file: FileResource
 ) => {
-  const result = await makeResizeAndUploadImgToFileStorage(
+  const result = await makeResizeAndUploadImageToFileStorage(
     AVATAR_IMG_MAX_SIZE_PIXELS
   )(auth, file);
   if (result.isErr()) {
@@ -94,7 +94,7 @@ const createReadableFromUrl = async (url: string): Promise<Readable> => {
   return Readable.fromWeb(response.body);
 };
 
-const makeResizeAndUploadImgToFileStorage = (maxSize: string) => {
+const makeResizeAndUploadImageToFileStorage = (maxSize: string) => {
   return async (auth: Authenticator, file: FileResource) =>
     resizeAndUploadToFileStorage(auth, file, {
       ImageHeight: maxSize,
@@ -110,7 +110,7 @@ interface ImageResizeParams {
 const resizeAndUploadToFileStorage = async (
   auth: Authenticator,
   file: FileResource,
-  resizeParams: ResizeParams
+  resizeParams: ImageResizeParams
 ) => {
   /* Skipping sharp() to check if it's the cause of high CPU / memory usage.
   const readStream = file.getReadStream({
@@ -398,7 +398,7 @@ const getProcessingFunction = ({
 
   if (isSupportedImageContentType(contentType)) {
     if (useCase === "conversation") {
-      return makeResizeAndUploadImgToFileStorage(
+      return makeResizeAndUploadImageToFileStorage(
         CONVERSATION_IMG_MAX_SIZE_PIXELS
       );
     } else if (useCase === "avatar") {

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -101,7 +101,8 @@ const makeResizeAndUploadImgToFileStorage = (maxSize: string) => {
       ImageWidth: maxSize,
     });
 };
-interface ResizeParams {
+
+interface ImageResizeParams {
   ImageHeight: string;
   ImageWidth: string;
 }


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/4693

## Description

Optimizes avatar upload processing by automatically resizing uploaded images to 256x256 pixels maximum. Previously, avatar uploads were simply copied to public storage without any processing, causing performance issues when users uploaded high-resolution images (e.g., 1024x1024) that were only displayed at 64x64. This change applies the same ConvertAPI-based resizing logic used for conversation images but with a smaller maximum size appropriate for avatars.

## Risk
Changes the avatar upload processing pipeline from direct public bucket upload to processed image resizing. There's a potential risk of breaking avatar uploads if ConvertAPI fails, though this uses the same resizing infrastructure already used for conversation images.

Zeropath flagged image processing operations. These warnings have been accepted as risks because we're re-using the existing ConvertAPI pipeline, and we are dealing with assistant avatars, which have an acceptable risk of leaking sensible data.

## Tests
Manual testing of avatar upload functionality with various image sizes to ensure proper resizing and display.

## Deploy Plan

- [x] Deploy on edge, test avatar upload
- [x] Deploy in prod
