### PR TITLE
[front] enh(webhooks): align design of Jira project selection with GitHub repo/orgs

### DIFF
--- a/front/lib/triggers/built-in-webhooks/github/components/CreateWebhookGithubConnection.tsx
+++ b/front/lib/triggers/built-in-webhooks/github/components/CreateWebhookGithubConnection.tsx
@@ -184,7 +184,7 @@ export function CreateWebhookGithubConnection({
                         size="sm"
                       />
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent className="w-80">
+                    <DropdownMenuContent className="w-80" align="start">
                       <DropdownMenuSearchbar
                         name="repository"
                         placeholder="Search repositories..."
@@ -252,7 +252,7 @@ export function CreateWebhookGithubConnection({
                         size="sm"
                       />
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent className="w-80">
+                    <DropdownMenuContent className="w-80" align="start">
                       <DropdownMenuSearchbar
                         name="organization"
                         placeholder="Search organizations..."

--- a/front/lib/triggers/built-in-webhooks/jira/components/CreateWebhookJiraConnection.tsx
+++ b/front/lib/triggers/built-in-webhooks/jira/components/CreateWebhookJiraConnection.tsx
@@ -138,7 +138,7 @@ export function CreateWebhookJiraConnection({
                         size="sm"
                       />
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent className="w-80">
+                    <DropdownMenuContent className="w-80" align="start">
                       <DropdownMenuSearchbar
                         name="project"
                         placeholder="Search projects..."

--- a/front/lib/triggers/built-in-webhooks/jira/components/CreateWebhookJiraConnection.tsx
+++ b/front/lib/triggers/built-in-webhooks/jira/components/CreateWebhookJiraConnection.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Chip,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -8,7 +9,6 @@ import {
   Label,
   PlusIcon,
   Spinner,
-  XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 
@@ -92,95 +92,95 @@ export function CreateWebhookJiraConnection({
 
   return (
     <div className="flex flex-col space-y-4">
-      <div>
-        <Label>
-          Projects{" "}
-          {selectedProjects.length === 0 && (
-            <span className="text-warning">*</span>
-          )}
-        </Label>
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Select Jira projects to monitor for events
-        </p>
-        {isServiceDataLoading ? (
-          <div className="mt-2 flex items-center gap-2 py-2">
-            <Spinner size="sm" />
-            <span className="text-sm text-muted-foreground">
-              Loading projects...
-            </span>
-          </div>
-        ) : (
-          <div className="mt-2 flex flex-col gap-2">
-            {selectedProjects.map((project) => (
-              <div
-                key={project.key}
-                className="border-border-light bg-background-light dark:bg-background-dark flex items-center justify-between rounded border px-3 py-2 dark:border-border-dark"
-              >
-                <div className="flex flex-col">
-                  <span className="text-sm font-medium">{project.name}</span>
-                  <span className="font-mono text-xs text-muted-foreground dark:text-muted-foreground-night">
-                    {project.key}
-                  </span>
-                </div>
-                <Button
-                  size="xs"
-                  variant="ghost"
-                  icon={XMarkIcon}
-                  onClick={() => handleRemoveProject(project)}
-                />
+      {isServiceDataLoading ? (
+        <div className="mt-2 flex items-center gap-2 py-2">
+          <Spinner size="sm" />
+          <span className="text-sm text-muted-foreground">
+            Loading projects...
+          </span>
+        </div>
+      ) : (
+        <>
+          <div>
+            <Label>
+              Projects{" "}
+              {selectedProjects.length === 0 && (
+                <span className="text-warning">*</span>
+              )}
+            </Label>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Choose which projects can activate this trigger
+            </p>
+            <div className="mt-2 flex flex-col gap-2">
+              <div className="flex flex-wrap items-center gap-1">
+                {selectedProjects.map((project) => (
+                  <Chip
+                    key={project.key}
+                    size="xs"
+                    label={`${project.key} - ${project.name}`}
+                    color="primary"
+                    className="m-0.5"
+                    onRemove={() => handleRemoveProject(project)}
+                  />
+                ))}
               </div>
-            ))}
-            {jiraProjects.length > 0 && (
-              <DropdownMenu open={showDropdown} onOpenChange={setShowDropdown}>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    label="Add project"
-                    variant="outline"
-                    icon={PlusIcon}
-                    className="w-full"
-                  />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent className="w-80">
-                  <DropdownMenuSearchbar
-                    name="project"
-                    placeholder="Search projects..."
-                    value={searchQuery}
-                    onChange={setSearchQuery}
-                  />
-                  <div className="max-h-64 overflow-y-auto">
-                    {projectsInDropdown.length > 0 ? (
-                      projectsInDropdown.map((project) => (
-                        <DropdownMenuItem
-                          key={project.key}
-                          onClick={() => handleAddProject(project)}
-                        >
-                          <div className="flex flex-col">
-                            <span className="text-sm font-medium">
-                              {project.name}
-                            </span>
-                            <span className="font-mono text-xs text-muted-foreground">
-                              {project.key}
-                            </span>
+              {jiraProjects.length > 0 && (
+                <div className="flex">
+                  <DropdownMenu
+                    open={showDropdown}
+                    onOpenChange={setShowDropdown}
+                  >
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        label="Add project"
+                        variant="outline"
+                        icon={PlusIcon}
+                        size="sm"
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-80">
+                      <DropdownMenuSearchbar
+                        name="project"
+                        placeholder="Search projects..."
+                        value={searchQuery}
+                        onChange={setSearchQuery}
+                      />
+                      <div className="max-h-64 overflow-y-auto">
+                        {projectsInDropdown.length > 0 ? (
+                          projectsInDropdown.map((project) => (
+                            <DropdownMenuItem
+                              key={project.key}
+                              onClick={() => handleAddProject(project)}
+                            >
+                              <div className="flex flex-col">
+                                <span className="text-sm font-medium">
+                                  {project.name}
+                                </span>
+                                <span className="font-mono text-xs text-muted-foreground">
+                                  {project.key}
+                                </span>
+                              </div>
+                            </DropdownMenuItem>
+                          ))
+                        ) : (
+                          <div className="px-2 py-6 text-center text-sm text-muted-foreground">
+                            No projects found
                           </div>
-                        </DropdownMenuItem>
-                      ))
-                    ) : (
-                      <div className="px-2 py-6 text-center text-sm text-muted-foreground">
-                        No projects found
+                        )}
                       </div>
-                    )}
-                  </div>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              )}
+            </div>
           </div>
-        )}
-      </div>
 
-      {selectedProjects.length === 0 && (
-        <p className="dark:text-warning-night mt-1 text-xs text-warning">
-          Please select at least one project to create the webhook
-        </p>
+          {selectedProjects.length === 0 && (
+            <p className="dark:text-warning-night mt-1 text-xs text-warning">
+              Please select at least one project to create the webhook
+            </p>
+          )}
+        </>
       )}
     </div>
   );

--- a/front/lib/triggers/built-in-webhooks/jira/components/CreateWebhookJiraConnection.tsx
+++ b/front/lib/triggers/built-in-webhooks/jira/components/CreateWebhookJiraConnection.tsx
@@ -109,7 +109,7 @@ export function CreateWebhookJiraConnection({
               )}
             </Label>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Choose which projects can activate this trigger
+              Select Jira projects to monitor for events
             </p>
             <div className="mt-2 flex flex-col gap-2">
               <div className="flex flex-wrap items-center gap-1">

--- a/front/lib/triggers/built-in-webhooks/jira/components/WebhookSourceJiraDetails.tsx
+++ b/front/lib/triggers/built-in-webhooks/jira/components/WebhookSourceJiraDetails.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon, Page } from "@dust-tt/sparkle";
+import { Chip, ExternalLinkIcon, Page } from "@dust-tt/sparkle";
 
 import type { WebhookDetailsComponentProps } from "@app/components/triggers/webhook_preset_components";
 import { JiraAdditionalDataSchema } from "@app/lib/triggers/built-in-webhooks/jira/jira_api_types";
@@ -24,32 +24,29 @@ export function WebhookSourceJiraDetails({
   return (
     <div className="space-y-4">
       <div>
-        <Page.H variant="h6">
-          Jira {projects.length === 1 ? "Project" : "Projects"}
-        </Page.H>
-        <div className="space-y-2">
-          {projects.map((project) => (
-            <div key={project.key} className="flex items-center gap-2">
-              <span className="font-mono text-sm text-foreground dark:text-foreground-night">
-                {project.key}
-              </span>
-              <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                {project.name}
-              </span>
-              {cloudId && (
-                <a
-                  href={`https://api.atlassian.com/ex/jira/${cloudId}/secure/admin/WebHookAdmin.jspa`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-action-500 hover:text-action-600 dark:text-action-400 dark:hover:text-action-300 inline-flex items-center gap-1 text-xs"
-                >
-                  View webhooks
-                  <ExternalLinkIcon className="h-3 w-3" />
-                </a>
-              )}
-            </div>
-          ))}
-        </div>
+        <Page.H variant="h6">Connected Sources</Page.H>
+      </div>
+      <div>
+        {projects.map((project) => (
+          <Chip
+            key={project.key}
+            label={`${project.key} - ${project.name}`}
+            icon={ExternalLinkIcon}
+            size="xs"
+            color="primary"
+            className="m-0.5"
+            onClick={
+              cloudId
+                ? () => {
+                    window.open(
+                      `https://api.atlassian.com/ex/jira/${cloudId}/secure/admin/WebHookAdmin.jspa`,
+                      "_blank"
+                    );
+                  }
+                : undefined
+            }
+          />
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

- This PR fixes the design in `WebhookSourceJiraDetails` to align on what we currently have for GitHub.
- It relies on proper sparkle components (`Chip`) rather than custom `span`s.

Before
<img width="421" height="609" alt="Screenshot 2025-10-31 at 1 25 24 PM" src="https://github.com/user-attachments/assets/d24586de-b0ff-43da-a8d0-f2931e214e53" />

After

<img width="421" height="609" alt="Screenshot 2025-10-31 at 4 06 41 PM" src="https://github.com/user-attachments/assets/9d1b7a03-0b5d-4da1-99c6-a805fcbe3498" />

## Tests

- Checked loaclly.

## Risk

- Low.

## Deploy Plan

- Deploy front.
