### PR TITLE
chore: phase out dust app to find agents and tools from voice

### DIFF
--- a/front/lib/api/assistant/voice_agent_finder.ts
+++ b/front/lib/api/assistant/voice_agent_finder.ts
@@ -1,0 +1,190 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types";
+import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
+
+const FIND_AGENTS_AND_TOOLS_FUNCTION_NAME = "find_agents_and_tools";
+
+const VoiceAgentFinderResponseSchema = t.type({
+  augmented_message: t.array(
+    t.union([
+      t.type({
+        type: t.literal("text"),
+        text: t.string,
+      }),
+      t.type({
+        type: t.literal("mention"),
+        name: t.string,
+      }),
+    ])
+  ),
+});
+
+const specifications = [
+  {
+    name: FIND_AGENTS_AND_TOOLS_FUNCTION_NAME,
+    description: "Find agents and tools in a message",
+    inputSchema: {
+      type: "object",
+      properties: {
+        augmented_message: {
+          type: "array",
+          description:
+            "A list of messages. Either text or mentions (for agents)",
+          items: {
+            type: "object",
+            properties: {
+              type: {
+                enum: ["text", "mention"],
+              },
+              id: {
+                type: "number",
+              },
+              name: {
+                type: "string",
+              },
+              text: {
+                type: "string",
+              },
+            },
+          },
+        },
+      },
+      required: ["augmented_message"],
+    },
+  },
+];
+
+const INSTRUCTIONS = `# Goal
+Your goal is to extract names of AI agents from the query. Think finding the "hey siri" or "ok google" from a text.
+The query is an output of a speech to text AI model. In this output we want to understand the intent of the users to call AI agents. We want you to call a function as a result.
+
+The list of possible agent names is: {{AGENTS_LIST}}
+
+## query
+The output of a speech to text AI model
+
+## function call
+Call the function \`find_agents_and_tools\`. It take only one parameter called \`augmented_message\`.
+\`augmented_message\` is an array of objects. Each element of the array are either:
+* text, format {"type":"text", "text":"$TEXT"}
+* mention, format {"type":"mention", "name":"$AGENT_NAME"}
+
+# Guidelines
+- Understand the intent of the user, as agents can be named as real life words
+- Ensure mentions are part of the agent list
+- As the output is from a speech to text model there can be some transcribing mistakes, make sure to take them into account
+- Put the mentions at the beginning of the array
+- An agent name can me multiple words in CamelCase, try to find them
+
+# Examples
+query: dust what time is it?
+agents_list: ["dust", "god", "soupinou"]
+function call: find_agents_and_tools with [{"type": "mention", "name": "dust"},{"type": "text", "text": "what time is it?"}]
+
+query: hey dost what time is it?
+agents_list: ["dust", "god", "soupinou"]
+function call: find_agents_and_tools with [{"type": "mention", "name": "dust"},{"type": "text", "text": "what time is it?"}]
+
+query: hey image what time is it?
+agents_list: ["dust", "god", "soupinou"]
+function call: find_agents_and_tools with [{"type": "text", "text": "hey image what time is it?"}]
+
+query: another one bites the dust
+agents_list: ["dust", "god", "soupinou"]
+function call: find_agents_and_tools with [{"type": "text", "text": "another one bites the dust"}]
+
+query: I want an image representing a bird
+agents_list: ["dust", "god", "soupinou"]
+function call: find_agents_and_tools with [{"type": "text", "text": "I want an image representing a bird"}]
+
+query: draft an email explaining to mickael the image of god he sent me is inappropriate
+agents_list: ["dust", "god", "soupinou"]
+function call: find_agents_and_tools with [{"type": "text", "text": "draft an email explaining to mickael the image of god he sent me is inappropriate"}]
+
+query: draft an email to mickael with dust and append an apology at the end
+agents_list: ["dust", "god", "soupinou"]
+function call: find_agents_and_tools with [{"type": "mention", "name": "dust"}, {"type": "text", "text": "draft an email to mickael"},{"type": "text", "text": "and append an apology at the end"}]
+
+query: I want to know more about the company culture god
+agents_list: ["dust", "god", "soupinou"]
+function call: find_agents_and_tools with [{"type": "mention", "name": "god"},{"type": "text", "text": "I want to know more about the company culture"}]
+
+query: Give me the time!
+agents_list: ["dust", "god", "soupinou", "GiveMeTheTime"]
+function call: find_agents_and_tools with [{"type": "mention", "name": "GiveMeTheTime"}]`;
+
+export type AugmentedMessageFromLLM =
+  | { type: "text"; text: string }
+  | { type: "mention"; name: string };
+
+export async function findAgentsInMessageGeneration(
+  auth: Authenticator,
+  inputs: { agentsList: string[]; message: string }
+): Promise<Result<{ augmentedMessages: AugmentedMessageFromLLM[] }, Error>> {
+  const model = getSmallWhitelistedModel(auth.getNonNullableWorkspace());
+  if (!model) {
+    return new Err(
+      new Error(
+        "Failed to find a whitelisted model to find agents and tools from voice"
+      )
+    );
+  }
+
+  const instructionsWithAgents = INSTRUCTIONS.replace(
+    "{{AGENTS_LIST}}",
+    JSON.stringify(inputs.agentsList)
+  );
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      functionCall: FIND_AGENTS_AND_TOOLS_FUNCTION_NAME,
+      modelId: model.modelId,
+      providerId: model.providerId,
+      temperature: 0.2,
+      useCache: false,
+    },
+    {
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            content: inputs.message.trim(),
+          },
+        ],
+      },
+      prompt: instructionsWithAgents,
+      specifications,
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  if (!res.value.actions?.[0].arguments) {
+    return new Ok({ augmentedMessages: [] });
+  }
+
+  const responseValidation = VoiceAgentFinderResponseSchema.decode(
+    res.value.actions[0].arguments
+  );
+
+  if (isLeft(responseValidation)) {
+    const pathError = reporter.formatValidationErrors(responseValidation.left);
+    return new Err(
+      new Error(
+        `Error retrieving augmented messages from arguments: ${pathError}`
+      )
+    );
+  }
+
+  return new Ok({
+    augmentedMessages: responseValidation.right.augmented_message,
+  });
+}

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -248,20 +248,6 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-  "voice-find-agent-and-tools": {
-    app: {
-      appId: "F15zoc9d8a",
-      appHash:
-        "ce806cd503d298c64ae97a8f786a60be62d81aa000fca02c363efec51356926f",
-    },
-    config: {
-      GET_AUGMENTED_MESSAGE: {
-        function_call: "find_agents_and_tools",
-        use_cache: false,
-        use_stream: true,
-      },
-    },
-  },
 };
 
 export type DustRegistryActionName = keyof typeof BaseDustProdActionRegistry;

