### PR TITLE
 Onboarding tool skeletton

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -18,6 +18,8 @@ import { SLIDESHOW_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/se
 import {
   DEEP_DIVE_NAME,
   DEEP_DIVE_SERVER_INSTRUCTIONS,
+  ONBOARDING_SERVER_DESC,
+  ONBOARDING_SERVER_NAME,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import type {
   InternalMCPServerDefinitionType,
@@ -98,6 +100,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "missing_action_catcher",
   "monday",
   "notion",
+  "onboarding",
   "openai_usage",
   "outlook_calendar",
   "outlook",
@@ -1282,6 +1285,27 @@ The directive should be used to display a clickable version of the agent name in
       documentationUrl: null,
       instructions: null,
       developerSecretSelection: "required",
+    },
+  },
+  onboarding: {
+    id: 42,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("onboarding_tool");
+    },
+    isPreview: false,
+    tools_stakes: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: ONBOARDING_SERVER_NAME,
+      version: "1.0.0",
+      description: ONBOARDING_SERVER_DESC,
+      authorization: null,
+      icon: "ActionBrainIcon",
+      documentationUrl: null,
+      instructions: null,
     },
   },
   [SEARCH_SERVER_NAME]: {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -35,6 +35,7 @@ import { default as microsoftTeamsServer } from "@app/lib/actions/mcp_internal_a
 import { default as missingActionCatcherServer } from "@app/lib/actions/mcp_internal_actions/servers/missing_action_catcher";
 import { default as mondayServer } from "@app/lib/actions/mcp_internal_actions/servers/monday";
 import { default as notionServer } from "@app/lib/actions/mcp_internal_actions/servers/notion";
+import { default as onboardingServer } from "@app/lib/actions/mcp_internal_actions/servers/onboarding";
 import { default as openaiUsageServer } from "@app/lib/actions/mcp_internal_actions/servers/openai_usage";
 import { default as outlookServer } from "@app/lib/actions/mcp_internal_actions/servers/outlook";
 import { default as outlookCalendarServer } from "@app/lib/actions/mcp_internal_actions/servers/outlook/calendar_server";
@@ -202,6 +203,8 @@ export async function getInternalMCPServer(
       return deepDiveServer(auth, agentLoopContext);
     case "http_client":
       return httpClientServer(auth, agentLoopContext);
+    case "onboarding":
+      return onboardingServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/onboarding.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/onboarding.ts
@@ -1,0 +1,166 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+import type { MCPError } from "@app/lib/actions/mcp_errors";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resource";
+import type { Result } from "@app/types";
+import { Ok } from "@app/types";
+
+const renderTasks = (
+  tasks: OnboardingTaskResource[]
+): Result<CallToolResult["content"], MCPError> => {
+  return new Ok([
+    {
+      type: "text" as const,
+      text: tasks.map((task) => task.toPrettyString()).join("\n"),
+    },
+  ]);
+};
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("onboarding");
+  const user = auth.user();
+
+  if (!user) {
+    server.tool(
+      "onboarding_not_available",
+      "Onboarding is configured to be scoped to users but no user is currently authenticated.",
+      {},
+      async () => {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "No onboarding tasks available as there is no user authenticated.",
+            },
+          ],
+        };
+      }
+    );
+    return server;
+  }
+
+  server.tool(
+    "retrieve",
+    `Retrieve all onboarding tasks for the current user`,
+    {},
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "onboarding", agentLoopContext },
+      async () => {
+        const tasks =
+          await OnboardingTaskResource.fetchAllForUserAndWorkspaceInAuth(auth);
+        return renderTasks(tasks);
+      }
+    )
+  );
+
+  /**
+   * Commented out for now as the tool to create new tasks is easy to misuse without proper context.
+   * We will start with a limited set of tasks that we generate automatically based on the user's needs.
+   */
+  // server.tool(
+  //   "create_task",
+  //   `Create a new onboarding task for the current user`,
+  //   {
+  //     context: z.string().describe("The context of the new task."),
+  //     kind: z.enum(ONBOARDING_TASK_KINDS).describe("The kind of the new task."),
+  //     toolName: z
+  //       .string()
+  //       .describe("The tool name of the new task.")
+  //       .nullable()
+  //       .optional(),
+  //   },
+  //   withToolLogging(
+  //     auth,
+  //     { toolNameForMonitoring: "onboarding", agentLoopContext },
+  //     async ({ context, kind, toolName }) => {
+  //       const result = await OnboardingTaskResource.makeNew(auth, {
+  //         context,
+  //         kind,
+  //         toolName,
+  //       });
+
+  //       return new Ok([
+  //         {
+  //           type: "text" as const,
+  //           text: `New onboarding task created: ${result.sId}`,
+  //         },
+  //       ]);
+  //     }
+  //   )
+  // );
+
+  server.tool(
+    "skip_task",
+    `Skip a specific onboarding task for the current user`,
+    {
+      sId: z.string().describe("The sId of the task to skip."),
+    },
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "onboarding", agentLoopContext },
+      async ({ sId }) => {
+        const task = await OnboardingTaskResource.fetchById(auth, sId);
+        if (!task) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `Task ${sId} not found`,
+            },
+          ]);
+        }
+        await task.markSkipped();
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Task ${sId} skipped`,
+          },
+        ]);
+      }
+    )
+  );
+
+  server.tool(
+    "complete_task",
+    `Complete a specific onboarding task for the current user`,
+    {
+      sId: z.string().describe("The sId of the task to complete."),
+    },
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "onboarding", agentLoopContext },
+      async ({ sId }) => {
+        const task = await OnboardingTaskResource.fetchById(auth, sId);
+        if (!task) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `Task ${sId} not found`,
+            },
+          ]);
+        }
+        await task.markCompleted();
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Task ${sId} completed`,
+          },
+        ]);
+      }
+    )
+  );
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/assistant/global_agents/configurations/dust/consts.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/consts.ts
@@ -19,3 +19,7 @@ Guidelines:
 - Let the user know that the handoff is launched by mentionning it before calling the deep dive tool.
 - The valid way to mention the @${DEEP_DIVE_NAME} agent is using the mention directive: ${mentionAgent({ name: DEEP_DIVE_NAME, sId: GLOBAL_AGENTS_SID.DEEP_DIVE })}
 `;
+
+export const ONBOARDING_SERVER_NAME = "onboarding";
+export const ONBOARDING_SERVER_DESC =
+  "Guide users through personalized product discovery with interactive onboarding tasks.";

--- a/front/lib/resources/onboarding_task_resource.ts
+++ b/front/lib/resources/onboarding_task_resource.ts
@@ -221,4 +221,8 @@ export class OnboardingTaskResource extends BaseResource<OnboardingTaskModel> {
       updatedAt: this.updatedAt,
     };
   }
+
+  toPrettyString(): string {
+    return `[${this.sId}] Status: ${this.getStatus()}, Context: ${this.context}, Kind: ${this.kind}, Tool Name: ${this.toolName ?? "N/A"}, Created At: ${this.createdAt.toISOString()}`;
+  }
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -103,6 +103,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "OpenAI tool for tracking API consumption and costs",
     stage: "on_demand",
   },
+  onboarding_tool: {
+    description: "Onboarding tool - Growth team experiment",
+    stage: "dust_only",
+  },
   salesforce_synced_queries: {
     description: "Salesforce Connection: retrieval on Synchronized queries",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -659,6 +659,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "monday_tool"
   | "noop_model_feature"
   | "notion_private_integration"
+  | "onboarding_tool"
   | "openai_o1_custom_assistants_feature"
   | "openai_o1_feature"
   | "openai_o1_high_reasoning_custom_assistants_feature"


### PR DESCRIPTION
## Description

Creates a new onboarding tool, hidden in the builder and added to dust, gated behind a feature flag.
For now it can only get tasks and mark them as skipped or completed. I commented out the tool to create new tasks. 

Then the rest is editing dust so it has access to the tool and the tasks, as we do for memories. 

Note: 
This is a first step, we need to iterate a lot on the instructions to make it smart.
We also need to iterate on when we show or not show this tool. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan 

Deploy front.