### PR TITLE
[front] - refactor(mcp): collapse details by default

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -339,12 +339,26 @@ export function GenericActionDetails({
     >
       {viewType !== "conversation" && (
         <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
-          <span className="heading-base">Inputs</span>
-          <RenderToolItemMarkdown text={inputs} type="input" />
+          <CollapsibleComponent
+            rootProps={{ defaultOpen: false }}
+            triggerChildren={
+              <div
+                className={cn(
+                  "text-foreground dark:text-foreground-night",
+                  "flex flex-row items-center gap-x-2"
+                )}
+              >
+                <span className="heading-base">Inputs</span>
+              </div>
+            }
+            contentChildren={
+              <RenderToolItemMarkdown text={inputs} type="input" />
+            }
+          />
 
           {action.output && (
             <CollapsibleComponent
-              rootProps={{ defaultOpen: !action.generatedFiles.length }}
+              rootProps={{ defaultOpen: false }}
               triggerChildren={
                 <div
                   className={cn(

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -99,7 +99,7 @@ export function MCPExtractActionDetails({
         {viewType === "sidebar" && (
           <div>
             <CollapsibleComponent
-              rootProps={{ defaultOpen: true }}
+              rootProps={{ defaultOpen: false }}
               triggerChildren={
                 <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
                   Results

--- a/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
@@ -53,7 +53,7 @@ function DatabaseSchemaSection({
 }) {
   return (
     <CollapsibleComponent
-      rootProps={{ defaultOpen: true }}
+      rootProps={{ defaultOpen: false }}
       triggerChildren={
         <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
           Database Schema

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -210,6 +210,7 @@ export function SearchResultDetails({
     );
   })();
 
+
   return (
     <ActionDetailsWrapper
       viewType={viewType}
@@ -239,7 +240,7 @@ export function SearchResultDetails({
           {actionOutput && viewType === "sidebar" && (
             <div>
               <CollapsibleComponent
-                rootProps={{ defaultOpen: true }}
+                rootProps={{ defaultOpen: false }}
                 triggerChildren={
                   <span className="text-sm font-bold text-foreground dark:text-foreground-night">
                     Results

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -210,7 +210,6 @@ export function SearchResultDetails({
     );
   })();
 
-
   return (
     <ActionDetailsWrapper
       viewType={viewType}


### PR DESCRIPTION
## Description

This PR changes the default behavior of MCP action detail components to have their collapsible sections collapsed by default instead of expanded.

**References:**
- https://github.com/dust-tt/tasks/issues/4961

## Risk

Low
 
## Tests

Locally

## Deploy Plan

- Deploy front
