### PR TITLE
[front/relocation] fix: Map user id in case of conflict on workOSUserId

### DIFF
--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -15,7 +15,7 @@ import {
   readFromRelocationStorage,
   writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
-import type {ModelId} from "@app/types";
+import type { ModelId } from "@app/types";
 import { removeNulls } from "@app/types";
 
 export async function writeCoreEntitiesToDestinationRegion({

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -15,7 +15,7 @@ import {
   readFromRelocationStorage,
   writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
-import type { ModelId } from "@app/types";
+import { removeNulls, type ModelId } from "@app/types";
 
 export async function writeCoreEntitiesToDestinationRegion({
   dataPath,
@@ -216,7 +216,11 @@ export async function prepareDestinationUserMapping({
     }
 
     const existingUsersByWorkOSId = new Map<string, ModelId>(
-      existingUsers.map((user) => [user.workOSUserId as string, user.id])
+      removeNulls(
+        existingUsers.map((user) =>
+          user.workOSUserId ? [user.workOSUserId, user.id] : null
+        )
+      )
     );
 
     const mapping: Record<string, ModelId> = {};

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -15,8 +15,8 @@ import {
   readFromRelocationStorage,
   writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
-import type { ModelId } from "@app/types";
-import { removeNulls } from "@app/types";
+import type { ModelId } from "@app/types/shared/model_id";
+import { removeNulls } from "@app/types/shared/utils/general";
 
 export async function writeCoreEntitiesToDestinationRegion({
   dataPath,

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -15,7 +15,8 @@ import {
   readFromRelocationStorage,
   writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
-import { removeNulls, type ModelId } from "@app/types";
+import type {ModelId} from "@app/types";
+import { removeNulls } from "@app/types";
 
 export async function writeCoreEntitiesToDestinationRegion({
   dataPath,

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -1,8 +1,9 @@
 import assert from "assert";
-import { QueryTypes } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 
 import type { RegionType } from "@app/lib/api/regions/config";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -12,7 +13,9 @@ import type {
 import {
   deleteFromRelocationStorage,
   readFromRelocationStorage,
+  writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { ModelId } from "@app/types";
 
 export async function writeCoreEntitiesToDestinationRegion({
   dataPath,
@@ -149,4 +152,105 @@ export async function processFrontTableChunk({
   localLogger.info("[SQL] Table chunk written successfully.");
 
   await deleteFromRelocationStorage(dataPath);
+}
+export async function prepareDestinationUserMapping({
+  destRegion,
+  sourceRegion,
+  workspaceId,
+  usersDataPath,
+}: {
+  destRegion: RegionType;
+  sourceRegion: RegionType;
+  workspaceId: string;
+  usersDataPath: string | null;
+}): Promise<string | null> {
+  const localLogger = logger.child({
+    destRegion,
+    sourceRegion,
+    workspaceId,
+  });
+
+  if (!usersDataPath) {
+    localLogger.info(
+      "[SQL Core Entities] No users data provided for mapping, skipping."
+    );
+    return null;
+  }
+
+  try {
+    const usersForMapping =
+      await readFromRelocationStorage<
+        { id: ModelId; workOSUserId: string | null }[]
+      >(usersDataPath);
+
+    const workOSUserIds = Array.from(
+      new Set(
+        usersForMapping
+          .map((user) => user.workOSUserId)
+          .filter((workOSUserId): workOSUserId is string => !!workOSUserId)
+      )
+    );
+
+    if (workOSUserIds.length === 0) {
+      localLogger.info(
+        "[SQL Core Entities] No WorkOS users to reconcile, skipping mapping."
+      );
+      return null;
+    }
+
+    const existingUsers = await UserModel.findAll({
+      attributes: ["id", "workOSUserId"],
+      where: {
+        workOSUserId: {
+          [Op.in]: workOSUserIds,
+        },
+      },
+      raw: true,
+    });
+
+    if (existingUsers.length === 0) {
+      localLogger.info(
+        "[SQL Core Entities] No conflicting users found in destination region."
+      );
+      return null;
+    }
+
+    const existingUsersByWorkOSId = new Map<string, ModelId>(
+      existingUsers.map((user) => [user.workOSUserId as string, user.id])
+    );
+
+    const mapping: Record<string, ModelId> = {};
+    for (const user of usersForMapping) {
+      if (!user.workOSUserId) {
+        continue;
+      }
+      const destinationUserId = existingUsersByWorkOSId.get(user.workOSUserId);
+      if (destinationUserId) {
+        mapping[user.id.toString()] = destinationUserId;
+      }
+    }
+
+    const mappingSize = Object.keys(mapping).length;
+    if (mappingSize === 0) {
+      localLogger.info(
+        "[SQL Core Entities] No divergent user IDs detected, mapping not created."
+      );
+      return null;
+    }
+
+    const userIdMappingPath = await writeToRelocationStorage(mapping, {
+      workspaceId,
+      type: "front",
+      operation: "user_id_mapping",
+    });
+
+    localLogger.info(
+      { mappingSize, userIdMappingPath },
+      "[SQL Core Entities] Created user ID mapping for destination region."
+    );
+
+    return userIdMappingPath;
+  } finally {
+    await deleteFromRelocationStorage(usersDataPath);
+  }
 }

--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -24,9 +24,9 @@ import {
 } from "@app/temporal/relocation/lib/file_storage/relocation";
 import { generateParameterizedInsertStatements } from "@app/temporal/relocation/lib/sql/insert";
 import { getTopologicalOrder } from "@app/temporal/relocation/lib/sql/schema/dependencies";
-import type { ModelId } from "@app/types/shared/model_id";
 import type { UserIdMapping } from "@app/temporal/relocation/lib/sql/user_mappings";
 import { mapUserIdsInRows } from "@app/temporal/relocation/lib/sql/user_mappings";
+import type { ModelId } from "@app/types/shared/model_id";
 
 const userIdMappingCache = new Map<string, UserIdMapping>();
 

--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -305,7 +305,7 @@ export async function readFrontTableChunk({
   const idClause = lastId ? `AND id > ${lastId}` : "";
 
   // eslint-disable-next-line dust/no-raw-sql
-  const rows = await frontSequelize.query<{ id: ModelId }>(
+  const rows = await frontSequelize.query<Record<string, any>>(
     `SELECT * FROM "${tableName}"
      WHERE "workspaceId" = :workspaceId ${idClause}
      ORDER BY id

--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -18,14 +18,41 @@ import type {
   RelocationBlob,
 } from "@app/temporal/relocation/activities/types";
 import {
+  readFromRelocationStorage,
   withJSONSerializationRetry,
   writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
 import { generateParameterizedInsertStatements } from "@app/temporal/relocation/lib/sql/insert";
 import { getTopologicalOrder } from "@app/temporal/relocation/lib/sql/schema/dependencies";
 import type { ModelId } from "@app/types/shared/model_id";
+import type { UserIdMapping } from "@app/temporal/relocation/lib/sql/user_mappings";
+import { mapUserIdsInRows } from "@app/temporal/relocation/lib/sql/user_mappings";
 
-export async function readCoreEntitiesFromSourceRegion({
+const userIdMappingCache = new Map<string, UserIdMapping>();
+
+async function loadUserIdMapping(
+  userIdMappingPath?: string | null
+): Promise<UserIdMapping> {
+  if (!userIdMappingPath) {
+    return new Map();
+  }
+
+  const cached = userIdMappingCache.get(userIdMappingPath);
+  if (cached) {
+    return cached;
+  }
+
+  const mappingRecord =
+    await readFromRelocationStorage<Record<string, ModelId>>(userIdMappingPath);
+  const mappingEntries = Object.entries(mappingRecord).map(
+    ([sourceId, destId]) => [Number(sourceId) as ModelId, destId] as const
+  );
+  const mapping = new Map<ModelId, ModelId>(mappingEntries);
+  userIdMappingCache.set(userIdMappingPath, mapping);
+  return mapping;
+}
+
+export async function collectWorkspaceUsersForMapping({
   destRegion,
   sourceRegion,
   workspaceId,
@@ -33,6 +60,71 @@ export async function readCoreEntitiesFromSourceRegion({
   destRegion: RegionType;
   sourceRegion: RegionType;
   workspaceId: string;
+}): Promise<string | null> {
+  const localLogger = logger.child({
+    destRegion,
+    sourceRegion,
+    workspaceId,
+  });
+
+  localLogger.info("[SQL Users] Collecting users for mapping.");
+
+  const workspace = await WorkspaceModel.findOne({
+    where: {
+      sId: workspaceId,
+    },
+    raw: true,
+  });
+  if (!workspace) {
+    throw new Error("Workspace not found.");
+  }
+
+  const { memberships } = await MembershipResource.getMembershipsForWorkspace({
+    workspace: renderLightWorkspaceType({ workspace }),
+  });
+  const userIds = Array.from(new Set(memberships.map((m) => m.userId)));
+
+  if (userIds.length === 0) {
+    localLogger.info("[SQL Users] No users associated with workspace.");
+    return null;
+  }
+
+  const users = await UserModel.findAll({
+    attributes: ["id", "workOSUserId"],
+    where: {
+      id: {
+        [Op.in]: userIds,
+      },
+    },
+    raw: true,
+  });
+
+  const payload = users.map((user) => ({
+    id: user.id,
+    workOSUserId: user.workOSUserId,
+  }));
+
+  const dataPath = await writeToRelocationStorage(payload, {
+    workspaceId,
+    type: "front",
+    operation: "collect_workspace_users_for_mapping",
+  });
+
+  localLogger.info({ dataPath }, "[SQL Users] Collected users for mapping.");
+
+  return dataPath;
+}
+
+export async function readCoreEntitiesFromSourceRegion({
+  destRegion,
+  sourceRegion,
+  workspaceId,
+  userIdMappingPath,
+}: {
+  destRegion: RegionType;
+  sourceRegion: RegionType;
+  workspaceId: string;
+  userIdMappingPath?: string | null;
 }) {
   const localLogger = logger.child({
     destRegion,
@@ -41,6 +133,14 @@ export async function readCoreEntitiesFromSourceRegion({
   });
 
   localLogger.info("[SQL Core Entities] Reading core entities.");
+
+  const userIdMapping = await loadUserIdMapping(userIdMappingPath);
+  if (userIdMapping.size > 0) {
+    localLogger.info(
+      { mappingSize: userIdMapping.size },
+      "[SQL Core Entities] Applying user ID mapping to source data."
+    );
+  }
 
   // Find the raw workspace.
   const workspace = await WorkspaceModel.findOne({
@@ -69,6 +169,16 @@ export async function readCoreEntitiesFromSourceRegion({
     raw: true,
   });
 
+  const usersForInsertion =
+    userIdMapping.size > 0
+      ? users.filter((user) => {
+          const mappedUserId = userIdMapping.get(user.id as ModelId);
+          return (
+            mappedUserId === undefined || mappedUserId === (user.id as ModelId)
+          );
+        })
+      : users;
+
   // Fetch all associated users metadata of the workspace.
   // Only fetch metadata where workspaceId is null (global) or matches the workspace being
   // relocated. This avoids FK violations when inserting into destination region for metadata
@@ -84,6 +194,23 @@ export async function readCoreEntitiesFromSourceRegion({
     },
     raw: true,
   });
+
+  const userMetadataForInsertion =
+    userIdMapping.size > 0
+      ? userMetadata.map((metadata) => {
+          const mappedUserId = userIdMapping.get(metadata.userId as ModelId);
+          if (
+            mappedUserId !== undefined &&
+            mappedUserId !== (metadata.userId as ModelId)
+          ) {
+            return {
+              ...metadata,
+              userId: mappedUserId,
+            };
+          }
+          return metadata;
+        })
+      : userMetadata;
 
   // eslint-disable-next-line dust/no-raw-sql
   const subscriptions = await frontSequelize.query<{ planId: ModelId }>(
@@ -110,12 +237,12 @@ export async function readCoreEntitiesFromSourceRegion({
       plans: generateParameterizedInsertStatements("plans", plans, {
         onConflict: "ignore",
       }),
-      users: generateParameterizedInsertStatements("users", users, {
+      users: generateParameterizedInsertStatements("users", usersForInsertion, {
         onConflict: "ignore",
       }),
       user_metadata: generateParameterizedInsertStatements(
         "user_metadata",
-        userMetadata,
+        userMetadataForInsertion,
         {
           onConflict: "ignore",
         }
@@ -162,7 +289,8 @@ export async function readFrontTableChunk({
   tableName,
   workspaceId,
   fileName,
-}: ReadTableChunkParams) {
+  userIdMappingPath,
+}: ReadTableChunkParams & { userIdMappingPath?: string | null }) {
   const localLogger = logger.child({
     destRegion,
     lastId,
@@ -197,11 +325,19 @@ export async function readFrontTableChunk({
     }
   );
 
+  const userIdMapping = await loadUserIdMapping(userIdMappingPath);
+  const normalizedRows =
+    userIdMapping.size > 0 ? mapUserIdsInRows(rows, userIdMapping) : rows;
+
   const blob: RelocationBlob = {
     statements: {
-      [tableName]: generateParameterizedInsertStatements(tableName, rows, {
-        onConflict: "ignore",
-      }),
+      [tableName]: generateParameterizedInsertStatements(
+        tableName,
+        normalizedRows,
+        {
+          onConflict: "ignore",
+        }
+      ),
     },
   };
 

--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -25,6 +25,7 @@ export interface ReadTableChunkParams {
   tableName: string;
   workspaceId: string;
   fileName?: string;
+  userIdMappingPath?: string | null;
 }
 
 export const CORE_API_CONCURRENCY_LIMIT = 48;

--- a/front/temporal/relocation/lib/sql/user_mappings.ts
+++ b/front/temporal/relocation/lib/sql/user_mappings.ts
@@ -1,0 +1,51 @@
+import type { ModelId } from "@app/types";
+
+export const USER_ID_COLUMN_NAMES = [
+  "authorId",
+  "editedByUserId",
+  "editor",
+  "invitedUserId",
+  "sharedBy",
+  "userId",
+] as const;
+
+export type UserIdMapping = Map<ModelId, ModelId>;
+
+export function mapUserIdsInRow<T extends Record<string, any>>(
+  row: T,
+  userIdMapping: UserIdMapping
+): T {
+  let updatedRow: T | null = null;
+
+  for (const column of USER_ID_COLUMN_NAMES) {
+    if (!(column in row)) {
+      continue;
+    }
+
+    const currentValue = row[column];
+    if (currentValue === null || currentValue === undefined) {
+      continue;
+    }
+
+    const mappedValue = userIdMapping.get(currentValue as ModelId);
+    if (mappedValue !== undefined) {
+      if (!updatedRow) {
+        updatedRow = { ...row };
+      }
+      (updatedRow as Record<string, any>)[column] = mappedValue;
+    }
+  }
+
+  return updatedRow ?? row;
+}
+
+export function mapUserIdsInRows<RowType extends Record<string, any>>(
+  rows: RowType[],
+  userIdMapping: UserIdMapping
+): RowType[] {
+  if (userIdMapping.size === 0) {
+    return rows;
+  }
+
+  return rows.map((row) => mapUserIdsInRow(row, userIdMapping));
+}

--- a/front/temporal/relocation/lib/sql/user_mappings.ts
+++ b/front/temporal/relocation/lib/sql/user_mappings.ts
@@ -1,4 +1,4 @@
-import type { ModelId } from "@app/types";
+import type { ModelId } from "@app/types/shared/model_id";
 
 export const USER_ID_COLUMN_NAMES = [
   "authorId",
@@ -29,9 +29,7 @@ export function mapUserIdsInRow(
 
     const mappedValue = userIdMapping.get(currentValue);
     if (mappedValue !== undefined) {
-      if (!updatedRow) {
-        updatedRow = { ...row };
-      }
+      updatedRow ??= { ...row };
       updatedRow[column] = mappedValue;
     }
   }

--- a/front/temporal/relocation/lib/sql/user_mappings.ts
+++ b/front/temporal/relocation/lib/sql/user_mappings.ts
@@ -11,11 +11,11 @@ export const USER_ID_COLUMN_NAMES = [
 
 export type UserIdMapping = Map<ModelId, ModelId>;
 
-export function mapUserIdsInRow<T extends Record<string, any>>(
-  row: T,
+export function mapUserIdsInRow(
+  row: Record<string, any>,
   userIdMapping: UserIdMapping
-): T {
-  let updatedRow: T | null = null;
+): Record<string, any> {
+  let updatedRow: Record<string, any> | null = null;
 
   for (const column of USER_ID_COLUMN_NAMES) {
     if (!(column in row)) {
@@ -27,22 +27,22 @@ export function mapUserIdsInRow<T extends Record<string, any>>(
       continue;
     }
 
-    const mappedValue = userIdMapping.get(currentValue as ModelId);
+    const mappedValue = userIdMapping.get(currentValue);
     if (mappedValue !== undefined) {
       if (!updatedRow) {
         updatedRow = { ...row };
       }
-      (updatedRow as Record<string, any>)[column] = mappedValue;
+      updatedRow[column] = mappedValue;
     }
   }
 
   return updatedRow ?? row;
 }
 
-export function mapUserIdsInRows<RowType extends Record<string, any>>(
-  rows: RowType[],
+export function mapUserIdsInRows(
+  rows: Record<string, any>[],
   userIdMapping: UserIdMapping
-): RowType[] {
+): Record<string, any>[] {
   if (userIdMapping.size === 0) {
     return rows;
   }


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/4962

## Description

Add 2 activities : 
- in the source region, read all id/workos user id and store in a file
- in destination region, check for existing users matching workOSUserId, then create and store mapping file

Update the core activity inserting users and users metadata . in readFrontTableChunk , read the mapping and update before generating the sql statements

## Tests

to be tested

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