--- a/front/lib/utils/find_agents_in_message.ts
+++ b/front/lib/utils/find_agents_in_message.ts
@@ -1,35 +1,20 @@
-import { runAction } from "@app/lib/actions/server";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import type { AugmentedMessageFromLLM } from "@app/lib/api/assistant/voice_agent_finder";
+import { findAgentsInMessageGeneration } from "@app/lib/api/assistant/voice_agent_finder";
 import type { Authenticator } from "@app/lib/auth";
-import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import logger from "@app/logger/logger";
-import {
-  assertNever,
-  getSmallWhitelistedModel,
-  GPT_4_1_MINI_MODEL_ID,
-  removeNulls,
-} from "@app/types";
+import { assertNever } from "@app/types";
 
-const _ACTION_NAME = "voice-find-agent-and-tools";
-
-export interface Mention {
-  type: "mention";
-  id: string;
-  name: string;
-}
-
-export interface Text {
-  type: "text";
-  text: string;
-}
-
-export type AugmentedMessage = Mention | Text;
-
-interface MentionFromLLM {
-  type: "mention";
-  name: string;
-}
-type AugmentedMessageFromLLM = MentionFromLLM | Text;
+export type AugmentedMessage =
+  | {
+      type: "mention";
+      id: string;
+      name: string;
+    }
+  | {
+      type: "text";
+      text: string;
+    };
 
 async function listAgents(auth: Authenticator) {
   const agents = await getAgentConfigurationsForView({
@@ -44,103 +29,28 @@ async function listAgents(auth: Authenticator) {
   }));
 }
 
