### PR TITLE
feat: handle structured output for openai models

### DIFF
--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -103,14 +103,11 @@ export async function getBuilderNameSuggestions(
     operationType: "name_suggestion",
     userId: auth.user()?.sId,
   };
-  const llm = await getLLM(
-    auth,
-    {
-      modelId: "mistral-small-latest",
-      bypassFeatureFlag: true,
-    },
-    traceContext
-  );
+  const llm = await getLLM(auth, {
+    modelId: "mistral-small-latest",
+    bypassFeatureFlag: true,
+    context: traceContext,
+  });
 
   if (llm === null) {
     return new Err(new Error("Model not found"));

--- a/front/lib/api/llm/clients/openai/__test__/openai.test.ts
+++ b/front/lib/api/llm/clients/openai/__test__/openai.test.ts
@@ -5,8 +5,12 @@ import {
   getOpenAIModelFamilyFromModelId,
   OPENAI_WHITELISTED_MODEL_IDS,
 } from "@app/lib/api/llm/clients/openai/types";
-import { TEST_CONVERSATIONS } from "@app/lib/api/llm/tests/conversations";
+import {
+  TEST_CONVERSATIONS,
+  TEST_STRUCTURED_OUTPUT_CONVERSATIONS,
+} from "@app/lib/api/llm/tests/conversations";
 import { LLMClientTestSuite } from "@app/lib/api/llm/tests/LLMClientTestSuite";
+import { TEST_STRUCTURED_OUTPUT_KEYS } from "@app/lib/api/llm/tests/schemas";
 import type {
   ConfigParams,
   TestConfig,
@@ -23,6 +27,9 @@ const OPENAI_MODEL_FAMILY_TO_TEST_CONFIGS: Record<
     { reasoningEffort: "light" },
     { reasoningEffort: "medium" },
     { reasoningEffort: "high" },
+    ...TEST_STRUCTURED_OUTPUT_KEYS.map((testStructuredOutputKey) => ({
+      testStructuredOutputKey,
+    })),
   ],
   "o3-no-vision": [
     { reasoningEffort: "none" },
@@ -102,7 +109,8 @@ class OpenAiTestSuite extends LLMClientTestSuite {
   }
 
   protected getSupportedConversations(
-    _modelId: ModelIdType
+    _modelId: ModelIdType,
+    config: TestConfig
   ): TestConversation[] {
     const family = getOpenAIModelFamilyFromModelId(_modelId);
     if (NO_VISION_FAMILIES.includes(family)) {
@@ -111,6 +119,14 @@ class OpenAiTestSuite extends LLMClientTestSuite {
         (conversation) => conversation.id !== "image-description"
       );
     }
+
+    if (config.testStructuredOutputKey) {
+      // Only use specific conversation for structured output config
+      return TEST_STRUCTURED_OUTPUT_CONVERSATIONS.filter(
+        (conversation) => conversation.id === config.testStructuredOutputKey
+      );
+    }
+
     return TEST_CONVERSATIONS;
   }
 }

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -13,6 +13,7 @@ import { handleError } from "@app/lib/api/llm/utils/openai_like/errors";
 import {
   toInput,
   toReasoning,
+  toResponseFormat,
   toTool,
 } from "@app/lib/api/llm/utils/openai_like/responses/conversation_to_openai";
 import { streamLLMEvents } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
@@ -58,6 +59,7 @@ export class OpenAIResponsesLLM extends LLM {
         temperature: this.temperature ?? undefined,
         reasoning: toReasoning(this.reasoningEffort),
         tools: specifications.map(toTool),
+        text: { format: toResponseFormat(this.responseFormat) },
       });
 
       yield* streamLLMEvents(events, this.metadata);

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -13,7 +13,6 @@ import { isOpenAIResponsesWhitelistedModelId } from "@app/lib/api/llm/clients/op
 import { XaiLLM } from "@app/lib/api/llm/clients/xai";
 import { isXaiWhitelistedModelId } from "@app/lib/api/llm/clients/xai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
