### PR TITLE
Add more posthog data

### DIFF
--- a/front/components/actions/mcp/AddToolsMenu.tsx
+++ b/front/components/actions/mcp/AddToolsMenu.tsx
@@ -123,7 +123,13 @@ export const AddToolsMenu = ({
                     createInternalMCPServer(mcpServer);
                   }
                 },
-                { tool_name: mcpServer.name }
+                {
+                  tool_name: mcpServer.name,
+                  tool_id: mcpServer.sId,
+                  tool_type: getDefaultRemoteMCPServerByName(mcpServer.name)
+                    ? "remote"
+                    : "internal",
+                }
               )}
             />
           ))}

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -540,8 +540,14 @@ export async function submitAgentBuilderForm({
         object: "create_agent",
         action: TRACKING_ACTIONS.SUBMIT,
         extra: {
+          agent_id: agentConfiguration.sId,
           scope: formData.agentSettings.scope,
           has_actions: processedActions.length > 0,
+          action_count: processedActions.length,
+          action_names: processedActions.map((a) => a.name).join(","),
+          has_instructions: !!formData.instructions,
+          model_id: formData.generationSettings.modelSettings.modelId,
+          model_provider: formData.generationSettings.modelSettings.providerId,
         },
       });
     }

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -149,8 +149,26 @@ export function ToolsPicker({
                     filteredServerViews[0].sId
                   );
                   if (isSelected) {
+                    trackEvent({
+                      area: TRACKING_AREAS.TOOLS,
+                      object: "tool_deselect",
+                      action: TRACKING_ACTIONS.SELECT,
+                      extra: {
+                        tool_id: filteredServerViews[0].sId,
+                        tool_name: filteredServerViews[0].server.name,
+                      },
+                    });
                     onDeselect(filteredServerViews[0]);
                   } else {
+                    trackEvent({
+                      area: TRACKING_AREAS.TOOLS,
+                      object: "tool_select",
+                      action: TRACKING_ACTIONS.SELECT,
+                      extra: {
+                        tool_id: filteredServerViews[0].sId,
+                        tool_name: filteredServerViews[0].server.name,
+                      },
+                    });
                     onSelect(filteredServerViews[0]);
                   }
                   setSearchText("");
@@ -177,6 +195,15 @@ export function ToolsPicker({
                     onClick={(e) => {
                       e.stopPropagation();
                       e.preventDefault();
+                      trackEvent({
+                        area: TRACKING_AREAS.TOOLS,
+                        object: "tool_select",
+                        action: TRACKING_ACTIONS.SELECT,
+                        extra: {
+                          tool_id: v.sId,
+                          tool_name: v.server.name,
+                        },
+                      });
                       onSelect(v);
                       setIsOpen(false);
                     }}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -204,6 +204,7 @@ export const InputBar = React.memo(function InputBar({
       object: "message_send",
       action: "submit",
       extra: {
+        conversation_id: conversationId || "new",
         has_attachments: attachedNodes.length > 0 || uploadedFiles.length > 0,
         has_tools: selectedMCPServerViews.length > 0,
         has_agents: mentionedAgents.length > 0,
@@ -211,8 +212,11 @@ export const InputBar = React.memo(function InputBar({
         has_custom_agent: mentionedAgents.some((a) => !isGlobalAgentId(a.sId)),
         is_new_conversation: !conversationId,
         agent_count: mentions.length,
+        agent_ids: mentionedAgents.map((a) => a.sId).join(","),
         attachment_count: attachedNodes.length + uploadedFiles.length,
         tool_count: selectedMCPServerViews.length,
+        tool_names: selectedMCPServerViews.map((t) => t.server.name).join(","),
+        message_length: markdown.length,
       },
     });
 

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -29,7 +29,12 @@ import {
 } from "@app/lib/connector_providers";
 import { useSystemSpace } from "@app/lib/swr/spaces";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  withTracking,
+} from "@app/lib/tracking";
 import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type {
   ConnectorProvider,
@@ -249,6 +254,15 @@ export const AddConnectionMenu = ({
           dataSource: DataSourceType;
           connector: ConnectorType;
         } = await res.json();
+        trackEvent({
+          area: TRACKING_AREAS.DATA_SOURCES,
+          object: "connection",
+          action: TRACKING_ACTIONS.CREATE,
+          extra: {
+            provider,
+            data_source_id: createdManagedDataSource.dataSource.sId,
+          },
+        });
         onCreated(createdManagedDataSource.dataSource);
       } else {
         const responseText = await res.text();

--- a/front/hooks/useYAMLUpload.ts
+++ b/front/hooks/useYAMLUpload.ts
@@ -2,6 +2,11 @@ import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+} from "@app/lib/tracking";
 import logger from "@app/logger/logger";
 import type { LightWorkspaceType } from "@app/types";
 import { normalizeError } from "@app/types";
@@ -65,6 +70,19 @@ export function useYAMLUpload({ owner }: UseYAMLUploadOptions) {
       }
 
       const result = await response.json();
+
+      trackEvent({
+        area: TRACKING_AREAS.BUILDER,
+        object: "create_agent",
+        action: TRACKING_ACTIONS.SUBMIT,
+        extra: {
+          agent_id: result.agentConfiguration.sId,
+          source: "yaml_upload",
+          scope: result.agentConfiguration.scope,
+          has_skipped_actions: result.skippedActions?.length > 0,
+        },
+      });
+
       if (result.skippedActions && result.skippedActions.length > 0) {
         sendNotification({
           title: "Agent created with warnings",

--- a/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
@@ -12,7 +12,6 @@ import { createGenericAgentConfiguration } from "@app/lib/api/assistant/configur
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { getLargeWhitelistedModel } from "@app/types";
@@ -245,13 +244,6 @@ async function handler(
           },
         });
       }
-
-      ServerSideTracking.trackAssistantCreated({
-        user: auth.user() ?? { id: "unknown", sId: "unknown" },
-        workspace: auth.workspace(),
-        assistant: result.value.agentConfiguration,
-        source: "generic_api",
-      });
 
       return res.status(200).json({
         agentConfiguration: result.value.agentConfiguration,

--- a/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
@@ -12,6 +12,7 @@ import { createGenericAgentConfiguration } from "@app/lib/api/assistant/configur
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { getLargeWhitelistedModel } from "@app/types";
@@ -244,6 +245,13 @@ async function handler(
           },
         });
       }
+
+      ServerSideTracking.trackAssistantCreated({
+        user: auth.user() ?? { id: "unknown", sId: "unknown" },
+        workspace: auth.workspace(),
+        assistant: result.value.agentConfiguration,
+        source: "generic_api",
+      });
 
       return res.status(200).json({
         agentConfiguration: result.value.agentConfiguration,


### PR DESCRIPTION








## Description

Adds PostHog tracking events to close analytics gaps in the self-serve funnel. Tracks data source creation (9% gap) and agent creation (5.5% gap) with additional context for better analytics.

**Data Source Creation**: Tracks `datasources:connection:create` after successful OAuth, BigQuery, Snowflake, and Webcrawler connection setup, capturing provider and data_source_id.

**Agent Creation - YAML Upload**: Tracks `builder:create_agent:submit` with `source: "yaml_upload"` after successful YAML-based agent creation, including agent_id, scope, and has_skipped_actions.

**Agent Creation - Form Submit**: Enriches existing tracking with agent_id, action_count, action_names, has_instructions, model_id, and model_provider to provide deeper insights into agent configurations.

**MCP Tools**: Tracks tool selection/deselection in ToolsPicker and AddToolsMenu with tool_id, tool_name, and tool_type (for AddToolsMenu).

**Message Sending**: Enriches existing tracking with conversation_id, agent_ids, tool_names, and message_length for better conversation analytics.

## Risk

Low risk. Only adds tracking events without changing application behavior. Events are fire-and-forget and failures won't impact user experience.

