### PR TITLE
[LLM Router] Clone anthropic events before processing

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -26,7 +26,7 @@ export async function* streamLLMEvents(
 ): AsyncGenerator<LLMEvent> {
   const stateContainer = { state: null };
 
-  // There is an issue in ANthropic SDK showcasing that stream events get mutated after they are yielded.
+  // There is an issue in Anthropic SDK showcasing that stream events get mutated after they are yielded.
   // https://github.com/anthropics/anthropic-sdk-typescript/issues/777
   // They say it has been fixed in the version we are using but in practice we still see it happening.
   // To work around this, we clone each event before processing it.

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -5,6 +5,7 @@ import type {
   MessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
 import { assertNever } from "@dust-tt/sparkle";
+import cloneDeep from "lodash/cloneDeep";
 
 import { validateContentBlockIndex } from "@app/lib/api/llm/clients/anthropic/utils/predicates";
 import type { StreamState } from "@app/lib/api/llm/clients/anthropic/utils/types";
@@ -31,9 +32,7 @@ export async function* streamLLMEvents(
   // They say it has been fixed in the version we are using but in practice we still see it happening.
   // To work around this, we clone each event before processing it.
   for await (const mutableMessageStreamEvent of messageStreamEvents) {
-    const messageStreamEvent = JSON.parse(
-      JSON.stringify(mutableMessageStreamEvent)
-    ) as MessageStreamEvent;
+    const messageStreamEvent = cloneDeep(mutableMessageStreamEvent);
     yield* handleMessageStreamEvent(
       messageStreamEvent,
       stateContainer,


### PR DESCRIPTION
## Description

There is an [issue](https://github.com/anthropics/anthropic-sdk-typescript/issues/777) we faced while streaming anthropic events. The events we received were mutable. They say they released the fix in v0.58.0 but in practice we still see the problem.

This is a hot fix in addition to answering to the anthropic issue.

## Tests

- Anhropic LLM is tested

## Risk

Low - feature flagged

## Deploy Plan

front
