### PR TITLE
[Front Sorting] Removes string length as a fuzzy ordering criteria

### DIFF
--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -277,6 +277,12 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
     return subFilterLastIndexA - subFilterLastIndexB;
   }
 
+  // Favor exact match
+  if (a.length !== b.length) {
+    if (a === query) return -1;
+    if (b === query) return 1;
+  }
+
   return 0;
 }
 

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -277,9 +277,6 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
     return subFilterLastIndexA - subFilterLastIndexB;
   }
 
-  if (a.length !== b.length) {
-    return a.length - b.length;
-  }
   return 0;
 }
 

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -279,8 +279,12 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
 
   // Favor exact match
   if (a.length !== b.length) {
-    if (a === query) return -1;
-    if (b === query) return 1;
+    if (a === query) {
+      return -1;
+    }
+    if (b === query) {
+      return 1;
+    }
   }
 
   return 0;

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -12,7 +12,6 @@ test("compareForFuzzySort should correctly compare strings", () => {
     { query: "gp", a: "gpt-4", b: "gemni-pro" },
     { query: "start", a: "robotstart", b: "strongrt" },
     { query: "mygod", a: "ohmygodbot", b: "moatmode" },
-    { query: "test", a: "test", b: "testlong" },
     { query: "test", a: "testlonger", b: "longtest" },
     { query: "eng", a: "eng", b: "slack-engineering-highlights" },
     { query: "c", a: "c", b: "RadicalFeedback" },

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -3,21 +3,38 @@ import { expect, test } from "vitest";
 import { compareForFuzzySort } from "@app/lib/utils";
 
 test("compareForFuzzySort should correctly compare strings", () => {
-  const data = [
+  const dataLessThan = [
     { query: "eng", a: "eng", b: "ContentMarketing" },
-    { query: "sql", a: "sqlGod", b: "sqlCoreGod" },
     { query: "sql", a: "sql", b: "sqlGod" },
     { query: "sql", a: "sql", b: "SEOQualityRater" },
     { query: "gp", a: "gpt-4", b: "GabHelp" },
     { query: "gp", a: "gpt-4", b: "gemni-pro" },
     { query: "start", a: "robotstart", b: "strongrt" },
     { query: "mygod", a: "ohmygodbot", b: "moatmode" },
+    { query: "test", a: "test", b: "testlong" },
     { query: "test", a: "testlonger", b: "longtest" },
     { query: "eng", a: "eng", b: "slack-engineering-highlights" },
     { query: "c", a: "c", b: "RadicalFeedback" },
   ];
 
-  for (const d of data) {
-    expect(compareForFuzzySort(d.query, d.a, d.b)).toBeLessThan(0);
+  const dataEqual = [
+    { query: "sql", a: "sqlGod", b: "sqlGod" },
+    { query: "eng", a: "eng1", b: "eng2" },
+    { query: "gp", a: "gpt-4", b: "gpt-5" },
+    { query: "test", a: "testl", b: "testlong" },
+  ];
+
+  for (const d of dataLessThan) {
+    expect(
+      compareForFuzzySort(d.query, d.a, d.b),
+      `Expected compareForFuzzySort("${d.query}", "${d.a}", "${d.b}") to be less than 0`
+    ).toBeLessThan(0);
+  }
+
+  for (const d of dataEqual) {
+    expect(
+      compareForFuzzySort(d.query, d.a, d.b),
+      `Expected compareForFuzzySort("${d.query}", "${d.a}", "${d.b}") to return 0`
+    ).toBe(0);
   }
 });


### PR DESCRIPTION
Description
---

Fixes e.g. claude-4.5-haiku coming before sonnet when we type "cl4", despite the sorting order for global agents.

Basically, string length here is not a criterion genreral enough that we'd want to sort generically with it in all fuzzy sorts; this criterion is left to downstream filters and sorts.

Risk
---
low

Deploy
---
front
