### PR TITLE
Remove todo: we don't want to improve the metadata from string to object

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -57,7 +57,6 @@ function assistantContentToParam(
         text: content.value,
       };
     case "reasoning":
-      // TODO(LLM-Router): better typing for signature extraction
       assert(content.value.reasoning, "Reasoning content is missing reasoning");
       const signature = extractEncryptedContentFromMetadata(
         content.value.metadata


### PR DESCRIPTION
## Description

Original PR trying to use an object is here: https://github.com/dust-tt/dust/pull/17768

This broke 2 things:
 - the content of the DB changed to object
 - the content send to dust apps was an object too

To implement this correctly we would need a full hybrid mode where we can handle both strings and objects to support legacy. I think it is worse than keeping the string metadata and parsing it, at least we know we have a string in DB.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

no

## Deploy Plan

deploy front
