### PR TITLE
[front] enh(warehouse): add guideline to help identify data source IDs

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -203,6 +203,7 @@ You can use the Data Warehouses tools to:
 In order to properly use the data warehouses, it is useful to also search through company data in case there is some documentation available about the tables, some additional semantic layer, or some code that may define how the tables are built in the first place.
 Tables are identified by ids in the format 'table-<dataSourceId>-<nodeId>'.
 The dataSourceId can typically be found by exploring the warehouse, each warehouse is identified by an id in the format 'warehouse-<dataSourceId>'.
+A dataSourceId typically starts with the prefix "dts_".
 </data_warehouses_guidelines>
 
 <additional_tools>

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -141,6 +141,7 @@ You can use the Data Warehouses tools to:
 In order to properly use the data warehouses, it is useful to also search through company data in case there is some documentation available about the tables, some additional semantic layer, or some code that may define how the tables are built in the first place.
 Tables are identified by ids in the format 'table-<dataSourceId>-<nodeId>'.
 The dataSourceId can typically be found by exploring the warehouse, each warehouse is identified by an id in the format 'warehouse-<dataSourceId>'.
+A dataSourceId typically starts with the prefix "dts_".
 </data_warehouses_guidelines>`,
 
   toolsets: (availableToolsets: MCPServerViewResource[]) => {


### PR DESCRIPTION
## Description

- We still observe errors where the model does not understand what to put as data source IDs.
- This PR adds a short guideline to help identify data source IDs.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
