### PR TITLE
[front] fix: Remove user impersonation when checking tool approval preferences

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -290,33 +290,6 @@ export async function getLastUserMessage(
   return new Ok(content);
 }
 
-export async function getUserMessageFromParentMessageId({
-  workspaceId,
-  conversationId,
-  parentMessageId,
-}: {
-  workspaceId: ModelId;
-  conversationId: ModelId;
-  parentMessageId: string;
-}): Promise<UserMessage | null> {
-  const message = await Message.findOne({
-    where: {
-      workspaceId,
-      conversationId,
-      sId: parentMessageId,
-    },
-    include: [
-      {
-        model: UserMessage,
-        as: "userMessage",
-      },
-    ],
-    attributes: ["id"],
-  });
-
-  return message?.userMessage ?? null;
-}
-
 /**
  * Conversation API
  */

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -137,8 +137,7 @@ async function createActionForTool(
   const { status } = await getExecutionStatusFromConfig(
     auth,
     actionConfiguration,
-    agentMessage,
-    conversation
+    agentMessage
   );
 
   const stepContent =


### PR DESCRIPTION
## Description

- This PR fixes the check on user preferences regarding tool approvals when coming from the public API, which currently operates by impersonating the user indicated by the context from the parent user message.
- Since this context can easily be tampered, this is a leak of the preferences of any user.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
