### PR TITLE
Add per conversation draft persistence through session storage

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -336,6 +336,7 @@ export const InputBar = React.memo(function InputBar({
             onMCPServerViewSelect={handleMCPServerViewSelect}
             onMCPServerViewDeselect={handleMCPServerViewDeselect}
             attachedNodes={attachedNodes}
+            conversationId={conversationId}
           />
         </div>
       </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -116,13 +116,8 @@ const InputBarContainer = ({
   const pastedAttachmentIdsRef = useRef<Set<string>>(new Set());
 
   // Draft persistence
-  const {
-    saveDraft,
-    loadDraft,
-    clearDraft,
-    hasDraft,
-  } = useDraftPersistence({
-    conversationId: conversationId || null,
+  const { saveDraft, loadDraft, clearDraft } = useDraftPersistence({
+    conversationId: conversationId ?? null,
     enabled: true,
   });
 
@@ -284,19 +279,25 @@ const InputBarContainer = ({
     // Only show notification if there's actual content in the draft
     if (draft && !disableAutoFocus) {
       // Check if draft has meaningful content (not just empty paragraphs)
-      const hasContent = draft.content &&
+      const hasContent =
+        draft.content &&
         Array.isArray(draft.content) &&
         draft.content.some((node) => {
           // Check if the node has actual text content
-          if (node.type === 'paragraph' && node.content && Array.isArray(node.content) && node.content.length > 0) {
+          if (
+            node.type === "paragraph" &&
+            node.content &&
+            Array.isArray(node.content) &&
+            node.content.length > 0
+          ) {
             return true;
           }
           // Check for mentions or other content types
-          if (node.type === 'mention') {
+          if (node.type === "mention") {
             return true;
           }
           // Check for pasted attachments
-          if (node.type === 'pastedAttachment') {
+          if (node.type === "pastedAttachment") {
             return true;
           }
           return false;
@@ -312,7 +313,7 @@ const InputBarContainer = ({
         }, 100);
       }
     }
-    return draft || undefined;
+    return draft ?? undefined;
   });
 
   const { editor, editorService } = useCustomEditor({

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -272,6 +272,8 @@ export interface CustomEditorProps {
   }) => void;
   longTextPasteCharsThreshold?: number;
   onInlineText?: (fileId: string, textContent: string) => void;
+  initialContent?: JSONContent;
+  onContentChange?: (content: JSONContent) => void;
 }
 
 const useCustomEditor = ({
@@ -284,6 +286,8 @@ const useCustomEditor = ({
   onLongTextPaste,
   longTextPasteCharsThreshold,
   onInlineText,
+  initialContent,
+  onContentChange,
 }: CustomEditorProps) => {
   const extensions = [
     StarterKit.configure({
@@ -326,6 +330,7 @@ const useCustomEditor = ({
   const editor = useEditor({
     autofocus: disableAutoFocus ? false : "end",
     extensions,
+    content: initialContent,
     editorProps: {
       attributes: {
         class: "border-0 outline-none overflow-y-auto h-full scrollbar-hide",
@@ -346,6 +351,11 @@ const useCustomEditor = ({
         }
         return false;
       },
+    },
+    onUpdate: ({ editor }) => {
+      if (onContentChange) {
+        onContentChange(editor.getJSON());
+      }
     },
   });
 

--- a/front/hooks/useDraftPersistence.ts
+++ b/front/hooks/useDraftPersistence.ts
@@ -1,0 +1,181 @@
+import type { JSONContent } from "@tiptap/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const DRAFT_STORAGE_PREFIX = "dust_draft_";
+const DRAFT_EXPIRY_DAYS = 7;
+const STORAGE_DEBOUNCE_MS = 500;
+
+interface DraftData {
+  content: JSONContent;
+  timestamp: number;
+}
+
+interface UseDraftPersistenceOptions {
+  conversationId: string | null;
+  enabled?: boolean;
+}
+
+export function useDraftPersistence({
+  conversationId,
+  enabled = true,
+}: UseDraftPersistenceOptions) {
+  const timeoutRef = useRef<NodeJS.Timeout>();
+  const [hasDraft, setHasDraft] = useState(false);
+  const [_draftLoaded, setDraftLoaded] = useState(false);
+
+  const getStorageKey = useCallback(() => {
+    const key = conversationId ?? "new";
+    return `${DRAFT_STORAGE_PREFIX}${key}`;
+  }, [conversationId]);
+
+  const cleanupOldDrafts = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const now = Date.now();
+    const expiryTime = DRAFT_EXPIRY_DAYS * 24 * 60 * 60 * 1000;
+    const keysToRemove: string[] = [];
+
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const key = sessionStorage.key(i);
+      if (!key || !key.startsWith(DRAFT_STORAGE_PREFIX)) {
+        continue;
+      }
+
+      try {
+        const item = sessionStorage.getItem(key);
+        if (!item) {
+          continue;
+        }
+
+        // Remove expired drafts
+        const draft: DraftData = JSON.parse(item);
+        if (now - draft.timestamp > expiryTime) {
+          keysToRemove.push(key);
+        }
+      } catch (e) {
+        keysToRemove.push(key);
+      }
+    }
+
+    keysToRemove.forEach((key) => sessionStorage.removeItem(key));
+  }, []);
+
+  const saveDraft = useCallback(
+    (content: JSONContent) => {
+      if (!enabled) {
+        return;
+      }
+
+      const storageKey = getStorageKey();
+      if (!storageKey) {
+        return;
+      }
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      // Debounce save
+      timeoutRef.current = setTimeout(() => {
+        try {
+          const draft: DraftData = {
+            content,
+            timestamp: Date.now(),
+          };
+
+          sessionStorage.setItem(storageKey, JSON.stringify(draft));
+          setHasDraft(true);
+        } catch (e) {
+          // Session storage quota exceeded handling: clean up and try again.
+          if (e instanceof DOMException && e.code === 22) {
+            cleanupOldDrafts();
+            try {
+              const draft: DraftData = {
+                content,
+                timestamp: Date.now(),
+              };
+              sessionStorage.setItem(storageKey, JSON.stringify(draft));
+              setHasDraft(true);
+            } catch {
+              // Still failed, give up
+            }
+          }
+        }
+      }, STORAGE_DEBOUNCE_MS);
+    },
+    [enabled, getStorageKey, cleanupOldDrafts]
+  );
+
+  // Load draft from session storage
+  const loadDraft = useCallback((): JSONContent | null => {
+    if (!enabled) {
+      return null;
+    }
+
+    const storageKey = getStorageKey();
+    if (!storageKey) {
+      return null;
+    }
+
+    try {
+      const item = sessionStorage.getItem(storageKey);
+      if (!item) {
+        return null;
+      }
+
+      const draft: DraftData = JSON.parse(item);
+      const now = Date.now();
+      const expiryTime = DRAFT_EXPIRY_DAYS * 24 * 60 * 60 * 1000;
+
+      if (now - draft.timestamp > expiryTime) {
+        sessionStorage.removeItem(storageKey);
+        return null;
+      }
+
+      setHasDraft(true);
+      setDraftLoaded(true);
+      return draft.content;
+    } catch (e) {
+      return null;
+    }
+  }, [enabled, getStorageKey]);
+
+  const clearDraft = useCallback(() => {
+    const storageKey = getStorageKey();
+    if (!storageKey) {
+      return;
+    }
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    try {
+      sessionStorage.removeItem(storageKey);
+      setHasDraft(false);
+    } catch (e) {
+      console.error("Failed to clear draft:", e);
+    }
+  }, [getStorageKey]);
+
+  useEffect(() => {
+    cleanupOldDrafts();
+  }, [cleanupOldDrafts]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    saveDraft,
+    loadDraft,
+    clearDraft,
+    hasDraft,
+  };
+}


### PR DESCRIPTION





## Description

Implements per-conversation draft persistence using session storage. When users type a message and navigate away or refresh, their draft is automatically saved and restored when they return to the same conversation. Drafts are stored with a conversation-specific key (or "new" for new conversations), expire after 7 days, and are cleared when a message is successfully sent. A success notification is shown when a draft is restored.

## Risk

Low. Uses session storage only (no database changes), with error handling for quota exceeded scenarios.

## Tests

Manual testing of draft save/restore flows across conversation navigation and page refreshes.
