### PR TITLE
[front] chore(triggers): refactor error handling in filter parsing

### DIFF
--- a/front/components/agent_builder/triggers/TriggerFilterRenderer.tsx
+++ b/front/components/agent_builder/triggers/TriggerFilterRenderer.tsx
@@ -153,30 +153,24 @@ export function TriggerFilterRenderer({ data }: TriggerFilterRendererProps) {
     return null;
   }
 
-  try {
-    const parsedData = parseMatcherExpression(data);
+  const parseResult = parseMatcherExpression(data);
 
-    return (
-      <div className="overflow-hidden rounded-xl border border-border px-4 py-4">
-        <div className="max-w-full overflow-x-auto text-sm">
-          <ExpressionNode expression={parsedData} />
-        </div>
-      </div>
-    );
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error &&
-      "message" in error &&
-      typeof error.message === "string"
-        ? error.message
-        : "unknown error";
+  if (parseResult.isErr()) {
     return (
       <div className="overflow-hidden px-4 py-4">
         <p className="text-sm text-warning">
-          Error parsing filter expression: {errorMessage}. Please check the
-          filter syntax.
+          Error parsing filter expression: {parseResult.error.message}. Please
+          check the filter syntax.
         </p>
       </div>
     );
   }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border px-4 py-4">
+      <div className="max-w-full overflow-x-auto text-sm">
+        <ExpressionNode expression={parseResult.value} />
+      </div>
+    </div>
+  );
 }

--- a/front/lib/matcher/matcher.test.ts
+++ b/front/lib/matcher/matcher.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import { matchPayload } from "./matcher";
 import { parseMatcherExpression } from "./parser";
