### PR TITLE
fix: remove redundancy in ilias' role title

### DIFF
--- a/front/pages/home/about.tsx
+++ b/front/pages/home/about.tsx
@@ -384,7 +384,7 @@ const PEOPLE: Record<
   },
   iliasbet: {
     name: "Ilias Bettahi",
-    title: "Tech Support Engineer",
+    title: "Support Engineer",
     image: "https://avatars.githubusercontent.com/iliasbet",
     linkedIn: "https://www.linkedin.com/in/iliasbet/",
     github: "https://github.com/iliasbet",


### PR DESCRIPTION
tech + engineer = redundant. simplified to support engineer.