### PR TITLE
[llm-router] Use makeScript to create the script running LLMs tests

### DIFF
--- a/front/scripts/test_llm_clients.ts
+++ b/front/scripts/test_llm_clients.ts
@@ -270,6 +270,24 @@ const TEST_CONVERSATIONS: TestConversation[] = [
   },
 ];
 
+/**
+ * Runs a test for the LLM client.
+ *
+ * To run all the tests:
+ * ```bash
+ * npx tsx scripts/test_llm_clients.ts --execute
+ * ```
+ *
+ * To run a single test conversation for a single provider (for each model):
+ * ```bash
+ * npx tsx scripts/test_llm_clients.ts --conversationIds simple-math --providers openai --execute
+ * ```
+ *
+ * @param config The test configuration.
+ * @param conversation The conversation to test.
+ * @param execute Whether to execute the test.
+ * @returns A promise that resolves when the test is complete.
+ */
 async function runTest(
   config: TestConfig,
   conversation: TestConversation,


### PR DESCRIPTION
## Description

Use makeScript to build the test script.
Add param to filter run per provider.
For instance to test all anthropic models on only the simplest test:

```
npx tsx scripts/test_llm_clients.ts --conversationIds simple-math --providers openai --execute
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
