### PR TITLE
use userEmailContext when getting tool execution status

### DIFF
--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -1,7 +1,7 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import { getUserMessageFromParentMessageId } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
-import { Message, UserMessage } from "@app/lib/models/assistant/conversation";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { AgentMessageType, ModelId } from "@app/types";
 import { assertNever } from "@app/types";
@@ -37,7 +37,7 @@ export async function getExecutionStatusFromConfig(
 
       // The user may not be populated, notably when using the public API.
       if (!user && workspace && agentMessage.parentMessageId) {
-        const userMessage = await getUserMessageFromParentMessage({
+        const userMessage = await getUserMessageFromParentMessageId({
           workspaceId: workspace.id,
           conversationId,
           parentMessageId: agentMessage.parentMessageId,
@@ -70,33 +70,6 @@ export async function getExecutionStatusFromConfig(
     default:
       assertNever(actionConfiguration.permission);
   }
-}
-
-async function getUserMessageFromParentMessage({
-  workspaceId,
-  conversationId,
-  parentMessageId,
-}: {
-  workspaceId: ModelId;
-  conversationId: ModelId;
-  parentMessageId: string;
-}) {
-  const message = await Message.findOne({
-    where: {
-      workspaceId,
-      conversationId,
-      sId: parentMessageId,
-    },
-    include: [
-      {
-        model: UserMessage,
-        as: "userMessage",
-      },
-    ],
-    attributes: ["id"],
-  });
-
-  return message?.userMessage ?? null;
 }
 
 const TOOLS_VALIDATION_WILDCARD = "*";

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -9,7 +9,8 @@ import { assertNever } from "@app/types";
 export async function getExecutionStatusFromConfig(
   auth: Authenticator,
   actionConfiguration: MCPToolConfigurationType,
-  agentMessage: AgentMessageType
+  agentMessage: AgentMessageType,
+  conversationId: ModelId
 ): Promise<{
   stake?: MCPToolStakeLevelType;
   status: "ready_allowed_implicitly" | "blocked_validation_required";
@@ -38,6 +39,7 @@ export async function getExecutionStatusFromConfig(
       if (!user && workspace && agentMessage.parentMessageId) {
         const userMessage = await getUserMessageFromParentMessage({
           workspaceId: workspace.id,
+          conversationId,
           parentMessageId: agentMessage.parentMessageId,
         });
 
@@ -72,14 +74,17 @@ export async function getExecutionStatusFromConfig(
 
 async function getUserMessageFromParentMessage({
   workspaceId,
+  conversationId,
   parentMessageId,
 }: {
   workspaceId: ModelId;
+  conversationId: ModelId;
   parentMessageId: string;
 }) {
   const message = await Message.findOne({
     where: {
       workspaceId,
+      conversationId,
       sId: parentMessageId,
     },
     include: [

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -2,7 +2,6 @@ import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { getUserMessageFromParentMessageId } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   AgentMessageType,
@@ -53,25 +52,8 @@ export async function getExecutionStatusFromConfig(
           const users = await UserResource.listUserWithExactEmails(workspace, [
             email,
           ]);
-          const potentialUser = users[0] ?? null;
 
-          // Security: Only use the email-based user lookup for authorization if the user
-          // is actually a participant in the conversation. This prevents API callers from
-          // impersonating other users by setting context.email to their email address.
-          if (potentialUser) {
-            const conversation = await ConversationResource.fetchByModelId(
-              conversationWithoutContent.id
-            );
-
-            if (conversation) {
-              const isParticipant =
-                await conversation.isConversationParticipant(potentialUser);
-
-              if (isParticipant) {
-                user = potentialUser;
-              }
-            }
-          }
+          user = users[0] ?? null;
         }
       }
 

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -1,0 +1,150 @@
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { Message, UserMessage } from "@app/lib/models/assistant/conversation";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { AgentMessageType, ModelId } from "@app/types";
+import { assertNever } from "@app/types";
+
+export async function getExecutionStatusFromConfig(
+  auth: Authenticator,
+  actionConfiguration: MCPToolConfigurationType,
+  agentMessage: AgentMessageType
+): Promise<{
+  stake?: MCPToolStakeLevelType;
+  status: "ready_allowed_implicitly" | "blocked_validation_required";
+  serverId?: string;
+}> {
+  // If the agent message is marked as "skipToolsValidation" we skip all tools validation
+  // irrespective of the `actionConfiguration.permission`. This is set when the agent message was
+  // created by an API call where the caller explicitly set `skipToolsValidation` to true.
+  if (agentMessage.skipToolsValidation) {
+    return { status: "ready_allowed_implicitly" };
+  }
+
+  // Permissions:
+  // - "never_ask": Automatically approved
+  // - "low": Ask user for approval and allow to automatically approve next time
+  // - "high": Ask for approval each time
+  // - undefined: Use default permission ("never_ask" for default tools, "high" for other tools)
+  switch (actionConfiguration.permission) {
+    case "never_ask":
+      return { status: "ready_allowed_implicitly" };
+    case "low": {
+      let user = auth.user();
+      const workspace = auth.workspace();
+
+      // The user may not be populated, notably when using the public API.
+      if (!user && workspace && agentMessage.parentMessageId) {
+        const userMessage = await getUserMessageFromParentMessage({
+          workspaceId: workspace.id,
+          parentMessageId: agentMessage.parentMessageId,
+        });
+
+        const email = userMessage?.userContextEmail ?? null;
+
+        if (email) {
+          const users = await UserResource.listUserWithExactEmails(workspace, [
+            email,
+          ]);
+          user = users[0] ?? null;
+        }
+      }
+
+      if (
+        user &&
+        (await hasUserAlwaysApprovedTool({
+          user,
+          mcpServerId: actionConfiguration.toolServerId,
+          functionCallName: actionConfiguration.name,
+        }))
+      ) {
+        return { status: "ready_allowed_implicitly" };
+      }
+      return { status: "blocked_validation_required" };
+    }
+    case "high":
+      return { status: "blocked_validation_required" };
+    default:
+      assertNever(actionConfiguration.permission);
+  }
+}
+
+async function getUserMessageFromParentMessage({
+  workspaceId,
+  parentMessageId,
+}: {
+  workspaceId: ModelId;
+  parentMessageId: string;
+}) {
+  const message = await Message.findOne({
+    where: {
+      workspaceId,
+      sId: parentMessageId,
+    },
+    include: [
+      {
+        model: UserMessage,
+        as: "userMessage",
+      },
+    ],
+    attributes: ["id"],
+  });
+
+  return message?.userMessage ?? null;
+}
+
+const TOOLS_VALIDATION_WILDCARD = "*";
+
+const getToolsValidationKey = (mcpServerId: string) =>
+  `toolsValidations:${mcpServerId}`;
+
+// The function call name is scoped by MCP servers so that the same tool name on different servers
+// does not conflict, which is why we use it here instead of the tool name.
+export async function setUserAlwaysApprovedTool({
+  user,
+  mcpServerId,
+  functionCallName,
+}: {
+  user: UserResource;
+  mcpServerId: string;
+  functionCallName: string;
+}) {
+  if (!functionCallName) {
+    throw new Error("functionCallName is required");
+  }
+  if (!mcpServerId) {
+    throw new Error("mcpServerId is required");
+  }
+
+  await user.upsertMetadataArray(
+    getToolsValidationKey(mcpServerId),
+    functionCallName
+  );
+}
+
+export async function hasUserAlwaysApprovedTool({
+  user,
+  mcpServerId,
+  functionCallName,
+}: {
+  user: UserResource;
+  mcpServerId: string;
+  functionCallName: string;
+}) {
+  if (!mcpServerId) {
+    throw new Error("mcpServerId is required");
+  }
+
+  if (!functionCallName) {
+    throw new Error("functionCallName is required");
+  }
+
+  const metadata = await user.getMetadataAsArray(
+    getToolsValidationKey(mcpServerId)
+  );
+  return (
+    metadata.includes(functionCallName) ||
+    metadata.includes(TOOLS_VALIDATION_WILDCARD)
+  );
+}

--- a/front/lib/actions/utils.test.ts
+++ b/front/lib/actions/utils.test.ts
@@ -4,7 +4,10 @@ import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 
-import { hasUserAlwaysApprovedTool, setUserAlwaysApprovedTool } from "./utils";
+import {
+  hasUserAlwaysApprovedTool,
+  setUserAlwaysApprovedTool,
+} from "./tool_status";
 
 describe("Tool validation utilities", () => {
   let user: UserResource;

--- a/front/lib/actions/utils.test.ts
+++ b/front/lib/actions/utils.test.ts
@@ -1,13 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
-import type { UserResource } from "@app/lib/resources/user_resource";
-import { UserFactory } from "@app/tests/utils/UserFactory";
-
 import {
   hasUserAlwaysApprovedTool,
   setUserAlwaysApprovedTool,
-} from "./tool_status";
+} from "@app/lib/actions/tool_status";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 
 describe("Tool validation utilities", () => {
   let user: UserResource;

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -1,7 +1,6 @@
 import { ToolsIcon } from "@dust-tt/sparkle";
 
 import type { ActionSpecification } from "@app/components/assistant_builder/types";
-import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { StepContext } from "@app/lib/actions/types";
 import {
@@ -14,10 +13,7 @@ import {
   isMCPInternalWebsearch,
 } from "@app/lib/actions/types/guards";
 import { getSupportedModelConfig } from "@app/lib/assistant";
-import type { Authenticator } from "@app/lib/auth";
-import type { UserResource } from "@app/lib/resources/user_resource";
-import type { AgentConfigurationType, AgentMessageType } from "@app/types";
-import { assertNever } from "@app/types";
+import type { AgentConfigurationType } from "@app/types";
 
 export const WEBSEARCH_ACTION_NUM_RESULTS = 16;
 export const SLACK_SEARCH_ACTION_NUM_RESULTS = 24;
@@ -176,106 +172,4 @@ export function computeStepContexts({
   }
 
   return stepContexts;
-}
-
-export async function getExecutionStatusFromConfig(
-  auth: Authenticator,
-  actionConfiguration: MCPToolConfigurationType,
-  agentMessage: AgentMessageType
-): Promise<{
-  stake?: MCPToolStakeLevelType;
-  status: "ready_allowed_implicitly" | "blocked_validation_required";
-  serverId?: string;
-}> {
-  // If the agent message is marked as "skipToolsValidation" we skip all tools validation
-  // irrespective of the `actionConfiguration.permission`. This is set when the agent message was
-  // created by an API call where the caller explicitly set `skipToolsValidation` to true.
-  if (agentMessage.skipToolsValidation) {
-    return { status: "ready_allowed_implicitly" };
-  }
-
-  // Permissions:
-  // - "never_ask": Automatically approved
-  // - "low": Ask user for approval and allow to automatically approve next time
-  // - "high": Ask for approval each time
-  // - undefined: Use default permission ("never_ask" for default tools, "high" for other tools)
-  switch (actionConfiguration.permission) {
-    case "never_ask":
-      return { status: "ready_allowed_implicitly" };
-    case "low": {
-      // The user may not be populated, notably when using the public API.
-      const user = auth.user();
-
-      if (
-        user &&
-        (await hasUserAlwaysApprovedTool({
-          user,
-          mcpServerId: actionConfiguration.toolServerId,
-          functionCallName: actionConfiguration.name,
-        }))
-      ) {
-        return { status: "ready_allowed_implicitly" };
-      }
-      return { status: "blocked_validation_required" };
-    }
-    case "high":
-      return { status: "blocked_validation_required" };
-    default:
-      assertNever(actionConfiguration.permission);
-  }
-}
-
-const TOOLS_VALIDATION_WILDCARD = "*";
-
-const getToolsValidationKey = (mcpServerId: string) =>
-  `toolsValidations:${mcpServerId}`;
-
-// The function call name is scoped by MCP servers so that the same tool name on different servers
-// does not conflict, which is why we use it here instead of the tool name.
-export async function setUserAlwaysApprovedTool({
-  user,
-  mcpServerId,
-  functionCallName,
-}: {
-  user: UserResource;
-  mcpServerId: string;
-  functionCallName: string;
-}) {
-  if (!functionCallName) {
-    throw new Error("functionCallName is required");
-  }
-  if (!mcpServerId) {
-    throw new Error("mcpServerId is required");
-  }
-
-  await user.upsertMetadataArray(
-    getToolsValidationKey(mcpServerId),
-    functionCallName
-  );
-}
-
-export async function hasUserAlwaysApprovedTool({
-  user,
-  mcpServerId,
-  functionCallName,
-}: {
-  user: UserResource;
-  mcpServerId: string;
-  functionCallName: string;
-}) {
-  if (!mcpServerId) {
-    throw new Error("mcpServerId is required");
-  }
-
-  if (!functionCallName) {
-    throw new Error("functionCallName is required");
-  }
-
-  const metadata = await user.getMetadataAsArray(
-    getToolsValidationKey(mcpServerId)
-  );
-  return (
-    metadata.includes(functionCallName) ||
-    metadata.includes(TOOLS_VALIDATION_WILDCARD)
-  );
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -290,6 +290,33 @@ export async function getLastUserMessage(
   return new Ok(content);
 }
 
+export async function getUserMessageFromParentMessageId({
+  workspaceId,
+  conversationId,
+  parentMessageId,
+}: {
+  workspaceId: ModelId;
+  conversationId: ModelId;
+  parentMessageId: string;
+}) {
+  const message = await Message.findOne({
+    where: {
+      workspaceId,
+      conversationId,
+      sId: parentMessageId,
+    },
+    include: [
+      {
+        model: UserMessage,
+        as: "userMessage",
+      },
+    ],
+    attributes: ["id"],
+  });
+
+  return message?.userMessage ?? null;
+}
+
 /**
  * Conversation API
  */

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -298,7 +298,7 @@ export async function getUserMessageFromParentMessageId({
   workspaceId: ModelId;
   conversationId: ModelId;
   parentMessageId: string;
-}) {
+}): Promise<UserMessage | null> {
   const message = await Message.findOne({
     where: {
       workspaceId,

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -5,7 +5,7 @@ import {
   getMCPApprovalStateFromUserApprovalState,
   isMCPApproveExecutionEvent,
 } from "@app/lib/actions/mcp";
-import { setUserAlwaysApprovedTool } from "@app/lib/actions/utils";
+import { setUserAlwaysApprovedTool } from "@app/lib/actions/tool_status";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -7,8 +7,8 @@ import type {
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import type { StepContext } from "@app/lib/actions/types";
-import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
 import type { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
 import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -137,7 +137,8 @@ async function createActionForTool(
   const { status } = await getExecutionStatusFromConfig(
     auth,
     actionConfiguration,
-    agentMessage
+    agentMessage,
+    conversation.id
   );
 
   const stepContent =

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -138,7 +138,7 @@ async function createActionForTool(
     auth,
     actionConfiguration,
     agentMessage,
-    conversation.id
+    conversation
   );
 
   const stepContent =


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/4809
- When making call via the API, as we use an API Key we couldn't know if the user had already checked "Always allow this tool". Now we can also get the user from userMessage context when available.
- We have to move some functions from utils.ts to tool_status.ts because it needs to import `Message` and `UserMessage`. utils.ts is used client side so we can't import `Message` and `UserMessage` there

```
Client components → import from lib/spaces.ts
lib/spaces.ts → imports MCP_SPECIFICATION from lib/actions/utils.ts
lib/actions/utils.ts → imports Message, UserMessage (at top level)
lib/models/assistant/conversation.ts → imports frontSequelize
lib/resources/storage/index.ts → imports statsd
lib/utils/statsd.ts → imports hot-shots which requires Node.js dns module
```

## Tests

Locally. Checked both from API and UI.

## Risk

Limited change but need to make sure there's no side effects

## Deploy Plan

Deploy front
