### PR TITLE
[front] perf: Remove openai-image in favor of gemini 2.5 flash image

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -1,6 +1,5 @@
 import { GoogleGenAI } from "@google/genai";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import OpenAI from "openai";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
@@ -9,7 +8,6 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
@@ -19,7 +17,6 @@ import { GEMINI_2_5_FLASH_IMAGE_MODEL_ID } from "@app/types/assistant/models/goo
 const IMAGE_GENERATION_RATE_LIMITER_KEY = "image_generation";
 const IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS = 60 * 60 * 24 * 7; // 1 week.
 
-// By default, OpenAI returns a PNG image.
 const DEFAULT_IMAGE_OUTPUT_FORMAT = "png";
 const DEFAULT_IMAGE_MIME_TYPE = "image/png";
 
@@ -44,19 +41,6 @@ function isValidGeminiInlineDataPart(
   part: unknown
 ): part is GeminiInlineDataPart {
   return GeminiInlineDataPartSchema.safeParse(part).success;
-}
-
-const OpenAIImageWithDataSchema = z.object({
-  b64_json: z.string(),
-});
-
-type OpenAIImageWithData = z.infer<typeof OpenAIImageWithDataSchema>;
-
-// Type guard to validate OpenAI images with data.
-function isValidOpenAIImageWithData(
-  image: unknown
-): image is OpenAIImageWithData {
-  return OpenAIImageWithDataSchema.safeParse(image).success;
 }
 
 function createServer(
@@ -105,11 +89,6 @@ function createServer(
       async ({ prompt, name, quality, size }, { sendNotification, _meta }) => {
         const workspace = auth.getNonNullableWorkspace();
 
-        // Check if Gemini feature flag is enabled.
-        const featureFlags = await getFeatureFlags(workspace);
-        const useGemini = featureFlags.includes("gemini_image_generation");
-        const provider = useGemini ? "gemini" : "openai";
-
         if (_meta?.progressToken) {
           const notification: MCPProgressNotificationType = {
             method: "notifications/progress",
@@ -146,12 +125,12 @@ function createServer(
         statsDClient.increment("tools.image_generation.generated", 1, [
           `quality:${quality}`,
           `size:${size}`,
-          `provider:${provider}`,
+          `provider:gemini`,
         ]);
 
         if (remaining <= 0) {
           statsDClient.increment("tools.image_generation.rate_limit_hit", 1, [
-            `provider:${provider}`,
+            `provider:gemini`,
           ]);
 
           return new Err(
@@ -168,156 +147,86 @@ function createServer(
         try {
           const credentials = dustManagedCredentials();
 
-          if (useGemini) {
-            // Use Gemini for image generation.
-            const gemini = new GoogleGenAI({
-              apiKey: credentials.GOOGLE_AI_STUDIO_API_KEY,
-            });
+          const gemini = new GoogleGenAI({
+            apiKey: credentials.GOOGLE_AI_STUDIO_API_KEY,
+          });
 
-            const aspectRatio =
-              SIZE_TO_ASPECT_RATIO[size] || SIZE_TO_ASPECT_RATIO["1024x1024"];
+          const aspectRatio =
+            SIZE_TO_ASPECT_RATIO[size] || SIZE_TO_ASPECT_RATIO["1024x1024"];
 
-            const response = await gemini.models.generateContent({
-              model: GEMINI_2_5_FLASH_IMAGE_MODEL_ID,
-              contents: prompt,
-              config: {
-                temperature: 0.7,
-                responseModalities: ["IMAGE"],
-                candidateCount: 1,
-                imageConfig: {
-                  aspectRatio,
-                },
+          const response = await gemini.models.generateContent({
+            model: GEMINI_2_5_FLASH_IMAGE_MODEL_ID,
+            contents: prompt,
+            config: {
+              temperature: 0.7,
+              responseModalities: ["IMAGE"],
+              candidateCount: 1,
+              imageConfig: {
+                aspectRatio,
               },
-            });
+            },
+          });
 
-            if (!response.candidates || response.candidates.length === 0) {
-              // Check if prompt was blocked by safety filters
-              if (response.promptFeedback?.blockReason) {
-                logger.error(
-                  {
-                    blockReason: response.promptFeedback.blockReason,
-                    safetyRatings: response.promptFeedback.safetyRatings,
-                    prompt,
-                  },
-                  "Gemini image generation: Prompt blocked by safety filters"
-                );
-                return new Err(
-                  new MCPError(
-                    `Image generation blocked by safety filters: ${response.promptFeedback.blockReason}`
-                  )
-                );
-              }
-              return new Err(new MCPError("No image generated."));
+          if (!response.candidates || response.candidates.length === 0) {
+            // Check if prompt was blocked by safety filters
+            if (response.promptFeedback?.blockReason) {
+              logger.error(
+                {
+                  blockReason: response.promptFeedback.blockReason,
+                  safetyRatings: response.promptFeedback.safetyRatings,
+                  prompt,
+                },
+                "Gemini image generation: Prompt blocked by safety filters"
+              );
+              return new Err(
+                new MCPError(
+                  `Image generation blocked by safety filters: ${response.promptFeedback.blockReason}`
+                )
+              );
             }
-
-            const content = response.candidates[0].content;
-
-            if (!content || !content.parts) {
-              return new Err(new MCPError("No image data in response"));
-            }
-
-            const imageParts = content.parts.filter(
-              isValidGeminiInlineDataPart
-            );
-
-            if (imageParts.length === 0) {
-              return new Err(new MCPError("No image data in response."));
-            }
-
-            statsDClient.increment(
-              "tools.image_generation.usage.input_tokens",
-              response.usageMetadata?.promptTokenCount ?? 0,
-              [`provider:${provider}`]
-            );
-            statsDClient.increment(
-              "tools.image_generation.usage.output_tokens",
-              response.usageMetadata?.candidatesTokenCount ?? 0,
-              [`provider:${provider}`]
-            );
-
-            const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
-
-            return new Ok(
-              imageParts.map((part) => ({
-                type: "image" as const,
-                mimeType: part.inlineData.mimeType ?? DEFAULT_IMAGE_MIME_TYPE,
-                data: part.inlineData.data,
-                name: fileName,
-              }))
-            );
-          } else {
-            // Use OpenAI for image generation.
-            const openai = new OpenAI({
-              apiKey: credentials.OPENAI_API_KEY,
-            });
-
-            const result = await openai.images.generate({
-              model: "gpt-image-1",
-              moderation: "low",
-              output_format: DEFAULT_IMAGE_OUTPUT_FORMAT,
-              prompt,
-              quality,
-              size,
-              user: `workspace-${workspace.sId}`,
-            });
-
-            statsDClient.increment(
-              "tools.image_generation.usage.input_tokens",
-              result.usage?.input_tokens ?? 0,
-              [`provider:${provider}`]
-            );
-            statsDClient.increment(
-              "tools.image_generation.usage.output_tokens",
-              result.usage?.output_tokens ?? 0,
-              [`provider:${provider}`]
-            );
-
-            if (!result.data) {
-              return new Err(new MCPError("No image generated."));
-            }
-
-            const imagesWithData = result.data.filter(
-              isValidOpenAIImageWithData
-            );
-
-            if (imagesWithData.length === 0) {
-              return new Err(new MCPError("No image data in response."));
-            }
-
-            const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
-
-            return new Ok(
-              imagesWithData.map((r) => ({
-                type: "image" as const,
-                mimeType: DEFAULT_IMAGE_MIME_TYPE,
-                data: r.b64_json,
-                name: fileName,
-              }))
-            );
+            return new Err(new MCPError("No image generated."));
           }
+
+          const content = response.candidates[0].content;
+
+          if (!content || !content.parts) {
+            return new Err(new MCPError("No image data in response"));
+          }
+
+          const imageParts = content.parts.filter(isValidGeminiInlineDataPart);
+
+          if (imageParts.length === 0) {
+            return new Err(new MCPError("No image data in response."));
+          }
+
+          statsDClient.increment(
+            "tools.image_generation.usage.input_tokens",
+            response.usageMetadata?.promptTokenCount ?? 0,
+            [`provider:gemini`]
+          );
+          statsDClient.increment(
+            "tools.image_generation.usage.output_tokens",
+            response.usageMetadata?.candidatesTokenCount ?? 0,
+            [`provider:gemini`]
+          );
+
+          const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
+
+          return new Ok(
+            imageParts.map((part) => ({
+              type: "image" as const,
+              mimeType: part.inlineData.mimeType ?? DEFAULT_IMAGE_MIME_TYPE,
+              data: part.inlineData.data,
+              name: fileName,
+            }))
+          );
         } catch (error) {
           logger.error(
             {
               error,
-              provider,
             },
             "Error generating image."
           );
-
-          if (error instanceof OpenAI.APIError) {
-            return new Err(
-              new MCPError(
-                `Error generating image. Image generation service error: Status: ` +
-                  `${error.status}, Code: ${error.code}, Message: ${error.message}`,
-                {
-                  // Don't track the error if we know it's not our fault: when openAI returns a 500, error.code is null.
-                  tracked:
-                    error.code !== null && error.code !== "moderation_blocked",
-                }
-              )
-            );
-          }
-
           return new Err(new MCPError("Error generating image."));
         }
       }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -58,11 +58,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to experimental Google AI Studio models",
     stage: "on_demand",
   },
-  gemini_image_generation: {
-    description:
-      "Use Gemini 2.5 Flash Image instead of OpenAI for image generation",
-    stage: "rolling_out",
-  },
   google_sheets_tool: {
     description: "Google Sheets MCP tool",
     stage: "rolling_out",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -661,7 +661,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "elevenlabs_tool"
   | "freshservice_tool"
   | "google_ai_studio_experimental_models_feature"
-  | "gemini_image_generation"
   | "google_sheets_tool"
   | "hootl_dev_webhooks"
   | "hootl_subscriptions"


### PR DESCRIPTION
## Description

Removes openai.image provider for `image_generation` tool

## Tests

Tested manually

## Risk

Low, banana has been on progressive rollout with no error recorded.

## Deploy Plan

- [ ] Deploy front in production