### PR TITLE
Support run agent file

### DIFF
--- a/front/lib/api/viz/files.ts
+++ b/front/lib/api/viz/files.ts
@@ -1,0 +1,175 @@
+import { Authenticator } from "@app/lib/auth";
+import {
+  ConversationModel,
+  Message,
+  UserMessage,
+} from "@app/lib/models/assistant/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { MAX_CONVERSATION_DEPTH } from "@app/pages/api/v1/w/[wId]/assistant/conversations";
+import type { LightWorkspaceType, Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+/**
+ * Check if conversationA is an ancestor of conversationB
+ * Includes cycle detection and depth limiting
+ */
+async function isAncestorConversation(
+  auth: Authenticator,
+  conversationA: ConversationResource,
+  conversationB: ConversationResource | ConversationModel,
+  visited: Set<string> = new Set(),
+  maxDepth: number = MAX_CONVERSATION_DEPTH
+): Promise<boolean> {
+  // Prevent infinite loops.
+  if (visited.size >= maxDepth) {
+    throw new Error("Maximum conversation depth exceeded");
+  }
+
+  // A conversation cannot be its own ancestor.
+  if (conversationA.sId === conversationB.sId) {
+    return false;
+  }
+
+  // Record the conversation as visited.
+  if (visited.has(conversationB.sId)) {
+    return false;
+  }
+  visited.add(conversationB.sId);
+
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
+  // Get the first user message from conversation B.
+  const firstUserMessage = await Message.findOne({
+    where: {
+      conversationId: conversationB.id,
+      workspaceId,
+    },
+    order: [
+      ["rank", "ASC"],
+      ["version", "ASC"],
+    ],
+    include: [
+      {
+        model: UserMessage,
+        as: "userMessage",
+        required: true,
+      },
+    ],
+  });
+
+  console.log(
+    "First user message:",
+    firstUserMessage?.conversationId,
+    firstUserMessage?.sId,
+    firstUserMessage?.userMessage?.userContextOriginMessageId
+  );
+
+  const originMessageId =
+    firstUserMessage?.userMessage?.userContextOriginMessageId;
+  if (!originMessageId) {
+    return false;
+  }
+
+  // Find the origin message and its conversation.
+  const originMessage = await Message.findOne({
+    where: {
+      workspaceId,
+      sId: originMessageId,
+    },
+    include: [
+      {
+        model: ConversationModel,
+        as: "conversation",
+        required: true,
+      },
+    ],
+  });
+
+  if (!originMessage?.conversation) {
+    return false;
+  }
+
+  // Direct parent match.
+  if (originMessage.conversation.sId === conversationA.sId) {
+    return true;
+  }
+
+  // Recursively check parent.
+  return isAncestorConversation(
+    auth,
+    conversationA,
+    originMessage.conversation,
+    visited,
+    maxDepth
+  );
+}
+
+export async function canAccessFileInConversation(
+  owner: LightWorkspaceType,
+  file: FileResource,
+  requestedConversationId: string
+): Promise<Result<true, Error>> {
+  const { useCase, useCaseMetadata } = file;
+  const isSupportedUsecase =
+    useCase === "tool_output" || useCase === "conversation";
+
+  // Verify supported use case.
+  if (!isSupportedUsecase) {
+    return new Err(new Error("Unsupported file use case"));
+  }
+
+  if (!useCaseMetadata?.conversationId) {
+    return new Err(new Error("File is not associated with a conversation"));
+  }
+
+  // Direct access, file belongs to the requested conversation.
+  if (useCaseMetadata.conversationId === requestedConversationId) {
+    return new Ok(true);
+  }
+
+  console.log(
+    " >> looking for:",
+    useCaseMetadata.conversationId,
+    "in",
+    requestedConversationId
+  );
+
+  const auth = await Authenticator.internalBuilderForWorkspace(owner.sId);
+
+  // We only need to verify if the conversation exists, but internalBuilderForWorkspace only has
+  // global group access and can't see agents from other groups that this conversation might
+  // reference.
+  const requestedConversation = await ConversationResource.fetchById(
+    auth,
+    requestedConversationId,
+    {
+      dangerouslySkipPermissionFiltering: true,
+    }
+  );
+  if (!requestedConversation) {
+    return new Err(new Error("Requested conversation not found"));
+  }
+
+  // Check if file belongs to a conversation created through a sub agent run.
+  const fileConversation = await ConversationResource.fetchById(
+    auth,
+    useCaseMetadata.conversationId
+  );
+  if (!fileConversation) {
+    return new Err(new Error("File conversation not found"));
+  }
+
+  // Traverse up the conversation hierarchy of the file's conversation.
+  const fileBelongsToSubConversation = await isAncestorConversation(
+    auth,
+    requestedConversation,
+    fileConversation
+  );
+
+  if (fileBelongsToSubConversation) {
+    return new Ok(true);
+  }
+
+  return new Err(new Error("Access to file denied"));
+}

--- a/front/lib/api/viz/files.ts
+++ b/front/lib/api/viz/files.ts
@@ -58,13 +58,6 @@ async function isAncestorConversation(
     ],
   });
 
