### PR TITLE
[sparkle] - feat(ButtonSwitch): introduce new component

### DIFF
--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -31,7 +31,7 @@ const useButtonsSwitch = () => {
 
 const listStyles = cva(
   cn(
-    "s-inline-flex s-items-center s-gap-1 s-rounded-2xl s-p-1",
+    "s-inline-flex s-items-center s-gap-1",
     "s-bg-primary-100 dark:s-bg-primary-900"
   ),
   {
@@ -40,9 +40,15 @@ const listStyles = cva(
         true: "s-w-full",
         false: "",
       },
+      size: {
+        xs: "s-rounded-lg s-p-0.5",
+        sm: "s-rounded-xl s-p-1",
+        md: "s-rounded-2xl s-p-1.5",
+      },
     },
     defaultVariants: {
       fullWidth: false,
+      size: "sm",
     },
   }
 );
@@ -97,7 +103,7 @@ export const ButtonsSwitchList = React.forwardRef<
         ref={ref}
         role="tablist"
         aria-orientation="horizontal"
-        className={cn(listStyles({ fullWidth }), className)}
+        className={cn(listStyles({ fullWidth, size }), className)}
         {...props}
       >
         <ButtonsSwitchContext.Provider value={context}>

--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -47,26 +47,13 @@ const listStyles = cva(
   }
 );
 
-type ButtonsSwitchListBaseProps = React.HTMLAttributes<HTMLDivElement> &
+type ButtonsSwitchListProps = React.HTMLAttributes<HTMLDivElement> &
   VariantProps<typeof listStyles> & {
     size?: ButtonSize;
     disabled?: boolean;
+    defaultValue?: string;
+    onValueChange?: (value: string) => void;
   };
-
-type ButtonsSwitchListControlledProps = {
-  value: string;
-  onValueChange: (value: string) => void;
-  defaultValue?: never;
-};
-
-type ButtonsSwitchListUncontrolledProps = {
-  value?: never;
-  onValueChange?: (value: string) => void;
-  defaultValue?: string;
-};
-
-type ButtonsSwitchListProps = ButtonsSwitchListBaseProps &
-  (ButtonsSwitchListControlledProps | ButtonsSwitchListUncontrolledProps);
 
 export const ButtonsSwitchList = React.forwardRef<
   HTMLDivElement,
@@ -77,7 +64,6 @@ export const ButtonsSwitchList = React.forwardRef<
       className,
       children,
       size = "sm",
-      value,
       defaultValue,
       onValueChange,
       disabled,
@@ -90,17 +76,14 @@ export const ButtonsSwitchList = React.forwardRef<
       string | undefined
     >(defaultValue);
 
-    const isControlled = value !== undefined;
-    const selected = isControlled ? value : internalValue;
+    const selected = internalValue;
 
     const handleChange = React.useCallback(
       (next: string) => {
-        if (!isControlled) {
-          setInternalValue(next);
-        }
+        setInternalValue(next);
         onValueChange?.(next);
       },
-      [isControlled, onValueChange]
+      [onValueChange]
     );
 
     const context: ButtonsSwitchContextType = React.useMemo(

--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -47,13 +47,14 @@ const listStyles = cva(
   }
 );
 
-type ButtonsSwitchListProps = React.HTMLAttributes<HTMLDivElement> &
-  VariantProps<typeof listStyles> & {
-    size?: ButtonSize;
-    disabled?: boolean;
-    defaultValue?: string;
-    onValueChange?: (value: string) => void;
-  };
+interface ButtonsSwitchListProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof listStyles> {
+  size?: ButtonSize;
+  disabled?: boolean;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+}
 
 export const ButtonsSwitchList = React.forwardRef<
   HTMLDivElement,
@@ -108,14 +109,12 @@ export const ButtonsSwitchList = React.forwardRef<
 );
 ButtonsSwitchList.displayName = "ButtonsSwitchList";
 
-type ButtonsSwitchProps = Omit<
-  React.ComponentProps<typeof Button>,
-  "size" | "variant"
-> & {
+interface ButtonsSwitchProps
+  extends Omit<React.ComponentProps<typeof Button>, "size" | "variant"> {
   value: string;
   label?: string;
   icon?: React.ComponentProps<typeof Button>["icon"];
-};
+}
 
 export const ButtonsSwitch = React.forwardRef<
   HTMLButtonElement,

--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -47,7 +47,7 @@ const listStyles = cva(
   }
 );
 
