### PR TITLE
Add missing parameters to fix specific oauth mcp server.

### DIFF
--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -36,6 +36,8 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       tos_uri: config.getClientFacingUrl() + "/terms",
       policy_uri: config.getClientFacingUrl() + "/privacy",
       software_id: "dust",
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
     };
   }
 


### PR DESCRIPTION
## Description

Some MCP servers (like contentsquare's) need these params.

## Tests

Locally

## Risk

Medium, could break other MCP servers.

## Deploy Plan

Deploy front