### PR TITLE
[front] - chore(obs): charts colors

### DIFF
--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -119,7 +119,8 @@ export function FeedbackDistributionChart({
             type="monotone"
             dataKey="positive"
             name="Positive"
-            stroke="hsl(var(--chart-1))"
+            className={FEEDBACK_DISTRIBUTION_PALETTE.positive}
+            stroke="currentColor"
             strokeWidth={2}
             dot={false}
           />
@@ -127,7 +128,8 @@ export function FeedbackDistributionChart({
             type="monotone"
             dataKey="negative"
             name="Negative"
-            stroke="hsl(var(--chart-4))"
+            className={FEEDBACK_DISTRIBUTION_PALETTE.negative}
+            stroke="currentColor"
             strokeWidth={2}
             dot={false}
           />

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -95,17 +95,16 @@ export function LatencyChart({
           margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
         >
           <defs>
-            <linearGradient id="fillAverage" x1="0" y1="0" x2="0" y2="1">
-              <stop
-                offset="5%"
-                stopColor="hsl(var(--chart-1))"
-                stopOpacity={0.8}
-              />
-              <stop
-                offset="95%"
-                stopColor="hsl(var(--chart-1))"
-                stopOpacity={0.1}
-              />
+            <linearGradient
+              id="fillAverage"
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+              className={LATENCY_PALETTE.average}
+            >
+              <stop offset="5%" stopColor="currentColor" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
             </linearGradient>
           </defs>
           <CartesianGrid vertical={false} className="stroke-border" />
@@ -149,8 +148,9 @@ export function LatencyChart({
             type="natural"
             dataKey="average"
             name="Average latency"
-            fill="url(#fillMessages)"
-            stroke="hsl(var(--chart-1))"
+            className={LATENCY_PALETTE.average}
+            fill="url(#fillAverage)"
+            stroke="currentColor"
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -135,41 +135,39 @@ export function UsageMetricsChart({
           margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
         >
           <defs>
-            <linearGradient id="fillMessages" x1="0" y1="0" x2="0" y2="1">
-              <stop
-                offset="5%"
-                stopColor="hsl(var(--chart-1))"
-                stopOpacity={0.8}
-              />
-              <stop
-                offset="95%"
-                stopColor="hsl(var(--chart-1))"
-                stopOpacity={0.1}
-              />
+            {/* Gradients use currentColor; color is set via classes */}
+            <linearGradient
+              id="fillMessages"
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+              className={USAGE_METRICS_PALETTE.messages}
+            >
+              <stop offset="5%" stopColor="currentColor" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
             </linearGradient>
-            <linearGradient id="fillConversations" x1="0" y1="0" x2="0" y2="1">
-              <stop
-                offset="5%"
-                stopColor="hsl(var(--chart-2))"
-                stopOpacity={0.8}
-              />
-              <stop
-                offset="95%"
-                stopColor="hsl(var(--chart-2))"
-                stopOpacity={0.1}
-              />
+            <linearGradient
+              id="fillConversations"
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+              className={USAGE_METRICS_PALETTE.conversations}
+            >
+              <stop offset="5%" stopColor="currentColor" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
             </linearGradient>
-            <linearGradient id="fillActiveUsers" x1="0" y1="0" x2="0" y2="1">
-              <stop
-                offset="5%"
-                stopColor="hsl(var(--chart-3))"
-                stopOpacity={0.8}
-              />
-              <stop
-                offset="95%"
-                stopColor="hsl(var(--chart-3))"
-                stopOpacity={0.1}
-              />
+            <linearGradient
+              id="fillActiveUsers"
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+              className={USAGE_METRICS_PALETTE.activeUsers}
+            >
+              <stop offset="5%" stopColor="currentColor" stopOpacity={0.8} />
+              <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
             </linearGradient>
           </defs>
           <CartesianGrid vertical={false} className="stroke-border" />
@@ -206,22 +204,25 @@ export function UsageMetricsChart({
             type="natural"
             dataKey="messages"
             name="Messages"
+            className={USAGE_METRICS_PALETTE.messages}
             fill="url(#fillMessages)"
-            stroke="hsl(var(--chart-1))"
+            stroke="currentColor"
           />
           <Area
             type="natural"
             dataKey="conversations"
             name="Conversations"
+            className={USAGE_METRICS_PALETTE.conversations}
             fill="url(#fillConversations)"
-            stroke="hsl(var(--chart-2))"
+            stroke="currentColor"
           />
           <Area
             type="natural"
             dataKey="activeUsers"
             name="Active users"
+            className={USAGE_METRICS_PALETTE.activeUsers}
             fill="url(#fillActiveUsers)"
-            stroke="hsl(var(--chart-3))"
+            stroke="currentColor"
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -36,13 +36,12 @@ export const VERSION_MARKER_STYLE = {
   labelOffsetIncrement: 15,
 } as const;
 
-// TODO: find a way to display more tools
 export const TOOL_COLORS = [
-  "text-[hsl(var(--chart-1))]",
-  "text-[hsl(var(--chart-2))]",
-  "text-[hsl(var(--chart-3))]",
-  "text-[hsl(var(--chart-4))]",
-  "text-[hsl(var(--chart-5))]",
+  "text-orange-300 dark:text-orange-300-night",
+  "text-golden-200 dark:text-golden-200-night",
+  "text-rose-200 dark:text-rose-200-night",
+  "text-violet-300 dark:text-violet-300-night",
+  "text-rose-300 dark:text-rose-300-night",
 ] as const;
 
 export const MAX_TOOLS_DISPLAYED = 5;

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -5,9 +5,9 @@ export type ObservabilityTimeRangeType =
 export const DEFAULT_PERIOD_DAYS = 14;
 
 export const USAGE_METRICS_PALETTE = {
-  messages: "text-[hsl(var(--chart-1))]",
-  conversations: "text-[hsl(var(--chart-2))]",
-  activeUsers: "text-[hsl(var(--chart-3))]",
+  messages: "text-golden-500 dark:text-golden-500-night",
+  conversations: "text-blue-400 dark:text-blue-400-night",
+  activeUsers: "text-violet-300 dark:text-violet-300-night",
 } as const;
 
 export const USAGE_METRICS_LEGEND = [

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -49,8 +49,8 @@ export const MAX_TOOLS_DISPLAYED = 5;
 export const OTHER_TOOLS_LABEL = "Others";
 
 export const FEEDBACK_DISTRIBUTION_PALETTE = {
-  positive: "text-[hsl(var(--chart-1))]",
-  negative: "text-[hsl(var(--chart-4))]",
+  positive: "text-green-400 dark:text-green-400-night",
+  negative: "text-rose-400 dark:text-rose-400-night",
 } as const;
 
 export const FEEDBACK_DISTRIBUTION_LEGEND = [

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -17,7 +17,7 @@ export const USAGE_METRICS_LEGEND = [
 ] as const;
 
 export const LATENCY_PALETTE = {
-  average: "text-[hsl(var(--chart-5))]",
+  average: "text-blue-400 dark:text-blue-400-night",
 } as const;
 
 export const LATENCY_LEGEND = [


### PR DESCRIPTION
## Description

This PR aligns the colors used in the observability charts with the Figma.

**References:**
- https://github.com/dust-tt/tasks/issues/5004

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front