### PR TITLE
[front] Add invitations table in profile page, handle invitation expiration

### DIFF
--- a/front/components/me/PendingInvitationsTable.tsx
+++ b/front/components/me/PendingInvitationsTable.tsx
@@ -1,0 +1,132 @@
+import { Button, DataTable, Label } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { MouseEvent } from "react";
+import { useMemo } from "react";
+
+import { isInvitationExpired } from "@app/components/members/utils";
+import { classNames } from "@app/lib/utils";
+import type { PendingInvitationOption } from "@app/types/membership_invitation";
+
+interface PendingInvitationsTableRow extends PendingInvitationOption {
+  isExpired: boolean;
+  onJoin: () => void;
+  onClick?: () => void;
+}
+
+interface PendingInvitationsTableProps {
+  invitations: PendingInvitationOption[];
+}
+
+export function PendingInvitationsTable({
+  invitations,
+}: PendingInvitationsTableProps) {
+  const sortedInvitations = useMemo(
+    () =>
+      invitations
+        .slice()
+        .sort((a, b) => a.workspaceName.localeCompare(b.workspaceName)),
+    [invitations]
+  );
+
+  const rows = useMemo<PendingInvitationsTableRow[]>(
+    () =>
+      sortedInvitations.map((invitation) => ({
+        ...invitation,
+        isExpired: isInvitationExpired(invitation.createdAt),
+        onJoin: () => {
+          if (isInvitationExpired(invitation.createdAt)) {
+            return;
+          }
+          window.location.assign(
+            `/api/login?inviteToken=${encodeURIComponent(invitation.token)}`
+          );
+        },
+      })),
+    [sortedInvitations]
+  );
+
+  const columns = useMemo<ColumnDef<PendingInvitationsTableRow>[]>(
+    () => [
+      {
+        accessorKey: "workspaceName",
+        header: "Workspace",
+        sortingFn: (rowA, rowB) =>
+          rowA.original.workspaceName.localeCompare(
+            rowB.original.workspaceName
+          ),
+        cell: ({ row }) => (
+          <DataTable.CellContent grow>
+            <div
+              className={classNames(
+                "flex flex-col gap-1 py-3",
+                row.original.isExpired && "opacity-60"
+              )}
+            >
+              <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                {row.original.workspaceName}
+              </span>
+              <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                Role: {row.original.initialRole}
+              </span>
+            </div>
+          </DataTable.CellContent>
+        ),
+        meta: {
+          className: "w-full",
+        },
+      },
+      {
+        id: "createdAt",
+        header: "Invited",
+        sortingFn: (rowA, rowB) =>
+          rowA.original.createdAt - rowB.original.createdAt,
+        cell: ({ row }) => (
+          <DataTable.CellContent>
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {new Date(row.original.createdAt).toLocaleString()}
+            </span>
+          </DataTable.CellContent>
+        ),
+        meta: {
+          className: "w-48",
+        },
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: ({ row }) => (
+          <DataTable.CellContent className="w-full justify-end">
+            <Button
+              size="xs"
+              variant={row.original.isExpired ? "outline" : "primary"}
+              label={row.original.isExpired ? "Expired" : "Join"}
+              disabled={row.original.isExpired}
+              onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                event.stopPropagation();
+                row.original.onJoin();
+              }}
+            />
+          </DataTable.CellContent>
+        ),
+        meta: {
+          className: "w-24",
+        },
+      },
+    ],
+    []
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {rows.length > 0 ? (
+        <DataTable
+          data={rows}
+          columns={columns}
+          sorting={[{ id: "workspaceName", desc: false }]}
+        />
+      ) : (
+        <Label>No pending invitations found.</Label>
+      )}
+    </div>
+  );
+}

--- a/front/components/me/PendingInvitationsTable.tsx
+++ b/front/components/me/PendingInvitationsTable.tsx
@@ -3,7 +3,6 @@ import type { ColumnDef } from "@tanstack/react-table";
 import type { MouseEvent } from "react";
 import { useMemo } from "react";
 
-import { isInvitationExpired } from "@app/components/members/utils";
 import { classNames } from "@app/lib/utils";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 
