### PR TITLE
feat(llm): wrap LLM calls to get retryable errors

### DIFF
--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -116,17 +116,13 @@ export async function getBuilderNameSuggestions(
     return new Err(new Error("Model not found"));
   }
 
-  const res = llm.stream({
+  const events = llm.stream({
     conversation,
     prompt,
     specifications,
   });
 
-  if (res.isErr()) {
-    return new Err(new Error("No suggestions found"));
-  }
-
-  for await (const event of res.value) {
+  for await (const event of events) {
     if (event.type === "tool_call") {
       const parsedArguments = safeParseJSON(event.content.arguments);
       if (parsedArguments.isErr()) {

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -1,4 +1,4 @@
-import Anthropic from "@anthropic-ai/sdk";
+import Anthropic, { APIError } from "@anthropic-ai/sdk";
 import type { ThinkingConfigParam } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
 
 import type { AnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
@@ -8,7 +8,9 @@ import {
   toMessage,
   toTool,
 } from "@app/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic";
+import { handleError } from "@app/lib/api/llm/clients/anthropic/utils/errors";
 import { LLM } from "@app/lib/api/llm/llm";
+import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
@@ -68,21 +70,28 @@ export class AnthropicLLM extends LLM {
     prompt,
     specifications,
   }: StreamParameters): AsyncGenerator<LLMEvent> {
-    const messages = conversation.messages.map(toMessage);
+    try {
+      const messages = conversation.messages.map(toMessage);
 
-    const events = this.client.messages.stream({
-      model: this.modelId,
-      thinking: this.thinkingConfig,
-      system: prompt,
-      messages,
-      // Thinking isn’t compatible with temperature: `temperature` may only be set to 1 when thinking is enabled.
-      temperature: this.thinkingConfig ? 1 : this.temperature,
-      stream: true,
+      const events = this.client.messages.stream({
+        model: this.modelId,
+        thinking: this.thinkingConfig,
+        system: prompt,
+        messages,
+        // Thinking isn’t compatible with temperature: `temperature` may only be set to 1 when thinking is enabled.
+        temperature: this.thinkingConfig ? 1 : this.temperature,
+        stream: true,
+        tools: specifications.map(toTool),
+        max_tokens: this.modelConfig.generationTokensCount,
+      });
 
-      tools: specifications.map(toTool),
-      max_tokens: this.modelConfig.generationTokensCount,
-    });
-
-    yield* streamLLMEvents(events, this.metadata);
+      yield* streamLLMEvents(events, this.metadata);
+    } catch (err) {
+      if (err instanceof APIError) {
+        yield handleError(err, this.metadata);
+      } else {
+        yield handleGenericError(err, this.metadata);
+      }
+    }
   }
 }

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -211,8 +211,10 @@ function* handleStopReason(
       yield {
         type: "error",
         content: {
+          type: "stop_error",
           message: `Stop reason: ${stopReason}`,
-          code: 0,
+          isRetryable: false,
+          statusCode: 0,
         },
         metadata,
       };

--- a/front/lib/api/llm/clients/anthropic/utils/errors.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/errors.ts
@@ -1,0 +1,155 @@
+import type { APIError } from "@anthropic-ai/sdk";
+import { APIConnectionError } from "@anthropic-ai/sdk";
+
+import type { LLMErrorInfo } from "@app/lib/api/llm/types/errors";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { normalizeError } from "@app/types";
+
+// https://github.com/anthropics/anthropic-sdk-typescript#handling-errors
+export const handleError = (
+  err: APIError,
+  metadata: LLMClientMetadata
+): LLMEvent => {
+  return {
+    type: "error",
+    content: categorizeAnthropicError(err, metadata),
+    metadata,
+  };
+};
+
+// From BaseAnthropic.shouldRetry
+// The function is private so we can't reuse it.
+function shouldRetry(error: APIError) {
+  // Note this is not a standard header.
+  const shouldRetryHeader = error.headers?.get("x-should-retry");
+
+  if (shouldRetryHeader === "true") {
+    return true;
+  }
+  if (shouldRetryHeader === "false") {
+    return false;
+  }
+
+  if (!error.status) {
+    return false;
+  }
+
+  // Retry on request timeouts.
+  if (error.status === 408) {
+    return true;
+  }
+
+  // Retry on lock timeouts.
+  if (error.status === 409) {
+    return true;
+  }
+
+  // Retry on rate limits.
+  if (error.status === 429) {
+    return true;
+  }
+
+  // Retry internal errors.
+  return error.status >= 500;
+}
+
+// Yes, this is mainly duplicated between all providers. We know for sure each provider has a different error handling and http status code.
+// So we want to be able to tweak this by provider
+function categorizeAnthropicError(
+  error: APIError,
+  metadata: LLMClientMetadata
+): LLMErrorInfo {
+  const normalized = normalizeError(error);
+
+  const statusCode = error.status ?? 500;
+  const isRetryable = shouldRetry(error);
+
+  if (error instanceof APIConnectionError) {
+    return {
+      type: "network_error",
+      message: `Network error connecting to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 400) {
+    return {
+      type: "invalid_request_error",
+      message: `Invalid request to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 401) {
+    return {
+      type: "authentication_error",
+      message: `Authentication failed for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 403) {
+    return {
+      type: "permission_error",
+      message: `Permission denied for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 404) {
+    return {
+      type: "not_found_error",
+      message: `Resource not found for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 422) {
+    return {
+      type: "invalid_request_error",
+      message: `Invalid request to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 429) {
+    return {
+      type: "rate_limit_error",
+      message: `Rate limit exceeded for ${metadata.clientId}/${metadata.modelId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode >= 500 && statusCode < 600) {
+    return {
+      type: "server_error",
+      message: `Server error from ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  return {
+    type: "unknown_error",
+    message: `Unknown error from ${metadata.clientId}: ${normalized.message}`,
+    isRetryable,
+    statusCode,
+    originalError: error,
+  };
+}

--- a/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
@@ -1,0 +1,100 @@
+import {
+  AuthenticationError,
+  BadRequestError,
+  InternalServerError,
+  NotFoundError,
+  PermissionDeniedError,
+  RateLimitError,
+} from "@anthropic-ai/sdk";
+import { describe, expect, it } from "vitest";
+
+import { handleError } from "@app/lib/api/llm/clients/anthropic/utils/errors";
+import type { ErrorEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { CLAUDE_4_SONNET_20250514_MODEL_ID } from "@app/types";
+
+const metadata: LLMClientMetadata = {
+  clientId: "anthropic" as const,
+  modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+};
+
+function makeHeaders() {
+  return new Headers([["request-id", "req_123"]]);
+}
+
+describe("handleError (Anthropic)", () => {
+  it("maps RateLimitError (429)", () => {
+    const err = new RateLimitError(
+      429,
+      { message: "Too Many Requests" },
+      undefined,
+      makeHeaders()
+    );
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.type).toBe("error");
+    expect(event.metadata).toEqual(metadata);
+    expect(event.content.statusCode).toBe(429);
+    expect(event.content.message.toLowerCase()).toContain("rate limit");
+    expect(event.content.message).toContain("anthropic");
+  });
+
+  it("maps BadRequestError (400)", () => {
+    const err = new BadRequestError(
+      400,
+      { message: "Bad Request" },
+      undefined,
+      makeHeaders()
+    );
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(400);
+    expect(event.content.message.toLowerCase()).toContain("invalid request");
+  });
+
+  it("maps AuthenticationError (401)", () => {
+    const err = new AuthenticationError(
+      401,
+      { message: "Unauthorized" },
+      undefined,
+      makeHeaders()
+    );
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(401);
+    expect(event.content.message.toLowerCase()).toContain("authentication");
+  });
+
+  it("maps PermissionDeniedError (403)", () => {
+    const err = new PermissionDeniedError(
+      403,
+      { message: "Forbidden" },
+      undefined,
+      makeHeaders()
+    );
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(403);
+    expect(event.content.message.toLowerCase()).toContain("permission");
+  });
+
+  it("maps NotFoundError (404)", () => {
+    const err = new NotFoundError(
+      404,
+      { message: "Not Found" },
+      undefined,
+      makeHeaders()
+    );
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(404);
+    expect(event.content.message.toLowerCase()).toContain("not found");
+  });
+
+  it("maps InternalServerError (500)", () => {
+    const err = new InternalServerError(
+      500,
+      { message: "Internal Server Error" },
+      undefined,
+      makeHeaders()
+    );
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(500);
+    expect(event.content.message.toLowerCase()).toContain("server error");
+  });
+});

--- a/front/lib/api/llm/clients/google/utils/errors.ts
+++ b/front/lib/api/llm/clients/google/utils/errors.ts
@@ -1,0 +1,96 @@
+import type { ApiError } from "@google/genai";
+
+import type { LLMErrorInfo } from "@app/lib/api/llm/types/errors";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { normalizeError } from "@app/types";
+
+// https://github.com/googleapis/js-genai#error-handling
+export const handleError = (
+  err: ApiError,
+  metadata: LLMClientMetadata
+): LLMEvent => {
+  return {
+    type: "error",
+    content: categorizeGenAIError(err, metadata),
+    metadata,
+  };
+};
+
+// Yes, this is mainly duplicated between all providers. We know for sure each provider has a different error handling and http status code.
+// So we want to be able to tweak this by provider
+function categorizeGenAIError(
+  error: ApiError,
+  metadata: LLMClientMetadata
+): LLMErrorInfo {
+  const normalized = normalizeError(error);
+  const statusCode = error.status;
+
+  if (statusCode === 400) {
+    return {
+      type: "invalid_request_error",
+      message: `Invalid request to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode: statusCode ?? 400,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 401) {
+    return {
+      type: "authentication_error",
+      message: `Authentication failed for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode: statusCode ?? 401,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 403) {
+    return {
+      type: "permission_error",
+      message: `Permission denied for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode: statusCode ?? 403,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 404) {
+    return {
+      type: "not_found_error",
+      message: `Resource not found for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode: statusCode ?? 404,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 429) {
+    return {
+      type: "rate_limit_error",
+      message: `Rate limit exceeded for ${metadata.clientId}/${metadata.modelId}. ${normalized.message}`,
+      isRetryable: true,
+      statusCode: statusCode ?? 429,
+      originalError: error,
+    };
+  }
+
+  if (statusCode >= 500 && statusCode < 600) {
+    return {
+      type: "server_error",
+      message: `Server error from ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: true,
+      statusCode: statusCode ?? 500,
+      originalError: error,
+    };
+  }
+
+  return {
+    type: "unknown_error",
+    message: `Unknown error from ${metadata.clientId}: ${normalized.message}`,
+    isRetryable: false,
+    statusCode: statusCode ?? 500,
+    originalError: error,
+  };
+}

--- a/front/lib/api/llm/clients/google/utils/google_to_events.ts
+++ b/front/lib/api/llm/clients/google/utils/google_to_events.ts
@@ -95,10 +95,12 @@ export async function* streamLLMEvents({
         reasoningContentParts = "";
         textContentParts = "";
         yield {
-          type: "error" as const,
+          type: "error",
           content: {
+            type: "stop_error",
+            isRetryable: false,
             message: "An error occurred during completion",
-            code: 500,
+            statusCode: 0,
           },
           metadata,
         };

--- a/front/lib/api/llm/clients/google/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/errors.test.ts
@@ -1,0 +1,59 @@
+import { ApiError } from "@google/genai";
+import { describe, expect, it } from "vitest";
+
+import { handleError } from "@app/lib/api/llm/clients/google/utils/errors";
+import type { ErrorEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { GEMINI_2_5_PRO_MODEL_ID } from "@app/types";
+
+const metadata: LLMClientMetadata = {
+  clientId: "google_ai_studio" as const,
+  modelId: GEMINI_2_5_PRO_MODEL_ID,
+};
+
+describe("handleError (Google)", () => {
+  it("maps ApiError 429 (rate limit)", () => {
+    const err = new ApiError({ message: "Too Many Requests", status: 429 });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.type).toBe("error");
+    expect(event.metadata).toEqual(metadata);
+    expect(event.content.statusCode).toBe(429);
+    expect(event.content.message.toLowerCase()).toContain("rate limit");
+    expect(event.content.message).toContain("google_ai_studio");
+  });
+
+  it("maps ApiError 400 (bad request)", () => {
+    const err = new ApiError({ message: "Bad Request", status: 400 });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(400);
+    expect(event.content.message.toLowerCase()).toContain("invalid request");
+  });
+
+  it("maps ApiError 401 (authentication)", () => {
+    const err = new ApiError({ message: "Unauthorized", status: 401 });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(401);
+    expect(event.content.message.toLowerCase()).toContain("authentication");
+  });
+
+  it("maps ApiError 403 (permission)", () => {
+    const err = new ApiError({ message: "Forbidden", status: 403 });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(403);
+    expect(event.content.message.toLowerCase()).toContain("permission");
+  });
+
+  it("maps ApiError 404 (not found)", () => {
+    const err = new ApiError({ message: "Not Found", status: 404 });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(404);
+    expect(event.content.message.toLowerCase()).toContain("not found");
+  });
+
+  it("maps ApiError 500 (server)", () => {
+    const err = new ApiError({ message: "Internal Server Error", status: 500 });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(500);
+    expect(event.content.message.toLowerCase()).toContain("server error");
+  });
+});

--- a/front/lib/api/llm/clients/mistral/utils/errors.ts
+++ b/front/lib/api/llm/clients/mistral/utils/errors.ts
@@ -1,0 +1,97 @@
+import type { MistralError } from "@mistralai/mistralai/models/errors/mistralerror";
+
+import type { LLMErrorInfo } from "@app/lib/api/llm/types/errors";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { normalizeError } from "@app/types";
+
+// https://github.com/mistralai/client-ts#error-handling
+export const handleError = (
+  err: MistralError,
+  metadata: LLMClientMetadata
+): LLMEvent => {
+  return {
+    type: "error",
+    content: categorizeMistralError(err, metadata),
+    metadata,
+  };
+};
+
+// Yes, this is mainly duplicated between all providers. We know for sure each provider has a different error handling and http status code.
+// So we want to be able to tweak this by provider
+// No specific error handling in Mistral's code
+function categorizeMistralError(
+  error: MistralError,
+  metadata: LLMClientMetadata
+): LLMErrorInfo {
+  const normalized = normalizeError(error);
+  const statusCode = error.statusCode;
+
+  if (statusCode === 400) {
+    return {
+      type: "invalid_request_error",
+      message: `Invalid request to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 401) {
+    return {
+      type: "authentication_error",
+      message: `Authentication failed for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 403) {
+    return {
+      type: "permission_error",
+      message: `Permission denied for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 404) {
+    return {
+      type: "not_found_error",
+      message: `Resource not found for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 429) {
+    return {
+      type: "rate_limit_error",
+      message: `Rate limit exceeded for ${metadata.clientId}/${metadata.modelId}. ${normalized.message}`,
+      isRetryable: true,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode >= 500 && statusCode < 600) {
+    return {
+      type: "server_error",
+      message: `Server error from ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: true,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  return {
+    type: "unknown_error",
+    message: `Unknown error from ${metadata.clientId}: ${normalized.message}`,
+    isRetryable: false,
+    statusCode: statusCode ?? 500,
+    originalError: error,
+  };
+}

--- a/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
+++ b/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
@@ -84,7 +84,12 @@ export async function* streamLLMEvents({
         textDelta = "";
         yield {
           type: "error" as const,
-          content: { message: "Maximum length reached", code: 413 },
+          content: {
+            type: "maximum_length",
+            isRetryable: false,
+            message: "Maximum length reached",
+            statusCode: 0,
+          },
           metadata,
         };
         break;
@@ -96,8 +101,10 @@ export async function* streamLLMEvents({
         yield {
           type: "error" as const,
           content: {
+            type: "stop_error",
+            isRetryable: false,
             message: "An error occurred during completion",
-            code: 500,
+            statusCode: 0,
           },
           metadata,
         };

--- a/front/lib/api/llm/clients/mistral/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/mistral/utils/test/errors.test.ts
@@ -1,0 +1,170 @@
+import { HTTPValidationError } from "@mistralai/mistralai/models/errors/httpvalidationerror";
+import { SDKError } from "@mistralai/mistralai/models/errors/sdkerror";
+import { describe, expect, it } from "vitest";
+
+import { handleError } from "@app/lib/api/llm/clients/mistral/utils/errors";
+import type { ErrorEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { MISTRAL_LARGE_MODEL_ID } from "@app/types";
+
+const metadata: LLMClientMetadata = {
+  clientId: "mistral" as const,
+  modelId: MISTRAL_LARGE_MODEL_ID,
+};
+
+function makeRequest(url = "https://api.mistral.ai/v1/mock") {
+  return new Request(url, { method: "POST" });
+}
+
+function makeResponse({
+  status,
+  contentType = "application/json",
+  body = "{}",
+}: {
+  status: number;
+  contentType?: string;
+  body?: string;
+}) {
+  return new Response(body, {
+    status,
+    headers: { "content-type": contentType },
+  });
+}
+
+describe("handleError (Mistral)", () => {
+  it("maps Rate Limit (429) via SDKError message", () => {
+    const req = makeRequest();
+    const res = makeResponse({
+      status: 429,
+      body: JSON.stringify({ message: "Too Many Requests: rate limit" }),
+    });
+    const err = new SDKError("", {
+      response: res,
+      request: req,
+      body: awaitBody(res),
+    });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.type).toBe("error");
+    expect(event.metadata).toEqual(metadata);
+    expect(event.content.statusCode).toBe(429);
+    expect(event.content.message.toLowerCase()).toContain("rate limit");
+    expect(event.content.message.toLowerCase()).toContain("mistral");
+  });
+
+  it("maps Invalid Request (400) via HTTPValidationError message", () => {
+    const req = makeRequest();
+    const res = makeResponse({
+      status: 400,
+      body: JSON.stringify({ message: "Bad Request" }),
+    });
+    const err = new HTTPValidationError(
+      {
+        detail: [
+          {
+            loc: [0],
+            msg: "Bad request: invalid request",
+            type: "bad_request",
+          },
+        ],
+      },
+      { response: res, request: req, body: "{}" }
+    );
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(400);
+    expect(event.content.message.toLowerCase()).toContain("invalid request");
+  });
+
+  it("maps Authentication (401) via SDKError body", () => {
+    const req = makeRequest();
+    const res = makeResponse({
+      status: 401,
+      body: JSON.stringify({ message: "Unauthorized" }),
+    });
+    const err = new SDKError("", {
+      response: res,
+      request: req,
+      body: awaitBody(res),
+    });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(401);
+    expect(event.content.message.toLowerCase()).toContain("authentication");
+  });
+
+  it("maps Permission (403) via SDKError body", () => {
+    const req = makeRequest();
+    const res = makeResponse({
+      status: 403,
+      body: JSON.stringify({ message: "Forbidden" }),
+    });
+    const err = new SDKError("", {
+      response: res,
+      request: req,
+      body: awaitBody(res),
+    });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(403);
+    expect(event.content.message.toLowerCase()).toContain("permission");
+  });
+
+  it("maps Not Found (404) via SDKError body", () => {
+    const req = makeRequest();
+    const res = makeResponse({
+      status: 404,
+      body: JSON.stringify({ message: "Not Found" }),
+    });
+    const err = new SDKError("", {
+      response: res,
+      request: req,
+      body: awaitBody(res),
+    });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(404);
+    expect(event.content.message.toLowerCase()).toContain("not found");
+  });
+
+  it("maps Server Error (500) via SDKError status", () => {
+    const req = makeRequest();
+    const res = makeResponse({
+      status: 500,
+      body: JSON.stringify({ message: "Internal Server Error" }),
+    });
+    const err = new SDKError("", {
+      response: res,
+      request: req,
+      body: awaitBody(res),
+    });
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(500);
+    expect(event.content.message.toLowerCase()).toContain("server error");
+  });
+
+  it("maps Context length exceeded via message", () => {
+    const req = makeRequest();
+    const res = makeResponse({
+      status: 400,
+      body: JSON.stringify({ message: "Context window too large" }),
+    });
+    const err = new HTTPValidationError(
+      {
+        detail: [
+          {
+            loc: [0],
+            msg: "Context window too large",
+            type: "bad_request",
+          },
+        ],
+      },
+      { response: res, request: req, body: "{}" }
+    );
+    const event = handleError(err, metadata) as ErrorEvent;
+    expect(event.content.statusCode).toBe(400);
+    expect(event.content.message.toLowerCase()).toContain("context");
+  });
+});
+
+function awaitBody(res: Response): string {
+  // In this test helper, we synchronously return the known body used to construct the Response
+  // to avoid async in test setup. This matches the string passed into SDKError.
+  // The Response itself is only used by the error class to extract status and headers in its message.
+  return (res as any)._bodySource?.toString?.() ?? "";
+}

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -10,9 +10,8 @@ import type {
   StreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
-import type { ModelIdType, ReasoningEffort, Result } from "@app/types";
-import { Err } from "@app/types";
-import { normalizeError, Ok } from "@app/types";
+import type { ModelIdType, ReasoningEffort } from "@app/types";
+import { normalizeError } from "@app/types";
 
 export abstract class LLM {
   protected modelId: ModelIdType;
@@ -50,7 +49,7 @@ export abstract class LLM {
   }
 
   /**
-   * Private method that wraps the abstract stream() with tracing functionality
+   * Private method that wraps the abstract internalStream() with tracing functionality
    */
   private async *streamWithTracing({
     conversation,
@@ -109,22 +108,16 @@ export abstract class LLM {
     return this.runId;
   }
 
-  stream({
+  async *stream({
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): Result<AsyncGenerator<LLMEvent>, Error> {
-    try {
-      return new Ok(
-        this.streamWithTracing({
-          conversation,
-          prompt,
-          specifications,
-        })
-      );
-    } catch (error) {
-      return new Err(normalizeError(Error));
-    }
+  }: StreamParameters): AsyncGenerator<LLMEvent> {
+    yield* this.streamWithTracing({
+      conversation,
+      prompt,
+      specifications,
+    });
   }
 
   protected abstract internalStream({

--- a/front/lib/api/llm/test/errors.test.ts
+++ b/front/lib/api/llm/test/errors.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+
+import { categorizeLLMError } from "@app/lib/api/llm/types/errors";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { CLAUDE_4_SONNET_20250514_MODEL_ID } from "@app/types";
+
+const metadata: LLMClientMetadata = {
+  clientId: "anthropic" as const,
+  modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+};
+
+function makeError(message: string) {
+  return new Error(message);
+}
+
+function makeErrorLikeWithStatus(message: string, status: number) {
+  // Return a plain object with a message and numeric status to exercise status extraction
+  // without mutating or using type assertions.
+  return { name: "Error", message, status } as const;
+}
+
+function expectCommon(
+  info: ReturnType<typeof categorizeLLMError>,
+  {
+    type,
+    isRetryable,
+    statusCode,
+  }: { type: string; isRetryable: boolean; statusCode: number }
+) {
+  expect(info.type).toBe(type);
+  expect(info.isRetryable).toBe(isRetryable);
+  expect(info.statusCode).toBe(statusCode);
+  // Message should include client id.
+  expect(info.message).toContain(String(metadata.clientId));
+}
+
+describe("categorizeLLMError", () => {
+  it("rate limit: by status 429", () => {
+    const info = categorizeLLMError(
+      makeErrorLikeWithStatus("anything", 429),
+      metadata
+    );
+    expectCommon(info, {
+      type: "rate_limit_error",
+      isRetryable: true,
+      statusCode: 429,
+    });
+    expect(info.message.toLowerCase()).toContain("rate limit");
+  });
+
+  it("rate limit: by message", () => {
+    const info = categorizeLLMError(
+      makeError("Too Many Requests from provider"),
+      metadata
+    );
+    expectCommon(info, {
+      type: "rate_limit_error",
+      isRetryable: true,
+      statusCode: 429,
+    });
+  });
+
+  it("overloaded: by status 503", () => {
+    const info = categorizeLLMError(
+      makeErrorLikeWithStatus("temporary issue", 503),
+      metadata
+    );
+    expectCommon(info, {
+      type: "overloaded_error",
+      isRetryable: true,
+      statusCode: 503,
+    });
+    expect(info.message.toLowerCase()).toContain("overloaded");
+  });
+
+  it("overloaded: by message", () => {
+    const info = categorizeLLMError(
+      makeError("Service Unavailable - capacity reached"),
+      metadata
+    );
+    expectCommon(info, {
+      type: "overloaded_error",
+      isRetryable: true,
+      statusCode: 503,
+    });
+  });
+
+  it("context length exceeded", () => {
+    const info = categorizeLLMError(
+      makeError("Maximum context length exceeded for this model"),
+      metadata
+    );
+    expectCommon(info, {
+      type: "context_length_exceeded",
+      isRetryable: false,
+      statusCode: 400,
+    });
+  });
+
+  it("authentication: by status 401", () => {
+    const info = categorizeLLMError(
+      makeErrorLikeWithStatus("Unauthorized", 401),
+      metadata
+    );
+    expectCommon(info, {
+      type: "authentication_error",
+      isRetryable: false,
+      statusCode: 401,
+    });
+  });
+
+  it("authentication: by message (api key)", () => {
+    const info = categorizeLLMError(
+      makeError("Invalid API key provided"),
+      metadata
+    );
+    expectCommon(info, {
+      type: "authentication_error",
+      isRetryable: false,
+      statusCode: 401,
+    });
+  });
+
+  it("permission: by status 403", () => {
+    const info = categorizeLLMError(
+      makeErrorLikeWithStatus("Forbidden", 403),
+      metadata
+    );
+    expectCommon(info, {
+      type: "permission_error",
+      isRetryable: false,
+      statusCode: 403,
+    });
+  });
+
+  it("permission: by message", () => {
+    const info = categorizeLLMError(
+      makeError("Permission denied: not allowed"),
+      metadata
+    );
+    expectCommon(info, {
+      type: "permission_error",
+      isRetryable: false,
+      statusCode: 403,
+    });
+  });
+
+  it("not found: by status 404", () => {
+    const info = categorizeLLMError(
+      makeErrorLikeWithStatus("anything", 404),
+      metadata
+    );
+    expectCommon(info, {
+      type: "not_found_error",
+      isRetryable: false,
+      statusCode: 404,
+    });
+  });
+
+  it("not found: by message", () => {
+    const info = categorizeLLMError(makeError("resource not found"), metadata);
+    expectCommon(info, {
+      type: "not_found_error",
+      isRetryable: false,
+      statusCode: 404,
+    });
+  });
+
+  it("invalid request: by status 400", () => {
+    const info = categorizeLLMError(
+      makeErrorLikeWithStatus("oops", 400),
+      metadata
+    );
+    expectCommon(info, {
+      type: "invalid_request_error",
+      isRetryable: false,
+      statusCode: 400,
+    });
+  });
+
+  it("invalid request: by message", () => {
+    const info = categorizeLLMError(
+      makeError("Bad Request: validation error"),
+      metadata
+    );
+    expectCommon(info, {
+      type: "invalid_request_error",
+      isRetryable: false,
+      statusCode: 400,
+    });
+  });
+
+  it("network error: by message", () => {
+    const info = categorizeLLMError(makeError("ECONNREFUSED"), metadata);
+    expectCommon(info, {
+      type: "network_error",
+      isRetryable: true,
+      statusCode: 500,
+    });
+  });
+
+  it("timeout error: by message", () => {
+    const info = categorizeLLMError(makeError("Operation timed out"), metadata);
+    expectCommon(info, {
+      type: "timeout_error",
+      isRetryable: true,
+      statusCode: 500,
+    });
+  });
+
+  it("stream error: by message", () => {
+    const info = categorizeLLMError(makeError("stream interrupted"), metadata);
+    expectCommon(info, {
+      type: "stream_error",
+      isRetryable: true,
+      statusCode: 500,
+    });
+  });
+
+  it("server error: by status 500", () => {
+    const info = categorizeLLMError(
+      makeErrorLikeWithStatus("Internal Server Error", 500),
+      metadata
+    );
+    expectCommon(info, {
+      type: "server_error",
+      isRetryable: true,
+      statusCode: 500,
+    });
+  });
+
+  it("server error: by message", () => {
+    const info = categorizeLLMError(
+      makeError("An internal server error occurred"),
+      metadata
+    );
+    expectCommon(info, {
+      type: "server_error",
+      isRetryable: true,
+      statusCode: 500,
+    });
+  });
+
+  it("unknown error (default)", () => {
+    const info = categorizeLLMError(
+      makeError("Something odd happened"),
+      metadata
+    );
+    expectCommon(info, {
+      type: "unknown_error",
+      isRetryable: false,
+      statusCode: 500,
+    });
+  });
+});

--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -1,0 +1,232 @@
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { normalizeError } from "@app/types";
+
+export type LLMErrorType =
+  // LLM errors
+  | "stop_error"
+  | "refusal_error"
+  | "maximum_length"
+  // HTTP errors
+  | "rate_limit_error"
+  | "overloaded_error"
+  | "context_length_exceeded"
+  | "invalid_request_error"
+  | "authentication_error"
+  | "permission_error"
+  | "not_found_error"
+  | "network_error"
+  | "timeout_error"
+  | "server_error"
+  | "stream_error"
+  | "unknown_error";
+
+export interface LLMErrorInfo {
+  type: LLMErrorType;
+  message: string;
+  isRetryable: boolean;
+  statusCode: number;
+  originalError?: unknown;
+}
+
+export function handleGenericError(
+  error: unknown,
+  metadata: LLMClientMetadata
+): LLMEvent {
+  return {
+    type: "error",
+    content: categorizeLLMError(error, metadata),
+    metadata,
+  };
+}
+
+/**
+ * Categorizes errors from http requests to LLM providers into specific types and determines if they are
+ * retryable based on their characteristics.
+ *
+ * WARNING: This function handles errors that are not specific to a single provider
+ * look for $provider/utils/errors.ts for provider-specific error handling.
+ */
+export function categorizeLLMError(
+  error: unknown,
+  metadata: LLMClientMetadata
+): LLMErrorInfo {
+  const normalized = normalizeError(error);
+  const errorMessage = normalized.message.toLowerCase();
+
+  // Extract status code if available.
+  const statusCode =
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof error.status === "number"
+      ? error.status
+      : undefined;
+
+  if (
+    statusCode === 429 ||
+    errorMessage.includes("rate limit") ||
+    errorMessage.includes("quota exceeded") ||
+    errorMessage.includes("too many requests")
+  ) {
+    return {
+      type: "rate_limit_error",
+      message: `Rate limit exceeded for ${metadata.clientId}/${metadata.modelId}. ${normalized.message}`,
+      isRetryable: true,
+      statusCode: statusCode ?? 429,
+      originalError: error,
+    };
+  }
+
+  // Check for overloaded/capacity errors (503).
+  if (
+    statusCode === 503 ||
+    errorMessage.includes("overloaded") ||
+    errorMessage.includes("capacity") ||
+    errorMessage.includes("service unavailable")
+  ) {
+    return {
+      type: "overloaded_error",
+      message: `${metadata.clientId} service is overloaded. ${normalized.message}`,
+      isRetryable: true,
+      statusCode: statusCode ?? 503,
+      originalError: error,
+    };
+  }
+
+  // Check for context length errors.
+  if (
+    errorMessage.includes("context") ||
+    errorMessage.includes("token limit") ||
+    errorMessage.includes("maximum context length") ||
+    errorMessage.includes("context window") ||
+    errorMessage.includes("too large")
+  ) {
+    return {
+      type: "context_length_exceeded",
+      message: `Context length exceeded for ${metadata.clientId}/${metadata.modelId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode: statusCode ?? 400,
+      originalError: error,
+    };
+  }
+
+  if (
+    statusCode === 401 ||
+    errorMessage.includes("unauthorized") ||
+    errorMessage.includes("authentication") ||
+    errorMessage.includes("api key")
+  ) {
+    return {
+      type: "authentication_error",
+      message: `Authentication failed for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode: statusCode ?? 401,
+      originalError: error,
+    };
+  }
+
+  if (
+    statusCode === 403 ||
+    errorMessage.includes("forbidden") ||
+    errorMessage.includes("permission")
+  ) {
+    return {
+      type: "permission_error",
+      message: `Permission denied for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode: statusCode ?? 403,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 404 || errorMessage.includes("not found")) {
+    return {
+      type: "not_found_error",
+      message: `Resource not found for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode: statusCode ?? 404,
+      originalError: error,
+    };
+  }
+
+  if (
+    statusCode === 400 ||
+    errorMessage.includes("invalid request") ||
+    errorMessage.includes("bad request") ||
+    errorMessage.includes("validation error")
+  ) {
+    return {
+      type: "invalid_request_error",
+      message: `Invalid request to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: false,
+      statusCode: statusCode ?? 400,
+      originalError: error,
+    };
+  }
+
+  // Check for network errors.
+  if (
+    errorMessage.includes("network") ||
+    errorMessage.includes("connection") ||
+    errorMessage.includes("econnrefused") ||
+    errorMessage.includes("enotfound") ||
+    errorMessage.includes("etimedout")
+  ) {
+    return {
+      type: "network_error",
+      message: `Network error connecting to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: true,
+      statusCode: statusCode ?? 500,
+      originalError: error,
+    };
+  }
+
+  // Check for timeout errors.
+  if (errorMessage.includes("timeout") || errorMessage.includes("timed out")) {
+    return {
+      type: "timeout_error",
+      message: `Request timeout for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: true,
+      statusCode: statusCode ?? 500,
+      originalError: error,
+    };
+  }
+
+  // Check for stream-specific errors.
+  if (
+    errorMessage.includes("stream") ||
+    errorMessage.includes("streaming") ||
+    errorMessage.includes("interrupted")
+  ) {
+    return {
+      type: "stream_error",
+      message: `Stream error from ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: true,
+      statusCode: statusCode ?? 500,
+      originalError: error,
+    };
+  }
+
+  if (
+    (statusCode != null && statusCode >= 500 && statusCode < 600) ||
+    errorMessage.includes("internal server error") ||
+    errorMessage.includes("server error")
+  ) {
+    return {
+      type: "server_error",
+      message: `Server error from ${metadata.clientId}. ${normalized.message}`,
+      isRetryable: true,
+      statusCode: statusCode ?? 500,
+      originalError: error,
+    };
+  }
+
+  return {
+    type: "unknown_error",
+    message: `Unknown error from ${metadata.clientId}: ${normalized.message}`,
+    isRetryable: false,
+    statusCode: statusCode ?? 500,
+    originalError: error,
+  };
+}

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -1,3 +1,4 @@
+import type { LLMErrorInfo } from "@app/lib/api/llm/types/errors";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 
 export type Delta = {
@@ -73,14 +74,9 @@ export interface SuccessCompletionEvent {
   metadata: LLMClientMetadata;
 }
 
-export interface CompletionError {
-  message: string;
-  code: number;
-}
-
-export interface ErrorCompletionEvent {
+export interface ErrorEvent {
   type: "error";
-  content: CompletionError;
+  content: LLMErrorInfo;
   metadata: LLMClientMetadata;
 }
 
@@ -92,4 +88,4 @@ export type LLMEvent =
   | ReasoningGeneratedEvent
   | TokenUsageEvent
   | SuccessCompletionEvent
-  | ErrorCompletionEvent;
+  | ErrorEvent;

--- a/front/lib/api/llm/utils/openai_like/errors.ts
+++ b/front/lib/api/llm/utils/openai_like/errors.ts
@@ -1,0 +1,155 @@
+import type { APIError } from "openai";
+import { APIConnectionError } from "openai";
+
+import type { LLMErrorInfo } from "@app/lib/api/llm/types/errors";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
+import { normalizeError } from "@app/types";
+
+// https://github.com/openai/openai-node#handling-errors
+export const handleError = (
+  err: APIError,
+  metadata: LLMClientMetadata
+): LLMEvent => {
+  return {
+    type: "error",
+    content: categorizeOpenAILikeError(err, metadata),
+    metadata,
+  };
+};
+
+// Based on openai.APIClient.shouldRetry
+// The function is private so we can't reuse it.
+function shouldRetry(error: APIError): boolean {
+  // Note this is not a standard header.
+  const shouldRetryHeader = error.headers?.["x-should-retry"];
+
+  // If the server explicitly says whether or not to retry, obey.
+  if (shouldRetryHeader === "true") {
+    return true;
+  }
+  if (shouldRetryHeader === "false") {
+    return false;
+  }
+
+  if (!error.status) {
+    return false;
+  }
+
+  // Retry on request timeouts.
+  if (error.status === 408) {
+    return true;
+  }
+
+  // Retry on lock timeouts.
+  if (error.status === 409) {
+    return true;
+  }
+
+  // Retry on rate limits.
+  if (error.status === 429) {
+    return true;
+  }
+
+  // Retry internal errors.
+  return error.status >= 500;
+}
+
+// Yes, this is mainly duplicated between all providers. We know for sure each provider has a different error handling and http status code.
+// So we want to be able to tweak this by provider
+function categorizeOpenAILikeError(
+  error: APIError,
+  metadata: LLMClientMetadata
+): LLMErrorInfo {
+  const normalized = normalizeError(error);
+  const statusCode = error.status ?? 500;
+  const isRetryable = shouldRetry(error);
+
+  if (error instanceof APIConnectionError) {
+    return {
+      type: "network_error",
+      message: `Network error connecting to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 400) {
+    return {
+      type: "invalid_request_error",
+      message: `Invalid request to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 401) {
+    return {
+      type: "authentication_error",
+      message: `Authentication failed for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 403) {
+    return {
+      type: "permission_error",
+      message: `Permission denied for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 404) {
+    return {
+      type: "not_found_error",
+      message: `Resource not found for ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 422) {
+    return {
+      type: "invalid_request_error",
+      message: `Invalid request to ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode === 429) {
+    return {
+      type: "rate_limit_error",
+      message: `Rate limit exceeded for ${metadata.clientId}/${metadata.modelId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  if (statusCode >= 500 && statusCode < 600) {
+    return {
+      type: "server_error",
+      message: `Server error from ${metadata.clientId}. ${normalized.message}`,
+      isRetryable,
+      statusCode,
+      originalError: error,
+    };
+  }
+
+  return {
+    type: "unknown_error",
+    message: `Unknown error from ${metadata.clientId}: ${normalized.message}`,
+    isRetryable,
+    statusCode,
+    originalError: error,
+  };
+}

--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -63,8 +63,10 @@ function responseOutputToEvent(
       return {
         type: "error",
         content: {
+          type: "refusal_error",
+          isRetryable: false,
           message: responseOutput.refusal,
-          code: 500,
+          statusCode: 500,
         },
         metadata,
       };

--- a/front/scripts/test_llm_clients.ts
+++ b/front/scripts/test_llm_clients.ts
@@ -388,15 +388,11 @@ async function runTest(
 
       conversationHistory.push(...conversationAction.messages);
 
-      const eventStreamResult = llm.stream({
+      const events = llm.stream({
         conversation: { messages: conversationHistory },
         prompt: conversation.systemPrompt,
         specifications: conversation.specifications ?? [],
       });
-
-      if (eventStreamResult.isErr()) {
-        throw eventStreamResult.error;
-      }
 
       let responseFromDeltas = "";
       let fullResponse = "";
@@ -407,7 +403,7 @@ async function runTest(
       let toolCallId = 1;
 
       // Collect all events
-      for await (const event of eventStreamResult.value) {
+      for await (const event of events) {
         switch (event.type) {
           case "text_delta":
             responseFromDeltas += event.content.delta;

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -28,25 +28,18 @@ export async function getOutputFromLLMStream(
     llm,
   }: GetOutputRequestParams & { llm: LLM }
 ): Promise<GetOutputResponse> {
-  const res = llm.stream({
+  const events = llm.stream({
     conversation: modelConversationRes.value.modelConversation,
     prompt,
     specifications,
   });
-
-  if (res.isErr()) {
-    return new Err({
-      type: "shouldRetryMessage",
-      message: res.error.message,
-    });
-  }
 
   const contents: Output["contents"] = [];
   const actions: Output["actions"] = [];
   let generation = "";
   let nativeChainOfThought = "";
 
-  for await (const event of res.value) {
+  for await (const event of events) {
     if (event.type === "error") {
       await flushParserTokens();
       return new Err({


### PR DESCRIPTION
## Description

Adds a better error handling. This does:
* adds a try/catch to get the errors from each provider
* Remove the `Result` from `stream`, it was a bad design, let's only use the events
* each error is marked "retryable" (or not) so we can handle retries in another PR

Notes: 
* I decided to reuse the LLMEvent type for errors, as I believe it simplifies its handling
* The code of the `handleError` is mostly duplicated _on purpose_. As discussed with @flvndvd, there is a high probability each provider understand errors differently, hence we'll need provider-specific error handling/retrying
* Next [PR](https://github.com/dust-tt/dust/pull/17586) improves the error with real TS `Error`. I wanted to split the PR to make it clearer

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
