### PR TITLE
feat: replace lone surrogates by � in tool results

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -48,6 +48,7 @@ import {
   isSupportedFileContentType,
   removeNulls,
   stripNullBytes,
+  toWellFormed,
 } from "@app/types";
 
 export async function processToolNotification(
@@ -172,7 +173,7 @@ export async function processToolResults(
           return {
             content: {
               type: block.type,
-              text: stripNullBytes(block.text),
+              text: toWellFormed(stripNullBytes(block.text)),
             },
             file: null,
           };
@@ -215,7 +216,7 @@ export async function processToolResults(
                 type: block.type,
                 resource: {
                   ...block.resource,
-                  text: stripNullBytes(block.resource.text),
+                  text: toWellFormed(stripNullBytes(block.resource.text)),
                 },
               },
               file,
@@ -279,7 +280,7 @@ export async function processToolResults(
             const text =
               "text" in block.resource &&
               typeof block.resource.text === "string"
-                ? stripNullBytes(block.resource.text)
+                ? toWellFormed(stripNullBytes(block.resource.text))
                 : null;
 
             // If the resource text is too large, we create a file and return a resource block that references the file.

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -181,3 +181,37 @@ export function asDisplayName(name?: string | null) {
 
   return formatAsDisplayName(name);
 }
+
+// Replace lone surrogates (actual Unicode surrogates, not escaped ones) with placeholder
+// High surrogates: \uD800-\uDBFF
+// Low surrogates: \uDC00-\uDFFF
+export function toWellFormed(content: string): string {
+  const placeholder = "\uFFFD";
+  let result = "";
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+    const charCode = content.charCodeAt(i);
+
+    // Check for high surrogate
+    if (charCode >= 0xd800 && charCode <= 0xdbff) {
+      // Check if it's followed by a low surrogate to form a valid pair
+      if (i + 1 < content.length) {
+        const nextCharCode = content.charCodeAt(i + 1);
+        if (nextCharCode >= 0xdc00 && nextCharCode <= 0xdfff) {
+          // Valid surrogate pair, keep both characters
+          result += char + content[i + 1];
+          i++; // Skip the next character as we've processed it
+          continue;
+        }
+      }
+      result += placeholder;
+    } else if (charCode >= 0xdc00 && charCode <= 0xdfff) {
+      result += placeholder;
+    } else {
+      result += char;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Description
Closes https://github.com/dust-tt/tasks/issues/5022

This PR aims at replacing lone surrogates in tool results so persisting such values in Postgresql does not throw.
This is a quick fix intended to mimic the new .toWellFormed() function of node, which has not been used here because it requires a new version of typescript which itself requires more memory for eslint to run

## Tests

Tested with the following test cases: 

```
  it.each([
    {
      name: "empty string",
      input: "",
    },
    {
      name: "simple ASCII text",
      input: "hello world \uDC00",
    },
    {
      name: "Unicode text with diacritics",
      input: "café naïve résumé",
    },
    {
      name: "mixed Unicode scripts",
      input: "Hello 你好 مرحبا 🌟",
    },
    {
      name: "simple emoji",
      input: "😀👍🎉",
    },
    {
      name: "escaped high surrogate",
      input: "\\uD800test",
    },
    {
      name: "escaped low surrogate",
      input: "prefix\\uDC00",
    },
    {
      name: "multiple escaped surrogates",
      input: "\\uD800\\uDC00\\uD801",
    },
    {
      name: "actual high surrogate",
      input: String.fromCharCode(0xd800) + "content",
    },
    {
      name: "mixed content with both types",
      input: "😀\\uD800" + String.fromCharCode(0xdc00),
    },
  ])("should handle $name correctly", ({ input }) => {
    expect(toWellFormed(input)).toBe(input.toWellFormed());
  });
```

Results:
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'empty string' correctly
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'simple ASCII text' correctly
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'Unicode text with diacritics' correctly
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'mixed Unicode scripts' correctly
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'simple emoji' correctly
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'escaped high surrogate' correctly
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'escaped low surrogate' correctly
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'multiple escaped surrogates' correctly
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'actual high surrogate' correctly
   ✓ cleanUtf8Content vs toWellFormed() comparison > should handle 'mixed content with both types' correctly

## Risk

Low : fix + string to string update

## Deploy Plan

Front