### PR TITLE
Refactor types to avoid confusion.

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -24,14 +24,14 @@ import { removeNulls } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   AgentContentItemType,
-  ErrorContentType,
+  AgentErrorContentType,
 } from "@app/types/assistant/agent_message_content";
 
 /**
  * Type for a step in agent message processing
  */
 export type Step = {
-  contents: Exclude<AgentContentItemType, ErrorContentType>[];
+  contents: Exclude<AgentContentItemType, AgentErrorContentType>[];
   actions: {
     call: FunctionCallType;
     result: FunctionMessageTypeModel;

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -24,7 +24,7 @@ import {
   isContentFragmentType,
   isUserMessageType,
 } from "@app/types";
-import type { TextContentType } from "@app/types/assistant/agent_message_content";
+import type { AgentTextContentType } from "@app/types/assistant/agent_message_content";
 
 /**
  * Renders agent message steps into model messages
@@ -44,7 +44,7 @@ export function renderAgentSteps(
     );
     if (stepsWithContent.length) {
       const lastStepWithContent = stepsWithContent[stepsWithContent.length - 1];
-      const textContents: TextContentType[] = [];
+      const textContents: AgentTextContentType[] = [];
       for (const content of lastStepWithContent.contents) {
         if (content.type === "text_content") {
           textContents.push(content);
@@ -72,7 +72,7 @@ export function renderAgentSteps(
         );
         continue;
       }
-      const textContents: TextContentType[] = [];
+      const textContents: AgentTextContentType[] = [];
       for (const content of step.contents) {
         if (content.type === "text_content") {
           textContents.push(content);

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -39,13 +39,13 @@ import { ConversationError, Err, Ok, removeNulls } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   AgentContentItemType,
-  ReasoningContentType,
-  TextContentType,
+  AgentReasoningContentType,
+  AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
 import {
-  isFunctionCallContent,
-  isReasoningContent,
-  isTextContent,
+  isAgentFunctionCallContent,
+  isAgentReasoningContent,
+  isAgentTextContent,
 } from "@app/types/assistant/agent_message_content";
 import type { ParsedContentItem } from "@app/types/assistant/conversation";
 
@@ -79,7 +79,7 @@ export async function generateParsedContents(
       parsedContents[step] = [];
     }
 
-    if (isReasoningContent(c.content)) {
+    if (isAgentReasoningContent(c.content)) {
       const reasoning = c.content.value.reasoning;
       if (reasoning && reasoning.trim()) {
         parsedContents[step].push({ kind: "reasoning", content: reasoning });
@@ -87,7 +87,7 @@ export async function generateParsedContents(
       continue;
     }
 
-    if (isTextContent(c.content)) {
+    if (isAgentTextContent(c.content)) {
       const contentParser = new AgentMessageContentParser(
         agentConfiguration,
         messageId,
@@ -106,7 +106,7 @@ export async function generateParsedContents(
       continue;
     }
 
-    if (isFunctionCallContent(c.content)) {
+    if (isAgentFunctionCallContent(c.content)) {
       const functionCallId = c.content.value.id;
       const matchingAction = actionsByCallId.get(functionCallId);
 
@@ -348,8 +348,10 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         agentStepContents
       );
 
-      const textContents: Array<{ step: number; content: TextContentType }> =
-        [];
+      const textContents: Array<{
+        step: number;
+        content: AgentTextContentType;
+      }> = [];
       for (const content of agentStepContents) {
         if (content.content.type === "text_content") {
           textContents.push({ step: content.step, content: content.content });
@@ -358,7 +360,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
 
       const reasoningContents: Array<{
         step: number;
-        content: ReasoningContentType;
+        content: AgentReasoningContentType;
       }> = [];
       for (const content of agentStepContents) {
         if (content.content.type === "reasoning") {

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -22,9 +22,9 @@ import type {
 } from "@app/types";
 import { assertNever, isString } from "@app/types";
 import type {
-  FunctionCallContentType,
-  ReasoningContentType,
-  TextContentType,
+  AgentFunctionCallContentType,
+  AgentReasoningContentType,
+  AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
 
 function userContentToParam(
@@ -48,7 +48,10 @@ function userContentToParam(
 }
 
 function assistantContentToParam(
-  content: TextContentType | ReasoningContentType | FunctionCallContentType
+  content:
+    | AgentTextContentType
+    | AgentReasoningContentType
+    | AgentFunctionCallContentType
 ): TextBlockParam | ImageBlockParam | ThinkingBlockParam | ToolUseBlockParam {
   switch (content.type) {
     case "text_content":

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -15,9 +15,9 @@ import type {
 } from "@app/types";
 import { assertNever } from "@app/types";
 import type {
-  FunctionCallContentType,
-  ReasoningContentType,
-  TextContentType,
+  AgentFunctionCallContentType,
+  AgentReasoningContentType,
+  AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 
@@ -109,7 +109,10 @@ async function functionMessageToResponses(
 }
 
 function assistantContentToPart(
-  content: ReasoningContentType | TextContentType | FunctionCallContentType
+  content:
+    | AgentReasoningContentType
+    | AgentTextContentType
+    | AgentFunctionCallContentType
 ): Part {
   switch (content.type) {
     case "reasoning":

--- a/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
+++ b/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
@@ -15,13 +15,13 @@ import type {
 } from "@app/types";
 import { assertNever } from "@app/types";
 import type {
-  FunctionCallContentType,
-  ReasoningContentType,
-  TextContentType,
+  AgentFunctionCallContentType,
+  AgentReasoningContentType,
+  AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
 
 function toContentChunk(
-  content: Content | TextContentType | ReasoningContentType
+  content: Content | AgentTextContentType | AgentReasoningContentType
 ): ContentChunk {
   switch (content.type) {
     case "text":
@@ -57,12 +57,14 @@ function toAssistantMessage(
 
   const textContents = message.contents
     .filter(
-      (c): c is TextContentType | ReasoningContentType =>
+      (c): c is AgentTextContentType | AgentReasoningContentType =>
         c.type !== "function_call"
     )
     .map(toContentChunk);
   const toolCalls = message.contents
-    .filter((c): c is FunctionCallContentType => c.type === "function_call")
+    .filter(
+      (c): c is AgentFunctionCallContentType => c.type === "function_call"
+    )
     .map((fc) => ({
       id: fc.value.id,
       function: {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -45,7 +45,7 @@ import type {
   AgentMCPActionType,
   AgentMCPActionWithOutputType,
 } from "@app/types/actions";
-import type { FunctionCallContentType } from "@app/types/assistant/agent_message_content";
+import type { AgentFunctionCallContentType } from "@app/types/assistant/agent_message_content";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -62,7 +62,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     model: ModelStaticWorkspaceAware<AgentMCPActionModel>,
     blob: Attributes<AgentMCPActionModel>,
     readonly stepContent: NonAttribute<
-      AgentStepContentResource & { value: FunctionCallContentType }
+      AgentStepContentResource & { value: AgentFunctionCallContentType }
     >,
     readonly metadata: {
       internalMCPServerName: InternalMCPServerNameType | null;

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -27,10 +27,10 @@ import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType, ModelId, Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 import type {
+  AgentFunctionCallContentType,
   AgentStepContentType,
-  FunctionCallContentType,
 } from "@app/types/assistant/agent_message_content";
-import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
+import { isAgentFunctionCallContent } from "@app/types/assistant/agent_message_content";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -308,9 +308,9 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
   }
 
   isFunctionCallContent(): this is AgentStepContentResource & {
-    value: FunctionCallContentType;
+    value: AgentFunctionCallContentType;
   } {
-    return isFunctionCallContent(this.value);
+    return isAgentFunctionCallContent(this.value);
   }
 
   async delete(

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -13,7 +13,7 @@ import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_t
 import { runModelActivity } from "@app/temporal/agent_loop/lib/run_model";
 import type { ModelId } from "@app/types";
 import { MAX_ACTIONS_PER_STEP } from "@app/types/assistant/agent";
-import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
+import { isAgentFunctionCallContent } from "@app/types/assistant/agent_message_content";
 import type {
   AgentLoopArgsWithTiming,
   AgentLoopExecutionData,
@@ -171,7 +171,7 @@ async function getExistingActionsAndBlobs(
       const [mcpAction] = stepContent.agentMCPActions;
 
       assert(
-        isFunctionCallContent(stepContent.value),
+        isAgentFunctionCallContent(stepContent.value),
         "Unexpected: step content is not a function call"
       );
 

--- a/front/temporal/agent_loop/lib/get_output_from_action.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_action.ts
@@ -14,7 +14,7 @@ import type {
   Output,
 } from "@app/temporal/agent_loop/lib/types";
 import { Err, Ok, safeParseJSON } from "@app/types";
-import type { ReasoningContentType } from "@app/types/assistant/agent_message_content";
+import type { AgentReasoningContentType } from "@app/types/assistant/agent_message_content";
 
 export async function getOutputFromAction(
   auth: Authenticator,
@@ -196,7 +196,7 @@ export async function getOutputFromAction(
                 provider: model.providerId,
                 region,
               },
-            } satisfies ReasoningContentType;
+            } satisfies AgentReasoningContentType;
           }
           return content;
         });

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -12,9 +12,9 @@ import type {
   UserMessageType,
 } from "@app/types";
 import type {
-  FunctionCallContentType,
-  ReasoningContentType,
-  TextContentType,
+  AgentFunctionCallContentType,
+  AgentReasoningContentType,
+  AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
 
 export type Output = {
@@ -24,7 +24,9 @@ export type Output = {
   }>;
   generation: string | null;
   contents: Array<
-    TextContentType | FunctionCallContentType | ReasoningContentType
+    | AgentTextContentType
+    | AgentFunctionCallContentType
+    | AgentReasoningContentType
   >;
 };
 

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -9,9 +9,9 @@ import type {
 } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
-  FunctionCallContentType,
-  ReasoningContentType,
-  TextContentType,
+  AgentFunctionCallContentType,
+  AgentReasoningContentType,
+  AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import { isOAuthProvider, isValidScope } from "@app/types/oauth/lib";
@@ -389,5 +389,8 @@ export type AgentStepContentEvent = {
   configurationId: string;
   messageId: string;
   index: number;
-  content: TextContentType | FunctionCallContentType | ReasoningContentType;
+  content:
+    | AgentTextContentType
+    | AgentFunctionCallContentType
+    | AgentReasoningContentType;
 };

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -1,12 +1,12 @@
 import type { ModelId, ModelProviderIdType } from "@app/types";
 import type { FunctionCallType } from "@app/types/assistant/generation";
 
-export type TextContentType = {
+export type AgentTextContentType = {
   type: "text_content";
   value: string;
 };
 
-export type ReasoningContentType = {
+export type AgentReasoningContentType = {
   type: "reasoning";
   value: {
     reasoning?: string;
@@ -17,12 +17,12 @@ export type ReasoningContentType = {
   };
 };
 
-export type FunctionCallContentType = {
+export type AgentFunctionCallContentType = {
   type: "function_call";
   value: FunctionCallType;
 };
 
-export type ErrorContentType = {
+export type AgentErrorContentType = {
   type: "error";
   value: {
     code: string;
@@ -32,32 +32,32 @@ export type ErrorContentType = {
 };
 
 export type AgentContentItemType =
-  | TextContentType
-  | ReasoningContentType
-  | FunctionCallContentType
-  | ErrorContentType;
+  | AgentTextContentType
+  | AgentReasoningContentType
+  | AgentFunctionCallContentType
+  | AgentErrorContentType;
 
-export function isTextContent(
+export function isAgentTextContent(
   content: AgentContentItemType
-): content is TextContentType {
+): content is AgentTextContentType {
   return content.type === "text_content";
 }
 
-export function isReasoningContent(
+export function isAgentReasoningContent(
   content: AgentContentItemType
-): content is ReasoningContentType {
+): content is AgentReasoningContentType {
   return content.type === "reasoning";
 }
 
-export function isFunctionCallContent(
+export function isAgentFunctionCallContent(
   content: AgentContentItemType
-): content is FunctionCallContentType {
+): content is AgentFunctionCallContentType {
   return content.type === "function_call";
 }
 
-export function isErrorContent(
+export function isAgentErrorContent(
   content: AgentContentItemType
-): content is ErrorContentType {
+): content is AgentErrorContentType {
   return content.type === "error";
 }
 

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -1,6 +1,6 @@
 import type {
   AgentContentItemType,
-  ErrorContentType,
+  AgentErrorContentType,
 } from "@app/types/assistant/agent_message_content";
 
 /**
@@ -65,7 +65,7 @@ export interface AssistantFunctionCallMessageTypeModel {
   content?: string;
   /** @deprecated, use contents instead. */
   function_calls: FunctionCallType[];
-  contents: Array<Exclude<AgentContentItemType, ErrorContentType>>;
+  contents: Array<Exclude<AgentContentItemType, AgentErrorContentType>>;
 }
 
 export interface AssistantContentMessageTypeModel {
@@ -73,7 +73,7 @@ export interface AssistantContentMessageTypeModel {
   name: string;
   /** @deprecated, use contents instead. */
   content?: string;
-  contents: Array<Exclude<AgentContentItemType, ErrorContentType>>;
+  contents: Array<Exclude<AgentContentItemType, AgentErrorContentType>>;
 }
 
 // This is the output of one function call

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -71,6 +71,12 @@ procs:
     shell: "source ~/.nvm/nvm.sh && nvm install && npm install && npm run dev:chrome"
     autostart: false
 
+  ngrok:
+    # Doc: https://www.notion.so/dust-tt/Runbook-Local-Setup-Slack-2ad003fc529d4144bb0ee61b7fd797c9?source=copy_link#2a728599d941807fb71dccb4addc0234
+    shell: "ngrok start localhost-via-https"
+    autostart: false
+
   novu:
+    # Doc: https://docs.novu.co/framework/studio
     shell: "npx novu@latest dev --port 3000"
     autostart: false


### PR DESCRIPTION
## Description

Small refactor to prefix all agent's content types with "Agent" to avoid confusion (isTextContent existed in 2 versions, one for agent, one for attachment).

## Tests

Green

## Risk

Low

## Deploy Plan

Deploy front