### PR TITLE
[front] enh(obs): update AB preview empty state

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,5 +1,5 @@
 import { Spinner, TestTubeIcon } from "@dust-tt/sparkle";
-import React, { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,5 +1,5 @@
-import { Spinner } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useRef } from "react";
+import { Spinner, TestTubeIcon } from "@dust-tt/sparkle";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -8,6 +8,8 @@ import {
   useDraftConversation,
 } from "@app/components/agent_builder/hooks/useAgentPreview";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
+import { EmptyPlaceholder } from "@app/components/agent_builder/observability/shared/EmptyPlaceholder";
+import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
@@ -240,10 +242,13 @@ export function AgentBuilderPreview() {
   const renderContent = () => {
     if (!hasContent) {
       return (
-        <EmptyState
-          message="Ready to test your agent?"
-          description="Add some instructions or actions to your agent to start testing it here."
-        />
+        <TabContentLayout title="Preview">
+          <EmptyPlaceholder
+            icon={TestTubeIcon}
+            title="Ready to test your agent?"
+            description="Add some instructions or actions to your agent to start testing it here."
+          />
+        </TabContentLayout>
       );
     }
 


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/17771.
- This PR aligns the design for the Preview tab in Agent builder when empty with the Insights and Feedback tabs.
- No Figma for this one, but followed the same pattern (same icon as the tab, same copy as before).

<img width="739" height="741" alt="Screenshot 2025-11-10 at 4 31 11 PM" src="https://github.com/user-attachments/assets/8cdef6ce-b3b2-49df-a230-91def92dbceb" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
