### PR TITLE
feat(front): add an endpoint to get member data

### DIFF
--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -10,8 +10,26 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { UserTypeWithWorkspaces, WithAPIErrorResponse } from "@app/types";
+import type {
+  RoleType,
+  UserTypeWithWorkspaces,
+  WithAPIErrorResponse,
+} from "@app/types";
 import { assertNever, isMembershipRoleType } from "@app/types";
+
+export type GetMemberResponseBody = {
+  member: {
+    id: string;
+    username: string;
+    email: string;
+    firstName: string;
+    lastName: string | null;
+    fullName: string;
+    image: string | null;
+    revoked: boolean;
+    role: RoleType;
+  };
+};
 
 export type PostMemberResponseBody = {
   member: UserTypeWithWorkspaces;
@@ -19,27 +37,12 @@ export type PostMemberResponseBody = {
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostMemberResponseBody>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetMemberResponseBody | PostMemberResponseBody>
+  >,
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(owner);
-  // Allow Dust Super User to force role for testing
-  const allowForSuperUserTesting =
-    showDebugTools(featureFlags) &&
-    auth.isDustSuperUser() &&
-    req.body.force === "true";
-
-  if (!auth.isAdmin() && !allowForSuperUserTesting) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can see memberships or modify it.",
-      },
-    });
-  }
 
   const userId = req.query.uId;
   if (!(typeof userId === "string")) {
@@ -64,7 +67,59 @@ async function handler(
   }
 
   switch (req.method) {
+    case "GET":
+      const membership =
+        await MembershipResource.getLatestMembershipOfUserInWorkspace({
+          user,
+          workspace: owner,
+        });
+
+      if (!membership) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_user_not_found",
+            message: "Could not find membership for the user.",
+          },
+        });
+      }
+
+      const response: GetMemberResponseBody = {
+        member: {
+          id: user.sId,
+          username: user.username,
+          email: user.email,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          fullName: user.fullName(),
+          image: user.imageUrl,
+          revoked: membership.isRevoked(),
+          role: membership.isRevoked() ? "none" : membership.role,
+        },
+      };
+
+      res.status(200).json(response);
+      return;
+
     case "POST":
+      const featureFlags = await getFeatureFlags(owner);
+      // Allow Dust Super User to force role for testing
+      const allowForSuperUserTesting =
+        showDebugTools(featureFlags) &&
+        auth.isDustSuperUser() &&
+        req.body.force === "true";
+
+      if (!auth.isAdmin() && !allowForSuperUserTesting) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "Only users that are `admins` for the current workspace can modify memberships.",
+          },
+        });
+      }
+
       // TODO(@fontanierh): use DELETE for revoking membership
       if (req.body.role === "revoked") {
         const revokeResult = await revokeAndTrackMembership(owner, user);
@@ -131,7 +186,6 @@ async function handler(
           }
         }
 
-        const featureFlags = await getFeatureFlags(owner);
         const allowLastAdminRemoval = showDebugTools(featureFlags);
 
         const updateRes = await MembershipResource.updateMembershipRole({
@@ -209,7 +263,8 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, POST is expected.",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
         },
       });
   }


### PR DESCRIPTION
## Description

As we'll be able to `@` users, having some kind of information on them could be useful. 

So this PR adds an endpoint to get some details of a user, in the same workspace. Next PR adds a pane to display this

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
