### PR TITLE
[front] - feat(obs): add version markers to all charts

### DIFF
--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -21,7 +21,7 @@ import { ChartContainer } from "@app/components/agent_builder/observability/shar
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
-import { useAgentErrorRate } from "@app/lib/swr/assistants";
+import { useAgentErrorRate, useAgentVersionMarkers } from "@app/lib/swr/assistants";
 
 const WARNING_THRESHOLD = 5;
 const CRITICAL_THRESHOLD = 10;
@@ -87,6 +87,13 @@ export function ErrorRateChart({
     isErrorRateLoading,
     isErrorRateError,
   } = useAgentErrorRate({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    disabled: !workspaceId || !agentConfigurationId,
+  });
+
+  const { versionMarkers } = useAgentVersionMarkers({
     workspaceId,
     agentConfigurationId,
     days: period,
@@ -206,6 +213,16 @@ export function ErrorRateChart({
             fill="url(#fillErrorRate)"
             stroke="hsl(var(--chart-4))"
           />
+          {mode === "timeRange" &&
+            versionMarkers.map((versionMarker) => (
+              <ReferenceLine
+                key={versionMarker.timestamp}
+                x={versionMarker.timestamp}
+                strokeDasharray="5 5"
+                strokeWidth={1}
+                stroke="hsl(var(--chart-5))"
+              />
+            ))}
         </AreaChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -21,7 +21,10 @@ import { ChartContainer } from "@app/components/agent_builder/observability/shar
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
-import { useAgentErrorRate, useAgentVersionMarkers } from "@app/lib/swr/assistants";
+import {
+  useAgentErrorRate,
+  useAgentVersionMarkers,
+} from "@app/lib/swr/assistants";
 
 const WARNING_THRESHOLD = 5;
 const CRITICAL_THRESHOLD = 10;

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -2,6 +2,7 @@ import {
   CartesianGrid,
   Line,
   LineChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -137,6 +138,16 @@ export function FeedbackDistributionChart({
             strokeWidth={2}
             dot={false}
           />
+          {mode === "timeRange" &&
+            versionMarkers.map((versionMarker) => (
+              <ReferenceLine
+                key={versionMarker.timestamp}
+                x={versionMarker.timestamp}
+                strokeDasharray="5 5"
+                strokeWidth={1}
+                stroke="hsl(var(--chart-5))"
+              />
+            ))}
         </LineChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -20,7 +20,10 @@ import { ChartContainer } from "@app/components/agent_builder/observability/shar
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
-import { useAgentLatency, useAgentVersionMarkers } from "@app/lib/swr/assistants";
+import {
+  useAgentLatency,
+  useAgentVersionMarkers,
+} from "@app/lib/swr/assistants";
 
 interface LatencyData {
   messages: number;

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -2,6 +2,7 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -19,7 +20,7 @@ import { ChartContainer } from "@app/components/agent_builder/observability/shar
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
-import { useAgentLatency } from "@app/lib/swr/assistants";
+import { useAgentLatency, useAgentVersionMarkers } from "@app/lib/swr/assistants";
 
 interface LatencyData {
   messages: number;
@@ -70,6 +71,13 @@ export function LatencyChart({
     isLatencyLoading,
     isLatencyError,
   } = useAgentLatency({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    disabled: !workspaceId || !agentConfigurationId,
+  });
+
+  const { versionMarkers } = useAgentVersionMarkers({
     workspaceId,
     agentConfigurationId,
     days: period,
@@ -154,6 +162,16 @@ export function LatencyChart({
             fill="url(#fillAverage)"
             stroke="currentColor"
           />
+          {mode === "timeRange" &&
+            versionMarkers.map((versionMarker) => (
+              <ReferenceLine
+                key={versionMarker.timestamp}
+                x={versionMarker.timestamp}
+                strokeDasharray="5 5"
+                strokeWidth={1}
+                stroke="hsl(var(--chart-5))"
+              />
+            ))}
         </AreaChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />


### PR DESCRIPTION
## Description

This PR implements version marker lines in `ErrorRate`, `FeedbackDistribution`, and `Latency` charts to enhance data visualization and make sure they are consistent with the `Tool Usage` chart.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front