### PR TITLE
feat: support tag filtering in file system tools search/find/locate

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -32,25 +32,39 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer("data_sources_file_system");
 
-  registerCatTool(auth, server, agentLoopContext, {
-    name: FILESYSTEM_CAT_TOOL_NAME,
-  });
-
   // Check if tags are dynamic before creating the search tool.
   const areTagsDynamic = agentLoopContext
     ? shouldAutoGenerateTags(agentLoopContext)
     : false;
+
+  registerCatTool(auth, server, agentLoopContext, {
+    name: FILESYSTEM_CAT_TOOL_NAME,
+  });
 
   registerListTool(auth, server, agentLoopContext, {
     name: FILESYSTEM_LIST_TOOL_NAME,
     areTagsDynamic,
   });
 
+  const searchToolDescription =
+    "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
+    "children of the designated nodes will be searched.";
+
+  const findToolDescription =
+    "Find content based on their title starting from a specific node. Can be used to find specific " +
+    "nodes by searching for their titles. The query title can be omitted to list all nodes " +
+    "starting from a specific node. This is like using 'find' in Unix.";
+
+  const locateInTreeToolDescription =
+    "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
+    "This is useful for understanding where a specific node is located within the data source structure. " +
+    "The path is returned as a list of nodes, with the first node being the data source root and " +
+    "the last node being the target node.";
+
   if (!areTagsDynamic) {
     server.tool(
       SEARCH_TOOL_NAME,
-      "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
-        "children of the designated nodes will be searched.",
+      searchToolDescription,
       SearchWithNodesInputSchema.shape,
       withToolLogging(
         auth,
@@ -65,9 +79,7 @@ function createServer(
 
     server.tool(
       FILESYSTEM_FIND_TOOL_NAME,
-      "Find content based on their title starting from a specific node. Can be used to find specific " +
-        "nodes by searching for their titles. The query title can be omitted to list all nodes " +
-        "starting from a specific node. This is like using 'find' in Unix.",
+      findToolDescription,
       DataSourceFilesystemFindInputSchema.shape,
       withToolLogging(
         auth,
@@ -82,10 +94,7 @@ function createServer(
 
     server.tool(
       FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
-      "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
-        "This is useful for understanding where a specific node is located within the data source structure. " +
-        "The path is returned as a list of nodes, with the first node being the data source root and " +
-        "the last node being the target node.",
+      locateInTreeToolDescription,
       DataSourceFilesystemLocateTreeInputSchema.shape,
       withToolLogging(
         auth,
@@ -106,8 +115,7 @@ function createServer(
 
     server.tool(
       SEARCH_TOOL_NAME,
-      "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
-        "children of the designated nodes will be searched.",
+      searchToolDescription,
       {
         ...SearchWithNodesInputSchema.shape,
         ...TagsInputSchema.shape,
@@ -129,9 +137,7 @@ function createServer(
 
     server.tool(
       FILESYSTEM_FIND_TOOL_NAME,
-      "Find content based on their title starting from a specific node. Can be used to find specific " +
-        "nodes by searching for their titles. The query title can be omitted to list all nodes " +
-        "starting from a specific node. This is like using 'find' in Unix.",
+      findToolDescription,
       {
         ...DataSourceFilesystemFindInputSchema.shape,
         ...TagsInputSchema.shape,
@@ -153,10 +159,7 @@ function createServer(
 
     server.tool(
       FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
-      "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
-        "This is useful for understanding where a specific node is located within the data source structure. " +
-        "The path is returned as a list of nodes, with the first node being the data source root and " +
-        "the last node being the target node.",
+      locateInTreeToolDescription,
       {
         ...DataSourceFilesystemLocateTreeInputSchema.shape,
         ...TagsInputSchema.shape,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -36,23 +36,6 @@ function createServer(
     name: FILESYSTEM_CAT_TOOL_NAME,
   });
 
-  server.tool(
-    FILESYSTEM_FIND_TOOL_NAME,
-    "Find content based on their title starting from a specific node. Can be used to find specific " +
-      "nodes by searching for their titles. The query title can be omitted to list all nodes " +
-      "starting from a specific node. This is like using 'find' in Unix.",
-    DataSourceFilesystemFindInputSchema.shape,
-    withToolLogging(
-      auth,
-      {
-        toolNameForMonitoring: FILESYSTEM_FIND_TOOL_NAME,
-        agentLoopContext,
-        enableAlerting: true,
-      },
-      async (params) => findCallback(auth, params)
-    )
-  );
-
   // Check if tags are dynamic before creating the search tool.
   const areTagsDynamic = agentLoopContext
     ? shouldAutoGenerateTags(agentLoopContext)
@@ -77,6 +60,41 @@ function createServer(
           enableAlerting: true,
         },
         async (params) => searchCallback(auth, agentLoopContext, params)
+      )
+    );
+
+    server.tool(
+      FILESYSTEM_FIND_TOOL_NAME,
+      "Find content based on their title starting from a specific node. Can be used to find specific " +
+        "nodes by searching for their titles. The query title can be omitted to list all nodes " +
+        "starting from a specific node. This is like using 'find' in Unix.",
+      DataSourceFilesystemFindInputSchema.shape,
+      withToolLogging(
+        auth,
+        {
+          toolNameForMonitoring: FILESYSTEM_FIND_TOOL_NAME,
+          agentLoopContext,
+          enableAlerting: true,
+        },
+        async (params) => findCallback(auth, params)
+      )
+    );
+
+    server.tool(
+      FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
+      "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
+        "This is useful for understanding where a specific node is located within the data source structure. " +
+        "The path is returned as a list of nodes, with the first node being the data source root and " +
+        "the last node being the target node.",
+      DataSourceFilesystemLocateTreeInputSchema.shape,
+      withToolLogging(
+        auth,
+        {
+          toolNameForMonitoring: FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
+          agentLoopContext,
+          enableAlerting: true,
+        },
+        async (params) => locateTreeCallback(auth, params)
       )
     );
   } else {
@@ -108,25 +126,56 @@ function createServer(
           })
       )
     );
-  }
 
-  server.tool(
-    FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
-    "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
-      "This is useful for understanding where a specific node is located within the data source structure. " +
-      "The path is returned as a list of nodes, with the first node being the data source root and " +
-      "the last node being the target node.",
-    DataSourceFilesystemLocateTreeInputSchema.shape,
-    withToolLogging(
-      auth,
+    server.tool(
+      FILESYSTEM_FIND_TOOL_NAME,
+      "Find content based on their title starting from a specific node. Can be used to find specific " +
+        "nodes by searching for their titles. The query title can be omitted to list all nodes " +
+        "starting from a specific node. This is like using 'find' in Unix.",
       {
-        toolNameForMonitoring: FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
-        agentLoopContext,
-        enableAlerting: true,
+        ...DataSourceFilesystemFindInputSchema.shape,
+        ...TagsInputSchema.shape,
       },
-      async (params) => locateTreeCallback(auth, params)
-    )
-  );
+      withToolLogging(
+        auth,
+        {
+          toolNameForMonitoring: FILESYSTEM_FIND_TOOL_NAME,
+          agentLoopContext,
+          enableAlerting: true,
+        },
+        async (params) =>
+          findCallback(auth, params, {
+            tagsIn: params.tagsIn,
+            tagsNot: params.tagsNot,
+          })
+      )
+    );
+
+    server.tool(
+      FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
+      "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
+        "This is useful for understanding where a specific node is located within the data source structure. " +
+        "The path is returned as a list of nodes, with the first node being the data source root and " +
+        "the last node being the target node.",
+      {
+        ...DataSourceFilesystemLocateTreeInputSchema.shape,
+        ...TagsInputSchema.shape,
+      },
+      withToolLogging(
+        auth,
+        {
+          toolNameForMonitoring: FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
+          agentLoopContext,
+          enableAlerting: true,
+        },
+        async (params) =>
+          locateTreeCallback(auth, params, {
+            tagsIn: params.tagsIn,
+            tagsNot: params.tagsNot,
+          })
+      )
+    );
+  }
 
   return server;
 }

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/locate_tree.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/locate_tree.ts
@@ -114,8 +114,7 @@ export async function locateTreeCallback(
       filter: {
         node_ids: parentNodeIds,
         data_source_views: makeCoreSearchNodesFilters(
-          agentDataSourceConfigurations,
-          { tagsIn, tagsNot }
+          agentDataSourceConfigurations
         ),
       },
     });

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
@@ -236,7 +236,8 @@ export async function searchCallback(
       filter: {
         node_ids: searchNodeIds,
         data_source_views: makeCoreSearchNodesFilters(
-          agentDataSourceConfigurations
+          agentDataSourceConfigurations,
+          { tagsIn, tagsNot }
         ),
       },
       options: {


### PR DESCRIPTION








## Description

Extends tag filtering support to the `find`, `search`, and `locate_tree` filesystem tools when tags are dynamic (exploratory search mode). The PR adds `tagsIn` and `tagsNot` parameters to these tools and passes them through to `makeCoreSearchNodesFilters` and includes conflict checking. This completes the tag filtering support for all filesystem tools, following the pattern established in #17536 for the `list` tool.

## Risk

Low - follows the same pattern already implemented for the `list` tool. The changes ensure tag filters are properly validated and applied to all filesystem operations.

## Tests

Tested locally with front

## Deploy Plan

Deploy Front.
