### PR TITLE
[front] enh(webhooks): improve copy, add default name

### DIFF
--- a/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
@@ -5,6 +5,7 @@ import type {
   AgentBuilderWebhookTriggerType,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { UserTypeWithWorkspaces } from "@app/types";
+import { asDisplayName } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 export const WebhookFormSchema = z.object({
@@ -31,7 +32,11 @@ export function getWebhookFormDefaultValues({
   webhookSourceView: WebhookSourceViewType | null;
 }): WebhookFormValues {
   return {
-    name: trigger?.name ?? "Webhook Trigger",
+    name:
+      trigger?.name ??
+      (webhookSourceView
+        ? `${webhookSourceView.webhookSource.name} trigger (${asDisplayName(webhookSourceView.provider)})`
+        : "Webhook Trigger"),
     enabled: trigger?.enabled ?? true,
     customPrompt: trigger?.customPrompt ?? "",
     webhookSourceViewSId: webhookSourceView?.sId ?? "",

--- a/front/components/triggers/AddTriggerMenu.tsx
+++ b/front/components/triggers/AddTriggerMenu.tsx
@@ -49,7 +49,7 @@ export const AddTriggerMenu = ({
           .map(([provider, preset]) => (
             <DropdownMenuItem
               key={`trigger-${provider}`}
-              label={preset.name + " Webhook"}
+              label={preset.name + " Trigger"}
               icon={getIcon(preset.icon)}
               onClick={() =>
                 isWebhookProvider(provider) && createWebhook(provider)

--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -80,13 +80,13 @@ export function CreateWebhookSourceFormContent({
       <Controller
         control={form.control}
         name="name"
-        render={({ field }) => (
+        render={({ field, fieldState }) => (
           <Input
             {...field}
             label="Name"
             placeholder="Name..."
-            isError={form.formState.errors.name !== undefined}
-            message={form.formState.errors.name?.message}
+            isError={fieldState.error !== undefined}
+            message={fieldState.error?.message}
             messageStatus="error"
             autoFocus
           />

--- a/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceWithProviderForm.tsx
@@ -42,7 +42,6 @@ export function CreateWebhookSourceWithProviderForm({
   const [isExtraConfigValid, setIsExtraConfigValid] = useState(false);
 
   const preset = WEBHOOK_PRESETS[provider];
-  const kindName = preset.name;
   const OAuthExtraConfigInput = preset.components.oauthExtraConfigInput;
 
   const handleConnectToProvider = async () => {
@@ -63,21 +62,21 @@ export function CreateWebhookSourceWithProviderForm({
       if (connectionRes.isErr()) {
         sendNotification({
           type: "error",
-          title: `Failed to connect to ${kindName}`,
+          title: `Failed to connect to ${preset.name}`,
           description: connectionRes.error.message,
         });
       } else {
         setConnection(connectionRes.value);
         sendNotification({
           type: "success",
-          title: `Connected to ${kindName}`,
+          title: `Connected to ${preset.name}`,
           description: "Fetching additional data for configuration...",
         });
       }
     } catch (error) {
       sendNotification({
         type: "error",
-        title: `Failed to connect to ${kindName}`,
+        title: `Failed to connect to ${preset.name}`,
         description: normalizeError(error).message,
       });
     } finally {
@@ -94,9 +93,9 @@ export function CreateWebhookSourceWithProviderForm({
   return (
     <div className="flex flex-col space-y-4">
       <div>
-        <Label>{kindName} Connection</Label>
+        <Label>{preset.name} Connection</Label>
         <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {kindName} connection is required
+          {preset.name} connection is required
         </p>
         {OAuthExtraConfigInput && (
           <div className="mt-4">

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -189,7 +189,7 @@ function WebhookSourceSheetContent({
   // Create form
   const createFormDefaultValues = useMemo<CreateWebhookSourceFormData>(
     () => ({
-      name: "",
+      name: `${mode.provider} Trigger`,
       secret: "",
       autoGenerate: true,
       signatureHeader: "",

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -550,7 +550,7 @@ function WebhookSourceSheetContent({
     () => [
       {
         id: "create",
-        title: `New ${mode.provider ? WEBHOOK_PRESETS[mode.provider].name : "Custom"} Webhook`,
+        title: `New ${mode.provider ? WEBHOOK_PRESETS[mode.provider].name : "Custom"} Trigger`,
         description: "",
         icon: getIcon(
           normalizeWebhookIcon(

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -45,6 +45,7 @@ import {
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { LightWorkspaceType, RequireAtLeastOne } from "@app/types";
+import { asDisplayName } from "@app/types";
 import type {
   WebhookProvider,
   WebhookSourceWithSystemViewType,
@@ -189,7 +190,7 @@ function WebhookSourceSheetContent({
   // Create form
   const createFormDefaultValues = useMemo<CreateWebhookSourceFormData>(
     () => ({
-      name: `${mode.provider} Trigger`,
+      name: `${asDisplayName(mode.provider)} Trigger`,
       secret: "",
       autoGenerate: true,
       signatureHeader: "",


### PR DESCRIPTION
## Description

- This PR improves the copy (webhook -> trigger) on various webhook source related pages and add a default name when creating a new webhook source.
- This PR also fixes the display for a few error states on the creation of a webhook source.

<img width="421" height="609" alt="Screenshot 2025-10-31 at 4 23 57 PM" src="https://github.com/user-attachments/assets/d5ea9f53-b70f-4da1-a636-1de9796784eb" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
