### PR TITLE
feat(front): add a user detail pane

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -19,6 +19,7 @@ import { GenerationContextProvider } from "@app/components/assistant/conversatio
 import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
+import { MemberDetails } from "@app/components/assistant/details/MemberDetails";
 import { WelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuide";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
@@ -86,6 +87,7 @@ const ConversationLayoutContent = ({
 }: ConversationLayoutContentProps) => {
   const router = useRouter();
   const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");
+  const { onOpenChange: onOpenChangeUserModal } = useURLSheet("userDetails");
   const { activeConversationId } = useConversationsNavigation();
   const { conversation, conversationError } = useConversation({
     conversationId: activeConversationId,
@@ -99,6 +101,14 @@ const ConversationLayoutContent = ({
     }
     return null;
   }, [router.query.agentDetails]);
+
+  const userSId = useMemo(() => {
+    const sid = router.query.userDetails ?? [];
+    if (isString(sid)) {
+      return sid;
+    }
+    return null;
+  }, [router.query.userDetails]);
 
   // Logic for the welcome tour guide. We display it if the welcome query param is set to true.
   const { startConversationRef, spaceMenuButtonRef, createAgentButtonRef } =
@@ -134,6 +144,12 @@ const ConversationLayoutContent = ({
             user={user}
             agentId={agentSId}
             onClose={() => onOpenChangeAgentModal(false)}
+          />
+
+          <MemberDetails
+            owner={owner}
+            userId={userSId}
+            onClose={() => onOpenChangeUserModal(false)}
           />
 
           <ConversationSidePanelProvider>

--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -154,8 +154,7 @@ export function AgentDetails({
             <div>
               <Chip
                 color={SCOPE_INFO[agentConfiguration.scope].color}
-                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                icon={SCOPE_INFO[agentConfiguration.scope].icon || undefined}
+                icon={SCOPE_INFO[agentConfiguration.scope].icon ?? undefined}
               >
                 {SCOPE_INFO[agentConfiguration.scope].label}
               </Chip>

--- a/front/components/assistant/details/MemberDetails.tsx
+++ b/front/components/assistant/details/MemberDetails.tsx
@@ -1,0 +1,91 @@
+import {
+  Avatar,
+  ContentMessage,
+  InformationCircleIcon,
+  LockIcon,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+
+import { UserInfoTab } from "@app/components/assistant/details/tabs/UserInfoTab";
+import { useMemberDetails } from "@app/lib/swr/assistants";
+import type { WorkspaceType } from "@app/types";
+
+type MemberDetailsProps = {
+  owner: WorkspaceType;
+  onClose: () => void;
+  userId: string | null;
+};
+
+export function MemberDetails({ userId, onClose, owner }: MemberDetailsProps) {
+  const { userDetails, isUserDetailsLoading, isUserDetailsError } =
+    useMemberDetails({
+      workspaceId: owner.sId,
+      userId: userId,
+    });
+
+  const DescriptionSection = () => (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <Avatar
+          name="User avatar"
+          visual={userDetails?.image ?? undefined}
+          size="lg"
+        />
+        <div className="flex grow flex-col gap-1">
+          <div className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">{`${userDetails?.fullName ?? ""}`}</div>
+        </div>
+      </div>
+      {userDetails?.revoked && (
+        <>
+          <ContentMessage
+            title="This user has been revoked."
+            variant="warning"
+            icon={InformationCircleIcon}
+            size="sm"
+          >
+            This user is no longer active in this workspace.
+            <br />
+          </ContentMessage>
+
+          <div className="flex justify-center"></div>
+        </>
+      )}
+    </div>
+  );
+
+  return (
+    <Sheet open={!!userId} onOpenChange={onClose}>
+      <SheetContent size="lg">
+        <VisuallyHidden>
+          <SheetTitle />
+        </VisuallyHidden>
+        {isUserDetailsLoading ? (
+          <div className="flex h-full w-full items-center justify-center">
+            <Spinner size="lg" />
+          </div>
+        ) : (
+          <>
+            <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
+              <DescriptionSection />
+            </SheetHeader>
+            <SheetContainer className="pb-4">
+              {isUserDetailsError ? (
+                <ContentMessage title="Not Available" icon={LockIcon} size="md">
+                  This user is not available.
+                </ContentMessage>
+              ) : (
+                <UserInfoTab userDetails={userDetails} owner={owner} />
+              )}
+            </SheetContainer>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/assistant/details/tabs/UserInfoTab.tsx
+++ b/front/components/assistant/details/tabs/UserInfoTab.tsx
@@ -1,0 +1,65 @@
+import { Page } from "@dust-tt/sparkle";
+
+import type { GetMemberResponseBody } from "@app/pages/api/w/[wId]/members/[uId]";
+import type { WorkspaceType } from "@app/types";
+
+interface UserInfoTabProps {
+  userDetails: GetMemberResponseBody["member"] | undefined;
+  owner: WorkspaceType;
+}
+
+export function UserInfoTab({ userDetails, owner: _owner }: UserInfoTabProps) {
+  if (!userDetails) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Page.SectionHeader
+        title="User information"
+        description="Details about this workspace member."
+      />
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <div className="text-xs font-medium text-muted-foreground">
+            Username
+          </div>
+          <div className="text-sm text-foreground dark:text-foreground-night">
+            {userDetails.username}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <div className="text-xs font-medium text-muted-foreground">Email</div>
+          <div className="text-sm text-foreground dark:text-foreground-night">
+            {userDetails.email}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <div className="text-xs font-medium text-muted-foreground">Name</div>
+          <div className="text-sm text-foreground dark:text-foreground-night">
+            {userDetails.fullName}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <div className="text-xs font-medium text-muted-foreground">Role</div>
+          <div className="text-sm text-foreground dark:text-foreground-night">
+            {userDetails.role}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <div className="text-xs font-medium text-muted-foreground">
+            Status
+          </div>
+          <div className="text-sm text-foreground dark:text-foreground-night">
+            {userDetails.revoked ? "Revoked" : "Active"}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/lib/mentions/ui/MentionDropdown.test.tsx
+++ b/front/lib/mentions/ui/MentionDropdown.test.tsx
@@ -150,7 +150,6 @@ describe("MentionDropdown", () => {
     await user.click(screen.getByRole("button", { name: "About @Alice" }));
 
     expect(openChangeMock).toHaveBeenCalledWith(true);
-    // setQueryParam(router, "agentDetails", mention.id)
     expect(setQueryParamMock).toHaveBeenCalled();
     const [routerArg, keyArg, valueArg] = setQueryParamMock.mock.calls[0];
     expect(keyArg).toBe("agentDetails");

--- a/front/lib/mentions/ui/MentionDropdown.tsx
+++ b/front/lib/mentions/ui/MentionDropdown.tsx
@@ -41,16 +41,17 @@ export const MentionDropdown = React.forwardRef<
 >(({ mention, owner, children }, ref) => {
   const router = useRouter();
   const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");
+  const { onOpenChange: onOpenChangeUserModal } = useURLSheet("userDetails");
 
   // Agent mention actions.
   if (isRichAgentMention(mention)) {
-    const handleStartConversation = async () => {
+    const handleAgentStartConversation = async () => {
       await router.push(
         getConversationRoute(owner.sId, "new", `agent=${mention.id}`)
       );
     };
 
-    const handleSeeDetails = () => {
+    const handleAgentSeeDetails = () => {
       onOpenChangeAgentModal(true);
       setQueryParam(router, "agentDetails", mention.id);
     };
@@ -62,12 +63,12 @@ export const MentionDropdown = React.forwardRef<
         </DropdownMenuTrigger>
         <DropdownMenuContent side="bottom" align="start">
           <DropdownMenuItem
-            onClick={handleStartConversation}
+            onClick={handleAgentStartConversation}
             icon={ChatBubbleBottomCenterTextIcon}
             label={`New conversation with @${mention.label}`}
           />
           <DropdownMenuItem
-            onClick={handleSeeDetails}
+            onClick={handleAgentSeeDetails}
             icon={EyeIcon}
             label={`About @${mention.label}`}
           />
@@ -78,6 +79,11 @@ export const MentionDropdown = React.forwardRef<
 
   // User mention actions.
   if (isRichUserMention(mention)) {
+    const handleUserSeeDetails = () => {
+      onOpenChangeUserModal(true);
+      setQueryParam(router, "userDetails", mention.id);
+    };
+
     return (
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -85,8 +91,9 @@ export const MentionDropdown = React.forwardRef<
         </DropdownMenuTrigger>
         <DropdownMenuContent side="bottom" align="start">
           <DropdownMenuItem
+            onClick={handleUserSeeDetails}
             icon={UserIcon}
-            label={`Profile of @${mention.label}: ${mention.description || ""}`}
+            label={`Profile of @${mention.label}${mention.description ? ": " + mention.description : ""}`}
           />
         </DropdownMenuContent>
       </DropdownMenu>

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -28,6 +28,7 @@ import type { GetUsageMetricsResponse } from "@app/pages/api/w/[wId]/assistant/a
 import type { GetVersionMarkersResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers";
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent";
+import type { GetMemberResponseBody } from "@app/pages/api/w/[wId]/members/[uId]";
 import type { PostAgentUserFavoriteRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_favorite";
 import type {
   AgentConfigurationType,
@@ -978,5 +979,28 @@ export function useAgentToolStepIndex({
     isToolStepIndexLoading: !error && !data && !disabled,
     isToolStepIndexError: error,
     isToolStepIndexValidating: isValidating,
+  };
+}
+
+export function useMemberDetails({
+  workspaceId,
+  userId,
+}: {
+  workspaceId: string;
+  userId: string | null;
+}) {
+  const userConfigurationFetcher: Fetcher<GetMemberResponseBody> = fetcher;
+
+  const { data, error, mutate, isValidating } = useSWRWithDefaults(
+    userId ? `/api/w/${workspaceId}/members/${userId}` : null,
+    userConfigurationFetcher
+  );
+
+  return {
+    userDetails: data?.member,
+    isUserDetailsLoading: !error && !data && !!userId,
+    isUserDetailsError: error,
+    isUserConfigurationValidating: isValidating,
+    mutateUserConfiguration: mutate,
   };
 }


### PR DESCRIPTION
## Description

Add a very simple user details pane, so we can display information about members. I'll be useful when we can `@` members.

For now it's hidden, to see it go to `http://localhost:3000/w/$WID/conversation/new?userDetails=$USER_SID`

<img width="630" height="543" alt="image" src="https://github.com/user-attachments/assets/94a6411b-3cde-4d7a-9b0d-9b5f5d397634" />
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
