### PR TITLE
feat: increase start to close timeout for syncTeamOnlyActivity

### DIFF
--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -21,8 +21,11 @@ const {
   startToCloseTimeout: "5 minutes",
 });
 
+const { syncTeamOnlyActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+});
+
 const {
-  syncTeamOnlyActivity,
   getTeamIdsToSyncActivity,
   getNextConversationBatchToSyncActivity,
   syncConversationBatchActivity,


### PR DESCRIPTION
## Description

Increase intercom syncTeamOnlyActivity start to close timeout from 5 to 10 mins

## Tests

## Risk

low

## Deploy Plan

connectors
