### PR TITLE
Don't send attachments if no files:write scope

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -298,8 +298,13 @@ async function streamAgentAnswerToSlack(
           actions
         );
 
-        const files = actions.flatMap((action) => action.generatedFiles);
-        const filesUploaded = await getFilesFromDust(files, dustAPI);
+        const authResult = await slackClient.auth.test();
+        const scopes = authResult.response_metadata?.scopes ?? [];
+        let filesUploaded: { file: Buffer; filename: string }[] = [];
+        if (scopes.includes("files:write")) {
+          const files = actions.flatMap((action) => action.generatedFiles);
+          filesUploaded = await getFilesFromDust(files, dustAPI);
+        }
 
         const slackContent = slackifyMarkdown(
           normalizeContentForSlack(formattedContent)

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -299,9 +299,11 @@ async function streamAgentAnswerToSlack(
         );
 
         const authResult = await slackClient.auth.test();
-        const scopes = authResult.response_metadata?.scopes ?? [];
         let filesUploaded: { file: Buffer; filename: string }[] = [];
-        if (scopes.includes("files:write")) {
+        if (
+          authResult.ok &&
+          authResult.response_metadata?.scopes?.includes("files:write")
+        ) {
           const files = actions.flatMap((action) => action.generatedFiles);
           filesUploaded = await getFilesFromDust(files, dustAPI);
         }

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -6,7 +6,6 @@ import slackifyMarkdown from "slackify-markdown";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
-import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { removeDiacritics } from "@app/lib/utils";
@@ -283,10 +282,9 @@ export async function executePostMessage(
   );
   message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
 
-  const currentRegion = regionsConfig.getCurrentRegion();
-  // Disable file upload in US region for now.
-  // TODO(2025-10-22 chris): remove this once Slack enables file:write scope
-  if (currentRegion === "us-central1") {
+  const authResult = await slackClient.auth.test();
+  const scopes = authResult.response_metadata?.scopes ?? [];
+  if (!scopes.includes("files:write")) {
     fileId = undefined;
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -283,8 +283,10 @@ export async function executePostMessage(
   message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
 
   const authResult = await slackClient.auth.test();
-  const scopes = authResult.response_metadata?.scopes ?? [];
-  if (!scopes.includes("files:write")) {
+  if (
+    !authResult.ok ||
+    !authResult.response_metadata?.scopes?.includes("files:write")
+  ) {
     fileId = undefined;
   }
 


### PR DESCRIPTION
## Description

The code now checks if the files:write scope is available before attempting to upload files on Slack.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front and connectors
