### PR TITLE
feat: re-enable tags management in exploratory search mode

### DIFF
--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -10,9 +10,11 @@ import { useCallback, useMemo } from "react";
 import { useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { TagSearchSection } from "@app/components/assistant_builder/tags/TagSearchSection";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
+import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   DataSourceTag,
   DataSourceViewType,
@@ -25,6 +27,14 @@ export function DataSourceViewTagsFilterDropdown() {
   const { updateSourcesTags, toggleInConversationFiltering } =
     useDataSourceBuilderContext();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
+  const additionalConfiguration = useWatch<
+    MCPFormData,
+    "configuration.additionalConfiguration"
+  >({
+    name: "configuration.additionalConfiguration",
+  });
+  const isExploratorySearchEnabled =
+    additionalConfiguration[ADVANCED_SEARCH_SWITCH] === true;
 
   const dataSourceViews = sources.in.reduce((acc, source) => {
     if (source.type === "data_source") {
@@ -187,11 +197,21 @@ export function DataSourceViewTagsFilterDropdown() {
         collisionPadding={20}
       >
         <div className="flex flex-col gap-8 p-2">
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-3">
             <Page.SectionHeader
               title="Filtering"
               description="Filter to only include content bearing must-have labels, and exclude content with must-not-have labels."
             />
+            {isExploratorySearchEnabled && (
+              <div className="rounded-md bg-info-100 p-3 text-xs text-info-900 dark:bg-info-900/20 dark:text-info-200">
+                In exploratory search mode, the agent will respect label
+                filtering{" "}
+                <span className="font-semibold">
+                  except when listing folders or files
+                </span>
+                .
+              </div>
+            )}
           </div>
 
           <TagSearchSection

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -10,11 +10,9 @@ import { useCallback, useMemo } from "react";
 import { useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { TagSearchSection } from "@app/components/assistant_builder/tags/TagSearchSection";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
-import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   DataSourceTag,
   DataSourceViewType,
@@ -27,14 +25,6 @@ export function DataSourceViewTagsFilterDropdown() {
   const { updateSourcesTags, toggleInConversationFiltering } =
     useDataSourceBuilderContext();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
-  const additionalConfiguration = useWatch<
-    MCPFormData,
-    "configuration.additionalConfiguration"
-  >({
-    name: "configuration.additionalConfiguration",
-  });
-  const isExploratorySearchEnabled =
-    additionalConfiguration[ADVANCED_SEARCH_SWITCH] === true;
 
   const dataSourceViews = sources.in.reduce((acc, source) => {
     if (source.type === "data_source") {
@@ -188,17 +178,7 @@ export function DataSourceViewTagsFilterDropdown() {
   return (
     <PopoverRoot>
       <PopoverTrigger asChild>
-        <Button
-          label="Filters"
-          variant="outline"
-          isSelect
-          disabled={isExploratorySearchEnabled}
-          tooltip={
-            isExploratorySearchEnabled
-              ? "Exploratory search mode doesn't support filtering data sources yet"
-              : undefined
-          }
-        />
+        <Button label="Filters" variant="outline" isSelect />
       </PopoverTrigger>
 
       <PopoverContent

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -53,7 +53,8 @@ export async function catCallback(
       node_ids: [nodeId],
       data_source_views: makeCoreSearchNodesFilters(
         agentDataSourceConfigurations,
-        additionalDynamicTags
+        additionalDynamicTags,
+        { useTagFilters: true }
       ),
     },
   });

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find.ts
@@ -57,10 +57,11 @@ export async function findCallback(
   // are searched. It is not straightforward to guess which data source it
   // belongs to, this is why irrelevant data sources are not directly
   // filtered out.
-  let viewFilter = makeCoreSearchNodesFilters(agentDataSourceConfigurations, {
-    tagsIn,
-    tagsNot,
-  });
+  let viewFilter = makeCoreSearchNodesFilters(
+    agentDataSourceConfigurations,
+    { tagsIn, tagsNot },
+    { useTagFilters: true }
+  );
 
   if (dataSourceNodeId) {
     viewFilter = viewFilter.filter(

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -83,7 +83,8 @@ export async function listCallback(
     // When nodeId is null, search for data sources only.
     const dataSourceViewFilter = makeCoreSearchNodesFilters(
       agentDataSourceConfigurations,
-      additionalDynamicTags
+      additionalDynamicTags,
+      { useTagFilters: false }
     ).map((view) => ({
       ...view,
       search_scope: "data_source_name" as const,
@@ -121,7 +122,8 @@ export async function listCallback(
       filter: {
         data_source_views: makeCoreSearchNodesFilters(
           [dataSourceConfig],
-          additionalDynamicTags
+          additionalDynamicTags,
+          { useTagFilters: false }
         ),
         node_ids: dataSourceConfig.filter.parents?.in ?? undefined,
         parent_id: dataSourceConfig.filter.parents?.in
@@ -137,7 +139,8 @@ export async function listCallback(
       filter: {
         data_source_views: makeCoreSearchNodesFilters(
           agentDataSourceConfigurations,
-          additionalDynamicTags
+          additionalDynamicTags,
+          { useTagFilters: false }
         ),
         parent_id: nodeId,
         mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/locate_tree.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/locate_tree.ts
@@ -87,7 +87,8 @@ export async function locateTreeCallback(
       node_ids: [nodeId],
       data_source_views: makeCoreSearchNodesFilters(
         agentDataSourceConfigurations,
-        { tagsIn, tagsNot }
+        { tagsIn, tagsNot },
+        { useTagFilters: true }
       ),
     },
   });
@@ -114,7 +115,9 @@ export async function locateTreeCallback(
       filter: {
         node_ids: parentNodeIds,
         data_source_views: makeCoreSearchNodesFilters(
-          agentDataSourceConfigurations
+          agentDataSourceConfigurations,
+          { tagsIn, tagsNot },
+          { useTagFilters: false }
         ),
       },
     });

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
@@ -237,7 +237,8 @@ export async function searchCallback(
         node_ids: searchNodeIds,
         data_source_views: makeCoreSearchNodesFilters(
           agentDataSourceConfigurations,
-          { tagsIn, tagsNot }
+          { tagsIn, tagsNot },
+          { useTagFilters: true }
         ),
       },
       options: {

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -43,14 +43,15 @@ export type ResolvedDataSourceConfiguration = DataSourceConfiguration & {
 
 export function makeCoreSearchNodesFilters(
   agentDataSourceConfigurations: ResolvedDataSourceConfiguration[],
-  additionalDynamicTags?: TagsInputType
+  additionalDynamicTags?: TagsInputType,
+  options: { useTagFilters: boolean } = { useTagFilters: false }
 ): CoreAPIDatasourceViewFilter[] {
   return agentDataSourceConfigurations.map(
     ({ dataSource, dataSourceView, filter }) => ({
       data_source_id: dataSource.dustAPIDataSourceId,
       view_filter: dataSourceView.parentsIn ?? [],
       filter: filter.parents?.in ?? undefined,
-      ...(additionalDynamicTags
+      ...(options.useTagFilters
         ? {
             tags: {
               in: [

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -50,7 +50,6 @@ export function makeCoreSearchNodesFilters(
       data_source_id: dataSource.dustAPIDataSourceId,
       view_filter: dataSourceView.parentsIn ?? [],
       filter: filter.parents?.in ?? undefined,
-      // FIXME(ap): Remove additionalDynamicTags condition and add support in other file system tools.
       ...(additionalDynamicTags
         ? {
             tags: {


### PR DESCRIPTION
<img width="1208" height="1088" alt="image" src="https://github.com/user-attachments/assets/8496734c-ff6e-4c50-99fd-dc40fec251c9" />







## Description

Partially re-enables tags management in exploratory search mode by introducing a `useTagFilters` flag in `makeCoreSearchNodesFilters`. The `list` tool explicitly disables tag filtering (`useTagFilters: false`) to allow proper filesystem navigation, while other tools (`cat`, `find`, `search`, `locate_tree`) enable it (`useTagFilters: true`). A disclaimer is added to the tag management modal explaining that label filtering is respected except when listing folders or files.

## Risk

Low - the changes are minimal and well-scoped. The `list` tool behavior remains unchanged (no tag filtering), while other tools that already support tag filtering continue to work as expected.

## Tests

Tested locally with front.




