### PR TITLE
[front] - feat(Obs): Time/Version switch

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.18",
-        "@dust-tt/sparkle": "^0.3.23",
+        "@dust-tt/sparkle": "^0.3.24",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1287,10 +1287,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.23.tgz",
-      "integrity": "sha512-Ssco+CvLhvwH+TUTNKo2l6mQzcv3XaapeXZ3FmAQaYrqw41bsICklR51g9Z/3DEsN3JCN7Ky3rHcrDMWzj3LGA==",
-      "license": "ISC",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.24.tgz",
+      "integrity": "sha512-J7mLPH3rfe4gE6PlIPkLtTU0Kmqa4nhFUMYndgz0qAMEaAbmAr4KEZz26YQUtN5DxF3r4yPadC1ZCRGYWWR3mw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.18",
-    "@dust-tt/sparkle": "^0.3.23",
+    "@dust-tt/sparkle": "^0.3.24",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -13,7 +13,6 @@ import { useEffect } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { FeedbackDistributionChart } from "@app/components/agent_builder/observability/charts/FeedbackDistributionChart";
-import { ToolLatencyChart } from "@app/components/agent_builder/observability/charts/ToolLatencyChart";
 import { ToolUsageChart } from "@app/components/agent_builder/observability/charts/ToolUsageChart";
 import { UsageMetricsChart } from "@app/components/agent_builder/observability/charts/UsageMetricsChart";
 import {
@@ -72,7 +71,6 @@ export function AgentBuilderObservability({
               <ChartContainerSkeleton />
               <ChartContainerSkeleton />
               <ChartContainerSkeleton />
-              <ChartContainerSkeleton />
             </>
           ) : (
             <>
@@ -85,10 +83,6 @@ export function AgentBuilderObservability({
                 agentConfigurationId={agentConfiguration.sId}
               />
               <ToolUsageChart
-                workspaceId={owner.sId}
-                agentConfigurationId={agentConfiguration.sId}
-              />
-              <ToolLatencyChart
                 workspaceId={owner.sId}
                 agentConfigurationId={agentConfiguration.sId}
               />

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -122,9 +122,10 @@ function HeaderGlobalSelector({
     if (
       mode === "version" &&
       !selectedVersion &&
-      (versionMarkers?.length ?? 0) > 0
+      versionMarkers &&
+      versionMarkers.length > 0
     ) {
-      const latest = versionMarkers![versionMarkers!.length - 1];
+      const latest = versionMarkers[versionMarkers.length - 1];
       setSelectedVersion(latest.version);
     }
   }, [mode, selectedVersion, versionMarkers, setSelectedVersion]);

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -1,13 +1,15 @@
 import {
   Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
   cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Label,
   LoadingBlock,
 } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { FeedbackDistributionChart } from "@app/components/agent_builder/observability/charts/FeedbackDistributionChart";
@@ -22,7 +24,10 @@ import {
   ObservabilityProvider,
   useObservability,
 } from "@app/components/agent_builder/observability/ObservabilityContext";
-import { useAgentConfiguration } from "@app/lib/swr/assistants";
+import {
+  useAgentConfiguration,
+  useAgentVersionMarkers,
+} from "@app/lib/swr/assistants";
 
 interface AgentBuilderObservabilityProps {
   agentConfigurationSId: string;
@@ -55,7 +60,10 @@ export function AgentBuilderObservability({
               Monitor key metrics and performance indicators for your agent.
             </span>
           </div>
-          <HeaderPeriodDropdown />
+          <HeaderGlobalSelector
+            workspaceId={owner.sId}
+            agentConfigurationId={agentConfiguration.sId}
+          />
         </div>
 
         <div className="grid grid-cols-1 gap-6">
@@ -92,25 +100,98 @@ export function AgentBuilderObservability({
   );
 }
 
-function HeaderPeriodDropdown() {
-  const { period, setPeriod } = useObservability();
+function HeaderGlobalSelector({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}) {
+  const {
+    mode,
+    setMode,
+    period,
+    setPeriod,
+    selectedVersion,
+    setSelectedVersion,
+  } = useObservability();
+
+  const { versionMarkers, isVersionMarkersLoading } = useAgentVersionMarkers({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    disabled: false,
+  });
+
+  // Default to latest version when entering version mode with available markers
+  useEffect(() => {
+    if (
+      mode === "version" &&
+      !selectedVersion &&
+      (versionMarkers?.length ?? 0) > 0
+    ) {
+      const latest = versionMarkers![versionMarkers!.length - 1];
+      setSelectedVersion(latest.version);
+    }
+  }, [mode, selectedVersion, versionMarkers, setSelectedVersion]);
+
   return (
-    <div className="flex items-center gap-2 pr-2">
-      <Label>Period:</Label>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button label={`${period}d`} size="xs" variant="outline" isSelect />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          {OBSERVABILITY_TIME_RANGE.map((p) => (
-            <DropdownMenuItem
-              key={p}
-              label={`${p}d`}
-              onClick={() => setPeriod(p)}
+    <div className="flex items-center gap-3 pr-2">
+      <ButtonsSwitchList defaultValue={mode} size="xs">
+        <ButtonsSwitch
+          value="timeRange"
+          label="Time range"
+          onClick={() => setMode("timeRange")}
+        />
+        <ButtonsSwitch
+          value="version"
+          label="Version"
+          onClick={() => setMode("version")}
+        />
+      </ButtonsSwitchList>
+
+      {mode === "timeRange" ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button label={`${period}d`} size="xs" variant="outline" isSelect />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {OBSERVABILITY_TIME_RANGE.map((p) => (
+              <DropdownMenuItem
+                key={p}
+                label={`${p}d`}
+                onClick={() => setPeriod(p)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              label={
+                selectedVersion
+                  ? `v${selectedVersion}`
+                  : isVersionMarkersLoading
+                    ? "Loading"
+                    : "Select"
+              }
+              size="xs"
+              variant="outline"
+              isSelect
             />
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {(versionMarkers ?? []).map((m) => (
+              <DropdownMenuItem
+                key={m.version}
+                label={`v${m.version}`}
+                onClick={() => setSelectedVersion(m.version)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   );
 }

--- a/front/components/agent_builder/observability/ObservabilityContext.tsx
+++ b/front/components/agent_builder/observability/ObservabilityContext.tsx
@@ -6,13 +6,10 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 export type ObservabilityMode = "timeRange" | "version";
 
 type ObservabilityContextValue = {
-  // Global mode selector
   mode: ObservabilityMode;
   setMode: (m: ObservabilityMode) => void;
-  // Time-range selection (used when mode = timeRange)
   period: ObservabilityTimeRangeType;
   setPeriod: (p: ObservabilityTimeRangeType) => void;
-  // Version selection (used when mode = version)
   selectedVersion: string | null;
   setSelectedVersion: (v: string | null) => void;
 };

--- a/front/components/agent_builder/observability/ObservabilityContext.tsx
+++ b/front/components/agent_builder/observability/ObservabilityContext.tsx
@@ -3,9 +3,18 @@ import { createContext, useContext, useState } from "react";
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 
+export type ObservabilityMode = "timeRange" | "version";
+
 type ObservabilityContextValue = {
+  // Global mode selector
+  mode: ObservabilityMode;
+  setMode: (m: ObservabilityMode) => void;
+  // Time-range selection (used when mode = timeRange)
   period: ObservabilityTimeRangeType;
   setPeriod: (p: ObservabilityTimeRangeType) => void;
+  // Version selection (used when mode = version)
+  selectedVersion: string | null;
+  setSelectedVersion: (v: string | null) => void;
 };
 
 const ObservabilityContext = createContext<ObservabilityContextValue | null>(
@@ -17,11 +26,22 @@ export function ObservabilityProvider({
 }: {
   children: React.ReactNode;
 }) {
+  const [mode, setMode] = useState<ObservabilityMode>("timeRange");
   const [period, setPeriod] =
     useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
+  const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
 
   return (
-    <ObservabilityContext.Provider value={{ period, setPeriod }}>
+    <ObservabilityContext.Provider
+      value={{
+        mode,
+        setMode,
+        period,
+        setPeriod,
+        selectedVersion,
+        setSelectedVersion,
+      }}
+    >
       {children}
     </ObservabilityContext.Provider>
   );

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -62,7 +62,7 @@ export function FeedbackDistributionChart({
 
   return (
     <ChartContainer
-      title="Feedback trends"
+      title="Feedback Trends"
       isLoading={isFeedbackDistributionLoading}
       errorMessage={
         isFeedbackDistributionError

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -3,11 +3,11 @@ import {
   CartesianGrid,
   Line,
   LineChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
-  ReferenceLine,
 } from "recharts";
 
 import { FeedbackDistributionTooltip } from "@app/components/agent_builder/observability/charts/ChartsTooltip";
@@ -19,8 +19,10 @@ import {
 import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
-import { useAgentFeedbackDistribution } from "@app/lib/swr/assistants";
-import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
+import {
+  useAgentFeedbackDistribution,
+  useAgentVersionMarkers,
+} from "@app/lib/swr/assistants";
 
 interface FeedbackDistributionChartProps {
   workspaceId: string;

--- a/front/components/agent_builder/observability/charts/ToolLatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolLatencyChart.tsx
@@ -7,6 +7,7 @@ import {
   Tooltip,
   XAxis,
   YAxis,
+  ReferenceLine,
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
@@ -67,7 +68,7 @@ export function ToolLatencyChart({
   workspaceId,
   agentConfigurationId,
 }: ToolLatencyChartProps) {
-  const { period } = useObservability();
+  const { period, mode, selectedVersion } = useObservability();
   const [selectedTool, setSelectedTool] = useState<string | null>(null);
 
   const { toolLatencyByVersion, isToolLatencyLoading, isToolLatencyError } =
@@ -217,6 +218,15 @@ export function ToolLatencyChart({
               boxShadow: "none",
             }}
           />
+          {mode === "version" && selectedVersion && (
+            <ReferenceLine
+              x={`v${selectedVersion}`}
+              stroke="hsl(var(--primary))"
+              strokeDasharray="5 5"
+              strokeWidth={2}
+              ifOverflow="extendDomain"
+            />
+          )}
           <Area
             type="natural"
             dataKey="avg"

--- a/front/components/agent_builder/observability/charts/ToolLatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolLatencyChart.tsx
@@ -3,11 +3,11 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
-  ReferenceLine,
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -15,6 +15,7 @@ import {
   Tooltip,
   XAxis,
   YAxis,
+  ReferenceLine,
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
@@ -39,8 +40,8 @@ export function ToolUsageChart({
   workspaceId: string;
   agentConfigurationId: string;
 }) {
-  const { period } = useObservability();
-  const [mode, setMode] = useState<ToolChartModeType>("version");
+  const { period, mode, selectedVersion } = useObservability();
+  const [toolMode, setToolMode] = useState<ToolChartModeType>("version");
 
   const {
     chartData,
@@ -50,7 +51,16 @@ export function ToolUsageChart({
     legendDescription,
     isLoading,
     errorMessage,
-  } = useToolUsageData({ workspaceId, agentConfigurationId, period, mode });
+  } = useToolUsageData({
+    workspaceId,
+    agentConfigurationId,
+    period,
+    mode: toolMode,
+    filterVersion:
+      mode === "version" && toolMode === "version"
+        ? selectedVersion
+        : undefined,
+  });
 
   const legendItems = useMemo(
     () =>
@@ -64,9 +74,9 @@ export function ToolUsageChart({
 
   const renderToolUsageTooltip = useCallback(
     (payload: TooltipContentProps<number, string>) => (
-      <ChartsTooltip {...payload} mode={mode} topTools={topTools} />
+      <ChartsTooltip {...payload} mode={toolMode} topTools={topTools} />
     ),
-    [mode, topTools]
+    [toolMode, topTools]
   );
 
   return (
@@ -82,14 +92,14 @@ export function ToolUsageChart({
               size="xs"
               variant="outline"
               isSelect
-              label={mode === "version" ? "Version" : "Step"}
+              label={toolMode === "version" ? "Version" : "Step"}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuRadioGroup
-              value={mode}
+              value={toolMode}
               onValueChange={(value) =>
-                isToolChartMode(value) && setMode(value)
+                isToolChartMode(value) && setToolMode(value)
               }
             >
               <DropdownMenuRadioItem value="version">
@@ -146,6 +156,18 @@ export function ToolUsageChart({
               boxShadow: "none",
             }}
           />
+          {mode === "version" &&
+            toolMode === "version" &&
+            selectedVersion &&
+            chartData.length > 0 && (
+              <ReferenceLine
+                x={`v${selectedVersion}`}
+                stroke="hsl(var(--primary))"
+                strokeDasharray="5 5"
+                strokeWidth={2}
+                ifOverflow="extendDomain"
+              />
+            )}
           {topTools.map((toolName) => (
             <Bar
               key={toolName}

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -11,11 +11,11 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
-  ReferenceLine,
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -3,11 +3,11 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
-  ReferenceLine,
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
@@ -20,8 +20,10 @@ import { useObservability } from "@app/components/agent_builder/observability/Ob
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
-import { useAgentUsageMetrics } from "@app/lib/swr/assistants";
-import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
+import {
+  useAgentUsageMetrics,
+  useAgentVersionMarkers,
+} from "@app/lib/swr/assistants";
 
 interface UsageMetricsData {
   messages: number;

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -7,6 +7,7 @@ import {
   Tooltip,
   XAxis,
   YAxis,
+  ReferenceLine,
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
@@ -20,6 +21,7 @@ import { ChartContainer } from "@app/components/agent_builder/observability/shar
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { useAgentUsageMetrics } from "@app/lib/swr/assistants";
+import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
 
 interface UsageMetricsData {
   messages: number;
@@ -81,7 +83,7 @@ export function UsageMetricsChart({
   workspaceId: string;
   agentConfigurationId: string;
 }) {
-  const { period } = useObservability();
+  const { period, mode, selectedVersion } = useObservability();
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     useAgentUsageMetrics({
       workspaceId,
@@ -90,6 +92,12 @@ export function UsageMetricsChart({
       interval: "day",
       disabled: !workspaceId || !agentConfigurationId,
     });
+  const { versionMarkers } = useAgentVersionMarkers({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    disabled: !workspaceId || !agentConfigurationId,
+  });
 
   const legendItems = USAGE_METRICS_LEGEND.map(({ key, label }) => ({
     key,
@@ -182,6 +190,25 @@ export function UsageMetricsChart({
               boxShadow: "none",
             }}
           />
+          {(versionMarkers ?? []).map((m) => {
+            const isSelected =
+              mode === "version" && selectedVersion === m.version;
+            return (
+              <ReferenceLine
+                key={m.version}
+                x={m.timestamp}
+                stroke={"hsl(var(--primary))"}
+                strokeWidth={isSelected ? 3 : 1.5}
+                strokeDasharray="5 5"
+                label={{
+                  value: `v${m.version}`,
+                  position: "top",
+                  fill: "hsl(var(--muted-foreground))",
+                }}
+                ifOverflow="extendDomain"
+              />
+            );
+          })}
           {/* Areas for each usage metric */}
           <Area
             type="natural"

--- a/front/components/agent_builder/observability/hooks.ts
+++ b/front/components/agent_builder/observability/hooks.ts
@@ -163,8 +163,10 @@ export function useToolUsageData(params: {
   agentConfigurationId: string;
   period: number;
   mode: ToolChartModeType;
+  filterVersion?: string | null;
 }): ToolUsageResult {
-  const { workspaceId, agentConfigurationId, period, mode } = params;
+  const { workspaceId, agentConfigurationId, period, mode, filterVersion } =
+    params;
 
   const exec = useAgentToolExecution({
     workspaceId,
@@ -182,7 +184,11 @@ export function useToolUsageData(params: {
   switch (mode) {
     case "version": {
       const rawData = exec.toolExecutionByVersion ?? [];
-      const normalizedData = normalizeVersionData(rawData);
+      let normalizedData = normalizeVersionData(rawData);
+      if (filterVersion) {
+        const vv = `v${filterVersion}`;
+        normalizedData = normalizedData.filter((d) => d.label === vv);
+      }
       const isLoading = exec.isToolExecutionLoading;
       const errorMessage = exec.isToolExecutionError
         ? "Failed to load tool execution data."
@@ -191,7 +197,9 @@ export function useToolUsageData(params: {
       return processToolUsageData(
         normalizedData,
         "Version",
-        "No tool execution data available for this period.",
+        filterVersion
+          ? "No tool execution data for the selected version."
+          : "No tool execution data available for this period.",
         `Shows the relative usage frequency (%) of the top ${MAX_TOOLS_DISPLAYED} tools for each agent version.`,
         isLoading,
         errorMessage

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/sdk": "^0.67.1",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.3.23",
+        "@dust-tt/sparkle": "^0.3.24",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1185,10 +1185,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.23.tgz",
-      "integrity": "sha512-Ssco+CvLhvwH+TUTNKo2l6mQzcv3XaapeXZ3FmAQaYrqw41bsICklR51g9Z/3DEsN3JCN7Ky3rHcrDMWzj3LGA==",
-      "license": "ISC",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.3.24.tgz",
+      "integrity": "sha512-J7mLPH3rfe4gE6PlIPkLtTU0Kmqa4nhFUMYndgz0qAMEaAbmAr4KEZz26YQUtN5DxF3r4yPadC1ZCRGYWWR3mw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -31,7 +31,7 @@
     "@anthropic-ai/sdk": "^0.67.1",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.3.23",
+    "@dust-tt/sparkle": "^0.3.24",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

This PR introduces a global observability mode selector in the agent builder that allows switching between two viewing modes: time range and version. In time range mode, users can filter observability data by time periods (7d, 14d, 30d), while in version mode, users can select specific agent versions to analyze.

## Risk

Low - behind FF

## Tests

- [x] Locally
- [ ] Front edge

## Deploy Plan

Deploy front
