### PR TITLE
[Workspace Analytics] Include inactive exports toggle

### DIFF
--- a/front/components/workspace/ActivityReport.tsx
+++ b/front/components/workspace/ActivityReport.tsx
@@ -72,7 +72,7 @@ export function ActivityReport({
                 }}
               />
               <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                Adds members and agents without messages to the exports.
+                Include members and agents without messages.
               </div>
             </div>
           </div>

--- a/front/components/workspace/ActivityReport.tsx
+++ b/front/components/workspace/ActivityReport.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Checkbox,
   ContextItem,
   GoogleSpreadsheetLogo,
   Icon,
@@ -13,6 +14,8 @@ interface ActivityReportProps {
   monthOptions: string[];
   downloadingMonth: string | null;
   handleDownload: (selectedMonth: string | null) => void;
+  includeInactive: boolean;
+  onIncludeInactiveChange: (value: boolean) => void;
 }
 
 const maxItemsPerPage = 4;
@@ -21,6 +24,8 @@ export function ActivityReport({
   monthOptions,
   downloadingMonth,
   handleDownload,
+  includeInactive,
+  onIncludeInactiveChange,
 }: ActivityReportProps) {
   const [pagination, setPagination] = useState({
     pageIndex: 0,
@@ -58,6 +63,18 @@ export function ActivityReport({
             <Page.P variant="secondary">
               Download workspace activity details.
             </Page.P>
+            <div className="flex flex-row items-center gap-2">
+              <Checkbox
+                label="Include inactive users and assistants"
+                checked={includeInactive}
+                onCheckedChange={() => {
+                  onIncludeInactiveChange(!includeInactive);
+                }}
+              />
+              <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                Adds members and agents without messages to the exports.
+              </div>
+            </div>
           </div>
           <div className="flex h-full flex-col">
             <ContextItem.List>

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -494,7 +494,7 @@ export async function getUserUsageData(
     })) as MembershipWithUser[];
 
     const existingEmails = new Set(
-      userUsage.map((usage) => usage.userEmail.toLowerCase())
+      userUsage.map((usage) => usage.userEmail?.toLowerCase())
     );
 
     memberships.forEach((membership) => {

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -491,7 +491,7 @@ export async function getUserUsageData(
           attributes: ["id", "email", "name"],
         },
       ],
-    })) as MembershipWithUser[];
+    })) satisfies MembershipWithUser[];
 
     const existingEmails = new Set(
       userUsage.map((usage) => usage.userEmail?.toLowerCase())
@@ -679,8 +679,8 @@ export async function getAssistantsUsageData(
              END                                         AS "settings",
              ac."modelId",
              ac."providerId",
-             ARRAY_REMOVE(ARRAY_AGG(DISTINCT aut."email"), NULL)::text[]
-                                                       AS "authorEmails",
+             ARRAY_REMOVE(ARRAY_AGG(DISTINCT aut."email"), NULL)::text[] 
+                                                         AS "authorEmails",
              COUNT(a."id")                               AS "messages",
              COUNT(DISTINCT u."id")                      AS "distinctUsersReached",
              COUNT(DISTINCT m."conversationId")          AS "distinctConversations",
@@ -691,7 +691,7 @@ export async function getAssistantsUsageData(
       FROM "agent_configurations" ac
              LEFT JOIN "users" aut ON ac."authorId" = aut."id"
              LEFT JOIN "agent_messages" a
-                       ON a."agentConfigurationId" = ac."sId"
+                      ON a."agentConfigurationId" = ac."sId"
                       AND a."status" = 'succeeded'
                       AND a."createdAt" BETWEEN :startDate AND :endDate
              LEFT JOIN "messages" m ON a."id" = m."agentMessageId"

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -16,6 +16,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type {
@@ -81,7 +82,8 @@ interface AgentUsageQueryResult {
   authorEmails: string[];
   messages: number;
   distinctUsersReached: number;
-  lastConfiguration: Date;
+  distinctConversations: number;
+  lastEdit: Date;
 }
 
 interface FeedbackQueryResult {
@@ -103,6 +105,10 @@ type GroupMembershipQueryResult = {
 
 type GroupMembershipWithGroup = GroupMembershipModel & {
   group: GroupModel;
+};
+
+type MembershipWithUser = MembershipModel & {
+  user: UserModel;
 };
 
 export async function unsafeGetUsageData(
@@ -328,9 +334,11 @@ export async function getUserGroupMemberships(
 export async function getUserUsageData(
   startDate: Date,
   endDate: Date,
-  workspace: WorkspaceType
+  workspace: WorkspaceType,
+  options?: { includeInactive?: boolean }
 ): Promise<string> {
   const wId = workspace.id;
+  const includeInactiveUsers = options?.includeInactive ?? false;
 
   const allUserMessages = await getFrontReplicaDbConnection().transaction(
     async (t) => {
@@ -467,6 +475,61 @@ export async function getUserUsageData(
     (a, b) => b.messageCount - a.messageCount
   );
 
+  if (includeInactiveUsers) {
+    const memberships = (await MembershipModel.findAll({
+      where: {
+        workspaceId: wId,
+        [Op.and]: [
+          { startAt: { [Op.lte]: endDate } },
+          { [Op.or]: [{ endAt: null }, { endAt: { [Op.gte]: startDate } }] },
+        ],
+      },
+      include: [
+        {
+          model: UserModel,
+          required: true,
+          attributes: ["id", "email", "name"],
+        },
+      ],
+    })) as MembershipWithUser[];
+
+    const existingEmails = new Set(
+      userUsage.map((usage) => usage.userEmail.toLowerCase())
+    );
+
+    memberships.forEach((membership) => {
+      const user = membership.user;
+      if (!user) {
+        return;
+      }
+
+      const email = user.email.toLowerCase();
+      if (existingEmails.has(email)) {
+        return;
+      }
+
+      const userId = membership.userId.toString();
+
+      userUsage.push({
+        userName: user.name || email,
+        userEmail: email,
+        messageCount: 0,
+        lastMessageSent: "",
+        activeDaysCount: 0,
+        groups: userGroupsMap[userId] || "",
+      });
+
+      existingEmails.add(email);
+    });
+
+    userUsage.sort((a, b) => {
+      if (b.messageCount !== a.messageCount) {
+        return b.messageCount - a.messageCount;
+      }
+      return a.userEmail.localeCompare(b.userEmail);
+    });
+  }
+
   if (!userUsage.length) {
     return "No data available for the selected period.";
   }
@@ -598,47 +661,48 @@ export async function getAssistantUsageData(
 export async function getAssistantsUsageData(
   startDate: Date,
   endDate: Date,
-  workspace: WorkspaceType
+  workspace: WorkspaceType,
+  options?: { includeInactive?: boolean }
 ): Promise<string> {
   const wId = workspace.id;
+  const includeInactiveAgents = options?.includeInactive ?? false;
   const readReplica = getFrontReplicaDbConnection();
   // eslint-disable-next-line dust/no-raw-sql -- Leggit
-  const mentions = await readReplica.query<AgentUsageQueryResult>(
+  const agents = await readReplica.query<AgentUsageQueryResult>(
     `
       SELECT ac."name",
              ac."description",
-             ac."modelId",
-             ac."providerId",
              CASE
                WHEN ac."scope" = 'visible' THEN 'published'
                WHEN ac."scope" = 'hidden' THEN 'unpublished'
                ELSE 'unknown'
-               END                              AS "settings",
-             ARRAY_AGG(DISTINCT aut."email")    AS "authorEmails",
-             COUNT(a."id")                      AS "messages",
-             COUNT(DISTINCT u."id")             AS "distinctUsersReached",
-             COUNT(DISTINCT m."conversationId") AS "distinctConversations",
-             MAX(CAST(ac."createdAt" AS DATE))  AS "lastEdit"
-      FROM "agent_messages" a
-             JOIN "messages" m ON a."id" = m."agentMessageId"
+             END                                         AS "settings",
+             ac."modelId",
+             ac."providerId",
+             ARRAY_REMOVE(ARRAY_AGG(DISTINCT aut."email"), NULL)::text[]
+                                                       AS "authorEmails",
+             COUNT(a."id")                               AS "messages",
+             COUNT(DISTINCT u."id")                      AS "distinctUsersReached",
+             COUNT(DISTINCT m."conversationId")          AS "distinctConversations",
+             COALESCE(
+               MAX(CAST(ac."updatedAt" AS DATE)),
+               MAX(CAST(ac."createdAt" AS DATE))
+             )                                           AS "lastEdit"
+      FROM "agent_configurations" ac
+             LEFT JOIN "users" aut ON ac."authorId" = aut."id"
+             LEFT JOIN "agent_messages" a
+                       ON a."agentConfigurationId" = ac."sId"
+                      AND a."status" = 'succeeded'
+                      AND a."createdAt" BETWEEN :startDate AND :endDate
+             LEFT JOIN "messages" m ON a."id" = m."agentMessageId"
              LEFT JOIN "messages" parent ON m."parentId" = parent."id"
              LEFT JOIN "user_messages" um ON um."id" = parent."userMessageId"
              LEFT JOIN "users" u ON um."userId" = u."id"
-             JOIN "agent_configurations" ac ON a."agentConfigurationId" = ac."sId"
-             JOIN "users" aut ON ac."authorId" = aut."id"
-      WHERE a."status" = 'succeeded'
-        AND a."createdAt" BETWEEN :startDate AND :endDate
-        AND ac."workspaceId" = :wId
+      WHERE ac."workspaceId" = :wId
         AND ac."status" = 'active'
         AND ac."scope" != 'hidden'
-      GROUP BY
-        ac."name",
-        ac."description",
-        ac."scope",
-        ac."modelId",
-        ac."providerId"
-      ORDER BY
-        "messages" DESC;
+      GROUP BY ac."id"
+      ORDER BY "messages" DESC, ac."name" ASC;
     `,
     {
       type: QueryTypes.SELECT,
@@ -649,10 +713,14 @@ export async function getAssistantsUsageData(
       },
     }
   );
-  if (!mentions.length) {
+  const filteredAgents = includeInactiveAgents
+    ? agents
+    : agents.filter((agent) => agent.messages > 0);
+
+  if (!filteredAgents.length) {
     return "No data available for the selected period.";
   }
-  return generateCsvFromQueryResult(mentions);
+  return generateCsvFromQueryResult(filteredAgents);
 }
 
 export async function getFeedbackUsageData(

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -494,9 +494,7 @@ export async function getUserUsageData(
     })) satisfies MembershipWithUser[];
 
     const existingEmails = new Set(
-      userUsage
-        .filter((usage) => usage.userEmail)
-        .map((usage) => usage.userEmail.toLowerCase())
+      userUsage.map((usage) => usage.userEmail?.toLowerCase())
     );
 
     memberships.forEach((membership) => {
@@ -527,6 +525,12 @@ export async function getUserUsageData(
     userUsage.sort((a, b) => {
       if (b.messageCount !== a.messageCount) {
         return b.messageCount - a.messageCount;
+      }
+      if (!b.userEmail) {
+        return -1;
+      }
+      if (!a.userEmail) {
+        return 1;
       }
       return a.userEmail.localeCompare(b.userEmail);
     });

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -494,7 +494,9 @@ export async function getUserUsageData(
     })) satisfies MembershipWithUser[];
 
     const existingEmails = new Set(
-      userUsage.map((usage) => usage.userEmail?.toLowerCase())
+      userUsage
+        .filter((usage) => usage.userEmail)
+        .map((usage) => usage.userEmail.toLowerCase())
     );
 
     memberships.forEach((membership) => {

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -82,6 +82,12 @@ import { assertNever } from "@app/types";
  *         schema:
  *           type: string
  *           enum: [users, inactive_users, assistant_messages, builders, assistants, feedback, all]
+ *       - in: query
+ *         name: includeInactive
+ *         required: false
+ *         description: Include users and assistants with zero messages in the export (defaults to false)
+ *         schema:
+ *           type: boolean
  *     responses:
  *       200:
  *         description: The usage data in CSV or JSON format, or a ZIP of multiple CSVs if table is equal to "all"

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -137,6 +137,7 @@ async function handler(
       }
 
       const query = r.data;
+      const includeInactive = query.includeInactive ?? false;
 
       // Add validation for JSON format with 'all' table
       if (query.format === "json" && query.table === "all") {
@@ -156,6 +157,7 @@ async function handler(
         start: startDate,
         end: endDate,
         workspace: owner,
+        includeInactive,
       });
 
       if (query.format === "json") {
@@ -253,15 +255,21 @@ async function fetchUsageData({
   start,
   end,
   workspace,
+  includeInactive = false,
 }: {
   table: UsageTableType;
   start: Date;
   end: Date;
   workspace: WorkspaceType;
+  includeInactive?: boolean;
 }): Promise<Partial<Record<UsageTableType, string>>> {
   switch (table) {
     case "users":
-      return { users: await getUserUsageData(start, end, workspace) };
+      return {
+        users: await getUserUsageData(start, end, workspace, {
+          includeInactive,
+        }),
+      };
     case "assistant_messages":
       return {
         assistant_messages: await getMessageUsageData(start, end, workspace),
@@ -270,7 +278,9 @@ async function fetchUsageData({
       return { builders: await getBuildersUsageData(start, end, workspace) };
     case "assistants":
       return {
-        assistants: await getAssistantsUsageData(start, end, workspace),
+        assistants: await getAssistantsUsageData(start, end, workspace, {
+          includeInactive,
+        }),
       };
     case "feedback":
       return {
@@ -279,10 +289,10 @@ async function fetchUsageData({
     case "all":
       const [users, assistant_messages, builders, assistants, feedback] =
         await Promise.all([
-          getUserUsageData(start, end, workspace),
+          getUserUsageData(start, end, workspace, { includeInactive }),
           getMessageUsageData(start, end, workspace),
           getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace),
+          getAssistantsUsageData(start, end, workspace, { includeInactive }),
           getFeedbackUsageData(start, end, workspace),
         ]);
       return {

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -73,7 +73,6 @@ import { assertNever } from "@app/types";
  *         description: |
  *           The name of the usage table to retrieve:
  *           - "users": The list of users categorized by their activity level.
- *           - "inactive_users": The of users that didn't sent any messages
  *           - "assistant_messages": The list of messages sent by users including the mentioned agents.
  *           - "builders": The list of builders categorized by their activity level.
  *           - "assistants": The list of workspace agents and their corresponding usage.
@@ -81,7 +80,7 @@ import { assertNever } from "@app/types";
  *           - "all": A concatenation of all the above tables.
  *         schema:
  *           type: string
- *           enum: [users, inactive_users, assistant_messages, builders, assistants, feedback, all]
+ *           enum: [users, assistant_messages, builders, assistants, feedback, all]
  *       - in: query
  *         name: includeInactive
  *         required: false

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -31,7 +31,7 @@ const usageTables = [
   "assistants",
   "feedback",
   "all",
-];
+] as const;
 type usageTableType = (typeof usageTables)[number];
 
 function getSupportedUsageTablesCodec(): t.Mixed {

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -98,12 +98,17 @@ async function handler(
 
       const query = queryValidation.right;
       const { endDate, startDate } = resolveDates(query);
+      const includeInactiveParam = req.query.includeInactive;
+      const includeInactive = Array.isArray(includeInactiveParam)
+        ? includeInactiveParam[0] === "true"
+        : includeInactiveParam === "true";
 
       const csvData = await fetchUsageData({
         table: query.table,
         start: startDate,
         end: endDate,
         workspace: owner,
+        includeInactive,
       });
       if (query.table === "all") {
         const zip = new JSZip();
@@ -175,15 +180,21 @@ async function fetchUsageData({
   start,
   end,
   workspace,
+  includeInactive = false,
 }: {
   table: usageTableType;
   start: Date;
   end: Date;
   workspace: WorkspaceType;
+  includeInactive?: boolean;
 }): Promise<Partial<Record<usageTableType, string>>> {
   switch (table) {
     case "users":
-      return { users: await getUserUsageData(start, end, workspace) };
+      return {
+        users: await getUserUsageData(start, end, workspace, {
+          includeInactive,
+        }),
+      };
     case "assistant_messages":
       return { mentions: await getMessageUsageData(start, end, workspace) };
     case "builders":
@@ -194,15 +205,17 @@ async function fetchUsageData({
       };
     case "assistants":
       return {
-        assistants: await getAssistantsUsageData(start, end, workspace),
+        assistants: await getAssistantsUsageData(start, end, workspace, {
+          includeInactive,
+        }),
       };
     case "all":
       const [users, assistant_messages, builders, assistants, feedback] =
         await Promise.all([
-          getUserUsageData(start, end, workspace),
+          getUserUsageData(start, end, workspace, { includeInactive }),
           getMessageUsageData(start, end, workspace),
           getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace),
+          getAssistantsUsageData(start, end, workspace, { includeInactive }),
           getFeedbackUsageData(start, end, workspace),
         ]);
       return { users, assistant_messages, builders, assistants, feedback };

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -31,7 +31,8 @@ const usageTables = [
   "assistants",
   "feedback",
   "all",
-] as const;
+];
+
 type usageTableType = (typeof usageTables)[number];
 
 function getSupportedUsageTablesCodec(): t.Mixed {

--- a/front/pages/w/[wId]/analytics/index.tsx
+++ b/front/pages/w/[wId]/analytics/index.tsx
@@ -36,6 +36,7 @@ export default function Analytics({
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [downloadingMonth, setDownloadingMonth] = useState<string | null>(null);
+  const [includeInactive, setIncludeInactive] = useState(false);
 
   const { subscriptions } = useWorkspaceSubscriptions({
     owner,
@@ -46,12 +47,19 @@ export default function Analytics({
       return;
     }
 
-    const queryString = `mode=month&start=${selectedMonth}&table=all`;
+    const queryParams = new URLSearchParams({
+      mode: "month",
+      start: selectedMonth,
+      table: "all",
+    });
+    if (includeInactive) {
+      queryParams.set("includeInactive", "true");
+    }
 
     setDownloadingMonth(selectedMonth);
     try {
       const response = await fetch(
-        `/api/w/${owner.sId}/workspace-usage?${queryString}`
+        `/api/w/${owner.sId}/workspace-usage?${queryParams.toString()}`
       );
 
       if (!response.ok) {
@@ -156,6 +164,8 @@ export default function Analytics({
               downloadingMonth={downloadingMonth}
               monthOptions={monthOptions}
               handleDownload={handleDownload}
+              includeInactive={includeInactive}
+              onIncludeInactiveChange={setIncludeInactive}
             />
           </div>
         </Page.Vertical>

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -4404,18 +4404,26 @@
             "in": "query",
             "name": "table",
             "required": true,
-            "description": "The name of the usage table to retrieve:\n- \"users\": The list of users categorized by their activity level.\n- \"inactive_users\": The of users that didn't sent any messages\n- \"assistant_messages\": The list of messages sent by users including the mentioned agents.\n- \"builders\": The list of builders categorized by their activity level.\n- \"assistants\": The list of workspace agents and their corresponding usage.\n- \"feedback\": The list of feedback given by users on the agent messages.\n- \"all\": A concatenation of all the above tables.\n",
+            "description": "The name of the usage table to retrieve:\n- \"users\": The list of users categorized by their activity level.\n- \"assistant_messages\": The list of messages sent by users including the mentioned agents.\n- \"builders\": The list of builders categorized by their activity level.\n- \"assistants\": The list of workspace agents and their corresponding usage.\n- \"feedback\": The list of feedback given by users on the agent messages.\n- \"all\": A concatenation of all the above tables.\n",
             "schema": {
               "type": "string",
               "enum": [
                 "users",
-                "inactive_users",
                 "assistant_messages",
                 "builders",
                 "assistants",
                 "feedback",
                 "all"
               ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "includeInactive",
+            "required": false,
+            "description": "Include users and assistants with zero messages in the export (defaults to false)",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2545,6 +2545,26 @@ const DateSchema = z
     "YYYY-MM or YYYY-MM-DD"
   );
 
+const IncludeInactiveSchema = z.preprocess((value) => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    const [first] = value;
+    if (first === undefined) {
+      return undefined;
+    }
+    return first === "true" || first === true;
+  }
+  if (typeof value === "string") {
+    return value === "true";
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return undefined;
+}, z.boolean().optional());
+
 export const GetWorkspaceUsageRequestSchema = z.union([
   z.object({
     start: DateSchema,
@@ -2552,6 +2572,7 @@ export const GetWorkspaceUsageRequestSchema = z.union([
     mode: z.literal("month"),
     table: SupportedUsageTablesSchema,
     format: z.enum(["csv", "json"]).optional().default("csv"),
+    includeInactive: IncludeInactiveSchema,
   }),
   z.object({
     start: DateSchema,
@@ -2559,6 +2580,7 @@ export const GetWorkspaceUsageRequestSchema = z.union([
     mode: z.literal("range"),
     table: SupportedUsageTablesSchema,
     format: z.enum(["csv", "json"]).optional().default("csv"),
+    includeInactive: IncludeInactiveSchema,
   }),
 ]);
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5006
- Add UI toggle on admin analytics page to include inactive users and assistants in downloads.
- Plumb includeInactive through usage export APIs and shared schema.
- Extend export builders to merge zero-activity members and agents when requested.

## Risks
Blast radius: Workspace analytics exports requested via admin UI or API
Risk: standard

## Deploy Plan
- deploy front
