### PR TITLE
[front] refactor: consolidate Jira clients (tools and webhook)

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -85,7 +85,7 @@ async function jiraApiCall<T extends z.ZodTypeAny>(
   }
 ): Promise<Result<z.infer<T>, JiraErrorResult>> {
   const client = new JiraClient(accessToken);
-  return client.jiraApiCall(endpoint, schema, {
+  return client.callAPI(endpoint, schema, {
     method: options.method,
     body: options.body,
     baseUrl: options.baseUrl,

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -82,7 +82,7 @@ async function listUsersPage(
   });
 
   const client = new JiraClient(accessToken);
-  return client.callAPI(
+  return client.call(
     `/rest/api/3/users/search?${params.toString()}`,
     JiraUsersSearchResultSchema,
     { baseUrl }
@@ -187,7 +187,7 @@ export async function getIssue({
   );
   params.set("fields", fieldList);
 
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/issue/${issueKey}?${params.toString()}`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/issue/${issueKey}?${params.toString()}`,
     JiraIssueSchema,
     { baseUrl }
   );
@@ -216,7 +216,7 @@ export async function getProjects(
 ): Promise<
   Result<z.infer<typeof JiraProjectSchema>[] | null, JiraErrorResult>
 > {
-  const result = await new JiraClient(accessToken).callAPI("/rest/api/3/project",
+  const result = await new JiraClient(accessToken).call("/rest/api/3/project",
     z.array(JiraProjectSchema),
     { baseUrl }
   );
@@ -231,7 +231,7 @@ export async function getProjectVersions(
 ): Promise<
   Result<z.infer<typeof JiraProjectVersionSchema>[], JiraErrorResult>
 > {
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/project/${projectKey}/versions`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/project/${projectKey}/versions`,
     z.array(JiraProjectVersionSchema),
     {
       baseUrl,
@@ -246,7 +246,7 @@ export async function getProject(
   accessToken: string,
   projectKey: string
 ): Promise<Result<z.infer<typeof JiraProjectSchema> | null, JiraErrorResult>> {
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/project/${projectKey}`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/project/${projectKey}`,
     JiraProjectSchema,
     { baseUrl }
   );
@@ -261,7 +261,7 @@ export async function getTransitions(
 ): Promise<
   Result<z.infer<typeof JiraTransitionsSchema> | null, JiraErrorResult>
 > {
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/issue/${issueKey}/transitions`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/issue/${issueKey}/transitions`,
     JiraTransitionsSchema,
     { baseUrl }
   );
@@ -336,7 +336,7 @@ export async function createComment(
     requestBody.visibility = visibility;
   }
 
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/issue/${issueKey}/comment`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/issue/${issueKey}/comment`,
     JiraCommentSchema,
     {
       method: "POST",
@@ -396,7 +396,7 @@ export async function searchIssues(
     requestBody.nextPageToken = nextPageToken;
   }
 
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/search/jql`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/search/jql`,
     JiraSearchResultSchema,
     {
       baseUrl,
@@ -453,7 +453,7 @@ export async function searchJiraIssuesUsingJql(
     requestBody.nextPageToken = nextPageToken;
   }
 
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/search/jql`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/search/jql`,
     JiraSearchResultSchema,
     {
       baseUrl,
@@ -489,7 +489,7 @@ export async function getIssueTypes(
     total: z.number().optional(),
   });
 
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/issue/createmeta/${projectKey}/issuetypes`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/issue/createmeta/${projectKey}/issuetypes`,
     IssueTypesResponseSchema,
     { baseUrl }
   );
@@ -511,7 +511,7 @@ export async function getIssueFields(
   Result<z.infer<typeof JiraCreateMetaSchema> | null, JiraErrorResult>
 > {
   const endpoint = `/rest/api/3/issue/createmeta/${projectKey}/issuetypes/${issueTypeId}`;
-  const result = await new JiraClient(accessToken).callAPI(
+  const result = await new JiraClient(accessToken).call(
     endpoint,
     JiraCreateMetaSchema,
     { baseUrl }
@@ -524,7 +524,7 @@ async function getUserInfo(
   baseUrl: string,
   accessToken: string
 ): Promise<Result<z.infer<typeof JiraUserInfoSchema>, JiraErrorResult>> {
-  return new JiraClient(accessToken).callAPI("/rest/api/3/myself",
+  return new JiraClient(accessToken).call("/rest/api/3/myself",
     JiraUserInfoSchema,
     { baseUrl }
   );
@@ -579,7 +579,7 @@ export async function transitionIssue(
     };
   }
 
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/issue/${issueKey}/transitions`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/issue/${issueKey}/transitions`,
     JiraTransitionIssueSchema,
     {
       method: "POST",
@@ -600,7 +600,7 @@ export async function getAllFields(
     JiraErrorResult
   >
 > {
-  const result = await new JiraClient(accessToken).callAPI("/rest/api/3/field",
+  const result = await new JiraClient(accessToken).call("/rest/api/3/field",
     JiraFieldsSchema,
     { baseUrl }
   );
@@ -640,7 +640,7 @@ export async function listFieldSummaries(
     JiraErrorResult
   >
 > {
-  const result = await new JiraClient(accessToken).callAPI("/rest/api/3/field",
+  const result = await new JiraClient(accessToken).call("/rest/api/3/field",
     JiraFieldsSchema,
     { baseUrl }
   );
@@ -696,7 +696,7 @@ export async function createIssue(
     issueData
   );
 
-  const result = await new JiraClient(accessToken).callAPI("/rest/api/3/issue",
+  const result = await new JiraClient(accessToken).call("/rest/api/3/issue",
     JiraIssueSchema,
     {
       method: "POST",
@@ -731,7 +731,7 @@ export async function updateIssue(
     updateData
   );
 
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/issue/${issueKey}`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/issue/${issueKey}`,
     z.void(),
     {
       method: "PUT",
@@ -785,7 +785,7 @@ export async function createIssueLink(
     };
   }
 
-  const result = await new JiraClient(accessToken).callAPI("/rest/api/3/issueLink",
+  const result = await new JiraClient(accessToken).call("/rest/api/3/issueLink",
     z.void(),
     {
       method: "POST",
@@ -802,7 +802,7 @@ export async function deleteIssueLink(
   accessToken: string,
   linkId: string
 ): Promise<Result<void, JiraErrorResult>> {
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/3/issueLink/${linkId}`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/3/issueLink/${linkId}`,
     z.void(),
     {
       method: "DELETE",
@@ -817,7 +817,7 @@ export async function getIssueLinkTypes(
   baseUrl: string,
   accessToken: string
 ): Promise<Result<z.infer<typeof JiraIssueLinkTypeSchema>[], JiraErrorResult>> {
-  const result = await new JiraClient(accessToken).callAPI("/rest/api/3/issueLinkType",
+  const result = await new JiraClient(accessToken).call("/rest/api/3/issueLinkType",
     z.object({
       issueLinkTypes: z.array(JiraIssueLinkTypeSchema),
     }),
@@ -1038,7 +1038,7 @@ export async function getIssueAttachments({
 }): Promise<
   Result<z.infer<typeof JiraAttachmentsResultSchema>, JiraErrorResult>
 > {
-  const result = await new JiraClient(accessToken).callAPI(`/rest/api/2/issue/${issueKey}?fields=attachment`,
+  const result = await new JiraClient(accessToken).call(`/rest/api/2/issue/${issueKey}?fields=attachment`,
     JiraIssueWithAttachmentsSchema,
     { baseUrl }
   );

--- a/front/lib/api/jira/client.ts
+++ b/front/lib/api/jira/client.ts
@@ -277,7 +277,7 @@ export class JiraClient {
     return new Ok(undefined);
   }
 
-  async jiraApiCall<T extends z.ZodTypeAny>(
+  private async callAPI<T extends z.ZodTypeAny>(
     endpoint: string,
     schema: T,
     options: {
@@ -286,8 +286,10 @@ export class JiraClient {
       baseUrl?: string;
     } = {}
   ): Promise<Result<z.infer<T>, JiraErrorResult>> {
-    const baseUrl =
-      options.baseUrl ?? (await this.getJiraBaseUrl()) ?? undefined;
+    let baseUrl = options.baseUrl;
+    if (!baseUrl) {
+      baseUrl = (await this.getJiraBaseUrl()) ?? undefined;
+    }
     if (!baseUrl) {
       return new Err("Failed to retrieve JIRA base URL");
     }

--- a/front/lib/api/jira/index.ts
+++ b/front/lib/api/jira/index.ts
@@ -1,0 +1,6 @@
+export { JiraClient } from "@app/lib/api/jira/client";
+export type {
+  JiraProjectType,
+  JiraResourceType,
+  JiraWebhookType,
+} from "@app/lib/api/jira/types";

--- a/front/lib/api/jira/types.ts
+++ b/front/lib/api/jira/types.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+export const JiraResourceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  url: z.string(),
+  scopes: z.array(z.string()),
+  avatarUrl: z.string(),
+});
+
+export const JiraProjectSchema = z.object({
+  id: z.string(),
+  key: z.string(),
+  name: z.string(),
+  self: z.string(),
+});
+
+export const JiraProjectsResponseSchema = z.object({
+  values: z.array(JiraProjectSchema),
+});
+
+export const JiraWebhookRegistrationResultSchema = z.object({
+  createdWebhookId: z.number().optional(),
+  errors: z.array(z.string()).optional(),
+});
+
+export const JiraCreateWebhookResponseSchema = z.object({
+  webhookRegistrationResult: z.array(JiraWebhookRegistrationResultSchema),
+});
+
+export const JiraWebhookSchema = z.object({
+  id: z.number(),
+  url: z.string(),
+  events: z.array(z.string()),
+  jqlFilter: z.string(),
+  expirationDate: z.string(),
+  fieldIdsFilter: z.array(z.string()).optional(),
+  issuePropertyKeysFilter: z.array(z.string()).optional(),
+});
+
+export const JiraWebhooksResponseSchema = z.object({
+  isLast: z.boolean(),
+  maxResults: z.number(),
+  startAt: z.number(),
+  total: z.number(),
+  values: z.array(JiraWebhookSchema),
+});
+
+export type JiraResourceType = z.infer<typeof JiraResourceSchema>;
+export type JiraProjectType = z.infer<typeof JiraProjectSchema>;
+export type JiraWebhookType = z.infer<typeof JiraWebhookSchema>;

--- a/front/lib/api/jira/types.ts
+++ b/front/lib/api/jira/types.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+// Basic schemas for webhooks
 export const JiraResourceSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -12,7 +13,7 @@ export const JiraProjectSchema = z.object({
   id: z.string(),
   key: z.string(),
   name: z.string(),
-  self: z.string(),
+  self: z.string().optional(),
 });
 
 export const JiraProjectsResponseSchema = z.object({
@@ -46,6 +47,418 @@ export const JiraWebhooksResponseSchema = z.object({
   values: z.array(JiraWebhookSchema),
 });
 
+// MCP-specific constants
+export const SEARCH_ISSUES_MAX_RESULTS = 20;
+export const SEARCH_USERS_MAX_RESULTS = 200;
+
+export const SUPPORTED_OPERATORS = ["=", "<", ">", "<=", ">=", "!="] as const;
+export type SupportedOperator = (typeof SUPPORTED_OPERATORS)[number];
+
+export const SORT_DIRECTIONS = ["ASC", "DESC"] as const;
+export type SortDirection = (typeof SORT_DIRECTIONS)[number];
+
+export const FIELD_MAPPINGS = {
+  assignee: { jqlField: "assignee" },
+  created: { jqlField: "created", supportsOperators: true },
+  dueDate: { jqlField: "dueDate", supportsOperators: true },
+  fixVersion: { jqlField: "fixVersion" },
+  issueType: { jqlField: "issueType" },
+  labels: { jqlField: "labels" },
+  priority: { jqlField: "priority" },
+  parentIssueKey: { jqlField: "parent" },
+  project: { jqlField: "project" },
+  reporter: { jqlField: "reporter" },
+  resolved: { jqlField: "resolved", supportsOperators: true },
+  status: { jqlField: "status" },
+  summary: { jqlField: "summary", supportsFuzzy: true },
+  customField: {
+    jqlField: "customField",
+    isCustomField: true,
+    supportsFuzzy: true,
+  },
+} as const;
+
+export const SEARCH_FILTER_FIELDS = Object.keys(
+  FIELD_MAPPINGS
+) as (keyof typeof FIELD_MAPPINGS)[];
+
+export type SearchFilterField = (typeof SEARCH_FILTER_FIELDS)[number];
+
+export interface SearchFilter {
+  field: string;
+  value: string;
+  fuzzy?: boolean;
+  customFieldName?: string;
+  operator?: SupportedOperator;
+}
+
+// Jira issue schemas
+export const JiraIssueFieldsSchema = z
+  .object({
+    project: z.object({
+      key: z.string(),
+    }),
+    summary: z.string(),
+    description: z
+      .object({
+        type: z.string(),
+        version: z.number(),
+        content: z.array(
+          z.object({
+            type: z.string(),
+            content: z.array(
+              z.object({
+                type: z.string(),
+                text: z.string().optional(),
+              })
+            ),
+          })
+        ),
+      })
+      .nullable(),
+    issuetype: z.object({
+      name: z.string(),
+    }),
+    priority: z.object({
+      name: z.string(),
+    }),
+    assignee: z
+      .object({
+        accountId: z.string(),
+      })
+      .nullable(),
+    reporter: z
+      .object({
+        accountId: z.string(),
+      })
+      .nullable(),
+    labels: z.array(z.string()).nullable(),
+    duedate: z.string().nullable().optional(),
+    parent: z
+      .object({
+        key: z.string(),
+      })
+      .nullable(),
+  })
+  .passthrough();
+
+export const JiraIssueSchema = z
+  .object({
+    id: z.string(),
+    key: z.string(),
+    browseUrl: z.string().optional(),
+    fields: JiraIssueFieldsSchema.deepPartial().optional(),
+  })
+  .passthrough();
+
+export const JiraProjectVersionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  released: z.boolean().optional(),
+  releaseDate: z.string().optional(),
+  startDate: z.string().optional(),
+  archived: z.boolean().optional(),
+});
+
+export const JiraTransitionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export const JiraTransitionsSchema = z.object({
+  transitions: z.array(JiraTransitionSchema),
+});
+
+export const JiraCreateMetaSchema = z.object({
+  fields: z.array(z.unknown()),
+});
+
+export const JiraFieldSchema = z.object({
+  id: z.string(),
+  key: z.string().optional(),
+  name: z.string(),
+  custom: z.boolean(),
+  schema: z
+    .object({
+      type: z.string(),
+      custom: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const JiraFieldsSchema = z.array(JiraFieldSchema);
+
+export const JiraSearchResultSchema = z.object({
+  issues: z.array(
+    z.object({
+      id: z.string(),
+      key: z.string(),
+      fields: JiraIssueFieldsSchema.deepPartial().optional(),
+    })
+  ),
+  isLast: z.boolean().optional(),
+  nextPageToken: z.string().optional(),
+});
+
+export const JiraUserInfoSchema = z
+  .object({
+    accountId: z.string(),
+    emailAddress: z.string(),
+    displayName: z.string(),
+    accountType: z.string(),
+    locale: z.string().optional(),
+  })
+  .passthrough();
+
+export const JiraConnectionInfoSchema = z.object({
+  user: z.object({
+    account_id: z.string(),
+    name: z.string(),
+    nickname: z.string(),
+  }),
+  instance: z.object({
+    cloud_id: z.string(),
+    site_url: z.string(),
+    site_name: z.string(),
+    api_base_url: z.string(),
+  }),
+});
+
+export const JiraTransitionIssueSchema = z.void();
+
+// Atlassian Document Format (ADF) schemas
+export const ADFMarkSchema = z.object({
+  type: z.string(),
+  attrs: z.record(z.any()).optional(),
+});
+
+export type ADFMark = z.infer<typeof ADFMarkSchema>;
+
+export const ADFTextNodeSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+  marks: z.array(ADFMarkSchema).optional(),
+});
+
+export type ADFTextNode = z.infer<typeof ADFTextNodeSchema>;
+
+export const ADFHardBreakNodeSchema = z.object({
+  type: z.literal("hardBreak"),
+});
+
+export type ADFHardBreakNode = z.infer<typeof ADFHardBreakNodeSchema>;
+
+export const ADFRuleNodeSchema = z.object({
+  type: z.literal("rule"),
+});
+
+export type ADFRuleNode = z.infer<typeof ADFRuleNodeSchema>;
+
+export const ADFContentNodeSchema: z.ZodType<any> = z.lazy(() =>
+  z.discriminatedUnion("type", [
+    ADFTextNodeSchema,
+    ADFHardBreakNodeSchema,
+    z.object({
+      type: z.enum([
+        "paragraph",
+        "heading",
+        "blockquote",
+        "panel",
+        "bulletList",
+        "orderedList",
+        "listItem",
+      ]),
+      attrs: z.record(z.any()).optional(),
+      content: z.array(ADFContentNodeSchema).optional(),
+    }),
+    z.object({
+      type: z.literal("codeBlock"),
+      attrs: z.record(z.any()).optional(),
+      content: z
+        .array(
+          z.object({
+            type: z.literal("text"),
+            text: z.string(),
+          })
+        )
+        .optional(),
+    }),
+    ADFRuleNodeSchema,
+    z.object({
+      type: z.enum(["table", "tableRow", "tableCell", "tableHeader"]),
+      attrs: z.record(z.any()).optional(),
+      content: z.array(ADFContentNodeSchema).optional(),
+    }),
+  ])
+);
+
+export type ADFContentNode = z.infer<typeof ADFContentNodeSchema>;
+
+export const ADFDocumentSchema = z.object({
+  type: z.literal("doc"),
+  version: z.literal(1),
+  content: z.array(ADFContentNodeSchema).optional(),
+});
+
+export type ADFDocument = z.infer<typeof ADFDocumentSchema>;
+
+export const JiraCreateIssueRequestSchema = JiraIssueFieldsSchema.partial({
+  description: true,
+  priority: true,
+  assignee: true,
+  reporter: true,
+  labels: true,
+  parent: true,
+})
+  .extend({
+    description: z.union([z.string(), ADFDocumentSchema]).optional(),
+  })
+  .passthrough();
+
+export const JiraSearchRequestSchema = z.object({
+  jql: z.string(),
+  maxResults: z.number(),
+  fields: z.array(z.string()),
+  nextPageToken: z.string().optional(),
+});
+
+export const JiraCreateCommentRequestSchema = z.object({
+  body: z.object({
+    type: z.literal("doc"),
+    version: z.number(),
+    content: z.array(
+      z.object({
+        type: z.string(),
+        content: z.array(
+          z.object({
+            type: z.string(),
+            text: z.string(),
+          })
+        ),
+      })
+    ),
+  }),
+  visibility: z
+    .object({
+      type: z.enum(["group", "role"]),
+      value: z.string(),
+    })
+    .optional(),
+});
+
+export const JiraTransitionRequestSchema = z.object({
+  transition: z.object({
+    id: z.string(),
+  }),
+  update: z
+    .object({
+      comment: z.array(
+        z.object({
+          add: z.object({
+            body: z.string(),
+          }),
+        })
+      ),
+    })
+    .optional(),
+});
+
+export const JiraIssueLinkTypeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  inward: z.string(),
+  outward: z.string(),
+});
+
+export const JiraCreateIssueLinkRequestSchema = z.object({
+  type: z.object({
+    name: z.string(),
+  }),
+  inwardIssue: z.object({
+    key: z.string(),
+  }),
+  outwardIssue: z.object({
+    key: z.string(),
+  }),
+  comment: z
+    .object({
+      body: z.string(),
+    })
+    .optional(),
+});
+
+export const JiraIssueTypeSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  subtask: z.boolean().optional(),
+});
+
+export const JiraUserSchema = z.object({
+  accountId: z.string(),
+  displayName: z.string(),
+  emailAddress: z.string().optional(),
+  accountType: z.string(),
+  active: z.boolean(),
+});
+
+export type JiraUser = z.infer<typeof JiraUserSchema>;
+
+export const JiraUsersSearchResultSchema = z.array(JiraUserSchema);
+
+export const JiraCommentSchema = z.object({
+  id: z.string(),
+  body: ADFDocumentSchema,
+});
+
+export const JiraAttachmentSchema = z.object({
+  id: z.string(),
+  filename: z.string(),
+  author: z.object({
+    accountId: z.string(),
+    displayName: z.string().optional(),
+    emailAddress: z.string().optional(),
+  }),
+  created: z.string(),
+  size: z.number(),
+  mimeType: z.string(),
+  content: z.string().optional(),
+  thumbnail: z.string().optional(),
+  self: z.string(),
+});
+
+export const JiraAttachmentsResultSchema = z.array(JiraAttachmentSchema);
+
+export const JiraIssueWithAttachmentsSchema = z.object({
+  id: z.string(),
+  key: z.string(),
+  fields: z.object({
+    attachment: z.array(JiraAttachmentSchema).optional(),
+  }),
+});
+
+// Exported types
 export type JiraResourceType = z.infer<typeof JiraResourceSchema>;
 export type JiraProjectType = z.infer<typeof JiraProjectSchema>;
 export type JiraWebhookType = z.infer<typeof JiraWebhookSchema>;
+export type JiraSearchResult = z.infer<typeof JiraSearchResultSchema>;
+export type JiraErrorResult = string;
+export type JiraIssue = z.infer<typeof JiraIssueSchema>;
+export type JiraProject = z.infer<typeof JiraProjectSchema>;
+export type JiraTransition = z.infer<typeof JiraTransitionSchema>;
+export type JiraComment = z.infer<typeof JiraCommentSchema>;
+export type JiraUserInfo = z.infer<typeof JiraUserInfoSchema>;
+export type JiraConnectionInfo = z.infer<typeof JiraConnectionInfoSchema>;
+export type JiraCreateIssueRequest = z.infer<
+  typeof JiraCreateIssueRequestSchema
+>;
+export type JiraIssueLinkType = z.infer<typeof JiraIssueLinkTypeSchema>;
+export type JiraCreateIssueLinkRequest = z.infer<
+  typeof JiraCreateIssueLinkRequestSchema
+>;
+export type JiraAttachment = z.infer<typeof JiraAttachmentSchema>;
+export type JiraAttachmentsResult = z.infer<typeof JiraAttachmentsResultSchema>;
+export type JiraIssueWithAttachments = z.infer<
+  typeof JiraIssueWithAttachmentsSchema
+>;

--- a/front/lib/triggers/built-in-webhooks/jira/jira_api_types.ts
+++ b/front/lib/triggers/built-in-webhooks/jira/jira_api_types.ts
@@ -12,7 +12,7 @@ const JiraProjectSchema = z.object({
   id: z.string(),
   key: z.string(),
   name: z.string(),
-  self: z.string(),
+  self: z.string().optional(),
 });
 
 export function isJiraProject(data: unknown): data is JiraProjectType {

--- a/front/lib/triggers/built-in-webhooks/jira/jira_api_types.ts
+++ b/front/lib/triggers/built-in-webhooks/jira/jira_api_types.ts
@@ -1,105 +1,27 @@
 import { z } from "zod";
 
-import type { Result } from "@app/types";
-import { Err, normalizeError, Ok } from "@app/types";
+import type {
+  JiraProjectType,
+  JiraResourceType,
+  JiraWebhookType,
+} from "@app/lib/api/jira";
 
-export const JiraResourceSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  url: z.string(),
-  scopes: z.array(z.string()),
-  avatarUrl: z.string(),
-});
+export type { JiraProjectType, JiraResourceType, JiraWebhookType };
 
-export type JiraResourceType = z.infer<typeof JiraResourceSchema>;
-
-export const JiraProjectSchema = z.object({
+const JiraProjectSchema = z.object({
   id: z.string(),
   key: z.string(),
   name: z.string(),
   self: z.string(),
 });
 
-export type JiraProjectType = z.infer<typeof JiraProjectSchema>;
-
 export function isJiraProject(data: unknown): data is JiraProjectType {
   const result = JiraProjectSchema.safeParse(data);
   return result.success;
 }
-
-export const JiraProjectsResponseSchema = z.object({
-  values: z.array(JiraProjectSchema),
-});
-
-export const JiraWebhookRegistrationResultSchema = z.object({
-  createdWebhookId: z.number().optional(),
-  errors: z.array(z.string()).optional(),
-});
-
-export const JiraCreateWebhookResponseSchema = z.object({
-  webhookRegistrationResult: z.array(JiraWebhookRegistrationResultSchema),
-});
 
 export const JiraAdditionalDataSchema = z.object({
   projects: z.array(JiraProjectSchema),
 });
 
 export type JiraAdditionalData = z.infer<typeof JiraAdditionalDataSchema>;
-
-export const JiraWebhookSchema = z.object({
-  id: z.number(),
-  url: z.string(),
-  events: z.array(z.string()),
-  jqlFilter: z.string(),
-  expirationDate: z.string(),
-  fieldIdsFilter: z.array(z.string()).optional(),
-  issuePropertyKeysFilter: z.array(z.string()).optional(),
-});
-
-export type JiraWebhookType = z.infer<typeof JiraWebhookSchema>;
-
-export const JiraWebhooksResponseSchema = z.object({
-  isLast: z.boolean(),
-  maxResults: z.number(),
-  startAt: z.number(),
-  total: z.number(),
-  values: z.array(JiraWebhookSchema),
-});
-
-export type JiraWebhooksResponseType = z.infer<
-  typeof JiraWebhooksResponseSchema
->;
-
-export async function validateJiraApiResponse<T extends z.ZodTypeAny>(
-  response: Response,
-  schema: T
-): Promise<Result<z.infer<T>, Error>> {
-  if (!response.ok) {
-    const errorText = await response.text();
-    return new Err(
-      new Error(`API request failed: ${response.statusText} - ${errorText}`)
-    );
-  }
-
-  let data: unknown;
-  try {
-    data = await response.json();
-  } catch (error) {
-    return new Err(
-      new Error(
-        `Failed to parse JSON response: ${normalizeError(error).message}`
-      )
-    );
-  }
-
-  const parseResult = schema.safeParse(data);
-  if (!parseResult.success) {
-    return new Err(
-      new Error(
-        `API response validation failed: ${parseResult.error.message}. Response: ${JSON.stringify(data)}`
-      )
-    );
-  }
-
-  return new Ok(parseResult.data);
-}

--- a/front/lib/triggers/built-in-webhooks/jira/jira_webhook_service.ts
+++ b/front/lib/triggers/built-in-webhooks/jira/jira_webhook_service.ts
@@ -1,7 +1,7 @@
 import config from "@app/lib/api/config";
+import { JiraClient } from "@app/lib/api/jira";
 import type { Authenticator } from "@app/lib/auth";
 import type { JiraAdditionalData } from "@app/lib/triggers/built-in-webhooks/jira/jira_api_types";
-import { JiraClient } from "@app/lib/triggers/built-in-webhooks/jira/jira_client";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, isString, OAuthAPI, Ok } from "@app/types";

--- a/front/scripts/dev/jira_delete_all_webhooks.ts
+++ b/front/scripts/dev/jira_delete_all_webhooks.ts
@@ -1,5 +1,5 @@
 import config from "@app/lib/api/config";
-import { JiraClient } from "@app/lib/triggers/built-in-webhooks/jira/jira_client";
+import { JiraClient } from "@app/lib/api/jira";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { OAuthAPI } from "@app/types";


### PR DESCRIPTION
## Description

- We have two consumers of the Jira API in front: the MCP server and the webhook source.
- This PR regroups both implementation into a single Jira client under `lib/api/jira`.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
