### PR TITLE
[front] enh(obs): update colors in dark mode

### DIFF
--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -166,20 +166,23 @@ export function ErrorRateChart({
               />
             </linearGradient>
           </defs>
-          <CartesianGrid vertical={false} className="stroke-border" />
+          <CartesianGrid
+            vertical={false}
+            className="stroke-border dark:stroke-border-night"
+          />
           <XAxis
             dataKey="date"
             type="category"
             scale="point"
             allowDuplicatedCategory={false}
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}
             minTickGap={16}
           />
           <YAxis
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -97,20 +97,23 @@ export function FeedbackDistributionChart({
           data={data}
           margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
         >
-          <CartesianGrid vertical={false} className="stroke-border" />
+          <CartesianGrid
+            vertical={false}
+            className="stroke-border dark:stroke-border-night"
+          />
           <XAxis
             dataKey="date"
             type="category"
             scale="point"
             allowDuplicatedCategory={false}
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}
             minTickGap={16}
           />
           <YAxis
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -127,20 +127,23 @@ export function LatencyChart({
               <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
             </linearGradient>
           </defs>
-          <CartesianGrid vertical={false} className="stroke-border" />
+          <CartesianGrid
+            vertical={false}
+            className="stroke-border dark:stroke-border-night"
+          />
           <XAxis
             dataKey="date"
             type="category"
             scale="point"
             allowDuplicatedCategory={false}
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}
             minTickGap={16}
           />
           <YAxis
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -117,10 +117,13 @@ export function ToolUsageChart({
           data={chartData}
           margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
         >
-          <CartesianGrid vertical={false} className="stroke-border" />
+          <CartesianGrid
+            vertical={false}
+            className="stroke-border dark:stroke-border-night"
+          />
           <XAxis
             dataKey="label"
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}
@@ -132,7 +135,7 @@ export function ToolUsageChart({
             }}
           />
           <YAxis
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -193,20 +193,23 @@ export function UsageMetricsChart({
               <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
             </linearGradient>
           </defs>
-          <CartesianGrid vertical={false} className="stroke-border" />
+          <CartesianGrid
+            vertical={false}
+            className="stroke-border dark:stroke-border-night"
+          />
           <XAxis
             dataKey="date"
             type="category"
             scale="point"
             allowDuplicatedCategory={false}
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}
             minTickGap={16}
           />
           <YAxis
-            className="text-xs text-muted-foreground"
+            className="text-xs text-muted-foreground dark:text-muted-foreground-night"
             tickLine={false}
             axisLine={false}
             tickMargin={8}

--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -32,7 +32,7 @@ export function ChartContainer({
   return (
     <div
       className={cn(
-        "bg-card rounded-lg border border-border p-4",
+        "bg-card rounded-lg border border-border p-4 dark:border-border-night",
         CHART_CONTAINER_HEIGHT_CLASS
       )}
     >
@@ -43,13 +43,17 @@ export function ChartContainer({
         )}
       >
         <div className="flex items-center gap-2">
-          <h3 className="text-lg font-medium text-foreground">{title}</h3>
+          <h3 className="text-lg font-medium text-foreground dark:text-foreground-night">
+            {title}
+          </h3>
           {statusChip}
         </div>
         <div className="flex items-center gap-3">{additionalControls}</div>
       </div>
       {description && (
-        <div className="mb-3 text-xs text-muted-foreground">{description}</div>
+        <div className="mb-3 text-xs text-muted-foreground dark:text-muted-foreground-night">
+          {description}
+        </div>
       )}
       {isLoading || message ? (
         <div
@@ -59,7 +63,9 @@ export function ChartContainer({
           {isLoading ? (
             <Spinner size="lg" />
           ) : (
-            <span className="text-sm text-muted-foreground">{message}</span>
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {message}
+            </span>
           )}
         </div>
       ) : (

--- a/front/components/agent_builder/observability/shared/ChartLegend.tsx
+++ b/front/components/agent_builder/observability/shared/ChartLegend.tsx
@@ -47,7 +47,9 @@ export function ChartLegend({ items }: ChartLegendProps) {
             className={item.colorClassName}
             rounded={item.key === "versionMarkers" ? "full" : "sm"}
           />
-          <span className="text-sm text-muted-foreground">{item.label}</span>
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {item.label}
+          </span>
         </div>
       ))}
     </div>

--- a/front/components/agent_builder/observability/shared/ChartTooltip.tsx
+++ b/front/components/agent_builder/observability/shared/ChartTooltip.tsx
@@ -36,25 +36,33 @@ export function ChartTooltipCard({ title, rows, footer }: ChartTooltipProps) {
   return (
     <div
       role="tooltip"
-      className="min-w-32 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl"
+      className="min-w-32 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl dark:border-border-night/50 dark:bg-background-night"
     >
-      {title && <div className="mb-1 font-medium text-foreground">{title}</div>}
+      {title && (
+        <div className="mb-1 font-medium text-foreground dark:text-foreground-night">
+          {title}
+        </div>
+      )}
       <ul className="space-y-1.5">
         {rows.map((r) => (
           <li key={r.label} className="flex items-center gap-2">
             {r.colorClassName && <LegendDot className={r.colorClassName} />}
-            <span className="text-muted-foreground">{r.label}</span>
-            <span className="ml-auto font-mono font-medium tabular-nums text-foreground">
+            <span className="text-muted-foreground dark:text-muted-foreground-night">
+              {r.label}
+            </span>
+            <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
               {r.value}
             </span>
             {typeof r.percent === "number" && (
-              <span className="text-muted-foreground">({r.percent}%)</span>
+              <span className="text-muted-foreground dark:text-muted-foreground-night">
+                ({r.percent}%)
+              </span>
             )}
           </li>
         ))}
       </ul>
       {footer && (
-        <div className="mt-1 border-t border-border/50 pt-1 text-muted-foreground">
+        <div className="mt-1 border-t border-border/50 pt-1 text-muted-foreground dark:border-border-night/50 dark:text-muted-foreground-night">
           {footer}
         </div>
       )}


### PR DESCRIPTION
## Description

The same colors were used in the `ChartContainer` for both light and dark modes.
This lead to the titles not being visible and the borders standing out.

Before
<img width="738" height="1053" alt="Screenshot 2025-11-06 at 2 43 26 PM" src="https://github.com/user-attachments/assets/e60a9f9b-1ad8-4c55-a4d5-28b859f798ce" />

After
<img width="738" height="1053" alt="Screenshot 2025-11-06 at 2 57 12 PM" src="https://github.com/user-attachments/assets/76a6e315-9967-46ce-b836-eb5bd098aae7" />


## Tests

- Checked locally

## Risk

- Low.

## Deploy Plan

- Deploy front.
