### PR TITLE
[front] enh(trigger): fix notification message on failed webhook creation

### DIFF
--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -123,36 +123,27 @@ export function useCreateWebhookSource({
   const createWebhookSource = async (
     input: PostWebhookSourcesBody
   ): Promise<WebhookSourceForAdminType | null> => {
-    try {
-      const response = await fetch(`/api/w/${owner.sId}/webhook_sources`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(input),
-      });
+    const response = await fetch(`/api/w/${owner.sId}/webhook_sources`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(input),
+    });
 
-      if (!response.ok) {
-        throw new Error("Network response was not ok");
-      }
-
-      sendNotification({
-        type: "success",
-        title: `Successfully created webhook source`,
-      });
-
-      void mutateWebhookSourcesWithViews();
-
-      const result = await response.json();
-      return result.webhookSource;
-    } catch (error) {
-      sendNotification({
-        type: "error",
-        title: `Failed to create webhook source`,
-      });
-
-      return null;
+    if (!response.ok) {
+      throw new Error("Network response was not ok");
     }
+
+    sendNotification({
+      type: "success",
+      title: `Successfully created webhook source`,
+    });
+
+    void mutateWebhookSourcesWithViews();
+
+    const result = await response.json();
+    return result.webhookSource;
   };
 
   return createWebhookSource;

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -132,12 +132,20 @@ export function useCreateWebhookSource({
     });
 
     if (!response.ok) {
-      throw new Error("Network response was not ok");
+      const errorData = await response.json();
+      const errorMessage = errorData.error?.message ?? "Unknown error";
+      sendNotification({
+        type: "error",
+        title: "Failed to create webhook source",
+        description: errorMessage,
+      });
+
+      return null;
     }
 
     sendNotification({
       type: "success",
-      title: `Successfully created webhook source`,
+      title: "Successfully created webhook source",
     });
 
     void mutateWebhookSourcesWithViews();

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -2,7 +2,12 @@ import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import {
+  emptyArray,
+  fetcher,
+  getErrorFromResponse,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
 import type { GetWebhookRequestsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/webhook_requests";
 import type { GetWebhookSourceViewsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views";
 import type {
@@ -132,14 +137,13 @@ export function useCreateWebhookSource({
     });
 
     if (!response.ok) {
-      const errorData = await response.json();
-      const errorMessage = errorData.error?.message ?? "Unknown error";
+      const errorData = await getErrorFromResponse(response);
+
       sendNotification({
         type: "error",
-        title: "Failed to create webhook source",
-        description: errorMessage,
+        title: `Error archiving agents`,
+        description: `Error: ${errorData.message}`,
       });
-
       return null;
     }
 

--- a/front/lib/triggers/built-in-webhooks/jira/jira_client.ts
+++ b/front/lib/triggers/built-in-webhooks/jira/jira_client.ts
@@ -112,16 +112,14 @@ export class JiraClient {
     );
 
     if (validationResult.isErr()) {
-      return new Err(
-        new Error(`Failed to create webhook: ${validationResult.error.message}`)
-      );
+      return new Err(new Error(validationResult.error.message));
     }
 
     const data = validationResult.value;
     const result = data.webhookRegistrationResult?.[0];
     if (!result?.createdWebhookId) {
       const errors = result?.errors?.join(", ") ?? "Unknown error";
-      return new Err(new Error(`Failed to create webhook: ${errors}`));
+      return new Err(new Error(errors));
     }
 
     return new Ok({ id: String(result.createdWebhookId) });

--- a/front/lib/triggers/built-in-webhooks/jira/jira_webhook_service.ts
+++ b/front/lib/triggers/built-in-webhooks/jira/jira_webhook_service.ts
@@ -133,7 +133,7 @@ export class JiraWebhookService implements RemoteWebhookService<"jira"> {
 
       if (createRes.isErr()) {
         errors.push(
-          `Failed to create webhook for project ${projectKey}: ${createRes.error.message}`
+          `Failed to register webhook for project ${projectKey}: ${createRes.error.message}`
         );
         continue;
       }
@@ -142,9 +142,7 @@ export class JiraWebhookService implements RemoteWebhookService<"jira"> {
     }
 
     if (Object.keys(webhookIds).length === 0) {
-      return new Err(
-        new Error(`Failed to create any webhooks. Errors: ${errors.join(", ")}`)
-      );
+      return new Err(new Error(errors.join(", ")));
     }
 
     return new Ok({

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -233,7 +233,7 @@ async function handler(
             status_code: 500,
             api_error: {
               type: "internal_server_error",
-              message: `Failed to create remote webhook: ${result.error.message}`,
+              message: result.error.message,
             },
           });
         }


### PR DESCRIPTION
## Description

- This PR fixes the message displayed in the notification shown when a webhook source creation fails, it currently includes several repetitions: `"Failed to create remote webhook: Failed to create any webhooks. Errors: Failed to create webhook for project Xx: Failed to create webhook: ${errorMessage}"`.


## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
