### PR TITLE
chore: phase out dust app to suggest agent instructions

### DIFF
--- a/front/lib/api/assistant/suggestions/index.ts
+++ b/front/lib/api/assistant/suggestions/index.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import { runAction } from "@app/lib/actions/server";
 import { getBuilderDescriptionSuggestions } from "@app/lib/api/assistant/suggestions/description";
 import { getBuilderEmojiSuggestions } from "@app/lib/api/assistant/suggestions/emoji";
+import { getBuilderInstructionsSuggestions } from "@app/lib/api/assistant/suggestions/instructions";
 import { getBuilderNameSuggestions } from "@app/lib/api/assistant/suggestions/name";
 import { getBuilderTagSuggestions } from "@app/lib/api/assistant/suggestions/tags";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
@@ -83,7 +84,10 @@ export async function getBuilderSuggestions(
 
     case "emoji":
       return getBuilderEmojiSuggestions(auth, inputs);
+
     case "instructions":
+      return getBuilderInstructionsSuggestions(auth, inputs);
+
     case "autocompletion": {
       const config = cloneBaseConfig(
         getDustProdActionRegistry()[`assistant-builder-${type}-suggestions`]

--- a/front/lib/api/assistant/suggestions/instructions.ts
+++ b/front/lib/api/assistant/suggestions/instructions.ts
@@ -1,0 +1,130 @@
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
+import type { Authenticator } from "@app/lib/auth";
+import type { BuilderSuggestionInputType, Result } from "@app/types";
+import { Err, GPT_4_TURBO_MODEL_ID, isStringArray, Ok } from "@app/types";
+
+const FUNCTION_NAME = "send_ranked_suggestions";
+
+const specifications = [
+  {
+    name: FUNCTION_NAME,
+    description:
+      "Send ranked suggestions, ordered by relevance to make the user instructions better.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        good_instructions: {
+          type: "boolean",
+          description:
+            "true if the instructions typed by the user are good for a large language model and do not need any change; false otherwise",
+        },
+        new_suggestions: {
+          type: "array",
+          items: {
+            type: "string",
+            description:
+              "A suggestion to improve the user's instructions to the assistant, phrased nicely, as a short question. It should not be more than thirty words.",
+          },
+          description:
+            "Array of two new suggestions that would improve the instructions.",
+        },
+        former_suggestions: {
+          type: "array",
+          items: {
+            type: "string",
+            description:
+              "A suggestion to improve the user's instructions to the assistant.",
+          },
+          description:
+            "Array of already existing, user provided suggestions that would improve the instructions",
+        },
+        ranked_suggestions: {
+          type: "array",
+          items: {
+            type: "string",
+            description:
+              "A suggestion to improve the user's instructions to the assistant.",
+          },
+          description:
+            "Array of the suggestions taken from new_suggestions and former_suggestions, ranked by most important first. That is, the suggestion that will improve the instructions for the LLM best should come first.",
+        },
+      },
+      required: [
+        "good_instructions",
+        "new_suggestions",
+        "former_suggestions",
+        "ranked_suggestions",
+      ],
+    },
+  },
+];
+
+function getConversationContext(inputs: BuilderSuggestionInputType) {
+  const currentInstructions =
+    "current_instructions" in inputs ? inputs.current_instructions : "";
+  const formerSuggestions =
+    "former_suggestions" in inputs ? inputs.former_suggestions : [];
+
+  const currentInstructionsText = currentInstructions
+    ? "Instructions I wrote for my assistant:\n" + currentInstructions
+    : "";
+
+  const messages = [
+    {
+      role: "user",
+      content: currentInstructionsText,
+    },
+  ];
+
+  if (formerSuggestions.length > 0) {
+    messages.push({
+      role: "user",
+      content:
+        "Former suggestions, that were already made regarding a former version of those instructions (you should make new suggestions that are different from those ones):\n" +
+        JSON.stringify(formerSuggestions),
+    });
+  }
+
+  return { messages };
+}
+
+export async function getBuilderInstructionsSuggestions(
+  auth: Authenticator,
+  inputs: BuilderSuggestionInputType
+): Promise<Result<SuggestionResults, Error>> {
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      functionCall: FUNCTION_NAME,
+      modelId: GPT_4_TURBO_MODEL_ID,
+      providerId: "openai",
+      temperature: 0.7,
+      useCache: false,
+    },
+    {
+      conversation: getConversationContext(inputs),
+      prompt:
+        'A user is working on a Saas product called Dust, a tool for creating custom assistants based on large language models, to help employees to be more productive. \n\nContext\n---\nA few elements to bear in mind:\n- On Dust, users can give assistants access to company data (on slack, notion, google drive, github, intercom, confluence). Assistants that are configured to use company data can do semantic searches before answering the user, and use the retrieved data to reply;\n- some companies have created "Dust apps" and for some advanced use cases assistants can execute those dust apps before answering;\n- advanced use cases also include allowing assistants to query structured data from Notion Databases or Google Spreadsheets, that is, treating those documents as SQL databases and running sql queries on them;\n- however, in the majority of cases, custom assistants are either asked to reply only (i.e. without searching data, acting or querying structured data), or to perform retrieval-augmented-generation, that is to do semantic search on data and add the result to the LLM\'s context before generating the reply.\n\nThe user is currently writing instructions for the large language model prompt that will be the basis of a custom assistant they are creating for a specific purpose.\n\nYour task\n---\nBased on the instructions the user has written, propose two new suggestions to improve them, different from the already-existing former suggestions the user provided. Indicate if the instructions are already very good as they are. Rank all suggestions (former and new) by most important first.\n',
+      specifications,
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  const args = res.value.actions?.[0]?.arguments;
+  if (
+    args?.good_instructions !== undefined &&
+    isStringArray(args.ranked_suggestions)
+  ) {
+    return new Ok({
+      status: "ok",
+      suggestions:
+        args.good_instructions === true ? [] : args.ranked_suggestions,
+    });
+  }
+
+  return new Err(new Error("No suggestions found"));
+}

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -135,20 +135,6 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-  "assistant-builder-instructions-suggestions": {
-    app: {
-      appId: "d995d868a8",
-      appHash:
-        "7fb9c826d9de74c98de2a675093f66eab9da93a1a2cb9bc0bcc919fd074cd7eb",
-    },
-    config: {
-      CREATE_SUGGESTIONS: {
-        // `provider_id` and `model_id` must be set by caller.
-        function_call: "send_ranked_suggestions",
-        use_cache: false,
-      },
-    },
-  },
   "assistant-builder-autocompletion-suggestions": {
     app: {
       appId: "eDoafmNqwn",


### PR DESCRIPTION








## Description

Phases out the assistant-builder-instructions-suggestions from the registry.

This follows the same pattern established in previous PRs that phased out the name (#16974), description (#16984), tags (#17032), and emoji (#17728) suggestion apps.

## Risk

Low

## Tests

Tested locally with front.

## Deploy Plan

Deploy Front.
