### PR TITLE
Make Notion incremental sync crawl new resources

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -387,7 +387,7 @@ export async function getPagesAndDatabasesToSync({
     };
   }
 
-  // We exclude pages that we have already seen since their lastEditedTs we recieved from
+  // We exclude pages that we have already seen since their lastEditedTs we received from
   // getPagesEditedSince.
   const existingPages = await NotionPage.findAll({
     where: {
@@ -428,10 +428,12 @@ export async function getPagesAndDatabasesToSync({
     },
     attributes: ["notionDatabaseId", "lastSeenTs"],
   });
-  localLogger.info(
-    { count: existingDatabases.length },
-    "Found existing databases"
-  );
+  if (existingDatabases.length > 0) {
+    localLogger.info(
+      { count: existingDatabases.length },
+      "Found existing databases"
+    );
+  }
   const lastSeenTsByDatabaseId = new Map<string, number>();
   for (const db of existingDatabases) {
     lastSeenTsByDatabaseId.set(db.notionDatabaseId, db.lastSeenTs.getTime());

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2515,6 +2515,14 @@ export async function getDiscoveredResourcesFromCache({
     "Discovered new resources."
   );
 
+  // Since we're about to process these resources, clear them from the cache
+  await NotionConnectorResourcesToCheckCacheEntry.destroy({
+    where: {
+      connectorId: connector.id,
+      workflowId: topLevelWorkflowId,
+    },
+  });
+
   return {
     pageIds: discoveredPageIds,
     databaseIds: discoveredDatabaseIds,

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,4 +1,4 @@
-const WORKFLOW_VERSION = 50;
+const WORKFLOW_VERSION = 51;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;
 export const GARBAGE_COLLECT_QUEUE_NAME = `notion-gc-queue-v${WORKFLOW_VERSION}`;
 

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,4 +1,4 @@
-const WORKFLOW_VERSION = 51;
+const WORKFLOW_VERSION = 50;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;
 export const GARBAGE_COLLECT_QUEUE_NAME = `notion-gc-queue-v${WORKFLOW_VERSION}`;
 
@@ -16,7 +16,7 @@ export const MAX_PENDING_UPSERT_ACTIVITIES_PER_CHILD_WORKFLOW = 5;
 export const MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES = 1;
 
 // If set to true, the workflow will process all discovered resources until empty.
-export const PROCESS_ALL_DISCOVERED_RESOURCES = true;
+export const PROCESS_ALL_DISCOVERED_RESOURCES = false;
 
 export const DATABASE_TO_CSV_MAX_SIZE = 256 * 1024 * 1024; // 256MB
 

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -16,7 +16,7 @@ export const MAX_PENDING_UPSERT_ACTIVITIES_PER_CHILD_WORKFLOW = 5;
 export const MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES = 1;
 
 // If set to true, the workflow will process all discovered resources until empty.
-export const PROCESS_ALL_DISCOVERED_RESOURCES = false;
+export const PROCESS_ALL_DISCOVERED_RESOURCES = true;
 
 export const DATABASE_TO_CSV_MAX_SIZE = 256 * 1024 * 1024; // 256MB
 

--- a/connectors/src/connectors/notion/temporal/workflows/index.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/index.ts
@@ -209,9 +209,6 @@ export async function notionSyncWorkflow({
           // of their child pages (effectively doing a crawl).
           forceResync: true,
         });
-        // Technically, we should clear NotionConnectorResourcesToCheckCacheEntry after each iteration,
-        // otherwise it keeps the already processed entries. In practice it's mostly harmless,
-        // as we have logic to not reprocess them, but it might make DB ops slightly less efficient.
       }
     } while (discoveredResources);
   } else {

--- a/connectors/src/connectors/notion/temporal/workflows/index.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/index.ts
@@ -200,7 +200,9 @@ export async function notionSyncWorkflow({
         queue: childWorkflowQueue,
         childWorkflowsNameSuffix: "discovered",
         topLevelWorkflowId,
-        forceResync: true, // Force resync to ensure we get all discovered resources
+        // Force resync to ensure DBs are processed immediately, which then allows discovery
+        // of their child pages.
+        forceResync: true,
       });
     }
   } while (discoveredResources && PROCESS_ALL_DISCOVERED_RESOURCES);


### PR DESCRIPTION
## Description

Allow the incremental sync to crawl new resources that it finds. There are 3 key changes, which are each quite simple:
1. Always run the 'discovered resources' logic, which was previously only done during initial sync. The reasoning is that see we found unknown pages (potentially entire trees), it is essentially an initial sync scenario for them. i.e. Sharing a large tree with Dust is not much different from picking that same tree when you first enable the Notion integration.
2. Set `PROCESS_ALL_DISCOVERED_RESOURCES` to true, so that we crawl all the new things that we found, not just 1 deep.
3. Use `forceResync` mode when upserting 'discovered resources'. This is to make sure that newly discovered DBs are upserted right away, which then lets is discover its pages and continue crawling. 

## Tests

Manual

## Risk

Medium. While a small change, it is fairly fundamental, and has the potential to disrupt things.

## Deploy Plan

Connectors.