### PR TITLE
[front] fix(webhook): 500 on wehbooks that could not be processed

### DIFF
--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -110,7 +110,7 @@ export const checkWebhookRequestForRateLimit = async (
   }
 };
 
-export const processWebhookRequest = async (
+export async function processWebhookRequest(
   auth: Authenticator,
   {
     webhookSource,
@@ -119,9 +119,9 @@ export const processWebhookRequest = async (
   }: {
     webhookSource: WebhookSourceForAdminType;
     headers: IncomingHttpHeaders;
-    body: any;
+    body: unknown;
   }
-) => {
+): Promise<Result<void, Error>> {
   // Store on GCS as a file
   const content = JSON.stringify({
     headers: Object.fromEntries(
@@ -178,7 +178,9 @@ export const processWebhookRequest = async (
     );
     return new Err(normalizedError);
   }
-};
+
+  return new Ok(undefined);
+}
 
 export async function fetchRecentWebhookRequestTriggersWithPayload(
   auth: Authenticator,

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -31,8 +31,18 @@ vi.mock("@app/lib/triggers/temporal/common/client", () => ({
   })),
 }));
 
+vi.mock("@app/lib/triggers/temporal/webhook/client", () => ({
+  launchAgentTriggerWebhookWorkflow: vi.fn(async () => ({
+    isOk: () => true,
+    isErr: () => false,
+    value: undefined,
+  })),
+}));
+
 vi.mock("@app/lib/file_storage", () => ({
-  getWebhookRequestsBucket: vi.fn(() => ({})),
+  getWebhookRequestsBucket: () => ({
+    uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
+  }),
 }));
 
 import handler from ".";

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -140,13 +140,22 @@ async function handler(
     });
   }
 
-  await processWebhookRequest(auth, {
+  const result = await processWebhookRequest(auth, {
     webhookSource: webhookSource.toJSONForAdmin(),
     headers,
     body,
   });
 
-  // Always return success as the processing will be done in the background
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "webhook_processing_error",
+        message: result.error.message,
+      },
+    });
+  }
+
   return res.status(200).json({ success: true });
 }
 

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -121,6 +121,7 @@ const API_ERROR_TYPES = [
   "webhook_source_view_not_found",
   "webhook_source_view_triggering_agent",
   "webhook_source_misconfiguration",
+  "webhook_processing_error",
   // MCP Server Connections:
   "mcp_server_connection_not_found",
   "mcp_server_view_not_found",


### PR DESCRIPTION
## Description

- This PR updates the endpoint `/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]` to return a 500 when the webhook could not be processed.
- The return type of `processWebhookRequest` is currently ignored, I think we want to 500 if we failed to process for some reason so that we log a 500 or even that the webhook is retried.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
