### PR TITLE
[front] - refacto(obs):: remove content value from message feedback

### DIFF
--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -82,7 +82,7 @@ export async function storeAgentAnalyticsActivity(
     user_id: userMessage.user?.sId ?? "unknown",
     workspace_id: workspace.sId,
     feedbacks: [],
-    content: agentMessage.content,
+    content: null,
   };
 
   await storeToElasticsearch(document);

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -289,7 +289,7 @@ export async function storeAgentMessageFeedbackActivity(
       feedback_id: agentMessageFeedback.id,
       user_id: agentMessageFeedback.user?.sId ?? "unknown",
       thumb_direction: agentMessageFeedback.thumbDirection,
-      content: agentMessageFeedback.content ?? undefined,
+      content: undefined,
       dismissed: agentMessageFeedback.dismissed,
       is_conversation_shared: agentMessageFeedback.isConversationShared,
       created_at: agentMessageFeedback.createdAt.toISOString(),


### PR DESCRIPTION
## Description

This PR no longer includes the `content` field's value when storing agent message feedback to ensure data consistency and privacy regulations compliance.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front