-import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -26,8 +25,14 @@ async function hasFeatureFlag(auth: Authenticator): Promise<boolean> {
 
 export async function getLLM(
   auth: Authenticator,
-  { modelId, temperature, reasoningEffort, bypassFeatureFlag }: LLMParameters,
-  context?: LLMTraceContext
+  {
+    modelId,
+    temperature,
+    reasoningEffort,
+    responseFormat,
+    bypassFeatureFlag,
+    context,
+  }: LLMParameters
 ): Promise<LLM | null> {
   const modelConfiguration = SUPPORTED_MODEL_CONFIGS.find(
     (config) => config.modelId === modelId
@@ -66,6 +71,7 @@ export async function getLLM(
       modelId,
       temperature,
       reasoningEffort,
+      responseFormat,
       bypassFeatureFlag,
       context,
     });

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -20,6 +20,7 @@ export abstract class LLM {
   protected modelId: ModelIdType;
   protected temperature: number | null;
   protected reasoningEffort: ReasoningEffort | null;
+  protected responseFormat: string | null;
   protected bypassFeatureFlag: boolean;
   protected metadata: LLMClientMetadata;
 
@@ -36,12 +37,14 @@ export abstract class LLM {
       clientId,
       modelId,
       reasoningEffort = "none",
+      responseFormat = null,
       temperature = AGENT_CREATIVITY_LEVEL_TEMPERATURES.balanced,
     }: LLMParameters & { clientId: string }
   ) {
     this.modelId = modelId;
     this.temperature = temperature;
     this.reasoningEffort = reasoningEffort;
+    this.responseFormat = responseFormat;
     this.bypassFeatureFlag = bypassFeatureFlag;
     this.metadata = { clientId, modelId };
 
@@ -74,6 +77,7 @@ export abstract class LLM {
       modelId: this.modelId,
       prompt,
       reasoningEffort: this.reasoningEffort,
+      responseFormat: this.responseFormat,
       specifications,
       temperature: this.temperature,
     });

--- a/front/lib/api/llm/tests/LLMClientTestSuite.ts
+++ b/front/lib/api/llm/tests/LLMClientTestSuite.ts
@@ -36,18 +36,22 @@ export abstract class LLMClientTestSuite {
 
   protected abstract getTestConfig(modelId: ModelIdType): TestConfig[];
   protected abstract getSupportedConversations(
-    modelId: ModelIdType
+    modelId: ModelIdType,
+    config: TestConfig
   ): TestConversation[];
 
   protected getConversationsToRun(
-    modelId: ModelIdType
+    modelId: ModelIdType,
+    config: TestConfig
   ): RunnableTestConversation[] {
-    return this.getSupportedConversations(modelId).map((conversation) => ({
-      name: conversation.name,
-      run: async (config: TestConfig) => {
-        await runConversation(conversation, config);
-      },
-    }));
+    return this.getSupportedConversations(modelId, config).map(
+      (conversation) => ({
+        name: conversation.name,
+        run: async (config: TestConfig) => {
+          await runConversation(conversation, config);
+        },
+      })
+    );
   }
 
   public generateTests(): void {
@@ -55,16 +59,18 @@ export abstract class LLMClientTestSuite {
       this.models.forEach((model) => {
         describe(`Model: ${model}`, () => {
           this.getTestConfig(model).forEach((config) => {
-            describe(`Config: temperature=${config.temperature}, reasoningEffort=${config.reasoningEffort}`, () => {
-              this.getConversationsToRun(model).forEach((conversation) => {
-                it(
-                  `should handle: ${conversation.name}`,
-                  { concurrent: true, timeout: TIMEOUT },
-                  async () => {
-                    await conversation.run(config);
-                  }
-                );
-              });
+            describe(`Config: temperature=${config.temperature}, reasoningEffort=${config.reasoningEffort}, responseFormat=${config.testStructuredOutputKey}`, () => {
+              this.getConversationsToRun(model, config).forEach(
+                (conversation) => {
+                  it(
+                    `should handle: ${conversation.name}`,
+                    { concurrent: true, timeout: TIMEOUT },
+                    async () => {
+                      await conversation.run(config);
+                    }
+                  );
+                }
+              );
             });
           });
         });

--- a/front/lib/api/llm/tests/schemas.ts
+++ b/front/lib/api/llm/tests/schemas.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+
+import type { ResponseFormat } from "@app/types";
+
+const UserProfileResponseFormat: ResponseFormat = {
+  type: "json_schema",
+  json_schema: {
+    name: "user_profile",
+    schema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Full name of the user" },
+        email: { type: "string", description: "Email address" },
+        age: { type: "number", description: "Age in years" },
+        is_active: {
+          type: "boolean",
+          description: "Whether the user account is active",
+        },
+      },
+      required: ["name", "email", "age", "is_active"],
+      additionalProperties: false,
+    },
+  },
+};
+
+const DataExtractionResponseFormat: ResponseFormat = {
+  type: "json_schema",
+  json_schema: {
+    name: "data_extraction",
+    strict: true,
+    schema: {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        author: { type: ["string", "null"] },
+        publication_date: { type: ["string", "null"] },
+        extracted_entities: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              type: {
+                type: "string",
+                enum: ["person", "organization", "location", "date"],
+              },
+              value: { type: "string" },
+              confidence: { type: "number" },
+            },
+            required: ["type", "value", "confidence"],
+            additionalProperties: false,
+          },
+        },
+        has_tables: { type: "boolean" },
+      },
+      required: [
+        "title",
+        "author",
+        "publication_date",
+        "extracted_entities",
+        "has_tables",
+      ],
+      additionalProperties: false,
+    },
+  },
+};
+
+const UserProfileStructuredOutputSchema = z.object({
+  name: z.string().describe("Full name of the user"),
+  email: z.string().email().describe("Email address"),
+  age: z.number().int().positive().describe("Age in years"),
+  is_active: z.boolean().describe("Whether the user account is active"),
+});
+
+const DataExtractionStructuredOutputSchema = z.object({
+  title: z.string(),
+  author: z.string().nullable(),
+  publication_date: z.string().nullable(),
+  extracted_entities: z.array(
+    z.object({
+      type: z.enum(["person", "organization", "location", "date"]),
+      value: z.string(),
+      confidence: z.number(),
+    })
+  ),
+  has_tables: z.boolean(),
+});
+
+export type TestStructuredOutputSchema =
+  | typeof UserProfileStructuredOutputSchema
+  | typeof DataExtractionStructuredOutputSchema;
+
+export const TEST_STRUCTURED_OUTPUT_KEYS = [
+  "user-profile",
+  "data-extraction",
+] as const;
+export type TestStructuredOutputKey =
+  (typeof TEST_STRUCTURED_OUTPUT_KEYS)[number];
+
+export const TEST_RESPONSE_FORMATS: Record<
+  TestStructuredOutputKey,
+  ResponseFormat
+> = {
+  "user-profile": UserProfileResponseFormat,
+  "data-extraction": DataExtractionResponseFormat,
+} as const;
+
+export const TEST_STRUCTURED_OUTPUT_SCHEMAS: Record<
+  TestStructuredOutputKey,
+  TestStructuredOutputSchema
+> = {
+  "user-profile": UserProfileStructuredOutputSchema,
+  "data-extraction": DataExtractionStructuredOutputSchema,
+} as const;

--- a/front/lib/api/llm/tests/types.ts
+++ b/front/lib/api/llm/tests/types.ts
@@ -1,5 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import type {
+  TestStructuredOutputKey,
+  TestStructuredOutputSchema,
+} from "@app/lib/api/llm/tests/schemas";
+import type {
   ModelConversationTypeMultiActions,
   ModelIdType,
   ModelProviderIdType,
@@ -10,6 +14,7 @@ export type TestConfig = {
   modelId: ModelIdType;
   temperature?: number | undefined;
   reasoningEffort?: ReasoningEffort | undefined;
+  testStructuredOutputKey?: TestStructuredOutputKey;
   provider: ModelProviderIdType;
 };
 
@@ -22,6 +27,10 @@ export type ResponseChecker =
       type: "has_tool_call";
       toolName: string;
       expectedArguments: string;
+    }
+  | {
+      type: "check_json_output";
+      schema: TestStructuredOutputSchema;
     }
   | null;
 
@@ -43,4 +52,5 @@ export interface RunnabletestConversation {
 export interface ConfigParams {
   temperature?: number;
   reasoningEffort?: ReasoningEffort;
+  testStructuredOutputKey?: TestStructuredOutputKey;
 }

--- a/front/lib/api/llm/traces/buffer.test.ts
+++ b/front/lib/api/llm/traces/buffer.test.ts
@@ -94,6 +94,7 @@ function createTestBuffer(traceId?: LLMTraceId, workspaceId?: string) {
     modelId: "gpt-4-turbo",
     prompt: faker.lorem.paragraph(),
     reasoningEffort: "medium",
+    responseFormat: null,
     specifications: [],
     temperature: 0.7,
   });

--- a/front/lib/api/llm/traces/buffer.ts
+++ b/front/lib/api/llm/traces/buffer.ts
@@ -77,6 +77,7 @@ export class LLMTraceBuffer {
     modelId,
     prompt,
     reasoningEffort,
+    responseFormat,
     specifications,
     temperature,
   }: {
@@ -84,6 +85,7 @@ export class LLMTraceBuffer {
     modelId: ModelIdType;
     prompt: string;
     reasoningEffort: ReasoningEffort | null;
+    responseFormat: string | null;
     specifications: unknown[];
     temperature: number | null;
   }) {
@@ -92,6 +94,7 @@ export class LLMTraceBuffer {
       modelId,
       prompt,
       reasoningEffort,
+      responseFormat,
       specifications,
       temperature,
     };

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -32,6 +32,7 @@ export interface LLMTraceInput {
   modelId: ModelIdType;
   prompt: string;
   reasoningEffort: ReasoningEffort | null;
+  responseFormat: string | null;
   specifications: unknown[];
   temperature: number | null;
 }

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -11,6 +11,7 @@ export type LLMParameters = {
   context?: LLMTraceContext;
   modelId: ModelIdType;
   reasoningEffort?: ReasoningEffort | null;
+  responseFormat?: string | null;
   temperature?: number | null;
 };
 

--- a/front/scripts/test_llm_clients.ts
+++ b/front/scripts/test_llm_clients.ts
@@ -339,6 +339,7 @@ async function runTest(
       modelId: config.modelId,
       temperature: config.temperature,
       reasoningEffort: config.reasoningEffort,
+      responseFormat: config.responseFormat,
       bypassFeatureFlag: true,
     });
     if (llm === null) {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -426,7 +426,13 @@ export async function runModelActivity(
     contextId: agentConfiguration.sId,
     userId: auth.user()?.sId,
   };
-  const llm = await getLLM(auth, { modelId: model.modelId }, traceContext);
+  const llm = await getLLM(auth, {
+    modelId: model.modelId,
+    temperature: agentConfiguration.model.temperature,
+    reasoningEffort: agentConfiguration.model.reasoningEffort,
+    responseFormat: agentConfiguration.model.responseFormat,
+    context: traceContext,
+  });
   const modelInteractionStartDate = performance.now();
 
   if (llm === null) {

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type {
   AgentReasoningEffort,
   EMBEDDING_PROVIDER_IDS,
@@ -75,3 +77,19 @@ export type ReasoningModelConfigurationType = {
   temperature: number | null;
 };
 export type EmbeddingProviderIdType = (typeof EMBEDDING_PROVIDER_IDS)[number];
+
+export const ResponseFormatSchema = z.object({
+  type: z.literal("json_schema"),
+  json_schema: z.object({
+    name: z.string(),
+    schema: z.object({
+      type: z.literal("object"),
+      properties: z.record(z.unknown()),
+      required: z.array(z.string()),
+      additionalProperties: z.boolean(),
+    }),
+    description: z.string().optional(),
+    strict: z.boolean().nullable().optional(),
+  }),
+});
+export type ResponseFormat = z.infer<typeof ResponseFormatSchema>;


### PR DESCRIPTION






## Description

Adds structured output support for OpenAI models by implementing the `responseFormat` parameter throughout the LLM stack. The `responseFormat` accepts a JSON schema that is passed to OpenAI's Responses API via the `text.format` parameter. This enables models to return structured JSON responses conforming to a specific schema, which is particularly useful for data extraction and structured information retrieval tasks.

The implementation includes comprehensive test coverage with a new test conversation that validates structured output by extracting user profile information and validating it against a Zod schema.

## Risk

Low - the feature is additive and only affects OpenAI models that support structured output (marked with `supportsResponseFormat: true`). Existing functionality remains unchanged when `responseFormat` is not provided.

## Tests

Added unit tests with a structured output test case that validates JSON schema compliance using Zod validation. Tested locally with front

## Deploy Plan

Deploy Front.
