### PR TITLE
[front] enh(obs): update empty feedback placeholder

### DIFF
--- a/front/components/agent_builder/AgentBuilderPerformance.tsx
+++ b/front/components/agent_builder/AgentBuilderPerformance.tsx
@@ -1,13 +1,9 @@
-import { ListCheckIcon } from "@dust-tt/sparkle";
-
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import { EmptyPlaceholder } from "@app/components/agent_builder/observability/shared/EmptyPlaceholder";
-import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
 import { AgentFeedback } from "@app/components/observability/AgentFeedback";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 
 interface AgentBuilderPerformanceProps {
-  agentConfigurationSId?: string;
+  agentConfigurationSId: string;
 }
 
 export function AgentBuilderPerformance({
@@ -21,15 +17,7 @@ export function AgentBuilderPerformance({
   });
 
   if (!agentConfiguration) {
-    return (
-      <TabContentLayout title="Feedback">
-        <EmptyPlaceholder
-          icon={ListCheckIcon}
-          title="Waiting for feedback"
-          description="When users give feedback on responses, you'll see it here."
-        />
-      </TabContentLayout>
-    );
+    return null;
   }
 
   return (

--- a/front/components/agent_builder/AgentBuilderPerformance.tsx
+++ b/front/components/agent_builder/AgentBuilderPerformance.tsx
@@ -1,22 +1,10 @@
+import { ListCheckIcon } from "@dust-tt/sparkle";
+
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { EmptyPlaceholder } from "@app/components/agent_builder/observability/shared/EmptyPlaceholder";
+import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
 import { AgentFeedback } from "@app/components/observability/AgentFeedback";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
-
-function NoAgentState() {
-  return (
-    <div className="flex h-full min-h-0 items-center justify-center">
-      <div className="px-4 text-center">
-        <div className="mb-2 text-lg font-medium text-foreground">
-          No Performance Data Available
-        </div>
-        <div className="max-w-sm text-muted-foreground">
-          Performance metrics will be available after your agent is created and
-          used in conversations.
-        </div>
-      </div>
-    </div>
-  );
-}
 
 interface AgentBuilderPerformanceProps {
   agentConfigurationSId?: string;
@@ -33,7 +21,15 @@ export function AgentBuilderPerformance({
   });
 
   if (!agentConfiguration) {
-    return <NoAgentState />;
+    return (
+      <TabContentLayout title="Feedback">
+        <EmptyPlaceholder
+          icon={ListCheckIcon}
+          title="Waiting for feedback"
+          description="When users give feedback on responses, you'll see it here."
+        />
+      </TabContentLayout>
+    );
   }
 
   return (

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -197,11 +197,20 @@ function ExpandedContent({
               />
             </TabContentLayout>
           ))}
-        {selectedTab === "performance" && (
-          <AgentBuilderPerformance
-            agentConfigurationSId={agentConfigurationSId}
-          />
-        )}
+        {selectedTab === "performance" &&
+          (agentConfigurationSId ? (
+            <AgentBuilderPerformance
+              agentConfigurationSId={agentConfigurationSId}
+            />
+          ) : (
+            <TabContentLayout title="Feedback">
+              <EmptyPlaceholder
+                icon={ListCheckIcon}
+                title="Waiting for feedback"
+                description="When users give feedback on responses, you'll see it here."
+              />
+            </TabContentLayout>
+          ))}
       </ObservabilityProvider>
     </div>
   );


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/17758.
- This PR implements the following [Figma](https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product---Core?node-id=19421-166869&p=f&t=oCyNnmCGrsknONZp-0) for the empty feedback placeholder.
- This design is aligned with the new one for the Insights tab.

<img width="739" height="741" alt="Screenshot 2025-11-10 at 12 25 23 PM" src="https://github.com/user-attachments/assets/e114b5a7-36dd-4a43-ad26-fa62bab1e969" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
