### PR TITLE
[front] feat(obs): Add empty placeholder on agent creation

### DIFF
--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -57,7 +57,7 @@ function ChartContainerSkeleton() {
   return (
     <div
       className={cn(
-        "bg-card flex flex-col rounded-lg border border-border p-4"
+        "bg-card flex flex-col rounded-lg border border-border p-4 dark:border-border-night"
       )}
     >
       <div className="mb-4 flex items-center justify-between">

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -1,6 +1,8 @@
-import { cn, LoadingBlock } from "@dust-tt/sparkle";
+import { BarChartIcon, cn, LoadingBlock } from "@dust-tt/sparkle";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { EmptyPlaceholder } from "@app/components/agent_builder/observability/shared/EmptyPlaceholder";
+import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
 import { AgentObservability } from "@app/components/observability/AgentObservability";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 
@@ -18,19 +20,31 @@ export function AgentBuilderObservability({
       agentConfigurationId: agentConfigurationSId,
     });
 
-  if (!agentConfiguration) {
-    return null;
+  if (isAgentConfigurationLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-6">
+        <ChartContainerSkeleton />
+        <ChartContainerSkeleton />
+        <ChartContainerSkeleton />
+        <ChartContainerSkeleton />
+        <ChartContainerSkeleton />
+      </div>
+    );
   }
 
-  return isAgentConfigurationLoading || !agentConfiguration ? (
-    <div className="grid grid-cols-1 gap-6">
-      <ChartContainerSkeleton />
-      <ChartContainerSkeleton />
-      <ChartContainerSkeleton />
-      <ChartContainerSkeleton />
-      <ChartContainerSkeleton />
-    </div>
-  ) : (
+  if (!agentConfiguration) {
+    return (
+      <TabContentLayout title="Insights">
+        <EmptyPlaceholder
+          icon={BarChartIcon}
+          title="Waiting for data"
+          description="Use your agent or share it with your team to see performance data."
+        />
+      </TabContentLayout>
+    );
+  }
+
+  return (
     <AgentObservability
       workspaceId={owner.sId}
       agentConfigurationId={agentConfiguration.sId}

--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -1,8 +1,6 @@
-import { BarChartIcon, cn, LoadingBlock } from "@dust-tt/sparkle";
+import { cn, LoadingBlock } from "@dust-tt/sparkle";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import { EmptyPlaceholder } from "@app/components/agent_builder/observability/shared/EmptyPlaceholder";
-import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
 import { AgentObservability } from "@app/components/observability/AgentObservability";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 
@@ -20,31 +18,19 @@ export function AgentBuilderObservability({
       agentConfigurationId: agentConfigurationSId,
     });
 
-  if (isAgentConfigurationLoading) {
-    return (
-      <div className="grid grid-cols-1 gap-6">
-        <ChartContainerSkeleton />
-        <ChartContainerSkeleton />
-        <ChartContainerSkeleton />
-        <ChartContainerSkeleton />
-        <ChartContainerSkeleton />
-      </div>
-    );
-  }
-
   if (!agentConfiguration) {
-    return (
-      <TabContentLayout title="Insights">
-        <EmptyPlaceholder
-          icon={BarChartIcon}
-          title="Waiting for data"
-          description="Use your agent or share it with your team to see performance data."
-        />
-      </TabContentLayout>
-    );
+    return null;
   }
 
-  return (
+  return isAgentConfigurationLoading || !agentConfiguration ? (
+    <div className="grid grid-cols-1 gap-6">
+      <ChartContainerSkeleton />
+      <ChartContainerSkeleton />
+      <ChartContainerSkeleton />
+      <ChartContainerSkeleton />
+      <ChartContainerSkeleton />
+    </div>
+  ) : (
     <AgentObservability
       workspaceId={owner.sId}
       agentConfigurationId={agentConfiguration.sId}

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -20,6 +20,8 @@ import { AgentBuilderPerformance } from "@app/components/agent_builder/AgentBuil
 import { AgentBuilderPreview } from "@app/components/agent_builder/AgentBuilderPreview";
 import { AgentBuilderTemplate } from "@app/components/agent_builder/AgentBuilderTemplate";
 import { ObservabilityProvider } from "@app/components/agent_builder/observability/ObservabilityContext";
+import { EmptyPlaceholder } from "@app/components/agent_builder/observability/shared/EmptyPlaceholder";
+import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
@@ -181,11 +183,20 @@ function ExpandedContent({
         </div>
       )}
       <ObservabilityProvider>
-        {selectedTab === "observability" && (
-          <AgentBuilderObservability
-            agentConfigurationSId={agentConfigurationSId ?? ""}
-          />
-        )}
+        {selectedTab === "observability" &&
+          (agentConfigurationSId ? (
+            <AgentBuilderObservability
+              agentConfigurationSId={agentConfigurationSId ?? ""}
+            />
+          ) : (
+            <TabContentLayout title="Insights">
+              <EmptyPlaceholder
+                icon={BarChartIcon}
+                title="Waiting for data"
+                description="Use your agent or share it with your team to see performance data."
+              />
+            </TabContentLayout>
+          ))}
         {selectedTab === "performance" && (
           <AgentBuilderPerformance
             agentConfigurationSId={agentConfigurationSId}

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -181,9 +181,9 @@ function ExpandedContent({
         </div>
       )}
       <ObservabilityProvider>
-        {selectedTab === "observability" && agentConfigurationSId && (
+        {selectedTab === "observability" && (
           <AgentBuilderObservability
-            agentConfigurationSId={agentConfigurationSId}
+            agentConfigurationSId={agentConfigurationSId ?? ""}
           />
         )}
         {selectedTab === "performance" && (
@@ -207,8 +207,7 @@ export function AgentBuilderRightPanel({
     usePreviewPanelContext();
   const { assistantTemplate, owner } = useAgentBuilderContext();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
-  const showObservability =
-    hasFeature("agent_builder_observability") && !!agentConfigurationSId;
+  const showObservability = hasFeature("agent_builder_observability");
 
   const hasTemplate = !!assistantTemplate;
 

--- a/front/components/agent_builder/observability/shared/EmptyPlaceholder.tsx
+++ b/front/components/agent_builder/observability/shared/EmptyPlaceholder.tsx
@@ -1,0 +1,28 @@
+import { Icon } from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+interface EmptyPlaceholderProps {
+  icon: ComponentType;
+  title: string;
+  description: string;
+}
+
+export function EmptyPlaceholder({
+  icon,
+  title,
+  description,
+}: EmptyPlaceholderProps) {
+  return (
+    <div className="flex min-h-[400px] flex-col items-center justify-center gap-3 text-center">
+      <Icon visual={icon} size="lg" className="text-muted-foreground" />
+      <div className="flex flex-col gap-2">
+        <div className="text-base font-medium text-foreground dark:text-foreground-night">
+          {title}
+        </div>
+        <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {description}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/observability/shared/EmptyPlaceholder.tsx
+++ b/front/components/agent_builder/observability/shared/EmptyPlaceholder.tsx
@@ -13,7 +13,7 @@ export function EmptyPlaceholder({
   description,
 }: EmptyPlaceholderProps) {
   return (
-    <div className="flex min-h-[400px] flex-col items-center justify-center gap-3 text-center">
+    <div className="flex h-96 flex-col items-center justify-center gap-3 text-center">
       <Icon visual={icon} size="lg" className="text-muted-foreground" />
       <div className="flex flex-col gap-2">
         <div className="text-base font-medium text-foreground dark:text-foreground-night">

--- a/front/components/agent_builder/observability/shared/EmptyPlaceholder.tsx
+++ b/front/components/agent_builder/observability/shared/EmptyPlaceholder.tsx
@@ -14,7 +14,11 @@ export function EmptyPlaceholder({
 }: EmptyPlaceholderProps) {
   return (
     <div className="flex h-96 flex-col items-center justify-center gap-3 text-center">
-      <Icon visual={icon} size="lg" className="text-muted-foreground" />
+      <Icon
+        visual={icon}
+        size="lg"
+        className="text-muted-foreground dark:text-muted-foreground-night"
+      />
       <div className="flex flex-col gap-2">
         <div className="text-base font-medium text-foreground dark:text-foreground-night">
           {title}

--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -128,9 +128,12 @@ export function AgentDetails({
   );
 
   const showPerformanceTabs =
-    (agentConfiguration?.canEdit ?? isAdmin(owner)) && !isGlobalAgent;
+    (agentConfiguration?.canEdit ?? isAdmin(owner)) &&
+    agentId != null &&
+    !isGlobalAgent;
 
   const showInsightsTabs =
+    agentId != null &&
     (agentConfiguration?.canEdit ?? isAdmin(owner)) &&
     !isGlobalAgent &&
     hasFeature("agent_builder_observability");

--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -128,12 +128,9 @@ export function AgentDetails({
   );
 
   const showPerformanceTabs =
-    (agentConfiguration?.canEdit ?? isAdmin(owner)) &&
-    agentId != null &&
-    !isGlobalAgent;
+    (agentConfiguration?.canEdit ?? isAdmin(owner)) && !isGlobalAgent;
 
   const showInsightsTabs =
-    agentId != null &&
     (agentConfiguration?.canEdit ?? isAdmin(owner)) &&
     !isGlobalAgent &&
     hasFeature("agent_builder_observability");


### PR DESCRIPTION
## Description

- This PR adds a placeholder for the Insights tab when creating a new agent.
- We currently hide the tab, the idea here is to increase awareness so that builders are incentivized to go back to this tab after gathering some data.
- Figma [here](https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product---Core?node-id=19421-166869&p=f&t=oCyNnmCGrsknONZp-0).

<img width="555" height="641" alt="Screenshot 2025-11-10 at 8 23 31 AM" src="https://github.com/user-attachments/assets/c5ffdd98-7508-4004-8df3-bcf77c2ef069" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
