### PR TITLE
Replacing DocumentTextIcon by ActionFrame in workspace settings

### DIFF
--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -1,9 +1,9 @@
 import {
+  ActionFrameIcon,
   ArrowPathIcon,
   Button,
   ContextItem,
   DiscordLogo,
-  DocumentTextIcon,
   GlobeAltIcon,
   Input,
   MicIcon,
@@ -504,7 +504,7 @@ function InteractiveContentSharingToggle({ owner }: { owner: WorkspaceType }) {
     <ContextItem
       title="Public Frame sharing"
       subElement="Allow Frames to be shared publicly via links"
-      visual={<DocumentTextIcon className="h-6 w-6" />}
+      visual={<ActionFrameIcon className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={
         <SliderToggle


### PR DESCRIPTION
## Description
We're not using the right icon in ws settings : 
<img width="856" height="77" alt="image" src="https://github.com/user-attachments/assets/a6c39723-6778-4691-ae64-eb06592a0be1" />


## Tests


## Risk
None

## Deploy Plan
Merge
