### PR TITLE
[front] Fix plugin view screen

### DIFF
--- a/front/lib/resources/plugin_run_resource.ts
+++ b/front/lib/resources/plugin_run_resource.ts
@@ -177,7 +177,9 @@ export class PluginRunResource extends BaseResource<PluginRunModel> {
       status: this.status,
       resourceType: this.resourceType,
       resourceId: this.resourceId,
-      args: parsedArgsResult.isOk() ? parsedArgsResult.value ?? {} : {},
+      args: parsedArgsResult.isOk()
+        ? parsedArgsResult.value ?? {}
+        : { rawContent: this.args },
     };
   }
 

--- a/front/lib/resources/plugin_run_resource.ts
+++ b/front/lib/resources/plugin_run_resource.ts
@@ -22,7 +22,7 @@ import type {
   PluginResourceTarget,
   Result,
 } from "@app/types";
-import { Err, normalizeError, Ok } from "@app/types";
+import { Err, normalizeError, Ok, safeParseJSON } from "@app/types";
 import type { PluginRunType } from "@app/types/poke/plugins";
 
 import type { UserResource } from "./user_resource";
@@ -168,6 +168,8 @@ export class PluginRunResource extends BaseResource<PluginRunModel> {
   }
 
   toJSON(): PluginRunType {
+    // The value in DB is truncated to POKE_PLUGIN_RUN_MAX_ARGS_LENGTH so may not be a valid JSON.
+    const parsedArgsResult = this.args ? safeParseJSON(this.args) : new Ok({});
     return {
       createdAt: this.createdAt.getTime(),
       author: this.author,
@@ -175,7 +177,7 @@ export class PluginRunResource extends BaseResource<PluginRunModel> {
       status: this.status,
       resourceType: this.resourceType,
       resourceId: this.resourceId,
-      args: this.args ? JSON.parse(this.args) : {},
+      args: parsedArgsResult.isOk() ? parsedArgsResult.value ?? {} : {},
     };
   }
 


### PR DESCRIPTION
## Description

- The Plugin run tab view on the Poke workspace page is broken for our workspace.
- The issue comes from the `JSON.parse` that fails due to the value in db not being valid JSON due to a truncation happening at write time.
- This PR fixes that, showing the raw content in a single big string instead.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
