### PR TITLE
[front/relocation] fix: Map user id in case of conflict on workOSUserId

### DIFF
--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -364,14 +364,15 @@ function applyUserIdMapping(
   userIdMapping: Map<ModelId, ModelId>,
   localLogger: typeof logger
 ): any[] {
-  // Common user-related foreign key column names
+  // User-related foreign key column names from Sequelize models
+  // Verified by scanning all models in lib/resources/storage/models and lib/models
   const userColumnNames = [
-    "userId",
-    "editedByUserId",
-    "createdByUserId",
-    "requestedByUserId",
-    "invitedByUserId",
-    "cancelledByUserId",
+    "authorId", // AgentConfiguration
+    "editedByUserId", // DataSource, DataSourceView, MCPServerView, WebhookSourcesView
+    "editor", // Trigger
+    "invitedUserId", // MembershipInvitation
+    "sharedBy", // FileShare
+    "userId", // All other models
   ];
 
   return applyIdMapping(

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -26,7 +26,7 @@ export async function writeCoreEntitiesToDestinationRegion({
   destRegion: RegionType;
   sourceRegion: RegionType;
   workspaceId: string;
-}): Promise<string> {
+}): Promise<{ userIdMappingPath: string }> {
   const localLogger = logger.child({
     destRegion,
     sourceRegion,
@@ -165,7 +165,7 @@ export async function writeCoreEntitiesToDestinationRegion({
     "[SQL Core Entities] User ID mapping stored"
   );
 
-  return userIdMappingPath;
+  return { userIdMappingPath };
 }
 
 export async function processFrontTableChunk({

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -12,7 +12,9 @@ import type {
 import {
   deleteFromRelocationStorage,
   readFromRelocationStorage,
+  writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { ModelId } from "@app/types";
 
 export async function writeCoreEntitiesToDestinationRegion({
   dataPath,
@@ -24,7 +26,7 @@ export async function writeCoreEntitiesToDestinationRegion({
   destRegion: RegionType;
   sourceRegion: RegionType;
   workspaceId: string;
-}) {
+}): Promise<string> {
   const localLogger = logger.child({
     destRegion,
     sourceRegion,
@@ -47,24 +49,85 @@ export async function writeCoreEntitiesToDestinationRegion({
     type: QueryTypes.INSERT,
   });
 
-  // 2) Create users in transaction.
+  // 2) Handle users with potential WorkOS ID conflicts.
+  // Build a mapping from source user IDs to destination user IDs.
+  const userIdMapping = new Map<ModelId, ModelId>();
+
   for (const { sql, params } of blob.statements.users) {
     await withTransaction(async (transaction) => {
+      // Extract column positions (minimal parsing - just need to know where id and email are)
+      const columnMatch = sql.match(/INSERT INTO "users" \((.*?)\) VALUES/);
+      if (!columnMatch) {
+        throw new Error("Failed to parse user INSERT statement");
+      }
+      const columns = columnMatch[1]
+        .split(",")
+        .map((col) => col.trim().replace(/"/g, ""));
+      const idIndex = columns.indexOf("id");
+      const numColumns = columns.length;
+
+      // Modify the SQL to use ON CONFLICT with DO UPDATE to detect conflicts
+      // xmax = 0 tells us if it was an insert (true) or conflict (false)
+      const modifiedSql = sql.replace(
+        /ON CONFLICT DO NOTHING/,
+        `ON CONFLICT ("workOSUserId") DO UPDATE SET "workOSUserId" = EXCLUDED."workOSUserId" RETURNING id, "workOSUserId", email, xmax = 0 AS inserted`
+      );
+
+      // Execute the INSERT/UPDATE
       // eslint-disable-next-line dust/no-raw-sql
-      await frontSequelize.query(sql, {
+      const results = await frontSequelize.query<{
+        id: ModelId;
+        workOSUserId: string | null;
+        email: string;
+        inserted: boolean;
+      }>(modifiedSql, {
         bind: params,
-        type: QueryTypes.INSERT,
+        type: QueryTypes.SELECT,
         transaction,
       });
+
+      // Process results to build mapping for conflicted users
+      // Correlate with params to get source IDs
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
+        if (!result.inserted) {
+          const sourceUserId = params[i * numColumns + idIndex] as ModelId;
+
+          // This was a conflict - user already existed
+          // Map source ID to the existing destination ID
+          userIdMapping.set(sourceUserId, result.id);
+
+          localLogger.info(
+            {
+              sourceUserId,
+              destinationUserId: result.id,
+              workOSUserId: result.workOSUserId,
+              email: result.email,
+            },
+            "[SQL Core Entities] Found existing user with same workOSUserId, mapping to existing user"
+          );
+        }
+      }
     });
   }
 
-  // 3) Create users metadata in transaction.
+  localLogger.info(
+    { mappingSize: userIdMapping.size },
+    "[SQL Core Entities] User ID mapping created"
+  );
+
+  // 3) Create users metadata in transaction, applying user ID mapping.
   for (const { sql, params } of blob.statements.user_metadata) {
     await withTransaction(async (transaction) => {
+      // Apply user ID mapping to user_metadata using the helper function
+      const mappedParams =
+        userIdMapping.size > 0
+          ? applyUserIdMapping(sql, params, userIdMapping, localLogger)
+          : params;
+
       // eslint-disable-next-line dust/no-raw-sql
       await frontSequelize.query(sql, {
-        bind: params,
+        bind: mappedParams,
         type: QueryTypes.INSERT,
         transaction,
       });
@@ -86,6 +149,23 @@ export async function writeCoreEntitiesToDestinationRegion({
   localLogger.info("[SQL Core Entities] Core entities written successfully.");
 
   await deleteFromRelocationStorage(dataPath);
+
+  // Store the user ID mapping for use in table processing
+  const userIdMappingPath = await writeToRelocationStorage(
+    Object.fromEntries(userIdMapping),
+    {
+      workspaceId,
+      type: "front",
+      operation: "user_id_mapping",
+    }
+  );
+
+  localLogger.info(
+    { userIdMappingPath, mappingSize: userIdMapping.size },
+    "[SQL Core Entities] User ID mapping stored"
+  );
+
+  return userIdMappingPath;
 }
 
 export async function processFrontTableChunk({
@@ -94,12 +174,14 @@ export async function processFrontTableChunk({
   sourceRegion,
   tableName,
   workspaceId,
+  userIdMappingPath,
 }: {
   dataPath: string;
   destRegion: string;
   sourceRegion: string;
   tableName: string;
   workspaceId: string;
+  userIdMappingPath?: string;
 }) {
   const localLogger = logger.child({
     destRegion,
@@ -128,6 +210,29 @@ export async function processFrontTableChunk({
     }
   }
 
+  // Load user ID mapping if provided
+  let userIdMapping: Map<ModelId, ModelId> | undefined;
+  if (userIdMappingPath) {
+    try {
+      const mappingData =
+        await readFromRelocationStorage<Record<string, ModelId>>(
+          userIdMappingPath
+        );
+      userIdMapping = new Map(
+        Object.entries(mappingData).map(([k, v]) => [Number(k) as ModelId, v])
+      );
+      localLogger.info(
+        { mappingSize: userIdMapping.size },
+        "[SQL] Loaded user ID mapping"
+      );
+    } catch (error) {
+      localLogger.warn(
+        { error, userIdMappingPath },
+        "[SQL] Failed to load user ID mapping, proceeding without it"
+      );
+    }
+  }
+
   for (const [tableName, statements] of Object.entries(blob.statements)) {
     logger.info(
       { tableName, dataPath, statementCount: statements.length },
@@ -135,18 +240,146 @@ export async function processFrontTableChunk({
     );
 
     for (const { sql, params } of statements) {
-      await withTransaction(async (transaction) =>
+      await withTransaction(async (transaction) => {
+        // Apply user ID mapping if provided and table has userId column
+        let mappedParams = params;
+
+        if (userIdMapping && userIdMapping.size > 0) {
+          mappedParams = applyUserIdMapping(
+            sql,
+            params,
+            userIdMapping,
+            localLogger
+          );
+        }
+
         // eslint-disable-next-line dust/no-raw-sql
-        frontSequelize.query(sql, {
-          bind: params,
+        await frontSequelize.query(sql, {
+          bind: mappedParams,
           type: QueryTypes.INSERT,
           transaction,
-        })
-      );
+        });
+      });
     }
   }
 
   localLogger.info("[SQL] Table chunk written successfully.");
 
   await deleteFromRelocationStorage(dataPath);
+}
+
+/**
+ * Generic function to apply ID mappings to SQL statement parameters.
+ * Can be used for any type of ID mapping (users, workspaces, etc.)
+ */
+function applyIdMapping(
+  sql: string,
+  params: any[],
+  columnNames: string[],
+  idMapping: Map<ModelId, ModelId>,
+  localLogger: typeof logger,
+  logPrefix: string
+): any[] {
+  // Extract table name and columns from INSERT statement
+  const tableMatch = sql.match(/INSERT INTO "([^"]+)" \((.*?)\) VALUES/);
+  if (!tableMatch) {
+    return params;
+  }
+
+  const tableName = tableMatch[1];
+  const columns = tableMatch[2]
+    .split(",")
+    .map((col) => col.trim().replace(/"/g, ""));
+
+  // Find indices of columns that need mapping
+  const columnIndices: Array<{ name: string; index: number }> = [];
+  columnNames.forEach((colName) => {
+    const idx = columns.indexOf(colName);
+    if (idx !== -1) {
+      columnIndices.push({ name: colName, index: idx });
+    }
+  });
+
+  if (columnIndices.length === 0) {
+    // No columns to map in this table
+    return params;
+  }
+
+  // Parse values section to determine number of rows
+  const valuesSection = sql.match(/VALUES (.*?)(;| ON CONFLICT)/)?.[1];
+  if (!valuesSection) {
+    return params;
+  }
+
+  const rowMatches = valuesSection.match(/\([^)]+\)/g);
+  if (!rowMatches) {
+    return params;
+  }
+
+  const numColumns = columns.length;
+  const mappedParams = [...params];
+  let paramIndex = 0;
+  let mappedCount = 0;
+
+  for (const _ of rowMatches) {
+    // For each column in this row, apply the mapping
+    for (const { index } of columnIndices) {
+      const actualParamIndex = paramIndex + index;
+      const sourceId = params[actualParamIndex] as ModelId | null;
+
+      if (sourceId !== null && sourceId !== undefined) {
+        const destinationId = idMapping.get(sourceId);
+
+        if (destinationId !== undefined) {
+          mappedParams[actualParamIndex] = destinationId;
+          mappedCount++;
+        }
+      }
+    }
+
+    paramIndex += numColumns;
+  }
+
+  if (mappedCount > 0) {
+    localLogger.info(
+      {
+        tableName,
+        mappedCount,
+        columns: columnIndices.map((c) => c.name),
+      },
+      `[SQL] ${logPrefix}`
+    );
+  }
+
+  return mappedParams;
+}
+
+/**
+ * Apply user ID mapping to SQL statement parameters.
+ * Handles userId and other user-related foreign key columns.
+ */
+function applyUserIdMapping(
+  sql: string,
+  params: any[],
+  userIdMapping: Map<ModelId, ModelId>,
+  localLogger: typeof logger
+): any[] {
+  // Common user-related foreign key column names
+  const userColumnNames = [
+    "userId",
+    "editedByUserId",
+    "createdByUserId",
+    "requestedByUserId",
+    "invitedByUserId",
+    "cancelledByUserId",
+  ];
+
+  return applyIdMapping(
+    sql,
+    params,
+    userColumnNames,
+    userIdMapping,
+    localLogger,
+    "Applied user ID mapping to table"
+  );
 }

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -126,7 +126,7 @@ export async function workspaceRelocateFrontWorkflow({
       workspaceId,
     });
 
-  const userIdMappingPath =
+  const { userIdMappingPath } =
     await destinationRegionActivities.writeCoreEntitiesToDestinationRegion({
       dataPath: coreEntitiesDataPath,
       destRegion,

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -126,12 +126,13 @@ export async function workspaceRelocateFrontWorkflow({
       workspaceId,
     });
 
-  await destinationRegionActivities.writeCoreEntitiesToDestinationRegion({
-    dataPath: coreEntitiesDataPath,
-    destRegion,
-    sourceRegion,
-    workspaceId,
-  });
+  const userIdMappingPath =
+    await destinationRegionActivities.writeCoreEntitiesToDestinationRegion({
+      dataPath: coreEntitiesDataPath,
+      destRegion,
+      sourceRegion,
+      workspaceId,
+    });
 
   const tablesOrder =
     await sourceRegionActivities.getTablesWithWorkspaceIdOrder();
@@ -147,6 +148,7 @@ export async function workspaceRelocateFrontWorkflow({
           tableName,
           destRegion,
           workspaceId,
+          userIdMappingPath,
         },
       ],
       memo,
@@ -173,9 +175,11 @@ export async function workspaceRelocateFrontTableWorkflow({
   tableName,
   destRegion,
   workspaceId,
+  userIdMappingPath,
 }: RelocationWorkflowBase & {
   tableName: string;
   lastProcessedId?: ModelId;
+  userIdMappingPath?: string;
 }) {
   // Create activity proxies with dynamic task queues.
   const sourceRegionActivities = getFrontSourceRegionActivities(sourceRegion);
@@ -194,6 +198,7 @@ export async function workspaceRelocateFrontTableWorkflow({
         workspaceId,
         tableName,
         lastProcessedId: currentId,
+        userIdMappingPath,
       });
     }
 
@@ -215,6 +220,7 @@ export async function workspaceRelocateFrontTableWorkflow({
         sourceRegion,
         tableName,
         workspaceId,
+        userIdMappingPath,
       });
     }
 


### PR DESCRIPTION
Fixes: [#4962](https://github.com/dust-tt/tasks/issues/4962)

## Description

Create a mapping file for userIds when inserting new users, in case of conflict on the workOSUserId. 
To do this we replace the "onconflict do nothing" generated by a noop update returning the existing values, get the original id from the sql statement and params, and store this in a mapping file in GCS relocation bucket.

An applyUserIdMapping can be called on any sql/params set, will check for different column names that are known as foreign keys to userId, and return transformed params. It's called on core entities for user_metadata, then on all tables in processFrontTableChunk.



## Tests

must be tested

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
