### PR TITLE
[front] enh(webhooks): add instrumentation around webhook trigger limits and errors

### DIFF
--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -81,12 +81,12 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
   static async makeNew(
     blob: CreationAttributes<WebhookRequestModel>,
     { transaction }: { transaction?: Transaction } = {}
-  ): Promise<Result<WebhookRequestResource, Error>> {
+  ): Promise<WebhookRequestResource> {
     const webhookRequest = await this.model.create(blob, {
       transaction,
     });
 
-    return new Ok(new this(this.model, webhookRequest.get()));
+    return new this(this.model, webhookRequest.get());
   }
 
   private static async baseFetch(

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -138,18 +138,11 @@ export async function processWebhookRequest(
   const bucket = getWebhookRequestsBucket();
 
   // Store in DB
-  const webhookRequestRes = await WebhookRequestResource.makeNew({
+  const webhookRequest = await WebhookRequestResource.makeNew({
     workspaceId: auth.getNonNullableWorkspace().id,
     webhookSourceId: webhookSource.id,
     status: "received",
   });
-
-  // Failure when storing in DB
-  if (webhookRequestRes.isErr()) {
-    return webhookRequestRes;
-  }
-
-  const webhookRequest = webhookRequestRes.value;
 
   const gcsPath = WebhookRequestResource.getGcsPath({
     workspaceId: auth.getNonNullableWorkspace().sId,

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -8,7 +8,7 @@ import type {
   MaxMessagesTimeframeType,
   Result,
 } from "@app/types";
-import { Err, normalizeError, Ok } from "@app/types";
+import { assertNever, Err, normalizeError, Ok } from "@app/types";
 
 export class RateLimitError extends Error {}
 
@@ -166,6 +166,6 @@ export function getTimeframeSecondsFromLiteral(
       return 60 * 60 * 24 * 30; // 30 days.
 
     default:
-      return 0;
+      assertNever(timeframeLiteral);
   }
 }

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -156,7 +156,6 @@ async function handler(
 
   if (result.isErr()) {
     statsDClient.increment("webhook_error.count", 1, [
-      `error_type:${result.error.code}`,
       `provider:${provider}`,
       `workspace_id:${workspace.sId}`,
     ]);

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
@@ -138,7 +138,7 @@ describe("DELETE /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
     req.query.webhookSourceId = webhookSource.sId;
 
     // Create associated webhook requests
-    const webhookRequest1 = await WebhookRequestResource.makeNew({
+    await WebhookRequestResource.makeNew({
       workspaceId: workspace.id,
       webhookSourceId: webhookSource.id,
       status: "received",
@@ -146,16 +146,13 @@ describe("DELETE /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
       errorMessage: null,
     });
 
-    const webhookRequest2 = await WebhookRequestResource.makeNew({
+    await WebhookRequestResource.makeNew({
       workspaceId: workspace.id,
       webhookSourceId: webhookSource.id,
       status: "processed",
       processedAt: new Date(),
       errorMessage: null,
     });
-
-    expect(webhookRequest1.isOk()).toBe(true);
-    expect(webhookRequest2.isOk()).toBe(true);
 
     // Verify the webhook requests were created
     const webhookRequests = await WebhookRequestResource.fetchByWebhookSourceId(


### PR DESCRIPTION
## Description

- This PR adds some observability around webhook triggers in the form of DD metrics, focusing on error rate and rate limits.
- It adds the following metrics, all by provider x workspace.
  - `webhook_rate_limit.hit.count`
  - `webhook_request.count`
  - `webhook_error.count`

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
