### PR TITLE
Add Salesloft beta tool

### DIFF
--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -162,6 +162,7 @@ async function getMCPServerActionConfiguration(
     : null;
   builderAction.configuration.additionalConfiguration =
     action.additionalConfiguration;
+  builderAction.configuration.secretName = action.secretName;
 
   return builderAction;
 }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -108,6 +108,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "run_agent",
   "run_dust_app",
   "salesforce",
+  "salesloft",
   "slack",
   "slack_bot",
   "sound_studio",
@@ -1251,6 +1252,33 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       // TODO(2025-11-04 aubin): add logo.
       icon: "GithubLogo",
+      documentationUrl: null,
+      instructions: null,
+      developerSecretSelection: "required",
+    },
+  },
+  salesloft: {
+    id: 41,
+    availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("salesloft_tool");
+    },
+    isPreview: true,
+    tools_stakes: {
+      get_current_user: "never_ask",
+      get_cadences: "never_ask",
+      get_tasks: "never_ask",
+      get_actions: "never_ask",
+    },
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "salesloft",
+      version: "1.0.0",
+      description: "Access Salesloft cadences, tasks, and actions.",
+      authorization: null,
+      icon: "ActionDocumentTextIcon",
       documentationUrl: null,
       instructions: null,
       developerSecretSelection: "required",

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -44,6 +44,7 @@ import { default as reasoningServer } from "@app/lib/actions/mcp_internal_action
 import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/run_agent";
 import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
