### PR TITLE
Migrate transctional emails to support@dust.tt

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -53,6 +53,12 @@ const config = {
   getSendgridApiKey: (): string => {
     return EnvironmentConfig.getEnvVariable("SENDGRID_API_KEY");
   },
+  getSupportEmailAddress: (): { name: string; email: string } => {
+    return {
+      name: "Dust team",
+      email: "support@dust.tt",
+    };
+  },
   getInvitationEmailTemplate: (): string => {
     return EnvironmentConfig.getEnvVariable(
       "SENDGRID_INVITATION_EMAIL_TEMPLATE_ID"

--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -23,10 +23,7 @@ export function getSgMailClient(): any {
 export async function sendGitHubDeletionEmail(email: string): Promise<void> {
   await sendEmailWithTemplate({
     to: email,
-    from: {
-      name: "Dust team",
-      email: "support@dust.help",
-    },
+    from: config.getSupportEmailAddress(),
     subject: "[Dust] GitHub connection deleted - important information",
     body: `<p>Your Dust connection to GitHub was deleted, along with all the related data on Dust servers.</p>
     <p>You can now uninstall the Dust app from your GitHub account to revoke authorizations initially granted to Dust when you connected the GitHub account.</p>
@@ -50,10 +47,7 @@ export async function sendCancelSubscriptionEmail(
 
   await sendEmailWithTemplate({
     to: email,
-    from: {
-      name: "Dust team",
-      email: "support@dust.help",
-    },
+    from: config.getSupportEmailAddress(),
     subject: `[Dust] Subscription canceled - important information`,
     body: `
       <p>You just canceled your subscription. It will be terminated at the end of your current billing period (${formattedDate}). You can reactivate your subscription at any time before then. If you do not reactivate your subscription, you will then be switched back to our free plan:</p>
@@ -74,10 +68,7 @@ export async function sendReactivateSubscriptionEmail(
 ): Promise<void> {
   await sendEmailWithTemplate({
     to: email,
-    from: {
-      name: "Dust team",
-      email: "support@dust.help",
-    },
+    from: config.getSupportEmailAddress(),
     subject: `[Dust] Your subscription has been reactivated`,
     body: `<p>You have requested to reactivate your subscription.</p>
       <p>Therefore, your subscription will not be canceled at the end of the billing period, no downgrade actions will take place, and you can continue using Dust as usual.</p>
@@ -92,10 +83,7 @@ export async function sendAdminSubscriptionPaymentFailedEmail(
 ): Promise<void> {
   await sendEmailWithTemplate({
     to: email,
-    from: {
-      name: "Dust team",
-      email: "support@dust.help",
-    },
+    from: config.getSupportEmailAddress(),
     subject: `[Dust] Your payment has failed`,
     body: `
       <p>Your payment has failed. Please visit ${customerPortailUrl} to edit your payment information.</p>
@@ -119,10 +107,7 @@ export async function sendAdminDataDeletionEmail({
 }): Promise<void> {
   await sendEmailWithTemplate({
     to: email,
-    from: {
-      name: "Dust team",
-      email: "support@dust.help",
-    },
+    from: config.getSupportEmailAddress(),
     subject: `${
       isLast ? "Last Reminder: " : ""
     }Your Dust data will be deleted in ${remainingDays} days`,

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -177,10 +177,7 @@ export async function sendWorkspaceInvitationEmail(
   // Send invite email.
   const message = {
     to: invitation.inviteEmail,
-    from: {
-      name: "Dust team",
-      email: "support@dust.help",
-    },
+    from: config.getSupportEmailAddress(),
     templateId: config.getInvitationEmailTemplate(),
     dynamic_template_data: {
       inviteLink: getMembershipInvitationUrl(owner, invitation.id),

--- a/front/pages/api/w/[wId]/data_sources/request_access.ts
+++ b/front/pages/api/w/[wId]/data_sources/request_access.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -117,7 +118,7 @@ async function handler(
 
   const result = await sendEmailWithTemplate({
     to: dataSource.editedByUser.email,
-    from: { name: "Dust team", email: "support@dust.help" },
+    from: config.getSupportEmailAddress(),
     replyTo: emailRequester,
     subject: `[Dust] Request Data source from ${emailRequester}`,
     body,

--- a/front/pages/api/w/[wId]/labs/request_access.ts
+++ b/front/pages/api/w/[wId]/labs/request_access.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
 import type { Authenticator } from "@app/lib/auth";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
@@ -96,7 +97,7 @@ async function handler(
 
   const result = await sendEmailWithTemplate({
     to: "support@dust.tt",
-    from: { name: "Dust team", email: "support@dust.help" },
+    from: config.getSupportEmailAddress(),
     subject: `[Dust] Labs Feature Request: ${featureName} from ${emailRequester}`,
     replyTo: emailRequester,
     body,

--- a/front/pages/api/w/[wId]/mcp/request_access.ts
+++ b/front/pages/api/w/[wId]/mcp/request_access.ts
@@ -6,6 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -120,7 +121,7 @@ async function handler(
 
   const result = await sendEmailWithTemplate({
     to: mcpServerView.editedByUser.email,
-    from: { name: "Dust team", email: "support@dust.help" },
+    from: config.getSupportEmailAddress(),
     replyTo: emailRequester,
     subject: `[Dust] Tools request from ${emailRequester}`,
     body,

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -696,10 +696,7 @@ export async function processTranscriptActivity(
 
     await sendEmailWithTemplate({
       to: user.email,
-      from: {
-        name: "Dust team",
-        email: "support@dust.help",
-      },
+      from: config.getSupportEmailAddress(),
       subject: `[DUST] Transcripts - ${transcriptTitle.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")}`,
       body: `${htmlAnswer}<div style="text-align: center; margin-top: 20px;">
     <a href="${getConversationRoute(owner.sId, conversation.sId, undefined, config.getClientFacingUrl())}"


### PR DESCRIPTION





## Description

Migrates all transactional emails from `support@dust.help` to `support@dust.tt`. This change creates a centralized `getSupportEmailAddress()` helper in the config that returns the Dust team sender information, replacing hardcoded email addresses throughout the codebase. The migration affects invitation emails, subscription management emails (cancellation, reactivation, payment failures), data deletion warnings, GitHub connection deletions, access request emails (data sources, labs features, MCP), and transcript processing notifications.

## Risk

Low. This is purely a sender address change with no impact on email functionality or delivery.

## Tests

Tested manually by verifying email sending works with the new address.

## Deploy Plan