+import type { MatcherExpression } from "./types";
+
+function parse(expression: string): MatcherExpression {
+  const result = parseMatcherExpression(expression);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}
 
 describe("matchPayload", () => {
   const samplePayload = {
@@ -22,212 +31,212 @@ describe("matchPayload", () => {
 
   describe("equality operator", () => {
     it("should match string equality", () => {
-      const matcher = parseMatcherExpression('(eq "user.name" "Alice")');
+      const matcher = parse('(eq "user.name" "Alice")');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match incorrect string", () => {
-      const matcher = parseMatcherExpression('(eq "user.name" "Bob")');
+      const matcher = parse('(eq "user.name" "Bob")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should match number equality", () => {
-      const matcher = parseMatcherExpression('(eq "count" 42)');
+      const matcher = parse('(eq "count" 42)');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should match boolean equality", () => {
-      const matcher = parseMatcherExpression('(eq "user.active" true)');
+      const matcher = parse('(eq "user.active" true)');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match wrong boolean", () => {
-      const matcher = parseMatcherExpression('(eq "user.active" false)');
+      const matcher = parse('(eq "user.active" false)');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should not match non-existent field", () => {
-      const matcher = parseMatcherExpression('(eq "nonexistent" "value")');
+      const matcher = parse('(eq "nonexistent" "value")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
   });
 
   describe("string operators", () => {
     it("should match starts-with", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(starts-with "user.email" "alice@")'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match incorrect prefix", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(starts-with "user.email" "bob@")'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should not match starts-with on non-string", () => {
-      const matcher = parseMatcherExpression('(starts-with "count" "42")');
+      const matcher = parse('(starts-with "count" "42")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
   });
 
   describe("array operators", () => {
     it("should match has single value", () => {
-      const matcher = parseMatcherExpression('(has "tags" "urgent")');
+      const matcher = parse('(has "tags" "urgent")');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match absent value", () => {
-      const matcher = parseMatcherExpression('(has "tags" "backend")');
+      const matcher = parse('(has "tags" "backend")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should match has-all when all values present", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(has-all "tags" ("urgent" "bug"))'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match has-all when one value missing", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(has-all "tags" ("urgent" "missing"))'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should match has-any when at least one value present", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(has-any "tags" ("missing" "urgent"))'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match has-any when no values present", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(has-any "tags" ("missing1" "missing2"))'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should not match array operators on non-array", () => {
-      const matcher = parseMatcherExpression('(has "user.name" "Alice")');
+      const matcher = parse('(has "user.name" "Alice")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
   });
 
   describe("numeric operators", () => {
     it("should match gt", () => {
-      const matcher = parseMatcherExpression('(gt "user.age" 25)');
+      const matcher = parse('(gt "user.age" 25)');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match gt when equal", () => {
-      const matcher = parseMatcherExpression('(gt "user.age" 30)');
+      const matcher = parse('(gt "user.age" 30)');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should match gte when equal", () => {
-      const matcher = parseMatcherExpression('(gte "user.age" 30)');
+      const matcher = parse('(gte "user.age" 30)');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should match gte when greater", () => {
-      const matcher = parseMatcherExpression('(gte "user.age" 25)');
+      const matcher = parse('(gte "user.age" 25)');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should match lt", () => {
-      const matcher = parseMatcherExpression('(lt "user.age" 35)');
+      const matcher = parse('(lt "user.age" 35)');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match lt when equal", () => {
-      const matcher = parseMatcherExpression('(lt "user.age" 30)');
+      const matcher = parse('(lt "user.age" 30)');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should match lte when equal", () => {
-      const matcher = parseMatcherExpression('(lte "user.age" 30)');
+      const matcher = parse('(lte "user.age" 30)');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should match lte when less", () => {
-      const matcher = parseMatcherExpression('(lte "user.age" 35)');
+      const matcher = parse('(lte "user.age" 35)');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match numeric operators on non-numbers", () => {
-      const matcher = parseMatcherExpression('(gt "user.name" 10)');
+      const matcher = parse('(gt "user.name" 10)');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
   });
 
   describe("existence operator", () => {
     it("should match exists for present field", () => {
-      const matcher = parseMatcherExpression('(exists "user.name")');
+      const matcher = parse('(exists "user.name")');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should match exists for nested field", () => {
-      const matcher = parseMatcherExpression('(exists "metadata.source")');
+      const matcher = parse('(exists "metadata.source")');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match exists for absent field", () => {
-      const matcher = parseMatcherExpression('(exists "nonexistent")');
+      const matcher = parse('(exists "nonexistent")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should not match exists for nested absent field", () => {
-      const matcher = parseMatcherExpression('(exists "user.missing.field")');
+      const matcher = parse('(exists "user.missing.field")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
   });
 
   describe("logical operators", () => {
     it("should match AND when all conditions true", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(and (eq "user.name" "Alice") (eq "user.age" 30))'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match AND when one condition false", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(and (eq "user.name" "Alice") (eq "user.age" 25))'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should match OR when at least one condition true", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(or (eq "user.name" "Bob") (eq "user.age" 30))'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match OR when all conditions false", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(or (eq "user.name" "Bob") (eq "user.age" 25))'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should match NOT when condition false", () => {
-      const matcher = parseMatcherExpression('(not (eq "user.name" "Bob"))');
+      const matcher = parse('(not (eq "user.name" "Bob"))');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match NOT when condition true", () => {
-      const matcher = parseMatcherExpression('(not (eq "user.name" "Alice"))');
+      const matcher = parse('(not (eq "user.name" "Alice"))');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should handle nested logical operators", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(and (or (eq "priority" 1) (eq "priority" 2)) (has "tags" "urgent"))'
       );
       expect(matchPayload(samplePayload, matcher)).toBe(true);
@@ -248,44 +257,44 @@ describe("matchPayload", () => {
     };
 
     it("should match wildcard path with has", () => {
-      const matcher = parseMatcherExpression('(has "items.*.name" "Item 2")');
+      const matcher = parse('(has "items.*.name" "Item 2")');
       expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(true);
     });
 
     it("should not match wildcard path when value absent", () => {
-      const matcher = parseMatcherExpression('(has "items.*.name" "Item 999")');
+      const matcher = parse('(has "items.*.name" "Item 999")');
       expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(false);
     });
 
     it("should match wildcard with has-all", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(has-all "items.*.status" ("active" "inactive"))'
       );
       expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(true);
     });
 
     it("should match wildcard with has-any", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(has-any "tags.*.label" ("urgent" "missing"))'
       );
       expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(true);
     });
 
     it("should not match wildcard on non-array", () => {
-      const matcher = parseMatcherExpression('(has "user.*.name" "value")');
+      const matcher = parse('(has "user.*.name" "value")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should handle wildcard with nested fields", () => {
-      const matcher = parseMatcherExpression('(eq "tags.*.color" "red")');
+      const matcher = parse('(eq "tags.*.color" "red")');
       expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(false);
       // eq doesn't work on arrays, but has would
-      const matcher2 = parseMatcherExpression('(has "tags.*.color" "red")');
+      const matcher2 = parse('(has "tags.*.color" "red")');
       expect(matchPayload(payloadWithArrayOfObjects, matcher2)).toBe(true);
     });
 
     it("should return undefined for missing array in wildcard path", () => {
-      const matcher = parseMatcherExpression('(has "missing.*.field" "value")');
+      const matcher = parse('(has "missing.*.field" "value")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
   });
@@ -319,42 +328,42 @@ describe("matchPayload", () => {
     };
 
     it("should match GitHub PR opened to main", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(and (eq "action" "opened") (eq "pull_request.base.ref" "main"))'
       );
       expect(matchPayload(githubPRPayload, matcher)).toBe(true);
     });
 
     it("should match PR with specific label", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(has "pull_request.labels.*.name" "feature")'
       );
       expect(matchPayload(githubPRPayload, matcher)).toBe(true);
     });
 
     it("should match PR with multiple required labels", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(has-all "pull_request.labels.*.name" ("feature" "high-priority"))'
       );
       expect(matchPayload(githubPRPayload, matcher)).toBe(true);
     });
 
     it("should match complex PR filter", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(and (eq "action" "opened") (eq "pull_request.base.ref" "main") (has "pull_request.labels.*.name" "high-priority"))'
       );
       expect(matchPayload(githubPRPayload, matcher)).toBe(true);
     });
 
     it("should match PR author and title pattern", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(and (eq "pull_request.user.login" "alice") (starts-with "pull_request.title" "[Feature]"))'
       );
       expect(matchPayload(githubPRPayload, matcher)).toBe(true);
     });
 
     it("should not match when conditions fail", () => {
-      const matcher = parseMatcherExpression(
+      const matcher = parse(
         '(and (eq "action" "opened") (has "pull_request.labels.*.name" "bug"))'
       );
       expect(matchPayload(githubPRPayload, matcher)).toBe(false);

--- a/front/lib/matcher/matcher.test.ts
+++ b/front/lib/matcher/matcher.test.ts
@@ -63,16 +63,12 @@ describe("matchPayload", () => {
 
   describe("string operators", () => {
     it("should match starts-with", () => {
-      const matcher = parse(
-        '(starts-with "user.email" "alice@")'
-      );
+      const matcher = parse('(starts-with "user.email" "alice@")');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match incorrect prefix", () => {
-      const matcher = parse(
-        '(starts-with "user.email" "bob@")'
-      );
+      const matcher = parse('(starts-with "user.email" "bob@")');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
@@ -94,30 +90,22 @@ describe("matchPayload", () => {
     });
 
     it("should match has-all when all values present", () => {
-      const matcher = parse(
-        '(has-all "tags" ("urgent" "bug"))'
-      );
+      const matcher = parse('(has-all "tags" ("urgent" "bug"))');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match has-all when one value missing", () => {
-      const matcher = parse(
-        '(has-all "tags" ("urgent" "missing"))'
-      );
+      const matcher = parse('(has-all "tags" ("urgent" "missing"))');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
     it("should match has-any when at least one value present", () => {
-      const matcher = parse(
-        '(has-any "tags" ("missing" "urgent"))'
-      );
+      const matcher = parse('(has-any "tags" ("missing" "urgent"))');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match has-any when no values present", () => {
-      const matcher = parse(
-        '(has-any "tags" ("missing1" "missing2"))'
-      );
+      const matcher = parse('(has-any "tags" ("missing1" "missing2"))');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
@@ -212,16 +200,12 @@ describe("matchPayload", () => {
     });
 
     it("should match OR when at least one condition true", () => {
-      const matcher = parse(
-        '(or (eq "user.name" "Bob") (eq "user.age" 30))'
-      );
+      const matcher = parse('(or (eq "user.name" "Bob") (eq "user.age" 30))');
       expect(matchPayload(samplePayload, matcher)).toBe(true);
     });
 
     it("should not match OR when all conditions false", () => {
-      const matcher = parse(
-        '(or (eq "user.name" "Bob") (eq "user.age" 25))'
-      );
+      const matcher = parse('(or (eq "user.name" "Bob") (eq "user.age" 25))');
       expect(matchPayload(samplePayload, matcher)).toBe(false);
     });
 
@@ -267,16 +251,12 @@ describe("matchPayload", () => {
     });
 
     it("should match wildcard with has-all", () => {
-      const matcher = parse(
-        '(has-all "items.*.status" ("active" "inactive"))'
-      );
+      const matcher = parse('(has-all "items.*.status" ("active" "inactive"))');
       expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(true);
     });
 
     it("should match wildcard with has-any", () => {
-      const matcher = parse(
-        '(has-any "tags.*.label" ("urgent" "missing"))'
-      );
+      const matcher = parse('(has-any "tags.*.label" ("urgent" "missing"))');
       expect(matchPayload(payloadWithArrayOfObjects, matcher)).toBe(true);
     });
 
@@ -335,9 +315,7 @@ describe("matchPayload", () => {
     });
 
     it("should match PR with specific label", () => {
-      const matcher = parse(
-        '(has "pull_request.labels.*.name" "feature")'
-      );
+      const matcher = parse('(has "pull_request.labels.*.name" "feature")');
       expect(matchPayload(githubPRPayload, matcher)).toBe(true);
     });
 

--- a/front/lib/matcher/parser.test.ts
+++ b/front/lib/matcher/parser.test.ts
@@ -10,8 +10,10 @@ describe("parseMatcherExpression", () => {
       const result = parseMatcherExpression(
         '(and (eq "field1" "value1") (eq "field2" "value2"))'
       );
-      expect(isLogicalExpression(result)).toBe(true);
-      const logical = result as LogicalExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isLogicalExpression(result.value)).toBe(true);
+      const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("and");
       expect(logical.expressions).toHaveLength(2);
     });
@@ -20,16 +22,20 @@ describe("parseMatcherExpression", () => {
       const result = parseMatcherExpression(
         '(or (eq "field1" "value1") (eq "field2" "value2"))'
       );
-      expect(isLogicalExpression(result)).toBe(true);
-      const logical = result as LogicalExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isLogicalExpression(result.value)).toBe(true);
+      const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("or");
       expect(logical.expressions).toHaveLength(2);
     });
 
     it("should parse NOT expression", () => {
       const result = parseMatcherExpression('(not (eq "field" "value"))');
-      expect(isLogicalExpression(result)).toBe(true);
-      const logical = result as LogicalExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isLogicalExpression(result.value)).toBe(true);
+      const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("not");
       expect(logical.expressions).toHaveLength(1);
     });
@@ -38,8 +44,10 @@ describe("parseMatcherExpression", () => {
       const result = parseMatcherExpression(
         '(and (or (eq "a" "1") (eq "b" "2")) (eq "c" "3"))'
       );
-      expect(isLogicalExpression(result)).toBe(true);
-      const logical = result as LogicalExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isLogicalExpression(result.value)).toBe(true);
+      const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("and");
       expect(logical.expressions).toHaveLength(2);
       expect(isLogicalExpression(logical.expressions[0])).toBe(true);
@@ -49,8 +57,10 @@ describe("parseMatcherExpression", () => {
   describe("equality operators", () => {
     it("should parse eq with string value", () => {
       const result = parseMatcherExpression('(eq "user.name" "Alice")');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("eq");
       expect(op.field).toBe("user.name");
       expect(op.value).toBe("Alice");
@@ -58,8 +68,10 @@ describe("parseMatcherExpression", () => {
 
     it("should parse eq with number value", () => {
       const result = parseMatcherExpression('(eq "count" 42)');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("eq");
       expect(op.field).toBe("count");
       expect(op.value).toBe(42);
@@ -67,8 +79,10 @@ describe("parseMatcherExpression", () => {
 
     it("should parse eq with boolean value", () => {
       const result = parseMatcherExpression('(eq "active" true)');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("eq");
       expect(op.field).toBe("active");
       expect(op.value).toBe(true);
@@ -78,8 +92,10 @@ describe("parseMatcherExpression", () => {
   describe("string operators", () => {
     it("should parse starts-with", () => {
       const result = parseMatcherExpression('(starts-with "email" "admin@")');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("starts-with");
       expect(op.field).toBe("email");
       expect(op.value).toBe("admin@");
@@ -89,8 +105,10 @@ describe("parseMatcherExpression", () => {
   describe("array operators", () => {
     it("should parse has", () => {
       const result = parseMatcherExpression('(has "tags" "urgent")');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("has");
       expect(op.field).toBe("tags");
       expect(op.value).toBe("urgent");
@@ -100,8 +118,10 @@ describe("parseMatcherExpression", () => {
       const result = parseMatcherExpression(
         '(has-all "tags" ("bug" "urgent"))'
       );
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("has-all");
       expect(op.field).toBe("tags");
       expect(op.values).toEqual(["bug", "urgent"]);
@@ -109,8 +129,10 @@ describe("parseMatcherExpression", () => {
 
     it("should parse has-any with array", () => {
       const result = parseMatcherExpression('(has-any "labels" ("p0" "p1"))');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("has-any");
       expect(op.field).toBe("labels");
       expect(op.values).toEqual(["p0", "p1"]);
@@ -120,8 +142,10 @@ describe("parseMatcherExpression", () => {
   describe("numeric operators", () => {
     it("should parse gt", () => {
       const result = parseMatcherExpression('(gt "age" 18)');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("gt");
       expect(op.field).toBe("age");
       expect(op.value).toBe(18);
@@ -129,24 +153,30 @@ describe("parseMatcherExpression", () => {
 
     it("should parse gte", () => {
       const result = parseMatcherExpression('(gte "score" 90)');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("gte");
       expect(op.value).toBe(90);
     });
 
     it("should parse lt", () => {
       const result = parseMatcherExpression('(lt "temperature" 100)');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("lt");
       expect(op.value).toBe(100);
     });
 
     it("should parse lte", () => {
       const result = parseMatcherExpression('(lte "price" 50.99)');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("lte");
       expect(op.value).toBe(50.99);
     });
@@ -155,8 +185,10 @@ describe("parseMatcherExpression", () => {
   describe("existence operator", () => {
     it("should parse exists", () => {
       const result = parseMatcherExpression('(exists "optional_field")');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("exists");
       expect(op.field).toBe("optional_field");
       expect(op.value).toBeUndefined();
@@ -168,8 +200,10 @@ describe("parseMatcherExpression", () => {
       const result = parseMatcherExpression(
         '(eq "message" "He said \\"hello\\"")'
       );
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.value).toBe('He said "hello"');
     });
 
@@ -177,84 +211,102 @@ describe("parseMatcherExpression", () => {
       const result = parseMatcherExpression(
         '(eq "user.profile.email" "test@example.com")'
       );
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.field).toBe("user.profile.email");
     });
 
     it("should parse wildcard paths", () => {
       const result = parseMatcherExpression('(has "tags.*.name" "urgent")');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.field).toBe("tags.*.name");
     });
   });
 
   describe("error handling", () => {
-    it("should throw on empty expression", () => {
-      expect(() => parseMatcherExpression("()")).toThrow("Empty expression");
+    it("should return error on empty expression", () => {
+      const result = parseMatcherExpression("()");
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toBe("Empty expression");
     });
 
-    it("should throw on unbalanced parentheses", () => {
-      expect(() => parseMatcherExpression('(eq "field" "value"')).toThrow(
-        "Unbalanced parentheses"
-      );
+    it("should return error on unbalanced parentheses", () => {
+      const result = parseMatcherExpression('(eq "field" "value"');
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toBe("Unbalanced parentheses");
     });
 
-    it("should throw on missing opening paren", () => {
-      expect(() => parseMatcherExpression('e(q "field" "value")')).toThrow(
-        "Expression must start with '('"
-      );
+    it("should return error on missing opening paren", () => {
+      const result = parseMatcherExpression('e(q "field" "value")');
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toBe("Expression must start with '('");
     });
 
-    it("should throw on unknown operator", () => {
-      expect(() => parseMatcherExpression('(unknown "field" "value")')).toThrow(
-        "Unknown operator: unknown"
-      );
+    it("should return error on unknown operator", () => {
+      const result = parseMatcherExpression('(unknown "field" "value")');
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toBe("Unknown operator: unknown");
     });
 
-    it("should throw on not with wrong arity", () => {
-      expect(() =>
-        parseMatcherExpression('(not (eq "a" "1") (eq "b" "2"))')
-      ).toThrow("not requires exactly one expression");
+    it("should return error on not with wrong arity", () => {
+      const result = parseMatcherExpression('(not (eq "a" "1") (eq "b" "2"))');
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toBe("not requires exactly one expression");
     });
 
-    it("should throw on missing field for eq", () => {
-      expect(() => parseMatcherExpression("(eq)")).toThrow(
-        "eq requires field and value(s)"
-      );
+    it("should return error on missing field for eq", () => {
+      const result = parseMatcherExpression("(eq)");
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toBe("eq requires field and value(s)");
     });
 
-    it("should throw on non-string field", () => {
-      expect(() => parseMatcherExpression("(eq 123 456)")).toThrow(
-        "Field must be a string"
-      );
+    it("should return error on non-string field", () => {
+      const result = parseMatcherExpression("(eq 123 456)");
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toBe("Field must be a string for eq");
     });
 
-    it("should throw on has-all without array", () => {
-      expect(() =>
-        parseMatcherExpression('(has-all "field" "single")')
-      ).toThrow("has-all requires a list of values");
+    it("should return error on has-all without array", () => {
+      const result = parseMatcherExpression('(has-all "field" "single")');
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toBe("has-all requires a list of values");
     });
 
-    it("should throw on unclosed string", () => {
-      expect(() => parseMatcherExpression('(eq "field" "unclosed)')).toThrow(
-        "Expected closing '\"'"
-      );
+    it("should return error on unclosed string", () => {
+      const result = parseMatcherExpression('(eq "field" "unclosed)');
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toContain("Expected closing '\"'");
     });
 
-    it("should throw on exists with wrong arity", () => {
-      expect(() => parseMatcherExpression('(exists "field" "extra")')).toThrow(
-        "exists requires exactly one expression"
-      );
+    it("should return error on exists with wrong arity", () => {
+      const result = parseMatcherExpression('(exists "field" "extra")');
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error.message).toBe("exists requires exactly one expression");
     });
   });
 
   describe("whitespace handling", () => {
     it("should handle extra whitespace", () => {
       const result = parseMatcherExpression('  (  eq   "field"   "value"  )  ');
-      expect(isOperationExpression(result)).toBe(true);
-      const op = result as OperationExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isOperationExpression(result.value)).toBe(true);
+      const op = result.value as OperationExpression;
       expect(op.op).toBe("eq");
       expect(op.field).toBe("field");
       expect(op.value).toBe("value");
@@ -264,8 +316,10 @@ describe("parseMatcherExpression", () => {
       const result = parseMatcherExpression(
         '(\n\tand\n\t\t(eq "a" "1")\n\t\t(eq "b" "2")\n)'
       );
-      expect(isLogicalExpression(result)).toBe(true);
-      const logical = result as LogicalExpression;
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+      expect(isLogicalExpression(result.value)).toBe(true);
+      const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("and");
       expect(logical.expressions).toHaveLength(2);
     });

--- a/front/lib/matcher/parser.test.ts
+++ b/front/lib/matcher/parser.test.ts
@@ -11,7 +11,9 @@ describe("parseMatcherExpression", () => {
         '(and (eq "field1" "value1") (eq "field2" "value2"))'
       );
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isLogicalExpression(result.value)).toBe(true);
       const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("and");
@@ -23,7 +25,9 @@ describe("parseMatcherExpression", () => {
         '(or (eq "field1" "value1") (eq "field2" "value2"))'
       );
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isLogicalExpression(result.value)).toBe(true);
       const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("or");
@@ -33,7 +37,9 @@ describe("parseMatcherExpression", () => {
     it("should parse NOT expression", () => {
       const result = parseMatcherExpression('(not (eq "field" "value"))');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isLogicalExpression(result.value)).toBe(true);
       const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("not");
@@ -45,7 +51,9 @@ describe("parseMatcherExpression", () => {
         '(and (or (eq "a" "1") (eq "b" "2")) (eq "c" "3"))'
       );
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isLogicalExpression(result.value)).toBe(true);
       const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("and");
@@ -58,7 +66,9 @@ describe("parseMatcherExpression", () => {
     it("should parse eq with string value", () => {
       const result = parseMatcherExpression('(eq "user.name" "Alice")');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("eq");
@@ -69,7 +79,9 @@ describe("parseMatcherExpression", () => {
     it("should parse eq with number value", () => {
       const result = parseMatcherExpression('(eq "count" 42)');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("eq");
@@ -80,7 +92,9 @@ describe("parseMatcherExpression", () => {
     it("should parse eq with boolean value", () => {
       const result = parseMatcherExpression('(eq "active" true)');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("eq");
@@ -93,7 +107,9 @@ describe("parseMatcherExpression", () => {
     it("should parse starts-with", () => {
       const result = parseMatcherExpression('(starts-with "email" "admin@")');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("starts-with");
@@ -106,7 +122,9 @@ describe("parseMatcherExpression", () => {
     it("should parse has", () => {
       const result = parseMatcherExpression('(has "tags" "urgent")');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("has");
@@ -119,7 +137,9 @@ describe("parseMatcherExpression", () => {
         '(has-all "tags" ("bug" "urgent"))'
       );
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("has-all");
@@ -130,7 +150,9 @@ describe("parseMatcherExpression", () => {
     it("should parse has-any with array", () => {
       const result = parseMatcherExpression('(has-any "labels" ("p0" "p1"))');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("has-any");
@@ -143,7 +165,9 @@ describe("parseMatcherExpression", () => {
     it("should parse gt", () => {
       const result = parseMatcherExpression('(gt "age" 18)');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("gt");
@@ -154,7 +178,9 @@ describe("parseMatcherExpression", () => {
     it("should parse gte", () => {
       const result = parseMatcherExpression('(gte "score" 90)');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("gte");
@@ -164,7 +190,9 @@ describe("parseMatcherExpression", () => {
     it("should parse lt", () => {
       const result = parseMatcherExpression('(lt "temperature" 100)');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("lt");
@@ -174,7 +202,9 @@ describe("parseMatcherExpression", () => {
     it("should parse lte", () => {
       const result = parseMatcherExpression('(lte "price" 50.99)');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("lte");
@@ -186,7 +216,9 @@ describe("parseMatcherExpression", () => {
     it("should parse exists", () => {
       const result = parseMatcherExpression('(exists "optional_field")');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("exists");
@@ -201,7 +233,9 @@ describe("parseMatcherExpression", () => {
         '(eq "message" "He said \\"hello\\"")'
       );
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.value).toBe('He said "hello"');
@@ -212,7 +246,9 @@ describe("parseMatcherExpression", () => {
         '(eq "user.profile.email" "test@example.com")'
       );
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.field).toBe("user.profile.email");
@@ -221,7 +257,9 @@ describe("parseMatcherExpression", () => {
     it("should parse wildcard paths", () => {
       const result = parseMatcherExpression('(has "tags.*.name" "urgent")');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.field).toBe("tags.*.name");
@@ -232,71 +270,93 @@ describe("parseMatcherExpression", () => {
     it("should return error on empty expression", () => {
       const result = parseMatcherExpression("()");
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error.message).toBe("Empty expression");
     });
 
     it("should return error on unbalanced parentheses", () => {
       const result = parseMatcherExpression('(eq "field" "value"');
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error.message).toBe("Unbalanced parentheses");
     });
 
     it("should return error on missing opening paren", () => {
       const result = parseMatcherExpression('e(q "field" "value")');
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error.message).toBe("Expression must start with '('");
     });
 
     it("should return error on unknown operator", () => {
       const result = parseMatcherExpression('(unknown "field" "value")');
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error.message).toBe("Unknown operator: unknown");
     });
 
     it("should return error on not with wrong arity", () => {
       const result = parseMatcherExpression('(not (eq "a" "1") (eq "b" "2"))');
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error.message).toBe("not requires exactly one expression");
     });
 
     it("should return error on missing field for eq", () => {
       const result = parseMatcherExpression("(eq)");
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error.message).toBe("eq requires field and value(s)");
     });
 
     it("should return error on non-string field", () => {
       const result = parseMatcherExpression("(eq 123 456)");
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error.message).toBe("Field must be a string for eq");
     });
 
     it("should return error on has-all without array", () => {
       const result = parseMatcherExpression('(has-all "field" "single")');
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error.message).toBe("has-all requires a list of values");
     });
 
     it("should return error on unclosed string", () => {
       const result = parseMatcherExpression('(eq "field" "unclosed)');
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
+      if (!result.isErr()) {
+        return;
+      }
       expect(result.error.message).toContain("Expected closing '\"'");
     });
 
     it("should return error on exists with wrong arity", () => {
       const result = parseMatcherExpression('(exists "field" "extra")');
       expect(result.isErr()).toBe(true);
-      if (!result.isErr()) return;
-      expect(result.error.message).toBe("exists requires exactly one expression");
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error.message).toBe(
+        "exists requires exactly one expression"
+      );
     });
   });
 
@@ -304,7 +364,9 @@ describe("parseMatcherExpression", () => {
     it("should handle extra whitespace", () => {
       const result = parseMatcherExpression('  (  eq   "field"   "value"  )  ');
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isOperationExpression(result.value)).toBe(true);
       const op = result.value as OperationExpression;
       expect(op.op).toBe("eq");
@@ -317,7 +379,9 @@ describe("parseMatcherExpression", () => {
         '(\n\tand\n\t\t(eq "a" "1")\n\t\t(eq "b" "2")\n)'
       );
       expect(result.isOk()).toBe(true);
-      if (!result.isOk()) return;
+      if (!result.isOk()) {
+        return;
+      }
       expect(isLogicalExpression(result.value)).toBe(true);
       const logical = result.value as LogicalExpression;
       expect(logical.op).toBe("and");

--- a/front/lib/matcher/parser.ts
+++ b/front/lib/matcher/parser.ts
@@ -1,14 +1,14 @@
-import { assertNever } from "@app/types";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
-
-import type { LogicalOp, MatcherExpression, Operation } from "./types";
 import {
   isDyadicOperation,
   isMonadicOperation,
   isOperator,
   isVariadicOperation,
-} from "./types";
+} from "@app/lib/matcher/types";
+import { assertNever } from "@app/types";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+import type { LogicalOp, MatcherExpression, Operation } from "./types";
 
 type ParserState = {
   expression: string;

--- a/front/lib/matcher/parser.ts
+++ b/front/lib/matcher/parser.ts
@@ -1,4 +1,6 @@
 import { assertNever } from "@app/types";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 import type { LogicalOp, MatcherExpression, Operation } from "./types";
 import {
@@ -8,18 +10,12 @@ import {
   isVariadicOperation,
 } from "./types";
 
-/**
- * Parses a Lisp-inspired matcher expression string into a structured format.
- *
- * @param expression - The Lisp-inspired expression string, e.g.:
- *   '(or (and (eq "pr.author" "adrien@dust.tt") (has "pr.labels" "bug")))'
- * @returns Parsed matcher expression as typed structure
- * @throws Error if the expression is invalid
- */
-export function parseMatcherExpression(expression: string): MatcherExpression {
-  let index = 0;
+type ParserState = {
+  expression: string;
+  index: number;
+};
 
-  // Check that it has a balanced number of parentheses.
+function checkBalancedParentheses(expression: string): Result<void, Error> {
   let openParentheses = 0;
   for (let i = 0; i < expression.length; i++) {
     if (expression[i] === "(") {
@@ -29,178 +25,252 @@ export function parseMatcherExpression(expression: string): MatcherExpression {
     }
   }
   if (openParentheses !== 0) {
-    throw new Error("Unbalanced parentheses");
+    return new Err(new Error("Unbalanced parentheses"));
   }
+  return new Ok(undefined);
+}
 
-  function skipWhitespace() {
-    while (index < expression.length && /\s/.test(expression[index])) {
-      index++;
-    }
+function skipWhitespace(state: ParserState): void {
+  while (
+    state.index < state.expression.length &&
+    /\s/.test(state.expression[state.index])
+  ) {
+    state.index++;
   }
+}
 
-  function parseString(): string {
-    if (expression[index] !== '"') {
-      throw new Error(`Expected '"' at position ${index}`);
-    }
-    index++; // Skip opening quote.
-    let str = "";
-    while (index < expression.length && expression[index] !== '"') {
-      if (expression[index] === "\\") {
-        index++;
-        if (index >= expression.length) {
-          throw new Error("Unexpected end of string");
-        }
+function parseString(state: ParserState): Result<string, Error> {
+  if (state.expression[state.index] !== '"') {
+    return new Err(new Error(`Expected '"' at position ${state.index}`));
+  }
+  state.index++; // Skip opening quote.
+  let str = "";
+  while (
+    state.index < state.expression.length &&
+    state.expression[state.index] !== '"'
+  ) {
+    if (state.expression[state.index] === "\\") {
+      state.index++;
+      if (state.index >= state.expression.length) {
+        return new Err(new Error("Unexpected end of string"));
       }
-      str += expression[index];
-      index++;
     }
-    if (expression[index] !== '"') {
-      throw new Error(`Expected closing '"' at position ${index}`);
-    }
-    index++; // Skip closing quote.
-    return str;
+    str += state.expression[state.index];
+    state.index++;
   }
-
-  function parseAtom(): string | number | boolean | null {
-    skipWhitespace();
-    if (expression[index] === '"') {
-      return parseString();
-    }
-    // Parse symbol, number, or boolean.
-    let atom = "";
-    while (index < expression.length && !/[\s()]/.test(expression[index])) {
-      atom += expression[index];
-      index++;
-    }
-    // Try to parse as boolean.
-    if (atom === "true") {
-      return true;
-    }
-    if (atom === "false") {
-      return false;
-    }
-    // Try to parse as null.
-    if (atom === "null") {
-      return null;
-    }
-    // Try to parse as number.
-    const num = Number(atom);
-    if (!isNaN(num) && atom !== "") {
-      return num;
-    }
-    return atom;
+  if (state.expression[state.index] !== '"') {
+    return new Err(
+      new Error(`Expected closing '"' at position ${state.index}`)
+    );
   }
+  state.index++; // Skip closing quote.
+  return new Ok(str);
+}
 
-  function parseList(): unknown[] {
-    const result: unknown[] = [];
-    skipWhitespace();
-    while (expression[index] !== ")") {
-      if (expression[index] === "(") {
-        index++; // Skip opening paren.
-        const list = parseList();
-        result.push(list);
-      } else {
-        result.push(parseAtom());
+function parseAtom(
+  state: ParserState
+): Result<string | number | boolean | null, Error> {
+  skipWhitespace(state);
+  if (state.expression[state.index] === '"') {
+    return parseString(state);
+  }
+  // Parse symbol, number, or boolean.
+  let atom = "";
+  while (
+    state.index < state.expression.length &&
+    !/[\s()]/.test(state.expression[state.index])
+  ) {
+    atom += state.expression[state.index];
+    state.index++;
+  }
+  // Try to parse as boolean.
+  if (atom === "true") {
+    return new Ok(true);
+  }
+  if (atom === "false") {
+    return new Ok(false);
+  }
+  // Try to parse as null.
+  if (atom === "null") {
+    return new Ok(null);
+  }
+  // Try to parse as number.
+  const num = Number(atom);
+  if (!isNaN(num) && atom !== "") {
+    return new Ok(num);
+  }
+  return new Ok(atom);
+}
+
+function parseList(state: ParserState): Result<unknown[], Error> {
+  const result: unknown[] = [];
+  skipWhitespace(state);
+  while (state.expression[state.index] !== ")") {
+    if (state.expression[state.index] === "(") {
+      state.index++; // Skip opening paren.
+      const listResult = parseList(state);
+      if (listResult.isErr()) {
+        return listResult;
       }
-      skipWhitespace();
+      result.push(listResult.value);
+    } else {
+      const atomResult = parseAtom(state);
+      if (atomResult.isErr()) {
+        return atomResult;
+      }
+      result.push(atomResult.value);
     }
-    index++; // Skip closing paren.
-    return result;
+    skipWhitespace(state);
   }
+  state.index++; // Skip closing paren.
+  return new Ok(result);
+}
 
-  function convertToTypedExpression(list: unknown[]): MatcherExpression {
-    if (list.length === 0) {
-      throw new Error("Empty expression");
+function handleVariadicOperation(
+  op: "and" | "or",
+  list: unknown[]
+): Result<MatcherExpression, Error> {
+  const expressions: MatcherExpression[] = [];
+  for (const item of list.slice(1)) {
+    if (!Array.isArray(item)) {
+      return new Err(new Error(`Expected list for ${op} operand`));
     }
-
-    const op = list[0];
-
-    if (!isOperator(op)) {
-      throw new Error(`Unknown operator: ${op}`);
+    const exprResult = convertToTypedExpression(item);
+    if (exprResult.isErr()) {
+      return exprResult;
     }
+    expressions.push(exprResult.value);
+  }
+  return new Ok({
+    op: op as LogicalOp,
+    expressions,
+  });
+}
 
-    // Handle logical operators (and, or, not).
-    if (isVariadicOperation(op)) {
-      const expressions = list.slice(1).map((item) => {
-        if (!Array.isArray(item)) {
-          throw new Error(`Expected list for ${op} operand`);
-        }
-        return convertToTypedExpression(item);
+function handleMonadicOperation(
+  op: "exists" | "not",
+  list: unknown[]
+): Result<MatcherExpression, Error> {
+  if (list.length !== 2) {
+    return new Err(new Error(`${op} requires exactly one expression`));
+  }
+  const expr = list[1];
+
+  switch (op) {
+    case "not":
+      if (!Array.isArray(expr)) {
+        return new Err(new Error("Expected list for not operand"));
+      }
+      const notExprResult = convertToTypedExpression(expr);
+      if (notExprResult.isErr()) {
+        return notExprResult;
+      }
+      return new Ok({
+        op: "not" as LogicalOp,
+        expressions: [notExprResult.value],
       });
-      return {
-        op: op as LogicalOp,
-        expressions,
-      };
-    }
-
-    if (isMonadicOperation(op)) {
-      if (list.length !== 2) {
-        throw new Error(`${op} requires exactly one expression`);
+    case "exists":
+      if (typeof expr !== "string") {
+        return new Err(new Error("Field must be a string for exists"));
       }
-      const expr = list[1];
-      switch (op) {
-        case "not":
-          if (!Array.isArray(expr)) {
-            throw new Error("Expected list for not operand");
-          }
-          return {
-            op: "not" as LogicalOp,
-            expressions: [convertToTypedExpression(expr)],
-          };
-        case "exists":
-          if (typeof expr !== "string") {
-            throw new Error("Field must be a string for exists");
-          }
-          return {
-            op: "exists" as Operation,
-            field: expr,
-          };
-        default:
-          assertNever(op);
-      }
-    }
+      return new Ok({
+        op: "exists" as Operation,
+        field: expr,
+      });
+    default:
+      assertNever(op);
+  }
+}
 
-    if (isDyadicOperation(op)) {
-      // Binary operators: (op field value) or (op field (values...))
-      if (list.length !== 3) {
-        throw new Error(`${op} requires field and value(s)`);
-      }
-      const field = list[1];
-      const valueOrValues = list[2];
+function handleDyadicOperation(
+  op: Operation | LogicalOp,
+  list: unknown[]
+): Result<MatcherExpression, Error> {
+  if (list.length !== 3) {
+    return new Err(new Error(`${op} requires field and value(s)`));
+  }
+  const field = list[1];
+  const valueOrValues = list[2];
 
-      if (typeof field !== "string") {
-        throw new Error(`Field must be a string for ${op}`);
-      }
-
-      // For array operators (has-all, has-any), expect an array of values.
-      if (op === "has-all" || op === "has-any") {
-        if (!Array.isArray(valueOrValues)) {
-          throw new Error(`${op} requires a list of values`);
-        }
-        return {
-          op: op as Operation,
-          field,
-          values: valueOrValues,
-        };
-      }
-
-      // For single-value operators, accept either value or single-element array.
-      return {
-        op: op as Operation,
-        field,
-        value: valueOrValues,
-      };
-    }
-
-    throw new Error(`Unknown operator: ${op}`);
+  if (typeof field !== "string") {
+    return new Err(new Error(`Field must be a string for ${op}`));
   }
 
-  skipWhitespace();
-  if (expression[index] !== "(") {
-    throw new Error("Expression must start with '('");
+  // For array operators (has-all, has-any), expect an array of values.
+  if (op === "has-all" || op === "has-any") {
+    if (!Array.isArray(valueOrValues)) {
+      return new Err(new Error(`${op} requires a list of values`));
+    }
+    return new Ok({
+      op: op as Operation,
+      field,
+      values: valueOrValues,
+    });
   }
-  index++; // Skip opening paren.
-  const list = parseList();
 
-  return convertToTypedExpression(list);
+  // For single-value operators, accept either value or single-element array.
+  return new Ok({
+    op: op as Operation,
+    field,
+    value: valueOrValues,
+  });
+}
+
+function convertToTypedExpression(
+  list: unknown[]
+): Result<MatcherExpression, Error> {
+  if (list.length === 0) {
+    return new Err(new Error("Empty expression"));
+  }
+
+  const op = list[0];
+
+  if (!isOperator(op)) {
+    return new Err(new Error(`Unknown operator: ${op}`));
+  }
+
+  if (isVariadicOperation(op)) {
+    return handleVariadicOperation(op, list);
+  }
+
+  if (isMonadicOperation(op)) {
+    return handleMonadicOperation(op, list);
+  }
+
+  if (isDyadicOperation(op)) {
+    return handleDyadicOperation(op, list);
+  }
+
+  return new Err(new Error(`Unknown operator: ${op}`));
+}
+
+/**
+ * Parses a Lisp-inspired matcher expression string into a structured format.
+ *
+ * @param expression - The Lisp-inspired expression string, e.g.:
+ *   '(or (and (eq "pr.author" "adrien@dust.tt") (has "pr.labels" "bug")))'
+ * @returns Result containing parsed matcher expression or Error if the expression is invalid
+ */
+export function parseMatcherExpression(
+  expression: string
+): Result<MatcherExpression, Error> {
+  const balanceCheck = checkBalancedParentheses(expression);
+  if (balanceCheck.isErr()) {
+    return balanceCheck;
+  }
+
+  const state: ParserState = { expression, index: 0 };
+
+  skipWhitespace(state);
+  if (state.expression[state.index] !== "(") {
+    return new Err(new Error("Expression must start with '('"));
+  }
+  state.index++; // Skip opening paren.
+
+  const listResult = parseList(state);
+  if (listResult.isErr()) {
+    return listResult;
+  }
+
+  return convertToTypedExpression(listResult.value);
 }

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -140,7 +140,9 @@ export function useWebhookFilterGenerator({
 
       const parseResult = parseMatcherExpression(r.filter);
       if (parseResult.isErr()) {
-        throw new Error(`Error generating filter: ${parseResult.error.message}`);
+        throw new Error(
+          `Error generating filter: ${parseResult.error.message}`
+        );
       }
 
       return { filter: r.filter };

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -138,12 +138,9 @@ export function useWebhookFilterGenerator({
         }
       );
 
-      try {
-        parseMatcherExpression(r.filter);
-      } catch (e: unknown) {
-        throw new Error(
-          `Error generating filter: ${normalizeError(e).message}`
-        );
+      const parseResult = parseMatcherExpression(r.filter);
+      if (parseResult.isErr()) {
+        throw new Error(`Error generating filter: ${parseResult.error.message}`);
       }
 
       return { filter: r.filter };

--- a/front/lib/triggers/temporal/webhook/activities.ts
+++ b/front/lib/triggers/temporal/webhook/activities.ts
@@ -18,7 +18,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import type { ContentFragmentInputWithFileIdType } from "@app/types";
-import { assertNever, errorToString, normalizeError } from "@app/types";
+import { assertNever, errorToString } from "@app/types";
 import type { WebhookTriggerType } from "@app/types/assistant/triggers";
 import { isWebhookTrigger } from "@app/types/assistant/triggers";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
@@ -263,12 +263,8 @@ export async function runTriggerWebhookActivity({
         `workspace_id:${workspaceId}`,
         `trigger_id:${trigger.sId}`,
       ];
-        // Filter triggers by payload matching
-        statsDClient.increment(
-          "webhook_filter.events_processed.count",
-          1,
-          tags
-        );
+      // Filter triggers by payload matching
+      statsDClient.increment("webhook_filter.events_processed.count", 1, tags);
 
       const parsedFilterResult = parseMatcherExpression(filter);
       if (parsedFilterResult.isErr()) {
@@ -284,12 +280,11 @@ export async function runTriggerWebhookActivity({
         continue;
       }
 
-        const r = matchPayload(body, parsedFilter);
-        if (r) {
-          statsDClient.increment("webhook_filter.events_passed.count", 1, tags);
+      const payloadMatchesFilter = matchPayload(body, parsedFilterResult.value);
+      if (payloadMatchesFilter) {
+        statsDClient.increment("webhook_filter.events_passed.count", 1, tags);
 
-          filteredTriggers.push(trigger);
-        }
+        filteredTriggers.push(trigger);
       }
     }
   }

--- a/front/lib/triggers/temporal/webhook/activities.ts
+++ b/front/lib/triggers/temporal/webhook/activities.ts
@@ -265,7 +265,6 @@ export async function runTriggerWebhookActivity({
       `workspace_id:${workspaceId}`,
       `trigger_id:${trigger.sId}`,
     ];
-    // Filter triggers by payload matching
     statsDClient.increment("webhook_filter.events_processed.count", 1, tags);
 
     const parsedFilterResult = parseMatcherExpression(filter);
@@ -285,7 +284,6 @@ export async function runTriggerWebhookActivity({
     const payloadMatchesFilter = matchPayload(body, parsedFilterResult.value);
     if (payloadMatchesFilter) {
       statsDClient.increment("webhook_filter.events_passed.count", 1, tags);
-
       filteredTriggers.push(trigger);
     }
   }


### PR DESCRIPTION
## Description

- The filter parsing method currently throws to indicate an invalid filter, which goes against our coding rules.
- This PR refactors it into a `Result`.

## Tests

- Well covered by tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
