### PR TITLE
chore: phase out dust app to summarize files

### DIFF
--- a/front/lib/api/files/file_snippet_generator.ts
+++ b/front/lib/api/files/file_snippet_generator.ts
@@ -1,0 +1,46 @@
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import type { ModelIdType, ModelProviderIdType, Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+export async function generateFileSnippet(
+  auth: Authenticator,
+  {
+    modelId,
+    providerId,
+  }: { modelId: ModelIdType; providerId: ModelProviderIdType },
+  inputs: { content: string }
+): Promise<Result<{ snippet: string }, Error>> {
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      modelId,
+      providerId,
+      temperature: 1.0,
+      useCache: false,
+    },
+    {
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            content: `Summarize in one ~256 characters paragraph:\n\n${inputs.content}`,
+          },
+        ],
+      },
+      prompt: "",
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(new Error(`Error generating snippet: ${res.error.message}`));
+  }
+
+  const snippet = res.value.generation;
+
+  if (!snippet) {
+    return new Err(new Error("No snippet generated from model"));
+  }
+
+  return new Ok({ snippet });
+}

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -177,20 +177,7 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-  "conversation-file-summarizer": {
-    app: {
-      appId: "iy1pjLCMzZ",
-      appHash:
-        "0cd0a82dcfaa327b2d5d1f645a314ea885e995a12921a1024ee96b92e8f15768",
-    },
-    config: {
-      MODEL: {
-        // `provider_id` and `model_id` must be set by caller.
-        use_cache: false,
-        use_stream: false,
-      },
-    },
-  },
+
   "assistant-v2-reason": {
     app: {
       appId: "hUJvIB2KDb",


### PR DESCRIPTION










## Description

Phases out the `conversation-file-summarizer` Dust app and replaces it with direct LLM calls using `runMultiActionsAgent`.

The conversation file summarizer app entry is removed from the registry. 

This follows the same pattern established in previous PRs that phased out other builder apps (names, descriptions, tags, emoji, instructions, cron-timezone, webhook-filter, tag-manager, voice-find-agent-and-tools).

## Risk

Low

## Tests

Tested locally with front.

## Deploy Plan

Deploy Front.
