### PR TITLE
[front] - fix(help): fix redirections in `HelpDropdown`

### DIFF
--- a/front/components/navigation/HelpDropdown.tsx
+++ b/front/components/navigation/HelpDropdown.tsx
@@ -27,8 +27,7 @@ import type {
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@app/types";
-import { isAgentMention } from "@app/types";
-import { GLOBAL_AGENTS_SID } from "@app/types";
+import { GLOBAL_AGENTS_SID, isAgentMention } from "@app/types";
 
 export function HelpDropdown({
   owner,
@@ -98,7 +97,7 @@ export function HelpDropdown({
           });
         } else {
           void router.push(
-            `/w/${owner.sId}/assistant/${conversationRes.value.sId}`
+            getConversationRoute(owner.sId, conversationRes.value.sId)
           );
         }
       },


### PR DESCRIPTION
## Description

This PR replaces direct router call with `getConversationRoute` helper function to determine the route for a conversation

**References:**
- https://github.com/dust-tt/tasks/issues/4964

## Tests

N/A

## Risk

Low, already broken

## Deploy Plan

Deploy front