### PR TITLE
[connector] feat: Add notion node deletion crawler

### DIFF
--- a/connectors/src/api/webhooks/webhook_notion.ts
+++ b/connectors/src/api/webhooks/webhook_notion.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 
 import { launchNotionWebhookProcessingWorkflow } from "@connectors/connectors/notion/temporal/client";
+import type { NotionWebhookEvent } from "@connectors/connectors/notion/temporal/signals";
 import { NotionConnectorState } from "@connectors/lib/models/notion";
 import mainLogger from "@connectors/logger/logger";
 import { withLogging } from "@connectors/logger/withlogging";
@@ -18,7 +19,7 @@ type NotionWebhookVerification = {
 
 type NotionWebhookEventPayload = {
   workspace_id: string;
-  type: string;
+  type: NotionWebhookEvent["type"];
   entity?: {
     id: string;
     [key: string]: unknown;

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -168,7 +168,22 @@ export async function deleteNotionUrl({
     },
   });
   if (page) {
-    await sendDeletionCrawlSignal(connector.id, page.notionPageId, "page");
+    const result = await sendDeletionCrawlSignal(
+      connector.id,
+      page.notionPageId,
+      "page"
+    );
+    if (result.isErr()) {
+      mainLogger.error(
+        {
+          error: result.error,
+          connectorId: connector.id,
+          pageId: page.notionPageId,
+        },
+        "Failed to send deletion crawl signal for page"
+      );
+      throw result.error;
+    }
   }
 
   const db = await NotionDatabase.findOne({
@@ -179,11 +194,22 @@ export async function deleteNotionUrl({
   });
 
   if (db) {
-    await sendDeletionCrawlSignal(
+    const result = await sendDeletionCrawlSignal(
       connector.id,
       db.notionDatabaseId,
       "database"
     );
+    if (result.isErr()) {
+      mainLogger.error(
+        {
+          error: result.error,
+          connectorId: connector.id,
+          databaseId: db.notionDatabaseId,
+        },
+        "Failed to send deletion crawl signal for database"
+      );
+      throw result.error;
+    }
   }
 
   return { deletedPage: !!page, deletedDb: !!db };

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1076,7 +1076,21 @@ export async function deletePageOrDatabaseIfArchived({
   if (!resourceIsAccessible) {
     // Send signal to deletion crawl workflow
     // The deletion crawl workflow will handle the actual deletion after checking parent/children
-    await sendDeletionCrawlSignal(connectorId, objectId, objectType);
+    const result = await sendDeletionCrawlSignal(
+      connectorId,
+      objectId,
+      objectType
+    );
+    if (result.isErr()) {
+      localLogger.error(
+        {
+          objectType,
+          error: result.error,
+        },
+        `Failed to send deletion crawl signal (archived/inaccessible)`
+      );
+      throw result.error;
+    }
     localLogger.info(
       {
         objectType,
@@ -3551,7 +3565,23 @@ export async function processWebhookEventActivity({
       },
       "Page deleted/archived, triggering deletion crawl"
     );
-    await sendDeletionCrawlSignal(connectorId, event.entity_id, "page");
+    const result = await sendDeletionCrawlSignal(
+      connectorId,
+      event.entity_id,
+      "page"
+    );
+    if (result.isErr()) {
+      logger.error(
+        {
+          ...loggerArgs,
+          eventType: event.type,
+          entityId: event.entity_id,
+          error: result.error,
+        },
+        "Failed to send deletion crawl signal for page"
+      );
+      throw result.error;
+    }
   } else if (event.type === "database.deleted") {
     logger.info(
       {
@@ -3561,7 +3591,23 @@ export async function processWebhookEventActivity({
       },
       "Database deleted/archived, triggering deletion crawl"
     );
-    await sendDeletionCrawlSignal(connectorId, event.entity_id, "database");
+    const result = await sendDeletionCrawlSignal(
+      connectorId,
+      event.entity_id,
+      "database"
+    );
+    if (result.isErr()) {
+      logger.error(
+        {
+          ...loggerArgs,
+          eventType: event.type,
+          entityId: event.entity_id,
+          error: result.error,
+        },
+        "Failed to send deletion crawl signal for database"
+      );
+      throw result.error;
+    }
   }
 }
 

--- a/connectors/src/connectors/notion/temporal/signals.ts
+++ b/connectors/src/connectors/notion/temporal/signals.ts
@@ -1,4 +1,7 @@
 import { defineSignal } from "@temporalio/workflow";
+import { z } from "zod";
+
+import logger from "@connectors/logger/logger";
 
 export type NotionWebhookEvent = {
   type: "database.deleted" | "page.deleted";
@@ -17,3 +20,44 @@ export type NotionDeletionCrawlSignal = {
 export const notionDeletionCrawlSignal = defineSignal<
   [NotionDeletionCrawlSignal]
 >("notion_deletion_crawl_signal");
+
+/**
+ * Zod schema for validating deletion crawl signal arguments
+ * Validates connectorId, resourceId, and resourceType together
+ */
+export const DeletionCrawlSignalArgsSchema = z.object({
+  connectorId: z
+    .number()
+    .int("Connector ID must be an integer")
+    .positive("Connector ID must be positive"),
+  resourceId: z.string().min(1, "Resource ID cannot be empty").trim(),
+  resourceType: z.enum(["page", "database"], {
+    errorMap: () => ({ message: "Resource type must be 'page' or 'database'" }),
+  }),
+});
+
+/**
+ * Type definition for deletion crawl signal arguments (inferred from schema)
+ */
+export type DeletionCrawlSignalArgs = z.infer<
+  typeof DeletionCrawlSignalArgsSchema
+>;
+
+/**
+ * Validates deletion crawl signal arguments using Zod schema
+ * @param args - The arguments to validate
+ * @returns Validated arguments or null if validation fails
+ */
+export function validateDeletionCrawlSignalArgs(
+  args: unknown
+): DeletionCrawlSignalArgs | null {
+  const result = DeletionCrawlSignalArgsSchema.safeParse(args);
+  if (!result.success) {
+    logger.warn(
+      { error: result.error.flatten(), receivedArgs: args },
+      "Invalid deletion crawl signal arguments"
+    );
+    return null;
+  }
+  return result.data;
+}

--- a/connectors/src/connectors/notion/temporal/signals.ts
+++ b/connectors/src/connectors/notion/temporal/signals.ts
@@ -1,7 +1,7 @@
 import { defineSignal } from "@temporalio/workflow";
 
 export type NotionWebhookEvent = {
-  type: string;
+  type: "data_source.deleted" | "page.deleted";
   entity_id: string;
 };
 

--- a/connectors/src/connectors/notion/temporal/signals.ts
+++ b/connectors/src/connectors/notion/temporal/signals.ts
@@ -8,3 +8,12 @@ export type NotionWebhookEvent = {
 export const notionWebhookSignal = defineSignal<[NotionWebhookEvent]>(
   "notion_webhook_signal"
 );
+
+export type NotionDeletionCrawlSignal = {
+  resourceId: string;
+  resourceType: "page" | "database";
+};
+
+export const notionDeletionCrawlSignal = defineSignal<
+  [NotionDeletionCrawlSignal]
+>("notion_deletion_crawl_signal");

--- a/connectors/src/connectors/notion/temporal/signals.ts
+++ b/connectors/src/connectors/notion/temporal/signals.ts
@@ -1,7 +1,7 @@
 import { defineSignal } from "@temporalio/workflow";
 
 export type NotionWebhookEvent = {
-  type: "data_source.deleted" | "page.deleted";
+  type: "database.deleted" | "page.deleted";
   entity_id: string;
 };
 

--- a/connectors/src/connectors/notion/temporal/workflows/deletion_crawl.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/deletion_crawl.ts
@@ -71,6 +71,7 @@ export async function notionDeletionCrawlWorkflow({
 
       seen.add(key);
 
+      // check only direct children + parent
       const discovered = await checkResourceAndQueueRelated({
         connectorId,
         resourceId: resource.resourceId,

--- a/connectors/src/connectors/notion/temporal/workflows/deletion_crawl.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/deletion_crawl.ts
@@ -1,0 +1,123 @@
+import {
+  condition,
+  continueAsNew,
+  proxyActivities,
+  setHandler,
+  workflowInfo,
+} from "@temporalio/workflow";
+
+import type * as activities from "@connectors/connectors/notion/temporal/activities";
+import type { NotionDeletionCrawlSignal } from "@connectors/connectors/notion/temporal/signals";
+import { notionDeletionCrawlSignal } from "@connectors/connectors/notion/temporal/signals";
+import type { ModelId } from "@connectors/types";
+
+const {
+  checkResourceAndQueueRelated,
+  batchDeleteResources,
+  clearWorkflowCache,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minute",
+});
+
+const DELETE_BATCH_SIZE = 100;
+
+/**
+ * Signal-based deletion crawl workflow.
+ * Receives signals for resources to check, maintains a "seen" cache to avoid duplicates,
+ * and recursively checks parent/children relationships.
+ * Auto-terminates after 5 minutes of inactivity.
+ */
+export async function notionDeletionCrawlWorkflow({
+  connectorId,
+  resourceQueue = [],
+}: {
+  connectorId: ModelId;
+  resourceQueue?: NotionDeletionCrawlSignal[];
+}) {
+  const seen = new Set<string>();
+  const topLevelWorkflowId = workflowInfo().workflowId;
+
+  // Clear workflow cache at start
+  await clearWorkflowCache({
+    connectorId,
+    topLevelWorkflowId,
+  });
+
+  // Helper to create unique key for seen tracking
+  const resourceKey = (resourceId: string, resourceType: string) =>
+    `${resourceType}:${resourceId}`;
+
+  // Set up signal handler
+  setHandler(notionDeletionCrawlSignal, (signal: NotionDeletionCrawlSignal) => {
+    const key = resourceKey(signal.resourceId, signal.resourceType);
+    // Only add to queue if not already seen
+    if (!seen.has(key)) {
+      resourceQueue.push(signal);
+    }
+  });
+
+  for (;;) {
+    // Wait for a resource signal, but stop the workflow if no signals arrive for 5 minutes
+    if (!(await condition(() => resourceQueue.length > 0, "5 minutes"))) {
+      return;
+    }
+
+    // Process all queued resources
+    while (resourceQueue.length > 0) {
+      const resource = resourceQueue.shift();
+      if (!resource) {
+        continue;
+      }
+
+      const key = resourceKey(resource.resourceId, resource.resourceType);
+
+      // Mark as seen before processing (prevents duplicates)
+      seen.add(key);
+
+      // Check this resource and get discovered parent/children
+      const discovered = await checkResourceAndQueueRelated({
+        connectorId,
+        resourceId: resource.resourceId,
+        resourceType: resource.resourceType,
+        workflowId: topLevelWorkflowId,
+      });
+
+      // Add discovered resources to queue (signal handler will check seen set)
+      for (const pageId of discovered.pageIds) {
+        const pageKey = resourceKey(pageId, "page");
+        if (!seen.has(pageKey)) {
+          resourceQueue.push({ resourceId: pageId, resourceType: "page" });
+        }
+      }
+
+      for (const databaseId of discovered.databaseIds) {
+        const dbKey = resourceKey(databaseId, "database");
+        if (!seen.has(dbKey)) {
+          resourceQueue.push({
+            resourceId: databaseId,
+            resourceType: "database",
+          });
+        }
+      }
+
+      if (workflowInfo().continueAsNewSuggested) {
+        await batchDeleteResources({
+          connectorId,
+          workflowId: topLevelWorkflowId,
+        });
+        await continueAsNew({ connectorId, resourceQueue });
+        return;
+      } else if (seen.size % DELETE_BATCH_SIZE == 0) {
+        await batchDeleteResources({
+          connectorId,
+          workflowId: topLevelWorkflowId,
+        });
+      }
+    }
+
+    await batchDeleteResources({
+      connectorId,
+      workflowId: topLevelWorkflowId,
+    });
+  }
+}

--- a/connectors/src/connectors/notion/temporal/workflows/index.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/index.ts
@@ -24,6 +24,7 @@ import type { ModelId } from "@connectors/types";
 export * from "./admins";
 export * from "./check_resources_accessibility";
 export * from "./children";
+export * from "./deletion_crawl";
 export * from "./garbage_collection";
 export * from "./process_webhooks";
 export * from "./upsert_database_queue";

--- a/connectors/src/connectors/notion/temporal/workflows/process_webhooks.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/process_webhooks.ts
@@ -19,10 +19,11 @@ const MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 4000;
 // Auto-terminates if no events arrive for 5 minutes.
 export async function notionProcessWebhooksWorkflow({
   connectorId,
+  eventQueue = [],
 }: {
   connectorId: ModelId;
+  eventQueue?: NotionWebhookEvent[];
 }) {
-  const eventQueue: NotionWebhookEvent[] = [];
   let processedCount = 0;
 
   setHandler(notionWebhookSignal, (event: NotionWebhookEvent) => {
@@ -48,7 +49,7 @@ export async function notionProcessWebhooksWorkflow({
 
     // After we reach our max, call continueAsNew() to limit history growth.
     if (processedCount > MAX_EVENTS_BEFORE_CONTINUE_AS_NEW) {
-      await continueAsNew({ connectorId });
+      await continueAsNew({ connectorId, eventQueue });
       return;
     }
   }

--- a/connectors/src/types/notion.ts
+++ b/connectors/src/types/notion.ts
@@ -17,6 +17,7 @@ export function getNotionWorkflowId(
     | "sync"
     | "garbage-collector"
     | "process-database-upsert-queue"
+    | "deletion-crawl"
     | "process-webhooks"
 ) {
   let wfName = `workflow-notion-${connectorId}`;
@@ -24,6 +25,8 @@ export function getNotionWorkflowId(
     wfName += "-garbage-collector";
   } else if (workflowType === "process-database-upsert-queue") {
     wfName += "-process-database-upsert-queue";
+  } else if (workflowType === "deletion-crawl") {
+    wfName += "-deletion-crawl";
   } else if (workflowType === "process-webhooks") {
     wfName += "-process-webhooks";
   }


### PR DESCRIPTION
## Description

Adds a signal-driven deletion crawl workflow for Notion resources to handle page and database deletions more efficiently. When a page or database is deleted/archived (detected via webhooks, or triggered via CLI), the workflow recursively checks parent and children to delete entire subtrees that became inaccessible. 

The end goal is to rely less on GC to handle deletion, and ultimately be able to run it 1/day instead of 1/5 minutes

## Risk

Low: The deletion crawl workflow operates recursively through parent/child relationships, which could potentially trigger unnecessary deletions if not handled correctly. However, each resource is explicitly checked for accessibility with the Notion API before deletion, so the workflow should not delete accessible resources.

## Tests

- [x] Tested via poke 
- [x] Tested via webhooks (local setup)

## Deploy Plan

- [x] Deploy connectors