### PR TITLE
[Workspace Analytics] Default include-inactive checked

### DIFF
--- a/front/pages/w/[wId]/analytics/index.tsx
+++ b/front/pages/w/[wId]/analytics/index.tsx
@@ -36,7 +36,7 @@ export default function Analytics({
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [downloadingMonth, setDownloadingMonth] = useState<string | null>(null);
-  const [includeInactive, setIncludeInactive] = useState(false);
+  const [includeInactive, setIncludeInactive] = useState(true);
 
   const { subscriptions } = useWorkspaceSubscriptions({
     owner,


### PR DESCRIPTION
## Description
Small UX tweak: default the analytics export checkbox to include users and assistants with zero activity.

## Risks
Blast radius: Admin analytics page export behavior
Risk: low

## Deploy Plan
- deploy front
