### PR TITLE
refactor: filesystem list tool registration

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -10,7 +10,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { registerCatTool } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat";
 import { findCallback } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find";
-import { listToolCallback } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list";
+import { listCallback } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list";
 import { locateTreeCallback } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/locate_tree";
 import { searchCallback } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search";
 import { registerFindTagsTool } from "@app/lib/actions/mcp_internal_actions/tools/tags/find_tags";
@@ -76,7 +76,7 @@ function createServer(
           agentLoopContext,
           enableAlerting: true,
         },
-        async (params) => listToolCallback(auth, params)
+        async (params) => listCallback(auth, params)
       )
     );
     server.tool(
@@ -145,7 +145,7 @@ function createServer(
           enableAlerting: true,
         },
         async (params) =>
-          listToolCallback(auth, params, {
+          listCallback(auth, params, {
             tagsIn: params.tagsIn,
             tagsNot: params.tagsNot,
           })

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -28,7 +28,7 @@ import type {
 } from "@app/types";
 import { CoreAPI, Err, Ok } from "@app/types";
 
-export async function listToolCallback(
+export async function listCallback(
   auth: Authenticator,
   {
     nodeId,

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -1,8 +1,6 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { FILESYSTEM_LIST_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { renderSearchResults } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
   extractDataSourceIdFromNodeId,
@@ -18,13 +16,7 @@ import type {
   DataSourceFilesystemListInputType,
   TagsInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
-import {
-  DataSourceFilesystemListInputSchema,
-  TagsInputSchema,
-} from "@app/lib/actions/mcp_internal_actions/types";
 import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
-import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 import type { Authenticator } from "@app/lib/auth";
@@ -36,67 +28,7 @@ import type {
 } from "@app/types";
 import { CoreAPI, Err, Ok } from "@app/types";
 
-export function registerListTool(
-  auth: Authenticator,
-  server: McpServer,
-  agentLoopContext: AgentLoopContextType | undefined,
-  {
-    name,
-    extraDescription,
-    areTagsDynamic,
-  }: { name: string; extraDescription?: string; areTagsDynamic: boolean }
-) {
-  const baseDescription =
-    "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
-    "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
-    "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
-    "the next step's nodeId. If a node output by this tool or the find tool has children " +
-    "(hasChildren: true), it means that this tool can be used again on it.";
-  const toolDescription = extraDescription
-    ? baseDescription + " " + extraDescription
-    : baseDescription;
-
-  if (areTagsDynamic) {
-    server.tool(
-      name,
-      toolDescription,
-      {
-        ...DataSourceFilesystemListInputSchema.shape,
-        ...TagsInputSchema.shape,
-      },
-      withToolLogging(
-        auth,
-        {
-          toolNameForMonitoring: FILESYSTEM_LIST_TOOL_NAME,
-          agentLoopContext,
-          enableAlerting: true,
-        },
-        async (params) =>
-          listToolCallback(auth, params, {
-            tagsIn: params.tagsIn,
-            tagsNot: params.tagsNot,
-          })
-      )
-    );
-  } else {
-    server.tool(
-      name,
-      toolDescription,
-      DataSourceFilesystemListInputSchema.shape,
-      withToolLogging(
-        auth,
-        {
-          toolNameForMonitoring: FILESYSTEM_LIST_TOOL_NAME,
-          agentLoopContext,
-          enableAlerting: true,
-        },
-        async (params) => listToolCallback(auth, params)
-      )
-    );
-  }
-}
-
-async function listToolCallback(
+export async function listToolCallback(
   auth: Authenticator,
   {
     nodeId,


### PR DESCRIPTION








## Description

Refactors the `list` tool registration by moving the tool registration logic from a dedicated `registerListTool` function into the main server file. This aligns with the pattern used for other filesystem tools (`find`, `search`, `locate_tree`) after the recent refactorings. The callback logic remains in its dedicated file, while the registration (including conditional tag support) is now handled directly in the server file for consistency.

## Risk

Low - pure refactoring with no behavioral changes. The tool registration logic is identical, just moved to a different location for better consistency across all filesystem tools.

## Tests

Tested locally with front

## Deploy Plan

Deploy Front.
