### PR TITLE
[front] fix(triggers): delete webhook source if remote webhook creation fails

### DIFF
--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -19,7 +19,7 @@ import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resou
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
-import { Err, normalizeError, Ok, redactString } from "@app/types";
+import { Ok, redactString } from "@app/types";
 import type {
   WebhookSourceForAdminType as WebhookSourceForAdminType,
   WebhookSourceType,
@@ -181,77 +181,66 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
 
     if (this.provider && this.remoteMetadata && this.oauthConnectionId) {
       const service = WEBHOOK_PRESETS[this.provider].webhookService;
-      try {
-        const result = await service.deleteWebhooks({
-          auth,
-          connectionId: this.oauthConnectionId,
-          remoteMetadata: this.remoteMetadata,
-        });
+      const result = await service.deleteWebhooks({
+        auth,
+        connectionId: this.oauthConnectionId,
+        remoteMetadata: this.remoteMetadata,
+      });
 
-        if (result.isErr()) {
-          logger.error(
-            { error: result.error },
-            `Failed to delete remote webhook on ${this.provider}`
-          );
-        }
-      } catch (error) {
+      if (result.isErr()) {
         logger.error(
-          { error },
+          { error: result.error },
           `Failed to delete remote webhook on ${this.provider}`
         );
-        // Continue with local deletion even if remote deletion fails
+      }
+      // Continue with local deletion even if remote deletion fails
+    }
+
+    // Find all webhook sources views for this webhook source
+    const webhookSourceViews = await WebhookSourcesViewModel.findAll({
+      where: {
+        workspaceId: owner.id,
+        webhookSourceId: this.id,
+      },
+    });
+
+    // Delete all triggers for each webhook source view
+    for (const webhookSourceView of webhookSourceViews) {
+      const triggers = await TriggerResource.listByWebhookSourceViewId(
+        auth,
+        webhookSourceView.id
+      );
+      for (const trigger of triggers) {
+        await trigger.delete(auth, { transaction });
       }
     }
 
-    try {
-      // Find all webhook sources views for this webhook source
-      const webhookSourceViews = await WebhookSourcesViewModel.findAll({
-        where: {
-          workspaceId: owner.id,
-          webhookSourceId: this.id,
-        },
-      });
+    // Directly delete the WebhookSourceViewModel to avoid a circular dependency.
+    await WebhookSourcesViewModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        webhookSourceId: this.id,
+      },
+      // Use 'hardDelete: true' to ensure the record is permanently deleted from the database,
+      // bypassing the soft deletion in place.
+      hardDelete: true,
+      transaction,
+    });
 
-      // Delete all triggers for each webhook source view
-      for (const webhookSourceView of webhookSourceViews) {
-        const triggers = await TriggerResource.listByWebhookSourceViewId(
-          auth,
-          webhookSourceView.id
-        );
-        for (const trigger of triggers) {
-          await trigger.delete(auth, { transaction });
-        }
-      }
+    // Directly delete the webhook requests associated with this webhook source
+    await WebhookRequestResource.deleteByWebhookSourceId(auth, this.id, {
+      transaction,
+    });
 
-      // Directly delete the WebhookSourceViewModel to avoid a circular dependency.
-      await WebhookSourcesViewModel.destroy({
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          webhookSourceId: this.id,
-        },
-        // Use 'hardDelete: true' to ensure the record is permanently deleted from the database,
-        // bypassing the soft deletion in place.
-        hardDelete: true,
-        transaction,
-      });
-
-      // Directly delete the webhook requests associated with this webhook source
-      await WebhookRequestResource.deleteByWebhookSourceId(auth, this.id, {
-        transaction,
-      });
-
-      // Then delete the webhook source itself
-      await WebhookSourceModel.destroy({
-        where: {
-          id: this.id,
-          workspaceId: owner.id,
-        },
-        transaction,
-      });
-      return new Ok(undefined);
-    } catch (error) {
-      return new Err(normalizeError(error));
-    }
+    // Then delete the webhook source itself
+    await WebhookSourceModel.destroy({
+      where: {
+        id: this.id,
+        workspaceId: owner.id,
+      },
+      transaction,
+    });
+    return new Ok(undefined);
   }
 
   static modelIdToSId({

--- a/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_service.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_service.ts
@@ -195,6 +195,10 @@ export class ZendeskWebhookService implements RemoteWebhookService<"zendesk"> {
       logger.warn(
         `Failed to delete Zendesk webhook: ${response.status} ${response.statusText} - ${errorText}`
       );
+
+      return new Err(
+        new Error(`Failed to delete Zendesk webhook: ${errorText}`)
+      );
     }
 
     return new Ok(undefined);

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -12,6 +12,7 @@ import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resourc
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { buildWebhookUrl } from "@app/lib/webhookSource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import type {
@@ -215,13 +216,24 @@ async function handler(
         });
 
         if (result.isErr()) {
-          // If remote webhook creation fails, we still keep the webhook source
-          // but return an error message so the user knows
+          // If remote webhook creation fails, delete the webhook source
+          const deleteResult = await webhookSource.delete(auth);
+          if (deleteResult.isErr()) {
+            // Log the delete failure but still return the original error
+            logger.error(
+              {
+                error: deleteResult.error,
+                webhookSourceId: webhookSource.sId,
+              },
+              "Failed to delete webhook source after remote webhook creation failed"
+            );
+          }
+
           return apiError(req, res, {
             status_code: 500,
             api_error: {
               type: "internal_server_error",
-              message: `Webhook source created but failed to create remote webhook: ${result.error.message}`,
+              message: `Failed to create remote webhook: ${result.error.message}`,
             },
           });
         }


### PR DESCRIPTION
## Description

- This PR updates the webhook source creation flow to prevent creating a webhook source without creating the webhook remotely.
- It works by deleting the webhook source if the remote webhook creation fails.
- The rationale is to prevent dangling webhook sources, given that we only surface the fact that the remote webhook was not created in a notification and are not aware of this afterwards. We now have the invariant one webhook source <-> one webhook registered remotely on the provider's side.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
