### PR TITLE
[front] fix: simplified invitation flow

### DIFF
--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -46,6 +46,7 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
         inviteEmail: email,
         status: "pending",
       },
+      order: [["createdAt", "DESC"]],
       include: [WorkspaceModel],
       // WORKSPACE_ISOLATION_BYPASS: We don't know the workspace yet, the user is not authed
       dangerouslyBypassWorkspaceIsolationSecurity: true,


### PR DESCRIPTION
## Description

This is fixing the flow when a user has just signed up, and they have pending invitations. 
If an invitation token is provided, always use it directly, without doing any redrirect. The user will join the target workspace and goes to the welcome page.
If no invitation token is provided, look for existing invitation before going to regular flow with workspace creation. 

This fixes https://github.com/dust-tt/tasks/issues/5024 , as if the user follows the invitation link for the new workspace, he will join it. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
