### PR TITLE
feat: use timestamp index rather than document

### DIFF
--- a/core/src/stores/migrations/20251107_add_partial_index_data_sources_documents_latest_status.sql
+++ b/core/src/stores/migrations/20251107_add_partial_index_data_sources_documents_latest_status.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_data_sources_documents_data_source_document_id_status_latest
+ON data_sources_documents (data_source, document_id) WHERE status = 'latest';

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -631,7 +631,7 @@ pub const POSTGRES_TABLES: [&'static str; 16] = [
     );",
 ];
 
-pub const SQL_INDEXES: [&'static str; 34] = [
+pub const SQL_INDEXES: [&'static str; 35] = [
     "CREATE INDEX IF NOT EXISTS
        idx_specifications_project_created ON specifications (project, created);",
     "CREATE INDEX IF NOT EXISTS
@@ -664,6 +664,9 @@ pub const SQL_INDEXES: [&'static str; 34] = [
     "CREATE INDEX IF NOT EXISTS
        idx_data_sources_documents_data_source_document_id
        ON data_sources_documents (data_source, document_id);",
+    "CREATE INDEX IF NOT EXISTS
+       idx_data_sources_documents_data_source_document_id_status_latest
+       ON data_sources_documents (data_source, document_id) WHERE status = 'latest';",
     "CREATE INDEX IF NOT EXISTS
        idx_data_sources_documents_data_source_status_timestamp
        ON data_sources_documents (data_source, status, timestamp);",


### PR DESCRIPTION
## Description

This PR relates to activity heartbeat-timing out.
Time out is most likely due to the query which does not use the best index.

Example stuck workflow : https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/intercom-sync-31079-team-5025594/019a5880-6bdd-7aba-a1c9-b9ac14ed19ed/history

Indexes :

**New**
idx_data_sources_documents_data_source_status_timestamp ON public.data_sources_documents USING btree (data_source, status, "timestamp")

**Old**
idx_data_sources_documents_data_source_document_id_status ON public.data_sources_documents USING btree (data_source, document_id, status)

## Tests

Not tested, keeping an eye on it as on-call

## Risk

Production-check activity failing - not critical

## Deploy Plan

front
