### PR TITLE
[connectors] fix: delete Confluence folders when deleting a Confluence connector

### DIFF
--- a/connectors/src/resources/connector/confluence.ts
+++ b/connectors/src/resources/connector/confluence.ts
@@ -2,6 +2,7 @@ import type { Transaction } from "sequelize";
 
 import {
   ConfluenceConfiguration,
+  ConfluenceFolder,
   ConfluencePage,
   ConfluenceSpace,
 } from "@connectors/lib/models/confluence";
@@ -45,6 +46,12 @@ export class ConfluenceConnectorStrategy
         transaction,
       }),
       ConfluenceSpace.destroy({
+        where: {
+          connectorId: connector.id,
+        },
+        transaction,
+      }),
+      ConfluenceFolder.destroy({
         where: {
           connectorId: connector.id,
         },

--- a/connectors/src/resources/connector/confluence.ts
+++ b/connectors/src/resources/connector/confluence.ts
@@ -38,32 +38,30 @@ export class ConfluenceConnectorStrategy
     connector: ConnectorResource,
     transaction: Transaction
   ): Promise<void> {
-    await Promise.all([
-      ConfluenceConfiguration.destroy({
-        where: {
-          connectorId: connector.id,
-        },
-        transaction,
-      }),
-      ConfluenceSpace.destroy({
-        where: {
-          connectorId: connector.id,
-        },
-        transaction,
-      }),
-      ConfluenceFolder.destroy({
-        where: {
-          connectorId: connector.id,
-        },
-        transaction,
-      }),
-      ConfluencePage.destroy({
-        where: {
-          connectorId: connector.id,
-        },
-        transaction,
-      }),
-    ]);
+    await ConfluenceConfiguration.destroy({
+      where: {
+        connectorId: connector.id,
+      },
+      transaction,
+    });
+    await ConfluenceSpace.destroy({
+      where: {
+        connectorId: connector.id,
+      },
+      transaction,
+    });
+    await ConfluenceFolder.destroy({
+      where: {
+        connectorId: connector.id,
+      },
+      transaction,
+    });
+    await ConfluencePage.destroy({
+      where: {
+        connectorId: connector.id,
+      },
+      transaction,
+    });
   }
 
   async fetchConfigurationsbyConnectorIds(): Promise<


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/4981.
- This PR fixes a data source deletion workflow currently stuck on a FK between `connectors` and `confluence_folders` by deleting the rows in `confluence_folders` when deleting the connector.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
