### PR TITLE
[front] - fix(obs): charts x-axis

### DIFF
--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -20,6 +20,7 @@ import { useObservability } from "@app/components/agent_builder/observability/Ob
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
 import { useAgentErrorRate } from "@app/lib/swr/assistants";
 
 const WARNING_THRESHOLD = 5;
@@ -80,9 +81,9 @@ export function ErrorRateChart({
   workspaceId,
   agentConfigurationId,
 }: ErrorRateChartProps) {
-  const { period } = useObservability();
+  const { period, mode } = useObservability();
   const {
-    errorRate: data,
+    errorRate: rawData,
     isErrorRateLoading,
     isErrorRateError,
   } = useAgentErrorRate({
@@ -91,6 +92,13 @@ export function ErrorRateChart({
     days: period,
     disabled: !workspaceId || !agentConfigurationId,
   });
+
+  const data = padSeriesToTimeRange(rawData, mode, period, (date) => ({
+    date,
+    total: 0,
+    failed: 0,
+    errorRate: 0,
+  }));
 
   const legendItems = ERROR_RATE_LEGEND.map(({ key, label }) => ({
     key,

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import {
   CartesianGrid,
   Line,
@@ -18,7 +17,10 @@ import {
 import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
-import { filterTimeSeriesByVersionWindow } from "@app/components/agent_builder/observability/utils";
+import {
+  filterTimeSeriesByVersionWindow,
+  padSeriesToTimeRange,
+} from "@app/components/agent_builder/observability/utils";
 import {
   useAgentFeedbackDistribution,
   useAgentVersionMarkers,
@@ -57,16 +59,18 @@ export function FeedbackDistributionChart({
     colorClassName: FEEDBACK_DISTRIBUTION_PALETTE[key],
   }));
 
-  const data = useMemo(
-    () =>
-      filterTimeSeriesByVersionWindow(
-        feedbackDistribution,
-        mode,
-        selectedVersion,
-        versionMarkers
-      ),
-    [feedbackDistribution, mode, selectedVersion, versionMarkers]
+  const filteredData = filterTimeSeriesByVersionWindow(
+    feedbackDistribution,
+    mode,
+    selectedVersion,
+    versionMarkers
   );
+
+  const data = padSeriesToTimeRange(filteredData, mode, period, (date) => ({
+    date,
+    positive: 0,
+    negative: 0,
+  }));
 
   return (
     <ChartContainer

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -18,6 +18,7 @@ import { useObservability } from "@app/components/agent_builder/observability/Ob
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
 import { useAgentLatency } from "@app/lib/swr/assistants";
 
 interface LatencyData {
@@ -63,9 +64,9 @@ export function LatencyChart({
   workspaceId: string;
   agentConfigurationId: string;
 }) {
-  const { period } = useObservability();
+  const { period, mode } = useObservability();
   const {
-    latency: data,
+    latency: rawData,
     isLatencyLoading,
     isLatencyError,
   } = useAgentLatency({
@@ -74,6 +75,12 @@ export function LatencyChart({
     days: period,
     disabled: !workspaceId || !agentConfigurationId,
   });
+
+  const data = padSeriesToTimeRange(rawData, mode, period, (date) => ({
+    date,
+    messages: 0,
+    average: 0,
+  }));
 
   const legendItems = LATENCY_LEGEND.map(({ key, label }) => ({
     key,

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import {
   Area,
   AreaChart,
@@ -23,6 +22,7 @@ import { ChartTooltipCard } from "@app/components/agent_builder/observability/sh
 import {
   filterTimeSeriesByVersionWindow,
   findVersionMarkerForDate,
+  padSeriesToTimeRange,
 } from "@app/components/agent_builder/observability/utils";
 import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 import {
@@ -121,15 +121,18 @@ export function UsageMetricsChart({
     colorClassName: USAGE_METRICS_PALETTE[key],
   }));
 
-  const data = useMemo(
-    () =>
-      filterTimeSeriesByVersionWindow(
-        usageMetrics,
-        mode,
-        selectedVersion,
-        versionMarkers
-      ),
-    [usageMetrics, mode, selectedVersion, versionMarkers]
+  const filteredData = filterTimeSeriesByVersionWindow(
+    usageMetrics,
+    mode,
+    selectedVersion,
+    versionMarkers
+  );
+
+  const data = padSeriesToTimeRange<UsageMetricsData>(
+    filteredData,
+    mode,
+    period,
+    (date) => ({ date, messages: 0, conversations: 0, activeUsers: 0 })
   );
 
   return (


### PR DESCRIPTION
## Description

This PR fixes chart x-axis rendering by ensuring time series data spans the full selected time range. Previously, when data was sparse or missing for certain dates, the x-axis would only cover dates with actual data points, making the charts appear inconsistent and harder to read. This PR adds padding functionality that fills in missing dates with zero-value data points, ensuring the x-axis always displays the complete time range.

## Risk

Low

## Tests

Locally

## Deploy Plan

Deploy front