### PR TITLE
feat: ungate DSFS for @\dust

### DIFF
--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -62,7 +62,6 @@ import type {
   AgentConfigurationType,
   AgentFetchVariant,
   GlobalAgentStatus,
-  WhitelistableFeature,
 } from "@app/types";
 import {
   GLOBAL_AGENTS_SID,
@@ -91,7 +90,6 @@ function getGlobalAgent({
   includeDataMCPServerView,
   memories,
   availableToolsets,
-  featureFlags,
 }: {
   auth: Authenticator;
   sId: string | number;
@@ -112,7 +110,6 @@ function getGlobalAgent({
   includeDataMCPServerView: MCPServerViewResource | null;
   memories: AgentMemoryResource[];
   availableToolsets: MCPServerViewResource[];
-  featureFlags: WhitelistableFeature[];
 }): AgentConfigurationType | null {
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
@@ -353,7 +350,6 @@ function getGlobalAgent({
         preFetchedDataSources,
         agentRouterMCPServerView,
         webSearchBrowseMCPServerView,
-        searchMCPServerView,
         dataSourcesFileSystemMCPServerView,
         toolsetsMCPServerView,
         deepDiveMCPServerView,
@@ -362,7 +358,6 @@ function getGlobalAgent({
         agentMemoryMCPServerView,
         memories,
         availableToolsets,
-        featureFlags,
       });
       break;
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
@@ -655,7 +650,6 @@ export async function getGlobalAgents(
       includeDataMCPServerView,
       memories,
       availableToolsets,
-      featureFlags: flags,
     })
   );
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -222,11 +222,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable mentions v2, aka mention users",
     stage: "on_demand",
   },
-  dust_global_data_source_file_system: {
-    description:
-      "Use the Data Sources File System MCP server on the @dust global agent (replaces search tool server)",
-    stage: "dust_only",
-  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -703,7 +703,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "legacy_dust_apps"
   | "llm_router_direct_requests"
   | "mentions_v2"
-  | "dust_global_data_source_file_system"
   | "http_client_tool"
 >();
 


### PR DESCRIPTION
## Description

We replaced the n+1 search tools by a DSFS on the dust global agent.
This reduces the number of tool servers, cleans up the configuration and lets the agent use `cat` to read files in full (and of course, other tools from DSFS).

This was still gated, but is now being released globally.

## Tests

In prod, through the gated setup

## Risk

Marginally increases response time in certain situations

## Deploy Plan

Deploy front