### PR TITLE
[front] enh(webhook): add event samples for improved filter generation

### DIFF
--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -1,5 +1,3 @@
-import type { JSONSchema7 as JSONSchema } from "json-schema";
-
 import { runActionStreamed } from "@app/lib/actions/server";
 import type { Authenticator } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
@@ -10,6 +8,7 @@ import {
   getSmallWhitelistedModel,
   Ok,
 } from "@app/types";
+import type { WebhookEvent } from "@app/types/triggers/webhooks_source_preset";
 
 function isValidIANATimezone(timezone: string): boolean {
   // Get the list of all supported IANA timezones
@@ -129,12 +128,10 @@ export async function generateWebhookFilter(
   auth: Authenticator,
   {
     naturalDescription,
-    eventSchema,
-    eventSample,
+    event,
   }: {
     naturalDescription: string;
-    eventSchema: JSONSchema;
-    eventSample: Record<string, unknown>;
+    event: WebhookEvent;
   }
 ): Promise<Result<{ filter: string }, Error>> {
   const owner = auth.getNonNullableWorkspace();
@@ -159,9 +156,9 @@ export async function generateWebhookFilter(
     config,
     [
       {
-        naturalDescription: naturalDescription,
-        expectedPayloadDescription: eventSchema,
-        eventSample,
+        naturalDescription,
+        expectedPayloadDescription: event.schema,
+        eventSample: event.sample,
       },
     ],
     {

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -130,9 +130,11 @@ export async function generateWebhookFilter(
   {
     naturalDescription,
     eventSchema,
+    eventSample,
   }: {
     naturalDescription: string;
     eventSchema: JSONSchema;
+    eventSample: Record<string, unknown>;
   }
 ): Promise<Result<{ filter: string }, Error>> {
   const owner = auth.getNonNullableWorkspace();
@@ -159,6 +161,7 @@ export async function generateWebhookFilter(
       {
         naturalDescription: naturalDescription,
         expectedPayloadDescription: eventSchema,
+        eventSample,
       },
     ],
     {

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -285,7 +285,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "XNcJCE7lUj",
       appHash:
-        "b077dc1e41ab00ee71cbebbd63b6b80f924320c6404c3a3de43359ffba8ba372",
+        "257965e90775f1ad81975aa4a5b5b6169338c79561432cfa7f4e4e13fd8bc0cf",
     },
     config: {
       CREATE_FILTER: {

--- a/front/lib/triggers/built-in-webhooks/github/github_webhook_source_presets.ts
+++ b/front/lib/triggers/built-in-webhooks/github/github_webhook_source_presets.ts
@@ -1,8 +1,14 @@
 import { CreateWebhookGithubConnection } from "@app/lib/triggers/built-in-webhooks/github/components/CreateWebhookGithubConnection";
 import { WebhookSourceGithubDetails } from "@app/lib/triggers/built-in-webhooks/github/components/WebhookSourceGithubDetails";
 import { GitHubWebhookService } from "@app/lib/triggers/built-in-webhooks/github/github_webhook_service";
-import { issuesSchema } from "@app/lib/triggers/built-in-webhooks/github/schemas/json_schema_issues";
-import { prSchema } from "@app/lib/triggers/built-in-webhooks/github/schemas/json_schema_pr";
+import {
+  issuesExample,
+  issuesSchema,
+} from "@app/lib/triggers/built-in-webhooks/github/schemas/json_schema_issues";
+import {
+  prExample,
+  prSchema,
+} from "@app/lib/triggers/built-in-webhooks/github/schemas/json_schema_pr";
 import type {
   PresetWebhook,
   WebhookEvent,
@@ -14,6 +20,7 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
   description:
     "Activity related to pull requests. The type of activity is specified in the `action` property of the payload object.",
   schema: prSchema,
+  sample: prExample,
 };
 
 const GITHUB_ISSUES_EVENT: WebhookEvent = {
@@ -22,6 +29,7 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
   description:
     "Activity related to an issue. The type of activity is specified in the `action` property of the payload object.",
   schema: issuesSchema,
+  sample: issuesExample,
 };
 
 export const GITHUB_WEBHOOK_PRESET: PresetWebhook<"github"> = {

--- a/front/lib/triggers/built-in-webhooks/github/schemas/json_schema_issues.ts
+++ b/front/lib/triggers/built-in-webhooks/github/schemas/json_schema_issues.ts
@@ -468,3 +468,51 @@ export const issuesSchema: JSONSchema = {
   },
   required: ["action", "issue", "repository", "sender"],
 };
+
+export const issuesExample = {
+  action: "opened",
+  issue: {
+    url: "https://api.github.com/repos/octocat/Hello-World/issues/1347",
+    id: 1234567890,
+    number: 1347,
+    title: "Bug: Application crashes on startup",
+    user: {
+      login: "octocat",
+      id: 1,
+      avatar_url: "https://avatars.githubusercontent.com/u/1?v=4",
+      type: "User",
+    },
+    labels: [
+      {
+        id: 208045946,
+        name: "bug",
+        color: "d73a4a",
+      },
+    ],
+    state: "open",
+    locked: false,
+    assignee: null,
+    assignees: [],
+    comments: 0,
+    created_at: "2023-01-20T10:30:00Z",
+    updated_at: "2023-01-20T10:30:00Z",
+    closed_at: null,
+    body: "The application crashes when starting up on Windows 11. Steps to reproduce: ...",
+  },
+  repository: {
+    id: 1296269,
+    name: "Hello-World",
+    full_name: "octocat/Hello-World",
+    owner: {
+      login: "octocat",
+      id: 1,
+    },
+    html_url: "https://github.com/octocat/Hello-World",
+    description: "My first repository on GitHub!",
+  },
+  sender: {
+    login: "octocat",
+    id: 1,
+    type: "User",
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/github/schemas/json_schema_pr.ts
+++ b/front/lib/triggers/built-in-webhooks/github/schemas/json_schema_pr.ts
@@ -608,3 +608,55 @@ export const prSchema: JSONSchema = {
   },
   required: ["action", "number", "pull_request", "repository", "sender"],
 };
+
+export const prExample = {
+  action: "opened",
+  number: 15,
+  pull_request: {
+    url: "https://api.github.com/repos/example_org/example_repo/pulls/15",
+    id: 1211243938,
+    html_url: "https://github.com/example_org/example_repo/pull/15",
+    number: 15,
+    state: "open",
+    locked: false,
+    title: "Add new feature",
+    user: {
+      login: "octocat",
+      id: 1234567,
+      avatar_url: "https://avatars.githubusercontent.com/u/1234567?v=4",
+      type: "User",
+    },
+    body: "This PR adds a new feature to improve performance",
+    created_at: "2023-01-20T09:03:04Z",
+    updated_at: "2023-01-20T09:03:04Z",
+    closed_at: null,
+    merged_at: null,
+    draft: false,
+    head: {
+      label: "example_org:feature-branch",
+      ref: "feature-branch",
+      sha: "07a6048532c799c58bf7eafdbc7d4eaf6b6bbde6",
+    },
+    base: {
+      label: "example_org:main",
+      ref: "main",
+      sha: "caf87bf0162986f2874ec1b668f1d576b9f99e76",
+    },
+  },
+  repository: {
+    id: 553972582,
+    name: "example_repo",
+    full_name: "example_org/example_repo",
+    owner: {
+      login: "example_org",
+      id: 2345678,
+    },
+    html_url: "https://github.com/example_org/example_repo",
+    description: "Example repository",
+  },
+  sender: {
+    login: "octocat",
+    id: 1234567,
+    type: "User",
+  },
+};

--- a/front/lib/triggers/built-in-webhooks/jira/jira_webhook_source_presets.ts
+++ b/front/lib/triggers/built-in-webhooks/jira/jira_webhook_source_presets.ts
@@ -1,7 +1,10 @@
 import { CreateWebhookJiraConnection } from "@app/lib/triggers/built-in-webhooks/jira/components/CreateWebhookJiraConnection";
 import { WebhookSourceJiraDetails } from "@app/lib/triggers/built-in-webhooks/jira/components/WebhookSourceJiraDetails";
 import { JiraWebhookService } from "@app/lib/triggers/built-in-webhooks/jira/jira_webhook_service";
-import { issueCreatedSchema } from "@app/lib/triggers/built-in-webhooks/jira/schemas/json_schema_issue_created";
+import {
+  issueCreatedExample,
+  issueCreatedSchema,
+} from "@app/lib/triggers/built-in-webhooks/jira/schemas/json_schema_issue_created";
 import type {
   PresetWebhook,
   WebhookEvent,
@@ -13,6 +16,7 @@ const JIRA_ISSUE_CREATED_EVENT: WebhookEvent = {
   description:
     "Triggered when a new issue is created in Jira. The event includes details about the issue, creator, and project.",
   schema: issueCreatedSchema,
+  sample: issueCreatedExample,
 };
 
 export const JIRA_WEBHOOK_PRESET: PresetWebhook<"jira"> = {

--- a/front/lib/triggers/built-in-webhooks/jira/schemas/json_schema_issue_created.ts
+++ b/front/lib/triggers/built-in-webhooks/jira/schemas/json_schema_issue_created.ts
@@ -178,3 +178,225 @@ export const issueCreatedSchema: JSONSchema = {
   },
   required: ["timestamp", "webhookEvent", "issue"],
 };
+
+export const issueCreatedExample = {
+  issue: {
+    id: "10001",
+    self: "https://example.atlassian.net/rest/api/2/10001",
+    key: "PROJ-1",
+    fields: {
+      statuscategorychangedate: "2025-01-15T10:30:00.000+0000",
+      issuetype: {
+        self: "https://example.atlassian.net/rest/api/2/issuetype/10001",
+        id: "10001",
+        description: "Tasks track small, distinct pieces of work.",
+        iconUrl:
+          "https://example.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10001?size=medium",
+        name: "Task",
+        subtask: false,
+        avatarId: 10001,
+        entityId: "00000000-0000-0000-0000-000000000000",
+        hierarchyLevel: 0,
+      },
+      components: [],
+      timespent: null,
+      timeoriginalestimate: null,
+      project: {
+        self: "https://example.atlassian.net/rest/api/2/project/10001",
+        id: "10001",
+        key: "PROJ",
+        name: "Example Project",
+        projectTypeKey: "software",
+        simplified: true,
+        avatarUrls: {
+          "48x48":
+            "https://example.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10001",
+          "24x24":
+            "https://example.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10001?size=small",
+          "16x16":
+            "https://example.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10001?size=xsmall",
+          "32x32":
+            "https://example.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10001?size=medium",
+        },
+      },
+      description: null,
+      fixVersions: [],
+      statusCategory: {
+        self: "https://example.atlassian.net/rest/api/2/statuscategory/2",
+        id: 2,
+        key: "new",
+        colorName: "blue-gray",
+        name: "New",
+      },
+      aggregatetimespent: null,
+      resolution: null,
+      timetracking: {},
+      customfield_10015: null,
+      security: null,
+      attachment: [],
+      aggregatetimeestimate: null,
+      resolutiondate: null,
+      workratio: -1,
+      summary: "Example issue summary",
+      issuerestriction: {
+        issuerestrictions: {},
+        shouldDisplay: true,
+      },
+      watches: {
+        self: "https://example.atlassian.net/rest/api/2/issue/PROJ-1/watchers",
+        watchCount: 0,
+        isWatching: true,
+      },
+      lastViewed: null,
+      creator: {
+        self: "https://example.atlassian.net/rest/api/2/user?accountId=000000%3A00000000-0000-0000-0000-000000000000",
+        accountId: "000000:00000000-0000-0000-0000-000000000000",
+        avatarUrls: {
+          "48x48":
+            "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+          "24x24":
+            "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+          "16x16":
+            "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+          "32x32":
+            "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+        },
+        displayName: "User",
+        active: true,
+        timeZone: "UTC",
+        accountType: "atlassian",
+      },
+      subtasks: [],
+      created: "2025-01-15T10:30:00.000+0000",
+      reporter: {
+        self: "https://example.atlassian.net/rest/api/2/user?accountId=000000%3A00000000-0000-0000-0000-000000000000",
+        accountId: "000000:00000000-0000-0000-0000-000000000000",
+        avatarUrls: {
+          "48x48":
+            "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+          "24x24":
+            "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+          "16x16":
+            "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+          "32x32":
+            "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+        },
+        displayName: "User",
+        active: true,
+        timeZone: "UTC",
+        accountType: "atlassian",
+      },
+      customfield_10021: null,
+      aggregateprogress: {
+        progress: 0,
+        total: 0,
+      },
+      priority: {
+        self: "https://example.atlassian.net/rest/api/2/priority/3",
+        iconUrl:
+          "https://example.atlassian.net/images/icons/priorities/medium_new.svg",
+        name: "Medium",
+        id: "3",
+      },
+      customfield_10001: null,
+      labels: [],
+      environment: null,
+      customfield_10019: "0|i000pr:",
+      timeestimate: null,
+      aggregatetimeoriginalestimate: null,
+      versions: [],
+      duedate: null,
+      progress: {
+        progress: 0,
+        total: 0,
+      },
+      votes: {
+        self: "https://example.atlassian.net/rest/api/2/issue/PROJ-1/votes",
+        votes: 0,
+        hasVoted: false,
+      },
+      issuelinks: [],
+      assignee: null,
+      updated: "2025-01-15T10:30:00.000+0000",
+      status: {
+        self: "https://example.atlassian.net/rest/api/2/status/10001",
+        description: "",
+        iconUrl: "https://example.atlassian.net/",
+        name: "To Do",
+        id: "10001",
+        statusCategory: {
+          self: "https://example.atlassian.net/rest/api/2/statuscategory/2",
+          id: 2,
+          key: "new",
+          colorName: "blue-gray",
+          name: "New",
+        },
+      },
+    },
+  },
+  issue_event_type_name: "issue_created",
+  changelog: {
+    id: "10001",
+    items: [
+      {
+        field: "summary",
+        fieldtype: "jira",
+        fieldId: "summary",
+        from: null,
+        fromString: null,
+        to: null,
+        toString: "Example issue summary",
+      },
+      {
+        field: "Status",
+        fieldtype: "jira",
+        fieldId: "status",
+        from: null,
+        fromString: null,
+        to: "10001",
+        toString: "To Do",
+      },
+      {
+        field: "priority",
+        fieldtype: "jira",
+        fieldId: "priority",
+        from: null,
+        fromString: null,
+        to: "3",
+        toString: "Medium",
+      },
+      {
+        field: "reporter",
+        fieldtype: "jira",
+        fieldId: "reporter",
+        from: null,
+        fromString: null,
+        to: "000000:00000000-0000-0000-0000-000000000000",
+        toString: "User",
+        tmpFromAccountId: null,
+        tmpToAccountId: "000000:00000000-0000-0000-0000-000000000000",
+      },
+    ],
+  },
+  webhookEvent: "jira:issue_created",
+  user: {
+    self: "https://example.atlassian.net/rest/api/2/user?accountId=000000%3A00000000-0000-0000-0000-000000000000",
+    accountId: "000000:00000000-0000-0000-0000-000000000000",
+    avatarUrls: {
+      "48x48":
+        "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+      "24x24":
+        "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+      "16x16":
+        "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+      "32x32":
+        "https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FU-0.png",
+    },
+    displayName: "User",
+    active: true,
+    timeZone: "UTC",
+    accountType: "atlassian",
+  },
+  matchedWebhookIds: [1],
+  timestamp: 1736937000000,
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_organization_created.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_organization_created.ts
@@ -75,3 +75,23 @@ export const organizationCreatedSchema: JSONSchema = {
     },
   },
 };
+
+export const organizationCreatedExample = {
+  type: "zen:event-type:organization.created",
+  account_id: 10973248,
+  subject: "zen:organization:6607619104125",
+  id: "a540ab78-88f2-49e1-93a7-16152a6f782c",
+  time: "2025-01-07T03:44:13Z",
+  zendesk_event_version: "2022-06-20",
+  detail: {
+    created_at: "2025-01-07T03:44:13Z",
+    id: "6607619104125",
+    name: "Acme Corporation",
+    shared_comments: false,
+    shared_tickets: false,
+    updated_at: "2025-01-07T03:44:13Z",
+    group_id: null,
+    external_id: null,
+  },
+  event: {},
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_agent_assignment_changed.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_agent_assignment_changed.ts
@@ -157,3 +157,25 @@ export const ticketAgentAssignmentChangedSchema: JSONSchema = {
     },
   },
 };
+
+export const ticketAgentAssignmentChangedExample = {
+  account_id: 22129848,
+  detail: {
+    id: "5158",
+    subject: "Cannot login to mobile app",
+    status: "OPEN",
+    priority: "URGENT",
+    assignee_id: "8447388090496",
+    created_at: "2025-01-08T10:12:07Z",
+    updated_at: "2025-01-08T12:15:45Z",
+  },
+  event: {
+    previous: 8447388090494,
+    current: 8447388090496,
+  },
+  id: "c6d7e8f9-0a1b-2c3d-4e5f-6a7b8c9d0e1f",
+  subject: "zen:ticket:5158",
+  time: "2025-01-08T12:15:45.789012345Z",
+  type: "zen:event-type:ticket.agent_assignment_changed",
+  zendesk_event_version: "2022-11-06",
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_comment_added.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_comment_added.ts
@@ -185,3 +185,32 @@ export const ticketCommentAddedSchema: JSONSchema = {
     },
   },
 };
+
+export const ticketCommentAddedExample = {
+  account_id: 22129848,
+  detail: {
+    id: "5158",
+    subject: "Cannot login to mobile app",
+    status: "OPEN",
+    priority: "HIGH",
+    created_at: "2025-01-08T10:12:07Z",
+    updated_at: "2025-01-08T14:25:30Z",
+  },
+  event: {
+    comment: {
+      id: 9876543210,
+      body: "We are investigating this issue and will update you shortly.",
+      is_public: true,
+      author: {
+        id: 8447388090495,
+        is_staff: true,
+        name: "Support Agent",
+      },
+    },
+  },
+  id: "d4f5c389-8f4a-4c2e-a1b9-8e4f39c71d52",
+  subject: "zen:ticket:5158",
+  time: "2025-01-08T14:25:30.123456789Z",
+  type: "zen:event-type:ticket.comment_added",
+  zendesk_event_version: "2022-11-06",
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_created.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_created.ts
@@ -148,3 +148,38 @@ export const ticketCreatedSchema: JSONSchema = {
     },
   },
 };
+
+export const ticketCreatedExample = {
+  account_id: 22129848,
+  detail: {
+    actor_id: "8447388090494",
+    assignee_id: "8447388090494",
+    brand_id: "8447346621310",
+    created_at: "2025-01-08T10:12:07Z",
+    custom_status: "8447320465790",
+    description: "Customer is experiencing login issues with the mobile app",
+    external_id: null,
+    form_id: "8646151517822",
+    group_id: "8447320466430",
+    id: "5158",
+    is_public: true,
+    organization_id: "8447346622462",
+    priority: "HIGH",
+    requester_id: "8447388090494",
+    status: "OPEN",
+    subject: "Cannot login to mobile app",
+    submitter_id: "8447388090494",
+    tags: ["mobile", "login"],
+    type: "PROBLEM",
+    updated_at: "2025-01-08T10:12:07Z",
+    via: {
+      channel: "web_service",
+    },
+  },
+  event: {},
+  id: "cbe4028c-7239-495d-b020-f22348516046",
+  subject: "zen:ticket:5158",
+  time: "2025-01-08T10:12:07.672717030Z",
+  type: "zen:event-type:ticket.created",
+  zendesk_event_version: "2022-11-06",
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_priority_changed.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_priority_changed.ts
@@ -159,3 +159,24 @@ export const ticketPriorityChangedSchema: JSONSchema = {
     },
   },
 };
+
+export const ticketPriorityChangedExample = {
+  account_id: 22129848,
+  detail: {
+    id: "5158",
+    subject: "Cannot login to mobile app",
+    status: "OPEN",
+    priority: "URGENT",
+    created_at: "2025-01-08T10:12:07Z",
+    updated_at: "2025-01-08T11:30:15Z",
+  },
+  event: {
+    current: "URGENT",
+    previous: "HIGH",
+  },
+  id: "b7c8d9e0-1f2a-3b4c-5d6e-7f8a9b0c1d2e",
+  subject: "zen:ticket:5158",
+  time: "2025-01-08T11:30:15.456789012Z",
+  type: "zen:event-type:ticket.priority_changed",
+  zendesk_event_version: "2022-11-06",
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_status_changed.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_status_changed.ts
@@ -179,3 +179,24 @@ export const ticketStatusChangedSchema: JSONSchema = {
     },
   },
 };
+
+export const ticketStatusChangedExample = {
+  account_id: 22129848,
+  detail: {
+    id: "5158",
+    subject: "Cannot login to mobile app",
+    status: "SOLVED",
+    priority: "HIGH",
+    created_at: "2025-01-08T10:12:07Z",
+    updated_at: "2025-01-08T16:45:20Z",
+  },
+  event: {
+    current: "SOLVED",
+    previous: "OPEN",
+  },
+  id: "a8b9c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d",
+  subject: "zen:ticket:5158",
+  time: "2025-01-08T16:45:20.987654321Z",
+  type: "zen:event-type:ticket.status_changed",
+  zendesk_event_version: "2022-11-06",
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_user_created.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_user_created.ts
@@ -74,3 +74,23 @@ export const userCreatedSchema: JSONSchema = {
     },
   },
 };
+
+export const userCreatedExample = {
+  type: "zen:event-type:user.created",
+  account_id: 12514403,
+  id: "6b9bbadf-5725-4e92-bebe-7b71011bf5f1",
+  subject: "zen:user:6596848315901",
+  time: "2025-01-08T05:33:18Z",
+  zendesk_event_version: "2022-06-20",
+  detail: {
+    created_at: "2025-01-08T05:27:58Z",
+    email: "[email protected]",
+    external_id: "",
+    default_group_id: "0",
+    id: "6596848315901",
+    organization_id: "0",
+    role: "end-user",
+    updated_at: "2025-01-08T05:33:18Z",
+  },
+  event: {},
+};

--- a/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_events.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/zendesk_webhook_events.ts
@@ -1,10 +1,31 @@
-import { organizationCreatedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_organization_created";
-import { ticketAgentAssignmentChangedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_agent_assignment_changed";
-import { ticketCommentAddedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_comment_added";
-import { ticketCreatedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_created";
-import { ticketPriorityChangedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_priority_changed";
-import { ticketStatusChangedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_status_changed";
-import { userCreatedSchema } from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_user_created";
+import {
+  organizationCreatedExample,
+  organizationCreatedSchema,
+} from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_organization_created";
+import {
+  ticketAgentAssignmentChangedExample,
+  ticketAgentAssignmentChangedSchema,
+} from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_agent_assignment_changed";
+import {
+  ticketCommentAddedExample,
+  ticketCommentAddedSchema,
+} from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_comment_added";
+import {
+  ticketCreatedExample,
+  ticketCreatedSchema,
+} from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_created";
+import {
+  ticketPriorityChangedExample,
+  ticketPriorityChangedSchema,
+} from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_priority_changed";
+import {
+  ticketStatusChangedExample,
+  ticketStatusChangedSchema,
+} from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_ticket_status_changed";
+import {
+  userCreatedExample,
+  userCreatedSchema,
+} from "@app/lib/triggers/built-in-webhooks/zendesk/schemas/json_schema_user_created";
 import type { WebhookEvent } from "@app/types/triggers/webhooks_source_preset";
 
 export const ZENDESK_TICKET_CREATED_EVENT: WebhookEvent = {
@@ -12,6 +33,7 @@ export const ZENDESK_TICKET_CREATED_EVENT: WebhookEvent = {
   value: "zen:event-type:ticket.created",
   description: "A ticket was created",
   schema: ticketCreatedSchema,
+  sample: ticketCreatedExample,
 };
 
 export const ZENDESK_TICKET_COMMENT_ADDED_EVENT: WebhookEvent = {
@@ -19,6 +41,7 @@ export const ZENDESK_TICKET_COMMENT_ADDED_EVENT: WebhookEvent = {
   value: "zen:event-type:ticket.comment_added",
   description: "A comment was added to a ticket",
   schema: ticketCommentAddedSchema,
+  sample: ticketCommentAddedExample,
 };
 
 export const ZENDESK_TICKET_STATUS_CHANGED_EVENT: WebhookEvent = {
@@ -26,6 +49,7 @@ export const ZENDESK_TICKET_STATUS_CHANGED_EVENT: WebhookEvent = {
   value: "zen:event-type:ticket.status_changed",
   description: "A ticket's status changed",
   schema: ticketStatusChangedSchema,
+  sample: ticketStatusChangedExample,
 };
 
 export const ZENDESK_TICKET_PRIORITY_CHANGED_EVENT: WebhookEvent = {
@@ -33,6 +57,7 @@ export const ZENDESK_TICKET_PRIORITY_CHANGED_EVENT: WebhookEvent = {
   value: "zen:event-type:ticket.priority_changed",
   description: "A ticket's priority changed",
   schema: ticketPriorityChangedSchema,
+  sample: ticketPriorityChangedExample,
 };
 
 export const ZENDESK_TICKET_AGENT_ASSIGNMENT_CHANGED_EVENT: WebhookEvent = {
@@ -40,6 +65,7 @@ export const ZENDESK_TICKET_AGENT_ASSIGNMENT_CHANGED_EVENT: WebhookEvent = {
   value: "zen:event-type:ticket.agent_assignment_changed",
   description: "A ticket was reassigned to another agent",
   schema: ticketAgentAssignmentChangedSchema,
+  sample: ticketAgentAssignmentChangedExample,
 };
 
 export const ZENDESK_USER_CREATED_EVENT: WebhookEvent = {
@@ -47,6 +73,7 @@ export const ZENDESK_USER_CREATED_EVENT: WebhookEvent = {
   value: "zen:event-type:user.created",
   description: "A user was created",
   schema: userCreatedSchema,
+  sample: userCreatedExample,
 };
 
 export const ZENDESK_ORGANIZATION_CREATED_EVENT: WebhookEvent = {
@@ -54,6 +81,7 @@ export const ZENDESK_ORGANIZATION_CREATED_EVENT: WebhookEvent = {
   value: "zen:event-type:organization.created",
   description: "An organization was created",
   schema: organizationCreatedSchema,
+  sample: organizationCreatedExample,
 };
 
 export const ZENDESK_WEBHOOK_EVENTS = [

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -71,8 +71,7 @@ async function handler(
 
       const r = await generateWebhookFilter(auth, {
         naturalDescription,
-        eventSchema: event.schema,
-        eventSample: event.sample,
+        event,
       });
 
       if (r.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -55,11 +55,11 @@ async function handler(
         provider,
       } = bodyValidation.data;
 
-      const eventSchema = WEBHOOK_PRESETS[provider].events.find(
+      const event = WEBHOOK_PRESETS[provider].events.find(
         (event) => event.value === eventValue
-      )?.schema;
+      );
 
-      if (!eventSchema) {
+      if (!event) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -71,7 +71,8 @@ async function handler(
 
       const r = await generateWebhookFilter(auth, {
         naturalDescription,
-        eventSchema,
+        eventSchema: event.schema,
+        eventSample: event.sample,
       });
 
       if (r.isErr()) {

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -31,7 +31,7 @@ export type WebhookEvent = {
   schema: JSONSchema;
 
   // Sample event that will be shown to the model to help it generate a filter.
-  sample: Record<string, unknown>;
+  sample: Record<string, unknown> | null;
 };
 
 export type PresetWebhook<P extends WebhookProvider = WebhookProvider> = {

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -29,6 +29,9 @@ export type WebhookEvent = {
 
   // The JSON schema describing the payload sent by the webhook for this event.
   schema: JSONSchema;
+
+  // Sample event that will be shown to the model to help it generate a filter.
+  sample: Record<string, unknown>;
 };
 
 export type PresetWebhook<P extends WebhookProvider = WebhookProvider> = {


### PR DESCRIPTION
## Description

- This PR exposes samples of each event to help the model generate filters for them.
- Part of the change is in the Dust app.
- The samples are anonymized.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
