### PR TITLE
[llmr-router] Add openai models in test + add id in reasoning

### DIFF
--- a/front/lib/api/llm/clients/openai/__test__/openai.test.ts
+++ b/front/lib/api/llm/clients/openai/__test__/openai.test.ts
@@ -24,6 +24,12 @@ const OPENAI_MODEL_FAMILY_TO_TEST_CONFIGS: Record<
     { reasoningEffort: "medium" },
     { reasoningEffort: "high" },
   ],
+  "o3-no-vision": [
+    { reasoningEffort: "none" },
+    { reasoningEffort: "light" },
+    { reasoningEffort: "medium" },
+    { reasoningEffort: "high" },
+  ],
   reasoning: [
     { reasoningEffort: "none" },
     { reasoningEffort: "light", temperature: 0 },
@@ -31,7 +37,10 @@ const OPENAI_MODEL_FAMILY_TO_TEST_CONFIGS: Record<
     { reasoningEffort: "high" },
   ],
   "non-reasoning": [{ temperature: 1 }, { temperature: 0 }],
+  "no-vision": [{ temperature: 1 }, { temperature: 0 }],
 };
+
+const NO_VISION_FAMILIES: OpenAIModelFamily[] = ["no-vision", "o3-no-vision"];
 
 // Mock the openai module to inject dangerouslyAllowBrowser: true
 vi.mock("openai", async (importOriginal) => {
@@ -95,7 +104,13 @@ class OpenAiTestSuite extends LLMClientTestSuite {
   protected getSupportedConversations(
     _modelId: ModelIdType
   ): TestConversation[] {
-    // Run all conversations for all OpenAI models
+    const family = getOpenAIModelFamilyFromModelId(_modelId);
+    if (NO_VISION_FAMILIES.includes(family)) {
+      // Filter out conversations that require vision capabilities
+      return TEST_CONVERSATIONS.filter(
+        (conversation) => conversation.id !== "image-description"
+      );
+    }
     return TEST_CONVERSATIONS;
   }
 }

--- a/front/lib/api/llm/clients/openai/types.ts
+++ b/front/lib/api/llm/clients/openai/types.ts
@@ -2,10 +2,27 @@ import flatMap from "lodash/flatMap";
 
 import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import type { ModelIdType } from "@app/types";
-import { O3_MODEL_ID } from "@app/types";
+import {
+  GPT_3_5_TURBO_MODEL_ID,
+  GPT_4_1_MINI_MODEL_ID,
+  GPT_4_1_MODEL_ID,
+  GPT_4_TURBO_MODEL_ID,
+  GPT_4O_20240806_MODEL_ID,
+  GPT_4O_MINI_MODEL_ID,
+  GPT_4O_MODEL_ID,
+  GPT_5_MINI_MODEL_ID,
+  GPT_5_MODEL_ID,
+  GPT_5_NANO_MODEL_ID,
+  O1_MODEL_ID,
+  O3_MINI_MODEL_ID,
+  O3_MODEL_ID,
+  O4_MINI_MODEL_ID,
+} from "@app/types";
 
 export const OPENAI_MODEL_FAMILIES = [
   "o3",
+  "o3-no-vision",
+  "no-vision",
   "non-reasoning",
   "reasoning",
 ] as const;
@@ -22,12 +39,33 @@ export const OPENAI_MODEL_FAMILY_CONFIGS: Record<
     modelIds: [O3_MODEL_ID],
     overwrites: { temperature: null },
   },
+  "o3-no-vision": {
+    modelIds: [O3_MINI_MODEL_ID],
+    overwrites: { temperature: null },
+  },
   reasoning: {
-    modelIds: [],
+    modelIds: [
+      O1_MODEL_ID,
+      O4_MINI_MODEL_ID,
+      GPT_5_MODEL_ID,
+      GPT_5_MINI_MODEL_ID,
+      GPT_5_NANO_MODEL_ID,
+    ],
     overwrites: { temperature: null },
   },
   "non-reasoning": {
-    modelIds: [],
+    modelIds: [
+      GPT_4_TURBO_MODEL_ID,
+      GPT_4O_MODEL_ID,
+      GPT_4O_MINI_MODEL_ID,
+      GPT_4_1_MODEL_ID,
+      GPT_4_1_MINI_MODEL_ID,
+      GPT_4O_20240806_MODEL_ID,
+    ],
+    overwrites: { reasoningEffort: null },
+  },
+  "no-vision": {
+    modelIds: [GPT_3_5_TURBO_MODEL_ID],
     overwrites: { reasoningEffort: null },
   },
 } as const;

