### PR TITLE
[front] perf: Add gemini-25-flash-image for image_generation tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -1,3 +1,4 @@
+import { GoogleGenAI } from "@google/genai";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import OpenAI from "openai";
 import { z } from "zod";
@@ -8,10 +9,12 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { dustManagedCredentials, Err, Ok } from "@app/types";
+import { GEMINI_2_5_FLASH_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 
 const IMAGE_GENERATION_RATE_LIMITER_KEY = "image_generation";
 const IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS = 60 * 60 * 24 * 7; // 1 week.
@@ -19,6 +22,29 @@ const IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS = 60 * 60 * 24 * 7; // 1 w
 // By default, OpenAI returns a PNG image.
 const DEFAULT_IMAGE_OUTPUT_FORMAT = "png";
 const DEFAULT_IMAGE_MIME_TYPE = "image/png";
+
+// Map tool size parameters to Gemini aspect ratios.
+const SIZE_TO_ASPECT_RATIO: Record<string, string> = {
+  "1024x1024": "1:1",
+  "1536x1024": "3:2",
+  "1024x1536": "2:3",
+};
+
+const GeminiInlineDataPartSchema = z.object({
+  inlineData: z.object({
+    data: z.string(),
+    mimeType: z.string().optional(),
+  }),
+});
+
+type GeminiInlineDataPart = z.infer<typeof GeminiInlineDataPartSchema>;
+
+// Type guard to validate Gemini inline data parts.
+function isValidGeminiInlineDataPart(
+  part: unknown
+): part is GeminiInlineDataPart {
+  return GeminiInlineDataPartSchema.safeParse(part).success;
+}
 
 function createServer(
   auth: Authenticator,
@@ -66,6 +92,11 @@ function createServer(
       async ({ prompt, name, quality, size }, { sendNotification, _meta }) => {
         const workspace = auth.getNonNullableWorkspace();
 
+        // Check if Gemini feature flag is enabled.
+        const featureFlags = await getFeatureFlags(workspace);
+        const useGemini = featureFlags.includes("gemini_image_generation");
+        const provider = useGemini ? "gemini" : "openai";
+
         if (_meta?.progressToken) {
           const notification: MCPProgressNotificationType = {
             method: "notifications/progress",
@@ -102,10 +133,13 @@ function createServer(
         statsDClient.increment("tools.image_generation.generated", 1, [
           `quality:${quality}`,
           `size:${size}`,
+          `provider:${provider}`,
         ]);
 
         if (remaining <= 0) {
-          statsDClient.increment("tools.image_generation.rate_limit_hit", 1);
+          statsDClient.increment("tools.image_generation.rate_limit_hit", 1, [
+            `provider:${provider}`,
+          ]);
 
           return new Err(
             new MCPError(
@@ -120,47 +154,140 @@ function createServer(
 
         try {
           const credentials = dustManagedCredentials();
-          const openai = new OpenAI({
-            apiKey: credentials.OPENAI_API_KEY,
-          });
 
-          const result = await openai.images.generate({
-            model: "gpt-image-1",
-            moderation: "low",
-            output_format: DEFAULT_IMAGE_OUTPUT_FORMAT,
-            prompt,
-            quality,
-            size,
-            user: `workspace-${workspace.sId}`,
-          });
+          if (useGemini) {
+            // Use Gemini for image generation.
+            const gemini = new GoogleGenAI({
+              apiKey: credentials.GOOGLE_AI_STUDIO_API_KEY,
+            });
 
-          statsDClient.increment(
-            "tools.image_generation.usage.input_tokens",
-            result.usage?.input_tokens ?? 0
-          );
-          statsDClient.increment(
-            "tools.image_generation.usage.output_tokens",
-            result.usage?.output_tokens ?? 0
-          );
+            const aspectRatio =
+              SIZE_TO_ASPECT_RATIO[size] || SIZE_TO_ASPECT_RATIO["1024x1024"];
 
-          if (!result.data) {
-            return new Err(new MCPError("No image generated."));
+            const response = await gemini.models.generateContent({
+              model: GEMINI_2_5_FLASH_IMAGE_MODEL_ID,
+              contents: prompt,
+              config: {
+                temperature: 0.7,
+                responseModalities: ["IMAGE"],
+                candidateCount: 1,
+                imageConfig: {
+                  aspectRatio,
+                },
+              },
+            });
+
+            if (!response.candidates || response.candidates.length === 0) {
+              // Check if prompt was blocked by safety filters
+              if (response.promptFeedback?.blockReason) {
+                logger.error(
+                  {
+                    blockReason: response.promptFeedback.blockReason,
+                    safetyRatings: response.promptFeedback.safetyRatings,
+                    prompt,
+                  },
+                  "Gemini image generation: Prompt blocked by safety filters"
+                );
+                return new Err(
+                  new MCPError(
+                    `Image generation blocked by safety filters: ${response.promptFeedback.blockReason}`
+                  )
+                );
+              }
+              return new Err(new MCPError("No image generated."));
+            }
+
+            const content = response.candidates[0].content;
+
+            if (!content || !content.parts) {
+              return new Err(new MCPError("No image data in response"));
+            }
+
+            const imageParts = content.parts.filter(
+              isValidGeminiInlineDataPart
+            );
+
+            if (imageParts.length === 0) {
+              return new Err(new MCPError("No image data in response."));
+            }
+
+            statsDClient.increment(
+              "tools.image_generation.usage.input_tokens",
+              response.usageMetadata?.promptTokenCount ?? 0,
+              [`provider:${provider}`]
+            );
+            statsDClient.increment(
+              "tools.image_generation.usage.output_tokens",
+              response.usageMetadata?.candidatesTokenCount ?? 0,
+              [`provider:${provider}`]
+            );
+
+            const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
+
+            return new Ok(
+              imageParts.map((part) => ({
+                type: "image" as const,
+                mimeType: part.inlineData.mimeType ?? DEFAULT_IMAGE_MIME_TYPE,
+                data: part.inlineData.data,
+                name: fileName,
+              }))
+            );
+          } else {
+            // Use OpenAI for image generation.
+            const openai = new OpenAI({
+              apiKey: credentials.OPENAI_API_KEY,
+            });
+
+            const result = await openai.images.generate({
+              model: "gpt-image-1",
+              moderation: "low",
+              output_format: DEFAULT_IMAGE_OUTPUT_FORMAT,
+              prompt,
+              quality,
+              size,
+              user: `workspace-${workspace.sId}`,
+            });
+
+            statsDClient.increment(
+              "tools.image_generation.usage.input_tokens",
+              result.usage?.input_tokens ?? 0,
+              [`provider:${provider}`]
+            );
+            statsDClient.increment(
+              "tools.image_generation.usage.output_tokens",
+              result.usage?.output_tokens ?? 0,
+              [`provider:${provider}`]
+            );
+
+            if (!result.data) {
+              return new Err(new MCPError("No image generated."));
+            }
+
+            const imagesWithData = result.data.filter(
+              (r): r is typeof r & { b64_json: string } =>
+                r.b64_json !== undefined && r.b64_json !== null
+            );
+
+            if (imagesWithData.length === 0) {
+              return new Err(new MCPError("No image data in response."));
+            }
+
+            const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
+
+            return new Ok(
+              imagesWithData.map((r) => ({
+                type: "image" as const,
+                mimeType: DEFAULT_IMAGE_MIME_TYPE,
+                data: r.b64_json,
+                name: fileName,
+              }))
+            );
           }
-
-          const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
-
-          return new Ok(
-            result.data.map((r) => ({
-              type: "image" as const,
-              mimeType: DEFAULT_IMAGE_MIME_TYPE,
-              data: r.b64_json!,
-              name: fileName,
-            }))
-          );
         } catch (error) {
           logger.error(
             {
               error,
+              provider,
             },
             "Error generating image."
           );

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -46,6 +46,19 @@ function isValidGeminiInlineDataPart(
   return GeminiInlineDataPartSchema.safeParse(part).success;
 }
 
+const OpenAIImageWithDataSchema = z.object({
+  b64_json: z.string(),
+});
+
+type OpenAIImageWithData = z.infer<typeof OpenAIImageWithDataSchema>;
+
+// Type guard to validate OpenAI images with data.
+function isValidOpenAIImageWithData(
+  image: unknown
+): image is OpenAIImageWithData {
+  return OpenAIImageWithDataSchema.safeParse(image).success;
+}
+
 function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
@@ -264,8 +277,7 @@ function createServer(
             }
 
             const imagesWithData = result.data.filter(
-              (r): r is typeof r & { b64_json: string } =>
-                r.b64_json !== undefined && r.b64_json !== null
+              isValidOpenAIImageWithData
             );
 
             if (imagesWithData.length === 0) {

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -7,8 +7,11 @@ export const GEMINI_2_FLASH_MODEL_ID = "gemini-2.0-flash" as const;
 export const GEMINI_2_FLASH_LITE_MODEL_ID = "gemini-2.0-flash-lite" as const;
 export const GEMINI_2_5_PRO_PREVIEW_MODEL_ID = "gemini-2.5-pro-preview-03-25";
 export const GEMINI_2_5_FLASH_MODEL_ID = "gemini-2.5-flash" as const;
+export const GEMINI_2_5_FLASH_IMAGE_MODEL_ID =
+  "gemini-2.5-flash-image" as const;
 export const GEMINI_2_5_FLASH_LITE_MODEL_ID = "gemini-2.5-flash-lite" as const;
 export const GEMINI_2_5_PRO_MODEL_ID = "gemini-2.5-pro" as const;
+
 // These Gemini preview models are deprecated (either replaced by a GA model or not making it to GA)
 export const GEMINI_2_FLASH_PREVIEW_MODEL_ID = "gemini-2.0-flash-exp" as const;
 export const GEMINI_2_FLASH_THINKING_PREVIEW_MODEL_ID =

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -54,6 +54,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to experimental Google AI Studio models",
     stage: "on_demand",
   },
+  gemini_image_generation: {
+    description:
+      "Use Gemini 2.5 Flash Image instead of OpenAI for image generation",
+    stage: "dust_only",
+  },
   google_sheets_tool: {
     description: "Google Sheets MCP tool",
     stage: "rolling_out",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -57,7 +57,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   gemini_image_generation: {
     description:
       "Use Gemini 2.5 Flash Image instead of OpenAI for image generation",
-    stage: "dust_only",
+    stage: "rolling_out",
   },
   google_sheets_tool: {
     description: "Google Sheets MCP tool",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -662,6 +662,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "elevenlabs_tool"
   | "freshservice_tool"
   | "google_ai_studio_experimental_models_feature"
+  | "gemini_image_generation"
   | "google_sheets_tool"
   | "hootl_dev_webhooks"
   | "hootl_subscriptions"


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/4732

## Description

This PR adds support for Gemini 2.5 Flash Image (aka Nano Banana) as an alternative provider for the image generation tool, controlled by the `gemini_image_generation` feature flag. The change addresses ongoing reliability issues with OpenAI's image generation endpoint by providing a fallback option.

The implementation adds the Gemini provider alongside the existing OpenAI integration, mapping size parameters to Gemini's aspect ratio format (1:1, 3:2, 2:3) and handling the different response structures between providers. Both providers return base64-encoded PNG images through the same MCP interface.

## Risk

Low - the feature is behind a `dust_only` feature flag and the OpenAI path remains the default. The code adds provider-specific metrics tagging to monitor both implementations separately.

## Tests

Manually tested image generation with both providers.

## Deploy Plan
- [x] Deploy front-edge, enable Enable the `gemini_image_generation` feature flag for dust.tt
- [ ] Deploy front. Enable the `gemini_image_generation` feature flag for dust.tt to test before broader rollout.
