### PR TITLE
[front] fix: check agent versions when listing blocked actions

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -73,7 +73,9 @@ import type { TagType } from "@app/types/tag";
 /**
  * Get one specific version of a single agent
  */
-export async function getAgentConfigurationWithVersion<V extends AgentFetchVariant>(
+export async function getAgentConfigurationWithVersion<
+  V extends AgentFetchVariant,
+>(
   auth: Authenticator,
   {
     agentId,

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -73,7 +73,7 @@ import type { TagType } from "@app/types/tag";
 /**
  * Get one specific version of a single agent
  */
-async function getAgentConfigurationWithVersion<V extends AgentFetchVariant>(
+export async function getAgentConfigurationWithVersion<V extends AgentFetchVariant>(
   auth: Authenticator,
   {
     agentId,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -249,8 +249,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           return null;
         }
         return {
-          sId: agentMessage.agentConfigurationId,
-          version: agentMessage.agentConfigurationVersion,
+          agentId: agentMessage.agentConfigurationId,
+          agentVersion: agentMessage.agentConfigurationVersion,
         };
       })
     );

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -21,7 +21,7 @@ import {
 } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
-import { getAgentConfigurationWithVersion } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurationsWithVersion } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
@@ -249,22 +249,18 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           return null;
         }
         return {
-          agentId: agentMessage.agentConfigurationId,
-          agentVersion: agentMessage.agentConfigurationVersion,
+          sId: agentMessage.agentConfigurationId,
+          version: agentMessage.agentConfigurationVersion,
         };
       })
     );
 
-    const agentConfigurations = removeNulls(
-      await Promise.all(
-        agentConfigVersionPairs.map(({ agentId, agentVersion }) =>
-          getAgentConfigurationWithVersion(auth, {
-            agentId,
-            agentVersion,
-            variant: "extra_light",
-          })
-        )
-      )
+    const agentConfigurations = await getAgentConfigurationsWithVersion(
+      auth,
+      agentConfigVersionPairs,
+      {
+        variant: "extra_light",
+      }
     );
 
     const mcpServerViewIds = [

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -21,7 +21,7 @@ import {
 } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurationWithVersion } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
@@ -241,18 +241,31 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     const blockedActionsList: BlockedToolExecution[] = [];
 
-    // We get the latest version here, it may show a different name than the one used when the
-    // action was created, taking this shortcut for the sake of simplicity.
-    const agentConfigurations = await getAgentConfigurations(auth, {
-      agentIds: [
-        ...new Set(
-          removeNulls(
-            blockedActions.map((a) => a.agentMessage?.agentConfigurationId)
-          )
-        ),
-      ],
-      variant: "extra_light",
-    });
+    // Fetch agent configurations with their specific versions from the actions.
+    const agentConfigVersionPairs = removeNulls(
+      blockedActions.map((a) => {
+        const agentMessage = a.agentMessage;
+        if (!agentMessage) {
+          return null;
+        }
+        return {
+          agentId: agentMessage.agentConfigurationId,
+          agentVersion: agentMessage.agentConfigurationVersion,
+        };
+      })
+    );
+
+    const agentConfigurations = removeNulls(
+      await Promise.all(
+        agentConfigVersionPairs.map(({ agentId, agentVersion }) =>
+          getAgentConfigurationWithVersion(auth, {
+            agentId,
+            agentVersion,
+            variant: "extra_light",
+          })
+        )
+      )
+    );
 
     const mcpServerViewIds = [
       ...new Set(
@@ -287,7 +300,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       }
 
       const agentConfiguration = agentConfigurations.find(
-        (a) => a.sId === agentMessage.agentConfigurationId
+        (a) =>
+          a.sId === agentMessage.agentConfigurationId &&
+          a.version === agentMessage.agentConfigurationVersion
       );
       assert(agentConfiguration, "Agent not found.");
 


### PR DESCRIPTION
## Description

- Fixed version of https://github.com/dust-tt/dust/pull/17468.
- Global agents can actually run tools that require user validation via JIT actions or toolset.
- This PR handles them properly.

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
