### PR TITLE
[llm-router] Add run id even in case of failure

### DIFF
--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -24,7 +24,8 @@ import { getAgentLoopData } from "@app/types/assistant/agent_run";
 
 export async function markAgentMessageAsFailed(
   agentMessageRow: AgentMessage,
-  error: ToolErrorEvent["error"]
+  error: ToolErrorEvent["error"],
+  runIds?: string[]
 ): Promise<void> {
   await agentMessageRow.update({
     completedAt: new Date(),
@@ -32,6 +33,7 @@ export async function markAgentMessageAsFailed(
     errorMessage: error.message,
     errorMetadata: error.metadata,
     status: "failed",
+    ...(runIds && { runIds }),
   });
 }
 
@@ -63,35 +65,45 @@ async function processEventForDatabase(
 
   switch (event.type) {
     case "agent_error":
-    case "tool_error":
-      // Store error in database.
-      await markAgentMessageAsFailed(agentMessageRow, event.error);
+      // Store error in database with runIds from the failed LLM call.
+      await markAgentMessageAsFailed(
+        agentMessageRow,
+        event.error,
+        event.runIds
+      );
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
         conversation,
       });
 
-      if (event.type === "agent_error") {
-        await AgentStepContentResource.createNewVersion({
-          workspaceId: agentMessageRow.workspaceId,
-          agentMessageId: agentMessageRow.id,
-          step,
-          index: 0, // Errors are the only content for this step
+      await AgentStepContentResource.createNewVersion({
+        workspaceId: agentMessageRow.workspaceId,
+        agentMessageId: agentMessageRow.id,
+        step,
+        index: 0, // Errors are the only content for this step
+        type: "error",
+        value: {
           type: "error",
           value: {
-            type: "error",
-            value: {
-              code: event.error.code,
-              message: event.error.message,
-              metadata: {
-                ...event.error.metadata,
-                category: event.error.metadata?.category ?? "",
-              },
+            code: event.error.code,
+            message: event.error.message,
+            metadata: {
+              ...event.error.metadata,
+              category: event.error.metadata?.category ?? "",
             },
           },
-        });
-      }
+        },
+      });
+      break;
+
+    case "tool_error":
+      await markAgentMessageAsFailed(agentMessageRow, event.error);
+
+      // Mark the conversation as errored.
+      await ConversationResource.markHasError(auth, {
+        conversation,
+      });
       break;
 
     case "agent_generation_cancelled":
@@ -263,6 +275,8 @@ export async function notifyWorkflowError(
         errorName: error.name || "UnknownError",
       },
     },
+    // Workflow errors occur outside of LLM execution, so use existing runIds from DB
+    runIds: messageRow.agentMessage.runIds ?? [],
   };
 
   await updateResourceAndPublishEvent(auth, {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -114,11 +114,14 @@ export async function runModelActivity(
 
   const model = getSupportedModelConfig(agentConfiguration.model);
 
-  async function publishAgentError(error: {
-    code: string;
-    message: string;
-    metadata: Record<string, string | number | boolean> | null;
-  }): Promise<void> {
+  async function publishAgentError(
+    error: {
+      code: string;
+      message: string;
+      metadata: Record<string, string | number | boolean> | null;
+    },
+    dustRunId?: string
+  ): Promise<void> {
     // Check if this is a multi_actions_error that hit max retries
     let logMessage = `Agent error: ${error.message}`;
     if (
@@ -148,6 +151,7 @@ export async function runModelActivity(
         configurationId: agentConfiguration.sId,
         messageId: agentMessage.sId,
         error,
+        runIds: dustRunId ? [...runIds, dustRunId] : runIds,
       },
       agentMessageRow,
       conversation,
@@ -368,7 +372,10 @@ export async function runModelActivity(
 
   // Errors occurring during the multi-actions-agent dust app may be retryable.
   // Their implicit code should be "multi_actions_error".
-  async function handlePossiblyRetryableError(message: string) {
+  async function handlePossiblyRetryableError(
+    message: string,
+    dustRunId?: string
+  ) {
     const { category, publicMessage, errorTitle } = categorizeAgentErrorMessage(
       {
         code: "multi_actions_error",
@@ -401,15 +408,18 @@ export async function runModelActivity(
       });
     }
 
-    await publishAgentError({
-      code: "multi_actions_error",
-      message: publicMessage,
-      metadata: {
-        category,
-        errorTitle,
-        retriesAttempted: autoRetryCount,
+    await publishAgentError(
+      {
+        code: "multi_actions_error",
+        message: publicMessage,
+        metadata: {
+          category,
+          errorTitle,
+          retriesAttempted: autoRetryCount,
+        },
       },
-    });
+      dustRunId
+    );
 
     return null;
   }
@@ -479,7 +489,9 @@ export async function runModelActivity(
 
     switch (error.type) {
       case "shouldRetryMessage":
-        return handlePossiblyRetryableError(error.message);
+        // Get the dustRunId from the llm object (if available)
+        const errorDustRunId = llm?.getTraceId();
+        return handlePossiblyRetryableError(error.message, errorDustRunId);
       case "shouldReturnNull":
         return null;
       default:

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -289,6 +289,7 @@ export type AgentErrorEvent = {
   configurationId: string;
   messageId: string;
   error: GenericErrorContent;
+  runIds?: string[];
 };
 
 // Generic event sent when an agent message is done (could be successful, failed, or cancelled).

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1282,6 +1282,7 @@ const AgentErrorEventSchema = z.object({
     message: z.string(),
     metadata: z.record(z.any()).nullable(),
   }),
+  runIds: z.array(z.string()).optional(),
 });
 export type AgentErrorEvent = z.infer<typeof AgentErrorEventSchema>;
 


### PR DESCRIPTION
## Description

Store the run id so we can debug llm step with failures:

<img width="1838" height="846" alt="image" src="https://github.com/user-attachments/assets/1223ee4c-8507-42e4-9e82-79d490cdcc69" />


## Tests

Manual testing that we have access to the trace

## Risk



## Deploy Plan

deploy front
