### PR TITLE
[front] - fix(obs): update Area chart smoothing type to monotone

### DIFF
--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -200,7 +200,7 @@ export function ErrorRateChart({
             strokeWidth={1.5}
           />
           <Area
-            type="natural"
+            type="monotone"
             dataKey="errorRate"
             name="Error rate"
             fill="url(#fillErrorRate)"

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -147,7 +147,7 @@ export function LatencyChart({
             }}
           />
           <Area
-            type="natural"
+            type="monotone"
             dataKey="average"
             name="Average time to complete output"
             className={LATENCY_PALETTE.average}

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -220,7 +220,7 @@ export function UsageMetricsChart({
           />
           {/* Areas for each usage metric */}
           <Area
-            type="natural"
+            type="monotone"
             dataKey="messages"
             name="Messages"
             className={USAGE_METRICS_PALETTE.messages}
@@ -228,7 +228,7 @@ export function UsageMetricsChart({
             stroke="currentColor"
           />
           <Area
-            type="natural"
+            type="monotone"
             dataKey="conversations"
             name="Conversations"
             className={USAGE_METRICS_PALETTE.conversations}
@@ -236,7 +236,7 @@ export function UsageMetricsChart({
             stroke="currentColor"
           />
           <Area
-            type="natural"
+            type="monotone"
             dataKey="activeUsers"
             name="Active users"
             className={USAGE_METRICS_PALETTE.activeUsers}


### PR DESCRIPTION
## Description

This PR fixes the Area chart smoothing from "natural" to "monotone" to improve graph readability across different charts to make sure the curve doesn't get below 0

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front