### PR TITLE
[front] - chore(obs): various charts tweaks

### DIFF
--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -130,6 +130,7 @@ export function ErrorRateChart({
   return (
     <ChartContainer
       title="Error rate"
+      description="Share of messages that failed (%). Warning at 5%, critical at 10%."
       statusChip={
         !isErrorRateLoading && !isErrorRateError && data.length > 0
           ? getStatusChip()

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -18,8 +18,12 @@ import {
 } from "@app/components/agent_builder/observability/constants";
 import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
-import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import {
+  ChartLegend,
+  legendFromConstant,
+} from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { VersionMarkersDots } from "@app/components/agent_builder/observability/shared/VersionMarkers";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
 import {
   useAgentErrorRate,
@@ -110,11 +114,13 @@ export function ErrorRateChart({
     errorRate: 0,
   }));
 
-  const legendItems = ERROR_RATE_LEGEND.map(({ key, label }) => ({
-    key,
-    label,
-    colorClassName: ERROR_RATE_PALETTE[key],
-  }));
+  const legendItems = legendFromConstant(
+    ERROR_RATE_LEGEND,
+    ERROR_RATE_PALETTE,
+    {
+      includeVersionMarker: mode === "timeRange" && versionMarkers.length > 0,
+    }
+  );
 
   const getStatusChip = () => {
     const latestErrorRate = data[data.length - 1]?.errorRate ?? 0;
@@ -217,16 +223,7 @@ export function ErrorRateChart({
             fill="url(#fillErrorRate)"
             stroke="hsl(var(--chart-4))"
           />
-          {mode === "timeRange" &&
-            versionMarkers.map((versionMarker) => (
-              <ReferenceLine
-                key={versionMarker.timestamp}
-                x={versionMarker.timestamp}
-                strokeDasharray="5 5"
-                strokeWidth={1}
-                stroke="hsl(var(--chart-5))"
-              />
-            ))}
+          <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
         </AreaChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -2,7 +2,6 @@ import {
   CartesianGrid,
   Line,
   LineChart,
-  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -17,7 +16,11 @@ import {
 } from "@app/components/agent_builder/observability/constants";
 import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
-import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import {
+  ChartLegend,
+  legendFromConstant,
+} from "@app/components/agent_builder/observability/shared/ChartLegend";
+import { VersionMarkersDots } from "@app/components/agent_builder/observability/shared/VersionMarkers";
 import {
   filterTimeSeriesByVersionWindow,
   padSeriesToTimeRange,
@@ -54,11 +57,13 @@ export function FeedbackDistributionChart({
     disabled: !workspaceId || !agentConfigurationId,
   });
 
-  const legendItems = FEEDBACK_DISTRIBUTION_LEGEND.map(({ key, label }) => ({
-    key,
-    label,
-    colorClassName: FEEDBACK_DISTRIBUTION_PALETTE[key],
-  }));
+  const legendItems = legendFromConstant(
+    FEEDBACK_DISTRIBUTION_LEGEND,
+    FEEDBACK_DISTRIBUTION_PALETTE,
+    {
+      includeVersionMarker: mode === "timeRange" && versionMarkers.length > 0,
+    }
+  );
 
   const filteredData = filterTimeSeriesByVersionWindow(
     feedbackDistribution,
@@ -139,16 +144,7 @@ export function FeedbackDistributionChart({
             strokeWidth={2}
             dot={false}
           />
-          {mode === "timeRange" &&
-            versionMarkers.map((versionMarker) => (
-              <ReferenceLine
-                key={versionMarker.timestamp}
-                x={versionMarker.timestamp}
-                strokeDasharray="5 5"
-                strokeWidth={1}
-                stroke="hsl(var(--chart-5))"
-              />
-            ))}
+          <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
         </LineChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -76,6 +76,7 @@ export function FeedbackDistributionChart({
   return (
     <ChartContainer
       title="Feedback Trends"
+      description="Daily counts of positive and negative feedback."
       isLoading={isFeedbackDistributionLoading}
       errorMessage={
         isFeedbackDistributionError

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -2,7 +2,6 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
-  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -17,8 +16,12 @@ import {
 } from "@app/components/agent_builder/observability/constants";
 import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
-import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import {
+  ChartLegend,
+  legendFromConstant,
+} from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { VersionMarkersDots } from "@app/components/agent_builder/observability/shared/VersionMarkers";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
 import {
   useAgentLatency,
@@ -93,11 +96,9 @@ export function LatencyChart({
     average: 0,
   }));
 
-  const legendItems = LATENCY_LEGEND.map(({ key, label }) => ({
-    key,
-    label,
-    colorClassName: LATENCY_PALETTE[key],
-  }));
+  const legendItems = legendFromConstant(LATENCY_LEGEND, LATENCY_PALETTE, {
+    includeVersionMarker: mode === "timeRange" && versionMarkers.length > 0,
+  });
 
   return (
     <ChartContainer
@@ -166,16 +167,7 @@ export function LatencyChart({
             fill="url(#fillAverage)"
             stroke="currentColor"
           />
-          {mode === "timeRange" &&
-            versionMarkers.map((versionMarker) => (
-              <ReferenceLine
-                key={versionMarker.timestamp}
-                x={versionMarker.timestamp}
-                strokeDasharray="5 5"
-                strokeWidth={1}
-                stroke="hsl(var(--chart-5))"
-              />
-            ))}
+          <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
         </AreaChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -102,6 +102,7 @@ export function LatencyChart({
   return (
     <ChartContainer
       title="Latency"
+      description="Average time to complete output (seconds). Lower is better."
       isLoading={isLatencyLoading}
       errorMessage={
         isLatencyError ? "Failed to load observability data." : undefined

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -82,6 +82,7 @@ export function ToolUsageChart({
   return (
     <ChartContainer
       title="Tool Usage"
+      description={legendDescription}
       isLoading={isLoading}
       errorMessage={errorMessage}
       emptyMessage={chartData.length === 0 ? emptyMessage : undefined}
@@ -179,9 +180,6 @@ export function ToolUsageChart({
         </BarChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />
-      <div className="mt-4 text-xs text-muted-foreground">
-        <p>{legendDescription}</p>
-      </div>
     </ChartContainer>
   );
 }

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -2,7 +2,6 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
-  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -17,8 +16,12 @@ import {
 } from "@app/components/agent_builder/observability/constants";
 import { useObservability } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
-import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import {
+  ChartLegend,
+  legendFromConstant,
+} from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { VersionMarkersDots } from "@app/components/agent_builder/observability/shared/VersionMarkers";
 import {
   filterTimeSeriesByVersionWindow,
   findVersionMarkerForDate,
@@ -115,11 +118,13 @@ export function UsageMetricsChart({
     disabled: !workspaceId || !agentConfigurationId,
   });
 
-  const legendItems = USAGE_METRICS_LEGEND.map(({ key, label }) => ({
-    key,
-    label,
-    colorClassName: USAGE_METRICS_PALETTE[key],
-  }));
+  const legendItems = legendFromConstant(
+    USAGE_METRICS_LEGEND,
+    USAGE_METRICS_PALETTE,
+    {
+      includeVersionMarker: mode === "timeRange" && versionMarkers.length > 0,
+    }
+  );
 
   const filteredData = filterTimeSeriesByVersionWindow(
     usageMetrics,
@@ -244,16 +249,7 @@ export function UsageMetricsChart({
             fill="url(#fillActiveUsers)"
             stroke="currentColor"
           />
-          {mode === "timeRange" &&
-            versionMarkers.map((versionMarker) => (
-              <ReferenceLine
-                key={versionMarker.timestamp}
-                x={versionMarker.timestamp}
-                strokeDasharray="5 5"
-                strokeWidth={1}
-                stroke="hsl(var(--chart-5))"
-              />
-            ))}
+          <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
         </AreaChart>
       </ResponsiveContainer>
       <ChartLegend items={legendItems} />

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -138,6 +138,7 @@ export function UsageMetricsChart({
   return (
     <ChartContainer
       title="Usage Metrics"
+      description="Daily totals of messages, conversations, and active users."
       isLoading={isUsageMetricsLoading}
       errorMessage={
         isUsageMetricsError ? "Failed to load observability data." : undefined

--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -14,6 +14,7 @@ interface ChartContainerProps {
   children: ReactNode;
   additionalControls?: ReactNode;
   statusChip?: ReactNode;
+  description?: string;
 }
 
 export function ChartContainer({
@@ -24,6 +25,7 @@ export function ChartContainer({
   children,
   additionalControls,
   statusChip,
+  description,
 }: ChartContainerProps) {
   const message = isLoading ? null : errorMessage ?? emptyMessage;
 
@@ -34,13 +36,21 @@ export function ChartContainer({
         CHART_CONTAINER_HEIGHT_CLASS
       )}
     >
-      <div className="mb-4 flex items-center justify-between">
+      <div
+        className={cn(
+          "flex items-center justify-between",
+          description ? "mb-2" : "mb-4"
+        )}
+      >
         <div className="flex items-center gap-2">
           <h3 className="text-lg font-medium text-foreground">{title}</h3>
           {statusChip}
         </div>
         <div className="flex items-center gap-3">{additionalControls}</div>
       </div>
+      {description && (
+        <div className="mb-3 text-xs text-muted-foreground">{description}</div>
+      )}
       {isLoading || message ? (
         <div
           className="flex items-center justify-center"

--- a/front/components/agent_builder/observability/shared/ChartLegend.tsx
+++ b/front/components/agent_builder/observability/shared/ChartLegend.tsx
@@ -1,5 +1,33 @@
 import { LegendDot } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 
+export type LegendEntry = {
+  key: string;
+  label: string;
+  colorClassName: string;
+};
+
+export function legendFromConstant<K extends string>(
+  legend: ReadonlyArray<{ key: K; label: string }>,
+  palette: Readonly<Record<K, string>>,
+  options?: { includeVersionMarker?: boolean }
+): LegendEntry[] {
+  const base: LegendEntry[] = legend.map(({ key, label }) => ({
+    key: String(key),
+    label,
+    colorClassName: palette[key],
+  }));
+
+  if (options?.includeVersionMarker) {
+    base.push({
+      key: "versionMarkers",
+      label: "Version Marker",
+      colorClassName: "text-gray-300 dark:text-gray-300-night",
+    });
+  }
+
+  return base;
+}
+
 interface LegendItem {
   key: string;
   label: string;
@@ -15,7 +43,10 @@ export function ChartLegend({ items }: ChartLegendProps) {
     <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
       {items.map((item) => (
         <div key={item.key} className="flex items-center gap-2">
-          <LegendDot className={item.colorClassName} />
+          <LegendDot
+            className={item.colorClassName}
+            rounded={item.key === "versionMarkers" ? "full" : "sm"}
+          />
           <span className="text-sm text-muted-foreground">{item.label}</span>
         </div>
       ))}

--- a/front/components/agent_builder/observability/shared/ChartTooltip.tsx
+++ b/front/components/agent_builder/observability/shared/ChartTooltip.tsx
@@ -2,15 +2,17 @@ import { cn } from "@dust-tt/sparkle";
 
 interface LegendDotProps {
   className: string;
+  rounded?: "sm" | "full";
 }
 
-export function LegendDot({ className }: LegendDotProps) {
+export function LegendDot({ className, rounded = "sm" }: LegendDotProps) {
   return (
     <span
       aria-hidden
       role="presentation"
       className={cn(
-        "inline-block h-2.5 w-2.5 rounded-sm bg-current",
+        "inline-block h-2.5 w-2.5 bg-current",
+        rounded === "full" ? "rounded-full" : "rounded-sm",
         className
       )}
     />

--- a/front/components/agent_builder/observability/shared/VersionMarkers.tsx
+++ b/front/components/agent_builder/observability/shared/VersionMarkers.tsx
@@ -4,10 +4,12 @@ import type { ObservabilityMode } from "@app/components/agent_builder/observabil
 
 type Marker = { timestamp: string };
 
-function MarkerDotLabel(props: any) {
-  const vb = props?.viewBox as
-    | { x: number; y: number; width: number; height: number }
-    | undefined;
+interface MarkerDotLabelProps {
+  viewBox?: { x: number; y: number; width: number; height: number };
+}
+
+function MarkerDotLabel({ viewBox }: MarkerDotLabelProps) {
+  const vb = viewBox;
   if (!vb) {
     return null;
   }
@@ -26,16 +28,19 @@ function MarkerDotLabel(props: any) {
   );
 }
 
+interface VersionMarkersDotsProps {
+  mode: ObservabilityMode;
+  versionMarkers: Marker[];
+}
+
 export function VersionMarkersDots({
   mode,
   versionMarkers,
-}: {
-  mode: ObservabilityMode;
-  versionMarkers: Marker[];
-}) {
+}: VersionMarkersDotsProps) {
   if (mode !== "timeRange" || versionMarkers.length === 0) {
     return null;
   }
+
   return (
     <>
       {versionMarkers.map((m) => (

--- a/front/components/agent_builder/observability/shared/VersionMarkers.tsx
+++ b/front/components/agent_builder/observability/shared/VersionMarkers.tsx
@@ -1,0 +1,55 @@
+import { ReferenceLine } from "recharts";
+
+import type { ObservabilityMode } from "@app/components/agent_builder/observability/ObservabilityContext";
+
+type Marker = { timestamp: string };
+
+function MarkerDotLabel(props: any) {
+  const vb = props?.viewBox as
+    | { x: number; y: number; width: number; height: number }
+    | undefined;
+  if (!vb) {
+    return null;
+  }
+  const cx = vb.x;
+  const cy = vb.y + vb.height;
+  return (
+    <g>
+      <circle
+        cx={cx}
+        cy={cy}
+        r={3}
+        className="text-gray-300 dark:text-gray-300-night"
+        fill="currentColor"
+      />
+    </g>
+  );
+}
+
+export function VersionMarkersDots({
+  mode,
+  versionMarkers,
+}: {
+  mode: ObservabilityMode;
+  versionMarkers: Marker[];
+}) {
+  if (mode !== "timeRange" || versionMarkers.length === 0) {
+    return null;
+  }
+  return (
+    <>
+      {versionMarkers.map((m) => (
+        <ReferenceLine
+          key={m.timestamp}
+          x={m.timestamp}
+          className="text-gray-300 dark:text-gray-300-night"
+          stroke="currentColor"
+          strokeDasharray="5 5"
+          strokeWidth={1}
+          ifOverflow="extendDomain"
+          label={<MarkerDotLabel />}
+        />
+      ))}
+    </>
+  );
+}


### PR DESCRIPTION
## Description

This PR standardizes chart UI patterns and improves visual consistency across observability charts. It introduces a `legendFromConstant` helper function to dynamically generate legend entries from chart constants, and adds a new `VersionMarkersDots` component that renders version markers as dots on the x-axis instead of full vertical reference lines. Chart descriptions are added to provide context for each metric, and the legend description for Tool Usage is moved into the `ChartContainer` component for consistency.

## Risk

Low

## Tests

- [x] Locally
- [ ] front-edge

## Deploy Plan

Deploy front