### PR TITLE
feat(cache-writes): report cache writes as such in core

### DIFF
--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -573,14 +573,10 @@ impl LLM for AnthropicLLM {
             usage: Some(LLMTokenUsage {
                 prompt_tokens: c.usage.input_tokens
                     + c.usage.cache_read_input_tokens.unwrap_or(0)
-                    // TODO(cache-writes): Once LLMTokenUsage supports reporting cache writes separately,
-                    // don't add the cache creation input tokens here.
                     + c.usage.cache_creation_input_tokens.unwrap_or(0),
                 completion_tokens: c.usage.output_tokens,
                 cached_tokens: c.usage.cache_read_input_tokens,
-                // TODO(cache-writes): Once LLMTokenUsage supports reporting cache writes separately,
-                // add the field below to LLMTokenUsage (in providers/llm.rs) and uncomment the next line.
-                // cache_creation_input_tokens: c.usage.cache_creation_input_tokens,
+                cache_creation_input_tokens: c.usage.cache_creation_input_tokens,
                 // Note: the model can actually use less than that, but best we can do is report
                 // the full budget.
                 reasoning_tokens: thinking_budget,

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -426,6 +426,7 @@ impl LLM for AzureOpenAILLM {
                     .prompt_tokens_details
                     .and_then(|details| details.cached_tokens),
                 reasoning_tokens: None,
+                cache_creation_input_tokens: None,
             }),
             provider_request_id: request_id,
         })

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -88,10 +88,8 @@ pub struct LLMTokenUsage {
     pub cached_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_tokens: Option<u64>,
-    // TODO(cache-writes): When ready to report cache writes separately, add the field below
-    // and plumb it from providers (e.g., Anthropic). Keep commented until the rollout step.
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // pub cache_creation_input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -1066,6 +1066,7 @@ impl LLM for MistralAILLM {
                 prompt_tokens: u.prompt_tokens,
                 cached_tokens: None,
                 reasoning_tokens: None,
+                cache_creation_input_tokens: None,
             }),
             provider_request_id: request_id,
             logprobs: None,

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1048,6 +1048,7 @@ impl LLM for OpenAILLM {
                     .prompt_tokens_details
                     .and_then(|details| details.cached_tokens),
                 reasoning_tokens: None,
+                cache_creation_input_tokens: None,
             }),
             provider_request_id: request_id,
         })

--- a/core/src/providers/openai_compatible_helpers.rs
+++ b/core/src/providers/openai_compatible_helpers.rs
@@ -761,6 +761,7 @@ pub async fn openai_compatible_chat_completion(
                 .prompt_tokens_details
                 .and_then(|details| details.cached_tokens),
             reasoning_tokens: None,
+            cache_creation_input_tokens: None,
         }),
         provider_request_id: request_id,
         logprobs: logprobs_from_choices(&c.choices),

--- a/core/src/providers/openai_responses_api_helpers.rs
+++ b/core/src/providers/openai_responses_api_helpers.rs
@@ -595,6 +595,7 @@ pub async fn openai_responses_api_completion(
             reasoning_tokens: usage
                 .output_tokens_details
                 .and_then(|details| details.reasoning_tokens),
+            cache_creation_input_tokens: None,
         }),
         provider_request_id: request_id,
         logprobs: None,


### PR DESCRIPTION
## Description

- Front now supports extracting and persisting `cache_creation_input_tokens` from traces
- This PR updates core to actually report cache creation separately from regular input tokens on Anthropic
- This needs to be marged after analytics stack is updated to take these into account

## Tests

Local

## Risk

Affects analytics. Should be merged once analytics is ready.

## Deploy Plan

Deploy `core` once analytics is ready