### PR TITLE
Add onboarding tasks resource & model

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -73,6 +73,7 @@ import {
   LabsTranscriptsHistoryModel,
 } from "@app/lib/resources/storage/models/labs_transcripts";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { OnboardingTaskModel } from "@app/lib/resources/storage/models/onboarding_tasks";
 import { PluginRunModel } from "@app/lib/resources/storage/models/plugin_runs";
 import {
   RunModel,
@@ -183,6 +184,7 @@ async function main() {
   await PluginRunModel.sync({ alter: true });
 
   await AgentMemoryModel.sync({ alter: true });
+  await OnboardingTaskModel.sync({ alter: true });
 
   process.exit(0);
 }

--- a/front/lib/resources/onboarding_task_resource.test.ts
+++ b/front/lib/resources/onboarding_task_resource.test.ts
@@ -86,9 +86,9 @@ describe("OnboardingTaskResource", () => {
 
     it("should include correct status in JSON", async () => {
       const completedTask = await OnboardingTaskFactory.create(authU1W1, {});
-      await completedTask.markCompleted(authU1W1);
+      await completedTask.markCompleted();
       const skippedTask = await OnboardingTaskFactory.create(authU1W1);
-      await skippedTask.markSkipped(authU1W1);
+      await skippedTask.markSkipped();
 
       const todoTask = await OnboardingTaskFactory.create(authU1W1);
       expect(completedTask.toJSON().status).toBe("achieved");
@@ -234,7 +234,7 @@ describe("OnboardingTaskResource", () => {
     it("should mark task as completed", async () => {
       const task = await OnboardingTaskFactory.create(authU1W1);
       expect(task.completedAt).toBeNull();
-      const result = await task.markCompleted(authU1W1);
+      const result = await task.markCompleted();
       expect(result.isOk()).toBe(true);
       expect(task.completedAt).toBeDefined();
       expect(task.completedAt).toBeInstanceOf(Date);
@@ -243,9 +243,9 @@ describe("OnboardingTaskResource", () => {
 
     it("should clear skipped status when marking as completed", async () => {
       const task = await OnboardingTaskFactory.create(authU1W1, {});
-      await task.markSkipped(authU1W1);
+      await task.markSkipped();
       expect(task.skippedAt).toBeDefined();
-      const result = await task.markCompleted(authU1W1);
+      const result = await task.markCompleted();
       expect(result.isOk()).toBe(true);
       expect(task.completedAt).toBeDefined();
       expect(task.skippedAt).toBeNull();
@@ -256,7 +256,7 @@ describe("OnboardingTaskResource", () => {
     it("should mark task as skipped", async () => {
       const task = await OnboardingTaskFactory.create(authU1W1);
       expect(task.skippedAt).toBeNull();
-      const result = await task.markSkipped(authU1W1);
+      const result = await task.markSkipped();
       expect(result.isOk()).toBe(true);
       expect(task.skippedAt).toBeDefined();
       expect(task.skippedAt).toBeInstanceOf(Date);
@@ -266,7 +266,7 @@ describe("OnboardingTaskResource", () => {
     it("should clear completed status when marking as skipped", async () => {
       const task = await OnboardingTaskFactory.create(authU1W1, {});
       expect(task.completedAt).toBeDefined();
-      const result = await task.markSkipped(authU1W1);
+      const result = await task.markSkipped();
       expect(result.isOk()).toBe(true);
       expect(task.skippedAt).toBeDefined();
       expect(task.completedAt).toBeNull();
@@ -281,13 +281,13 @@ describe("OnboardingTaskResource", () => {
 
     it("should return 'achieved' for completed tasks", async () => {
       const task = await OnboardingTaskFactory.create(authU1W1);
-      await task.markCompleted(authU1W1);
+      await task.markCompleted();
       expect(task.getStatus()).toBe("achieved");
     });
 
     it("should return 'skipped' for skipped tasks", async () => {
       const task = await OnboardingTaskFactory.create(authU1W1);
-      await task.markSkipped(authU1W1);
+      await task.markSkipped();
       expect(task.getStatus()).toBe("skipped");
     });
   });

--- a/front/lib/resources/onboarding_task_resource.test.ts
+++ b/front/lib/resources/onboarding_task_resource.test.ts
@@ -1,0 +1,388 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { OnboardingTaskFactory } from "@app/tests/utils/OnboardingTaskFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types";
+
+describe("OnboardingTaskResource", () => {
+  let workspace1: WorkspaceType;
+  let workspace2: WorkspaceType;
+
+  let user1: UserResource;
+  let user2: UserResource;
+
+  let authU1W1: Authenticator;
+  let authU1W2: Authenticator;
+
+  let authU2W1: Authenticator;
+  let authU2W2: Authenticator;
+
+  beforeEach(async () => {
+    workspace1 = await WorkspaceFactory.basic();
+    workspace2 = await WorkspaceFactory.basic();
+
+    user1 = await UserFactory.basic();
+    user2 = await UserFactory.basic();
+
+    authU1W1 = await Authenticator.fromUserIdAndWorkspaceId(
+      user1.sId,
+      workspace1.sId
+    );
+    authU2W1 = await Authenticator.fromUserIdAndWorkspaceId(
+      user2.sId,
+      workspace1.sId
+    );
+
+    authU1W2 = await Authenticator.fromUserIdAndWorkspaceId(
+      user1.sId,
+      workspace2.sId
+    );
+    authU2W2 = await Authenticator.fromUserIdAndWorkspaceId(
+      user2.sId,
+      workspace2.sId
+    );
+  });
+
+  /** *************************************************************
+   * Very basic tests first:
+   * makeNew and serialization.
+   ************************************************************** */
+  describe("makeNew", () => {
+    it("should create a new onboarding task", async () => {
+      const task = await OnboardingTaskResource.makeNew(authU1W1, {
+        context: "Soupinou is the best",
+        kind: "learning",
+        toolName: null,
+      });
+      expect(task).toBeDefined();
+      expect(task.sId).toMatch(/^obt_/);
+      expect(task.workspaceId).toBe(workspace1.id);
+      expect(task.userId).toBe(user1.id);
+      expect(task.context).toBe("Soupinou is the best");
+      expect(task.kind).toBe("learning");
+      expect(task.toolName).toBeNull();
+      expect(task.completedAt).toBeNull();
+      expect(task.skippedAt).toBeNull();
+    });
+  });
+
+  describe("toJSON", () => {
+    it("should serialize task to JSON with correct structure", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1, {
+        toolName: "notion",
+      });
+      const json = task.toJSON();
+      expect(json).toEqual({
+        sId: task.sId,
+        context: task.context,
+        kind: task.kind,
+        toolName: task.toolName,
+        status: "to_do",
+        createdAt: task.createdAt,
+        updatedAt: task.updatedAt,
+      });
+    });
+
+    it("should include correct status in JSON", async () => {
+      const completedTask = await OnboardingTaskFactory.create(authU1W1, {});
+      await completedTask.markCompleted(authU1W1);
+      const skippedTask = await OnboardingTaskFactory.create(authU1W1);
+      await skippedTask.markSkipped(authU1W1);
+
+      const todoTask = await OnboardingTaskFactory.create(authU1W1);
+      expect(completedTask.toJSON().status).toBe("achieved");
+      expect(skippedTask.toJSON().status).toBe("skipped");
+      expect(todoTask.toJSON().status).toBe("to_do");
+    });
+
+    it("should handle null toolName in JSON", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1, {
+        kind: "learning",
+        toolName: null,
+      });
+
+      const json = task.toJSON();
+      expect(json.toolName).toBeNull();
+    });
+  });
+
+  describe("modelIdToSId", () => {
+    it("should generate correct sId from model id and workspace id", () => {
+      const sId = OnboardingTaskResource.modelIdToSId({
+        id: 123,
+        workspaceId: 456,
+      });
+      expect(sId).toMatch(/^obt_/);
+    });
+  });
+
+  /** *************************************************************
+   * Fetch tests:
+   * We check that the resource is correctly scoped to the user and workspace.
+   ************************************************************** */
+  describe("fetchById", () => {
+    let task1: OnboardingTaskResource;
+    let task2: OnboardingTaskResource;
+
+    beforeEach(async () => {
+      // We only create tasks for the first user and workspace.
+      task1 = await OnboardingTaskFactory.create(authU1W1);
+      task2 = await OnboardingTaskFactory.create(authU1W1);
+    });
+
+    it("should fetch task by sId", async () => {
+      const fetched = await OnboardingTaskResource.fetchById(
+        authU1W1,
+        task1.sId
+      );
+      expect(fetched).toBeDefined();
+      expect(fetched?.sId).toBe(task1.sId);
+      expect(fetched?.id).toBe(task1.id);
+      expect(fetched?.context).toBe(task1.context);
+    });
+
+    it("should not fetch task if auth is for a different user", async () => {
+      const fetched = await OnboardingTaskResource.fetchById(
+        authU2W1,
+        task1.sId
+      );
+      expect(fetched).toBeNull();
+    });
+    it("should not fetch task if auth is for a different workspace", async () => {
+      const fetched = await OnboardingTaskResource.fetchById(
+        authU1W2,
+        task2.sId
+      );
+      expect(fetched).toBeNull();
+    });
+
+    it("should return null for non-existent sId", async () => {
+      const fetched = await OnboardingTaskResource.fetchById(
+        authU1W1,
+        "obt_soupinou"
+      );
+      expect(fetched).toBeNull();
+    });
+  });
+
+  describe("fetchByIds", () => {
+    let tasks: OnboardingTaskResource[];
+
+    beforeEach(async () => {
+      // We only create tasks for the first user and workspace.
+      tasks = await OnboardingTaskFactory.createMultiple(authU1W1, 3);
+    });
+
+    it("should fetch multiple tasks by sIds", async () => {
+      const sIds = tasks.map((t) => t.sId);
+      const fetched = await OnboardingTaskResource.fetchByIds(authU1W1, sIds);
+      expect(fetched).toHaveLength(3);
+      expect(fetched.map((t) => t.sId).sort()).toEqual(sIds.sort());
+    });
+
+    it("should filter out invalid sIds", async () => {
+      const sIds = [tasks[0].sId, "obt_soupinou", tasks[1].sId];
+      const fetched = await OnboardingTaskResource.fetchByIds(authU1W1, sIds);
+      expect(fetched).toHaveLength(2);
+      expect(fetched.map((t) => t.sId).sort()).toEqual(
+        [tasks[0].sId, tasks[1].sId].sort()
+      );
+    });
+
+    it("should not fetch tasks from different user", async () => {
+      const sIds = tasks.map((t) => t.sId);
+      const fetched = await OnboardingTaskResource.fetchByIds(authU2W1, sIds);
+      expect(fetched).toHaveLength(0);
+    });
+
+    it("should not fetch tasks from different workspace", async () => {
+      const sIds = tasks.map((t) => t.sId);
+      const fetched = await OnboardingTaskResource.fetchByIds(authU1W2, sIds);
+      expect(fetched).toHaveLength(0);
+    });
+  });
+
+  describe("fetchAll", () => {
+    let tasks: OnboardingTaskResource[];
+    beforeEach(async () => {
+      tasks = await OnboardingTaskFactory.createMultiple(authU1W1, 3);
+    });
+    it("should fetch all tasks for the user and workspace", async () => {
+      const fetched = await OnboardingTaskResource.fetchAll(authU1W1);
+      expect(fetched).toHaveLength(3);
+      expect(fetched.map((t) => t.sId).sort()).toEqual(
+        tasks.map((t) => t.sId).sort()
+      );
+    });
+    it("should not fetch tasks from different user", async () => {
+      const fetched = await OnboardingTaskResource.fetchAll(authU2W1);
+      expect(fetched).toHaveLength(0);
+    });
+
+    it("should not fetch tasks from different workspace", async () => {
+      const fetched = await OnboardingTaskResource.fetchAll(authU1W2);
+      expect(fetched).toHaveLength(0);
+    });
+  });
+
+  /** *************************************************************
+   * Test around task statuses:
+   * We check that the task status is correctly set when marking as completed or skipped.
+   * We also check that the status is correctly cleared when marking as completed or skipped.
+   ************************************************************** */
+  describe("markCompleted", () => {
+    it("should mark task as completed", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1);
+      expect(task.completedAt).toBeNull();
+      const result = await task.markCompleted(authU1W1);
+      expect(result.isOk()).toBe(true);
+      expect(task.completedAt).toBeDefined();
+      expect(task.completedAt).toBeInstanceOf(Date);
+      expect(task.skippedAt).toBeNull();
+    });
+
+    it("should clear skipped status when marking as completed", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1, {});
+      await task.markSkipped(authU1W1);
+      expect(task.skippedAt).toBeDefined();
+      const result = await task.markCompleted(authU1W1);
+      expect(result.isOk()).toBe(true);
+      expect(task.completedAt).toBeDefined();
+      expect(task.skippedAt).toBeNull();
+    });
+  });
+
+  describe("markSkipped", () => {
+    it("should mark task as skipped", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1);
+      expect(task.skippedAt).toBeNull();
+      const result = await task.markSkipped(authU1W1);
+      expect(result.isOk()).toBe(true);
+      expect(task.skippedAt).toBeDefined();
+      expect(task.skippedAt).toBeInstanceOf(Date);
+      expect(task.completedAt).toBeNull();
+    });
+
+    it("should clear completed status when marking as skipped", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1, {});
+      expect(task.completedAt).toBeDefined();
+      const result = await task.markSkipped(authU1W1);
+      expect(result.isOk()).toBe(true);
+      expect(task.skippedAt).toBeDefined();
+      expect(task.completedAt).toBeNull();
+    });
+  });
+
+  describe("getStatus", () => {
+    it("should return 'to_do' for new tasks", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1);
+      expect(task.getStatus()).toBe("to_do");
+    });
+
+    it("should return 'achieved' for completed tasks", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1);
+      await task.markCompleted(authU1W1);
+      expect(task.getStatus()).toBe("achieved");
+    });
+
+    it("should return 'skipped' for skipped tasks", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1);
+      await task.markSkipped(authU1W1);
+      expect(task.getStatus()).toBe("skipped");
+    });
+  });
+
+  /** *************************************************************
+   * Delete tests:
+   * We check that the resource is correctly scoped to the user and workspace.
+   ************************************************************** */
+  describe("delete", () => {
+    it("should delete a task", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1);
+      const sId = task.sId;
+      const result = await task.delete(authU1W1, {});
+      expect(result.isOk()).toBe(true);
+      const fetched = await OnboardingTaskResource.fetchById(authU1W1, sId);
+      expect(fetched).toBeNull();
+    });
+
+    it("should not delete task from different user", async () => {
+      const task = await OnboardingTaskFactory.create(authU1W1);
+      const sId = task.sId;
+      const result = await task.delete(authU2W1, {});
+      // The delete should succeed (no error) but not actually delete the task.
+      expect(result.isOk()).toBe(true);
+      const fetched = await OnboardingTaskResource.fetchById(authU1W1, sId);
+      expect(fetched).toBeDefined();
+      expect(fetched?.sId).toBe(sId);
+    });
+  });
+
+  describe("deleteAllForUser", () => {
+    it("should delete all tasks for a specific user", async () => {
+      const task1 = await OnboardingTaskFactory.create(authU1W1);
+      const task2 = await OnboardingTaskFactory.create(authU1W1);
+      const otherUserTask = await OnboardingTaskFactory.create(authU2W1);
+
+      await OnboardingTaskResource.deleteAllForUser(authU1W1, user1.toJSON());
+
+      // User's tasks should be deleted.
+      const fetched1 = await OnboardingTaskResource.fetchById(
+        authU1W1,
+        task1.sId
+      );
+      const fetched2 = await OnboardingTaskResource.fetchById(
+        authU1W1,
+        task2.sId
+      );
+      expect(fetched1).toBeNull();
+      expect(fetched2).toBeNull();
+
+      // Other user's task should still exist.
+      const fetchedOther = await OnboardingTaskResource.fetchById(
+        authU2W1,
+        otherUserTask.sId
+      );
+      expect(fetchedOther).toBeDefined();
+      expect(fetchedOther?.sId).toBe(otherUserTask.sId);
+    });
+  });
+
+  describe("deleteAllForWorkspace", () => {
+    it("should delete all tasks for a workspace", async () => {
+      const task1 = await OnboardingTaskFactory.create(authU1W1);
+      const task2 = await OnboardingTaskFactory.create(authU1W1);
+      const task3 = await OnboardingTaskFactory.create(authU2W1);
+      const taskOtherWorkspace = await OnboardingTaskFactory.create(authU2W2);
+
+      await OnboardingTaskResource.deleteAllForWorkspace(authU1W1);
+
+      const fetched1 = await OnboardingTaskResource.fetchById(
+        authU1W1,
+        task1.sId
+      );
+      const fetched2 = await OnboardingTaskResource.fetchById(
+        authU1W1,
+        task2.sId
+      );
+      const fetched3 = await OnboardingTaskResource.fetchById(
+        authU2W1,
+        task3.sId
+      );
+      const fetched4 = await OnboardingTaskResource.fetchById(
+        authU2W2,
+        taskOtherWorkspace.sId
+      );
+
+      expect(fetched1).toBeNull();
+      expect(fetched2).toBeNull();
+      expect(fetched3).toBeNull();
+      expect(fetched4).toBeDefined();
+      expect(fetched4?.sId).toBe(taskOtherWorkspace.sId);
+    });
+  });
+});

--- a/front/lib/resources/onboarding_task_resource.ts
+++ b/front/lib/resources/onboarding_task_resource.ts
@@ -6,7 +6,6 @@ import type {
 } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
-import { DustError } from "@app/lib/error";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { OnboardingTaskKind } from "@app/lib/resources/storage/models/onboarding_tasks";
 import { OnboardingTaskModel } from "@app/lib/resources/storage/models/onboarding_tasks";
@@ -15,7 +14,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { ModelId, Result, UserType } from "@app/types";
-import { Err, Ok, removeNulls } from "@app/types";
+import { Ok, removeNulls } from "@app/types";
 
 export type OnboardingTaskStatus = "to_do" | "achieved" | "skipped";
 
@@ -119,19 +118,8 @@ export class OnboardingTaskResource extends BaseResource<OnboardingTaskModel> {
   }
 
   async markCompleted(
-    auth: Authenticator,
     transaction?: Transaction
   ): Promise<Result<OnboardingTaskResource, Error>> {
-    const workspace = auth.getNonNullableWorkspace();
-    const user = auth.getNonNullableUser();
-    if (this.workspaceId !== workspace.id || this.userId !== user.id) {
-      return new Err(
-        new DustError(
-          "unauthorized",
-          "User does not have access to this onboarding task"
-        )
-      );
-    }
     await this.update(
       {
         completedAt: new Date(),
@@ -143,19 +131,8 @@ export class OnboardingTaskResource extends BaseResource<OnboardingTaskModel> {
   }
 
   async markSkipped(
-    auth: Authenticator,
     transaction?: Transaction
   ): Promise<Result<OnboardingTaskResource, Error>> {
-    const workspace = auth.getNonNullableWorkspace();
-    const user = auth.getNonNullableUser();
-    if (this.workspaceId !== workspace.id || this.userId !== user.id) {
-      return new Err(
-        new DustError(
-          "unauthorized",
-          "User does not have access to this onboarding task"
-        )
-      );
-    }
     await this.update(
       {
         skippedAt: new Date(),

--- a/front/lib/resources/onboarding_task_resource.ts
+++ b/front/lib/resources/onboarding_task_resource.ts
@@ -1,0 +1,254 @@
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+} from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { OnboardingTaskKind } from "@app/lib/resources/storage/models/onboarding_tasks";
+import { OnboardingTaskModel } from "@app/lib/resources/storage/models/onboarding_tasks";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { ModelId, Result, UserType } from "@app/types";
+import { Err, Ok, removeNulls } from "@app/types";
+
+export type OnboardingTaskStatus = "to_do" | "achieved" | "skipped";
+
+export type OnboardingTask = {
+  sId: string;
+  context: string;
+  kind: OnboardingTaskKind;
+  toolName: string | null;
+  status: OnboardingTaskStatus;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// This design will be moved up to BaseResource once we transition away from Sequelize.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
+export interface OnboardingTaskResource
+  extends ReadonlyAttributesType<OnboardingTaskModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class OnboardingTaskResource extends BaseResource<OnboardingTaskModel> {
+  static model: ModelStaticWorkspaceAware<OnboardingTaskModel> =
+    OnboardingTaskModel;
+
+  constructor(
+    model: ModelStatic<OnboardingTaskModel>,
+    blob: Attributes<OnboardingTaskModel>
+  ) {
+    super(OnboardingTaskModel, blob);
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    blob: CreationAttributes<OnboardingTaskModel>,
+    transaction?: Transaction
+  ) {
+    const task = await OnboardingTaskModel.create(
+      {
+        ...blob,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: auth.getNonNullableUser().id,
+      },
+      { transaction }
+    );
+
+    return new this(OnboardingTaskModel, task.get());
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<OnboardingTaskModel>,
+    transaction?: Transaction
+  ): Promise<OnboardingTaskResource[]> {
+    const { where, ...otherOptions } = options ?? {};
+
+    const tasks = await OnboardingTaskModel.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: auth.getNonNullableUser().id,
+      },
+      ...otherOptions,
+      transaction,
+    });
+
+    return tasks.map((t) => new this(OnboardingTaskModel, t.get()));
+  }
+
+  static async fetchAll(
+    auth: Authenticator
+  ): Promise<OnboardingTaskResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: auth.getNonNullableUser().id,
+      },
+    });
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    sId: string
+  ): Promise<OnboardingTaskResource | null> {
+    const id = getResourceIdFromSId(sId);
+    if (!id) {
+      return null;
+    }
+
+    const [task] = await this.baseFetch(auth, {
+      where: {
+        id,
+      },
+    });
+
+    return task ?? null;
+  }
+
+  static async fetchByIds(
+    auth: Authenticator,
+    sIds: string[]
+  ): Promise<OnboardingTaskResource[]> {
+    const modelIds = removeNulls(sIds.map(getResourceIdFromSId));
+
+    return this.baseFetch(auth, {
+      where: {
+        id: modelIds,
+      },
+    });
+  }
+
+  async markCompleted(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<Result<OnboardingTaskResource, Error>> {
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+    if (this.workspaceId !== workspace.id || this.userId !== user.id) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "User does not have access to this onboarding task"
+        )
+      );
+    }
+    await this.update(
+      {
+        completedAt: new Date(),
+        skippedAt: null,
+      },
+      transaction
+    );
+    return new Ok(this);
+  }
+
+  async markSkipped(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<Result<OnboardingTaskResource, Error>> {
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+    if (this.workspaceId !== workspace.id || this.userId !== user.id) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "User does not have access to this onboarding task"
+        )
+      );
+    }
+    await this.update(
+      {
+        skippedAt: new Date(),
+        completedAt: null,
+      },
+      transaction
+    );
+    return new Ok(this);
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction }
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: auth.getNonNullableUser().id,
+        id: this.id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+
+  // This one is not taking the user from the auth object, since it's used from an admin auth object without a user.
+  static async deleteAllForUser(
+    auth: Authenticator,
+    user: UserType
+  ): Promise<void> {
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: user.id,
+      },
+    });
+  }
+
+  static async deleteAllForWorkspace(auth: Authenticator): Promise<undefined> {
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+
+  getStatus(): OnboardingTaskStatus {
+    if (this.completedAt !== null) {
+      return "achieved";
+    }
+    if (this.skippedAt !== null) {
+      return "skipped";
+    }
+    return "to_do";
+  }
+
+  get sId(): string {
+    return OnboardingTaskResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("onboarding_task", {
+      id,
+      workspaceId,
+    });
+  }
+
+  toJSON(): OnboardingTask {
+    return {
+      sId: this.sId,
+      context: this.context,
+      kind: this.kind,
+      toolName: this.toolName,
+      status: this.getStatus(),
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+}

--- a/front/lib/resources/onboarding_task_resource.ts
+++ b/front/lib/resources/onboarding_task_resource.ts
@@ -19,7 +19,7 @@ import { Err, Ok, removeNulls } from "@app/types";
 
 export type OnboardingTaskStatus = "to_do" | "achieved" | "skipped";
 
-export type OnboardingTask = {
+export type OnboardingTaskType = {
   sId: string;
   context: string;
   kind: OnboardingTaskKind;
@@ -83,7 +83,7 @@ export class OnboardingTaskResource extends BaseResource<OnboardingTaskModel> {
     return tasks.map((t) => new this(OnboardingTaskModel, t.get()));
   }
 
-  static async fetchAll(
+  static async fetchAllForUserAndWorkspaceInAuth(
     auth: Authenticator
   ): Promise<OnboardingTaskResource[]> {
     return this.baseFetch(auth, {
@@ -98,18 +98,11 @@ export class OnboardingTaskResource extends BaseResource<OnboardingTaskModel> {
     auth: Authenticator,
     sId: string
   ): Promise<OnboardingTaskResource | null> {
-    const id = getResourceIdFromSId(sId);
-    if (!id) {
+    const tasks = await this.fetchByIds(auth, [sId]);
+    if (tasks.length === 0) {
       return null;
     }
-
-    const [task] = await this.baseFetch(auth, {
-      where: {
-        id,
-      },
-    });
-
-    return task ?? null;
+    return tasks[0];
   }
 
   static async fetchByIds(
@@ -240,7 +233,7 @@ export class OnboardingTaskResource extends BaseResource<OnboardingTaskModel> {
     });
   }
 
-  toJSON(): OnboardingTask {
+  toJSON(): OnboardingTaskType {
     return {
       sId: this.sId,
       context: this.context,

--- a/front/lib/resources/storage/models/onboarding_tasks.ts
+++ b/front/lib/resources/storage/models/onboarding_tasks.ts
@@ -1,0 +1,82 @@
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+
+export const ONBOARDING_TASK_KINDS = [
+  "tool_setup_admin",
+  "tool_setup_personal",
+  "tool_use",
+  "learning",
+] as const;
+export type OnboardingTaskKind = (typeof ONBOARDING_TASK_KINDS)[number];
+
+export class OnboardingTaskModel extends WorkspaceAwareModel<OnboardingTaskModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare context: string;
+  declare kind: OnboardingTaskKind;
+  declare toolName: string | null;
+
+  declare completedAt: Date | null;
+  declare skippedAt: Date | null;
+
+  declare userId: ForeignKey<UserModel["id"]>;
+  declare user: NonAttribute<UserModel>;
+}
+
+OnboardingTaskModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    context: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    kind: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        isIn: [ONBOARDING_TASK_KINDS],
+      },
+    },
+    toolName: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    completedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    skippedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  },
+  {
+    modelName: "onboarding_tasks",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["workspaceId", "userId"],
+        name: "onboarding_tasks_workspace_user",
+      },
+    ],
+  }
+);
+
+UserModel.hasMany(OnboardingTaskModel, {
+  foreignKey: { allowNull: false },
+  onDelete: "RESTRICT",
+});

--- a/front/lib/resources/storage/models/onboarding_tasks.ts
+++ b/front/lib/resources/storage/models/onboarding_tasks.ts
@@ -80,3 +80,8 @@ UserModel.hasMany(OnboardingTaskModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
+
+OnboardingTaskModel.belongsTo(UserModel, {
+  foreignKey: { name: "userId", allowNull: false },
+  onDelete: "RESTRICT",
+});

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -37,6 +37,7 @@ const RESOURCES_PREFIX = {
   agent_step_content: "asc",
   agent_memory: "amm",
   agent_message_feedback: "amf",
+  onboarding_task: "obt",
 
   // Resource relative to triggers.
   trigger: "trg",

--- a/front/migrations/db/migration_401.sql
+++ b/front/migrations/db/migration_401.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "onboarding_tasks" (
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "context" TEXT NOT NULL,
+    "kind" VARCHAR(255) NOT NULL,
+    "toolName" VARCHAR(255),
+    "completedAt" TIMESTAMP WITH TIME ZONE,
+    "skippedAt" TIMESTAMP WITH TIME ZONE,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , 
+    "userId" BIGINT NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, 
+    PRIMARY KEY ("id")
+);
+CREATE INDEX "onboarding_tasks_workspace_user" ON "onboarding_tasks" ("workspaceId", "userId");

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -37,6 +37,7 @@ import { KeyResource } from "@app/lib/resources/key_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resource";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
@@ -469,6 +470,7 @@ export async function deleteMembersActivity({
             userId: user.id,
           },
         });
+        await OnboardingTaskResource.deleteAllForUser(auth, user.toJSON());
 
         await user.delete(auth, {});
       }
@@ -605,6 +607,7 @@ export async function deleteWorkspaceActivity({
     },
   });
   await AgentMemoryResource.deleteAllForWorkspace(auth);
+  await OnboardingTaskResource.deleteAllForWorkspace(auth);
 
   hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -24,6 +24,7 @@ import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
@@ -107,6 +108,7 @@ export async function scrubWorkspaceData({
   await deleteAllConversations(auth);
   await archiveAssistants(auth);
   await deleteAgentMemories(auth);
+  await deleteOnboardingTasks(auth);
   await deleteTags(auth);
   await deleteTrackers(auth);
   await deleteDatasources(auth);
@@ -205,6 +207,10 @@ async function archiveAssistants(auth: Authenticator) {
 
 async function deleteAgentMemories(auth: Authenticator) {
   await AgentMemoryResource.deleteAllForWorkspace(auth);
+}
+
+async function deleteOnboardingTasks(auth: Authenticator) {
+  await OnboardingTaskResource.deleteAllForWorkspace(auth);
 }
 
 async function deleteTags(auth: Authenticator) {

--- a/front/tests/utils/OnboardingTaskFactory.ts
+++ b/front/tests/utils/OnboardingTaskFactory.ts
@@ -10,8 +10,8 @@ export class OnboardingTaskFactory {
     auth: Authenticator,
     {
       context = faker.lorem.sentence(),
-      kind = faker.helpers.arrayElement(ONBOARDING_TASK_KINDS),
-      toolName = Math.random() > 0.5 ? faker.lorem.word() : null,
+      kind = "learning",
+      toolName = null,
     }: {
       context?: string;
       kind?: OnboardingTaskKind;

--- a/front/tests/utils/OnboardingTaskFactory.ts
+++ b/front/tests/utils/OnboardingTaskFactory.ts
@@ -1,0 +1,54 @@
+import { faker } from "@faker-js/faker";
+
+import type { Authenticator } from "@app/lib/auth";
+import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resource";
+import type { OnboardingTaskKind } from "@app/lib/resources/storage/models/onboarding_tasks";
+import { ONBOARDING_TASK_KINDS } from "@app/lib/resources/storage/models/onboarding_tasks";
+
+export class OnboardingTaskFactory {
+  static async create(
+    auth: Authenticator,
+    {
+      context = faker.lorem.sentence(),
+      kind = faker.helpers.arrayElement(ONBOARDING_TASK_KINDS),
+      toolName = Math.random() > 0.5 ? faker.lorem.word() : null,
+    }: {
+      context?: string;
+      kind?: OnboardingTaskKind;
+      toolName?: string | null;
+    } = {}
+  ) {
+    const task = await OnboardingTaskResource.makeNew(auth, {
+      context,
+      kind,
+      toolName,
+    });
+
+    return task;
+  }
+
+  static async createMultiple(
+    auth: Authenticator,
+    count: number,
+    overrides?: {
+      context?: string;
+      kind?: OnboardingTaskKind;
+      toolName?: string | null;
+    }
+  ) {
+    const tasks = [];
+    for (let i = 0; i < count; i++) {
+      const task = await this.create(auth, {
+        context: overrides?.context
+          ? `${overrides.context} ${i + 1}`
+          : `Test task ${i + 1}`,
+        kind:
+          overrides?.kind ??
+          ONBOARDING_TASK_KINDS[i % ONBOARDING_TASK_KINDS.length],
+        toolName: overrides?.toolName,
+      });
+      tasks.push(task);
+    }
+    return tasks;
+  }
+}


### PR DESCRIPTION
## Description

We need a new model to store onboarding tasks for the project @\dust Zero to One. 

This PR: 
- Adds new model.
- Adds new resource.
- Adds migration file. 
- Adds tests for the resource. 
- Update the scrub workspaces workflows to delete this data (required since delete `RESTRICT`)

## Tests

`npm test -- lib/resources/onboarding_task_resource.test.ts`

## Risk

Model not used yet on the app. 
Can be rolled back. 

## Deploy Plan

Run migration. 
Deploy front. 
