### PR TITLE
[front] feat(poke): add button to check if a workflow is stuck

### DIFF
--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -155,6 +155,15 @@ export function ViewDataSourceTable({
                       <PokeTableCell>{isRunning ? "✅" : "❌"}</PokeTableCell>
                     </PokeTableRow>
                     <PokeTableRow>
+                      <PokeTableCell>Is Stuck?</PokeTableCell>
+                      <PokeTableCell>
+                        <CheckConnectorStuck
+                          owner={owner}
+                          dsId={dataSource.sId}
+                        />
+                      </PokeTableCell>
+                    </PokeTableRow>
+                    <PokeTableRow>
                       <PokeTableCell>Paused at</PokeTableCell>
                       <PokeTableCell>
                         {connector?.pausedAt ? (
@@ -249,14 +258,6 @@ export function ViewDataSourceTable({
                       </PokeTableCell>
                     </PokeTableRow>
                   </>
-                )}
-                {connector && (
-                  <PokeTableRow>
-                    <PokeTableCell>Is stuck?</PokeTableCell>
-                    <PokeTableCell>
-                      <CheckConnectorStuck owner={owner} dsId={dataSource.sId} />
-                    </PokeTableCell>
-                  </PokeTableRow>
                 )}
               </PokeTableBody>
             </PokeTable>

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -374,7 +374,7 @@ function CheckConnectorStuck({ owner, dsId }: CheckConnectorStuckProps) {
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
         <Chip
-          label={result.isStuck ? "Stuck!" : "Not Stuck"}
+          label={result.isStuck ? "Stuck" : "Not Stuck"}
           color={result.isStuck ? "warning" : "success"}
           size="xs"
         />

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -377,7 +377,7 @@ function CheckConnectorStuck({
         label={isLoading ? "Checking..." : "Check"}
         icon={isLoading ? Spinner : MagnifyingGlassIcon}
         disabled={isLoading}
-        onClick={!isLoading && !isRunning ? checkStuck : undefined}
+        onClick={!isLoading ? checkStuck : undefined}
         size="xs"
       />
     );
@@ -456,8 +456,8 @@ function StuckActivitiesModal({
             />
             {result.workflows.map((workflow) => (
               <div key={workflow.workflowId} className="flex flex-col gap-2">
-                <div className="rounded-lg border border-structure-200 dark:border-structure-200-dark">
-                  <div className="border-b border-structure-200 px-4 py-3 dark:border-structure-200-dark">
+                <div className="border-structure-200 dark:border-structure-200-dark rounded-lg border">
+                  <div className="border-structure-200 dark:border-structure-200-dark border-b px-4 py-3">
                     <div className="text-sm font-semibold">
                       {workflow.workflowId}
                     </div>
@@ -469,7 +469,7 @@ function StuckActivitiesModal({
                     {workflow.stuckActivities.map((activity, idx) => (
                       <div
                         key={idx}
-                        className="border-b border-structure-200 px-4 py-3 last:border-b-0 dark:border-structure-200-dark"
+                        className="border-structure-200 dark:border-structure-200-dark border-b px-4 py-3 last:border-b-0"
                       >
                         <div className="flex items-center justify-between gap-3">
                           <span className="text-sm">

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -423,9 +423,6 @@ function CheckConnectorStuck({
                     >
                       <div>Activity: {activity.activityType}</div>
                       <div>Attempt: {activity.attempt}</div>
-                      {activity.maximumAttempts && (
-                        <div>Max Attempts: {activity.maximumAttempts}</div>
-                      )}
                       {activity.lastFailure && (
                         <div className="mt-1 text-warning-500">
                           Last Failure: {activity.lastFailure}

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -457,9 +457,10 @@ function StuckActivitiesModal({
             />
             {result.workflows.map((workflow) => (
               <ContextItem.List key={workflow.workflowId} hasBorder>
-                <ContextItem.SectionHeader
+                <ContextItem
                   title={workflow.workflowId}
-                  description={`Status: ${workflow.status}`}
+                  visual={null}
+                  hasSeparator={false}
                 />
                 {workflow.stuckActivities.map((activity, idx) => (
                   <ContextItem

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -475,14 +475,13 @@ function StuckActivitiesModal({
                         size="xs"
                       />
                     }
-                    subElement={
-                      activity.lastFailure ? (
-                        <div className="text-sm text-warning-500">
-                          {activity.lastFailure}
-                        </div>
-                      ) : null
-                    }
-                  />
+                  >
+                    {activity.lastFailure ? (
+                      <div className="text-sm text-warning-500">
+                        {activity.lastFailure}
+                      </div>
+                    ) : null}
+                  </ContextItem>
                 ))}
               </ContextItem.List>
             ))}

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   Chip,
   ContentMessage,
-  ContextItem,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -456,34 +455,43 @@ function StuckActivitiesModal({
               }
             />
             {result.workflows.map((workflow) => (
-              <ContextItem.List key={workflow.workflowId} hasBorder>
-                <ContextItem.SectionHeader
-                  title={workflow.workflowId}
-                  description={`Status: ${workflow.status}`}
-                />
-                {workflow.stuckActivities.map((activity, idx) => (
-                  <ContextItem
-                    key={idx}
-                    title={
-                      <span className="text-sm">{activity.activityType}</span>
-                    }
-                    visual={
-                      <Chip
-                        color="warning"
-                        label={`${activity.attempt} attempts`}
-                        size="xs"
-                      />
-                    }
-                    subElement={
-                      activity.lastFailure ? (
-                        <div className="text-sm text-warning-500">
-                          {activity.lastFailure}
+              <div key={workflow.workflowId} className="flex flex-col gap-2">
+                <div className="rounded-lg border border-structure-200 dark:border-structure-200-dark">
+                  <div className="border-b border-structure-200 px-4 py-3 dark:border-structure-200-dark">
+                    <div className="text-sm font-semibold">
+                      {workflow.workflowId}
+                    </div>
+                    <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                      Status: {workflow.status}
+                    </div>
+                  </div>
+                  <div className="flex flex-col">
+                    {workflow.stuckActivities.map((activity, idx) => (
+                      <div
+                        key={idx}
+                        className="border-b border-structure-200 px-4 py-3 last:border-b-0 dark:border-structure-200-dark"
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="text-sm">
+                            {activity.activityType}
+                          </span>
+                          <Chip
+                            color="warning"
+                            label={`${activity.attempt} attempts`}
+                            size="xs"
+                          />
                         </div>
-                      ) : null
-                    }
-                  />
-                ))}
-              </ContextItem.List>
+                        {activity.lastFailure && (
+                          <div className="mt-2 text-xs text-warning-500">
+                            <span className="font-medium">Last Failure: </span>
+                            {activity.lastFailure}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
             ))}
           </div>
         </DialogContainer>

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Chip,
   ContentMessage,
+  ContextItem,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -455,43 +456,34 @@ function StuckActivitiesModal({
               }
             />
             {result.workflows.map((workflow) => (
-              <div key={workflow.workflowId} className="flex flex-col gap-2">
-                <div className="border-structure-200 dark:border-structure-200-dark rounded-lg border">
-                  <div className="border-structure-200 dark:border-structure-200-dark border-b px-4 py-3">
-                    <div className="text-sm font-semibold">
-                      {workflow.workflowId}
-                    </div>
-                    <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                      Status: {workflow.status}
-                    </div>
-                  </div>
-                  <div className="flex flex-col">
-                    {workflow.stuckActivities.map((activity, idx) => (
-                      <div
-                        key={idx}
-                        className="border-structure-200 dark:border-structure-200-dark border-b px-4 py-3 last:border-b-0"
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <span className="text-sm">
-                            {activity.activityType}
-                          </span>
-                          <Chip
-                            color="warning"
-                            label={`${activity.attempt} attempts`}
-                            size="xs"
-                          />
+              <ContextItem.List key={workflow.workflowId} hasBorder>
+                <ContextItem.SectionHeader
+                  title={workflow.workflowId}
+                  description={`Status: ${workflow.status}`}
+                />
+                {workflow.stuckActivities.map((activity, idx) => (
+                  <ContextItem
+                    key={idx}
+                    title={
+                      <span className="text-sm">{activity.activityType}</span>
+                    }
+                    visual={
+                      <Chip
+                        color="warning"
+                        label={`${activity.attempt} attempts`}
+                        size="xs"
+                      />
+                    }
+                    subElement={
+                      activity.lastFailure ? (
+                        <div className="text-sm text-warning-500">
+                          {activity.lastFailure}
                         </div>
-                        {activity.lastFailure && (
-                          <div className="mt-2 text-xs text-warning-500">
-                            <span className="font-medium">Last Failure: </span>
-                            {activity.lastFailure}
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
+                      ) : null
+                    }
+                  />
+                ))}
+              </ContextItem.List>
             ))}
           </div>
         </DialogContainer>

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -424,9 +424,9 @@ interface StuckActivitiesModalProps {
 function StuckActivitiesModal({
   show,
   onClose,
-  result,
+  result: { workflows },
 }: StuckActivitiesModalProps) {
-  const totalStuckActivities = result.workflows.reduce(
+  const totalStuckActivities = workflows.reduce(
     (sum, wf) => sum + wf.stuckActivities.length,
     0
   );
@@ -452,10 +452,10 @@ function StuckActivitiesModal({
               title={
                 `Found ${totalStuckActivities} stuck ` +
                 `${totalStuckActivities === 1 ? "activity" : "activities"} ` +
-                `across ${result.workflows.length} workflow${pluralize(result.workflows.length)}`
+                `across ${workflows.length} workflow${pluralize(workflows.length)}`
               }
             />
-            {result.workflows.map((workflow) => (
+            {workflows.map((workflow) => (
               <ContextItem.List key={workflow.workflowId} hasBorder>
                 <ContextItem
                   title={workflow.workflowId}
@@ -476,11 +476,11 @@ function StuckActivitiesModal({
                       />
                     }
                   >
-                    {activity.lastFailure ? (
+                    {activity.lastFailure && (
                       <div className="text-sm text-warning-500">
                         {activity.lastFailure}
                       </div>
-                    ) : null}
+                    )}
                   </ContextItem>
                 ))}
               </ContextItem.List>

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -375,7 +375,7 @@ function CheckConnectorStuck({ owner, dsId }: CheckConnectorStuckProps) {
       <div className="flex items-center gap-2">
         <Chip
           label={result.isStuck ? "Stuck" : "Not Stuck"}
-          color={result.isStuck ? "warning" : "success"}
+          color={result.isStuck ? "info" : "success"}
           size="xs"
         />
         {result.isStuck && result.workflows.length > 0 && (

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -396,14 +396,14 @@ function CheckConnectorStuck({ owner, dsId }: CheckConnectorStuckProps) {
             return (
               <div key={workflow.workflowId} className="rounded border p-2">
                 <div className="mb-1 font-semibold">{workflow.workflowId}</div>
-                <div className="text-muted-foreground">
+                <div className="text-muted-foreground dark:text-muted-foreground-night">
                   Status: {workflow.status}
                 </div>
                 <div className="mt-1 flex flex-col gap-1">
                   {workflow.stuckActivities.map((activity, idx) => (
                     <div
                       key={idx}
-                      className="rounded bg-gray-50 p-2 dark:bg-gray-800"
+                      className="rounded bg-muted-background p-2 dark:bg-muted-background-night"
                     >
                       <div>Activity: {activity.activityType}</div>
                       <div>Attempt: {activity.attempt}</div>
@@ -411,7 +411,7 @@ function CheckConnectorStuck({ owner, dsId }: CheckConnectorStuckProps) {
                         <div>Max Attempts: {activity.maximumAttempts}</div>
                       )}
                       {activity.lastFailure && (
-                        <div className="mt-1 text-red-600 dark:text-red-400">
+                        <div className="mt-1 text-warning-500">
                           Last Failure: {activity.lastFailure}
                         </div>
                       )}

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -11,6 +11,7 @@ import {
   ScrollArea,
   ScrollBar,
   Spinner,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
 import Link from "next/link";
@@ -383,10 +384,15 @@ function CheckConnectorStuck({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
-        <Chip
-          label={result.isStuck ? "Stuck" : "Not Stuck"}
-          color={result.isStuck ? "info" : "success"}
-          size="xs"
+        <Tooltip
+          label={result.message}
+          trigger={
+            <Chip
+              label={result.isStuck ? "Stuck" : "Not Stuck"}
+              color={result.isStuck ? "info" : "success"}
+              size="xs"
+            />
+          }
         />
         {result.isStuck && result.workflows.length > 0 && (
           <Button

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -160,6 +160,7 @@ export function ViewDataSourceTable({
                         <CheckConnectorStuck
                           owner={owner}
                           dsId={dataSource.sId}
+                          isRunning={isRunning}
                         />
                       </PokeTableCell>
                     </PokeTableRow>
@@ -329,9 +330,14 @@ function RawObjectsModal({
 interface CheckConnectorStuckProps {
   owner: WorkspaceType;
   dsId: string;
+  isRunning: boolean;
 }
 
-function CheckConnectorStuck({ owner, dsId }: CheckConnectorStuckProps) {
+function CheckConnectorStuck({
+  owner,
+  dsId,
+  isRunning,
+}: CheckConnectorStuckProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState<CheckStuckResponseBody | null>(null);
   const [showDetails, setShowDetails] = useState(false);
@@ -357,6 +363,10 @@ function CheckConnectorStuck({ owner, dsId }: CheckConnectorStuckProps) {
     }
   };
 
+  if (!isRunning) {
+    return <Chip label="Not Running" color="primary" size="xs" />;
+  }
+
   if (!result) {
     return (
       <Button
@@ -364,7 +374,7 @@ function CheckConnectorStuck({ owner, dsId }: CheckConnectorStuckProps) {
         label={isLoading ? "Checking..." : "Check"}
         icon={isLoading ? Spinner : MagnifyingGlassIcon}
         disabled={isLoading}
-        onClick={checkStuck}
+        onClick={!isLoading && !isRunning ? checkStuck : undefined}
         size="xs"
       />
     );

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
@@ -37,15 +37,10 @@ const STUCK_THRESHOLD = 5; // Consider an activity stuck if it has 5+ attempts
 function flattenStuckWorkflows(info: StuckWorkflowInfo): StuckWorkflowInfo[] {
   const result: StuckWorkflowInfo[] = [];
 
-  // Add current workflow if it has stuck activities (without children).
   if (info.stuckActivities.length > 0) {
-    result.push({
-      ...info,
-      childWorkflows: [],
-    });
+    result.push(info);
   }
 
-  // Recursively process child workflows.
   for (const child of info.childWorkflows) {
     result.push(...flattenStuckWorkflows(child));
   }

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
@@ -1,0 +1,218 @@
+import type { Client, WorkflowExecutionDescription } from "@temporalio/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { getWorkflowIdsForConnector } from "@app/types/connectors/workflows";
+
+export interface PendingActivityInfo {
+  activityId: string;
+  activityType: string;
+  attempt: number;
+  maximumAttempts: number | null;
+  lastFailure: string | null;
+  state: string;
+}
+
+export interface StuckWorkflowInfo {
+  workflowId: string;
+  status: string;
+  pendingActivities: PendingActivityInfo[];
+  stuckActivities: PendingActivityInfo[];
+  childWorkflows: StuckWorkflowInfo[];
+}
+
+export interface CheckStuckResponseBody {
+  isStuck: boolean;
+  workflows: StuckWorkflowInfo[];
+  message: string;
+}
+
+const STUCK_THRESHOLD = 5; // Consider an activity stuck if it has 5+ attempts
+
+async function checkWorkflowStuck(
+  client: Client,
+  workflowId: string,
+  visitedWorkflowIds: Set<string> = new Set()
+): Promise<StuckWorkflowInfo | null> {
+  // Prevent infinite loops if there are circular child workflows
+  if (visitedWorkflowIds.has(workflowId)) {
+    return null;
+  }
+  visitedWorkflowIds.add(workflowId);
+
+  try {
+    const handle = client.workflow.getHandle(workflowId);
+    const description: WorkflowExecutionDescription = await handle.describe();
+
+    const pendingActivities: PendingActivityInfo[] = [];
+    const stuckActivities: PendingActivityInfo[] = [];
+
+    // Check pending activities
+    if (description.raw.pendingActivities) {
+      for (const activity of description.raw.pendingActivities) {
+        const activityInfo: PendingActivityInfo = {
+          activityId: activity.activityId ?? "unknown",
+          activityType: activity.activityType?.name ?? "unknown",
+          attempt: activity.attempt ?? 0,
+          maximumAttempts: activity.maximumAttempts ?? null,
+          lastFailure: activity.lastFailure?.message ?? null,
+          state: activity.state?.toString() ?? "unknown",
+        };
+
+        pendingActivities.push(activityInfo);
+
+        // Check if this activity is stuck (has many retries)
+        if (activityInfo.attempt >= STUCK_THRESHOLD) {
+          stuckActivities.push(activityInfo);
+        }
+      }
+    }
+
+    // Check child workflows recursively
+    const childWorkflows: StuckWorkflowInfo[] = [];
+    if (description.raw.pendingChildren) {
+      for (const child of description.raw.pendingChildren) {
+        if (child.workflowId) {
+          const childInfo = await checkWorkflowStuck(
+            client,
+            child.workflowId,
+            visitedWorkflowIds
+          );
+          if (childInfo) {
+            childWorkflows.push(childInfo);
+          }
+        }
+      }
+    }
+
+    return {
+      workflowId,
+      status: description.status.name,
+      pendingActivities,
+      stuckActivities,
+      childWorkflows,
+    };
+  } catch (error) {
+    // Workflow might not exist or might be completed
+    return null;
+  }
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<CheckStuckResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  const { dsId } = req.query;
+  if (typeof dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      if (!dataSource.connectorId || !dataSource.connectorProvider) {
+        return res.status(200).json({
+          isStuck: false,
+          workflows: [],
+          message: "This data source does not have a connector.",
+        });
+      }
+
+      const client = await getTemporalClientForConnectorsNamespace();
+      const workflowIds = getWorkflowIdsForConnector(
+        parseInt(dataSource.connectorId, 10),
+        dataSource.connectorProvider
+      );
+
+      if (workflowIds.length === 0) {
+        return res.status(200).json({
+          isStuck: false,
+          workflows: [],
+          message: `Workflow checking not implemented for connector type: ${dataSource.connectorProvider}`,
+        });
+      }
+
+      const workflows: StuckWorkflowInfo[] = [];
+      let hasStuckActivities = false;
+
+      for (const workflowId of workflowIds) {
+        const workflowInfo = await checkWorkflowStuck(client, workflowId);
+        if (workflowInfo) {
+          workflows.push(workflowInfo);
+
+          // Check if this workflow or any of its children have stuck activities
+          const checkStuck = (info: StuckWorkflowInfo): boolean => {
+            if (info.stuckActivities.length > 0) {
+              return true;
+            }
+            return info.childWorkflows.some((child) => checkStuck(child));
+          };
+
+          if (checkStuck(workflowInfo)) {
+            hasStuckActivities = true;
+          }
+        }
+      }
+
+      const message = hasStuckActivities
+        ? `Found ${workflows.reduce((count, wf) => count + wf.stuckActivities.length, 0)} stuck activities (${STUCK_THRESHOLD}+ retries)`
+        : workflows.length > 0
+          ? "No stuck activities found"
+          : "No running workflows found";
+
+      return res.status(200).json({
+        isStuck: hasStuckActivities,
+        workflows,
+        message,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -50,7 +50,6 @@ import {
   isSlackAutoReadPatterns,
   safeParseJSON,
 } from "@app/types";
-import type { CheckStuckResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 
@@ -577,6 +576,7 @@ const DataSourcePage = ({
       <div className="flex flex-row gap-x-6">
         <ViewDataSourceTable
           dataSource={dataSource}
+          owner={owner}
           temporalWorkspace={temporalWorkspace}
           coreDataSource={coreDataSource}
           connector={connector}
@@ -633,9 +633,6 @@ const DataSourcePage = ({
                 icon={LockIcon}
               />
             ) : null}
-            {dataSource.connectorProvider && (
-              <CheckConnectorStuck owner={owner} dsId={dataSource.sId} />
-            )}
             {dataSource.connectorProvider === "notion" && (
               <>
                 <Button
@@ -1165,97 +1162,6 @@ function ZendeskTicketCheck({
           </div>
         )}
       </div>
-    </div>
-  );
-}
-
-interface CheckConnectorStuckProps {
-  owner: WorkspaceType;
-  dsId: string;
-}
-
-function CheckConnectorStuck({ owner, dsId }: CheckConnectorStuckProps) {
-  const [isLoading, setIsLoading] = useState(false);
-  const [result, setResult] = useState<CheckStuckResponseBody | null>(null);
-
-  const checkStuck = async () => {
-    setIsLoading(true);
-    try {
-      const res = await fetch(
-        `/api/poke/workspaces/${owner.sId}/data_sources/${dsId}/check-stuck`
-      );
-      if (!res.ok) {
-        const err = await res.json();
-        alert(`Failed to check connector status: ${JSON.stringify(err)}`);
-        return;
-      }
-      const data = await res.json();
-      setResult(data);
-    } catch (error) {
-      alert(`Error checking connector: ${error}`);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  return (
-    <div className="mb-2 flex flex-col gap-2 rounded-md border px-2 py-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
-      <div className="flex items-center gap-2 px-2 pt-2">
-        <Button
-          variant="outline"
-          label={isLoading ? "Checking..." : "Check if Stuck"}
-          icon={isLoading ? Spinner : MagnifyingGlassIcon}
-          disabled={isLoading}
-          onClick={checkStuck}
-        />
-      </div>
-      {result && (
-        <div className="flex flex-col gap-2 rounded-md p-4 pt-2">
-          <Chip
-            label={result.isStuck ? "Stuck!" : "Not Stuck"}
-            color={result.isStuck ? "warning" : "success"}
-          />
-          <div className="text-sm">{result.message}</div>
-          {result.isStuck && result.workflows.length > 0 && (
-            <div className="mt-2 flex flex-col gap-2">
-              {result.workflows.map((workflow) => {
-                if (workflow.stuckActivities.length === 0) {
-                  return null;
-                }
-                return (
-                  <div key={workflow.workflowId} className="rounded border p-2">
-                    <div className="mb-2 font-semibold">
-                      {workflow.workflowId}
-                    </div>
-                    <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                      Status: {workflow.status}
-                    </div>
-                    <div className="mt-2 flex flex-col gap-1">
-                      {workflow.stuckActivities.map((activity, idx) => (
-                        <div
-                          key={idx}
-                          className="rounded bg-gray-50 p-2 text-xs dark:bg-gray-800"
-                        >
-                          <div>Activity: {activity.activityType}</div>
-                          <div>Attempt: {activity.attempt}</div>
-                          {activity.maximumAttempts && (
-                            <div>Max Attempts: {activity.maximumAttempts}</div>
-                          )}
-                          {activity.lastFailure && (
-                            <div className="mt-1 text-red-600 dark:text-red-400">
-                              Last Failure: {activity.lastFailure}
-                            </div>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/front/types/connectors/workflows.ts
+++ b/front/types/connectors/workflows.ts
@@ -1,4 +1,4 @@
-import type { ModelId } from "@app/types";
+import type { ConnectorProvider, ModelId } from "@app/types";
 
 export function getNotionWorkflowId(
   connectorId: ModelId,
@@ -41,4 +41,36 @@ export function microsoftIncrementalSyncWorkflowId(connectorId: ModelId) {
 
 export function microsoftGarbageCollectionWorkflowId(connectorId: ModelId) {
   return `microsoft-garbageCollection-${connectorId}`;
+}
+
+export function getWorkflowIdsForConnector(
+  connectorId: ModelId,
+  connectorType: ConnectorProvider
+): string[] {
+  switch (connectorType) {
+    case "notion":
+      return [
+        getNotionWorkflowId(connectorId, "sync"),
+        getNotionWorkflowId(connectorId, "garbage-collector"),
+        getNotionWorkflowId(connectorId, "process-database-upsert-queue"),
+      ];
+    case "intercom":
+      return [getIntercomSyncWorkflowId(connectorId)];
+    case "zendesk":
+      return [
+        getZendeskSyncWorkflowId(connectorId),
+        getZendeskGarbageCollectionWorkflowId(connectorId),
+      ];
+    case "google_drive":
+      return [googleDriveIncrementalSyncWorkflowId(connectorId)];
+    case "confluence":
+      return [makeConfluenceSyncWorkflowId(connectorId)];
+    case "microsoft":
+      return [
+        microsoftIncrementalSyncWorkflowId(connectorId),
+        microsoftGarbageCollectionWorkflowId(connectorId),
+      ];
+    default:
+      return [];
+  }
 }


### PR DESCRIPTION
## Description

This PR adds a button in the Poke data source page to check if a connector is stuck.
It operates by calling Temporal and checking if a workflow or one of its children workflow has pending activities that have a lot of retries.

<img width="333" height="500" alt="Screenshot 2025-11-07 at 8 48 08 AM" src="https://github.com/user-attachments/assets/c49efd54-9b0d-428d-8746-48ba93bafef4" />

<img width="470" height="290" alt="Screenshot 2025-11-07 at 8 49 34 AM" src="https://github.com/user-attachments/assets/8824c1bb-4757-4c67-aef1-9d9a527905c9" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
