### PR TITLE
[front] - fix(obs): mode switch

### DIFF
--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -18,11 +18,11 @@ import {
 import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import { filterTimeSeriesByVersionWindow } from "@app/components/agent_builder/observability/utils";
 import {
   useAgentFeedbackDistribution,
   useAgentVersionMarkers,
 } from "@app/lib/swr/assistants";
-import { filterTimeSeriesByVersionWindow } from "@app/components/agent_builder/observability/utils";
 
 interface FeedbackDistributionChartProps {
   workspaceId: string;

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -19,11 +19,11 @@ import { useObservability } from "@app/components/agent_builder/observability/Ob
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { filterTimeSeriesByVersionWindow } from "@app/components/agent_builder/observability/utils";
 import {
   useAgentUsageMetrics,
   useAgentVersionMarkers,
 } from "@app/lib/swr/assistants";
-import { filterTimeSeriesByVersionWindow } from "@app/components/agent_builder/observability/utils";
 
 interface UsageMetricsData {
   messages: number;


### PR DESCRIPTION
## Description

When switching between time range and version modes in the observability dashboard, the `FeedbackDistributionChart` and `UsageMetricsChart` were displaying all data points regardless of the selected version. This PR fixes the mode switch by filtering time series data based on the selected version window.

## Risk

Low

## Tests

- [x] Locally
- [x] front-edge

## Deploy Plan

Deploy front