### PR TITLE
Add help capabilities to @dust global agent

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -405,7 +405,7 @@ export function _getDustGlobalAgent(
   // Decide which MCP server to use for data sources: default `search`,
   // or `data_sources_file_system` when the feature flag is enabled.
   const dataSourcesServerView = hasFilesystemTools
-    ? dataSourcesFileSystemMCPServerView ?? null
+    ? (dataSourcesFileSystemMCPServerView ?? null)
     : searchMCPServerView;
 
   // Only add the action if there are data sources and the chosen MCP server is available.


### PR DESCRIPTION
Enhanced the @dust agent to handle Dust-related help queries by:
- Adding search_dust_docs tool for accessing official Dust documentation
- Including help-specific guidelines in the agent instructions
- Instructing the agent to use site:dust.tt web searches for Dust info
- Ensuring the agent provides links to docs and community support
- Setting clear boundaries against inventing features or making promises

When users ask about how to use Dust, the @dust agent will now:
1. Search the official documentation
2. Use targeted web searches
3. Provide clear, accurate answers
4. Link to https://docs.dust.tt and community support

This allows @dust to handle help queries directly without requiring
users to specifically invoke the @help agent.