### PR TITLE
Rework multi-invitations workflows

### DIFF
--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -86,7 +86,7 @@ export function RunPluginDialog({
 
   // Scroll to feedback section when error or result appears
   useEffect(() => {
-    if ((error || result) && feedbackRef.current) {
+    if ((error ?? result) && feedbackRef.current) {
       feedbackRef.current.scrollIntoView({
         behavior: "smooth",
         block: "nearest",

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -87,7 +87,10 @@ export function RunPluginDialog({
   // Scroll to feedback section when error or result appears
   useEffect(() => {
     if ((error || result) && feedbackRef.current) {
-      feedbackRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      feedbackRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
     }
   }, [error, result]);
 
@@ -98,102 +101,102 @@ export function RunPluginDialog({
           "w-auto",
           "bg-muted-background dark:bg-muted-background-night",
           "sm:min-w-[600px] sm:max-w-[1000px]",
-          "max-h-[90vh] flex flex-col overflow-hidden"
+          "flex max-h-[90vh] flex-col overflow-hidden"
         )}
       >
         <DialogHeader className="flex-shrink-0">
           <DialogTitle>Run {plugin.name} plugin</DialogTitle>
           <DialogDescription>{plugin.description}</DialogDescription>
         </DialogHeader>
-        <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="min-h-0 flex-1 overflow-y-auto">
           <DialogContainer>
-          {isLoading || (hasAsyncArgs && isLoadingAsyncArgs) ? (
-            <Spinner />
-          ) : !manifest ? (
-            <PokeAlert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <PokeAlertTitle>Error</PokeAlertTitle>
-              <PokeAlertDescription>
-                Plugin could not be loaded.
-              </PokeAlertDescription>
-            </PokeAlert>
-          ) : (
-            <>
-              {manifest.warning && (
-                <PokeAlert variant="destructive">
-                  <PokeAlertTitle>Warning</PokeAlertTitle>
-                  <PokeAlertDescription>
-                    {manifest.warning}
-                  </PokeAlertDescription>
-                </PokeAlert>
-              )}
-              {isLoadingAsyncArgs ? (
-                <Spinner />
-              ) : (
-                <PluginForm
-                  disabled={result !== null}
-                  manifest={manifest}
-                  asyncArgs={asyncArgs}
-                  onSubmit={onSubmit}
-                />
-              )}
-              {/* Feedback section - appears right after the form/Run button */}
-              <div ref={feedbackRef}>
-                {error && (
+            {isLoading || (hasAsyncArgs && isLoadingAsyncArgs) ? (
+              <Spinner />
+            ) : !manifest ? (
+              <PokeAlert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <PokeAlertTitle>Error</PokeAlertTitle>
+                <PokeAlertDescription>
+                  Plugin could not be loaded.
+                </PokeAlertDescription>
+              </PokeAlert>
+            ) : (
+              <>
+                {manifest.warning && (
                   <PokeAlert variant="destructive">
-                    <PokeAlertTitle>Error</PokeAlertTitle>
-                    <PokeAlertDescription>{error}</PokeAlertDescription>
-                  </PokeAlert>
-                )}
-                {result && result.display === "text" && (
-                  <PokeAlert variant="success">
-                    <PokeAlertTitle>Success</PokeAlertTitle>
+                    <PokeAlertTitle>Warning</PokeAlertTitle>
                     <PokeAlertDescription>
-                      {result.value} - Make sure to reload.
+                      {manifest.warning}
                     </PokeAlertDescription>
                   </PokeAlert>
                 )}
-                {result && result.display === "textWithLink" && (
-                  <PokeAlert variant="success">
-                    <PokeAlertTitle>Success</PokeAlertTitle>
-                    <PokeAlertDescription>
-                      <p>{result.value} - Make sure to reload.</p>
-                      <Button
-                        onClick={() => {
-                          window.open(result.link, "_blank");
-                        }}
-                        label={result.linkText}
-                        variant="highlight"
-                        className="mt-2"
-                      />
-                    </PokeAlertDescription>
-                  </PokeAlert>
+                {isLoadingAsyncArgs ? (
+                  <Spinner />
+                ) : (
+                  <PluginForm
+                    disabled={result !== null}
+                    manifest={manifest}
+                    asyncArgs={asyncArgs}
+                    onSubmit={onSubmit}
+                  />
                 )}
-                {result && result.display === "json" && (
-                  <div className="mb-4 mt-4">
-                    <div className="mb-2 font-medium">Result:</div>
-                    <div className="max-h-[400px] overflow-auto rounded-lg bg-gray-800 p-4">
-                      <pre className="copy-sm whitespace-pre-wrap break-words font-mono text-gray-200">
-                        {JSON.stringify(result.value, null, 2)}
-                      </pre>
+                {/* Feedback section - appears right after the form/Run button */}
+                <div ref={feedbackRef}>
+                  {error && (
+                    <PokeAlert variant="destructive">
+                      <PokeAlertTitle>Error</PokeAlertTitle>
+                      <PokeAlertDescription>{error}</PokeAlertDescription>
+                    </PokeAlert>
+                  )}
+                  {result && result.display === "text" && (
+                    <PokeAlert variant="success">
+                      <PokeAlertTitle>Success</PokeAlertTitle>
+                      <PokeAlertDescription>
+                        {result.value} - Make sure to reload.
+                      </PokeAlertDescription>
+                    </PokeAlert>
+                  )}
+                  {result && result.display === "textWithLink" && (
+                    <PokeAlert variant="success">
+                      <PokeAlertTitle>Success</PokeAlertTitle>
+                      <PokeAlertDescription>
+                        <p>{result.value} - Make sure to reload.</p>
+                        <Button
+                          onClick={() => {
+                            window.open(result.link, "_blank");
+                          }}
+                          label={result.linkText}
+                          variant="highlight"
+                          className="mt-2"
+                        />
+                      </PokeAlertDescription>
+                    </PokeAlert>
+                  )}
+                  {result && result.display === "json" && (
+                    <div className="mb-4 mt-4">
+                      <div className="mb-2 font-medium">Result:</div>
+                      <div className="max-h-[400px] overflow-auto rounded-lg bg-gray-800 p-4">
+                        <pre className="copy-sm whitespace-pre-wrap break-words font-mono text-gray-200">
+                          {JSON.stringify(result.value, null, 2)}
+                        </pre>
+                      </div>
                     </div>
-                  </div>
-                )}
-                {result && result.display === "markdown" && (
-                  <div className="mb-4 mt-4">
-                    <div className="mb-2 font-medium">Result:</div>
-                    <div className="max-h-[400px] overflow-auto rounded-lg bg-gray-800 p-4">
-                      <Markdown
-                        content={result.value}
-                        textColor="text-slate-500 dark:text-foreground-night"
-                      />
+                  )}
+                  {result && result.display === "markdown" && (
+                    <div className="mb-4 mt-4">
+                      <div className="mb-2 font-medium">Result:</div>
+                      <div className="max-h-[400px] overflow-auto rounded-lg bg-gray-800 p-4">
+                        <Markdown
+                          content={result.value}
+                          textColor="text-slate-500 dark:text-foreground-night"
+                        />
+                      </div>
                     </div>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-        </DialogContainer>
+                  )}
+                </div>
+              </>
+            )}
+          </DialogContainer>
         </div>
       </DialogContent>
     </Dialog>

--- a/front/lib/api/invitation_context.ts
+++ b/front/lib/api/invitation_context.ts
@@ -55,7 +55,6 @@ export async function analyzeInvitationContext(
         invitationCount: pendingInvitations.length,
         workspaces: pendingInvitations.map((i) => ({
           id: i.workspace.sId,
-          name: i.workspace.name,
         })),
       },
       "[analyzeInvitationContext] User has multiple pending invitations - creating new workspace"

--- a/front/lib/api/invitation_context.ts
+++ b/front/lib/api/invitation_context.ts
@@ -1,0 +1,67 @@
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+
+export interface InvitationContext {
+  hasExplicitToken: boolean;
+  hasWorkspaceContext: boolean;
+  pendingInvitations: MembershipInvitationResource[];
+  shouldAutoRedirect: boolean;
+  warningMessage?: string;
+}
+
+export async function analyzeInvitationContext(
+  user: UserResource,
+  {
+    inviteToken,
+    targetWorkspaceId,
+  }: {
+    inviteToken?: string;
+    targetWorkspaceId?: string;
+  }
+): Promise<InvitationContext> {
+  const pendingInvitations =
+    await MembershipInvitationResource.getAllPendingForEmail(user.email);
+
+  const context: InvitationContext = {
+    hasExplicitToken: !!inviteToken,
+    hasWorkspaceContext: !!targetWorkspaceId,
+    pendingInvitations,
+    shouldAutoRedirect: false,
+  };
+
+  // Never auto-redirect if user has explicit context (token or workspace ID)
+  if (context.hasExplicitToken || context.hasWorkspaceContext) {
+    return context;
+  }
+
+  // One invitation - auto-redirect
+  if (pendingInvitations.length === 1) {
+    context.shouldAutoRedirect = true;
+    logger.info(
+      {
+        userId: user.id,
+        workspaceId: pendingInvitations[0].workspace.sId,
+        email: user.email,
+      },
+      "[analyzeInvitationContext] Auto-redirecting user to single pending invitation"
+    );
+  } else if (pendingInvitations.length > 1) {
+    // Multiple invitations - don't auto-redirect
+    context.warningMessage = `User has ${pendingInvitations.length} pending invitations - not auto-redirecting`;
+    logger.warn(
+      {
+        userId: user.id,
+        email: user.email,
+        invitationCount: pendingInvitations.length,
+        workspaces: pendingInvitations.map((i) => ({
+          id: i.workspace.sId,
+          name: i.workspace.name,
+        })),
+      },
+      "[analyzeInvitationContext] User has multiple pending invitations - creating new workspace"
+    );
+  }
+
+  return context;
+}

--- a/front/lib/api/invitation_context.ts
+++ b/front/lib/api/invitation_context.ts
@@ -52,7 +52,6 @@ export async function analyzeInvitationContext(
     logger.warn(
       {
         userId: user.id,
-        email: user.email,
         invitationCount: pendingInvitations.length,
         workspaces: pendingInvitations.map((i) => ({
           id: i.workspace.sId,

--- a/front/lib/api/poke/plugins/global/create_workspace.ts
+++ b/front/lib/api/poke/plugins/global/create_workspace.ts
@@ -3,7 +3,6 @@ import { createPlugin } from "@app/lib/api/poke/types";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
-import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { Plan } from "@app/lib/models/plan";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { getRegionDisplay } from "@app/lib/poke/regions";
@@ -103,16 +102,8 @@ export const createWorkspacePlugin = createPlugin({
     if (allPendingInvitations.length > 0) {
       if (args.revokeExistingInvitations) {
         const invitationIds = allPendingInvitations.map((inv) => inv.id);
-        const [updatedCount] = await MembershipInvitationModel.update(
-          { status: "revoked" },
-          {
-            where: {
-              id: invitationIds,
-              status: "pending",
-            },
-          }
-        );
-        revokedCount = updatedCount;
+        revokedCount =
+          await MembershipInvitationResource.revokeByIds(invitationIds);
         infoMessages.push(
           `✅ Revoked ${revokedCount} existing invitation${revokedCount > 1 ? "s" : ""} for ${email}`
         );

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -47,6 +47,8 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
         status: "pending",
       },
       include: [WorkspaceModel],
+      // Order by createdAt to ensure consistent behavior - oldest invitation first
+      order: [["createdAt", "ASC"]],
       // WORKSPACE_ISOLATION_BYPASS: We don't know the workspace yet, the user is not authed
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
@@ -76,6 +78,28 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
           workspace: invitation.workspace,
         })
       : null;
+  }
+
+  static async getAllPendingForEmail(
+    email: string
+  ): Promise<MembershipInvitationResource[]> {
+    const invitations = await this.model.findAll({
+      where: {
+        inviteEmail: email,
+        status: "pending",
+      },
+      include: [WorkspaceModel],
+      order: [["createdAt", "ASC"]],
+      // WORKSPACE_ISOLATION_BYPASS: We don't know the workspace yet, the user is not authed
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    return invitations.map(
+      (invitation) =>
+        new MembershipInvitationResource(this.model, invitation.get(), {
+          workspace: invitation.workspace,
+        })
+    );
   }
 
   static async getPendingForToken(

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -167,6 +167,21 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     });
   }
 
+  static async revokeByIds(invitationIds: number[]): Promise<number> {
+    const [updatedCount] = await this.model.update(
+      { status: "revoked" },
+      {
+        where: {
+          id: invitationIds,
+          status: "pending",
+        },
+        // WORKSPACE_ISOLATION_BYPASS: We're revoking invitations across workspaces
+        dangerouslyBypassWorkspaceIsolationSecurity: true,
+      }
+    );
+    return updatedCount;
+  }
+
   delete(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     auth: Authenticator,

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -73,6 +73,21 @@ interface WorkspaceTenantIsolationSecurityBypassOptions<T>
   dangerouslyBypassWorkspaceIsolationSecurity?: boolean;
 }
 
+interface WorkspaceTenantIsolationSecurityBypassUpdateOptions<T>
+  extends UpdateOptions<T> {
+  /**
+   * When true, BYPASSES CRITICAL TENANT ISOLATION SECURITY for this update.
+   *
+   * SECURITY REQUIREMENT: You MUST include a comment explaining why this security bypass
+   * is necessary using the format:
+   * // WORKSPACE_ISOLATION_BYPASS: [explanation]
+   *
+   * This should only be used in critical scenarios where an update legitimately needs
+   * to operate across workspaces or without workspace context.
+   */
+  dangerouslyBypassWorkspaceIsolationSecurity?: boolean;
+}
+
 function isWorkspaceIsolationBypassEnabled<T>(
   options: FindOptions<T>
 ): options is WorkspaceTenantIsolationSecurityBypassOptions<T> {
@@ -193,6 +208,12 @@ export type ModelStaticWorkspaceAware<M extends WorkspaceAwareModel> =
       identifier: any,
       options: WorkspaceTenantIsolationSecurityBypassOptions<Attributes<M>>
     ): Promise<M | null>;
+    update(
+      values: Partial<Attributes<M>>,
+      options: WorkspaceTenantIsolationSecurityBypassUpdateOptions<
+        Attributes<M>
+      >
+    ): Promise<[affectedCount: number]>;
   };
 export type ModelStaticSoftDeletable<
   M extends SoftDeletableWorkspaceAwareModel,


### PR DESCRIPTION
Fixes invitation confusion when users have multiple pending workspace invitations. Previously, the system would unpredictably auto-redirect users to any pending invitation, causing newly created workspaces to become orphaned.

## Key Changes

1.  **Smarter invitation auto-redirect logic**: Only auto-redirects when users have exactly ONE pending invitation and no explicit context
    
2.  **Poke workspace creation safeguard**: Blocks creation when pending invitations exist, with option to revoke them first
    
3.  **Better UX**: Improved plugin modal scrolling and moved error messages next to the Run button
    

## Behavior Changes

**Before:**

*   User clicks invitation link for Workspace A → might join Workspace B (unpredictable)
    
*   Poke creates workspace blindly → orphaned workspaces when user joins different workspace
    
*   User signs up with 2+ invitations → auto-redirected to oldest one (arbitrary choice)
    

**After:**

*   User clicks invitation link for Workspace A → ALWAYS joins Workspace A (token respected)
    
*   Poke blocks workspace creation if invitations exist → admin can revoke or cancel
    
*   User signs up with 2+ invitations → creates new workspace (no auto-selection)
    
*   User signs up with 1 invitation → auto-redirected to it (convenient UX preserved)
    

## Risk

Changes login flow for newly created users with multiple pending invitations - they will no longer be auto-redirected. This is the intended behavior to prevent confusion.
    

## Deploy Plan
No migrations required. Changes are backward compatible.