-interface ButtonsSwitchListProps
+export interface ButtonsSwitchListProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof listStyles> {
   size?: ButtonSize;

--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -1,0 +1,177 @@
+import { cva, VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { Button } from "@sparkle/components/Button";
+import { cn } from "@sparkle/lib/utils";
+
+type ButtonSize = Extract<
+  React.ComponentProps<typeof Button>["size"],
+  "xs" | "sm" | "md"
+>;
+
+type ButtonsSwitchContextType = {
+  value?: string;
+  onValueChange?: (value: string) => void;
+  size: ButtonSize;
+  disabled?: boolean;
+};
+
+const ButtonsSwitchContext =
+  React.createContext<ButtonsSwitchContextType | null>(null);
+
+const useButtonsSwitch = () => {
+  const ctx = React.useContext(ButtonsSwitchContext);
+  if (!ctx) {
+    throw new Error(
+      "ButtonsSwitch must be used within a ButtonsSwitchList component"
+    );
+  }
+  return ctx;
+};
+
+const listStyles = cva(
+  cn(
+    "s-inline-flex s-items-center s-gap-1 s-rounded-2xl s-p-1",
+    "s-bg-primary-100 dark:s-bg-primary-900"
+  ),
+  {
+    variants: {
+      fullWidth: {
+        true: "s-w-full",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      fullWidth: false,
+    },
+  }
+);
+
+type ButtonsSwitchListBaseProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof listStyles> & {
+    size?: ButtonSize;
+    disabled?: boolean;
+  };
+
+type ButtonsSwitchListControlledProps = {
+  value: string;
+  onValueChange: (value: string) => void;
+  defaultValue?: never;
+};
+
+type ButtonsSwitchListUncontrolledProps = {
+  value?: never;
+  onValueChange?: (value: string) => void;
+  defaultValue?: string;
+};
+
+type ButtonsSwitchListProps = ButtonsSwitchListBaseProps &
+  (ButtonsSwitchListControlledProps | ButtonsSwitchListUncontrolledProps);
+
+export const ButtonsSwitchList = React.forwardRef<
+  HTMLDivElement,
+  ButtonsSwitchListProps
+>(
+  (
+    {
+      className,
+      children,
+      size = "sm",
+      value,
+      defaultValue,
+      onValueChange,
+      disabled,
+      fullWidth,
+      ...props
+    },
+    ref
+  ) => {
+    const [internalValue, setInternalValue] = React.useState<
+      string | undefined
+    >(defaultValue);
+
+    const isControlled = value !== undefined;
+    const selected = isControlled ? value : internalValue;
+
+    const handleChange = React.useCallback(
+      (next: string) => {
+        if (!isControlled) {
+          setInternalValue(next);
+        }
+        onValueChange?.(next);
+      },
+      [isControlled, onValueChange]
+    );
+
+    const context: ButtonsSwitchContextType = React.useMemo(
+      () => ({ value: selected, onValueChange: handleChange, size, disabled }),
+      [selected, handleChange, size, disabled]
+    );
+
+    return (
+      <div
+        ref={ref}
+        role="tablist"
+        aria-orientation="horizontal"
+        className={cn(listStyles({ fullWidth }), className)}
+        {...props}
+      >
+        <ButtonsSwitchContext.Provider value={context}>
+          {children}
+        </ButtonsSwitchContext.Provider>
+      </div>
+    );
+  }
+);
+ButtonsSwitchList.displayName = "ButtonsSwitchList";
+
+type ButtonsSwitchProps = Omit<
+  React.ComponentProps<typeof Button>,
+  "size" | "variant"
+> & {
+  value: string;
+  label?: string;
+  icon?: React.ComponentProps<typeof Button>["icon"];
+};
+
+export const ButtonsSwitch = React.forwardRef<
+  HTMLButtonElement,
+  ButtonsSwitchProps
+>(({ className, value, label, icon, disabled, onClick, ...props }, ref) => {
+  const {
+    value: selected,
+    onValueChange,
+    size,
+    disabled: groupDisabled,
+  } = useButtonsSwitch();
+
+  const isActive = selected === value;
+  const isDisabled = disabled || groupDisabled;
+
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+    if (isDisabled) {
+      return;
+    }
+    onValueChange?.(value);
+    onClick?.(e);
+  };
+
+  return (
+    <Button
+      ref={ref}
+      role="tab"
+      aria-selected={isActive}
+      size={size}
+      variant={isActive ? "outline" : "ghost-secondary"}
+      label={label}
+      icon={icon}
+      className={className}
+      disabled={isDisabled}
+      onClick={handleClick}
+      {...props}
+    />
+  );
+});
+ButtonsSwitch.displayName = "ButtonsSwitch";
+
+export default ButtonsSwitch;

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -17,6 +17,7 @@ export type {
   RegularButtonProps,
 } from "./Button";
 export { Button } from "./Button";
+export { ButtonsSwitch,ButtonsSwitchList } from "./ButtonsSwitch";
 export type { CardProps } from "./Card";
 export { Card, CardActionButton, CardGrid } from "./Card";
 export type { CheckboxProps } from "./Checkbox";
@@ -158,7 +159,6 @@ export { ScrollArea, ScrollBar } from "./ScrollArea";
 export { SearchDropdownMenu } from "./SearchDropdownMenu";
 export { SearchInput, SearchInputWithPopover } from "./SearchInput";
 export { Separator } from "./Separator";
-export { ButtonsSwitchList, ButtonsSwitch } from "./ButtonsSwitch";
 export {
   Sheet,
   SheetClose,

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -158,6 +158,7 @@ export { ScrollArea, ScrollBar } from "./ScrollArea";
 export { SearchDropdownMenu } from "./SearchDropdownMenu";
 export { SearchInput, SearchInputWithPopover } from "./SearchInput";
 export { Separator } from "./Separator";
+export { ButtonsSwitchList, ButtonsSwitch } from "./ButtonsSwitch";
 export {
   Sheet,
   SheetClose,

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -17,7 +17,7 @@ export type {
   RegularButtonProps,
 } from "./Button";
 export { Button } from "./Button";
-export { ButtonsSwitch,ButtonsSwitchList } from "./ButtonsSwitch";
+export { ButtonsSwitch, ButtonsSwitchList } from "./ButtonsSwitch";
 export type { CardProps } from "./Card";
 export { Card, CardActionButton, CardGrid } from "./Card";
 export type { CheckboxProps } from "./Checkbox";

--- a/sparkle/src/stories/ButtonsSwitch.stories.tsx
+++ b/sparkle/src/stories/ButtonsSwitch.stories.tsx
@@ -1,10 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import React, { useState } from "react";
+import React from "react";
 
-import {
-  ButtonsSwitch,
-  ButtonsSwitchList,
-} from "../index_with_tw_base";
+import { ButtonsSwitch, ButtonsSwitchList } from "../index_with_tw_base";
 
 const meta = {
   title: "Components/ButtonsSwitch",
@@ -27,20 +24,11 @@ export const Default: Story = {
 };
 
 export const Controlled: Story = {
-  render: () => {
-    const [value, setValue] = useState("time");
-    return (
-      <div className="s-flex s-flex-col s-gap-4 s-p-4">
-        <ButtonsSwitchList value={value} onValueChange={setValue}>
-          <ButtonsSwitch value="time" label="Time range" />
-          <ButtonsSwitch value="version" label="Version" />
-          <ButtonsSwitch value="other" label="Other" />
-        </ButtonsSwitchList>
-        <div className="s-text-sm s-text-muted-foreground">
-          Selected: <span className="s-font-medium s-text-foreground">{value}</span>
-        </div>
-      </div>
-    );
-  },
+  render: () => (
+    <ButtonsSwitchList defaultValue="time">
+      <ButtonsSwitch value="time" label="Time range" />
+      <ButtonsSwitch value="version" label="Version" />
+      <ButtonsSwitch value="other" label="Other" />
+    </ButtonsSwitchList>
+  ),
 };
-

--- a/sparkle/src/stories/ButtonsSwitch.stories.tsx
+++ b/sparkle/src/stories/ButtonsSwitch.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+
+import {
+  ButtonsSwitch,
+  ButtonsSwitchList,
+} from "../index_with_tw_base";
+
+const meta = {
+  title: "Components/ButtonsSwitch",
+  component: ButtonsSwitchList,
+  tags: ["autodocs"],
+} satisfies Meta<typeof ButtonsSwitchList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="s-w-[360px] s-p-4">
+      <ButtonsSwitchList defaultValue="time" className="s-w-fit">
+        <ButtonsSwitch value="time" label="Time range" />
+        <ButtonsSwitch value="version" label="Version" />
+      </ButtonsSwitchList>
+    </div>
+  ),
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = useState("time");
+    return (
+      <div className="s-flex s-flex-col s-gap-4 s-p-4">
+        <ButtonsSwitchList value={value} onValueChange={setValue}>
+          <ButtonsSwitch value="time" label="Time range" />
+          <ButtonsSwitch value="version" label="Version" />
+          <ButtonsSwitch value="other" label="Other" />
+        </ButtonsSwitchList>
+        <div className="s-text-sm s-text-muted-foreground">
+          Selected: <span className="s-font-medium s-text-foreground">{value}</span>
+        </div>
+      </div>
+    );
+  },
+};
+


### PR DESCRIPTION
## Description

This PR introduces a new sparkle component to be used in the "Observability" tab in the agent builder. 

<img width="201" height="92" alt="Screenshot 2025-10-31 at 15 18 49" src="https://github.com/user-attachments/assets/77369529-217e-4b2b-a230-1dabeae0f52c" />

## Tests

Storybook

## Risk

None, not used yet 

## Deploy Plan

- Publish RC
- Publish GR