### PR TITLE
[llm-router] config + tests for anthropic models

### DIFF
--- a/front/lib/api/llm/clients/anthropic/__test__/anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/__test__/anthropic.test.ts
@@ -69,7 +69,7 @@ vi.mock("@app/types", async (importOriginal) => {
  *
  * Run it with:
  * ```
- * VITE_RUN_LLM_TESTS=true NODE_ENV=test VITE_DUST_MANAGED_OPENAI_API_KEY=$DUST_MANAGED_OPENAI_API_KEY npm run test -- __test__/openai.test.ts
+ * VITE_RUN_LLM_TESTS=true NODE_ENV=test VITE_DUST_MANAGED_ANTHROPIC_API_KEY=$DUST_MANAGED_ANTHROPIC_API_KEY npm run test -- __test__/anthropic.test.ts
  * ```
  */
 class AnthropicTestSuite extends LLMClientTestSuite {

--- a/front/lib/api/llm/clients/anthropic/__test__/anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/__test__/anthropic.test.ts
@@ -1,0 +1,97 @@
+import { vi } from "vitest";
+
+import type { AnthropicModelFamily } from "@app/lib/api/llm/clients/anthropic/types";
+import {
+  ANTHROPIC_WHITELISTED_MODEL_IDS,
+  getAnthropicModelFamilyFromModelId,
+} from "@app/lib/api/llm/clients/anthropic/types";
+import { TEST_CONVERSATIONS } from "@app/lib/api/llm/tests/conversations";
+import { LLMClientTestSuite } from "@app/lib/api/llm/tests/LLMClientTestSuite";
+import type {
+  ConfigParams,
+  TestConfig,
+  TestConversation,
+} from "@app/lib/api/llm/tests/types";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+
+const ANTHROPIC_MODEL_FAMILY_TO_TEST_CONFIGS: Record<
+  AnthropicModelFamily,
+  ConfigParams[]
+> = {
+  reasoning: [
+    { reasoningEffort: "none" },
+    { reasoningEffort: "light" },
+    { reasoningEffort: "medium" },
+    { reasoningEffort: "high" },
+  ],
+  "non-reasoning": [{ temperature: 1 }, { temperature: 0.25 }],
+};
+
+// Mock the @anthropic-ai/sdk module to inject dangerouslyAllowBrowser: true
+vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalAnthropic = actual.default;
+
+  class AnthropicWithBrowserSupport extends OriginalAnthropic {
+    constructor(config: ConstructorParameters<typeof OriginalAnthropic>[0]) {
+      super({
+        ...config,
+        dangerouslyAllowBrowser: true,
+      });
+    }
+  }
+
+  return {
+    // @ts-expect-error actual is unknown
+    ...actual,
+    default: AnthropicWithBrowserSupport,
+  };
+});
+
+// Inject Dust managed Anthropic credentials for testing
+vi.mock("@app/types", async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return {
+    // @ts-expect-error actual is unknown
+    ...actual,
+    dustManagedCredentials: vi.fn(() => ({
+      ANTHROPIC_API_KEY: process.env.VITE_DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
+    })),
+  };
+});
+
+/**
+ * Anthropic LLM Client Test Suite.
+ *
+ * This is run conditionnally if the VITE_RUN_LLM_TESTS environment variable is set to "true".
+ *
+ * Run it with:
+ * ```
+ * VITE_RUN_LLM_TESTS=true NODE_ENV=test VITE_DUST_MANAGED_OPENAI_API_KEY=$DUST_MANAGED_OPENAI_API_KEY npm run test -- __test__/openai.test.ts
+ * ```
+ */
+class AnthropicTestSuite extends LLMClientTestSuite {
+  protected provider = "anthropic" as const;
+  protected models = ANTHROPIC_WHITELISTED_MODEL_IDS;
+
+  protected getTestConfig(modelId: ModelIdType): TestConfig[] {
+    const family = getAnthropicModelFamilyFromModelId(modelId);
+    return ANTHROPIC_MODEL_FAMILY_TO_TEST_CONFIGS[family].map(
+      (configParams) => ({
+        ...configParams,
+        modelId,
+        provider: this.provider,
+      })
+    );
+  }
+
+  protected getSupportedConversations(
+    _modelId: ModelIdType
+  ): TestConversation[] {
+    return TEST_CONVERSATIONS;
+  }
+}
+
+new AnthropicTestSuite().generateTests();

