### PR TITLE
[llm-router] Fix empty string params in tool call

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -320,7 +320,7 @@ function toolCall({
     content: {
       id: id,
       name: name,
-      arguments: parseToolArguments(input),
+      arguments: parseToolArguments(input, name),
     },
     metadata,
   };

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -72,7 +72,7 @@ function assistantContentToParam(
         type: "tool_use",
         id: content.value.id,
         name: content.value.name,
-        input: parseToolArguments(content.value.arguments),
+        input: parseToolArguments(content.value.arguments, content.value.name),
       };
     }
   }

--- a/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { streamLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/anthropic_to_events";
+import { emptyToolCallLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call";
 import { reasoningLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning";
 import { toolUseLLMEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use";
+import { emptyToolCallModelEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/empty_tool_call";
 import { reasoningModelEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/reasoning";
 import { toolUseModelEvents } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/tool_use";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
@@ -39,6 +41,19 @@ describe("streamLLMEvents", () => {
         ...e,
         metadata: { ...e.metadata, ...metadata },
       }))
+    );
+  });
+
+  it("should handle empty tool call parameters", async () => {
+    const messageStreamEvents = createAsyncGenerator(emptyToolCallModelEvents);
+    const result = [];
+
+    for await (const event of streamLLMEvents(messageStreamEvents, metadata)) {
+      result.push(event);
+    }
+
+    expect(result).toEqual(
+      emptyToolCallLLMEvents.map((e) => ({ ...e, metadata }))
     );
   });
 });

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
@@ -1,0 +1,68 @@
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import { CLAUDE_4_SONNET_20250514_MODEL_ID } from "@app/types";
+
+export const emptyToolCallLLMEvents: LLMEvent[] = [
+  {
+    type: "tool_call",
+    content: {
+      id: "EmptyToolCall1",
+      name: "test_tool",
+      arguments: {},
+    },
+    metadata: {
+      clientId: "anthropic" as const,
+      modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+    },
+  },
+  {
+    type: "token_usage",
+    content: {
+      inputTokens: 100,
+      outputTokens: 20,
+      cachedTokens: 0,
+      cacheCreationTokens: 0,
+      totalTokens: 120,
+    },
+    metadata: {
+      clientId: "anthropic" as const,
+      modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+    },
+  },
+  {
+    type: "success",
+    aggregated: [
+      {
+        type: "tool_call",
+        content: {
+          id: "EmptyToolCall1",
+          name: "test_tool",
+          arguments: {},
+        },
+        metadata: {
+          clientId: "anthropic" as const,
+          modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+        },
+      },
+    ],
+    reasoningGenerated: undefined,
+    textGenerated: undefined,
+    toolCalls: [
+      {
+        type: "tool_call",
+        content: {
+          id: "EmptyToolCall1",
+          name: "test_tool",
+          arguments: {},
+        },
+        metadata: {
+          clientId: "anthropic" as const,
+          modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+        },
+      },
+    ],
+    metadata: {
+      clientId: "anthropic" as const,
+      modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+    },
+  },
+];

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/empty_tool_call.ts
@@ -1,0 +1,69 @@
+import type { MessageStreamEvent } from "@anthropic-ai/sdk/resources/messages.mjs";
+
+import { CLAUDE_4_SONNET_20250514_MODEL_ID } from "@app/types";
+
+export const emptyToolCallModelEvents: MessageStreamEvent[] = [
+  {
+    type: "message_start",
+    message: {
+      type: "message",
+      model: CLAUDE_4_SONNET_20250514_MODEL_ID,
+      id: "msg_017KE6ziN29Ks5KyL3jGE7RR",
+      role: "assistant",
+      content: [],
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: {
+        input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation: {
+          ephemeral_5m_input_tokens: 0,
+          ephemeral_1h_input_tokens: 0,
+        },
+        output_tokens: 0,
+        service_tier: "standard",
+        server_tool_use: null,
+      },
+    },
+  },
+  {
+    type: "content_block_start",
+    index: 0,
+    content_block: {
+      type: "tool_use",
+      id: "EmptyToolCall1",
+      name: "test_tool",
+      input: "",
+    },
+  },
+  {
+    type: "content_block_delta",
+    index: 0,
+    delta: {
+      type: "input_json_delta",
+      partial_json: "",
+    },
+  },
+  {
+    type: "content_block_stop",
+    index: 0,
+  },
+  {
+    type: "message_delta",
+    delta: {
+      stop_reason: "tool_use",
+      stop_sequence: null,
+    },
+    usage: {
+      input_tokens: 100,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      output_tokens: 20,
+      server_tool_use: null,
+    },
+  },
+  {
+    type: "message_stop",
+  },
+];

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -119,7 +119,7 @@ function assistantContentToPart(
         functionCall: {
           id: content.value.id,
           name: content.value.name,
-          args: parseToolArguments(content.value.arguments),
+          args: parseToolArguments(content.value.arguments, content.value.name),
         },
       };
     }

