### PR TITLE
Increase Notion webhook rate limit to 3000 per min

### DIFF
--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -80,7 +80,7 @@ export function startServer(port: number) {
         const clientIp = req.ip;
         const remainingRequests = await rateLimiter({
           key: `rate_limit:${clientIp}`,
-          maxPerTimeframe: 1000,
+          maxPerTimeframe: req.path.endsWith("/notion") ? 3000 : 1000,
           timeframeSeconds: 60,
           logger: logger,
         });


### PR DESCRIPTION
## Description

1000 per minute is too low for fairly typical Notion webhook traffic. If we hit a peak and send back 429s, they pause the integration.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
