### PR TITLE
Filter Teams messages on date

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/utils.ts
@@ -6,6 +6,69 @@ import { XMLParser, XMLValidator } from "fast-xml-parser";
 
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+// Microsoft Teams Message Types
+
+export interface TeamsUser {
+  id: string;
+  displayName: string;
+  userIdentityType: string;
+}
+
+export interface TeamsIdentitySet {
+  application: unknown | null;
+  device: unknown | null;
+  user: TeamsUser | null;
+}
+
+export interface TeamsMessageBody {
+  contentType: "html" | "text";
+  content: string;
+}
+
+export interface TeamsChannelIdentity {
+  teamId: string;
+  channelId: string;
+}
+
+export interface TeamsMentionedIdentity {
+  application: unknown | null;
+  device: unknown | null;
+  conversation: unknown | null;
+  user: TeamsUser | null;
+}
+
+export interface TeamsMention {
+  id: number;
+  mentionText: string;
+  mentioned: TeamsMentionedIdentity;
+}
+
+export interface TeamsMessage {
+  id: string;
+  replyToId: string | null;
+  etag: string;
+  messageType: string;
+  createdDateTime: string;
+  lastModifiedDateTime: string;
+  lastEditedDateTime: string | null;
+  deletedDateTime: string | null;
+  subject: string | null;
+  summary: string | null;
+  chatId: string | null;
+  importance: string;
+  locale: string;
+  webUrl: string;
+  policyViolation: unknown | null;
+  eventDetail: unknown | null;
+  from: TeamsIdentitySet;
+  body: TeamsMessageBody;
+  channelIdentity: TeamsChannelIdentity | null;
+  attachments: unknown[];
+  mentions: TeamsMention[];
+  reactions: unknown[];
+  messageHistory: unknown[];
+}
+
 export async function getGraphClient(
   authInfo?: AuthInfo
 ): Promise<Client | null> {


### PR DESCRIPTION
## Description

This PR adds date-based filtering and full pagination support to the `list_messages` tool in the Microsoft Teams MCP server. Previously, the tool was limited to 50 messages maximum. Now it can retrieve up to 200 messages and supports filtering by date range using fromDate and toDate parameters (ISO 8601 format). The implementation follows pagination links from the Graph API and stops when messages fall outside the requested date range or the 200-message limit is reached. This addresses issues where users needed to retrieve recent messages from specific time periods.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
