### PR TITLE
Log only if agents found

### DIFF
--- a/front/scripts/update_agent_models.ts
+++ b/front/scripts/update_agent_models.ts
@@ -24,11 +24,13 @@ async function updateWorkspaceAssistants(
     where: whereClause,
   });
 
-  console.log(
-    `Found ${agentConfigurations.length} ${
-      onlyActive ? "active " : ""
-    }agent configurations with model ${fromModel} in workspace ${workspaceId}`
-  );
+  if (agentConfigurations.length !== 0) {
+    console.log(
+      `Found ${agentConfigurations.length} ${
+        onlyActive ? "active " : ""
+      }agent configurations with model ${fromModel} in workspace ${workspaceId}`
+    );
+  }
 
   const excluded = new Set(excludeAgentsIds);
 


### PR DESCRIPTION
## Description

Reduces logging noise in the update_agent_models.ts script by only logging when agent configurations are found. Previously, the script would log for every workspace even when no agents matched the criteria, which created unnecessary output.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
