### PR TITLE
[Slack Bot] Change env variable names for uninstall

### DIFF
--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -42,7 +42,7 @@ import type {
 import { isSlackAutoReadPatterns, safeParseJSON } from "@connectors/types";
 import { withTransaction } from "@connectors/types/shared/utils/sql_utils";
 
-const { SLACK_BOT_CLIENT_ID, SLACK_BOT_CLIENT_SECRET } = process.env;
+const { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } = process.env;
 
 export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigurationType> {
   readonly provider: ConnectorProvider = "slack_bot";
@@ -293,8 +293,8 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
           );
           const uninstallRes = await uninstallSlack(
             connectionId,
-            SLACK_BOT_CLIENT_ID,
-            SLACK_BOT_CLIENT_SECRET
+            SLACK_CLIENT_ID,
+            SLACK_CLIENT_SECRET
           );
 
           if (uninstallRes.isErr()) {
@@ -375,8 +375,8 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
       try {
         const uninstallRes = await uninstallSlack(
           connector.connectionId,
-          SLACK_BOT_CLIENT_ID,
-          SLACK_BOT_CLIENT_SECRET
+          SLACK_CLIENT_ID,
+          SLACK_CLIENT_SECRET
         );
 
         if (uninstallRes.isErr() && !force) {


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/4976 as well as multiple reported errors such as
- [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1758725799066229?thread_ts=1758725263.874669&cid=C05F84CFP0E)
- [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1757749664496679?thread_ts=1757748763.205859&cid=C05F84CFP0E)

SLACK_BOT_[ID/SECRET] have never been defined and added to secrets

Dust had been working with SLACK_CLIENT_ID all along, except for the uninstall part which bugged.

Risks
---
low, only on uninstall/reinstall of slack bot

Deploy
---
front