-  console.log(
-    "First user message:",
-    firstUserMessage?.conversationId,
-    firstUserMessage?.sId,
-    firstUserMessage?.userMessage?.userContextOriginMessageId
-  );
-
   const originMessageId =
     firstUserMessage?.userMessage?.userContextOriginMessageId;
   if (!originMessageId) {
@@ -105,6 +98,24 @@ async function isAncestorConversation(
   );
 }
 
+/**
+ * Check if a file can be accessed within a conversation context.
+ *
+ * This function handles two cases:
+ * 1. Direct access: File belongs to the same conversation as the frame
+ * 2. Hierarchical access: File belongs to a sub-conversation created via run_agent handovers
+ *
+ * For the hierarchical case, the current implementation requires traversing conversation chains by
+ * following userContextOriginMessageId references, which is fragile and performance-intensive. This
+ * depth checking logic is a temporary solution that will be simplified once the overall data model
+ * is improved to better represent conversation relationships.
+ *
+ * Current pain points:
+ * - Multiple database queries to traverse the hierarchy
+ * - Manual cycle detection and depth limiting
+ * - Complex permission filtering workarounds
+ * - No direct foreign key relationships between parent/child conversations
+ */
 export async function canAccessFileInConversation(
   owner: LightWorkspaceType,
   file: FileResource,
@@ -127,13 +138,6 @@ export async function canAccessFileInConversation(
   if (useCaseMetadata.conversationId === requestedConversationId) {
     return new Ok(true);
   }
-
-  console.log(
-    " >> looking for:",
-    useCaseMetadata.conversationId,
-    "in",
-    requestedConversationId
-  );
 
   const auth = await Authenticator.internalBuilderForWorkspace(owner.sId);
 

--- a/front/pages/api/v1/viz/files/fileId.test.ts
+++ b/front/pages/api/v1/viz/files/fileId.test.ts
@@ -1,15 +1,74 @@
+import type { PublicPostConversationsRequestBody } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
 import { Readable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// Mock Redis connection to prevent REDIS_URI errors
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisClient: vi.fn().mockReturnValue({
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue("OK"),
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn().mockResolvedValue(1),
+    ttl: vi.fn().mockResolvedValue(-1),
+    del: vi.fn().mockResolvedValue(1),
+  }),
+}));
+
+// Mock the cache utility to prevent Redis calls
+vi.mock("@app/lib/utils/cache", async () => {
+  const actual = await vi.importActual("@app/lib/utils/cache");
+  return {
+    ...actual,
+    cacheWithRedis: vi.fn().mockImplementation((fn, resolver, options) => {
+      // Return a function that bypasses caching and calls the original function
+      return async (...args: any[]) => {
+        // For seat counting, return a mock value directly
+        const key = resolver(...args);
+        if (key.includes("seats") || key.includes("active")) {
+          return 100; // Mock 100 active seats
+        }
+        // For other cached functions, call the original
+        return await fn(...args);
+      };
+    }),
+    invalidateCacheWithRedis: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// Mock the rate limiter functions
+vi.mock("@app/lib/utils/rate_limiter", () => ({
+  rateLimiter: vi.fn().mockResolvedValue(999), // Return high number = no limit
+  getTimeframeSecondsFromLiteral: vi.fn().mockReturnValue(60),
+}));
+
+// Mock rate limit key generators
+vi.mock("@app/lib/api/assistant/rate_limits", () => ({
+  makeMessageRateLimitKeyForWorkspace: vi
+    .fn()
+    .mockReturnValue("test-message-key"),
+  makeAgentMentionsRateLimitKeyForWorkspace: vi
+    .fn()
+    .mockReturnValue("test-mentions-key"),
+}));
+
+// Mock seat counting functions directly
+vi.mock("@app/lib/plans/usage/seats", () => ({
+  countActiveSeatsInWorkspace: vi.fn().mockResolvedValue(100),
+  countActiveSeatsInWorkspaceCached: vi.fn().mockResolvedValue(100),
+}));
+
 import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import { mentionAgent } from "@app/lib/mentions";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { LightWorkspaceType } from "@app/types";
 import { frameContentType } from "@app/types/files";
 
+import publicConversationsHandler from "../../w/[wId]/assistant/conversations/index";
 import handler from "./[fileId]";
 
 describe("/api/v1/viz/files/[fileId] security tests", () => {
@@ -529,6 +588,287 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         type: "workspace_auth_error",
         message: "Invalid or expired access token.",
       },
+    });
+  });
+
+  describe("conversation hierarchy access tests", () => {
+    it("should allow access to files from sub-conversations created by agent handover", async () => {
+      const {
+        req: parentReq,
+        res: parentRes,
+        workspace,
+        key,
+      } = await createPublicApiMockRequest({
+        method: "POST",
+      });
+
+      // Create parent conversation A using API.
+      const parentBody: PublicPostConversationsRequestBody = {
+        title: "Parent Conversation",
+        visibility: "unlisted",
+        depth: 0,
+        message: {
+          content: `${mentionAgent({
+            name: "noop",
+            sId: "noop",
+          })} Hello from parent`,
+          mentions: [{ configurationId: "noop" }],
+          context: {
+            timezone: "UTC",
+            username: "test-user",
+            fullName: "Test User",
+            email: "test@example.com",
+            profilePictureUrl: null,
+            origin: "web",
+          },
+        },
+      };
+
+      parentReq.body = parentBody;
+      parentReq.query.wId = workspace.sId;
+
+      await publicConversationsHandler(parentReq, parentRes);
+
+      expect(parentRes._getStatusCode()).toBe(200);
+      const parentData = parentRes._getJSONData();
+      const parentConversation = parentData.conversation;
+      const parentMessageId = parentData.message.sId;
+
+      console.log("Parent conversation created:", parentConversation.id);
+
+      const { req: childReq, res: childRes } = await createPublicApiMockRequest(
+        {
+          method: "POST",
+        }
+      );
+
+      // Use a new request to avoid state carry-over. But reuse same workspace and key.
+      childReq.headers = {
+        authorization: "Bearer " + key.secret,
+      };
+      childReq.query.wId = workspace.sId;
+
+      // Create sub-conversation B that references parent message using API.
+      const body: PublicPostConversationsRequestBody = {
+        title: "Child Conversation",
+        visibility: "unlisted",
+        depth: 1,
+        message: {
+          content: `${mentionAgent({
+            name: "noop",
+            sId: "noop",
+          })} Hello from child`,
+          mentions: [{ configurationId: "noop" }],
+          context: {
+            timezone: "UTC",
+            username: "test-user",
+            fullName: "Test User",
+            email: "test@example.com",
+            profilePictureUrl: null,
+            origin: "web",
+            originMessageId: parentMessageId, // This creates the hierarchy!
+          },
+        },
+      };
+
+      childReq.body = body;
+
+      await publicConversationsHandler(childReq, childRes);
+
+      expect(childRes._getStatusCode()).toBe(200);
+      const childData = childRes._getJSONData();
+      const childConversation = childData.conversation;
+
+      console.log("Child conversation created:", childConversation.id);
+
+      // Create frame file in parent conversation A.
+      const frameFile = await FileFactory.create(workspace, null, {
+        contentType: frameContentType,
+        fileName: "frame.html",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: parentConversation.sId },
+      });
+
+      // Create target file in sub-conversation B.
+      const targetFile = await FileFactory.create(workspace, null, {
+        contentType: "text/plain",
+        fileName: "sub-conversation-file.txt",
+        fileSize: 500,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: childConversation.sId },
+      });
+
+      const frameShareInfo = await frameFile.getShareInfo();
+      const fileToken = frameShareInfo?.shareUrl.split("/").at(-1);
+      if (!fileToken) {
+        throw new Error("No file token found");
+      }
+
+      const accessToken = generateVizAccessToken({
+        fileToken,
+        workspaceId: workspace.sId,
+        shareScope: "public",
+      });
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { fileId: targetFile.sId },
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+
+      vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+        file: frameFile,
+        content: "<html>Frame content</html>",
+        shareScope: "public",
+      });
+
+      vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+        Readable.from(["Sub-conversation file content"])
+      );
+
+      await handler(req, res);
+
+      // Should succeed - file from sub-conversation should be accessible
+      expect(res._getStatusCode()).toBe(200);
+    });
+
+    it("should reject access to files from unrelated conversations", async () => {
+      const {
+        req: parentReq,
+        res: parentRes,
+        workspace,
+        key,
+      } = await createPublicApiMockRequest({
+        method: "POST",
+      });
+
+      // Create conversation A using API.
+      const parentBody: PublicPostConversationsRequestBody = {
+        title: "Parent Conversation",
+        visibility: "unlisted",
+        message: {
+          content: `${mentionAgent({
+            name: "noop",
+            sId: "noop",
+          })} Hello from parent`,
+          mentions: [{ configurationId: "noop" }],
+          context: {
+            timezone: "UTC",
+            username: "test-user",
+            fullName: "Test User",
+            email: "test@example.com",
+            profilePictureUrl: null,
+            origin: "web",
+          },
+        },
+      };
+
+      parentReq.body = parentBody;
+      parentReq.query.wId = workspace.sId;
+
+      await publicConversationsHandler(parentReq, parentRes);
+
+      expect(parentRes._getStatusCode()).toBe(200);
+      const parentData = parentRes._getJSONData();
+      const conversationA = parentData.conversation;
+
+      const { req: otherReq, res: otherRes } = await createPublicApiMockRequest(
+        {
+          method: "POST",
+        }
+      );
+
+      // Use a new request to avoid state carry-over. But reuse same workspace and key.
+      otherReq.headers = {
+        authorization: "Bearer " + key.secret,
+      };
+      otherReq.query.wId = workspace.sId;
+
+      // Create another unrelated conversation B using API.
+      const body: PublicPostConversationsRequestBody = {
+        title: "Another Conversation",
+        visibility: "unlisted",
+        depth: 0,
+        message: {
+          content: `${mentionAgent({
+            name: "noop",
+            sId: "noop",
+          })} Hello from child`,
+          mentions: [{ configurationId: "noop" }],
+          context: {
+            timezone: "UTC",
+            username: "test-user",
+            fullName: "Test User",
+            email: "test@example.com",
+            profilePictureUrl: null,
+            origin: "web",
+          },
+        },
+      };
+
+      otherReq.body = body;
+
+      await publicConversationsHandler(otherReq, otherRes);
+
+      expect(otherRes._getStatusCode()).toBe(200);
+      const childData = otherRes._getJSONData();
+      const conversationB = childData.conversation;
+
+      // Create frame file in conversation A.
+      const frameFile = await FileFactory.create(workspace, null, {
+        contentType: frameContentType,
+        fileName: "frame.html",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversationA.sId },
+      });
+
+      // Create target file in unrelated conversation B.
+      const targetFile = await FileFactory.create(workspace, null, {
+        contentType: "text/plain",
+        fileName: "sub-conversation-file.txt",
+        fileSize: 500,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversationB.sId },
+      });
+
+      const frameShareInfo = await frameFile.getShareInfo();
+      const fileToken = frameShareInfo?.shareUrl.split("/").at(-1);
+      if (!fileToken) {
+        throw new Error("No file token found");
+      }
+
+      const accessToken = generateVizAccessToken({
+        fileToken,
+        workspaceId: workspace.sId,
+        shareScope: "public",
+      });
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { fileId: targetFile.sId },
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+
+      vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+        file: frameFile,
+        content: "<html>Frame content</html>",
+        shareScope: "public",
+      });
+
+      vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+        Readable.from(["Sub-conversation file content"])
+      );
+
+      await handler(req, res);
+
+      // Should fail - file from unrelated conversation.
+      expect(res._getStatusCode()).toBe(404);
     });
   });
 });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -41,7 +41,7 @@ import {
   isEmptyString,
 } from "@app/types";
 
