### PR TITLE
[front] enh(webhook): Bump filter generation to large model

### DIFF
--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -3,7 +3,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { getDustProdAction } from "@app/lib/registry";
 import { cloneBaseConfig } from "@app/lib/registry";
 import type { Result } from "@app/types";
-import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
+import {
+  Err,
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+  Ok,
+} from "@app/types";
 
 function isValidIANATimezone(timezone: string): boolean {
   // Get the list of all supported IANA timezones
@@ -130,7 +135,7 @@ export async function generateWebhookFilter(
 ): Promise<Result<{ filter: string }, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = getSmallWhitelistedModel(owner);
+  const model = getLargeWhitelistedModel(owner);
   if (!model) {
     return new Err(
       new Error("Failed to find a whitelisted model to generate filter")

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1,7 +1,7 @@
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import {
   CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG,
+  CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
 import {
   GEMINI_2_5_FLASH_MODEL_CONFIG,
@@ -72,7 +72,7 @@ export function getLargeWhitelistedModel(
   owner: WorkspaceType
 ): ModelConfigurationType | null {
   if (isProviderWhitelisted(owner, "anthropic")) {
-    return CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG;
+    return CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG;
   }
   return getLargeNonAnthropicWhitelistedModel(owner);
 }


### PR DESCRIPTION
## Description

- We've observed that generating the Lisp-like filter query from a JSON schema is not an easy task, therefore bumping the model used from the first small whitelisted model to the first large whitelisted model.
- This PR also updates the first large whitelisted model from sonnet 4 to sonnet 4.5, which effectively changes the Helper global agent, the builder suggestions and the feedback analyzer global agent.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
