### PR TITLE
[Connectors][Webcrawler] Include connectorId in logs for webcrawler activities and DS ops

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -268,7 +268,7 @@ async function startCrawlJob(
     await syncFailed(connector.id, "webcrawling_error");
   } else {
     logger.info(
-      { crawlerId: crawlerResponse.id, url },
+      { crawlerId: crawlerResponse.id, url, connectorId: connector.id },
       "Firecrawl crawler started"
     );
 
@@ -277,7 +277,7 @@ async function startCrawlJob(
     } else {
       // Shouldn't happen, but based on the types, let's make sure
       logger.warn(
-        { webCrawlerConfigId: webCrawlerConfig.id, url },
+        { webCrawlerConfigId: webCrawlerConfig.id, url, connectorId: connector.id },
         "No ID found when creating a Firecrawl crawler"
       );
     }
@@ -301,7 +301,7 @@ async function startBatchScrapeJob(
 
   if (!mapUrlResult.success) {
     logger.error(
-      { url, connector: connector.id, webCrawlerConfigId: webCrawlerConfig.id },
+      { url, connectorId: connector.id, webCrawlerConfigId: webCrawlerConfig.id },
       `Error mapping rootUrl: ${mapUrlResult.error}`
     );
     return;
@@ -331,7 +331,7 @@ async function startBatchScrapeJob(
     await syncFailed(connector.id, "webcrawling_error");
   } else {
     logger.info(
-      { jobId: batchScrapeResponse.id, url },
+      { jobId: batchScrapeResponse.id, url, connectorId: connector.id },
       "Firecrawl crawler started"
     );
 
@@ -340,7 +340,7 @@ async function startBatchScrapeJob(
     } else {
       // Shouldn't happen, but based on the types, let's make sure
       logger.warn(
-        { webCrawlerConfigId: webCrawlerConfig.id, url },
+        { webCrawlerConfigId: webCrawlerConfig.id, url, connectorId: connector.id },
         "No ID found when creating a Firecrawl crawler"
       );
     }
@@ -379,7 +379,11 @@ export async function webCrawlerGarbageCollector(
       Context.current().heartbeat({
         type: "delete_page",
       });
-      await deleteDataSourceDocument(dataSourceConfig, page.documentId);
+      await deleteDataSourceDocument(
+        dataSourceConfig,
+        page.documentId,
+        { connectorId }
+      );
       await page.destroy();
     }
   } while (pagesToDelete.length > 0);
@@ -403,6 +407,7 @@ export async function webCrawlerGarbageCollector(
       await deleteDataSourceFolder({
         dataSourceConfig,
         folderId: folder.internalId,
+        loggerArgs: { connectorId },
       });
       await folder.destroy();
     }
@@ -647,6 +652,7 @@ export async function firecrawlCrawlPage(
         tags: [`title:${stripNullBytes(pageTitle)}`],
         parents: parentFolderIds,
         parentId: parentFolderIds[1] || null,
+        loggerArgs: { connectorId },
         upsertContext: {
           sync_type: "batch",
         },

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -277,7 +277,11 @@ async function startCrawlJob(
     } else {
       // Shouldn't happen, but based on the types, let's make sure
       logger.warn(
-        { webCrawlerConfigId: webCrawlerConfig.id, url, connectorId: connector.id },
+        {
+          webCrawlerConfigId: webCrawlerConfig.id,
+          url,
+          connectorId: connector.id,
+        },
         "No ID found when creating a Firecrawl crawler"
       );
     }
@@ -301,7 +305,11 @@ async function startBatchScrapeJob(
 
   if (!mapUrlResult.success) {
     logger.error(
-      { url, connectorId: connector.id, webCrawlerConfigId: webCrawlerConfig.id },
+      {
+        url,
+        connectorId: connector.id,
+        webCrawlerConfigId: webCrawlerConfig.id,
+      },
       `Error mapping rootUrl: ${mapUrlResult.error}`
     );
     return;
@@ -340,7 +348,11 @@ async function startBatchScrapeJob(
     } else {
       // Shouldn't happen, but based on the types, let's make sure
       logger.warn(
-        { webCrawlerConfigId: webCrawlerConfig.id, url, connectorId: connector.id },
+        {
+          webCrawlerConfigId: webCrawlerConfig.id,
+          url,
+          connectorId: connector.id,
+        },
         "No ID found when creating a Firecrawl crawler"
       );
     }
@@ -379,11 +391,9 @@ export async function webCrawlerGarbageCollector(
       Context.current().heartbeat({
         type: "delete_page",
       });
-      await deleteDataSourceDocument(
-        dataSourceConfig,
-        page.documentId,
-        { connectorId }
-      );
+      await deleteDataSourceDocument(dataSourceConfig, page.documentId, {
+        connectorId,
+      });
       await page.destroy();
     }
   } while (pagesToDelete.length > 0);


### PR DESCRIPTION
## Description
- Context: https://github.com/dust-tt/tasks/issues/5058
- Add connectorId to logs in webcrawler Temporal activities, and propagate connectorId via `loggerArgs` to Dust data source operations (document/folder upserts/deletes) invoked by those activities. This makes it much easier to correlate logs per connector when diagnosing crawl failures (e.g., sticky `webcrawling_error`) and webhook anomalies (e.g., missing `scrapeId`).

## Risks
Blast radius: Connectors service only — webcrawler activities logging + DS ops log context in webcrawler paths.
Risk: low

## Deploy Plan
- Deploy connectors
