### PR TITLE
fix: build after merge of #17536

### DIFF
--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -196,6 +196,7 @@ export function _getFeedbackAnalyzerIncludeDataToolConfiguration({
               ],
               not: [],
             },
+            tags: null,
           },
           workspaceId: config.getDustAppsWorkspaceId(),
         },


### PR DESCRIPTION



## Description

Fixes build error after merging #17536 by adding the missing required `tags` field to the feedback analyzer's include data tool configuration. PR #17536 changed `DataSourceFilter` to require the `tags` field instead of it being optional.

## Risk

None - this is a build fix that adds a required field with default values.

## Tests

Build passes.

## Deploy Plan

Deploy Front.
