### PR TITLE
[front] hootl: better generation for webhook filters

### DIFF
--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
@@ -84,6 +84,10 @@ export function ScheduleEditionScheduler({
 
   const triggerCronGeneration = useDebounceWithAbort(
     async (txt: string, signal: AbortSignal) => {
+      if (txt.length < MIN_DESCRIPTION_LENGTH) {
+        return;
+      }
+
       setValue("schedule.cron", "");
       const result = await textAsCronRule(txt, signal);
 
@@ -101,7 +105,7 @@ export function ScheduleEditionScheduler({
         }
       }
     },
-    { delay: 500, minLength: MIN_DESCRIPTION_LENGTH }
+    { delay: 500 }
   );
 
   const cronDescription = useMemo(() => {

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
@@ -105,7 +105,7 @@ export function ScheduleEditionScheduler({
         }
       }
     },
-    { delay: 500 }
+    { delayMs: 500 }
   );
 
   const cronDescription = useMemo(() => {

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
@@ -94,7 +94,7 @@ export function WebhookEditionFilters({
         }
       }
     },
-    { delay: 500 }
+    { delayMs: 500 }
   );
 
   // Update form field when naturalDescription changes

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
@@ -21,6 +21,8 @@ interface WebhookEditionFiltersProps {
   workspace: LightWorkspaceType;
 }
 
+const MIN_DESCRIPTION_LENGTH = 10;
+
 export function WebhookEditionFilters({
   isEditor,
   webhookSourceView,
@@ -62,11 +64,9 @@ export function WebhookEditionFilters({
 
   const generateFilter = useWebhookFilterGenerator({ workspace });
 
-  const MIN_DESCRIPTION_LENGTH = 10;
-
   const triggerFilterGeneration = useDebounceWithAbort(
     async (txt: string, signal: AbortSignal) => {
-      if (!selectedEventSchema) {
+      if (txt.length < MIN_DESCRIPTION_LENGTH || !selectedEventSchema) {
         setFilterGenerationStatus("idle");
         return;
       }
@@ -94,7 +94,7 @@ export function WebhookEditionFilters({
         }
       }
     },
-    { delay: 500, minLength: MIN_DESCRIPTION_LENGTH }
+    { delay: 500 }
   );
 
   // Update form field when naturalDescription changes

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
@@ -1,5 +1,5 @@
 import { Label, Spinner, TextArea } from "@dust-tt/sparkle";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { useController, useFormContext, useWatch } from "react-hook-form";
 
 import { TriggerFilterRenderer } from "@app/components/agent_builder/triggers/TriggerFilterRenderer";

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -57,3 +57,98 @@ export function useDebounce(
     cancel: debouncedUpdate.cancel,
   };
 }
+
+interface UseDebounceWithAbortOptions {
+  delay?: number;
+  minLength?: number;
+}
+
+/**
+ * Hook that debounces an async function call with AbortController support.
+ * Useful for API calls that should be cancelled when a new request is made.
+ *
+ * @param asyncFn - The async function to debounce. It receives the value and an AbortSignal.
+ * @param options - Configuration options (delay, minLength)
+ * @returns A trigger function that accepts a value and triggers the debounced async call
+ *
+ * @example
+ * const generateFilter = useWebhookFilterGenerator({ workspace });
+ * const trigger = useDebounceWithAbort(
+ *   async (description: string, signal: AbortSignal) => {
+ *     const result = await generateFilter({
+ *       naturalDescription: description,
+ *       eventSchema: selectedEventSchema,
+ *       signal,
+ *     });
+ *     // Update state with result
+ *   },
+ *   { delay: 500, minLength: 10 }
+ * );
+ *
+ * // Later, in an onChange handler:
+ * trigger(e.target.value);
+ */
+export function useDebounceWithAbort<T = string>(
+  asyncFn: (value: T, signal: AbortSignal) => Promise<void>,
+  options: UseDebounceWithAbortOptions = {}
+) {
+  const { delay = 500, minLength = 0 } = options;
+
+  const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const trigger = useCallback(
+    (value: T) => {
+      // Clear existing debounce timeout
+      if (debounceHandle.current) {
+        clearTimeout(debounceHandle.current);
+        debounceHandle.current = undefined;
+      }
+
+      // Check minimum length for string values
+      const shouldSkip =
+        minLength > 0 &&
+        typeof value === "string" &&
+        value.trim().length < minLength;
+
+      if (shouldSkip) {
+        // Cancel any pending request
+        if (abortControllerRef.current) {
+          abortControllerRef.current.abort();
+          abortControllerRef.current = null;
+        }
+        return;
+      }
+
+      // Debounce the async call
+      debounceHandle.current = setTimeout(() => {
+        // Cancel previous request
+        if (abortControllerRef.current) {
+          abortControllerRef.current.abort();
+        }
+
+        // Create new abort controller
+        abortControllerRef.current = new AbortController();
+        const signal = abortControllerRef.current.signal;
+
+        // Execute async function
+        void asyncFn(value, signal);
+      }, delay);
+    },
+    [asyncFn, delay, minLength]
+  );
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceHandle.current) {
+        clearTimeout(debounceHandle.current);
+      }
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, []);
+
+  return trigger;
+}

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -59,7 +59,7 @@ export function useDebounce(
 }
 
 interface UseDebounceWithAbortOptions {
-  delay?: number;
+  delayMs?: number;
 }
 
 /**
@@ -92,7 +92,7 @@ export function useDebounceWithAbort<T = string>(
   asyncFn: (value: T, signal: AbortSignal) => Promise<void>,
   options: UseDebounceWithAbortOptions = {}
 ) {
-  const { delay = 500 } = options;
+  const { delayMs = 500 } = options;
 
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -118,9 +118,9 @@ export function useDebounceWithAbort<T = string>(
 
         // Execute async function
         void asyncFn(value, signal);
-      }, delay);
+      }, delayMs);
     },
-    [asyncFn, delay]
+    [asyncFn, delayMs]
   );
 
   // Cleanup on unmount

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -285,7 +285,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "XNcJCE7lUj",
       appHash:
-        "9fa1ef11941288335a3cfcdcef9b4c811464ba3dddd8d72e2c0ca7922f7a0e93",
+        "2b6d050561b51820a4901a8379df9513136900af7f39ede287a03c9120a453e3",
     },
     config: {
       CREATE_FILTER: {

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -112,9 +112,11 @@ export function useWebhookFilterGenerator({
     async ({
       naturalDescription,
       eventSchema,
+      signal,
     }: {
       naturalDescription: string;
       eventSchema: Record<string, any>;
+      signal?: AbortSignal;
     }): Promise<{ filter: string }> => {
       const r = await fetcher(
         `/api/w/${workspace.sId}/assistant/agent_configurations/webhook_filter_generator`,
@@ -124,6 +126,7 @@ export function useWebhookFilterGenerator({
             naturalDescription,
             eventSchema,
           }),
+          signal,
         }
       );
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR adds the same debounce behaviour we do for schedules for the webhook generation
This also bumps the dust app version, prompt was edited

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, way better results

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Sync dust apps in EU
Deploy