### PR TITLE
Chrisjow/anthropic prompt caching

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -70,13 +70,15 @@ export class AnthropicLLM extends LLM {
       const events = this.client.messages.stream({
         model: this.modelId,
         thinking: toThinkingConfig(this.reasoningEffort),
-        system: [{
-          type: "text",
-          text: prompt,
-          cache_control: {
-            type: "ephemeral",
+        system: [
+          {
+            type: "text",
+            text: prompt,
+            cache_control: {
+              type: "ephemeral",
+            },
           },
-        }],
+        ],
         messages,
         temperature: this.temperature ?? undefined,
         stream: true,

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -70,7 +70,13 @@ export class AnthropicLLM extends LLM {
       const events = this.client.messages.stream({
         model: this.modelId,
         thinking: toThinkingConfig(this.reasoningEffort),
-        system: prompt,
+        system: [{
+          type: "text",
+          text: prompt,
+          cache_control: {
+            type: "ephemeral",
+          },
+        }],
         messages,
         temperature: this.temperature ?? undefined,
         stream: true,

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -280,10 +280,8 @@ function tokenUsage(
     content: {
       inputTokens: usage.input_tokens ?? 0,
       outputTokens: usage.output_tokens,
-      // TODO(LLM-Router) Need to split between cache read and hit
-      cachedTokens:
-        (usage.cache_creation_input_tokens ?? 0) +
-        (usage.cache_read_input_tokens ?? 0),
+      cachedTokens: usage.cache_read_input_tokens ?? 0,
+      cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
       totalTokens: (usage.input_tokens ?? 0) + usage.output_tokens,
     },
     metadata,

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
@@ -69,6 +69,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
       inputTokens: 2500,
       outputTokens: 180,
       cachedTokens: 0,
+      cacheCreationTokens: 0,
       totalTokens: 2680,
     },
     metadata: {

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
@@ -50,6 +50,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
       inputTokens: 1766,
       outputTokens: 128,
       cachedTokens: 0,
+      cacheCreationTokens: 0,
       totalTokens: 1894,
     },
     metadata: {

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -55,6 +55,7 @@ export type LLMOutputItem =
 // Completion results
 
 export interface TokenUsage {
+  cacheCreationTokens?: number;
   cachedTokens?: number;
   inputTokens: number;
   outputTokens: number;

--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -130,6 +130,7 @@ function responseCompleted(
   } = response.usage;
   // even if in the types `input_tokens_details` and `output_tokens_details` are NOT optional,
   // some providers (e.g. Fireworks) return them as null
+  // NB: OpenAI API does not return the number of cache writes
   const cachedTokens = response.usage.input_tokens_details?.cached_tokens;
   const reasoningTokens =
     response.usage.output_tokens_details?.reasoning_tokens;


### PR DESCRIPTION
## Description

Enables Anthropic prompt caching for the system prompt by wrapping it in a cache_control structure with ephemeral type. This allows Claude to cache the system prompt across multiple requests, reducing input token costs for subsequent calls with the same system prompt.

## Tests

Send to messages in the same conversation to the same Anthropic agent
<img width="692" height="133" alt="image" src="https://github.com/user-attachments/assets/68cc7d9d-d3bb-4614-b6f5-b2d18f5c379e" />
<img width="692" height="133" alt="image" src="https://github.com/user-attachments/assets/8251af87-e0cf-4b5f-835a-d13c275a5c47" />


## Risk

Low

## Deploy Plan

Deploy front
