### PR TITLE
Rollback invoke response

### DIFF
--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -252,17 +252,11 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
             };
             localLogger.info(
               cardResponse,
-              "Invoke reponse: tool execution approval card refresh response"
+              "Tool execution approval card refresh response"
             );
 
-            // For Bot Framework invoke activities, send response through context
-            await context.sendActivity({
-              type: "invokeResponse",
-              value: {
-                status: 200,
-                body: cardResponse,
-              },
-            });
+            res.set("Content-Type", "application/json; charset=utf-8");
+            res.status(200).json(cardResponse);
           } else {
             localLogger.info(
               {


### PR DESCRIPTION
## Description

Microsoft Teams - Rollback the invokeResponse activity, in order to send a classic 200 HTTP response when Teams client asks for card refresh

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy connectors
