### PR TITLE
feat(llm): add retries

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -62,6 +62,8 @@ export class AnthropicLLM extends LLM {
     }
     this.client = new Anthropic({
       apiKey: ANTHROPIC_API_KEY,
+      // We want to handle the retries ourselves
+      maxRetries: 0,
     });
   }
 

--- a/front/lib/api/llm/clients/fireworks/index.ts
+++ b/front/lib/api/llm/clients/fireworks/index.ts
@@ -64,6 +64,8 @@ export class FireworksLLM extends LLM {
     this.client = new OpenAI({
       apiKey: FIREWORKS_API_KEY,
       baseURL: "https://api.fireworks.ai/inference/v1",
+      // We want to handle the retries ourselves
+      maxRetries: 0,
     });
   }
 

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -45,6 +45,7 @@ export class GoogleLLM extends LLM {
         "GOOGLE_AI_STUDIO_API_KEY environment variable is required"
       );
     }
+    // as far as I know, there are no retries for google genai
     this.client = new GoogleGenAI({
       apiKey: GOOGLE_AI_STUDIO_API_KEY,
     });

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -45,6 +45,8 @@ export class MistralLLM extends LLM {
     }
     this.client = new Mistral({
       apiKey: MISTRAL_API_KEY,
+      // We want to handle the retries ourselves
+      retryConfig: { strategy: "none" },
     });
   }
 

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -68,6 +68,8 @@ export class OpenAIResponsesLLM extends LLM {
     this.client = new OpenAI({
       apiKey: OPENAI_API_KEY,
       baseURL: OPENAI_BASE_URL ?? "https://api.openai.com/v1",
+      // We want to handle the retries ourselves
+      maxRetries: 0,
     });
   }
 

--- a/front/lib/api/llm/clients/xai/index.ts
+++ b/front/lib/api/llm/clients/xai/index.ts
@@ -64,6 +64,8 @@ export class XaiLLM extends LLM {
     this.client = new OpenAI({
       apiKey: XAI_API_KEY,
       baseURL: "https://api.x.ai/v1",
+      // We want to handle the retries ourselves
+      maxRetries: 0,
     });
   }
 

