### PR TITLE
[front] Bump webhook filter generation Dust app

### DIFF
--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -285,7 +285,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "XNcJCE7lUj",
       appHash:
-        "2b6d050561b51820a4901a8379df9513136900af7f39ede287a03c9120a453e3",
+        "b077dc1e41ab00ee71cbebbd63b6b80f924320c6404c3a3de43359ffba8ba372",
     },
     config: {
       CREATE_FILTER: {


### PR DESCRIPTION
## Description

- The Dust app was edited to add some instructions about nested fields.
```
  - When adding a filter on nested objects, make sure that your expression contains all the fields in the nesting, separated by dots (e.g. `ticket.fields.organization.name` if the nesting is that the ticket object contains a fields object, which contains an organization, which contains a name property)
```

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
