### PR TITLE
Update mprocs and add start script to wait on each-others.

### DIFF
--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -11,6 +11,7 @@ procs:
   core:
     cwd: "<CONFIG_DIR>/../core"
     shell: "bacon core-api"
+
   sqlite-workers:
     cwd: "<CONFIG_DIR>/../core"
     env:
@@ -19,25 +20,52 @@ procs:
       DATABASES_STORE_DATABASE_URI: "postgresql://dev:dev@localhost:5432/dust_databases_store"
       CORE_API_KEY: "soupinou"
     shell: "bacon sqlite-worker"
+
   oauth:
     cwd: "<CONFIG_DIR>/../core"
     shell: "bacon oauth"
-  front:
-    cwd: "<CONFIG_DIR>/../front"
-    shell: "source ~/.nvm/nvm.sh && nvm install && npm install && ./admin/dev.sh"
-  front-workers:
-    cwd: "<CONFIG_DIR>/../front"
-    shell: "source ~/.nvm/nvm.sh && nvm install && npm install && ./admin/dev_worker.sh"
+
   sdks-js:
     cwd: "<CONFIG_DIR>/../sdks/js"
-    shell: "source ~/.nvm/nvm.sh && nvm install && npm install && ./admin/dev.sh"
+    shell: |
+      set -euo pipefail
+      source ~/.nvm/nvm.sh && nvm install && npm install && ./admin/dev.sh
+
+  front:
+    cwd: "<CONFIG_DIR>/../front"
+    shell: |
+      set -euo pipefail
+      READY_FILE="../sdks/js/dist/client.esm.js.map"
+      echo "Waiting for sdks-js to compile..."
+      echo "Expecting file: $READY_FILE"
+      while [ ! -f "$READY_FILE" ]; do sleep 1; done
+      echo "sdks-js ready. Starting front."
+      source ~/.nvm/nvm.sh && nvm install && npm install && ./admin/dev.sh
+
+  front-workers:
+    cwd: "<CONFIG_DIR>/../front"
+    shell: |
+      set -euo pipefail
+      echo "Waiting for front to be ready..."
+      until curl -sf http://localhost:3000/api/healthz; do sleep 1; done
+      echo "front ready. Starting front-workers."
+      source ~/.nvm/nvm.sh && nvm install && npm install && ./admin/dev_worker.sh
+
   connectors:
     cwd: "<CONFIG_DIR>/../connectors"
-    shell: "source ~/.nvm/nvm.sh && nvm install && npm install && ./admin/dev.sh"
+    shell: |
+      set -euo pipefail
+      READY_FILE="../sdks/js/dist/client.esm.js.map"
+      echo "Waiting for sdks-js to compile..."
+      while [ ! -f "$READY_FILE" ]; do sleep 1; done
+      echo "sdks-js ready. Starting connectors."
+      source ~/.nvm/nvm.sh && nvm install && npm install && ./admin/dev.sh
+
   sparkle:
     cwd: "<CONFIG_DIR>/../sparkle"
     shell: "source ~/.nvm/nvm.sh && nvm install && npm install && npm run storybook"
     autostart: false
+
   extension:
     cwd: "<CONFIG_DIR>/../extension"
     shell: "source ~/.nvm/nvm.sh && nvm install && npm install && npm run dev:chrome"

--- a/tools/start-mprocs.sh
+++ b/tools/start-mprocs.sh
@@ -1,4 +1,4 @@
-#bin/bash
+#!/bin/bash
 
 # Tiny script to start the dev environment using mprocs.
 # Needed to clear the dist of the sdks-js project before starting front so it waits for the sdks-js to be ready.

--- a/tools/start-mprocs.sh
+++ b/tools/start-mprocs.sh
@@ -1,0 +1,10 @@
+#bin/bash
+
+# Tiny script to start the dev environment using mprocs.
+# Needed to clear the dist of the sdks-js project before starting front so it waits for the sdks-js to be ready.
+
+# Clear the dist of the sdks-js project
+rm -rf ../sdks/js/dist
+
+# Start the dev environment using mprocs
+mprocs


### PR DESCRIPTION
## Description

Update mprocs to have front & connectors wait on sdk-js and front-worker wait on front.

## Tests

Locally

## Risk

Low, dev tooling

## Deploy Plan

Just merge