### PR TITLE
[front] feat(obs): add backend support for versioned latency and error rate data

### DIFF
--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -16,6 +16,7 @@ import {
   ERROR_RATE_LEGEND,
   ERROR_RATE_PALETTE,
 } from "@app/components/agent_builder/observability/constants";
+import { useErrorRateData } from "@app/components/agent_builder/observability/hooks";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import {
@@ -28,10 +29,7 @@ import {
   getErrorRateChipInfo,
   padSeriesToTimeRange,
 } from "@app/components/agent_builder/observability/utils";
-import {
-  useAgentErrorRate,
-  useAgentVersionMarkers,
-} from "@app/lib/swr/assistants";
+import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
 
 interface ErrorRateData {
   total: number;
@@ -90,14 +88,14 @@ export function ErrorRateChart({
 }: ErrorRateChartProps) {
   const { period, mode } = useObservabilityContext();
   const {
-    errorRate: rawData,
-    isErrorRateLoading,
-    isErrorRateError,
-  } = useAgentErrorRate({
+    data: rawData,
+    isLoading: isErrorRateLoading,
+    errorMessage: isErrorRateError,
+  } = useErrorRateData({
     workspaceId,
     agentConfigurationId,
-    days: period,
-    disabled: !workspaceId || !agentConfigurationId,
+    period,
+    mode,
   });
 
   const { versionMarkers } = useAgentVersionMarkers({

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -14,6 +14,7 @@ import {
   LATENCY_LEGEND,
   LATENCY_PALETTE,
 } from "@app/components/agent_builder/observability/constants";
+import { useLatencyData } from "@app/components/agent_builder/observability/hooks";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import {
@@ -23,10 +24,7 @@ import {
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { VersionMarkersDots } from "@app/components/agent_builder/observability/shared/VersionMarkers";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
-import {
-  useAgentLatency,
-  useAgentVersionMarkers,
-} from "@app/lib/swr/assistants";
+import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
 
 interface LatencyData {
   messages: number;
@@ -73,14 +71,14 @@ export function LatencyChart({
 }) {
   const { period, mode } = useObservabilityContext();
   const {
-    latency: rawData,
-    isLatencyLoading,
-    isLatencyError,
-  } = useAgentLatency({
+    data: rawData,
+    isLoading: isLatencyLoading,
+    errorMessage: isLatencyError,
+  } = useLatencyData({
     workspaceId,
     agentConfigurationId,
-    days: period,
-    disabled: !workspaceId || !agentConfigurationId,
+    period,
+    mode,
   });
 
   const { versionMarkers } = useAgentVersionMarkers({

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -4,11 +4,13 @@ export function buildAgentAnalyticsBaseQuery({
   workspaceId,
   agentId,
   days,
+  version,
   feedbackNestedQuery,
 }: {
   workspaceId: string;
   agentId: string;
   days?: number;
+  version?: string;
   feedbackNestedQuery?: estypes.QueryDslQueryContainer;
 }): estypes.QueryDslQueryContainer {
   const filters: estypes.QueryDslQueryContainer[] = [
@@ -18,6 +20,9 @@ export function buildAgentAnalyticsBaseQuery({
 
   if (days) {
     filters.push({ range: { timestamp: { gte: `now-${days}d/d` } } });
+  }
+  if (version) {
+    filters.push({ term: { "configuration.version": version } });
   }
   if (feedbackNestedQuery) {
     filters.push({ nested: { path: "feedbacks", query: feedbackNestedQuery } });

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -810,15 +810,18 @@ export function useAgentLatency({
   workspaceId,
   agentConfigurationId,
   days = DEFAULT_PERIOD_DAYS,
+  version,
   disabled,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   days?: number;
+  version?: string;
   disabled?: boolean;
 }) {
   const fetcherFn: Fetcher<GetLatencyResponse> = fetcher;
-  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/latency?days=${days}`;
+  const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/latency?days=${days}${versionParam}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,
@@ -837,15 +840,18 @@ export function useAgentErrorRate({
   workspaceId,
   agentConfigurationId,
   days = DEFAULT_PERIOD_DAYS,
+  version,
   disabled,
 }: {
   workspaceId: string;
   agentConfigurationId: string;
   days?: number;
+  version?: string;
   disabled?: boolean;
 }) {
   const fetcherFn: Fetcher<GetErrorRateResponse> = fetcher;
-  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/error_rate?days=${days}`;
+  const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/error_rate?days=${days}${versionParam}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -13,6 +13,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional(),
+  version: z.string().optional(),
 });
 
 export type GetErrorRateResponse = {
@@ -73,6 +74,7 @@ async function handler(
       }
 
       const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+      const version = q.data.version;
 
       const owner = auth.getNonNullableWorkspace();
 
@@ -80,6 +82,7 @@ async function handler(
         workspaceId: owner.sId,
         agentId: assistant.sId,
         days,
+        version,
       });
 
       const errorRateResult = await fetchErrorRate(baseQuery);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -13,6 +13,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional(),
+  version: z.string().optional(),
 });
 
 export type GetLatencyResponse = {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -80,6 +80,7 @@ async function handler(
         workspaceId: owner.sId,
         agentId: assistant.sId,
         days,
+        version: q.data.version,
       });
 
       const latencyResult = await fetchLatency(baseQuery);


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/5036.
- This PR adds support for retrieving the latency and the error rate data for a specific version, handled via an additional query parameter.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
