### PR TITLE
[front] chore(include): remove `DATA_SOURCE_INCLUDE_QUERY`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -327,28 +327,6 @@ export const isSearchResultResourceType = (
   );
 };
 
-// Data source inclusion outputs, query and results
-export const IncludeQueryResourceSchema = z.object({
-  mimeType: z.literal(
-    INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_INCLUDE_QUERY
-  ),
-  text: z.string(),
-  uri: z.literal(""),
-});
-
-export type IncludeQueryResourceType = z.infer<
-  typeof IncludeQueryResourceSchema
->;
-
-export const isIncludeQueryResourceType = (
-  outputBlock: CallToolResult["content"][number]
-): outputBlock is { type: "resource"; resource: IncludeQueryResourceType } => {
-  return (
-    outputBlock.type === "resource" &&
-    IncludeQueryResourceSchema.safeParse(outputBlock.resource).success
-  );
-};
-
 export const WarningResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.WARNING),
   warningTitle: z.string(),

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -10,7 +10,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
-  IncludeQueryResourceType,
   IncludeResultResourceType,
   WarningResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -74,10 +73,7 @@ function createServer(
         | TextContent
         | {
             type: "resource";
-            resource:
-              | IncludeResultResourceType
-              | IncludeQueryResourceType
-              | WarningResourceType;
+            resource: IncludeResultResourceType | WarningResourceType;
           }
       )[],
       MCPError
@@ -219,10 +215,6 @@ function createServer(
         type: "resource" as const,
         resource: result,
       })),
-      {
-        type: "resource" as const,
-        resource: makeQueryResource(timeFrame ?? null),
-      },
       ...(warningResource
         ? [
             {
@@ -267,16 +259,6 @@ function createServer(
   }
 
   return server;
-}
-
-function makeQueryResource(
-  timeFrame: TimeFrame | null
-): IncludeQueryResourceType {
-  return {
-    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_INCLUDE_QUERY,
-    text: `Requested to include documents ${renderRelativeTimeFrameForToolOutput(timeFrame)}.`,
-    uri: "",
-  };
 }
 
 function makeWarningResource(

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -6,7 +6,6 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { MAX_RESOURCE_CONTENT_SIZE } from "@app/lib/actions/action_output_limits";
 import {
   isBlobResource,
-  isIncludeQueryResourceType,
   isRunAgentQueryResourceType,
   isSearchQueryResourceType,
   isToolGeneratedFile,
@@ -105,7 +104,6 @@ export function rewriteContentForModel(
   if (
     isToolMarkerResourceType(content) ||
     isSearchQueryResourceType(content) ||
-    isIncludeQueryResourceType(content) ||
     isWebsearchQueryResourceType(content) ||
     isRunAgentQueryResourceType(content)
   ) {

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -25,7 +25,7 @@ type UnderscoreToDash<T extends string> = T extends `${infer A}_${infer B}`
  */
 function generateConnectorRelativeMimeTypes<
   P extends ConnectorProvider,
-  T extends Uppercase<string>[]
+  T extends Uppercase<string>[],
 >({
   provider,
   resourceTypes,
@@ -193,7 +193,7 @@ export const INCLUDABLE_INTERNAL_CONTENT_NODE_MIME_TYPES = {
 
 function generateToolMimeTypes<
   P extends Uppercase<string>,
-  T extends Uppercase<string>[]
+  T extends Uppercase<string>[],
 >({
   category,
   resourceTypes,

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -25,7 +25,7 @@ type UnderscoreToDash<T extends string> = T extends `${infer A}_${infer B}`
  */
 function generateConnectorRelativeMimeTypes<
   P extends ConnectorProvider,
-  T extends Uppercase<string>[],
+  T extends Uppercase<string>[]
 >({
   provider,
   resourceTypes,
@@ -193,7 +193,7 @@ export const INCLUDABLE_INTERNAL_CONTENT_NODE_MIME_TYPES = {
 
 function generateToolMimeTypes<
   P extends Uppercase<string>,
-  T extends Uppercase<string>[],
+  T extends Uppercase<string>[]
 >({
   category,
   resourceTypes,
@@ -250,7 +250,6 @@ const TOOL_MIME_TYPES = {
       "FILESYSTEM_PATH",
       "DATA_SOURCE_NODE_LIST",
       "DATA_SOURCE_NODE_CONTENT",
-      "DATA_SOURCE_INCLUDE_QUERY",
       "DATA_SOURCE_INCLUDE_RESULT",
       "EXTRACT_QUERY",
       "EXTRACT_RESULT",

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -212,28 +212,6 @@ export const isSearchResultResourceType = (
   );
 };
 
-// Data source inclusion outputs, query and results
-export const IncludeQueryResourceSchema = z.object({
-  mimeType: z.literal(
-    INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_INCLUDE_QUERY
-  ),
-  text: z.string(),
-  uri: z.literal(""),
-});
-
-export type IncludeQueryResourceType = z.infer<
-  typeof IncludeQueryResourceSchema
->;
-
-export const isIncludeQueryResourceType = (
-  outputBlock: CallToolResult["content"][number]
-): outputBlock is { type: "resource"; resource: IncludeQueryResourceType } => {
-  return (
-    outputBlock.type === "resource" &&
-    IncludeQueryResourceSchema.safeParse(outputBlock.resource).success
-  );
-};
-
 export const WarningResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.WARNING),
   warningTitle: z.string(),


### PR DESCRIPTION
## Description

- This PR removes the type `DATA_SOURCE_INCLUDE_QUERY`, which describes the inputs of the include tool and is sent in the outputs for the UI.
- This output type stopped being read in https://github.com/dust-tt/dust/pull/17235 to rely on the inputs instead.
- The version of the Chrome extension that doesn't rely on it is version 0.0.28, and version 0.0.27 was last used on last Wednesday modulo sampling ([logs](https://app.datadoghq.eu/logs?query=service%3Adust-chrome-extension&agg_m=count&agg_m_source=base&agg_q=version&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22datadog16%22%2Cnull%2Cnull%5D&refresh_mode=sliding&saved-view-id=191015&storage=hot&top_n=10&top_o=top&viz=timeseries&x_missing=true&from_ts=1762155498903&to_ts=1762760298903&live=true)).

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
