### PR TITLE
Log context window hit and tokenizer endpoint calls

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -103,11 +103,14 @@ export async function renderConversationForModel(
 
   let isContextWindowHit = false;
   function logContextWindowHit(interactionsCount: number) {
-    logger.info({
-      workspaceId: conversation.owner.sId,
-      conversationId: conversation.sId,
-      interactionsCount, // Number of interactions before hitting the context window
-    }, "Conversation hit context window");
+    logger.info(
+      {
+        workspaceId: conversation.owner.sId,
+        conversationId: conversation.sId,
+        interactionsCount, // Number of interactions before hitting the context window
+      },
+      "Conversation hit context window"
+    );
   }
 
   if (currentInteractionTokens > availableTokens) {
@@ -138,17 +141,21 @@ export async function renderConversationForModel(
   const previousInteractions = interactions.slice(0, -1);
 
   // prune previous interactions.
-  const { interactions: prunedPreviousInteractions, contextWindowHitCount } = prunePreviousInteractions(
-    previousInteractions,
-    availableTokens,
-    PREVIOUS_INTERACTIONS_TO_PRESERVE
-  );
+  const { interactions: prunedPreviousInteractions, contextWindowHitCount } =
+    prunePreviousInteractions(
+      previousInteractions,
+      availableTokens,
+      PREVIOUS_INTERACTIONS_TO_PRESERVE
+    );
   if (!isContextWindowHit && contextWindowHitCount > 0) {
     logContextWindowHit(contextWindowHitCount + 1); // we add 1 to include the current interaction
     isContextWindowHit = true;
   }
 
-  const prunedInteractions = [...prunedPreviousInteractions, currentInteraction];
+  const prunedInteractions = [
+    ...prunedPreviousInteractions,
+    currentInteraction,
+  ];
 
   // Select interactions that fit within token budget.
   const selected: MessageWithTokens[] = [];

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -141,14 +141,14 @@ export async function renderConversationForModel(
   const previousInteractions = interactions.slice(0, -1);
 
   // prune previous interactions.
-  const { interactions: prunedPreviousInteractions, contextWindowHitCount } =
+  const { interactions: prunedPreviousInteractions, contextWindowHitPosition } =
     prunePreviousInteractions(
       previousInteractions,
       availableTokens,
       PREVIOUS_INTERACTIONS_TO_PRESERVE
     );
-  if (!isContextWindowHit && contextWindowHitCount > 0) {
-    logContextWindowHit(contextWindowHitCount + 1); // we add 1 to include the current interaction
+  if (!isContextWindowHit && contextWindowHitPosition > 0) {
+    logContextWindowHit(contextWindowHitPosition + 1); // we add 1 to include the current interaction
     isContextWindowHit = true;
   }
 

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -108,9 +108,10 @@ export function prunePreviousInteractions(
   inputInteractions: InteractionWithTokens[],
   maxTokens: number,
   interactionsToPreserve: number
-): InteractionWithTokens[] {
+): { interactions: InteractionWithTokens[]; contextWindowHitCount: number } {
   const interactions = [...inputInteractions];
 
+  let contextWindowHitCount = 0;
   let shouldPrune = false;
   let availableTokens = maxTokens;
   for (let i = interactions.length - 1; i >= 0; i--) {
@@ -137,6 +138,7 @@ export function prunePreviousInteractions(
       interactions[i] = pruneAllToolResults(interaction);
       interactionTokens = getInteractionTokenCount(interaction);
       shouldPrune = true;
+      contextWindowHitCount = interactions.length - i; // contextWindowHitCount is the number of interactions before hitting the context window
     } else {
       // Interaction fits within the token budget.
       // We keep it as-is
@@ -146,5 +148,8 @@ export function prunePreviousInteractions(
     availableTokens -= interactionTokens;
   }
 
-  return interactions;
+  return {
+    interactions,
+    contextWindowHitCount,
+  };
 }

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -108,10 +108,10 @@ export function prunePreviousInteractions(
   inputInteractions: InteractionWithTokens[],
   maxTokens: number,
   interactionsToPreserve: number
-): { interactions: InteractionWithTokens[]; contextWindowHitCount: number } {
+): { interactions: InteractionWithTokens[]; contextWindowHitPosition: number } {
   const interactions = [...inputInteractions];
 
-  let contextWindowHitCount = 0;
+  let contextWindowHitPosition = 0;
   let shouldPrune = false;
   let availableTokens = maxTokens;
   for (let i = interactions.length - 1; i >= 0; i--) {
@@ -138,7 +138,7 @@ export function prunePreviousInteractions(
       interactions[i] = pruneAllToolResults(interaction);
       interactionTokens = getInteractionTokenCount(interaction);
       shouldPrune = true;
-      contextWindowHitCount = interactions.length - i; // contextWindowHitCount is the number of interactions before hitting the context window
+      contextWindowHitPosition = interactions.length - i; // contextWindowHitPosition is the number of interactions before hitting the context window
     } else {
       // Interaction fits within the token budget.
       // We keep it as-is
@@ -150,6 +150,6 @@ export function prunePreviousInteractions(
 
   return {
     interactions,
-    contextWindowHitCount,
+    contextWindowHitPosition,
   };
 }

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1504,12 +1504,15 @@ export class CoreAPI {
     providerId: string;
   }): Promise<CoreAPIResponse<{ counts: number[] }>> {
     const credentials = dustManagedCredentials();
-    this._logger.info({
-      textsLength: texts.length,
-      modelId,
-      providerId,
-    }, "Calling core API tokenizer batch count endpoint");
-    
+    this._logger.info(
+      {
+        textsLength: texts.length,
+        modelId,
+        providerId,
+      },
+      "Calling core API tokenizer batch count endpoint"
+    );
+
     const response = await this._fetchWithError(
       `${this._url}/tokenize/batch/count`,
       {

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1504,6 +1504,12 @@ export class CoreAPI {
     providerId: string;
   }): Promise<CoreAPIResponse<{ counts: number[] }>> {
     const credentials = dustManagedCredentials();
+    this._logger.info({
+      textsLength: texts.length,
+      modelId,
+      providerId,
+    }, "Calling core API tokenizer batch count endpoint");
+    
     const response = await this._fetchWithError(
       `${this._url}/tokenize/batch/count`,
       {


### PR DESCRIPTION
## Description

Adds observability for:
- context window hits, including the number of interactions that fit before hitting the limit
- and tokenizer endpoint usage, including the number of texts (in order to monitor if provider tokenizers rate limits would be reached)

These new logs and their metadata will be used in Datadog.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