--- a/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
+++ b/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
@@ -206,7 +206,10 @@ function toToolEvent({
 
   let args: Record<string, unknown>;
   if (isString(toolCall.function.arguments)) {
-    args = parseToolArguments(toolCall.function.arguments);
+    args = parseToolArguments(
+      toolCall.function.arguments,
+      toolCall.function.name
+    );
   } else {
     args = toolCall.function.arguments;
   }

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -179,6 +179,30 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     ],
   },
   {
+    id: "tool-call-without-params",
+    name: "Tool call without params",
+    systemPrompt: SYSTEM_PROMPT,
+    conversationActions: [
+      userMessage("Use a call to list my files"),
+      userToolCall("ListFiles", "[users.pdf,zebra.png]"),
+    ],
+    expectedInResponses: [
+      hasToolCall("ListFiles", {}),
+      containsTextChecker(["users.pdf", "zebra.png"]),
+    ],
+    specifications: [
+      {
+        name: "ListFiles",
+        description: "List all files in the user's account.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    ],
+  },
+  {
     id: "image-description",
     name: "Image description",
     systemPrompt: SYSTEM_PROMPT,

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
@@ -102,7 +102,10 @@ export async function* streamLLMEvents(
                 content: {
                   id: toolCall.id,
                   name: toolCall.name,
-                  arguments: parseToolArguments(toolCall.arguments),
+                  arguments: parseToolArguments(
+                    toolCall.arguments,
+                    toolCall.name
+                  ),
                 },
                 metadata,
               };

--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -106,7 +106,7 @@ function itemToEvents(
           content: {
             id: item.call_id,
             name: item.name,
-            arguments: parseToolArguments(item.arguments),
+            arguments: parseToolArguments(item.arguments, item.name),
           },
           metadata,
         },

--- a/front/lib/api/llm/utils/tool_arguments.ts
+++ b/front/lib/api/llm/utils/tool_arguments.ts
@@ -2,14 +2,22 @@ import isObject from "lodash/isObject";
 
 import { safeParseJSON } from "@app/types";
 
-export const parseToolArguments = (input: string): Record<string, unknown> => {
+export const parseToolArguments = (
+  input: string,
+  toolName: string
+): Record<string, unknown> => {
+  if (input.trim() === "") {
+    return {};
+  }
   const parsed = safeParseJSON(input);
   if (parsed.isErr()) {
-    throw new Error(`Failed to parse tool call arguments: ${parsed.error}`);
+    throw new Error(
+      `Failed to parse arguments in call to tool '${toolName}': ${parsed.error}`
+    );
   }
   if (!isObject(parsed.value) || !parsed.value) {
     throw new Error(
-      `Tool call arguments must be an object and not undefined, got ${typeof parsed.value}`
+      `Tool call arguments must be an object and not undefined, got ${typeof parsed.value}. Tool is '${toolName}'.`
     );
   }
 


### PR DESCRIPTION
## Description

 - Return empty object for empty string when parsing tool calls
 - Add test for it
 - Add tool name in logs of the tool parser

## Tests

```
VITE_RUN_LLM_TESTS=true NODE_ENV=test VITE_DUST_MANAGED_ANTHROPIC_API_KEY=$DUST_MANAGED_ANTHROPIC_API_KEY npm run test -- __test__/anthropic.test.ts -t "Tool call without params"

> front@0.1.0 test
> FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI vitest --run __test__/anthropic.test.ts -t Tool call without params


[...]

 Test Files  1 passed (1)
      Tests  18 passed | 90 skipped (108)
   Start at  10:00:07
   Duration  93.39s (transform 574ms, setup 498ms, collect 1.48s, tests 88.41s, environment 296ms, prepare 36ms)
```

## Risk

no

## Deploy Plan

deploy front