-const MAX_CONVERSATION_DEPTH = 4;
+export const MAX_CONVERSATION_DEPTH = 4;
 
 /**
  * @swagger

--- a/front/vite.globalSetup.ts
+++ b/front/vite.globalSetup.ts
@@ -25,6 +25,7 @@ export default async function setup() {
     // Add any other essential vars you need to keep
     FRONT_DATABASE_URI: process.env.FRONT_DATABASE_URI,
     REDIS_CACHE_URI: process.env.REDIS_CACHE_URI,
+    REDIS_URI: process.env.REDIS_URI,
     NEXT_PUBLIC_DUST_CLIENT_FACING_URL: "http://fake-url",
     ENABLE_BOT_CRAWLING: process.env.ENABLE_BOT_CRAWLING,
     DUST_US_URL: "http://fake-url",

--- a/viz/app/content/ClientVisualizationWrapper.tsx
+++ b/viz/app/content/ClientVisualizationWrapper.tsx
@@ -32,12 +32,6 @@ export function ClientVisualizationWrapper({
     [allowedOrigins, identifier]
   );
 
-  // Create RPC data API for dynamic fetching.
-  console.log(
-    ">> Creating RPCDataAPI with sendCrossDocumentMessage:",
-    sendCrossDocumentMessage
-  );
-
   const dataAPI = useMemo(
     () => new RPCDataAPI(sendCrossDocumentMessage),
     [sendCrossDocumentMessage]


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
With the release of `@deep-dive` we can now have sub agent runs generating files that will be used in a frame generated by the top-level/parent conversation. This case does not work right now, as we exclusively rely on the `useCaseMetadata` on the file. This PR adds an helper to traverse the hierarchy upward to ensure that the file result from a conversation triggers from a sub agent run.

The data model is currently pretty painful around this part and the simplest way I found is to use the `userContextOriginMessageId`. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
