### PR TITLE
More posthog tracking

### DIFF
--- a/front/components/actions/mcp/AddToolsMenu.tsx
+++ b/front/components/actions/mcp/AddToolsMenu.tsx
@@ -123,7 +123,13 @@ export const AddToolsMenu = ({
                     createInternalMCPServer(mcpServer);
                   }
                 },
-                { tool_name: mcpServer.name, tool_id: mcpServer.sId }
+                {
+                  tool_name: mcpServer.name,
+                  tool_id: mcpServer.sId,
+                  tool_type: getDefaultRemoteMCPServerByName(mcpServer.name)
+                    ? "remote"
+                    : "internal",
+                }
               )}
             />
           ))}

--- a/front/components/actions/mcp/AddToolsMenu.tsx
+++ b/front/components/actions/mcp/AddToolsMenu.tsx
@@ -123,7 +123,7 @@ export const AddToolsMenu = ({
                     createInternalMCPServer(mcpServer);
                   }
                 },
-                { tool_name: mcpServer.name }
+                { tool_name: mcpServer.name, tool_id: mcpServer.sId }
               )}
             />
           ))}

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -543,6 +543,11 @@ export async function submitAgentBuilderForm({
           agent_id: agentConfiguration.sId,
           scope: formData.agentSettings.scope,
           has_actions: processedActions.length > 0,
+          action_count: processedActions.length,
+          action_names: processedActions.map((a) => a.name).join(","),
+          has_instructions: !!formData.instructions,
+          model_id: formData.generationSettings.modelSettings.modelId,
+          model_provider: formData.generationSettings.modelSettings.providerId,
         },
       });
     }

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -540,6 +540,7 @@ export async function submitAgentBuilderForm({
         object: "create_agent",
         action: TRACKING_ACTIONS.SUBMIT,
         extra: {
+          agent_id: agentConfiguration.sId,
           scope: formData.agentSettings.scope,
           has_actions: processedActions.length > 0,
         },

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -149,8 +149,26 @@ export function ToolsPicker({
                     filteredServerViews[0].sId
                   );
                   if (isSelected) {
+                    trackEvent({
+                      area: TRACKING_AREAS.TOOLS,
+                      object: "tool_deselect",
+                      action: TRACKING_ACTIONS.SELECT,
+                      extra: {
+                        tool_id: filteredServerViews[0].sId,
+                        tool_name: filteredServerViews[0].server.name,
+                      },
+                    });
                     onDeselect(filteredServerViews[0]);
                   } else {
+                    trackEvent({
+                      area: TRACKING_AREAS.TOOLS,
+                      object: "tool_select",
+                      action: TRACKING_ACTIONS.SELECT,
+                      extra: {
+                        tool_id: filteredServerViews[0].sId,
+                        tool_name: filteredServerViews[0].server.name,
+                      },
+                    });
                     onSelect(filteredServerViews[0]);
                   }
                   setSearchText("");

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -177,6 +177,15 @@ export function ToolsPicker({
                     onClick={(e) => {
                       e.stopPropagation();
                       e.preventDefault();
+                      trackEvent({
+                        area: TRACKING_AREAS.TOOLS,
+                        object: "tool_select",
+                        action: TRACKING_ACTIONS.SELECT,
+                        extra: {
+                          tool_id: v.sId,
+                          tool_name: v.server.name,
+                        },
+                      });
                       onSelect(v);
                       setIsOpen(false);
                     }}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -204,7 +204,7 @@ export const InputBar = React.memo(function InputBar({
       object: "message_send",
       action: "submit",
       extra: {
-        conversation_id: conversationId || "new",
+        conversation_id: conversationId ?? "new",
         has_attachments: attachedNodes.length > 0 || uploadedFiles.length > 0,
         has_tools: selectedMCPServerViews.length > 0,
         has_agents: mentionedAgents.length > 0,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -204,6 +204,13 @@ export const InputBar = React.memo(function InputBar({
       object: "message_send",
       action: "submit",
       extra: {
+        ...(conversationId ? { conversation_id: conversationId } : {}),
+        ...(mentionedAgents.length > 0
+          ? { agent_ids: mentionedAgents.map((a) => a.sId).join(",") }
+          : {}),
+        ...(selectedMCPServerViews.length > 0
+          ? { tool_ids: selectedMCPServerViews.map((sv) => sv.sId).join(",") }
+          : {}),
         has_attachments: attachedNodes.length > 0 || uploadedFiles.length > 0,
         has_tools: selectedMCPServerViews.length > 0,
         has_agents: mentionedAgents.length > 0,

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -204,13 +204,7 @@ export const InputBar = React.memo(function InputBar({
       object: "message_send",
       action: "submit",
       extra: {
-        ...(conversationId ? { conversation_id: conversationId } : {}),
-        ...(mentionedAgents.length > 0
-          ? { agent_ids: mentionedAgents.map((a) => a.sId).join(",") }
-          : {}),
-        ...(selectedMCPServerViews.length > 0
-          ? { tool_ids: selectedMCPServerViews.map((sv) => sv.sId).join(",") }
-          : {}),
+        conversation_id: conversationId || "new",
         has_attachments: attachedNodes.length > 0 || uploadedFiles.length > 0,
         has_tools: selectedMCPServerViews.length > 0,
         has_agents: mentionedAgents.length > 0,
@@ -218,8 +212,11 @@ export const InputBar = React.memo(function InputBar({
         has_custom_agent: mentionedAgents.some((a) => !isGlobalAgentId(a.sId)),
         is_new_conversation: !conversationId,
         agent_count: mentions.length,
+        agent_ids: mentionedAgents.map((a) => a.sId).join(","),
         attachment_count: attachedNodes.length + uploadedFiles.length,
         tool_count: selectedMCPServerViews.length,
+        tool_names: selectedMCPServerViews.map((t) => t.server.name).join(","),
+        message_length: markdown.length,
       },
     });
 

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -29,7 +29,12 @@ import {
 } from "@app/lib/connector_providers";
 import { useSystemSpace } from "@app/lib/swr/spaces";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import { trackEvent, TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  withTracking,
+} from "@app/lib/tracking";
 import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type {
   ConnectorProvider,
@@ -249,6 +254,15 @@ export const AddConnectionMenu = ({
           dataSource: DataSourceType;
           connector: ConnectorType;
         } = await res.json();
+        trackEvent({
+          area: TRACKING_AREAS.DATA_SOURCES,
+          object: "connection",
+          action: TRACKING_ACTIONS.CREATE,
+          extra: {
+            provider,
+            data_source_id: createdManagedDataSource.dataSource.sId,
+          },
+        });
         onCreated(createdManagedDataSource.dataSource);
         // Track data source creation with ID
         trackEvent({

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -29,7 +29,7 @@ import {
 } from "@app/lib/connector_providers";
 import { useSystemSpace } from "@app/lib/swr/spaces";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import { trackEvent, TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type {
   ConnectorProvider,
@@ -250,6 +250,16 @@ export const AddConnectionMenu = ({
           connector: ConnectorType;
         } = await res.json();
         onCreated(createdManagedDataSource.dataSource);
+        // Track data source creation with ID
+        trackEvent({
+          area: TRACKING_AREAS.DATA_SOURCES,
+          object: "create",
+          action: "success",
+          extra: {
+            data_source_id: createdManagedDataSource.dataSource.sId,
+            provider: provider,
+          },
+        });
       } else {
         const responseText = await res.text();
         sendNotification({

--- a/front/hooks/useYAMLUpload.ts
+++ b/front/hooks/useYAMLUpload.ts
@@ -2,6 +2,11 @@ import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+} from "@app/lib/tracking";
 import logger from "@app/logger/logger";
 import type { LightWorkspaceType } from "@app/types";
 import { normalizeError } from "@app/types";
@@ -65,6 +70,19 @@ export function useYAMLUpload({ owner }: UseYAMLUploadOptions) {
       }
 
       const result = await response.json();
+
+      trackEvent({
+        area: TRACKING_AREAS.BUILDER,
+        object: "create_agent",
+        action: TRACKING_ACTIONS.SUBMIT,
+        extra: {
+          agent_id: result.agentConfiguration.sId,
+          source: "yaml_upload",
+          scope: result.agentConfiguration.scope,
+          has_skipped_actions: result.skippedActions?.length > 0,
+        },
+      });
+
       if (result.skippedActions && result.skippedActions.length > 0) {
         sendNotification({
           title: "Agent created with warnings",


### PR DESCRIPTION





## Description

Adds IDs to existing PostHog tracking events to enable better analytics and data correlation. This follows up on previous tracking improvements by including entity identifiers (`tool_id`, `agent_id`, `conversation_id`, `data_source_id`) alongside the existing event metadata, allowing us to track specific entities through the funnel and correlate events across different areas of the application.

## Risk

Low risk. Only enriches existing tracking events with additional metadata without changing application behavior or adding new tracking points.

## Tests

Manual verification that events are properly tracked with the new ID fields in PostHog.

## Deploy Plan
