### PR TITLE
chore: phase out dust app to generate trigger cron schedule

### DIFF
--- a/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
+++ b/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
@@ -1,0 +1,109 @@
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types";
+import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
+
+const SET_SCHEDULE_FUNCTION_NAME = "set_schedule";
+const SET_TIMEZONE_FUNCTION_NAME = "set_tz";
+
+const specifications = [
+  {
+    name: SET_SCHEDULE_FUNCTION_NAME,
+    description: "Setup a schedule for triggering an assistant",
+    inputSchema: {
+      type: "object",
+      properties: {
+        cron: {
+          type: "string",
+          description: "The schedule expressed in cron format.",
+        },
+      },
+      required: ["cron"],
+    },
+  },
+  {
+    name: SET_TIMEZONE_FUNCTION_NAME,
+    description: "Setup a timezone for triggering an assistant",
+    inputSchema: {
+      type: "object",
+      properties: {
+        timezone: {
+          type: "string",
+          description: "The timezone expressed in IANA Timezone format.",
+        },
+      },
+      required: ["timezone"],
+    },
+  },
+];
+
+export async function getCronTimezoneGeneration(
+  auth: Authenticator,
+  inputs: { naturalDescription: string; defaultTimezone: string }
+): Promise<Result<{ cron: string; timezone: string }, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const model = getSmallWhitelistedModel(owner);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model to generate cron rule")
+    );
+  }
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      modelId: model.modelId,
+      providerId: model.providerId,
+      temperature: 0.7,
+      useCache: false,
+    },
+    {
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            content: JSON.stringify(inputs),
+          },
+        ],
+      },
+      prompt:
+        "The user is currently adding a schedule to trigger an assistant based on a large language model. The user is describing the schedule in natural language.\n\n" +
+        "For the cron generation (set_schedule):\n" +
+        "You must interpret the description, convert it to the cron format and call set_schedule with the cron rule as an argument.\n\n" +
+        "For the timezone generation (set_tz):\n" +
+        "You must interpret the description, get the requested timezone from the user, and call set_tz with the timezone as an argument.\n" +
+        "If no timezone is specified in the naturalDescription, return the defaultTimezone.\n" +
+        "ALWAYS use IANA Timezone such as Europe/Paris, or America/New_York.",
+      specifications,
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  let cron: string | null = null;
+  let timezone: string | null = null;
+
+  if (res.value.actions) {
+    for (const action of res.value.actions) {
+      if (action.name === SET_SCHEDULE_FUNCTION_NAME) {
+        cron = action.arguments.cron;
+      }
+      if (action.name === SET_TIMEZONE_FUNCTION_NAME) {
+        timezone = action.arguments.timezone;
+      }
+    }
+  }
+
+  if (!cron) {
+    return new Err(new Error("No cron rule generated"));
+  }
+
+  if (!timezone) {
+    return new Err(new Error("No timezone generated"));
+  }
+
+  return new Ok({ cron, timezone });
+}

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -248,25 +248,6 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-  "assistant-builder-cron-timezone-generator": {
-    app: {
-      appId: "T454vmSliN",
-      appHash:
-        "a7183268ee1d99e56774a5c93e6d715eb684bbfab9d34da99e0b92d299bfbde7",
-    },
-    config: {
-      CREATE_CRON: {
-        function_call: "set_schedule",
-        use_cache: false,
-        use_stream: true,
-      },
-      CREATE_TZ: {
-        function_call: "set_tz",
-        use_cache: false,
-        use_stream: true,
-      },
-    },
-  },
   "assistant-builder-webhook-filter-generator": {
     app: {
       appId: "XNcJCE7lUj",

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -47,12 +47,7 @@ async function handler(
         });
       }
 
-      const { naturalDescription, defaultTimezone } = bodyValidation.data;
-
-      const r = await generateCronRule(auth, {
-        naturalDescription,
-        defaultTimezone,
-      });
+      const r = await generateCronRule(auth, bodyValidation.data);
 
       if (r.isErr()) {
         const cleanMessage = [


### PR DESCRIPTION





## Description

Phases out the `assistant-builder-cron-timezone-generator` Dust app and replaces it with direct LLM calls using `runMultiActionsAgent`.

The PR creates a new `cron_timezone.ts` file containing the cron and timezone generation logic with function calling specifications for `set_schedule` and `set_tz`.

The `generateCronRule` function is refactored to delegate the generation to the new `getCronTimezoneGeneration` function, which calls the multi-actions agent with both function specifications and extracts the cron rule and timezone from the returned actions.

The cron timezone generator app entry is removed from the registry. This follows the same pattern established in previous PRs that phased out builder suggestion apps (names, descriptions, tags, emoji, instructions).

## Risk

Low 

## Tests

Tested locally with front.

## Deploy Plan

Deploy Front.