--- a/front/lib/api/llm/tests/LLMClientTestSuite.ts
+++ b/front/lib/api/llm/tests/LLMClientTestSuite.ts
@@ -59,10 +59,10 @@ export abstract class LLMClientTestSuite {
               this.getConversationsToRun(model).forEach((conversation) => {
                 it(
                   `should handle: ${conversation.name}`,
+                  { concurrent: true, timeout: TIMEOUT },
                   async () => {
                     await conversation.run(config);
-                  },
-                  TIMEOUT
+                  }
                 );
               });
             });

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -88,10 +88,10 @@ function userToolCall(
   };
 }
 
-function containsTextChecker(substring: string): ResponseChecker {
+function containsTextChecker(anyString: string[]): ResponseChecker {
   return {
     type: "text_contains",
-    substring,
+    anyString,
   };
 }
 
@@ -114,7 +114,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     conversationActions: [
       userMessage("Be concise. What is 2+2? Just give the number."),
     ],
-    expectedInResponses: [containsTextChecker("4")],
+    expectedInResponses: [containsTextChecker(["4"])],
   },
   {
     id: "yes-no-question",
@@ -123,7 +123,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     conversationActions: [
       userMessage("Answer only yes or no. Is Paris the capital of France?"),
     ],
-    expectedInResponses: [containsTextChecker("yes")],
+    expectedInResponses: [containsTextChecker(["yes"])],
   },
   {
     id: "multi-step-conversation",
@@ -133,7 +133,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
       userMessage("Be very brief. Hello my name is Stan ! How are you?"),
       userMessage("What is my name ?"),
     ],
-    expectedInResponses: [null, containsTextChecker("Stan")],
+    expectedInResponses: [null, containsTextChecker(["Stan"])],
   },
   {
     id: "tool-usage",
@@ -145,7 +145,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     ],
     expectedInResponses: [
       hasToolCall("GetUserId", "Stan"),
-      containsTextChecker("88888"),
+      containsTextChecker(["88888", "88 888"]),
     ],
     specifications: [
       {
@@ -174,7 +174,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
         "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/481px-Cat03.jpg"
       ),
     ],
-    expectedInResponses: [containsTextChecker("cat")],
+    expectedInResponses: [containsTextChecker(["cat"])],
   },
 ];
 
