### PR TITLE
[connectors] (teams) Cleaned logs

### DIFF
--- a/connectors/src/api/webhooks/webhook_teams.ts
+++ b/connectors/src/api/webhooks/webhook_teams.ts
@@ -166,10 +166,6 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
       switch (context.activity.type) {
         case "message":
           if (!connector) {
-            localLogger.error(
-              "No Microsoft Bot configuration found for tenant"
-            );
-
             res.status(400).json({ error: "Connector not found" });
             return;
           }
@@ -182,9 +178,6 @@ export async function webhookTeamsAPIHandler(req: Request, res: Response) {
           break;
         case "invoke":
           if (!connector) {
-            localLogger.error(
-              "No Microsoft Bot configuration found for tenant"
-            );
             res.status(400).json({ error: "Connector not found" });
             return;
           }
@@ -279,11 +272,6 @@ async function handleMessage(
     );
     return;
   }
-
-  localLogger.info(
-    { activityId: thinkingActivity.value },
-    "Successfully sent thinking card"
-  );
 
   const result = await botAnswerMessage(
     context,


### PR DESCRIPTION
## Description

The log "No Microsoft Bot configuration found for tenant" will always appear on one of the 2 regions, even if it's configured on the other. Removing as it just add noise.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
