### PR TITLE
feat(input-caching): properly account for cache write costs

### DIFF
--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -573,9 +573,14 @@ impl LLM for AnthropicLLM {
             usage: Some(LLMTokenUsage {
                 prompt_tokens: c.usage.input_tokens
                     + c.usage.cache_read_input_tokens.unwrap_or(0)
+                    // TODO(cache-writes): Once LLMTokenUsage supports reporting cache writes separately,
+                    // don't add the cache creation input tokens here.
                     + c.usage.cache_creation_input_tokens.unwrap_or(0),
                 completion_tokens: c.usage.output_tokens,
                 cached_tokens: c.usage.cache_read_input_tokens,
+                // TODO(cache-writes): Once LLMTokenUsage supports reporting cache writes separately,
+                // add the field below to LLMTokenUsage (in providers/llm.rs) and uncomment the next line.
+                // cache_creation_input_tokens: c.usage.cache_creation_input_tokens,
                 // Note: the model can actually use less than that, but best we can do is report
                 // the full budget.
                 reasoning_tokens: thinking_budget,

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -88,6 +88,10 @@ pub struct LLMTokenUsage {
     pub cached_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_tokens: Option<u64>,
+    // TODO(cache-writes): When ready to report cache writes separately, add the field below
+    // and plumb it from providers (e.g., Anthropic). Keep commented until the rollout step.
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub cache_creation_input_tokens: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -451,16 +451,18 @@ const DEFAULT_PRICING = MODEL_PRICING[DEFAULT_PRICING_MODEL_ID];
 function calculateTokenUsageCostForUsage(usage: RunUsageType): number {
   const pricing = MODEL_PRICING[usage.modelId] ?? DEFAULT_PRICING;
 
-  const cachedTokens = usage.cachedTokens ?? 0;
-  const uncachedPromptTokens = Math.max(usage.promptTokens - cachedTokens, 0);
+  const cachedReadTokens = usage.cachedTokens ?? 0;
+  const cacheWriteTokens = usage.cacheCreationTokens ?? 0;
 
-  const cachedInputRate = pricing.cache_read_input_tokens ?? pricing.input;
+  const cachedReadRate = pricing.cache_read_input_tokens ?? pricing.input;
+  const cacheWriteRate = pricing.cache_creation_input_tokens ?? pricing.input;
 
-  return (
-    (uncachedPromptTokens / 1_000_000) * pricing.input +
-    (cachedTokens / 1_000_000) * cachedInputRate +
-    (usage.completionTokens / 1_000_000) * pricing.output
-  );
+  const inputCost = (usage.promptTokens / 1_000_000) * pricing.input;
+  const cachedReadCost = (cachedReadTokens / 1_000_000) * cachedReadRate;
+  const cacheWriteCost = (cacheWriteTokens / 1_000_000) * cacheWriteRate;
+  const outputCost = (usage.completionTokens / 1_000_000) * pricing.output;
+
+  return inputCost + cachedReadCost + cacheWriteCost + outputCost;
 }
 
 export function calculateTokenUsageCost(usages: RunUsageType[]): number {

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -256,11 +256,25 @@ export class RunResource extends BaseResource<RunModel> {
 
   async recordRunUsage(usages: RunUsageType[]) {
     await RunUsageModel.bulkCreate(
-      usages.map((usage) => ({
-        runId: this.id,
-        workspaceId: this.workspaceId,
-        ...usage,
-      }))
+      usages.map(
+        ({
+          providerId,
+          modelId,
+          promptTokens,
+          completionTokens,
+          cachedTokens,
+          cacheCreationTokens,
+        }) => ({
+          runId: this.id,
+          workspaceId: this.workspaceId,
+          providerId,
+          modelId,
+          promptTokens,
+          completionTokens,
+          cachedTokens,
+          cacheCreationTokens: cacheCreationTokens ?? null,
+        })
+      )
     );
   }
 
@@ -278,6 +292,7 @@ export class RunResource extends BaseResource<RunModel> {
       promptTokens: usage.promptTokens,
       providerId: usage.providerId as ModelProviderIdType,
       cachedTokens: usage.cachedTokens,
+      cacheCreationTokens: usage.cacheCreationTokens,
     }));
   }
 }
@@ -297,4 +312,6 @@ export interface RunUsageType {
   promptTokens: number;
   providerId: ModelProviderIdType;
   cachedTokens: number | null;
+  // Optional: tokens spent writing to cache (e.g., Anthropic cache creation)
+  cacheCreationTokens?: number | null;
 }

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -71,6 +71,7 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
   declare promptTokens: number;
   declare completionTokens: number;
   declare cachedTokens: number | null;
+  declare cacheCreationTokens: number | null;
 }
 
 RunUsageModel.init(
@@ -92,6 +93,11 @@ RunUsageModel.init(
       allowNull: false,
     },
     cachedTokens: {
+      type: DataTypes.INTEGER,
+      defaultValue: null,
+      allowNull: true,
+    },
+    cacheCreationTokens: {
       type: DataTypes.INTEGER,
       defaultValue: null,
       allowNull: true,

--- a/front/migrations/db/migration_399.sql
+++ b/front/migrations/db/migration_399.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."run_usages" ADD COLUMN "cacheCreationTokens" INTEGER DEFAULT NULL;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -64,6 +64,7 @@ function extractUsageFromExecutions(
             prompt_tokens: number;
             completion_tokens: number;
             cached_tokens?: number;
+            cache_creation_input_tokens?: number;
             reasoning_tokens?: number;
           };
         };
@@ -71,6 +72,7 @@ function extractUsageFromExecutions(
           const promptTokens = token_usage.prompt_tokens;
           const completionTokens = token_usage.completion_tokens;
           const cachedTokens = token_usage.cached_tokens;
+          const cacheCreationTokens = token_usage.cache_creation_input_tokens;
 
           usages.push({
             providerId: block.provider_id,
@@ -78,6 +80,7 @@ function extractUsageFromExecutions(
             promptTokens,
             completionTokens,
             cachedTokens: cachedTokens ?? null,
+            cacheCreationTokens: cacheCreationTokens ?? null,
           });
         }
       }


### PR DESCRIPTION
## Description

Step 1 out of 2 to properly track cache writes.

This essentially pretends that they exist from `front` standpoint: speculatively extract the value from traces, include it in the cost computation, persist it in DB.

Step 2 will be to update anthropic impl in `core` to start separating cache writes from regular input tokens.

## Tests

Local

## Risk

Migration + analytics / cost blast radius

## Deploy Plan
Apply migration, then deploy front