### PR TITLE
chore: phase out dust app to suggest agent tags

### DIFF
--- a/front/lib/api/assistant/tag_manager.ts
+++ b/front/lib/api/assistant/tag_manager.ts
@@ -1,0 +1,178 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import { formatValidationErrors } from "io-ts-reporters";
+
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types";
+import { Err, getLargeWhitelistedModel, Ok } from "@app/types";
+
+const SEND_TAGS_FUNCTION_NAME = "send_tags";
+
+const WorkspaceTagSuggestionsResponseSchema = t.type({
+  suggestions: t.union([
+    t.array(
+      t.type({
+        name: t.string,
+        agentIds: t.array(t.string),
+      })
+    ),
+    t.null,
+    t.undefined,
+  ]),
+});
+
+const specifications = [
+  {
+    name: SEND_TAGS_FUNCTION_NAME,
+    description: "Send tagging plan for the assistant",
+    inputSchema: {
+      type: "object",
+      properties: {
+        suggestions: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+                description: "The tag name",
+              },
+              agentIds: {
+                type: "array",
+                description: "The ids of the agents that match this tag",
+                items: {
+                  type: "string",
+                  description: "The agent id",
+                },
+              },
+            },
+            required: ["name", "agentIds"],
+          },
+        },
+      },
+      required: ["suggestions"],
+    },
+  },
+];
+
+const INSTRUCTIONS = `From the provided list of agents, extract about 15 tags and assign them to at least 20 agents. An agent can have multiple tags. You must associate all the agents from the "Agents list" to at least one tag.
+
+Sends the tagging plan : A json list with the following format:
+
+[
+ {
+   name: "Marketing",
+   agentIds: ["8864464fad", "O91N1C6gMM"]
+ },
+ ...
+]
+
+With "name" the name of the tag, and "agentIds" the list of unique identifier of each agent that should have this tag. This list must contains valid identifier, matching a value in the "Identifier" line of the "Agents list", and must not contains duplicate.
+
+- Keep tags short and descriptive.
+- Avoid special characters, capitalize tag name
+- Favor tags that are activity "Write, Code" or function related (Sales, Design, Product)
+- Create tags for departments
+- Do not use capabilities names as tags
+- Identifies which team primarily uses the agent
+- Function: describes the agent's main purpose
+
+For example, this could be a list of valid tags:
+
+Writing
+Planning
+Sales
+Support
+Marketing
+Research
+Analysis
+Development
+Finance
+HR
+Operations
+Design
+Strategy
+Training
+Compliance
+Procurement
+Security
+Legal
+Quality
+Product
+
+=================================
+Agents list :
+=================================
+{{INPUT.agents}}`;
+
+export type WorkspaceTagSuggestion = {
+  name: string;
+  agentIds: string[];
+};
+
+export async function getWorkspaceTagSuggestions(
+  auth: Authenticator,
+  inputs: { formattedAgents: string }
+): Promise<Result<{ suggestions?: WorkspaceTagSuggestion[] | null }, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const model = getLargeWhitelistedModel(owner);
+  if (!model) {
+    return new Err(
+      new Error(
+        "Failed to find a whitelisted model to generate tag suggestions"
+      )
+    );
+  }
+
+  const { formattedAgents } = inputs;
+
+  const instructionsWithAgents = INSTRUCTIONS.replace(
+    "{{INPUT.agents}}",
+    formattedAgents
+  );
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      functionCall: SEND_TAGS_FUNCTION_NAME,
+      modelId: model.modelId,
+      providerId: model.providerId,
+      temperature: 0.7,
+      useCache: false,
+    },
+    {
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            content: "Please suggest tags.",
+          },
+        ],
+      },
+      prompt: instructionsWithAgents,
+      specifications,
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  const responseValidation = WorkspaceTagSuggestionsResponseSchema.decode(
+    res.value.actions?.[0].arguments
+  );
+
+  if (isLeft(responseValidation)) {
+    return new Err(
+      new Error(
+        `Error retrieving tag suggestions from arguments: ${formatValidationErrors(responseValidation.left)}`
+      )
+    );
+  }
+
+  return new Ok({
+    suggestions: responseValidation.right.suggestions,
+  });
+}

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -220,20 +220,6 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-  "tag-manager-initial-suggestions": {
-    app: {
-      appId: "Huz76iC3FJ",
-      appHash:
-        "4c86322b20fa685fcbd87b23c5220e9be14fd56014a3f356a6cfe07b3573ab5d",
-    },
-    config: {
-      CREATE_SUGGESTIONS: {
-        function_call: "send_tags",
-        use_cache: false,
-        use_stream: true,
-      },
-    },
-  },
   "assistant-builder-webhook-filter-generator": {
     app: {
       appId: "XNcJCE7lUj",

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -1,16 +1,13 @@
-import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { runAction } from "@app/lib/actions/server";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { getWorkspaceTagSuggestions } from "@app/lib/api/assistant/tag_manager";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { cloneBaseConfig, getDustProdActionRegistry } from "@app/lib/registry";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { getLargeWhitelistedModel, isAdmin, removeNulls } from "@app/types";
+import { isAdmin, removeNulls } from "@app/types";
 
 const DEFAULT_SUGGESTIONS = [
   "Writing",
@@ -34,19 +31,6 @@ const DEFAULT_SUGGESTIONS = [
   "Quality",
   "Product",
 ];
-
-const AppResponseSchema = t.type({
-  suggestions: t.union([
-    t.array(
-      t.type({
-        name: t.string,
-        agentIds: t.array(t.string),
-      })
-    ),
-    t.null,
-    t.undefined,
-  ]),
-});
 
 const GetSuggestionsResponseBodySchema = t.type({
   suggestions: t.union([
@@ -107,65 +91,21 @@ async function handler(
         });
       }
 
-      const model = getLargeWhitelistedModel(owner);
+      const suggestionsResponse = await getWorkspaceTagSuggestions(auth, {
+        formattedAgents,
+      });
 
-      if (!model) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `No whitelisted models were found for the workspace.`,
-          },
-        });
-      }
-
-      const config = cloneBaseConfig(
-        getDustProdActionRegistry()["tag-manager-initial-suggestions"].config
-      );
-      config.CREATE_SUGGESTIONS.provider_id = model.providerId;
-      config.CREATE_SUGGESTIONS.model_id = model.modelId;
-
-      const suggestionsResponse = await runAction(
-        auth,
-        "tag-manager-initial-suggestions",
-        config,
-        [
-          {
-            agents: formattedAgents,
-          },
-        ]
-      );
-
-      if (suggestionsResponse.isErr() || !suggestionsResponse.value.results) {
-        const message = suggestionsResponse.isErr()
-          ? JSON.stringify(suggestionsResponse.error)
-          : "No results available";
+      if (suggestionsResponse.isErr()) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message,
+            message: suggestionsResponse.error.message,
           },
         });
       }
 