-function getActionConfig(auth: Authenticator) {
-  const config = cloneBaseConfig(getDustProdAction(_ACTION_NAME).config);
-  const model = getSmallWhitelistedModel(auth.getNonNullableWorkspace());
-  config.GET_AUGMENTED_MESSAGE.provider_id = model?.providerId ?? "openai";
-  config.GET_AUGMENTED_MESSAGE.model_id =
-    model?.modelId ?? GPT_4_1_MINI_MODEL_ID;
-  return config;
-}
-
 export const findAgentsInMessage = async (
   auth: Authenticator,
   message: string
-) => {
+): Promise<AugmentedMessage[]> => {
   const agents = await listAgents(auth);
   const agentListForLLM = agents.map((a) => a.name);
-  const config = getActionConfig(auth);
 
-  const res = await runAction(auth, _ACTION_NAME, config, [
-    {
-      agents_list: agentListForLLM,
-      message,
-    },
-  ]);
+  const res = await findAgentsInMessageGeneration(auth, {
+    agentsList: agentListForLLM,
+    message,
+  });
 
   if (res.isErr()) {
-    logger.error(
-      `Action ${_ACTION_NAME} failed to process message: ${res.error.type} ${res.error.message}`
-    );
-    return [{ type: "message", text: message }];
+    logger.error(`Failed to find agents in message: ${res.error.message}`);
+    return [{ type: "text", text: message }];
   }
 
-  const {
-    status: { run },
-    traces,
-    results,
-  } = res.value;
-
-  switch (run) {
-    case "errored":
-      const error = removeNulls(traces.map((t) => t[1][0][0].error)).join(", ");
-      logger.error(
-        `Action ${_ACTION_NAME} failed to process message: ${error}`
-      );
-
-      return [{ type: "message", text: message }];
-    case "succeeded":
-      if (!results || results.length === 0) {
-        logger.error(
-          `Action ${_ACTION_NAME} failed to process message: no results returned while run was successful`
-        );
-        return [{ type: "message", text: message }];
-      }
-
-      logger.debug(
-        `Action ${_ACTION_NAME} output: ${JSON.stringify(results[0][0])}`
-      );
-
-      // as it's the output of a LLM we ensure we only keep valid augmented messages
-      const augmentedMessagesFromLLM = asAugmentedMessageFromLLMArray(
-        results[0][0]?.value
-      );
-      // then we transform the LLM output to something the frontend understands
-      return augmentedMessagesFromLLM.map((m) =>
-        messageFromLLMToAugmentedMessage(agents, m)
-      );
-
-    case "running":
-      logger.error(
-        `Action ${_ACTION_NAME} is still running, expected to be done`
-      );
-      return [{ type: "message", text: message }];
-    default:
-      assertNever(run);
-  }
+  // Transform the LLM output to something the frontend understands.
+  return res.value.augmentedMessages.map((m) =>
+    messageFromLLMToAugmentedMessage(agents, m)
+  );
 };
-
-function asAugmentedMessageFromLLMArray(
-  value: unknown
-): AugmentedMessageFromLLM[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter((item) => {
-    if (!item || typeof item !== "object") {
-      return false;
-    }
-
-    const obj = item as Record<string, unknown>;
-
-    if (obj.type === "mention" && typeof obj.name === "string") {
-      return true;
-    }
-
-    return obj.type === "text" && typeof obj.text === "string";
-  });
-}
 
 const messageFromLLMToAugmentedMessage = (
   agentLists: { id: string; name: string }[],


### PR DESCRIPTION



## Description

Phases out the `voice-find-agent-and-tools` Dust app and replaces it with direct LLM calls using `runMultiActionsAgent`.

The `findAgentsInMessage` utility function is refactored to use the new `findAgentsInMessageGeneration` function, simplifying the implementation by removing the old Dust app action handling logic. The voice agent finder app entry is removed from the registry. 

This follows the same pattern established in previous PRs that phased out other builder apps (names, descriptions, tags, emoji, instructions, cron-timezone, webhook-filter, tag-manager).

[Dust app reference](https://dust.tt/w/78bda07b39/spaces/vlt_rICtlrSEpWqX/apps/F15zoc9d8a)

## Risk

Low

## Tests

Tested locally

## Deploy Plan

Deploy Front.
