### PR TITLE
[front] fix(obs): display versioned data for `Error/LatencyChart`

### DIFF
--- a/front/components/agent_builder/observability/ObservabilityContext.tsx
+++ b/front/components/agent_builder/observability/ObservabilityContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useMemo, useState } from "react";
 
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 
 export type ObservabilityMode = "timeRange" | "version";
 
@@ -10,8 +11,8 @@ type ObservabilityContextValue = {
   setMode: (m: ObservabilityMode) => void;
   period: ObservabilityTimeRangeType;
   setPeriod: (p: ObservabilityTimeRangeType) => void;
-  selectedVersion: string | null;
-  setSelectedVersion: (v: string | null) => void;
+  selectedVersion: AgentVersionMarker | null;
+  setSelectedVersion: (v: AgentVersionMarker | null) => void;
 };
 
 const ObservabilityContext = createContext<ObservabilityContextValue | null>(
@@ -26,7 +27,8 @@ export function ObservabilityProvider({
   const [mode, setMode] = useState<ObservabilityMode>("timeRange");
   const [period, setPeriod] =
     useState<ObservabilityTimeRangeType>(DEFAULT_PERIOD_DAYS);
-  const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
+  const [selectedVersion, setSelectedVersion] =
+    useState<AgentVersionMarker | null>(null);
 
   const value = useMemo(
     () => ({

--- a/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
+++ b/front/components/agent_builder/observability/charts/ErrorRateChart.tsx
@@ -98,7 +98,7 @@ export function ErrorRateChart({
     agentConfigurationId,
     period,
     mode,
-    filterVersion: selectedVersion,
+    filterVersion: selectedVersion?.version,
   });
 
   const { versionMarkers } = useAgentVersionMarkers({

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   Area,
   AreaChart,
@@ -69,16 +70,18 @@ export function LatencyChart({
   workspaceId: string;
   agentConfigurationId: string;
 }) {
-  const { period, mode } = useObservabilityContext();
+  const { period, mode, selectedVersion } = useObservabilityContext();
+
   const {
     data: rawData,
-    isLoading: isLatencyLoading,
-    errorMessage: isLatencyError,
+    isLoading,
+    errorMessage,
   } = useLatencyData({
     workspaceId,
     agentConfigurationId,
     period,
     mode,
+    filterVersion: selectedVersion,
   });
 
   const { versionMarkers } = useAgentVersionMarkers({
@@ -88,11 +91,21 @@ export function LatencyChart({
     disabled: !workspaceId || !agentConfigurationId,
   });
 
-  const data = padSeriesToTimeRange(rawData, mode, period, (date) => ({
-    date,
-    messages: 0,
-    average: 0,
-  }));
+  const data = useMemo(() => {
+    if (mode === "timeRange") {
+      const dataWithDate = rawData.map((item) => ({
+        ...item,
+        date: item.date!,
+      }));
+      return padSeriesToTimeRange(dataWithDate, mode, period, (date) => ({
+        date,
+        label: date,
+        messages: 0,
+        average: 0,
+      }));
+    }
+    return rawData;
+  }, [rawData, mode, period]);
 
   const legendItems = legendFromConstant(LATENCY_LEGEND, LATENCY_PALETTE, {
     includeVersionMarker: mode === "timeRange" && versionMarkers.length > 0,
@@ -102,10 +115,8 @@ export function LatencyChart({
     <ChartContainer
       title="Latency"
       description="Average time to complete output (seconds). Lower is better."
-      isLoading={isLatencyLoading}
-      errorMessage={
-        isLatencyError ? "Failed to load observability data." : undefined
-      }
+      isLoading={isLoading}
+      errorMessage={errorMessage}
     >
       <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
         <AreaChart

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -81,7 +81,7 @@ export function LatencyChart({
     agentConfigurationId,
     period,
     mode,
-    filterVersion: selectedVersion,
+    filterVersion: selectedVersion?.version,
   });
 
   const { versionMarkers } = useAgentVersionMarkers({

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -58,7 +58,7 @@ export function ToolUsageChart({
     mode: toolMode,
     filterVersion:
       mode === "version" && toolMode === "version"
-        ? selectedVersion
+        ? selectedVersion?.version
         : undefined,
   });
 

--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -3,6 +3,7 @@ import {
   TOOL_COLORS,
 } from "@app/components/agent_builder/observability/constants";
 import type { ObservabilityMode } from "@app/components/agent_builder/observability/ObservabilityContext";
+import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
 
 export type VersionMarker = { version: string; timestamp: string };
 
@@ -64,7 +65,7 @@ export function findVersionMarkerForDate(
 export function filterTimeSeriesByVersionWindow<T extends { date: string }>(
   points: T[] | undefined,
   mode: ObservabilityMode,
-  selectedVersion: string | null,
+  selectedVersion: AgentVersionMarker | null,
   versionMarkers?: VersionMarker[] | null
 ): T[] {
   const pts = points ?? [];
@@ -76,7 +77,9 @@ export function filterTimeSeriesByVersionWindow<T extends { date: string }>(
     return pts;
   }
 
-  const idx = versionMarkers.findIndex((m) => m.version === selectedVersion);
+  const idx = versionMarkers.findIndex(
+    (m) => m.version === selectedVersion.version
+  );
   if (idx < 0) {
     return pts;
   }

--- a/front/components/observability/SharedObservabilityFilterSelector.tsx
+++ b/front/components/observability/SharedObservabilityFilterSelector.tsx
@@ -51,8 +51,7 @@ export function SharedObservabilityFilterSelector({
       versionMarkers &&
       versionMarkers.length > 0
     ) {
-      const value = getVersionValue(versionMarkers[versionMarkers.length - 1]);
-      setSelectedVersion(value);
+      setSelectedVersion(versionMarkers[versionMarkers.length - 1]);
     }
   }, [mode, selectedVersion, versionMarkers, setSelectedVersion]);
 
@@ -97,7 +96,7 @@ export function SharedObservabilityFilterSelector({
             <Button
               label={
                 selectedVersion
-                  ? selectedVersion
+                  ? getVersionValue(selectedVersion)
                   : isVersionMarkersLoading
                     ? "Loading"
                     : "Not available"
@@ -110,16 +109,13 @@ export function SharedObservabilityFilterSelector({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuLabel label="Last 30 days" />
-            {(versionMarkers ?? []).map((m) => {
-              const versionValue = getVersionValue(m);
-              return (
-                <DropdownMenuItem
-                  key={m.version}
-                  label={versionValue}
-                  onClick={() => setSelectedVersion(versionValue)}
-                />
-              );
-            })}
+            {(versionMarkers ?? []).map((marker) => (
+              <DropdownMenuItem
+                key={marker.version}
+                label={getVersionValue(marker)}
+                onClick={() => setSelectedVersion(marker)}
+              />
+            ))}
           </DropdownMenuContent>
         </DropdownMenu>
       )}

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -22,7 +22,7 @@ export function buildAgentAnalyticsBaseQuery({
     filters.push({ range: { timestamp: { gte: `now-${days}d/d` } } });
   }
   if (version) {
-    filters.push({ term: { "configuration.version": version } });
+    filters.push({ term: { agent_version: version } });
   }
   if (feedbackNestedQuery) {
     filters.push({ nested: { path: "feedbacks", query: feedbackNestedQuery } });


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5036.
- This PR displays the data for the selected version for the `ErrorChart` and `LatencyChart` in the Insights tab of the Agent Builder in version mode (toggle on the upper right corner).
- The state is updated to store the entire version marker type rather than only the version.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