--- a/front/lib/api/llm/clients/anthropic/types.ts
+++ b/front/lib/api/llm/clients/anthropic/types.ts
@@ -1,3 +1,6 @@
+import flatMap from "lodash/flatMap";
+
+import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import type { ModelIdType } from "@app/types";
 import {
   CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG,
@@ -8,22 +11,44 @@ import {
   CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG,
 } from "@app/types";
 
-export const ANTHROPIC_WHITELISTED_NON_REASONING_MODEL_IDS: ModelIdType[] = [
-  CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.modelId,
-  CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
-];
+export const ANTHROPIC_MODEL_FAMILIES = ["non-reasoning", "reasoning"] as const;
+export type AnthropicModelFamily = (typeof ANTHROPIC_MODEL_FAMILIES)[number];
 
-export const ANTHROPIC_WHITELISTED_REASONING_MODEL_IDS: ModelIdType[] = [
-  CLAUDE_4_OPUS_DEFAULT_MODEL_CONFIG.modelId,
-  CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG.modelId,
-  CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG.modelId,
-  CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
-];
+export const ANTHROPIC_MODEL_FAMILIES_CONFIGS: Record<
+  AnthropicModelFamily,
+  {
+    modelIds: ModelIdType[];
+    overwrites: Partial<LLMParameters>;
+  }
+> = {
+  "non-reasoning": {
+    modelIds: [
+      CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG.modelId,
+      CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
+    ],
+    overwrites: { reasoningEffort: null },
+  },
+  reasoning: {
+    modelIds: [
+      CLAUDE_4_OPUS_DEFAULT_MODEL_CONFIG.modelId,
+      CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG.modelId,
+      CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG.modelId,
+      CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
+    ],
+    // Thinking isn’t compatible with temperature: `temperature` may only be set to 1 when thinking is enabled.
+    overwrites: { temperature: 1 },
+  },
+};
 
-export const ANTHROPIC_WHITELISTED_MODEL_IDS: ModelIdType[] = [
-  ...ANTHROPIC_WHITELISTED_NON_REASONING_MODEL_IDS,
-  ...ANTHROPIC_WHITELISTED_REASONING_MODEL_IDS,
-];
+export type AnthropicWhitelistedModelId = {
+  [K in AnthropicModelFamily]: (typeof ANTHROPIC_MODEL_FAMILIES_CONFIGS)[K]["modelIds"][number];
+}[AnthropicModelFamily];
+export const ANTHROPIC_WHITELISTED_MODEL_IDS =
+  flatMap<AnthropicWhitelistedModelId>(
+    Object.values(ANTHROPIC_MODEL_FAMILIES_CONFIGS).map(
+      (config) => config.modelIds
+    )
+  );
 
 export function isAnthropicWhitelistedModelId(
   modelId: ModelIdType
@@ -31,5 +56,34 @@ export function isAnthropicWhitelistedModelId(
   return new Set<string>(ANTHROPIC_WHITELISTED_MODEL_IDS).has(modelId);
 }
 
-export type AnthropicWhitelistedModelId =
-  (typeof ANTHROPIC_WHITELISTED_MODEL_IDS)[number];
+export function getAnthropicModelFamilyFromModelId(
+  modelId: AnthropicWhitelistedModelId
+): AnthropicModelFamily {
+  const family = ANTHROPIC_MODEL_FAMILIES.find((family) =>
+    ANTHROPIC_MODEL_FAMILIES_CONFIGS[family].modelIds.includes(modelId)
+  );
+  if (!family) {
+    throw new Error(
+      `Model ID ${modelId} does not belong to any Anthropic model family`
+    );
+  }
+  return family;
+}
+
+export function overwriteLLMParameters(
+  llMParameters: LLMParameters & {
+    modelId: AnthropicWhitelistedModelId;
+  }
+): LLMParameters & { modelId: AnthropicWhitelistedModelId } & {
+  clientId: "anthropic";
+} {
+  const config = Object.values(ANTHROPIC_MODEL_FAMILIES_CONFIGS).find(
+    (config) => new Set<string>(config.modelIds).has(llMParameters.modelId)
+  );
+
+  return {
+    ...llMParameters,
+    ...config?.overwrites,
+    clientId: "anthropic" as const,
+  };
+}

--- a/front/lib/api/llm/clients/anthropic/types.ts
+++ b/front/lib/api/llm/clients/anthropic/types.ts
@@ -71,18 +71,18 @@ export function getAnthropicModelFamilyFromModelId(
 }
 
 export function overwriteLLMParameters(
-  llMParameters: LLMParameters & {
+  llmParameters: LLMParameters & {
     modelId: AnthropicWhitelistedModelId;
   }
 ): LLMParameters & { modelId: AnthropicWhitelistedModelId } & {
   clientId: "anthropic";
 } {
   const config = Object.values(ANTHROPIC_MODEL_FAMILIES_CONFIGS).find(
-    (config) => new Set<string>(config.modelIds).has(llMParameters.modelId)
+    (config) => new Set<string>(config.modelIds).has(llmParameters.modelId)
   );
 
   return {
-    ...llMParameters,
+    ...llmParameters,
     ...config?.overwrites,
     clientId: "anthropic" as const,
   };

--- a/front/lib/api/llm/clients/openai/__test__/openai.test.ts
+++ b/front/lib/api/llm/clients/openai/__test__/openai.test.ts
@@ -69,6 +69,16 @@ vi.mock("@app/types", async (importOriginal) => {
   };
 });
 
+/**
+ * Open AI LLM Client Test Suite.
+ *
+ * This is run conditionnally if the VITE_RUN_LLM_TESTS environment variable is set to "true".
+ *
+ * Run it with:
+ * ```
+ * VITE_RUN_LLM_TESTS=true NODE_ENV=test VITE_DUST_MANAGED_OPENAI_API_KEY=$DUST_MANAGED_OPENAI_API_KEY npm run test -- __test__/openai.test.ts
+ * ```
+ */
 class OpenAiTestSuite extends LLMClientTestSuite {
   protected provider = "openai" as const;
   protected models = OPENAI_WHITELISTED_MODEL_IDS;

--- a/front/scripts/relocation/relocate_workspace.ts
+++ b/front/scripts/relocation/relocate_workspace.ts
@@ -6,9 +6,9 @@ import {
 import { pauseAllLabsWorkflows } from "@app/lib/api/labs";
 import type { RegionType } from "@app/lib/api/regions/config";
 import {
-  SUPPORTED_REGIONS,
   config,
   isRegionType,
+  SUPPORTED_REGIONS,
 } from "@app/lib/api/regions/config";
 import {
   deleteWorkspace,

--- a/front/scripts/test_llm_clients.ts
+++ b/front/scripts/test_llm_clients.ts
@@ -3,10 +3,6 @@ import { assertNever } from "@dust-tt/sparkle";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { getLLM } from "@app/lib/api/llm";
 import {
-  ANTHROPIC_WHITELISTED_NON_REASONING_MODEL_IDS,
-  ANTHROPIC_WHITELISTED_REASONING_MODEL_IDS,
-} from "@app/lib/api/llm/clients/anthropic/types";
-import {
   GOOGLE_AI_STUDIO_WHITELISTED_NON_REASONING_MODEL_IDS,
   GOOGLE_AI_STUDIO_WHITELISTED_REASONING_MODEL_IDS,
 } from "@app/lib/api/llm/clients/google/types";
@@ -133,14 +129,6 @@ function generateNotThinkingTestConfigs(
 }
 
 const TEST_CONFIGS: TestConfig[] = [
-  // Anthropic
-  ...ANTHROPIC_WHITELISTED_REASONING_MODEL_IDS.flatMap((modelId) =>
-    generateThinkingTestConfigs("anthropic", modelId)
-  ),
-  ...ANTHROPIC_WHITELISTED_NON_REASONING_MODEL_IDS.flatMap((modelId) =>
-    generateNotThinkingTestConfigs("anthropic", modelId)
-  ),
-
   // Google AI Studio
   ...GOOGLE_AI_STUDIO_WHITELISTED_NON_REASONING_MODEL_IDS.flatMap((modelId) =>
     generateNotThinkingTestConfigs("google_ai_studio", modelId)


### PR DESCRIPTION
## Description

Migrate Anthropic to the new test suite

## Tests

```
 ✓ lib/api/llm/clients/anthropic/__test__/anthropic.test.ts (100 tests) 169584ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=1, reasoningEffort=undefined > should handle: Simple Math 1283ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=1, reasoningEffort=undefined > should handle: Yes/No Question 1150ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=1, reasoningEffort=undefined > should handle: 2 steps conversation 2888ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=1, reasoningEffort=undefined > should handle: Tool usage required 8596ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=1, reasoningEffort=undefined > should handle: Image description 5787ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=0.25, reasoningEffort=undefined > should handle: Simple Math 1194ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=0.25, reasoningEffort=undefined > should handle: Yes/No Question 1326ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=0.25, reasoningEffort=undefined > should handle: 2 steps conversation 2792ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=0.25, reasoningEffort=undefined > should handle: Tool usage required 7278ms
   ✓ anthropic LLM provider tests > Model: claude-3-opus-20240229 > Config: temperature=0.25, reasoningEffort=undefined > should handle: Image description 5055ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=1, reasoningEffort=undefined > should handle: Simple Math 830ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=1, reasoningEffort=undefined > should handle: Yes/No Question 582ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=1, reasoningEffort=undefined > should handle: 2 steps conversation 1863ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=1, reasoningEffort=undefined > should handle: Tool usage required 2552ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=1, reasoningEffort=undefined > should handle: Image description 3994ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=0.25, reasoningEffort=undefined > should handle: Simple Math 712ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=0.25, reasoningEffort=undefined > should handle: Yes/No Question 887ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=0.25, reasoningEffort=undefined > should handle: 2 steps conversation 2171ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=0.25, reasoningEffort=undefined > should handle: Tool usage required 2523ms
   ✓ anthropic LLM provider tests > Model: claude-3-5-haiku-20241022 > Config: temperature=0.25, reasoningEffort=undefined > should handle: Image description 4044ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: Simple Math 1417ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: Yes/No Question 1293ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: 2 steps conversation 3962ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: Tool usage required 4527ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: Image description 8533ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: Simple Math 2773ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: Yes/No Question 2617ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: 2 steps conversation 5354ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: Tool usage required 6973ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: Image description 8791ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: Simple Math 2880ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: Yes/No Question 2971ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: 2 steps conversation 6109ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: Tool usage required 5626ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: Image description 11555ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: Simple Math 3466ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: Yes/No Question 3759ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: 2 steps conversation 5153ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: Tool usage required 5229ms
   ✓ anthropic LLM provider tests > Model: claude-4-opus-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: Image description 13368ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: Simple Math 2438ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: Yes/No Question 2246ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: 2 steps conversation 5153ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: Tool usage required 4423ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=none > should handle: Image description 7777ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: Simple Math 2815ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: Yes/No Question 3287ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: 2 steps conversation 6532ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: Tool usage required 5949ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=light > should handle: Image description 11973ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: Simple Math 3625ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: Yes/No Question 3327ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: 2 steps conversation 5093ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: Tool usage required 7123ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=medium > should handle: Image description 9708ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: Simple Math 2878ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: Yes/No Question 3747ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: 2 steps conversation 5756ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: Tool usage required 6246ms
   ✓ anthropic LLM provider tests > Model: claude-4-sonnet-20250514 > Config: temperature=undefined, reasoningEffort=high > should handle: Image description 11120ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=none > should handle: Simple Math 2256ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=none > should handle: Yes/No Question 2054ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=none > should handle: 2 steps conversation 5260ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=none > should handle: Tool usage required 5113ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=none > should handle: Image description 7082ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=light > should handle: Simple Math 3022ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=light > should handle: Yes/No Question 3004ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=light > should handle: 2 steps conversation 6204ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=light > should handle: Tool usage required 5730ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=light > should handle: Image description 9217ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=medium > should handle: Simple Math 3277ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=medium > should handle: Yes/No Question 3448ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=medium > should handle: 2 steps conversation 6327ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=medium > should handle: Tool usage required 5916ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=medium > should handle: Image description 9740ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=high > should handle: Simple Math 2909ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=high > should handle: Yes/No Question 3171ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=high > should handle: 2 steps conversation 6133ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=high > should handle: Tool usage required 6359ms
   ✓ anthropic LLM provider tests > Model: claude-sonnet-4-5-20250929 > Config: temperature=undefined, reasoningEffort=high > should handle: Image description 11041ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=none > should handle: Simple Math 1163ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=none > should handle: Yes/No Question 1596ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=none > should handle: 2 steps conversation 2299ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=none > should handle: Tool usage required 2794ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=none > should handle: Image description 3362ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=light > should handle: Simple Math 1451ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=light > should handle: Yes/No Question 1385ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=light > should handle: 2 steps conversation 3580ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=light > should handle: Tool usage required 4459ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=light > should handle: Image description 5896ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=medium > should handle: Simple Math 1478ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=medium > should handle: Yes/No Question 1293ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=medium > should handle: 2 steps conversation 2969ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=medium > should handle: Tool usage required 5414ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=medium > should handle: Image description 5250ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=high > should handle: Simple Math 1122ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=high > should handle: Yes/No Question 1164ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=high > should handle: 2 steps conversation 2952ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=high > should handle: Tool usage required 11071ms
   ✓ anthropic LLM provider tests > Model: claude-haiku-4-5-20251001 > Config: temperature=undefined, reasoningEffort=high > should handle: Image description 5224ms

 Test Files  1 passed (1)
      Tests  100 passed (100)
   Start at  11:56:37
   Duration  174.44s (transform 539ms, setup 512ms, collect 1.41s, tests 169.58s, environment 314ms, prepare 33ms)
```

## Risk

no, still befind feaature flag

## Deploy Plan

deploy front
