### PR TITLE
[front] (enh): Add page to choose right invitation

### DIFF
--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -218,6 +218,7 @@ export async function handleEnterpriseSignUpFlow(
 export async function handleRegularSignupFlow(
   session: SessionWithUser,
   user: UserResource,
+  activeMemberships: MembershipResource[],
   targetWorkspaceId?: string
 ): Promise<
   Result<
@@ -228,14 +229,9 @@ export async function handleRegularSignupFlow(
     AuthFlowError | SSOEnforcedError
   >
 > {
-  const { memberships: activeMemberships, total } =
-    await MembershipResource.getActiveMemberships({
-      users: [user],
-    });
-
   // Return early if the user is already a member of a workspace and is not attempting to join
   // another one.
-  if (total !== 0 && !targetWorkspaceId) {
+  if (activeMemberships.length > 0 && !targetWorkspaceId) {
     return new Ok({
       flow: null,
       workspace: null,

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -55,7 +55,6 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
       },
       order: [["createdAt", "DESC"]],
       include: [WorkspaceModel],
-      order: [["createdAt", "DESC"]],
       // WORKSPACE_ISOLATION_BYPASS: Invitations can span multiple workspaces prior to login.
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -41,22 +41,31 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
   static async getPendingForEmail(
     email: string
   ): Promise<MembershipInvitationResource | null> {
-    const pendingInvitation = await this.model.findOne({
+    const pendingInvitations = await this.listPendingForEmail(email);
+    return pendingInvitations.length > 0 ? pendingInvitations[0] : null;
+  }
+
+  static async listPendingForEmail(
+    email: string
+  ): Promise<MembershipInvitationResource[]> {
+    const invitations = await this.model.findAll({
       where: {
         inviteEmail: email,
         status: "pending",
       },
       order: [["createdAt", "DESC"]],
       include: [WorkspaceModel],
-      // WORKSPACE_ISOLATION_BYPASS: We don't know the workspace yet, the user is not authed
+      order: [["createdAt", "DESC"]],
+      // WORKSPACE_ISOLATION_BYPASS: Invitations can span multiple workspaces prior to login.
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 
-    return pendingInvitation
-      ? new MembershipInvitationResource(this.model, pendingInvitation.get(), {
-          workspace: pendingInvitation.workspace,
+    return invitations.map(
+      (invitation) =>
+        new MembershipInvitationResource(this.model, invitation.get(), {
+          workspace: invitation.workspace,
         })
-      : null;
+    );
   }
 
   static async getPendingForEmailAndWorkspace(

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -10,6 +10,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { createOrUpdateUser, fetchUserFromSession } from "@app/lib/iam/users";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -109,17 +110,33 @@ async function handler(
     targetWorkspace = workspace;
     targetFlow = flow;
   } else {
-    // When user is just created, and no invitation is already provided, check if there is a
-    // pending invitation. If it does, we will use the first one and redirect to the join page.
-    const pendingInvitation =
-      userCreated && !membershipInvite
-        ? await MembershipInvitationResource.getPendingForEmail(user.email)
+    const { memberships } = await MembershipResource.getActiveMemberships({
+      users: [user],
+    });
+
+    // When user has no memberships, and no invitation is already provided, check if there is a
+    // pending invitation.
+    const pendingInvitations =
+      memberships.length === 0 && !membershipInvite
+        ? await MembershipInvitationResource.listPendingForEmail(user.email)
         : null;
 
-    const finalMembershipInvite = membershipInvite ?? pendingInvitation;
+    // More than one pending invitation, redirect to invite choose page - otherwise use the first one.
+    if (pendingInvitations && pendingInvitations.length > 1) {
+      res.redirect("/invite-choose");
+      return;
+    }
+
+    const finalMembershipInvite = membershipInvite ?? pendingInvitations?.[0];
     const loginFctn = finalMembershipInvite
       ? async () => handleMembershipInvite(user, finalMembershipInvite)
-      : async () => handleRegularSignupFlow(session, user, targetWorkspaceId);
+      : async () =>
+          handleRegularSignupFlow(
+            session,
+            user,
+            memberships,
+            targetWorkspaceId
+          );
 
     const result = await loginFctn();
     if (result.isErr()) {

--- a/front/pages/invite-choose.tsx
+++ b/front/pages/invite-choose.tsx
@@ -91,9 +91,7 @@ export default function InviteChoosePage({
         <div className="flex flex-col gap-4">
           {invitations.length === 0 ? (
             <div className="body-sm text-muted-foreground">
-              We couldn&apos;t find any pending invitations for{
-                " "
-              }
+              We couldn&apos;t find any pending invitations for{" "}
               {user?.email ?? "your account"}. Please contact your workspace
               admin or try another email address.
             </div>
@@ -134,4 +132,3 @@ export default function InviteChoosePage({
     </Page>
   );
 }
-

--- a/front/pages/invite-choose.tsx
+++ b/front/pages/invite-choose.tsx
@@ -1,0 +1,137 @@
+import {
+  BarHeader,
+  Button,
+  DustLogoSquare,
+  Icon,
+  Page,
+} from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import { useCallback } from "react";
+
+import { getMembershipInvitationToken } from "@app/lib/api/invitation";
+import {
+  getUserFromSession,
+  withDefaultUserAuthPaywallWhitelisted,
+} from "@app/lib/iam/session";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { useUser } from "@app/lib/swr/user";
+
+type PendingInvitationOption = {
+  invitationId: number;
+  invitationSid: string;
+  token: string;
+  workspaceName: string;
+  workspaceSid: string;
+  initialRole: string;
+  createdAt: number;
+};
+
+export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
+  userFirstName: string;
+  invitations: PendingInvitationOption[];
+}>(async (context, _auth, session) => {
+  const user = await getUserFromSession(session);
+  if (!user) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const invitationsResources =
+    await MembershipInvitationResource.listPendingForEmail(user.email);
+
+  const invitations = invitationsResources.map((invitation) => {
+    const workspace = invitation.workspace;
+
+    return {
+      invitationId: invitation.id,
+      invitationSid: invitation.sId,
+      token: getMembershipInvitationToken(invitation.id),
+      workspaceName: workspace.name,
+      workspaceSid: workspace.sId,
+      initialRole: invitation.initialRole,
+      createdAt: invitation.createdAt.getTime(),
+    } satisfies PendingInvitationOption;
+  });
+
+  return {
+    props: {
+      userFirstName: user.firstName,
+      invitations,
+    },
+  };
+});
+
+export default function InviteChoosePage({
+  userFirstName,
+  invitations,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { user } = useUser();
+
+  const handleInvitationSelection = useCallback(async (token: string) => {
+    if (typeof window !== "undefined") {
+      window.location.assign(
+        `/api/login?inviteToken=${encodeURIComponent(token)}`
+      );
+    }
+  }, []);
+
+  return (
+    <Page variant="normal">
+      <BarHeader title="Joining Dust" className="ml-10 lg:ml-0" />
+      <div className="mx-auto mt-40 flex max-w-2xl flex-col gap-8">
+        <div className="flex flex-col gap-2">
+          <div className="items-left justify-left flex flex-row">
+            <Icon visual={DustLogoSquare} size="md" />
+          </div>
+          <span className="heading-2xl text-foreground dark:text-foreground-night">
+            Hello {userFirstName}!
+          </span>
+        </div>
+        <div className="flex flex-col gap-4">
+          {invitations.length === 0 ? (
+            <div className="body-sm text-muted-foreground">
+              We couldn&apos;t find any pending invitations for{
+                " "
+              }
+              {user?.email ?? "your account"}. Please contact your workspace
+              admin or try another email address.
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4">
+              <div className="body-md text-foreground">
+                Choose the workspace you would like to join:
+              </div>
+              <div className="flex flex-col gap-3">
+                {invitations.map((invitation) => (
+                  <div
+                    key={invitation.invitationSid}
+                    className="border-border-light bg-wash dark:bg-wash-dark flex items-center justify-between gap-4 rounded-xl border p-4 shadow-sm dark:border-border-night"
+                  >
+                    <div className="flex flex-col gap-1">
+                      <span className="body-md font-medium text-foreground dark:text-foreground-night">
+                        {invitation.workspaceName}
+                      </span>
+                      <span className="body-sm text-muted-foreground">
+                        Role: {invitation.initialRole}
+                      </span>
+                    </div>
+                    <Button
+                      label="Join"
+                      variant="primary"
+                      size="sm"
+                      onClick={() =>
+                        handleInvitationSelection(invitation.token)
+                      }
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </Page>
+  );
+}
+


### PR DESCRIPTION
## Description

If the user has multiple pending invitations, reidrects to a page where they can choose the correct invite instead of taking the first one.
Handle also the case where the user has not just been created, but has no membership (so still use the same flow even if they comes back later, or if they have been revoked)

<img width="407" height="340" alt="Screenshot 2025-11-07 at 13 12 29" src="https://github.com/user-attachments/assets/c011266d-f2e4-4a1b-ac3a-ea7898bcd001" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front