@@ -237,7 +237,7 @@ export const runConversation = async (
           break;
         case "reasoning_generated":
           fullReasoning = event.content.text;
-          const encryptedContent = event.metadata.encrypted_content ?? "";
+          const { clientId: _, modelId: __, ...otherMetadata } = event.metadata;
           conversationHistory.push({
             role: "assistant",
             name: "Assistant",
@@ -246,9 +246,7 @@ export const runConversation = async (
                 type: "reasoning",
                 value: {
                   reasoning: event.content.text,
-                  metadata: JSON.stringify({
-                    encrypted_content: encryptedContent,
-                  }),
+                  metadata: JSON.stringify(otherMetadata),
                   tokens: 12,
                   provider: config.provider,
                 },
@@ -290,9 +288,11 @@ export const runConversation = async (
     expect(fullResponse, "Full response should match deltas").toBe(
       responseFromDeltas
     );
-    expect(fullReasoning, "Full reasoning should match deltas").toBe(
-      reasoningFromDeltas
-    );
+    if (reasoningFromDeltas.length > 0) {
+      // sometimes the final reasoning message is just a summary, so reasoning deltas
+      // and end message may differ: we cannot just check equality
+      expect(fullReasoning.length).toBeGreaterThan(0);
+    }
     // Google answers 0 for short answers, so let's check that we got at least 1 total token
     if (outputTokens === 0) {
       expect(totalTokens).not.toBeNull();
@@ -305,9 +305,13 @@ export const runConversation = async (
     if (expectedInResponse !== null) {
       switch (expectedInResponse.type) {
         case "text_contains":
-          expect(fullResponse.toLowerCase()).toContain(
-            expectedInResponse.substring.toLowerCase()
+          const expected = expectedInResponse.anyString.map((s) =>
+            s.toLowerCase()
           );
+          expect(
+            expected.some((str) => fullResponse.toLowerCase().includes(str)),
+            `Response should contain at least one of the expected substrings ${expected}`
+          ).toBe(true);
           break;
         case "has_tool_call":
           const { toolName, expectedArguments } = expectedInResponse;

--- a/front/lib/api/llm/tests/types.ts
+++ b/front/lib/api/llm/tests/types.ts
@@ -16,7 +16,7 @@ export type TestConfig = {
 export type ResponseChecker =
   | {
       type: "text_contains";
-      substring: string;
+      anyString: string[];
     }
   | {
       type: "has_tool_call";

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -44,7 +44,7 @@ export interface TextGeneratedEvent {
 export interface ReasoningGeneratedEvent {
   type: "reasoning_generated";
   content: Text;
-  metadata: LLMClientMetadata & { encrypted_content?: string };
+  metadata: LLMClientMetadata & { id?: string; encrypted_content?: string };
 }
 
 export type LLMOutputItem =

--- a/front/lib/api/llm/utils/index.ts
+++ b/front/lib/api/llm/utils/index.ts
@@ -21,3 +21,17 @@ export function extractEncryptedContentFromMetadata(metadata: string): string {
       : "";
   return encryptedContent;
 }
+
+export function extractIdFromMetadata(metadata: string): string {
+  const parsed = safeParseJSON(metadata);
+  if (parsed.isErr()) {
+    throw new Error(
+      `Failed to parse reasoning metadata JSON: ${parsed.error.message}`
+    );
+  }
+  const id =
+    parsed.value && "id" in parsed.value && isString(parsed.value.id)
+      ? parsed.value.id
+      : "";
+  return id;
+}

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -13,6 +13,7 @@ import type {
 } from "openai/resources/shared";
 
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { extractIdFromMetadata } from "@app/lib/api/llm/utils";
 import type {
   ModelConversationTypeMultiActions,
   ReasoningEffort,
@@ -57,9 +58,9 @@ function toAssistantInputItem(
       };
     case "reasoning":
       assert(content.value.reasoning, "Expected non-null reasoning content");
+      const id = extractIdFromMetadata(content.value.metadata);
       return {
-        // TODO(LLM-Router 2025-10-28): Use reasoning id sent by provider
-        id: "",
+        id,
         type: "reasoning",
         summary: [{ type: "summary_text", text: content.value.reasoning }],
       };

--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -103,7 +103,7 @@ function itemToEvents(
         content: {
           text: summary.text,
         },
-        metadata,
+        metadata: { ...metadata, id: item.id },
       }));
     default:
       // TODO(LLM-Router 2025-10-28): Send error event

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
@@ -65,6 +65,7 @@ export const reasoningLLMEvents = [
       text: "**Solving the Equation**\n\nWe need to solve the equation.\n\n",
     },
     metadata: {
+      id: "rs_06e2b572b276da09016901d7350ae08198ba76145524efe4b2",
       clientId: "openai_responses",
       modelId: "gpt-5",
     },
@@ -75,6 +76,7 @@ export const reasoningLLMEvents = [
       text: "**Solving the Quadratic**\n\nTo solve the equation $$x^2 + 2x + 1 = 0$$, I can factor it...",
     },
     metadata: {
+      id: "rs_06e2b572b276da09016901d7350ae08198ba76145524efe4b2",
       clientId: "openai_responses",
       modelId: "gpt-5",
     },

--- a/front/lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts
@@ -39,6 +39,11 @@ describe("streamLLMEvents", () => {
       result.push(event);
     }
 
-    expect(result).toEqual(reasoningLLMEvents.map((e) => ({ ...e, metadata })));
+    expect(result).toEqual(
+      reasoningLLMEvents.map((e) => ({
+        ...e,
+        metadata: { ...e.metadata, ...metadata },
+      }))
+    );
   });
 });


### PR DESCRIPTION
## Description

Adds all the openai models
This requires supporting the "id" for reasoning

I'm using "id" like the rust did here:

https://github.com/dust-tt/dust/blob/0627b2c892599c8a1d9c9b2fa6ba355025ef3e01/core/src/providers/openai_responses_api_helpers.rs#L148-L149

Rust  also has a "encrypted_content" field but I'm not sure what it corresponds to in the API :/

## Tests

```
VITE_RUN_LLM_TESTS=true NODE_ENV=test VITE_DUST_MANAGED_OPENAI_API_KEY=$DUST_MANAGED_OPENAI_API_KEY npm run test -- __test__/openai.test.ts
```


```
 Test Files  1 passed (1)
      Tests  204 passed (204)
   Start at  11:25:48
   Duration  299.79s (transform 528ms, setup 414ms, collect 1.32s, tests 295.84s, environment 132ms, prepare 27ms)
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
