### PR TITLE
fix: filesystem tag filtering for list and cat tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -10,14 +10,13 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { registerCatTool } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat";
 import { findCallback } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find";
-import { listCallback } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list";
+import { registerListTool } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list";
 import { locateTreeCallback } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/locate_tree";
 import { searchCallback } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search";
 import { registerFindTagsTool } from "@app/lib/actions/mcp_internal_actions/tools/tags/find_tags";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import {
   DataSourceFilesystemFindInputSchema,
-  DataSourceFilesystemListInputSchema,
   DataSourceFilesystemLocateTreeInputSchema,
   SearchWithNodesInputSchema,
   TagsInputSchema,
@@ -42,12 +41,9 @@ function createServer(
     name: FILESYSTEM_CAT_TOOL_NAME,
   });
 
-  const listToolDescription =
-    "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
-    "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
-    "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
-    "the next step's nodeId. If a node output by this tool or the find tool has children " +
-    "(hasChildren: true), it means that this tool can be used again on it.";
+  registerListTool(auth, server, agentLoopContext, {
+    name: FILESYSTEM_LIST_TOOL_NAME,
+  });
 
   const searchToolDescription =
     "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
@@ -65,20 +61,6 @@ function createServer(
     "the last node being the target node.";
 
   if (!areTagsDynamic) {
-    server.tool(
-      FILESYSTEM_LIST_TOOL_NAME,
-      listToolDescription,
-      DataSourceFilesystemListInputSchema.shape,
-      withToolLogging(
-        auth,
-        {
-          toolNameForMonitoring: FILESYSTEM_LIST_TOOL_NAME,
-          agentLoopContext,
-          enableAlerting: true,
-        },
-        async (params) => listCallback(auth, params)
-      )
-    );
     server.tool(
       SEARCH_TOOL_NAME,
       searchToolDescription,
@@ -129,28 +111,6 @@ function createServer(
     registerFindTagsTool(auth, server, agentLoopContext, {
       name: FIND_TAGS_TOOL_NAME,
     });
-
-    server.tool(
-      FILESYSTEM_LIST_TOOL_NAME,
-      listToolDescription,
-      {
-        ...DataSourceFilesystemListInputSchema.shape,
-        ...TagsInputSchema.shape,
-      },
-      withToolLogging(
-        auth,
-        {
-          toolNameForMonitoring: FILESYSTEM_LIST_TOOL_NAME,
-          agentLoopContext,
-          enableAlerting: true,
-        },
-        async (params) =>
-          listCallback(auth, params, {
-            tagsIn: params.tagsIn,
-            tagsNot: params.tagsNot,
-          })
-      )
-    );
 
     server.tool(
       SEARCH_TOOL_NAME,

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/helpers.ts
@@ -27,9 +27,10 @@ export async function getAvailableWarehouses(
   >
 > {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const dataSourceViewFilter = makeCoreSearchNodesFilters(
-    dataSourceConfigurations
-  ).map((view) => ({
+  const dataSourceViewFilter = makeCoreSearchNodesFilters({
+    agentDataSourceConfigurations: dataSourceConfigurations,
+    includeTagFilters: false,
+  }).map((view) => ({
     ...view,
     search_scope: "data_source_name" as const,
   }));
@@ -153,7 +154,10 @@ export async function getWarehouseNodes(
   const result = await coreAPI.searchNodes({
     query,
     filter: {
-      data_source_views: makeCoreSearchNodesFilters(configsToUse),
+      data_source_views: makeCoreSearchNodesFilters({
+        agentDataSourceConfigurations: configsToUse,
+        includeTagFilters: false,
+      }),
       parent_id: parentIdToUse ?? undefined,
       node_ids: nodeIdsToUse,
     },
@@ -316,7 +320,10 @@ export async function validateTables(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const searchResult = await coreAPI.searchNodes({
     filter: {
-      data_source_views: makeCoreSearchNodesFilters([relevantConfig]),
+      data_source_views: makeCoreSearchNodesFilters({
+        agentDataSourceConfigurations: [relevantConfig],
+        includeTagFilters: false,
+      }),
       node_ids: parsedTables.map((t) => t.nodeId),
     },
   });

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -109,7 +109,6 @@ export function registerCatTool(
             node_ids: [nodeId],
             data_source_views: makeCoreSearchNodesFilters({
               agentDataSourceConfigurations,
-              includeTagFilters: true,
             }),
           },
         });

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find.ts
@@ -59,7 +59,6 @@ export async function findCallback(
   // filtered out.
   let viewFilter = makeCoreSearchNodesFilters({
     agentDataSourceConfigurations,
-    includeTagFilters: true,
     additionalDynamicTags,
   });
 

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find.ts
@@ -28,7 +28,7 @@ export async function findCallback(
     rootNodeId,
     mimeTypes,
   }: DataSourceFilesystemFindInputType,
-  { tagsIn, tagsNot }: { tagsIn?: string[]; tagsNot?: string[] } = {}
+  additionalDynamicTags: { tagsIn?: string[]; tagsNot?: string[] } = {}
 ): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
@@ -41,7 +41,7 @@ export async function findCallback(
 
   const conflictingTags = checkConflictingTags(
     agentDataSourceConfigurations.map(({ filter }) => filter.tags),
-    { tagsIn, tagsNot }
+    additionalDynamicTags
   );
   if (conflictingTags) {
     return new Err(new MCPError(conflictingTags, { tracked: false }));
@@ -57,9 +57,10 @@ export async function findCallback(
   // are searched. It is not straightforward to guess which data source it
   // belongs to, this is why irrelevant data sources are not directly
   // filtered out.
-  let viewFilter = makeCoreSearchNodesFilters(agentDataSourceConfigurations, {
-    tagsIn,
-    tagsNot,
+  let viewFilter = makeCoreSearchNodesFilters({
+    agentDataSourceConfigurations,
+    includeTagFilters: true,
+    additionalDynamicTags,
   });
 
   if (dataSourceNodeId) {

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -95,11 +95,14 @@ export function registerListTool(
 
         let searchResult: Result<CoreAPISearchNodesResponse, CoreAPIError>;
 
+        // By-pass tag filters when exploring the filesystem hierarchy
+        const includeTagFilters = false;
+
         if (!nodeId) {
           // When nodeId is null, search for data sources only.
           const dataSourceViewFilter = makeCoreSearchNodesFilters({
             agentDataSourceConfigurations,
-            includeTagFilters: false,
+            includeTagFilters,
           }).map((view) => ({
             ...view,
             search_scope: "data_source_name" as const,
@@ -137,7 +140,7 @@ export function registerListTool(
             filter: {
               data_source_views: makeCoreSearchNodesFilters({
                 agentDataSourceConfigurations: [dataSourceConfig],
-                includeTagFilters: false,
+                includeTagFilters,
               }),
               node_ids: dataSourceConfig.filter.parents?.in ?? undefined,
               parent_id: dataSourceConfig.filter.parents?.in
@@ -153,7 +156,7 @@ export function registerListTool(
             filter: {
               data_source_views: makeCoreSearchNodesFilters({
                 agentDataSourceConfigurations,
-                includeTagFilters: false,
+                includeTagFilters,
               }),
               parent_id: nodeId,
               mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { renderSearchResults } from "@app/lib/actions/mcp_internal_actions/rendering";
@@ -7,16 +7,14 @@ import {
   isDataSourceNodeId,
   makeQueryResourceForList,
 } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/utils";
-import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import {
   getAgentDataSourceConfigurations,
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type {
-  DataSourceFilesystemListInputType,
-  TagsInputType,
-} from "@app/lib/actions/mcp_internal_actions/types";
+import { DataSourceFilesystemListInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 import type { Authenticator } from "@app/lib/auth";
@@ -28,145 +26,170 @@ import type {
 } from "@app/types";
 import { CoreAPI, Err, Ok } from "@app/types";
 
-export async function listCallback(
+export function registerListTool(
   auth: Authenticator,
-  {
-    nodeId,
-    dataSources,
-    limit,
-    mimeTypes,
-    sortBy,
-    nextPageCursor,
-  }: DataSourceFilesystemListInputType,
-  additionalDynamicTags: TagsInputType = {}
-): Promise<Result<CallToolResult["content"], MCPError>> {
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const fetchResult = await getAgentDataSourceConfigurations(auth, dataSources);
+  server: McpServer,
+  agentLoopContext: AgentLoopContextType | undefined,
+  { name, extraDescription }: { name: string; extraDescription?: string }
+) {
+  const baseDescription =
+    "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
+    "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
+    "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
+    "the next step's nodeId. If a node output by this tool or the find tool has children " +
+    "(hasChildren: true), it means that this tool can be used again on it.";
+  const toolDescription = extraDescription
+    ? baseDescription + "\n" + extraDescription
+    : baseDescription;
 
-  if (fetchResult.isErr()) {
-    return new Err(new MCPError(fetchResult.error.message));
-  }
-  const agentDataSourceConfigurations = fetchResult.value;
+  server.tool(
+    name,
+    toolDescription,
+    DataSourceFilesystemListInputSchema.shape,
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: name,
+        agentLoopContext,
+        enableAlerting: true,
+      },
+      async ({
+        nodeId,
+        dataSources,
+        limit,
+        mimeTypes,
+        sortBy,
+        nextPageCursor,
+      }) => {
+        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+        const fetchResult = await getAgentDataSourceConfigurations(
+          auth,
+          dataSources
+        );
 
-  const authRes = await ensureAuthorizedDataSourceViews(
-    auth,
-    agentDataSourceConfigurations.map((c) => c.dataSourceViewId)
-  );
-  if (authRes.isErr()) {
-    return new Err(authRes.error);
-  }
+        if (fetchResult.isErr()) {
+          return new Err(new MCPError(fetchResult.error.message));
+        }
+        const agentDataSourceConfigurations = fetchResult.value;
 
-  const conflictingTags = checkConflictingTags(
-    agentDataSourceConfigurations.map(({ filter }) => filter.tags),
-    additionalDynamicTags
-  );
-  if (conflictingTags) {
-    return new Err(new MCPError(conflictingTags, { tracked: false }));
-  }
+        const authRes = await ensureAuthorizedDataSourceViews(
+          auth,
+          agentDataSourceConfigurations.map((c) => c.dataSourceViewId)
+        );
+        if (authRes.isErr()) {
+          return new Err(authRes.error);
+        }
 
-  const options = {
-    cursor: nextPageCursor,
-    limit,
-    sort: sortBy
-      ? [
+        const options = {
+          cursor: nextPageCursor,
+          limit,
+          sort: sortBy
+            ? [
+                {
+                  field: sortBy,
+                  direction: getSearchNodesSortDirection(sortBy),
+                },
+              ]
+            : undefined,
+        };
+
+        let searchResult: Result<CoreAPISearchNodesResponse, CoreAPIError>;
+
+        if (!nodeId) {
+          // When nodeId is null, search for data sources only.
+          const dataSourceViewFilter = makeCoreSearchNodesFilters({
+            agentDataSourceConfigurations,
+            includeTagFilters: false,
+          }).map((view) => ({
+            ...view,
+            search_scope: "data_source_name" as const,
+          }));
+
+          searchResult = await coreAPI.searchNodes({
+            filter: {
+              data_source_views: dataSourceViewFilter,
+              mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
+            },
+            options,
+          });
+        } else if (isDataSourceNodeId(nodeId)) {
+          // If it's a data source node ID, extract the data source ID and list its root contents.
+          const dataSourceId = extractDataSourceIdFromNodeId(nodeId);
+          if (!dataSourceId) {
+            return new Err(
+              new MCPError("Invalid data source node ID format", {
+                tracked: false,
+              })
+            );
+          }
+
+          const dataSourceConfig = agentDataSourceConfigurations.find(
+            ({ dataSource }) => dataSource.dustAPIDataSourceId === dataSourceId
+          );
+
+          if (!dataSourceConfig) {
+            return new Err(
+              new MCPError(`Data source not found for ID: ${dataSourceId}`)
+            );
+          }
+
+          searchResult = await coreAPI.searchNodes({
+            filter: {
+              data_source_views: makeCoreSearchNodesFilters({
+                agentDataSourceConfigurations: [dataSourceConfig],
+                includeTagFilters: false,
+              }),
+              node_ids: dataSourceConfig.filter.parents?.in ?? undefined,
+              parent_id: dataSourceConfig.filter.parents?.in
+                ? undefined
+                : ROOT_PARENT_ID,
+              mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
+            },
+            options,
+          });
+        } else {
+          // Regular node listing.
+          searchResult = await coreAPI.searchNodes({
+            filter: {
+              data_source_views: makeCoreSearchNodesFilters({
+                agentDataSourceConfigurations,
+                includeTagFilters: false,
+              }),
+              parent_id: nodeId,
+              mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
+            },
+            options,
+          });
+        }
+
+        if (searchResult.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to list folder contents: ${searchResult.error.message}`
+            )
+          );
+        }
+
+        return new Ok([
           {
-            field: sortBy,
-            direction: getSearchNodesSortDirection(sortBy),
+            type: "resource",
+            resource: makeQueryResourceForList(
+              nodeId,
+              mimeTypes,
+              nextPageCursor
+            ),
           },
-        ]
-      : undefined,
-  };
-
-  let searchResult: Result<CoreAPISearchNodesResponse, CoreAPIError>;
-
-  if (!nodeId) {
-    // When nodeId is null, search for data sources only.
-    const dataSourceViewFilter = makeCoreSearchNodesFilters(
-      agentDataSourceConfigurations,
-      additionalDynamicTags
-    ).map((view) => ({
-      ...view,
-      search_scope: "data_source_name" as const,
-    }));
-
-    searchResult = await coreAPI.searchNodes({
-      filter: {
-        data_source_views: dataSourceViewFilter,
-        mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
-      },
-      options,
-    });
-  } else if (isDataSourceNodeId(nodeId)) {
-    // If it's a data source node ID, extract the data source ID and list its root contents.
-    const dataSourceId = extractDataSourceIdFromNodeId(nodeId);
-    if (!dataSourceId) {
-      return new Err(
-        new MCPError("Invalid data source node ID format", {
-          tracked: false,
-        })
-      );
-    }
-
-    const dataSourceConfig = agentDataSourceConfigurations.find(
-      ({ dataSource }) => dataSource.dustAPIDataSourceId === dataSourceId
-    );
-
-    if (!dataSourceConfig) {
-      return new Err(
-        new MCPError(`Data source not found for ID: ${dataSourceId}`)
-      );
-    }
-
-    searchResult = await coreAPI.searchNodes({
-      filter: {
-        data_source_views: makeCoreSearchNodesFilters(
-          [dataSourceConfig],
-          additionalDynamicTags
-        ),
-        node_ids: dataSourceConfig.filter.parents?.in ?? undefined,
-        parent_id: dataSourceConfig.filter.parents?.in
-          ? undefined
-          : ROOT_PARENT_ID,
-        mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
-      },
-      options,
-    });
-  } else {
-    // Regular node listing.
-    searchResult = await coreAPI.searchNodes({
-      filter: {
-        data_source_views: makeCoreSearchNodesFilters(
-          agentDataSourceConfigurations,
-          additionalDynamicTags
-        ),
-        parent_id: nodeId,
-        mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
-      },
-      options,
-    });
-  }
-
-  if (searchResult.isErr()) {
-    return new Err(
-      new MCPError(
-        `Failed to list folder contents: ${searchResult.error.message}`
-      )
-    );
-  }
-
-  return new Ok([
-    {
-      type: "resource",
-      resource: makeQueryResourceForList(nodeId, mimeTypes, nextPageCursor),
-    },
-    {
-      type: "resource",
-      resource: renderSearchResults(
-        searchResult.value,
-        agentDataSourceConfigurations
-      ),
-    },
-  ]);
+          {
+            type: "resource",
+            resource: renderSearchResults(
+              searchResult.value,
+              agentDataSourceConfigurations
+            ),
+          },
+        ]);
+      }
+    )
+  );
 }
 
 function getSearchNodesSortDirection(

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/locate_tree.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/locate_tree.ts
@@ -87,7 +87,6 @@ export async function locateTreeCallback(
       node_ids: [nodeId],
       data_source_views: makeCoreSearchNodesFilters({
         agentDataSourceConfigurations,
-        includeTagFilters: true,
         additionalDynamicTags,
       }),
     },
@@ -116,7 +115,7 @@ export async function locateTreeCallback(
         node_ids: parentNodeIds,
         data_source_views: makeCoreSearchNodesFilters({
           agentDataSourceConfigurations,
-          includeTagFilters: false,
+          includeTagFilters: false, // By-pass tag filters when searching the parents nodes
         }),
       },
     });

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
@@ -240,7 +240,7 @@ export async function searchCallback(
         node_ids: searchNodeIds,
         data_source_views: makeCoreSearchNodesFilters({
           agentDataSourceConfigurations,
-          includeTagFilters: true,
+
           additionalDynamicTags,
         }),
       },

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -43,11 +43,11 @@ export type ResolvedDataSourceConfiguration = DataSourceConfiguration & {
 
 export function makeCoreSearchNodesFilters({
   agentDataSourceConfigurations,
-  includeTagFilters,
+  includeTagFilters = true,
   additionalDynamicTags,
 }: {
   agentDataSourceConfigurations: ResolvedDataSourceConfiguration[];
-  includeTagFilters: boolean;
+  includeTagFilters?: boolean;
   additionalDynamicTags?: TagsInputType;
 }): CoreAPIDatasourceViewFilter[] {
   return agentDataSourceConfigurations.map(

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -41,17 +41,21 @@ export type ResolvedDataSourceConfiguration = DataSourceConfiguration & {
   dataSourceView: DataSourceViewResource;
 };
 
-export function makeCoreSearchNodesFilters(
-  agentDataSourceConfigurations: ResolvedDataSourceConfiguration[],
-  additionalDynamicTags?: TagsInputType
-): CoreAPIDatasourceViewFilter[] {
+export function makeCoreSearchNodesFilters({
+  agentDataSourceConfigurations,
+  includeTagFilters,
+  additionalDynamicTags,
+}: {
+  agentDataSourceConfigurations: ResolvedDataSourceConfiguration[];
+  includeTagFilters: boolean;
+  additionalDynamicTags?: TagsInputType;
+}): CoreAPIDatasourceViewFilter[] {
   return agentDataSourceConfigurations.map(
     ({ dataSource, dataSourceView, filter }) => ({
       data_source_id: dataSource.dustAPIDataSourceId,
       view_filter: dataSourceView.parentsIn ?? [],
       filter: filter.parents?.in ?? undefined,
-      // FIXME(ap): Remove additionalDynamicTags condition and add support in other file system tools.
-      ...(additionalDynamicTags
+      ...(includeTagFilters
         ? {
             tags: {
               in: [


### PR DESCRIPTION




## Description

Fixes tag filtering implementation for the `list` and `cat`.

- Refactor`makeCoreSearchNodesFilters` to accept an object parameter with an explicit `includeTagFilters` flag.

- Refactor of `list` tool from `listCallback` to `registerListTool` for coherence with the `cat` tool.

- Fix of `list` tool to use `includeTagFilters: false` to ensure proper filesystem navigation without tag restrictions.

- Fix of `cat` tool to use `includeTagFilters: true` to apply user-defined tag filtering through the agent configuration.

- All data warehouse helpers are updated to explicitly disable tag filtering (`includeTagFilters: false`) as they don't support it.

## Risk

Low

## Tests

Tested locally with front.

## Deploy Plan

Deploy Front.
