### PR TITLE
[front] enh(webhooks): remove JSON schema from `/webhook_filter_generator`'s payload 

### DIFF
--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
@@ -10,6 +10,7 @@ import cronstrue from "cronstrue";
 import React, { useMemo, useState } from "react";
 import { useController, useFormContext, useWatch } from "react-hook-form";
 
+import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useTextAsCronRule } from "@app/lib/swr/agent_triggers";
 import type { LightWorkspaceType } from "@app/types";
@@ -56,7 +57,8 @@ export function ScheduleEditionScheduler({
   isEditor,
   owner,
 }: ScheduleEditionSchedulerProps) {
-  const { control, setValue, getFieldState, formState } = useFormContext();
+  const { control, setValue, getFieldState, formState } =
+    useFormContext<TriggerViewsSheetFormValues>();
 
   const {
     field: {

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
@@ -34,18 +34,19 @@ export function WebhookEditionFilters({
 }: WebhookEditionFiltersProps) {
   const { setError, control } = useFormContext<TriggerViewsSheetFormValues>();
 
-  const selectedEvent = useWatch({ control, name: "webhook.event" });
+  const selectedEventValue = useWatch({ control, name: "webhook.event" });
 
-  const selectedEventSchema = useMemo<WebhookEvent | null>(() => {
-    if (!selectedEvent || !selectedPreset) {
+  const selectedEvent = useMemo<WebhookEvent | null>(() => {
+    if (!selectedEventValue || !selectedPreset) {
       return null;
     }
 
     return (
-      selectedPreset.events.find((event) => event.value === selectedEvent) ??
-      null
+      selectedPreset.events.find(
+        (event) => event.value === selectedEventValue
+      ) ?? null
     );
-  }, [selectedEvent, selectedPreset]);
+  }, [selectedEventValue, selectedPreset]);
   const {
     field: filterField,
     fieldState: { error: filterError },
@@ -68,7 +69,7 @@ export function WebhookEditionFilters({
 
   const triggerFilterGeneration = useDebounceWithAbort(
     async (txt: string, signal: AbortSignal) => {
-      if (txt.length < MIN_DESCRIPTION_LENGTH || !selectedEventSchema) {
+      if (txt.length < MIN_DESCRIPTION_LENGTH || !selectedEvent) {
         setFilterGenerationStatus("idle");
         return;
       }
@@ -76,7 +77,7 @@ export function WebhookEditionFilters({
       try {
         const result = await generateFilter({
           naturalDescription: txt,
-          eventSchema: selectedEventSchema.schema,
+          event: selectedEvent,
           signal,
         });
 
@@ -154,7 +155,7 @@ export function WebhookEditionFilters({
             value={naturalDescriptionValue ?? ""}
             disabled={!isEditor}
             onChange={(e) => {
-              if (!selectedEvent || !selectedPreset) {
+              if (!selectedEventValue || !selectedPreset) {
                 setError("webhook.event", {
                   type: "manual",
                   message: "Please select an event first",

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from "react";
 import { useController, useFormContext, useWatch } from "react-hook-form";
 
 import { TriggerFilterRenderer } from "@app/components/agent_builder/triggers/TriggerFilterRenderer";
+import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useWebhookFilterGenerator } from "@app/lib/swr/agent_triggers";
 import type { LightWorkspaceType } from "@app/types";
@@ -31,7 +32,7 @@ export function WebhookEditionFilters({
   availableEvents,
   workspace,
 }: WebhookEditionFiltersProps) {
-  const { setError, control } = useFormContext();
+  const { setError, control } = useFormContext<TriggerViewsSheetFormValues>();
 
   const selectedEvent = useWatch({ control, name: "webhook.event" });
 

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionFilters.tsx
@@ -76,7 +76,7 @@ export function WebhookEditionFilters({
       try {
         const result = await generateFilter({
           naturalDescription: txt,
-          eventSchema: selectedEventSchema,
+          eventSchema: selectedEventSchema.schema,
           signal,
         });
 

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -1,7 +1,8 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
 import { runActionStreamed } from "@app/lib/actions/server";
 import type { Authenticator } from "@app/lib/auth";
-import { getDustProdAction } from "@app/lib/registry";
-import { cloneBaseConfig } from "@app/lib/registry";
+import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import type { Result } from "@app/types";
 import {
   Err,
@@ -130,7 +131,7 @@ export async function generateWebhookFilter(
     eventSchema,
   }: {
     naturalDescription: string;
-    eventSchema: Record<string, unknown>;
+    eventSchema: JSONSchema;
   }
 ): Promise<Result<{ filter: string }, Error>> {
   const owner = auth.getNonNullableWorkspace();

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -130,7 +130,7 @@ export async function generateWebhookFilter(
     eventSchema,
   }: {
     naturalDescription: string;
-    eventSchema: Record<string, any>;
+    eventSchema: Record<string, unknown>;
   }
 ): Promise<Result<{ filter: string }, Error>> {
   const owner = auth.getNonNullableWorkspace();

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -31,6 +31,9 @@ export const TOO_FREQUENT_MESSAGE =
 export const WEBHOOK_FILTER_GENERIC_ERROR_MESSAGE =
   "Unable to generate a filter. Please try rephrasing.";
 
+const CRON_REGEXP =
+  /^((((\d+,)+\d+|(\d+(\/|-|#)\d+)|\d+L?|\*(\/\d+)?|L(-\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$/;
+
 export async function generateCronRule(
   auth: Authenticator,
   {
@@ -109,9 +112,7 @@ export async function generateCronRule(
   if (
     !cronRule ||
     cronRule.split(" ").length !== 5 ||
-    !cronRule.match(
-      /^((((\d+,)+\d+|(\d+(\/|-|#)\d+)|\d+L?|\*(\/\d+)?|L(-\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$/
-    )
+    !cronRule.match(CRON_REGEXP)
   ) {
     return new Err(new Error(GENERIC_ERROR_MESSAGE));
   }

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -15,6 +15,10 @@ import type {
   PostTextAsCronRuleRequestBody,
   PostTextAsCronRuleResponseBody,
 } from "@app/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule";
+import type {
+  PostWebhookFilterGeneratorRequestBody,
+  PostWebhookFilterGeneratorResponseBody,
+} from "@app/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator";
 import type { GetUserTriggersResponseBody } from "@app/pages/api/w/[wId]/me/triggers";
 import type { LightWorkspaceType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
@@ -115,17 +119,17 @@ export function useWebhookFilterGenerator({
       signal,
     }: {
       naturalDescription: string;
-      eventSchema: Record<string, any>;
+      eventSchema: Record<string, unknown>;
       signal?: AbortSignal;
     }): Promise<{ filter: string }> => {
-      const r = await fetcher(
+      const r: PostWebhookFilterGeneratorResponseBody = await fetcher(
         `/api/w/${workspace.sId}/assistant/agent_configurations/webhook_filter_generator`,
         {
           method: "POST",
           body: JSON.stringify({
             naturalDescription,
             eventSchema,
-          }),
+          } satisfies PostWebhookFilterGeneratorRequestBody),
           signal,
         }
       );

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -22,6 +22,7 @@ import type {
 import type { GetUserTriggersResponseBody } from "@app/pages/api/w/[wId]/me/triggers";
 import type { LightWorkspaceType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
+import type { WebhookEvent } from "@app/types/triggers/webhooks_source_preset";
 
 export function useAgentTriggers({
   workspaceId,
@@ -115,11 +116,11 @@ export function useWebhookFilterGenerator({
   const generateFilter = useCallback(
     async ({
       naturalDescription,
-      eventSchema,
+      event,
       signal,
     }: {
       naturalDescription: string;
-      eventSchema: Record<string, unknown>;
+      event: WebhookEvent;
       signal?: AbortSignal;
     }): Promise<{ filter: string }> => {
       const r: PostWebhookFilterGeneratorResponseBody = await fetcher(
@@ -128,7 +129,7 @@ export function useWebhookFilterGenerator({
           method: "POST",
           body: JSON.stringify({
             naturalDescription,
-            eventSchema,
+            eventSchema: event.schema ?? null,
           } satisfies PostWebhookFilterGeneratorRequestBody),
           signal,
         }

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -22,7 +22,7 @@ import type {
 import type { GetUserTriggersResponseBody } from "@app/pages/api/w/[wId]/me/triggers";
 import type { LightWorkspaceType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
-import type { WebhookEvent } from "@app/types/triggers/webhooks_source_preset";
+import type { WebhookProvider } from "@app/types/triggers/webhooks";
 
 export function useAgentTriggers({
   workspaceId,
@@ -117,10 +117,12 @@ export function useWebhookFilterGenerator({
     async ({
       naturalDescription,
       event,
+      provider,
       signal,
     }: {
       naturalDescription: string;
-      event: WebhookEvent;
+      event: string;
+      provider: WebhookProvider;
       signal?: AbortSignal;
     }): Promise<{ filter: string }> => {
       const r: PostWebhookFilterGeneratorResponseBody = await fetcher(
@@ -129,7 +131,8 @@ export function useWebhookFilterGenerator({
           method: "POST",
           body: JSON.stringify({
             naturalDescription,
-            eventSchema: event.schema ?? null,
+            event,
+            provider,
           } satisfies PostWebhookFilterGeneratorRequestBody),
           signal,
         }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -57,7 +57,7 @@ async function handler(
 
       const eventSchema = WEBHOOK_PRESETS[provider].events.find(
         (event) => event.value === eventValue
-      );
+      )?.schema;
 
       if (!eventSchema) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -6,6 +6,10 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import {
+  WEBHOOK_PRESETS,
+  WEBHOOK_PROVIDERS,
+} from "@app/types/triggers/webhooks";
 
 export type PostWebhookFilterGeneratorResponseBody = {
   filter: string;
@@ -13,7 +17,8 @@ export type PostWebhookFilterGeneratorResponseBody = {
 
 const PostWebhookFilterGeneratorRequestBodySchema = z.object({
   naturalDescription: z.string(),
-  eventSchema: z.any(),
+  event: z.string(),
+  provider: z.enum(WEBHOOK_PROVIDERS),
 });
 
 export type PostWebhookFilterGeneratorRequestBody = z.infer<
@@ -44,7 +49,25 @@ async function handler(
         });
       }
 
-      const { naturalDescription, eventSchema } = bodyValidation.data;
+      const {
+        naturalDescription,
+        event: eventValue,
+        provider,
+      } = bodyValidation.data;
+
+      const eventSchema = WEBHOOK_PRESETS[provider].events.find(
+        (event) => event.value === eventValue
+      );
+
+      if (!eventSchema) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid event: ${eventValue} for provider ${provider}.`,
+          },
+        });
+      }
 
       const r = await generateWebhookFilter(auth, {
         naturalDescription,


### PR DESCRIPTION
## Description

- The endpoint that calls the Dust app to generate the filter for a webhook currently expects the entire JSON schema in its payload.
- This PR changes this to only exchange the provider and then retrieve the JSON schema in the backend.
- We also used to pass the event instead of event.schema.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
