### PR TITLE
[Agents] Preview mode recognizes newly added tools

### DIFF
--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -142,6 +142,7 @@ export function useDraftConversation({
           });
         }
 
+        // Update mentions in the message data to use the current draft agent
         mentions = mentions.map((mention) =>
           mention.id === draftAgent?.sId && currentAgent?.sId
             ? { ...mention, id: currentAgent.sId }

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -142,10 +142,9 @@ export function useDraftConversation({
           });
         }
 
-        // Update mentions in the message data to use the current draft agent
         mentions = mentions.map((mention) =>
           mention.id === draftAgent?.sId && currentAgent?.sId
-            ? { ...mention, configurationId: currentAgent.sId }
+            ? { ...mention, id: currentAgent.sId }
             : mention
         );
       } catch (error) {


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5046

Preview messages could still reference the previous draft agent id, so newly added tools were not recognized and appeared "no access". The code updated a non-used property on rich mentions; we now update the mention id to the latest draft agent sId before submit.

 
<img width="1266" height="604" alt="image" src="https://github.com/user-attachments/assets/9e3fdf45-11f0-4303-b38f-02241b5f941b" />


## Risks
Blast radius: Agent Builder preview message submission and tool selection
Risk: low

## Deploy Plan
- deploy front

## Tests
- [x] New agent → add tool → preview → send; tool usable immediately
- [x] Normal conversations still convert mentions to configurationId as before