### PR TITLE
feat: always use cache_control on anthropic

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -322,9 +322,6 @@ impl Block for Chat {
                 if let Some(Value::Object(s)) = v.get("anthropic_thinking") {
                     extras["anthropic_thinking"] = json!(s.clone());
                 }
-                if let Some(Value::Bool(s)) = v.get("prompt_caching") {
-                    extras["prompt_caching"] = json!(s.clone());
-                }
                 if let Some(Value::Array(a)) = v.get("anthropic_beta_flags") {
                     extras["anthropic_beta_flags"] = json!(a
                         .iter()

--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -335,7 +335,7 @@ impl Block for Chat {
                         .collect::<Result<Vec<String>>>()?);
                 }
 
-                match extras.as_object().unwrap().keys().len() {
+                match extras.as_object().ok_or(anyhow!("Invalid `extras` in configuration for chat block `{}`: expecting an object", name))?.keys().len() {
                     0 => None,
                     _ => Some(extras),
                 }

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -409,9 +409,6 @@ impl Block for LLM {
                 if let Some(Value::String(s)) = v.get("reasoning_effort") {
                     extras["reasoning_effort"] = json!(s.clone());
                 }
-                if let Some(Value::Bool(s)) = v.get("prompt_caching") {
-                    extras["prompt_caching"] = json!(s.clone());
-                }
 
                 match extras.as_object().unwrap().keys().len() {
                     0 => None,

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -410,7 +410,15 @@ impl Block for LLM {
                     extras["reasoning_effort"] = json!(s.clone());
                 }
 
-                match extras.as_object().unwrap().keys().len() {
+                match extras
+                    .as_object()
+                    .ok_or(anyhow!(
+                        "Invalid `extras` in configuration for llm block `{}`: expecting an object",
+                        name
+                    ))?
+                    .keys()
+                    .len()
+                {
                     0 => None,
                     _ => Some(extras),
                 }

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -85,7 +85,6 @@ impl AnthropicLLM {
         stream: bool,
         thinking: Option<(String, u64)>,
         beta_flags: &Vec<&str>,
-        prompt_caching: bool,
     ) -> Value {
         let is_claude_4_5 =
             self.id.starts_with("claude-sonnet-4-5") || self.id.starts_with("claude-haiku-4-5");
@@ -116,11 +115,8 @@ impl AnthropicLLM {
         }
 
         if system.is_some() {
-            if prompt_caching {
-                body["system"] = json!([{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]);
-            } else {
-                body["system"] = json!(system);
-            }
+            body["system"] =
+                json!([{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]);
         }
 
         if let Some((thinking_type, thinking_budget_tokens)) = thinking {
@@ -169,7 +165,6 @@ impl AnthropicLLM {
         stop_sequences: &Vec<String>,
         max_tokens: i32,
         beta_flags: &Vec<&str>,
-        prompt_caching: bool,
     ) -> Result<(ChatResponse, Option<String>)> {
         assert!(self.api_key.is_some());
 
@@ -185,7 +180,6 @@ impl AnthropicLLM {
             false,
             None,
             beta_flags,
-            prompt_caching,
         );
 
         let body = self.backend.build_request_body(base_body, &self.id);
@@ -251,7 +245,6 @@ impl AnthropicLLM {
         beta_flags: &Vec<&str>,
         event_sender: UnboundedSender<Value>,
         thinking: Option<(String, u64)>,
-        prompt_caching: bool,
     ) -> Result<(ChatResponse, Option<String>)> {
         let base_body = self.build_base_request_body(
             messages,
@@ -265,7 +258,6 @@ impl AnthropicLLM {
             true,
             thinking,
             beta_flags,
-            prompt_caching,
         );
 
         let body = self.backend.build_request_body(base_body, &self.id);
@@ -409,29 +401,19 @@ impl LLM for AnthropicLLM {
             None => (None, 0),
         };
 
-        let prompt_caching = match &extras {
-            None => false,
-            Some(v) => match v.get("prompt_caching") {
-                Some(Value::Bool(b)) => *b,
-                _ => false,
-            },
-        };
-
         let mut anthropic_messages =
             get_anthropic_chat_messages(messages[slice_from..].to_vec()).await?;
 
-        if prompt_caching {
-            anthropic_messages
-                .last_mut()
-                .map(|last| match last.content.last_mut() {
-                    Some(last_content) => {
-                        last_content.cache_control = Some(AnthropicCacheControl {
-                            r#type: AnthropicCacheControlType::Ephemeral,
-                        })
-                    }
-                    _ => {}
-                });
-        }
+        anthropic_messages
+            .last_mut()
+            .map(|last| match last.content.last_mut() {
+                Some(last_content) => {
+                    last_content.cache_control = Some(AnthropicCacheControl {
+                        r#type: AnthropicCacheControlType::Ephemeral,
+                    })
+                }
+                _ => {}
+            });
 
         let tools = functions
             .iter()
@@ -539,7 +521,6 @@ impl LLM for AnthropicLLM {
                     &beta_flags,
                     es,
                     thinking,
-                    prompt_caching,
                 )
                 .await?
             }
@@ -560,7 +541,6 @@ impl LLM for AnthropicLLM {
                         None => get_max_tokens(self.id.as_str()) as i32,
                     },
                     &beta_flags,
-                    prompt_caching,
                 )
                 .await?
             }

--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -12,7 +12,6 @@ import { Err, Ok } from "@app/types";
 export interface LLMConfig {
   functionCall?: string | null;
   modelId: ModelIdType;
-  promptCaching?: boolean;
   providerId: ModelProviderIdType;
   reasoningEffort?: string;
   responseFormat?: string;

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -564,7 +564,6 @@ export function _getDeepDiveGlobalAgent(
     modelId: modelConfig.modelConfiguration.modelId,
     temperature: 1.0,
     reasoningEffort: modelConfig.reasoningEffort,
-    promptCaching: true,
   };
 
   deepAgent.model = model;

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -273,7 +273,6 @@ export function _getDustGlobalAgent(
         modelId: modelConfiguration.modelId,
         temperature: 0.7,
         reasoningEffort: modelConfiguration.defaultReasoningEffort,
-        promptCaching: modelConfiguration.supportsPromptCaching,
       }
     : dummyModelConfiguration;
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -366,11 +366,6 @@ export async function runModelActivity(
     runConfig.MODEL.anthropic_beta_flags = anthropicBetaFlags;
   }
 
-  // Set prompt_caching from agent configuration
-  if (agentConfiguration.model.promptCaching) {
-    runConfig.MODEL.prompt_caching = agentConfiguration.model.promptCaching;
-  }
-
   // Errors occurring during the multi-actions-agent dust app may be retryable.
   // Their implicit code should be "multi_actions_error".
   async function handlePossiblyRetryableError(message: string) {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -99,7 +99,6 @@ export type AgentModelConfigurationType = {
   temperature: number;
   reasoningEffort?: AgentReasoningEffort;
   responseFormat?: string;
-  promptCaching?: boolean;
 };
 
 export type AgentFetchVariant = "light" | "full" | "extra_light";


### PR DESCRIPTION
## Description

- removes all config related to prompt caching from `front`
- anthropic provider in core always passes cache_control (always cache)

## Tests

Local

## Risk

Medium (blast radius technically pretty high)

## Deploy Plan

Deploy core and front.