+import { default as salesloftServer } from "@app/lib/actions/mcp_internal_actions/servers/salesloft";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
 import { default as slackBotServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_bot";
 import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_personal";
@@ -151,6 +152,8 @@ export async function getInternalMCPServer(
       return extractDataServer(auth, agentLoopContext);
     case "salesforce":
       return salesforceServer(auth, agentLoopContext);
+    case "salesloft":
+      return salesloftServer(auth, agentLoopContext);
     case "gmail":
       return gmailServer(auth, agentLoopContext);
     case "google_calendar":

--- a/front/lib/actions/mcp_internal_actions/servers/salesloft/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesloft/index.ts
@@ -1,0 +1,190 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { SalesloftActionWithDetails } from "@app/lib/actions/mcp_internal_actions/servers/salesloft/salesloft_api_helper";
+import { getActionsWithDetails } from "@app/lib/actions/mcp_internal_actions/servers/salesloft/salesloft_api_helper";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import type { Authenticator } from "@app/lib/auth";
+import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { decrypt, Err, normalizeError, Ok } from "@app/types";
+
+async function getBearerToken(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): Promise<string | null> {
+  const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
+  if (
+    !toolConfig ||
+    !isLightServerSideMCPToolConfiguration(toolConfig) ||
+    !toolConfig.secretName
+  ) {
+    return null;
+  }
+
+  const secret = await DustAppSecret.findOne({
+    where: {
+      name: toolConfig.secretName,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
+  });
+
+  const bearerToken = secret
+    ? decrypt(secret.hash, auth.getNonNullableWorkspace().sId)
+    : null;
+
+  return bearerToken;
+}
+
+function formatActionAsString(action: SalesloftActionWithDetails): string {
+  const parts: string[] = [];
+
+  parts.push(`Action #${action.action.id}`);
+  parts.push(`Type: ${action.action.type}`);
+  parts.push(`Status: ${action.action.status}`);
+  parts.push(`Due: ${action.action.due ? "Yes" : "No"}`);
+  if (action.action.due_on) {
+    parts.push(`Due On: ${new Date(action.action.due_on).toLocaleString()}`);
+  }
+
+  if (action.person) {
+    const personName = [action.person.first_name, action.person.last_name]
+      .filter(Boolean)
+      .join(" ");
+    parts.push(`\nPerson: ${personName || "Unknown"}`);
+    if (action.person.email_address) {
+      parts.push(`  Email: ${action.person.email_address}`);
+    }
+    if (action.person.phone) {
+      parts.push(`  Phone: ${action.person.phone}`);
+    }
+  }
+
+  if (action.cadence) {
+    parts.push(`\nCadence: ${action.cadence.name}`);
+    if (action.cadence.team_cadence) {
+      parts.push(`  (Team Cadence)`);
+    }
+  }
+
+  if (action.step) {
+    parts.push(
+      `\nStep: ${action.step.name} (Step #${action.step.step_number}, Type: ${action.step.type})`
+    );
+  }
+
+  if (action.task) {
+    parts.push(`\nTask: ${action.task.subject ?? "No subject"}`);
+    if (action.task.due_date) {
+      parts.push(
+        `  Due Date: ${new Date(action.task.due_date).toLocaleString()}`
+      );
+    }
+    if (action.task.current_state) {
+      parts.push(`  State: ${action.task.current_state}`);
+    }
+  }
+
+  if (action.user) {
+    parts.push(
+      `\nAssigned User: ${action.user.first_name} ${action.user.last_name} (${action.user.email})`
+    );
+  }
+
+  if (action.action_details) {
+    parts.push(`\nAction Details: Available`);
+  }
+
+  return parts.join("\n");
+}
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("salesloft");
+
+  server.tool(
+    "get_actions",
+    "Get actions with COMPLETE related information for full context. " +
+      "By default, returns only currently due or overdue actions, but can be configured to return all actions. " +
+      "Follows Salesloft best practices: " +
+      "1. Gets steps (with has_due_actions filter when configured) " +
+      "2. Gets cadences associated with those steps (complete cadence information) " +
+      "3. Gets actions for those steps using step_id filter (more efficient than querying all actions) " +
+      "4. Gets person/contact information for each action (complete contact details) " +
+      "This provides comprehensive context needed to understand and execute each action.",
+    {
+      include_due_actions_only: z
+        .boolean()
+        .describe(
+          "Whether to only include actions that are currently due or overdue. Defaults to true."
+        )
+        .default(true),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: "salesloft_get_actions",
+        agentLoopContext,
+      },
+      async ({ include_due_actions_only }) => {
+        const bearerToken = await getBearerToken(auth, agentLoopContext);
+        if (!bearerToken) {
+          return new Err(
+            new MCPError(
+              "No bearer token found. Please configure a secret for this Salesloft integration"
+            )
+          );
+        }
+
+        try {
+          const actionsWithDetails = await getActionsWithDetails(bearerToken, {
+            includeDueActionsOnly: include_due_actions_only,
+          });
+
+          const actionTypeText = include_due_actions_only
+            ? "due or overdue"
+            : "";
+
+          if (actionsWithDetails.length === 0) {
+            return new Ok([
+              {
+                type: "text" as const,
+                text: include_due_actions_only
+                  ? "No due or overdue actions found."
+                  : "No actions found.",
+              },
+            ]);
+          }
+
+          const formattedText = actionsWithDetails
+            .map((action, index) => {
+              return `--- Action ${index + 1} of ${actionsWithDetails.length} ---\n${formatActionAsString(
+                action
+              )}`;
+            })
+            .join("\n\n");
+
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `Found ${actionsWithDetails.length} ${actionTypeText} action(s):\n\n${formattedText}`,
+            },
+          ]);
+        } catch (error: unknown) {
+          return new Err(
+            new MCPError(normalizeError(error).message ?? "Operation failed")
+          );
+        }
+      }
+    )
+  );
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/salesloft/salesloft_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesloft/salesloft_api_helper.ts
@@ -1,0 +1,566 @@
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types";
+
+const SALESLOFT_API_BASE_URL = "https://api.salesloft.com/v2";
+
+interface SalesloftUser {
+  id: number;
+  email: string;
+  first_name: string;
+  last_name: string;
+}
+
+interface SalesloftCadence {
+  id: number;
+  name: string;
+  team_cadence: boolean;
+}
+
+interface SalesloftPerson {
+  id: number;
+  first_name: string | null;
+  last_name: string | null;
+  email_address: string | null;
+  phone: string | null;
+}
+
+interface SalesloftStep {
+  id: number;
+  cadence_id: number;
+  name: string;
+  step_number: number;
+  type: string;
+}
+
+interface SalesloftAction {
+  id: number;
+  type: string;
+  due: boolean;
+  status: string;
+  due_on: string | null;
+  action_details: {
+    id: number;
+    _href: string;
+  } | null;
+  user: {
+    id: number;
+    _href: string;
+  } | null;
+  person: {
+    id: number;
+    _href: string;
+  } | null;
+  cadence: {
+    id: number;
+    _href: string;
+  } | null;
+  step: {
+    id: number;
+    _href: string;
+  } | null;
+  task: {
+    id: number;
+    _href: string;
+  } | null;
+}
+
+interface SalesloftTask {
+  id: number;
+  subject: string | null;
+  due_date: string | null;
+  current_state: string | null;
+}
+
+interface SalesloftActionDetails {
+  [key: string]: unknown;
+}
+
+export interface SalesloftActionWithDetails {
+  action: SalesloftAction;
+  person: SalesloftPerson | null;
+  cadence: SalesloftCadence | null;
+  step: SalesloftStep | null;
+  task: SalesloftTask | null;
+  user: SalesloftUser | null;
+  action_details: SalesloftActionDetails | null;
+}
+
+interface SalesloftApiResponse<T> {
+  data: T[];
+  metadata: {
+    paging?: {
+      per_page: number;
+      current_page: number;
+      next_page: number | null;
+      prev_page: number | null;
+    };
+  };
+}
+
+async function handleSalesloftError(
+  response: Response,
+  errorText: string
+): Promise<never> {
+  let errorMessage = `Salesloft API error: ${response.status} ${response.statusText}`;
+
+  if (errorText) {
+    try {
+      const errorData = JSON.parse(errorText);
+
+      if (response.status === 422 && errorData.errors) {
+        const fieldErrors = Object.entries(errorData.errors)
+          .map(
+            ([field, errors]) =>
+              `${field}: ${Array.isArray(errors) ? errors.join(", ") : errors}`
+          )
+          .join("; ");
+        errorMessage += ` - ${fieldErrors}`;
+      } else if (errorData.error) {
+        errorMessage += ` - ${errorData.error}`;
+      } else if (errorData.message) {
+        errorMessage += ` - ${errorData.message}`;
+      } else {
+        errorMessage += ` - ${errorText.substring(0, 200)}`;
+      }
+    } catch {
+      errorMessage += ` - ${errorText.substring(0, 200)}`;
+    }
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(
+      `Authentication failed: ${errorMessage}. Please verify your bearer token is valid.`
+    );
+  }
+
+  throw new Error(errorMessage);
+}
+
+async function makeSalesloftRequest<T>(
+  accessToken: string,
+  endpoint: string,
+  params?: Record<string, string | number | boolean>
+): Promise<SalesloftApiResponse<T>> {
+  const url = new URL(`${SALESLOFT_API_BASE_URL}${endpoint}`);
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      url.searchParams.append(key, String(value));
+    });
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    await handleSalesloftError(response, errorText);
+  }
+
+  const jsonResponse = await response.json();
+
+  if (!jsonResponse || typeof jsonResponse !== "object") {
+    throw new Error("Invalid response format from Salesloft API");
+  }
+
+  return jsonResponse;
+}
+
+async function getAllPages<T>(
+  accessToken: string,
+  endpoint: string,
+  params?: Record<string, string | number | boolean>
+): Promise<T[]> {
+  const allResults: T[] = [];
+  let currentPage = 1;
+  const perPage = 100;
+  let hasMorePages = true;
+  const maxPages = 1000;
+  let pagesFetched = 0;
+
+  while (hasMorePages && pagesFetched < maxPages) {
+    const response = await makeSalesloftRequest<T>(accessToken, endpoint, {
+      ...params,
+      page: currentPage,
+      per_page: perPage,
+    });
+
+    if (!response.data || !Array.isArray(response.data)) {
+      logger.warn(
+        {
+          endpoint,
+          currentPage,
+          response: response,
+        },
+        "Response missing data array, stopping pagination"
+      );
+      break;
+    }
+
+    allResults.push(...response.data);
+
+    if (
+      !response.metadata?.paging ||
+      !response.metadata.paging.next_page ||
+      response.data.length < perPage
+    ) {
+      hasMorePages = false;
+    } else {
+      currentPage++;
+      pagesFetched++;
+    }
+  }
+
+  if (pagesFetched >= maxPages) {
+    logger.warn(
+      {
+        endpoint,
+        totalResults: allResults.length,
+      },
+      "Reached maximum page limit, stopping pagination"
+    );
+  }
+
+  return allResults;
+}
+
+export async function getCurrentUser(
+  accessToken: string
+): Promise<SalesloftUser> {
+  const url = new URL(`${SALESLOFT_API_BASE_URL}/me`);
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    await handleSalesloftError(response, errorText);
+  }
+
+  const userData = await response.json();
+
+  if (!userData?.id) {
+    throw new Error("Invalid user data returned from Salesloft API");
+  }
+
+  return {
+    id: userData.id,
+    email: userData.email,
+    first_name: userData.first_name,
+    last_name: userData.last_name,
+  };
+}
+
+async function getCadencesByIds(
+  accessToken: string,
+  cadenceIds: number[]
+): Promise<Map<number, SalesloftCadence>> {
+  if (cadenceIds.length === 0) {
+    return new Map();
+  }
+
+  const cadences = await getAllPages<SalesloftCadence>(
+    accessToken,
+    "/cadences",
+    {}
+  );
+
+  const cadenceMap = new Map<number, SalesloftCadence>();
+  for (const cadence of cadences) {
+    if (cadenceIds.includes(cadence.id)) {
+      cadenceMap.set(cadence.id, {
+        id: cadence.id,
+        name: cadence.name,
+        team_cadence: cadence.team_cadence,
+      });
+    }
+  }
+  return cadenceMap;
+}
+
+async function getPeopleByIds(
+  accessToken: string,
+  personIds: number[]
+): Promise<Map<number, SalesloftPerson>> {
+  if (personIds.length === 0) {
+    return new Map();
+  }
+
+  const people = await getAllPages<SalesloftPerson>(accessToken, "/people", {});
+
+  const peopleMap = new Map<number, SalesloftPerson>();
+  for (const person of people) {
+    if (personIds.includes(person.id)) {
+      peopleMap.set(person.id, {
+        id: person.id,
+        first_name: person.first_name,
+        last_name: person.last_name,
+        email_address: person.email_address,
+        phone: person.phone,
+      });
+    }
+  }
+  return peopleMap;
+}
+
+async function getTasksByIds(
+  accessToken: string,
+  taskIds: number[]
+): Promise<Map<number, SalesloftTask>> {
+  if (taskIds.length === 0) {
+    return new Map();
+  }
+
+  const tasks = await getAllPages<SalesloftTask>(accessToken, "/tasks", {});
+
+  const taskMap = new Map<number, SalesloftTask>();
+  for (const task of tasks) {
+    if (taskIds.includes(task.id)) {
+      taskMap.set(task.id, {
+        id: task.id,
+        subject: task.subject,
+        due_date: task.due_date,
+        current_state: task.current_state,
+      });
+    }
+  }
+  return taskMap;
+}
+
+async function getUsersByIds(
+  accessToken: string,
+  userIds: number[]
+): Promise<Map<number, SalesloftUser>> {
+  if (userIds.length === 0) {
+    return new Map();
+  }
+
+  const users = await getAllPages<SalesloftUser>(accessToken, "/users", {});
+
+  const userMap = new Map<number, SalesloftUser>();
+  for (const user of users) {
+    if (userIds.includes(user.id)) {
+      userMap.set(user.id, {
+        id: user.id,
+        email: user.email,
+        first_name: user.first_name,
+        last_name: user.last_name,
+      });
+    }
+  }
+  return userMap;
+}
+
+async function getActionDetails(
+  accessToken: string,
+  actionType: string,
+  actionDetailsId: number
+): Promise<SalesloftActionDetails | null> {
+  try {
+    let endpoint: string | null = null;
+
+    if (actionType === "phone") {
+      endpoint = `/action_details/call_instructions/${actionDetailsId}`;
+    }
+
+    if (!endpoint) {
+      return null;
+    }
+
+    const response = await makeSalesloftRequest<SalesloftActionDetails>(
+      accessToken,
+      endpoint
+    );
+
+    if (!response.data || response.data.length === 0) {
+      return null;
+    }
+
+    return response.data[0] as SalesloftActionDetails;
+  } catch (error) {
+    logger.warn(
+      {
+        error: normalizeError(error),
+        actionType,
+        actionDetailsId,
+      },
+      "Failed to get action details (this may be expected for some action types)"
+    );
+    return null;
+  }
+}
+
+export async function getSteps(
+  accessToken: string,
+  userId?: number,
+  options?: {
+    cadenceId?: number;
+    hasDueActions?: boolean;
+  }
+): Promise<SalesloftStep[]> {
+  const params: Record<string, string | number | boolean> = {};
+  if (userId) {
+    params.user_id = userId;
+  }
+  if (options?.cadenceId) {
+    params.cadence_id = options.cadenceId;
+  }
+  if (options?.hasDueActions) {
+    params.has_due_actions = true;
+  }
+  const steps = await getAllPages<SalesloftStep>(accessToken, "/steps", params);
+  return steps.map((step) => ({
+    id: step.id,
+    cadence_id: step.cadence_id,
+    name: step.name,
+    step_number: step.step_number,
+    type: step.type,
+  }));
+}
+
+export async function getActions(
+  accessToken: string,
+  userId?: number,
+  options?: {
+    stepId?: number;
+    dueOnLte?: string;
+    cadenceId?: number;
+  }
+): Promise<SalesloftAction[]> {
+  const params: Record<string, string | number> = {};
+  if (userId) {
+    params.user_id = userId;
+  }
+  if (options?.stepId) {
+    params.step_id = options.stepId;
+  }
+  if (options?.dueOnLte) {
+    params["due_on[lte]"] = options.dueOnLte;
+  }
+  if (options?.cadenceId) {
+    params.cadence_id = options.cadenceId;
+  }
+  const actions = await getAllPages<SalesloftAction>(
+    accessToken,
+    "/actions",
+    params
+  );
+  return actions.map((action) => ({
+    id: action.id,
+    type: action.type,
+    due: action.due,
+    status: action.status,
+    due_on: action.due_on,
+    action_details: action.action_details,
+    user: action.user,
+    person: action.person,
+    cadence: action.cadence,
+    step: action.step,
+    task: action.task,
+  }));
+}
+
+export async function getActionsWithDetails(
+  accessToken: string,
+  options?: {
+    includeDueActionsOnly?: boolean;
+  }
+): Promise<SalesloftActionWithDetails[]> {
+  const user = await getCurrentUser(accessToken);
+
+  const steps = await getSteps(accessToken, user.id, {
+    hasDueActions: options?.includeDueActionsOnly,
+  });
+
+  if (steps.length === 0) {
+    return [];
+  }
+
+  const cadenceIds = [...new Set(steps.map((step) => step.cadence_id))];
+
+  const cadenceMap = await getCadencesByIds(accessToken, cadenceIds);
+
+  const dueOnLte = options?.includeDueActionsOnly
+    ? new Date().toISOString()
+    : undefined;
+
+  const actionPromises = steps.map((step) =>
+    getActions(accessToken, user.id, {
+      stepId: step.id,
+      dueOnLte,
+    })
+  );
+
+  const actionArrays = await Promise.all(actionPromises);
+  const allActions = actionArrays.flat();
+
+  if (allActions.length === 0) {
+    return [];
+  }
+
+  const personIds = [
+    ...new Set(
+      allActions
+        .map((action) => action.person?.id ?? null)
+        .filter((id): id is number => id !== null)
+    ),
+  ];
+
+  const taskIds = [
+    ...new Set(
+      allActions
+        .map((action) => action.task?.id ?? null)
+        .filter((id): id is number => id !== null)
+    ),
+  ];
+
+  const userIds = [
+    ...new Set(
+      allActions
+        .map((action) => action.user?.id ?? null)
+        .filter((id): id is number => id !== null)
+    ),
+  ];
+
+  const peopleMap = await getPeopleByIds(accessToken, personIds);
+
+  const taskMap = await getTasksByIds(accessToken, taskIds);
+
+  const userMap = await getUsersByIds(accessToken, userIds);
+
+  const stepMap = new Map<number, SalesloftStep>();
+  for (const step of steps) {
+    stepMap.set(step.id, step);
+  }
+
+  const actionDetailsPromises = allActions.map((action) =>
+    action.action_details?.id && action.type
+      ? getActionDetails(accessToken, action.type, action.action_details.id)
+      : Promise.resolve(null)
+  );
+  const actionDetailsArray = await Promise.all(actionDetailsPromises);
+
+  const actionsWithDetails: SalesloftActionWithDetails[] = allActions.map(
+    (action, index) => ({
+      action,
+      person: action.person?.id
+        ? peopleMap.get(action.person.id) ?? null
+        : null,
+      cadence: action.cadence?.id
+        ? cadenceMap.get(action.cadence.id) ?? null
+        : null,
+      step: action.step?.id ? stepMap.get(action.step.id) ?? null : null,
+      task: action.task?.id ? taskMap.get(action.task.id) ?? null : null,
+      user: action.user?.id ? userMap.get(action.user.id) ?? null : null,
+      action_details: actionDetailsArray[index] ?? null,
+    })
+  );
+
+  return actionsWithDetails;
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -117,6 +117,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Salesforce MCP tool (activated by default on most plans, FF to override the plan config)",
     stage: "on_demand",
   },
+  salesloft_tool: {
+    description: "Salesloft MCP tool",
+    stage: "dust_only",
+  },
   salesforce_tool_write: {
     description: "Salesforce MCP tool: write operations (update_object)",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -684,6 +684,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_synced_queries"
   | "salesforce_tool_write"
   | "salesforce_tool"
+  | "salesloft_tool"
   | "show_debug_tools"
   | "slack_bot_mcp"
   | "slack_enhanced_default_agent"


### PR DESCRIPTION
## Description

* Salesloft MCP tool to gather all open actions. The API pattern is a bit abnormal. Following their recommendation in docs: https://developers.salesloft.com/docs/platform/api-basics/retrieving-actions-cadences-steps/
* Will remain behind FF and only available to single customer who would like to work with me to validate this
* Also fixing bug in server_side_props_helper where secretName isn't being loaded into initial configuration

## Tests

* I do not have access to Salesloft yet. Have meeting scheduled to obtain the API key and test.

## Risk

* Not customer facing yet. Marked as dust only

## Deploy Plan

* Deploy front