### PR TITLE
Fire GTM event for hubspot submit

### DIFF
--- a/front/components/home/HubSpotForm.tsx
+++ b/front/components/home/HubSpotForm.tsx
@@ -63,6 +63,13 @@ export default function HubSpotForm() {
             object: "hubspot_form",
             action: "submit",
           });
+          // Push event to Google Tag Manager
+          if (typeof window !== "undefined") {
+            window.dataLayer = window.dataLayer ?? [];
+            window.dataLayer.push({
+              event: "hubspot_form_submitted",
+            });
+          }
         }
       }
 
@@ -88,6 +95,13 @@ export default function HubSpotForm() {
             object: "hubspot_form",
             action: "submit",
           });
+          // Push event to Google Tag Manager
+          if (typeof window !== "undefined") {
+            window.dataLayer = window.dataLayer ?? [];
+            window.dataLayer.push({
+              event: "hubspot_form_submitted",
+            });
+          }
         }
       }
 

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -8,6 +8,9 @@ type DataLayer =
       user_email: string;
       company_name: string;
       gclid: string | null;
+    }
+  | {
+      event: "hubspot_form_submitted";
     };
 
 interface Signals {


### PR DESCRIPTION





## Description

Adds Google Tag Manager event tracking for HubSpot form submissions. When a user submits the contact form, a `hubspot_form_submitted` event is now pushed to the GTM dataLayer, enabling conversion tracking for marketing campaigns.

## Risk

None. The change only adds event tracking without modifying form behavior.

## Tests

Tested manually by verifying the `hubspot_form_submitted` event appears in the dataLayer after form submission.