@@ -32,9 +31,8 @@ export function PendingInvitationsTable({
     () =>
       sortedInvitations.map((invitation) => ({
         ...invitation,
-        isExpired: isInvitationExpired(invitation.createdAt),
         onJoin: () => {
-          if (isInvitationExpired(invitation.createdAt)) {
+          if (invitation.isExpired) {
             return;
           }
           window.location.assign(

--- a/front/components/members/EditInvitationModal.tsx
+++ b/front/components/members/EditInvitationModal.tsx
@@ -24,8 +24,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 
-import { isInvitationExpired } from "./utils";
-
 export function EditInvitationModal({
   owner,
   invitation,
@@ -93,7 +91,7 @@ export function EditInvitationModal({
                 <div className="text-muted-foreground dark:text-muted-foreground-night">
                   Invitation sent on{" "}
                   {new Date(invitation.createdAt).toLocaleDateString()}
-                  {isInvitationExpired(invitation.createdAt) && (
+                  {invitation.isExpired && (
                     <span className="ml-2 text-red-500">(expired)</span>
                   )}
                 </div>

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -31,7 +31,9 @@ export function InvitationsList({
   owner: WorkspaceType;
   searchText?: string;
 }) {
-  const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner);
+  const { invitations, isInvitationsLoading } = useWorkspaceInvitations(owner, {
+    includeExpired: true,
+  });
   const [selectedInvite, setSelectedInvite] =
     useState<MembershipInvitationType | null>(null);
   const sendNotification = useSendNotification();

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -18,8 +18,6 @@ import { sendInvitations } from "@app/lib/invitations";
 import { useWorkspaceInvitations } from "@app/lib/swr/memberships";
 import type { MembershipInvitationType, WorkspaceType } from "@app/types";
 
-import { isInvitationExpired } from "./utils";
-
 type RowData = MembershipInvitationType & {
   onClick: () => void;
 };
@@ -66,7 +64,7 @@ export function InvitationsList({
       header: "Invitation Email",
       accessorKey: "inviteEmail",
       cell: (info: CellContext<RowData, string>) => {
-        const isExpired = isInvitationExpired(info.row.original.createdAt);
+        const isExpired = info.row.original.isExpired;
         return (
           <DataTable.CellContent>
             <div className="flex items-center gap-2">

--- a/front/components/members/utils.ts
+++ b/front/components/members/utils.ts
@@ -1,7 +1,0 @@
-import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
-
-export function isInvitationExpired(createdAt: number): boolean {
-  const now = Date.now();
-  const expirationTime = createdAt + INVITATION_EXPIRATION_TIME_SEC * 1000;
-  return now > expirationTime;
-}

--- a/front/components/poke/invitations/columns.tsx
+++ b/front/components/poke/invitations/columns.tsx
@@ -12,7 +12,6 @@ export function makeColumnsForInvitations(
       accessorKey: "sId",
       header: "ID",
     },
-
     {
       accessorKey: "inviteEmail",
       header: "email",
@@ -20,6 +19,10 @@ export function makeColumnsForInvitations(
     {
       accessorKey: "status",
       header: "Status",
+    },
+    {
+      accessorKey: "isExpired",
+      header: "Expired",
     },
     {
       accessorKey: "inviteLink",

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -24,7 +24,6 @@ import type {
   APIErrorWithStatusCode,
   LightWorkspaceType,
   MembershipInvitationType,
-  ModelId,
   Result,
   SubscriptionType,
   UserType,
@@ -151,13 +150,16 @@ export async function updateOrCreateInvitation(
 }
 
 export function getMembershipInvitationToken(
-  invitationId: ModelId,
-  expiresAtEpochSeconds: number
+  invitation: MembershipInvitationType
 ) {
+  const expirationEpochSeconds =
+    Math.floor(invitation.createdAt / 1000) + INVITATION_EXPIRATION_TIME_SEC;
+
   return sign(
     {
-      membershipInvitationId: invitationId,
-      exp: expiresAtEpochSeconds,
+      membershipInvitationId: invitation.id,
+      iat: Math.floor(invitation.createdAt / 1000),
+      exp: expirationEpochSeconds,
     },
     config.getDustInviteTokenSecret()
   );
@@ -174,12 +176,7 @@ export function getMembershipInvitationUrl(
   owner: LightWorkspaceType,
   invitation: MembershipInvitationType
 ) {
-  const expirationEpochSeconds =
-    Math.floor(invitation.createdAt / 1000) + INVITATION_EXPIRATION_TIME_SEC;
-  const invitationToken = getMembershipInvitationToken(
-    invitation.id,
-    expirationEpochSeconds
-  );
+  const invitationToken = getMembershipInvitationToken(invitation);
   return getMembershipInvitationUrlForToken(owner, invitationToken);
 }
 

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -1,10 +1,9 @@
 import sgMail from "@sendgrid/mail";
 import { escape } from "html-escaper";
 import { sign } from "jsonwebtoken";
-import type { Transaction } from "sequelize";
-import { Op } from "sequelize";
+import type {Transaction} from "sequelize";
+import { Op  } from "sequelize";
 
-import { isInvitationExpired } from "@app/components/members/utils";
 import config from "@app/lib/api/config";
 import {
   getMembers,
@@ -15,7 +14,6 @@ import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { isEmailValid } from "@app/lib/utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
@@ -31,18 +29,7 @@ import type {
 } from "@app/types";
 import { Err, Ok, sanitizeString } from "@app/types";
 
-function typeFromModel(
-  invitation: MembershipInvitationModel
-): MembershipInvitationType {
-  return {
-    sId: invitation.sId,
-    id: invitation.id,
-    inviteEmail: invitation.inviteEmail,
-    status: invitation.status,
-    initialRole: invitation.initialRole,
-    createdAt: invitation.createdAt.getTime(),
-  };
-}
+import { MembershipInvitationResource } from "../resources/membership_invitation_resource";
 
 export async function getInvitation(
   auth: Authenticator,
@@ -57,96 +44,51 @@ export async function getInvitation(
     return null;
   }
 
-  const invitation = await MembershipInvitationModel.findOne({
-    where: {
-      workspaceId: owner.id,
-      sId: invitationId,
-    },
-  });
+  const invitation = await MembershipInvitationResource.fetchById(
+    auth,
+    invitationId
+  );
 
   if (!invitation) {
     return null;
   }
 
-  return typeFromModel(invitation);
-}
-
-export async function updateInvitationStatusAndRole(
-  auth: Authenticator,
-  {
-    invitation,
-    status,
-    role,
-  }: {
-    invitation: MembershipInvitationType;
-    status: "pending" | "consumed" | "revoked";
-    role: ActiveRoleType;
-  }
-): Promise<MembershipInvitationType> {
-  const owner = auth.workspace();
-  if (!owner || !auth.isAdmin()) {
-    throw new Error("Unauthorized attempt to update invitation status.");
-  }
-
-  const existingInvitation = await MembershipInvitationModel.findOne({
-    where: {
-      workspaceId: owner.id,
-      id: invitation.id,
-    },
-  });
-
-  if (!existingInvitation) {
-    throw new Err("Invitation unexpectedly not found.");
-  }
-
-  await existingInvitation.update({
-    status: status,
-    initialRole: role,
-  });
-
-  return typeFromModel(existingInvitation);
+  return invitation.toJSON();
 }
 
 export async function updateOrCreateInvitation(
-  owner: WorkspaceType,
+  auth: Authenticator,
   inviteEmail: string,
   initialRole: ActiveRoleType,
   transaction?: Transaction
 ): Promise<MembershipInvitationType> {
   // check for prior existing pending invitation
-  const existingInvitation = await MembershipInvitationModel.findOne({
-    where: {
-      workspaceId: owner.id,
-      inviteEmail: sanitizeString(inviteEmail),
-      status: "pending",
-    },
-    transaction,
-  });
-
-  if (
-    existingInvitation &&
-    isInvitationExpired(existingInvitation.createdAt.getTime())
-  ) {
-    await existingInvitation.update({ status: "revoked" }, { transaction });
-  } else if (existingInvitation) {
-    await existingInvitation.update({
-      initialRole,
+  const existingInvitation =
+    await MembershipInvitationResource.getPendingForEmailAndWorkspace({
+      email: sanitizeString(inviteEmail),
+      includeExpired: true,
+      workspace: auth.getNonNullableWorkspace(),
+      transaction,
     });
-    return typeFromModel(existingInvitation);
+
+  if (existingInvitation && existingInvitation.isExpired()) {
+    await existingInvitation.revoke(transaction);
+  } else if (existingInvitation) {
+    await existingInvitation.updateRole(initialRole, transaction);
+    return existingInvitation.toJSON();
   }
 
-  return typeFromModel(
-    await MembershipInvitationModel.create(
-      {
-        sId: generateRandomModelSId(),
-        workspaceId: owner.id,
-        inviteEmail: sanitizeString(inviteEmail),
-        status: "pending",
-        initialRole,
-      },
-      { transaction }
-    )
+  const newInvitation = await MembershipInvitationResource.makeNew(
+    auth,
+    {
+      inviteEmail: sanitizeString(inviteEmail),
+      status: "pending",
+      initialRole,
+    },
+    transaction
   );
+
+  return newInvitation.toJSON();
 }
 
 export function getMembershipInvitationToken(
@@ -208,61 +150,6 @@ export async function sendWorkspaceInvitationEmail(
  * @param auth Authenticator
  * @returns MenbershipInvitation[] members of the workspace
  */
-
-export async function getRecentPendingAndRevokedInvitations(
-  auth: Authenticator,
-  transaction?: Transaction
-): Promise<{
-  pending: MembershipInvitationType[];
-  revoked: MembershipInvitationType[];
-}> {
-  const owner = auth.workspace();
-  if (!owner) {
-    return {
-      pending: [],
-      revoked: [],
-    };
-  }
-  if (!auth.isAdmin()) {
-    throw new Error(
-      "Only users that are `admins` for the current workspace can see membership invitations or modify it."
-    );
-  }
-  const oneDayAgo = new Date();
-  oneDayAgo.setDate(oneDayAgo.getDate() - 1);
-  const invitations = await MembershipInvitationModel.findAll({
-    where: {
-      workspaceId: owner.id,
-      status: ["pending", "revoked"],
-      createdAt: {
-        [Op.gt]: oneDayAgo,
-      },
-    },
-    transaction,
-  });
-
-  const groupedInvitations: Record<
-    "pending" | "revoked",
-    MembershipInvitationType[]
-  > = {
-    revoked: [],
-    pending: [],
-  };
-
-  for (const i of invitations) {
-    const status = i.status as "pending" | "revoked";
-    groupedInvitations[status].push({
-      sId: i.sId,
-      id: i.id,
-      status,
-      inviteEmail: i.inviteEmail,
-      initialRole: i.initialRole,
-      createdAt: i.createdAt.getTime(),
-    });
-  }
-
-  return groupedInvitations;
-}
 
 export async function batchUnrevokeInvitations(
   auth: Authenticator,
@@ -374,10 +261,11 @@ export async function handleMembershipInvitations(
         transaction: t,
       });
 
-      const unconsumedInvitations = await getRecentPendingAndRevokedInvitations(
-        auth,
-        t
-      );
+      const unconsumedInvitations =
+        await MembershipInvitationResource.listRecentPendingAndRevokedInvitations(
+          auth,
+          t
+        );
       if (
         unconsumedInvitations.pending.length >=
         MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY
@@ -456,7 +344,7 @@ export async function handleMembershipInvitations(
 
           try {
             const invitation = await updateOrCreateInvitation(
-              owner,
+              auth,
               email,
               role,
               t

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -1,8 +1,8 @@
 import sgMail from "@sendgrid/mail";
 import { escape } from "html-escaper";
 import { sign } from "jsonwebtoken";
-import type {Transaction} from "sequelize";
-import { Op  } from "sequelize";
+import type { Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 import config from "@app/lib/api/config";
 import {

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -152,14 +152,14 @@ export async function updateOrCreateInvitation(
 export function getMembershipInvitationToken(
   invitation: MembershipInvitationType
 ) {
-  const expirationEpochSeconds =
-    Math.floor(invitation.createdAt / 1000) + INVITATION_EXPIRATION_TIME_SEC;
+  const iat = Math.floor(invitation.createdAt / 1000);
+  const exp = iat + INVITATION_EXPIRATION_TIME_SEC;
 
   return sign(
     {
       membershipInvitationId: invitation.id,
-      iat: Math.floor(invitation.createdAt / 1000),
-      exp: expirationEpochSeconds,
+      iat,
+      exp,
     },
     config.getDustInviteTokenSecret()
   );

--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -189,10 +189,10 @@ export async function handleEnterpriseSignUpFlow(
 
   // Look if there is a pending membership invitation for the user at the workspace.
   const pendingMembershipInvitation =
-    await MembershipInvitationResource.getPendingForEmailAndWorkspace(
-      user.email,
-      workspace.id
-    );
+    await MembershipInvitationResource.getPendingForEmailAndWorkspace({
+      email: user.email,
+      workspace,
+    });
 
   // Initialize membership if it's not present or has been previously revoked. In the case of
   // enterprise connections, Dust access is overridden by the identity management service.

--- a/front/lib/iam/errors.ts
+++ b/front/lib/iam/errors.ts
@@ -10,6 +10,7 @@ export class SSOEnforcedError extends Error {
 
 type AuthFlowErrorCodeType =
   | "invalid_invitation_token"
+  | "expired_invitation"
   | "invitation_token_email_mismatch"
   | "invalid_domain"
   | "membership_update_error"

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -113,7 +113,7 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     }
     const oneDayAgo = new Date();
     oneDayAgo.setDate(oneDayAgo.getDate() - 1);
-    const invitations = await MembershipInvitationModel.findAll({
+    const invitations = await this.model.findAll({
       where: {
         workspaceId: owner.id,
         status: ["pending", "revoked"],
@@ -133,12 +133,14 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     };
 
     for (const i of invitations) {
-      const status = i.status as "pending" | "revoked";
-      groupedInvitations[status].push(
-        new MembershipInvitationResource(this.model, i.get(), {
-          workspace: i.workspace,
-        })
-      );
+      const status = i.status;
+      if (status === "pending" || status === "revoked") {
+        groupedInvitations[status].push(
+          new MembershipInvitationResource(this.model, i.get(), {
+            workspace: i.workspace,
+          })
+        );
+      }
     }
 
     return groupedInvitations;
@@ -222,7 +224,7 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
       );
     }
 
-    const invitations = await MembershipInvitationModel.findAll({
+    const invitations = await this.model.findAll({
       where: {
         workspaceId: owner.id,
         status: "pending",

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -1,8 +1,6 @@
 import { verify } from "jsonwebtoken";
-import type {Attributes, CreationAttributes, Transaction} from "sequelize";
-import {
-  Op
-} from "sequelize";
+import type { Attributes, CreationAttributes, Transaction } from "sequelize";
+import { Op } from "sequelize";
 
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -132,8 +132,7 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
         status: "pending",
       },
     });
-    console.log("invitations", invitations);
-    console.log("includeExpired", includeExpired);
+
     return invitations
       .filter(
         (invitation) =>

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -51,13 +51,6 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     );
   }
 
-  static async getPendingForEmail(
-    email: string
-  ): Promise<MembershipInvitationResource | null> {
-    const pendingInvitations = await this.listPendingForEmail({ email });
-    return pendingInvitations[0] ?? null;
-  }
-
   static async listPendingForEmail({
     email,
     includeExpired = false,

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -18,7 +18,8 @@ import type {
   Result,
 } from "@app/types";
 import { Err, Ok } from "@app/types";
-import { WorkspaceResource } from "./workspace_resource";
+
+import type { WorkspaceResource } from "./workspace_resource";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -67,11 +67,14 @@ export function useMembers({
   };
 }
 
-export function useWorkspaceInvitations(owner: LightWorkspaceType) {
+export function useWorkspaceInvitations(
+  owner: LightWorkspaceType,
+  { includeExpired = false }: { includeExpired?: boolean } = {}
+) {
   const workspaceInvitationsFetcher: Fetcher<GetWorkspaceInvitationsResponseBody> =
     fetcher;
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/invitations`,
+    `/api/w/${owner.sId}/invitations?includeExpired=${includeExpired}`,
     workspaceInvitationsFetcher
   );
 

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -118,7 +118,9 @@ async function handler(
     // pending invitation.
     const pendingInvitations =
       memberships.length === 0 && !membershipInvite
-        ? await MembershipInvitationResource.listPendingForEmail(user.email)
+        ? await MembershipInvitationResource.listPendingForEmail({
+            email: user.email,
+          })
         : null;
 
     // More than one pending invitation, redirect to invite choose page - otherwise use the first one.

--- a/front/pages/api/lookup/[resource]/index.ts
+++ b/front/pages/api/lookup/[resource]/index.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import config from "@app/lib/api/config";
 import {
   handleLookupWorkspace,
-  lookupUserRegionByEmail,
+  hasEmailLocalRegionAffinity,
 } from "@app/lib/api/regions/lookup";
 import { getBearerToken } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -122,7 +122,7 @@ async function handler(
           });
         }
         response = {
-          exists: await lookupUserRegionByEmail(bodyValidation.right.user),
+          exists: await hasEmailLocalRegionAffinity(bodyValidation.right.user),
         };
       }
       break;

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -4,17 +4,16 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import {
-  getPendingInvitations,
-  updateInvitationStatusAndRole,
-} from "@app/lib/api/invitation";
+import { updateInvitationStatusAndRole } from "@app/lib/api/invitation";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
 const PokeDeleteInvitationRequestBodySchema = t.type({
   email: t.string,
+  includeExpired: t.boolean,
 });
 
 type PokePostInvitationResponseBody = {
@@ -70,7 +69,10 @@ async function handler(
       );
 
       const pendingInvitations =
-        await getPendingInvitations(workspaceAdminAuth);
+        await MembershipInvitationResource.getPendingInvitations(
+          workspaceAdminAuth,
+          true
+        );
 
       const invitation = pendingInvitations.find(
         (inv) => inv.inviteEmail === email
@@ -87,7 +89,7 @@ async function handler(
       }
 
       await updateInvitationStatusAndRole(workspaceAdminAuth, {
-        invitation,
+        invitation: invitation.toJSON(),
         status: "revoked",
         role: invitation.initialRole,
       });

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -4,7 +4,6 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import { updateInvitationStatusAndRole } from "@app/lib/api/invitation";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
@@ -13,7 +12,6 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 const PokeDeleteInvitationRequestBodySchema = t.type({
   email: t.string,
-  includeExpired: t.boolean,
 });
 
 type PokePostInvitationResponseBody = {
@@ -88,11 +86,7 @@ async function handler(
         });
       }
 
-      await updateInvitationStatusAndRole(workspaceAdminAuth, {
-        invitation: invitation.toJSON(),
-        status: "revoked",
-        role: invitation.initialRole,
-      });
+      await invitation.revoke();
 
       res.status(200).json({ success: true, email });
       return;

--- a/front/pages/api/poke/workspaces/[wId]/invitations.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations.ts
@@ -71,7 +71,7 @@ async function handler(
       const pendingInvitations =
         await MembershipInvitationResource.getPendingInvitations(
           workspaceAdminAuth,
-          true
+          { includeExpired: true }
         );
 
       const invitation = pendingInvitations.find(

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -5,8 +5,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { handleMembershipInvitations } from "@app/lib/api/invitation";
-import { getPendingInvitations } from "@app/lib/api/invitation";
 import type { Authenticator } from "@app/lib/auth";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type {
   MembershipInvitationType,
@@ -72,8 +72,13 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const invitations = await getPendingInvitations(auth);
-      res.status(200).json({ invitations });
+      const includeExpired = req.query.includeExpired === "true";
+      const invitations =
+        await MembershipInvitationResource.getPendingInvitations(
+          auth,
+          includeExpired
+        );
+      res.status(200).json({ invitations: invitations.map((i) => i.toJSON()) });
       return;
 
     case "POST":

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -74,10 +74,9 @@ async function handler(
     case "GET":
       const includeExpired = req.query.includeExpired === "true";
       const invitations =
-        await MembershipInvitationResource.getPendingInvitations(
-          auth,
-          includeExpired
-        );
+        await MembershipInvitationResource.getPendingInvitations(auth, {
+          includeExpired,
+        });
       res.status(200).json({ invitations: invitations.map((i) => i.toJSON()) });
       return;
 

--- a/front/pages/invite-choose.tsx
+++ b/front/pages/invite-choose.tsx
@@ -9,7 +9,6 @@ import type { InferGetServerSidePropsType } from "next";
 import { useCallback } from "react";
 
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
-import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import {
   getUserFromSession,
   withDefaultUserAuthPaywallWhitelisted,
@@ -40,11 +39,7 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
     return {
       invitationId: invitation.id,
       invitationSid: invitation.sId,
-      token: getMembershipInvitationToken(
-        invitation.id,
-        Math.floor(invitation.createdAt.getTime() / 1000) +
-          INVITATION_EXPIRATION_TIME_SEC
-      ),
+      token: getMembershipInvitationToken(invitation.toJSON()),
       workspaceName: workspace.name,
       workspaceSid: workspace.sId,
       initialRole: invitation.initialRole,

--- a/front/pages/invite-choose.tsx
+++ b/front/pages/invite-choose.tsx
@@ -37,13 +37,11 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
     const workspace = invitation.workspace;
 
     return {
-      invitationId: invitation.id,
-      invitationSid: invitation.sId,
       token: getMembershipInvitationToken(invitation.toJSON()),
       workspaceName: workspace.name,
-      workspaceSid: workspace.sId,
       initialRole: invitation.initialRole,
       createdAt: invitation.createdAt.getTime(),
+      isExpired: invitation.isExpired(),
     };
   });
 
@@ -96,7 +94,7 @@ export default function InviteChoosePage({
               <div className="flex flex-col gap-3">
                 {invitations.map((invitation) => (
                   <div
-                    key={invitation.invitationSid}
+                    key={invitation.workspaceName}
                     className="border-border-light bg-wash dark:bg-wash-dark flex items-center justify-between gap-4 rounded-xl border p-4 shadow-sm dark:border-border-night"
                   >
                     <div className="flex flex-col gap-1">

--- a/front/pages/invite-choose.tsx
+++ b/front/pages/invite-choose.tsx
@@ -30,7 +30,9 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   }
 
   const invitationsResources =
-    await MembershipInvitationResource.listPendingForEmail(user.email);
+    await MembershipInvitationResource.listPendingForEmail({
+      email: user.email,
+    });
 
   const invitations = invitationsResources.map((invitation) => {
     const workspace = invitation.workspace;

--- a/front/pages/invite-choose.tsx
+++ b/front/pages/invite-choose.tsx
@@ -15,16 +15,7 @@ import {
 } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { useUser } from "@app/lib/swr/user";
-
-type PendingInvitationOption = {
-  invitationId: number;
-  invitationSid: string;
-  token: string;
-  workspaceName: string;
-  workspaceSid: string;
-  initialRole: string;
-  createdAt: number;
-};
+import type { PendingInvitationOption } from "@app/types/membership_invitation";
 
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   userFirstName: string;
@@ -51,7 +42,7 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
       workspaceSid: workspace.sId,
       initialRole: invitation.initialRole,
       createdAt: invitation.createdAt.getTime(),
-    } satisfies PendingInvitationOption;
+    };
   });
 
   return {

--- a/front/pages/invite-choose.tsx
+++ b/front/pages/invite-choose.tsx
@@ -9,6 +9,7 @@ import type { InferGetServerSidePropsType } from "next";
 import { useCallback } from "react";
 
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
+import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import {
   getUserFromSession,
   withDefaultUserAuthPaywallWhitelisted,
@@ -37,7 +38,11 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
     return {
       invitationId: invitation.id,
       invitationSid: invitation.sId,
-      token: getMembershipInvitationToken(invitation.id),
+      token: getMembershipInvitationToken(
+        invitation.id,
+        Math.floor(invitation.createdAt.getTime() / 1000) +
+          INVITATION_EXPIRATION_TIME_SEC
+      ),
       workspaceName: workspace.name,
       workspaceSid: workspace.sId,
       initialRole: invitation.initialRole,
@@ -59,7 +64,7 @@ export default function InviteChoosePage({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { user } = useUser();
 
-  const handleInvitationSelection = useCallback(async (token: string) => {
+  const handleInvitationSelection = useCallback((token: string) => {
     if (typeof window !== "undefined") {
       window.location.assign(
         `/api/login?inviteToken=${encodeURIComponent(token)}`

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -177,11 +177,6 @@ export default function NoWorkspace({
                 </span>{" "}
                 for more informations or to add you again.
               </span>
-              <span className="copy-md text-muted-foreground dark:text-muted-foreground-night">
-                If you're looking to establish{" "}
-                <strong>a new, separate workspace</strong> continue with the
-                following step:
-              </span>
             </div>
           )}
         </div>

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -31,7 +31,9 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
   const [{ members }, pendingInvitations] = await Promise.all([
     getMembers(auth),
-    MembershipInvitationResource.getPendingInvitations(auth, true),
+    MembershipInvitationResource.getPendingInvitations(auth, {
+      includeExpired: true,
+    }),
   ]);
 
   return {

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -1,7 +1,6 @@
 import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 
-import { isInvitationExpired } from "@app/components/members/utils";
 import { InvitationsDataTable } from "@app/components/poke/invitations/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
 import PokeLayout from "@app/components/poke/PokeLayout";
@@ -43,7 +42,6 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
         const i = invite.toJSON();
         return {
           ...i,
-          status: isInvitationExpired(i.createdAt) ? "expired" : "pending",
           inviteLink: getMembershipInvitationUrl(owner, i),
         };
       }),

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -5,12 +5,10 @@ import { isInvitationExpired } from "@app/components/members/utils";
 import { InvitationsDataTable } from "@app/components/poke/invitations/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
 import PokeLayout from "@app/components/poke/PokeLayout";
-import {
-  getMembershipInvitationUrl,
-  getPendingInvitations,
-} from "@app/lib/api/invitation";
+import { getMembershipInvitationUrl } from "@app/lib/api/invitation";
 import { getMembers } from "@app/lib/api/workspace";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import type {
   MembershipInvitationTypeWithLink,
   UserTypeWithWorkspaces,
@@ -33,17 +31,20 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
   const [{ members }, pendingInvitations] = await Promise.all([
     getMembers(auth),
-    getPendingInvitations(auth),
+    MembershipInvitationResource.getPendingInvitations(auth, true),
   ]);
 
   return {
     props: {
       members,
-      pendingInvitations: pendingInvitations.map((invite) => ({
-        ...invite,
-        status: isInvitationExpired(invite.createdAt) ? "expired" : "pending",
-        inviteLink: getMembershipInvitationUrl(owner, invite),
-      })),
+      pendingInvitations: pendingInvitations.map((invite) => {
+        const i = invite.toJSON();
+        return {
+          ...i,
+          status: isInvitationExpired(i.createdAt) ? "expired" : "pending",
+          inviteLink: getMembershipInvitationUrl(owner, i),
+        };
+      }),
       owner,
     },
   };

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -1,7 +1,7 @@
 import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
-import React from "react";
 
+import { isInvitationExpired } from "@app/components/members/utils";
 import { InvitationsDataTable } from "@app/components/poke/invitations/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
 import PokeLayout from "@app/components/poke/PokeLayout";
@@ -41,7 +41,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       members,
       pendingInvitations: pendingInvitations.map((invite) => ({
         ...invite,
-        inviteLink: getMembershipInvitationUrl(owner, invite.id),
+        status: isInvitationExpired(invite.createdAt) ? "expired" : "pending",
+        inviteLink: getMembershipInvitationUrl(owner, invite),
       })),
       owner,
     },

--- a/front/pages/w/[wId]/me/index.tsx
+++ b/front/pages/w/[wId]/me/index.tsx
@@ -20,7 +20,6 @@ import { UserToolsTable } from "@app/components/me/UserToolsTable";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
-import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { useUser } from "@app/lib/swr/user";
@@ -58,11 +57,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
         workspaceSid: workspace.sId,
         initialRole: invitation.initialRole,
         createdAt: invitation.createdAt.getTime(),
-        token: getMembershipInvitationToken(
-          invitation.id,
-          Math.floor(invitation.createdAt.getTime() / 1000) +
-            INVITATION_EXPIRATION_TIME_SEC
-        ),
+        token: getMembershipInvitationToken(invitation.toJSON()),
       };
     }
   );

--- a/front/pages/w/[wId]/me/index.tsx
+++ b/front/pages/w/[wId]/me/index.tsx
@@ -20,6 +20,7 @@ import { UserToolsTable } from "@app/components/me/UserToolsTable";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
+import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { useUser } from "@app/lib/swr/user";
@@ -55,7 +56,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
         workspaceSid: workspace.sId,
         initialRole: invitation.initialRole,
         createdAt: invitation.createdAt.getTime(),
-        token: getMembershipInvitationToken(invitation.id),
+        token: getMembershipInvitationToken(
+          invitation.id,
+          Math.floor(invitation.createdAt.getTime() / 1000) +
+            INVITATION_EXPIRATION_TIME_SEC
+        ),
       };
     }
   );

--- a/front/pages/w/[wId]/me/index.tsx
+++ b/front/pages/w/[wId]/me/index.tsx
@@ -43,7 +43,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const invitationResources =
-    await MembershipInvitationResource.listPendingForEmail(userResource.email);
+    await MembershipInvitationResource.listPendingForEmail({
+      email: userResource.email,
+    });
 
   const pendingInvitations: PendingInvitationOption[] = invitationResources.map(
     (invitation) => {

--- a/front/pages/w/[wId]/me/index.tsx
+++ b/front/pages/w/[wId]/me/index.tsx
@@ -51,13 +51,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       const workspace = invitation.workspace;
 
       return {
-        invitationId: invitation.id,
-        invitationSid: invitation.sId,
         workspaceName: workspace.name,
-        workspaceSid: workspace.sId,
         initialRole: invitation.initialRole,
         createdAt: invitation.createdAt.getTime(),
         token: getMembershipInvitationToken(invitation.toJSON()),
+        isExpired: invitation.isExpired(),
       };
     }
   );

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -8,7 +8,7 @@ import { ActiveRoleSchema } from "./user";
 export type MembershipInvitationType = {
   sId: string;
   id: ModelId;
-  status: "pending" | "consumed" | "revoked";
+  status: "pending" | "consumed" | "revoked" | "expired";
   inviteEmail: string;
   initialRole: ActiveRoleType;
   createdAt: number;
@@ -18,7 +18,7 @@ export type MembershipInvitationTypeWithLink = MembershipInvitationType & {
   inviteLink: string;
 };
 
-export type PendingInvitationOption = {
+export interface PendingInvitationOption {
   invitationId: number;
   invitationSid: string;
   token: string;
@@ -26,7 +26,7 @@ export type PendingInvitationOption = {
   workspaceSid: string;
   initialRole: ActiveRoleType;
   createdAt: number;
-};
+}
 
 // Types for the invite form in Poke.
 

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -18,6 +18,16 @@ export type MembershipInvitationTypeWithLink = MembershipInvitationType & {
   inviteLink: string;
 };
 
+export type PendingInvitationOption = {
+  invitationId: number;
+  invitationSid: string;
+  token: string;
+  workspaceName: string;
+  workspaceSid: string;
+  initialRole: ActiveRoleType;
+  createdAt: number;
+};
+
 // Types for the invite form in Poke.
 
 export const InviteMemberFormSchema = t.type({

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -8,10 +8,11 @@ import { ActiveRoleSchema } from "./user";
 export type MembershipInvitationType = {
   sId: string;
   id: ModelId;
-  status: "pending" | "consumed" | "revoked" | "expired";
+  status: "pending" | "consumed" | "revoked";
   inviteEmail: string;
   initialRole: ActiveRoleType;
   createdAt: number;
+  isExpired: boolean;
 };
 
 export type MembershipInvitationTypeWithLink = MembershipInvitationType & {
@@ -19,13 +20,11 @@ export type MembershipInvitationTypeWithLink = MembershipInvitationType & {
 };
 
 export interface PendingInvitationOption {
-  invitationId: number;
-  invitationSid: string;
   token: string;
   workspaceName: string;
-  workspaceSid: string;
   initialRole: ActiveRoleType;
   createdAt: number;
+  isExpired: boolean;
 }
 
 // Types for the invite form in Poke.


### PR DESCRIPTION
## Description

Add an invitation table in the profile page, if the user has valid pending invitations. Allow to click on an invite and follow the link to join the workspace.

Fixed the invitation resources to correctly handle expiration - it was not enforced on the resources, only the invitation token was expiring based on its generation time. Since it was possible to use invitations without a token - or regenerate a token on any invitation, expiration was useless. Token expiration date is set at inviation expiration to be consistent. 
In members management, "resend invitation" revoke the old one and re-create a nee valid invitation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Break invitation flow


## Deploy Plan

deploy front