-      const responseValidation = AppResponseSchema.decode(
-        suggestionsResponse.value.results[0][0].value
-      );
-      if (isLeft(responseValidation)) {
-        const pathError = reporter.formatValidationErrors(
-          responseValidation.left
-        );
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: `Invalid response from action: ${pathError}`,
-          },
-        });
-      }
-
-      const suggestions = responseValidation.right.suggestions?.map((s) => ({
+      const suggestions = suggestionsResponse.value.suggestions?.map((s) => ({
         name: s.name,
         agents: removeNulls(
           s.agentIds.map((id) => agents.find((agent) => agent.sId === id))


### PR DESCRIPTION





## Description

Phases out the `tag-manager-initial-suggestions` Dust app and replaces it with direct LLM calls using `runMultiActionsAgent`.

The `suggest_from_agents` API endpoint is refactored to use the new `getWorkspaceTagSuggestions` function instead of the old Dust app flow. The tag manager app entry is removed from the registry.

This follows the same pattern established in previous PRs that phased out other builder apps (names, descriptions, tags, emoji, instructions, cron-timezone, webhook-filter).

[Dust app reference](https://dust.tt/w/78bda07b39/spaces/vlt_rICtlrSEpWqX/apps/Huz76iC3FJ)

## Risk

Low

## Tests

Tested locally with front.

## Deploy Plan

Deploy Front.
