### PR TITLE
Dynamic Google thinking budget

### DIFF
--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -1,7 +1,10 @@
 import { ApiError, GoogleGenAI } from "@google/genai";
 
 import type { GoogleAIStudioWhitelistedModelId } from "@app/lib/api/llm/clients/google/types";
-import { getGoogleModelFamilyFromModelId } from "@app/lib/api/llm/clients/google/types";
+import {
+  getGoogleModelFamilyFromModelId,
+  GOOGLE_REASONING_EFFORT_TO_THINKING_BUDGET,
+} from "@app/lib/api/llm/clients/google/types";
 import {
   toContent,
   toTool,
@@ -63,8 +66,11 @@ export class GoogleLLM extends LLM {
         modelFamily === "reasoning"
           ? {
               includeThoughts: true,
-              // TODO(LLM-Router 2025-10-27): update according to effort
-              thinkingBudget: 1024,
+              thinkingBudget: this.reasoningEffort
+                ? GOOGLE_REASONING_EFFORT_TO_THINKING_BUDGET[
+                    this.reasoningEffort
+                  ]
+                : undefined,
             }
           : undefined;
 

--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -55,7 +55,7 @@ export const GOOGLE_REASONING_EFFORT_TO_THINKING_BUDGET: {
   [key in ReasoningEffort]: number;
 } = {
   none: 0,
-  light: 0, // for light reasoning, we use chain of thought from prompt instead of thinking budget
-  medium: 1024,
+  light: 1024,
+  medium: 2048,
   high: 4096,
-}; // inspired by Claude 4 thinking budget tokens
+};

--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -55,7 +55,7 @@ export const GOOGLE_REASONING_EFFORT_TO_THINKING_BUDGET: {
   [key in ReasoningEffort]: number;
 } = {
   none: 0,
-  light: 0,
+  light: 0, // for light reasoning, we use chain of thought from prompt instead of thinking budget
   medium: 1024,
   high: 4096,
 }; // inspired by Claude 4 thinking budget tokens

--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -1,4 +1,4 @@
-import type { ModelIdType } from "@app/types";
+import type { ModelIdType, ReasoningEffort } from "@app/types";
 import {
   GEMINI_2_5_FLASH_LITE_MODEL_ID,
   GEMINI_2_5_FLASH_MODEL_ID,
@@ -50,3 +50,12 @@ export function getGoogleModelFamilyFromModelId(
 
   throw new Error(`Unknown Google model ID: ${modelId}`);
 }
+
+export const GOOGLE_REASONING_EFFORT_TO_THINKING_BUDGET: {
+  [key in ReasoningEffort]: number;
+} = {
+  none: 0,
+  light: 0,
+  medium: 1024,
+  high: 4096,
+}; // inspired by Claude 4 thinking budget tokens


### PR DESCRIPTION
## Description

Makes the Google thinking budget dynamic based on the reasoningEffort parameter instead of using a hardcoded 1024 tokens. The mapping follows the Claude 4 thinking budget pattern: none and light map to 0 (no thinking), medium to 1024 tokens, and high to 4096 tokens. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
