### PR TITLE
enh(frames): prompt for using images from conversation files

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
@@ -65,6 +65,10 @@ export const VIZ_FILE_HANDLING_GUIDELINES = `
   - To let users download data from the visualization, use the \`triggerUserFileDownload()\` function.
   - \`triggerUserFileDownload\` has to be imported from \`"@dust/react-hooks"\`.
   - Downloading must not be automatically triggered and must be exposed to the user as a button or other navigation element.
+\n+- Using image files from the conversation:
+  - Always load images via \`useFile()\` to obtain a \`File\` object — never reference images directly by URL/path or by copying the \`<attachment/>\` tag contents.
+  - Create a local object URL from the \`File\` when rendering (e.g. \`const src = URL.createObjectURL(file)\`).
+  - Use the resulting object URL for \`<img src={src} alt="..." />\` or as a background image; do not attempt to fetch remote images (no internet access).
 `;
 
 export const VIZ_LIBRARY_USAGE = `


### PR DESCRIPTION
## Description

Improves the Frames prompt to include guidelines around using images from conversation files.

Without this prompt, the model tends to reference images by ID instead of properly using the `useFile` function.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
