### PR TITLE
chore: phase out dust app to suggess agent emoji

### DIFF
--- a/front/lib/api/assistant/suggestions/emoji.ts
+++ b/front/lib/api/assistant/suggestions/emoji.ts
@@ -1,0 +1,127 @@
+import { isLeft } from "fp-ts/lib/Either";
+
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
+import type { Authenticator } from "@app/lib/auth";
+import type { BuilderSuggestionInputType, Result } from "@app/types";
+import {
+  BuilderEmojiSuggestionsResponseBodySchema,
+  Err,
+  GPT_3_5_TURBO_MODEL_ID,
+  Ok,
+} from "@app/types";
+
+const FUNCTION_NAME = "send_suggestions";
+
+const specifications = [
+  {
+    name: FUNCTION_NAME,
+    description: "Send suggestions of names for the assistants",
+    inputSchema: {
+      type: "object",
+      properties: {
+        suggestions: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              emoji: {
+                type: "string",
+                description: "The emoji. Use only standard emojis.",
+              },
+              backgroundColor: {
+                type: "string",
+                description: "Tailwind CSS class for the background color",
+                enum: [
+                  "bg-green-200",
+                  "bg-green-300",
+                  "bg-yellow-200",
+                  "bg-yellow-300",
+                  "bg-blue-200",
+                  "bg-blue-300",
+                  "bg-red-200",
+                  "bg-red-300",
+                  "bg-purple-200",
+                  "bg-purple-300",
+                  "bg-orange-200",
+                  "bg-orange-300",
+                ],
+              },
+            },
+            required: ["emoji", "backgroundColor"],
+          },
+          description: "Suggest one to three emojis for the assistant",
+        },
+      },
+      required: ["suggestions"],
+    },
+  },
+];
+
+function getConversationContext(inputs: BuilderSuggestionInputType) {
+  const instructions = "instructions" in inputs ? inputs.instructions : "";
+
+  const instructionsText = instructions
+    ? "\nAssistant instructions\n======\n" + JSON.stringify(instructions)
+    : "";
+
+  const initialPrompt =
+    "Please suggest one to three good emojis for an AI agent" +
+    (instructions ? " based on the following data:" : ".");
+
+  return {
+    messages: [
+      {
+        role: "user",
+        content: initialPrompt + instructionsText,
+      },
+    ],
+  };
+}
+
+export async function getBuilderEmojiSuggestions(
+  auth: Authenticator,
+  inputs: BuilderSuggestionInputType
+): Promise<Result<SuggestionResults, Error>> {
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      functionCall: FUNCTION_NAME,
+      modelId: GPT_3_5_TURBO_MODEL_ID,
+      providerId: "openai",
+      temperature: 0.7,
+      useCache: false,
+    },
+    {
+      conversation: getConversationContext(inputs),
+      prompt:
+        "Task Overview: Assist in the customization of a virtual assistant’s visual identity by selecting an emoji for its avatar. The assistant's design and purpose will be described in each message you receive.\n\nObjective: Your main responsibility is to choose an emoji that captures the essence of the assistant, reflecting its unique functions, personality, or the context in which it will be used.\n\nGuidelines:\n- Broaden Your Choices: Consider a wide range of emojis to find one that uniquely represents the assistant's qualities or use case. Avoid defaulting to common choices unless they are the best fit. Try to avoid the generic 🤖 that could work for all assistants, unless the topic is truly about robots.\n- Relevance is Key: Select emojis that directly relate to the assistant’s described characteristics or intended environment. For instance, a 🎨 might suit a creative design tool, while a 📚 could represent a learning aid.\n- Compatibility Consideration: Ensure that your choices adhere to the Unicode standard to guarantee that the emoji displays correctly across all platforms.",
+      specifications,
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  if (res.value.actions?.[0]?.arguments?.suggestions) {
+    const suggestionsResult = BuilderEmojiSuggestionsResponseBodySchema.decode(
+      res.value.actions[0].arguments
+    );
+
+    if (isLeft(suggestionsResult)) {
+      return new Err(
+        new Error(
+          `Error retrieving suggestions from arguments: ${res.value.actions[0].arguments}`
+        )
+      );
+    }
+
+    return new Ok({
+      status: "ok",
+      ...suggestionsResult.right,
+    });
+  }
+
+  return new Err(new Error("No suggestions found"));
+}

--- a/front/lib/api/assistant/suggestions/index.ts
+++ b/front/lib/api/assistant/suggestions/index.ts
@@ -4,6 +4,7 @@ import * as reporter from "io-ts-reporters";
 
 import { runAction } from "@app/lib/actions/server";
 import { getBuilderDescriptionSuggestions } from "@app/lib/api/assistant/suggestions/description";
+import { getBuilderEmojiSuggestions } from "@app/lib/api/assistant/suggestions/emoji";
 import { getBuilderNameSuggestions } from "@app/lib/api/assistant/suggestions/name";
 import { getBuilderTagSuggestions } from "@app/lib/api/assistant/suggestions/tags";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
@@ -81,6 +82,7 @@ export async function getBuilderSuggestions(
       return getBuilderTagSuggestions(auth, inputs);
 
     case "emoji":
+      return getBuilderEmojiSuggestions(auth, inputs);
     case "instructions":
     case "autocompletion": {
       const config = cloneBaseConfig(

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -163,20 +163,6 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-  "assistant-builder-emoji-suggestions": {
-    app: {
-      appId: "b69YdlJ3PJ",
-      appHash:
-        "0b6b63def0224321f2bece0751bad632baca33f6d5bb596bbeb3f95b6bea5966",
-    },
-    config: {
-      CREATE_SUGGESTIONS: {
-        // `provider_id` and `model_id` must be set by caller.
-        function_call: "send_suggestions",
-        use_cache: false,
-      },
-    },
-  },
   "assistant-builder-process-action-schema-generator": {
     app: {
       appId: "b36c7416bd",


### PR DESCRIPTION





## Description

Phases out the `assistant-builder-emoji-suggestions` from the registry.

This follows the same pattern established in previous PRs that phased out the name (#16974), description (#16984), and tags (#17032) suggestion apps.

## Risk

Low

## Tests

Tested locally with front.

## Deploy Plan

Deploy Front.
