### PR TITLE
[Frontend] Make generated content popover scrollable

### DIFF
--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -223,7 +223,7 @@ export const ConversationFilesPopover = ({
         />
       </PopoverTrigger>
       <PopoverContent
-        className="flex w-96 max-h-[80vh] flex-col gap-3 overflow-hidden"
+        className="flex w-96 flex-col gap-3"
         align="end"
         onOpenAutoFocus={(e) => e.preventDefault()}
         onAnimationEnd={() => {
@@ -232,11 +232,15 @@ export const ConversationFilesPopover = ({
           }
         }}
       >
-        <div className="heading-base mb-2 text-primary dark:text-primary-night">
-          Generated Content
-        </div>
-        {/* Scroll within the content area only. */}
-        <ScrollArea className="flex-1 flex flex-col gap-3">
+        {/*
+          Constrain height so long lists become scrollable within the popover.
+          Without an explicit height, the ScrollArea expands with content and
+          the popover can overflow the viewport, making items unreachable.
+        */}
+        <ScrollArea className="flex max-h-[80vh] flex-col gap-3">
+          <div className="heading-base mb-2 text-primary dark:text-primary-night">
+            Generated Content
+          </div>
 
           {isConversationFilesLoading ? (
             <div className="flex w-full items-center justify-center p-8">

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -232,11 +232,6 @@ export const ConversationFilesPopover = ({
           }
         }}
       >
-        {/*
-          Constrain height so long lists become scrollable within the popover.
-          Without an explicit height, the ScrollArea expands with content and
-          the popover can overflow the viewport, making items unreachable.
-        */}
         <ScrollArea className="flex max-h-[80vh] flex-col gap-3">
           <div className="heading-base mb-2 text-primary dark:text-primary-night">
             Generated Content

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -237,7 +237,7 @@ export const ConversationFilesPopover = ({
           Without an explicit height, the ScrollArea expands with content and
           the popover can overflow the viewport, making items unreachable.
         */}
-        <ScrollArea className="flex max-h-[80vh] h-[480px] flex-col gap-3">
+        <ScrollArea className="flex max-h-[80vh] flex-col gap-3">
           <div className="heading-base mb-2 text-primary dark:text-primary-night">
             Generated Content
           </div>

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -232,7 +232,12 @@ export const ConversationFilesPopover = ({
           }
         }}
       >
-        <ScrollArea className="flex flex-col gap-3">
+        {/*
+          Constrain height so long lists become scrollable within the popover.
+          Without an explicit height, the ScrollArea expands with content and
+          the popover can overflow the viewport, making items unreachable.
+        */}
+        <ScrollArea className="flex max-h-[80vh] h-[480px] flex-col gap-3">
           <div className="heading-base mb-2 text-primary dark:text-primary-night">
             Generated Content
           </div>

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -223,7 +223,7 @@ export const ConversationFilesPopover = ({
         />
       </PopoverTrigger>
       <PopoverContent
-        className="flex w-96 flex-col gap-3"
+        className="flex w-96 max-h-[80vh] flex-col gap-3 overflow-hidden"
         align="end"
         onOpenAutoFocus={(e) => e.preventDefault()}
         onAnimationEnd={() => {
@@ -232,15 +232,11 @@ export const ConversationFilesPopover = ({
           }
         }}
       >
-        {/*
-          Constrain height so long lists become scrollable within the popover.
-          Without an explicit height, the ScrollArea expands with content and
-          the popover can overflow the viewport, making items unreachable.
-        */}
-        <ScrollArea className="flex max-h-[80vh] flex-col gap-3">
-          <div className="heading-base mb-2 text-primary dark:text-primary-night">
-            Generated Content
-          </div>
+        <div className="heading-base mb-2 text-primary dark:text-primary-night">
+          Generated Content
+        </div>
+        {/* Scroll within the content area only. */}
+        <ScrollArea className="flex-1 flex flex-col gap-3">
 
           {isConversationFilesLoading ? (
             <div className="flex w-full items-center justify-center p-8">


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5057

Constrain the ScrollArea inside the “Generated Content” popover so long lists are scrollable and do not overflow the viewport. Implemented by adding `h-[480px]` and `max-h-[80vh]` to the ScrollArea in `front/components/assistant/conversation/ConversationFilesPopover.tsx`.

<img width="892" height="1241" alt="image" src="https://github.com/user-attachments/assets/a6ed74ab-e1db-457d-9e0b-644894201ace" />

## Risks
Blast radius: Conversation files popover rendering only.
Risk: low

## Deploy Plan
- deploy front