### PR TITLE
[front] feat(obs): add error rate graph

### DIFF
--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -98,11 +98,11 @@ export function AgentBuilderObservability({
                 workspaceId={owner.sId}
                 agentConfigurationId={agentConfiguration.sId}
               />
-              <LatencyChart
+              <ErrorRateChart
                 workspaceId={owner.sId}
                 agentConfigurationId={agentConfiguration.sId}
               />
-              <ErrorRateChart
+              <LatencyChart
                 workspaceId={owner.sId}
                 agentConfigurationId={agentConfiguration.sId}
               />

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -12,6 +12,7 @@ import {
 import { useEffect } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { ErrorRateChart } from "@app/components/agent_builder/observability/charts/ErrorRateChart";
 import { FeedbackDistributionChart } from "@app/components/agent_builder/observability/charts/FeedbackDistributionChart";
 import { LatencyChart } from "@app/components/agent_builder/observability/charts/LatencyChart";
 import { ToolUsageChart } from "@app/components/agent_builder/observability/charts/ToolUsageChart";
@@ -81,6 +82,7 @@ export function AgentBuilderObservability({
               <ChartContainerSkeleton />
               <ChartContainerSkeleton />
               <ChartContainerSkeleton />
+              <ChartContainerSkeleton />
             </>
           ) : (
             <>
@@ -97,6 +99,10 @@ export function AgentBuilderObservability({
                 agentConfigurationId={agentConfiguration.sId}
               />
               <LatencyChart
+                workspaceId={owner.sId}
+                agentConfigurationId={agentConfiguration.sId}
+              />
+              <ErrorRateChart
                 workspaceId={owner.sId}
                 agentConfigurationId={agentConfiguration.sId}
               />

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -22,6 +22,9 @@ import { ChartLegend } from "@app/components/agent_builder/observability/shared/
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { useAgentErrorRate } from "@app/lib/swr/assistants";
 
+const WARNING_THRESHOLD = 5;
+const CRITICAL_THRESHOLD = 10;
+
 interface ErrorRateData {
   total: number;
   failed: number;
@@ -101,9 +104,9 @@ export function ErrorRateChart({
       : 0;
 
   const getStatusChip = () => {
-    if (averageErrorRate < 5) {
+    if (averageErrorRate < WARNING_THRESHOLD) {
       return <Chip color="success" size="xs" label="HEALTHY" />;
-    } else if (averageErrorRate < 10) {
+    } else if (averageErrorRate < CRITICAL_THRESHOLD) {
       return <Chip color="info" size="xs" label="WARNING" />;
     } else {
       return <Chip color="warning" size="xs" label="CRITICAL" />;

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -158,6 +158,18 @@ export function ErrorRateChart({
               boxShadow: "none",
             }}
           />
+          <ReferenceLine
+            y={5}
+            stroke="hsl(var(--warning))"
+            strokeDasharray="3 3"
+            strokeWidth={1.5}
+          />
+          <ReferenceLine
+            y={10}
+            stroke="hsl(var(--destructive))"
+            strokeDasharray="3 3"
+            strokeWidth={1.5}
+          />
           <Area
             type="natural"
             dataKey="errorRate"

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -44,10 +44,10 @@ function ErrorRateTooltip({
     return null;
   }
   const first = payload[0];
-  if (!first?.payload || !isErrorRateData(first.payload)) {
+  const row = first.payload;
+  if (!row || !isErrorRateData(row)) {
     return null;
   }
-  const row = first.payload;
   const title = typeof label === "number" ? String(label) : label;
   return (
     <ChartTooltipCard
@@ -98,7 +98,7 @@ export function ErrorRateChart({
     colorClassName: ERROR_RATE_PALETTE[key],
   }));
 
-  const latestErrorRate = data[data.length - 1].errorRate ?? 0;
+  const latestErrorRate = data[data.length - 1]?.errorRate ?? 0;
 
   const getStatusChip = () => {
     if (latestErrorRate < WARNING_THRESHOLD) {

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -1,7 +1,9 @@
+import { Chip } from "@dust-tt/sparkle";
 import {
   Area,
   AreaChart,
   CartesianGrid,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -93,9 +95,32 @@ export function ErrorRateChart({
     colorClassName: ERROR_RATE_PALETTE[key],
   }));
 
+  const averageErrorRate =
+    data.length > 0
+      ? data.reduce((sum, point) => sum + point.errorRate, 0) / data.length
+      : 0;
+
+  const getStatusChip = () => {
+    if (averageErrorRate < 5) {
+      return <Chip color="success" size="xs" label="HEALTHY" />;
+    } else if (averageErrorRate < 10) {
+      return <Chip color="info" size="xs" label="WARNING" />;
+    } else {
+      return <Chip color="warning" size="xs" label="CRITICAL" />;
+    }
+  };
+
   return (
     <ChartContainer
-      title="Error rate"
+      title={
+        <div className="flex items-center gap-2">
+          <span>Error rate</span>
+          {!isErrorRateLoading &&
+            !isErrorRateError &&
+            data.length > 0 &&
+            getStatusChip()}
+        </div>
+      }
       isLoading={isErrorRateLoading}
       errorMessage={
         isErrorRateError ? "Failed to load observability data." : undefined

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -112,14 +112,11 @@ export function ErrorRateChart({
 
   return (
     <ChartContainer
-      title={
-        <div className="flex items-center gap-2">
-          <span>Error rate</span>
-          {!isErrorRateLoading &&
-            !isErrorRateError &&
-            data.length > 0 &&
-            getStatusChip()}
-        </div>
+      title="Error rate"
+      statusChip={
+        !isErrorRateLoading && !isErrorRateError && data.length > 0
+          ? getStatusChip()
+          : undefined
       }
       isLoading={isErrorRateLoading}
       errorMessage={

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -43,7 +43,7 @@ function ErrorRateTooltip({
     return null;
   }
   const row = first.payload;
-  const title = typeof label === "string" ? label : String(label);
+  const title = typeof label === "number" ? String(label) : label;
   return (
     <ChartTooltipCard
       title={title}

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -30,10 +30,11 @@ function isErrorRateData(data: unknown): data is ErrorRateData {
   return typeof data === "object" && data !== null && "errorRate" in data;
 }
 
-function ErrorRateTooltip(
-  props: TooltipContentProps<number, string>
-): JSX.Element | null {
-  const { active, payload, label } = props;
+function ErrorRateTooltip({
+  active,
+  payload,
+  label,
+}: TooltipContentProps<number, string>): JSX.Element | null {
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -65,13 +66,15 @@ function ErrorRateTooltip(
   );
 }
 
+interface ErrorRateChartProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+}
+
 export function ErrorRateChart({
   workspaceId,
   agentConfigurationId,
-}: {
-  workspaceId: string;
-  agentConfigurationId: string;
-}) {
+}: ErrorRateChartProps) {
   const { period } = useObservability();
   const {
     errorRate: data,

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -1,0 +1,170 @@
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+import {
+  CHART_HEIGHT,
+  ERROR_RATE_LEGEND,
+  ERROR_RATE_PALETTE,
+} from "@app/components/agent_builder/observability/constants";
+import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
+import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
+import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { useAgentErrorRate } from "@app/lib/swr/assistants";
+
+interface ErrorRateData {
+  total: number;
+  failed: number;
+  errorRate: number;
+}
+
+function isErrorRateData(data: unknown): data is ErrorRateData {
+  return typeof data === "object" && data !== null && "errorRate" in data;
+}
+
+function ErrorRateTooltip(
+  props: TooltipContentProps<number, string>
+): JSX.Element | null {
+  const { active, payload, label } = props;
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+  const first = payload[0];
+  if (!first?.payload || !isErrorRateData(first.payload)) {
+    return null;
+  }
+  const row = first.payload;
+  const title = typeof label === "string" ? label : String(label);
+  return (
+    <ChartTooltipCard
+      title={title}
+      rows={[
+        {
+          label: "Error rate",
+          value: `${row.errorRate}%`,
+          colorClassName: ERROR_RATE_PALETTE.errorRate,
+        },
+        {
+          label: "Failed",
+          value: String(row.failed),
+        },
+        {
+          label: "Total messages",
+          value: String(row.total),
+        },
+      ]}
+    />
+  );
+}
+
+export function ErrorRateChart({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}) {
+  const { period } = useObservability();
+  const {
+    errorRate: data,
+    isErrorRateLoading,
+    isErrorRateError,
+  } = useAgentErrorRate({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    disabled: !workspaceId || !agentConfigurationId,
+  });
+
+  const legendItems = ERROR_RATE_LEGEND.map(({ key, label }) => ({
+    key,
+    label,
+    colorClassName: ERROR_RATE_PALETTE[key],
+  }));
+
+  return (
+    <ChartContainer
+      title="Error rate"
+      isLoading={isErrorRateLoading}
+      errorMessage={
+        isErrorRateError ? "Failed to load observability data." : undefined
+      }
+    >
+      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+        <AreaChart
+          data={data}
+          margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+        >
+          <defs>
+            <linearGradient id="fillErrorRate" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="hsl(var(--chart-4))"
+                stopOpacity={0.8}
+              />
+              <stop
+                offset="95%"
+                stopColor="hsl(var(--chart-4))"
+                stopOpacity={0.1}
+              />
+            </linearGradient>
+          </defs>
+          <CartesianGrid vertical={false} className="stroke-border" />
+          <XAxis
+            dataKey="date"
+            type="category"
+            scale="point"
+            allowDuplicatedCategory={false}
+            className="text-xs text-muted-foreground"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            minTickGap={16}
+          />
+          <YAxis
+            className="text-xs text-muted-foreground"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            type="number"
+            allowDecimals={true}
+            domain={[0, 100]}
+            label={{
+              value: "Error rate (%)",
+              angle: -90,
+              position: "insideLeft",
+              style: { textAnchor: "middle" },
+            }}
+          />
+          <Tooltip
+            content={ErrorRateTooltip}
+            cursor={false}
+            wrapperStyle={{ outline: "none" }}
+            contentStyle={{
+              background: "transparent",
+              border: "none",
+              padding: 0,
+              boxShadow: "none",
+            }}
+          />
+          <Area
+            type="natural"
+            dataKey="errorRate"
+            name="Error rate"
+            fill="url(#fillErrorRate)"
+            stroke="hsl(var(--chart-4))"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+      <ChartLegend items={legendItems} />
+    </ChartContainer>
+  );
+}

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -98,9 +98,8 @@ export function ErrorRateChart({
     colorClassName: ERROR_RATE_PALETTE[key],
   }));
 
-  const latestErrorRate = data[data.length - 1]?.errorRate ?? 0;
-
   const getStatusChip = () => {
+    const latestErrorRate = data[data.length - 1]?.errorRate ?? 0;
     if (latestErrorRate < WARNING_THRESHOLD) {
       return <Chip color="success" size="xs" label="HEALTHY" />;
     } else if (latestErrorRate < CRITICAL_THRESHOLD) {

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -98,15 +98,12 @@ export function ErrorRateChart({
     colorClassName: ERROR_RATE_PALETTE[key],
   }));
 
-  const averageErrorRate =
-    data.length > 0
-      ? data.reduce((sum, point) => sum + point.errorRate, 0) / data.length
-      : 0;
+  const latestErrorRate = data[data.length - 1].errorRate ?? 0;
 
   const getStatusChip = () => {
-    if (averageErrorRate < WARNING_THRESHOLD) {
+    if (latestErrorRate < WARNING_THRESHOLD) {
       return <Chip color="success" size="xs" label="HEALTHY" />;
-    } else if (averageErrorRate < CRITICAL_THRESHOLD) {
+    } else if (latestErrorRate < CRITICAL_THRESHOLD) {
       return <Chip color="info" size="xs" label="WARNING" />;
     } else {
       return <Chip color="warning" size="xs" label="CRITICAL" />;

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -57,3 +57,11 @@ export const FEEDBACK_DISTRIBUTION_LEGEND = [
   { key: "positive", label: "Positive" },
   { key: "negative", label: "Negative" },
 ] as const;
+
+export const ERROR_RATE_PALETTE = {
+  errorRate: "text-[hsl(var(--chart-4))]",
+} as const;
+
+export const ERROR_RATE_LEGEND = [
+  { key: "errorRate", label: "Error rate" },
+] as const;

--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -7,7 +7,7 @@ import {
 } from "@app/components/agent_builder/observability/constants";
 
 interface ChartContainerProps {
-  title: string;
+  title: string | ReactNode;
   isLoading: boolean;
   errorMessage?: string;
   emptyMessage?: string;

--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -7,12 +7,13 @@ import {
 } from "@app/components/agent_builder/observability/constants";
 
 interface ChartContainerProps {
-  title: string | ReactNode;
+  title: string;
   isLoading: boolean;
   errorMessage?: string;
   emptyMessage?: string;
   children: ReactNode;
   additionalControls?: ReactNode;
+  statusChip?: ReactNode;
 }
 
 export function ChartContainer({
@@ -22,6 +23,7 @@ export function ChartContainer({
   emptyMessage,
   children,
   additionalControls,
+  statusChip,
 }: ChartContainerProps) {
   const message = isLoading ? null : errorMessage ?? emptyMessage;
 
@@ -33,7 +35,10 @@ export function ChartContainer({
       )}
     >
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-lg font-medium text-foreground">{title}</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-medium text-foreground">{title}</h3>
+          {statusChip}
+        </div>
         <div className="flex items-center gap-3">{additionalControls}</div>
       </div>
       {isLoading || message ? (

--- a/front/lib/api/assistant/observability/error_rate.ts
+++ b/front/lib/api/assistant/observability/error_rate.ts
@@ -1,0 +1,80 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import {
+  bucketsToArray,
+  formatUTCDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const DEFAULT_METRIC_VALUE = 0;
+
+export type ErrorRatePoint = {
+  date: string;
+  total: number;
+  failed: number;
+  errorRate: number;
+};
+
+type ByIntervalBucket = {
+  key: number;
+  doc_count: number;
+  failed_messages?: estypes.AggregationsFilterAggregate;
+};
+
+type ErrorRateAggs = {
+  by_interval?: estypes.AggregationsMultiBucketAggregateBase<ByIntervalBucket>;
+};
+
+export async function fetchErrorRate(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Result<ErrorRatePoint[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_interval: {
+      date_histogram: {
+        field: "timestamp",
+        calendar_interval: "day",
+      },
+      aggs: {
+        failed_messages: {
+          filter: {
+            term: { status: "failed" },
+          },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<never, ErrorRateAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const buckets = bucketsToArray<ByIntervalBucket>(
+    result.value.aggregations?.by_interval?.buckets
+  );
+
+  const points: ErrorRatePoint[] = buckets
+    .filter((b) => b.doc_count > 0)
+    .map((b) => {
+      const date = formatUTCDateFromMillis(b.key);
+      const total = b.doc_count ?? DEFAULT_METRIC_VALUE;
+      const failed = b.failed_messages?.doc_count ?? DEFAULT_METRIC_VALUE;
+      const errorRate =
+        total > 0 ? Math.round((failed / total) * 10000) / 100 : 0;
+
+      return {
+        date,
+        total,
+        failed,
+        errorRate,
+      };
+    });
+
+  return new Ok(points);
+}

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -19,6 +19,7 @@ import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentConfigurationAnalyticsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics";
+import type { GetErrorRateResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate";
 import type { GetFeedbackDistributionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution";
 import type { GetLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency";
 import type { GetToolExecutionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution";
@@ -829,6 +830,33 @@ export function useAgentLatency({
     isLatencyLoading: !error && !data && !disabled,
     isLatencyError: error,
     isLatencyValidating: isValidating,
+  };
+}
+
+export function useAgentErrorRate({
+  workspaceId,
+  agentConfigurationId,
+  days = DEFAULT_PERIOD_DAYS,
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetErrorRateResponse> = fetcher;
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/error_rate?days=${days}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    errorRate: data?.points ?? emptyArray(),
+    isErrorRateLoading: !error && !data && !disabled,
+    isErrorRateError: error,
+    isErrorRateValidating: isValidating,
   };
 }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -1,0 +1,113 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { ErrorRatePoint } from "@app/lib/api/assistant/observability/error_rate";
+import { fetchErrorRate } from "@app/lib/api/assistant/observability/error_rate";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional(),
+});
+
+export type GetErrorRateResponse = {
+  points: ErrorRatePoint[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetErrorRateResponse>>,
+  auth: Authenticator
+) {
+  if (typeof req.query.aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent configuration ID.",
+      },
+    });
+  }
+
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: req.query.aId,
+    variant: "light",
+  });
+
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  if (!assistant.canEdit && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only editors can get agent observability.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        agentId: assistant.sId,
+        days,
+      });
+
+      const errorRateResult = await fetchErrorRate(baseQuery);
+
+      if (errorRateResult.isErr()) {
+        const e = errorRateResult.error;
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve error rate: ${e.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        points: errorRateResult.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -1,6 +1,6 @@
 import type { ThumbReaction } from "@app/components/assistant/conversation/FeedbackSelector";
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
-import type { AgentMessageType } from "@app/types";
+import type { AgentMessageStatus } from "@app/types";
 
 /**
  * Types for agent analytics data stored in Elasticsearch
@@ -38,7 +38,7 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   conversation_id: string;
   latency_ms: number;
   message_id: string;
-  status: AgentMessageType["status"];
+  status: AgentMessageStatus;
   timestamp: string; // ISO date string.
   tokens: AgentMessageAnalyticsTokens;
   tools_used: AgentMessageAnalyticsToolUsed[];


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/4996.
- This PR implements the endpoint, hook and front-end to display a chart on the error rate.
- This was vastly inspired from the existing charts.

<img width="738" height="302" alt="Screenshot 2025-11-04 at 10 48 01 AM" src="https://github.com/user-attachments/assets/1e3b81f9-2990-4462-9f7b-8aa8a71802c9" />

## Tests

- Checked locally.

## Risk

- Low, behind FF I think.

## Deploy Plan

- Deploy front.