--- a/front/lib/api/llm/llm.test.ts
+++ b/front/lib/api/llm/llm.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { LLM } from "@app/lib/api/llm/llm";
+import type {
+  LLMEvent,
+  TextGeneratedEvent,
+} from "@app/lib/api/llm/types/events";
+import { EventError } from "@app/lib/api/llm/types/events";
+import type { StreamParameters } from "@app/lib/api/llm/types/options";
+import { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+
+// Helper: minimal non-tracing `authenticator` so streamWithTracing bypasses tracing.
+function makeAuth(): Authenticator {
+  return new Authenticator({
+    role: "none",
+    groups: [],
+    user: null,
+    workspace: null,
+    subscription: null,
+  });
+}
+
+// Helpers to build events used in tests.
+const metadata = { clientId: "test", modelId: "gpt-4-turbo" } as const;
+
+function textEvent(text: string): TextGeneratedEvent {
+  return { type: "text_generated", content: { text }, metadata };
+}
+
+function retryableError(message = "Retryable error"): EventError {
+  return new EventError(
+    {
+      type: "overloaded_error",
+      isRetryable: true,
+      message,
+    },
+    metadata
+  );
+}
+
+function nonRetryableError(message = "Fatal error"): EventError {
+  return new EventError(
+    {
+      type: "context_length_exceeded",
+      isRetryable: false,
+      message,
+    },
+    metadata
+  );
+}
+
+// Test double: LLM subclass with scripted attempts.
+class TestLLM extends LLM {
+  private readonly attempts: LLMEvent[][];
+  public internalCalls = 0;
+
+  constructor(attempts: LLMEvent[][]) {
+    super(makeAuth(), { clientId: "test", modelId: "gpt-4-turbo" });
+    this.attempts = attempts;
+  }
+
+  protected async *internalStream(
+    _: StreamParameters
+  ): AsyncGenerator<LLMEvent> {
+    this.internalCalls += 1;
+    const idx = this.internalCalls - 1;
+    const events = this.attempts[idx] ?? [];
+    for (const e of events) {
+      yield e;
+    }
+  }
+}
+
+const defaultArgs: StreamParameters = {
+  conversation: { messages: [] },
+  prompt: "",
+  specifications: [],
+};
+
+describe("LLM.stream retries", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("no error: events pass through, no retries", async () => {
+    const llm = new TestLLM([[textEvent("ok")]]);
+
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const out: LLMEvent[] = [];
+    const gen = llm.stream(defaultArgs, {
+      retries: 3,
+      delayBetweenRetriesMs: 50,
+    });
+    const consume = (async () => {
+      for await (const e of gen) {
+        out.push(e);
+      }
+    })();
+
+    await consume; // no timers to run
+
+    expect(out.map((e) => e.type)).toEqual(["text_generated"]);
+    expect(llm.internalCalls).toBe(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("retryable error then success: one retry, backoff, no error yielded", async () => {
+    const llm = new TestLLM([[retryableError()], [textEvent("ok")]]);
+
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const out: LLMEvent[] = [];
+    const gen = llm.stream(defaultArgs, {
+      retries: 3,
+      delayBetweenRetriesMs: 100,
+    });
+
+    const consume = (async () => {
+      for await (const e of gen) {
+        out.push(e);
+      }
+    })();
+
+    // The first retry waits 100 ms
+    await vi.runAllTimersAsync();
+    await consume;
+
+    expect(out.map((e) => e.type)).toEqual(["text_generated"]);
+    expect(llm.internalCalls).toBe(2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [firstWarnArgs] = warnSpy.mock.calls as any[];
+    expect(firstWarnArgs[0]?.sleepTime).toBe(100);
+    expect(firstWarnArgs[0]?.attempt).toBe(1);
+  });
+
+  test("non-retryable error: yields error and stops without retry", async () => {
+    const llm = new TestLLM([[nonRetryableError()]]);
+
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const out: LLMEvent[] = [];
+    const gen = llm.stream(defaultArgs, {
+      retries: 5,
+      delayBetweenRetriesMs: 100,
+    });
+
+    const consume = (async () => {
+      for await (const e of gen) {
+        out.push(e);
+      }
+    })();
+
+    await consume;
+
+    expect(out).toHaveLength(1);
+    const e = out[0] as EventError;
+    expect(e.type).toBe("error");
+    expect(e.content.isRetryable).toBe(false);
+    expect(llm.internalCalls).toBe(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("retryable error then non-retryable: retries once then yields non-retryable error", async () => {
+    const llm = new TestLLM([[retryableError()], [nonRetryableError()]]);
+
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const out: LLMEvent[] = [];
+    const gen = llm.stream(defaultArgs, {
+      retries: 4,
+      delayBetweenRetriesMs: 10,
+    });
+
+    const consume = (async () => {
+      for await (const e of gen) {
+        out.push(e);
+      }
+    })();
+
+    await vi.runAllTimersAsync();
+    await consume;
+
+    expect(llm.internalCalls).toBe(2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const last = out[out.length - 1] as EventError;
+    expect(last.type).toBe("error");
+    expect(last.content.isRetryable).toBe(false);
+  });
+
+  test("too many retries: yields maximum_retries with accumulated errors", async () => {
+    const retries = 3;
+    const attempts: LLMEvent[][] = Array.from({ length: retries }, () => [
+      retryableError(),
+    ]);
+    const llm = new TestLLM(attempts);
+
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    const out: LLMEvent[] = [];
+    const gen = llm.stream(defaultArgs, {
+      retries,
+      delayBetweenRetriesMs: 200,
+    });
+
+    const consume = (async () => {
+      for await (const e of gen) {
+        out.push(e);
+      }
+    })();
+
+    await vi.runAllTimersAsync();
+    await consume;
+
+    expect(llm.internalCalls).toBe(retries);
+    expect(warnSpy).toHaveBeenCalledTimes(retries);
+
+    const types = out.map((e) => e.type);
+    // Only the final maximum_retries error should be yielded.
+    expect(types).toEqual(["error"]);
+
+    const finalError = out[0] as EventError;
+    expect(finalError.content.type).toBe("maximum_retries");
+    expect(finalError.accumulatedErrors).toHaveLength(retries);
+
+    // Check quadratic backoff values in `warn` logs
+    const sleepTimes = warnSpy.mock.calls.map(
+      (args: any[]) => args[0]?.sleepTime
+    );
+    expect(sleepTimes).toEqual([200, 800, 1800]);
+  });
+});

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -4,12 +4,14 @@ import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/components/agent_build
 import { LLMTraceBuffer } from "@app/lib/api/llm/traces/buffer";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import { EventError } from "@app/lib/api/llm/types/events";
 import type {
   LLMClientMetadata,
   LLMParameters,
   StreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import type { ModelIdType, ReasoningEffort } from "@app/types";
 
 export abstract class LLM {
@@ -96,16 +98,58 @@ export abstract class LLM {
     return this.runId;
   }
 
-  async *stream({
-    conversation,
-    prompt,
-    specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
-    yield* this.streamWithTracing({
-      conversation,
-      prompt,
-      specifications,
-    });
+  async *stream(
+    args: StreamParameters,
+    retryOptions?: { retries?: number; delayBetweenRetriesMs?: number }
+  ): AsyncGenerator<LLMEvent> {
+    const retries = retryOptions?.retries ?? 3;
+    const delayBetweenRetriesMs = retryOptions?.delayBetweenRetriesMs ?? 1000;
+
+    const accumulatedErrors: EventError[] = [];
+    for (let i = 0; i < retries; i++) {
+      for await (const event of this.streamWithTracing(args)) {
+        const isError = event.type === "error";
+        const isRetryableError = isError && event.content.isRetryable;
+
+        if (!isRetryableError) {
+          yield event;
+          return;
+        }
+
+        if (!isError) {
+          yield event;
+          continue;
+        }
+
+        accumulatedErrors.push(event);
+
+        const sleepTime = delayBetweenRetriesMs * (i + 1) ** 2;
+        logger.warn(
+          {
+            error: event.content.originalError,
+            attempt: i + 1,
+            retries,
+            sleepTime,
+          },
+          "Error while calling LLM. Retrying..."
+        );
+        await new Promise((resolve) => setTimeout(resolve, sleepTime));
+      }
+
+      if (accumulatedErrors.length === 0) {
+        return;
+      }
+    }
+
+    yield new EventError(
+      {
+        type: "maximum_retries",
+        isRetryable: false,
+        message: "Maximum retries reached",
+      },
+      this.metadata,
+      accumulatedErrors
+    );
   }
 
   protected abstract internalStream({

--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -20,7 +20,9 @@ export type LLMErrorType =
   | "timeout_error"
   | "server_error"
   | "stream_error"
-  | "unknown_error";
+  | "unknown_error"
+  // Other
+  | "maximum_retries";
 
 export interface LLMErrorInfo {
   type: LLMErrorType;

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -78,12 +78,18 @@ export class EventError extends Error {
   public readonly type = "error";
   public readonly content: LLMErrorInfo;
   public readonly metadata: LLMClientMetadata;
+  public readonly accumulatedErrors: EventError[] = [];
 
-  constructor(content: LLMErrorInfo, metadata: LLMClientMetadata) {
+  constructor(
+    content: LLMErrorInfo,
+    metadata: LLMClientMetadata,
+    accumulatedErrors: EventError[] = []
+  ) {
     super(content.message);
 
     this.content = content;
     this.metadata = metadata;
+    this.accumulatedErrors = accumulatedErrors;
   }
 }
 


### PR DESCRIPTION
## Description

Add retries for LLM based on the retryability of errors.

I couldn't use `front/types/shared/retries.ts` as I wanted a custom algorithm to know when to retry.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
