### PR TITLE
[front] enh(Zendesk): add search ticket tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1599,6 +1599,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: {
       get_ticket: "never_ask",
+      search_tickets: "never_ask",
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
@@ -1,7 +1,13 @@
 import type { z } from "zod";
 
-import type { ZendeskTicket } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
-import { ZendeskTicketResponseSchema } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
+import type {
+  ZendeskSearchResponse,
+  ZendeskTicket,
+} from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
+import {
+  ZendeskSearchResponseSchema,
+  ZendeskTicketResponseSchema,
+} from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -65,5 +71,34 @@ export class ZendeskClient {
     }
 
     return new Ok(result.value.ticket);
+  }
+
+  async searchTickets(
+    query: string,
+    sortBy?: string,
+    sortOrder?: string
+  ): Promise<Result<ZendeskSearchResponse, Error>> {
+    const params = new URLSearchParams({
+      query: `type:ticket ${query}`,
+    });
+
+    if (sortBy) {
+      params.append("sort_by", sortBy);
+    }
+
+    if (sortOrder) {
+      params.append("sort_order", sortOrder);
+    }
+
+    const result = await this.getRequest(
+      `search.json?${params.toString()}`,
+      ZendeskSearchResponseSchema
+    );
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    return new Ok(result.value);
   }
 }

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
@@ -20,7 +20,8 @@ function createServer(
 
   server.tool(
     "get_ticket",
-    "Retrieve a Zendesk ticket by its ID. Returns the ticket details including subject, description, status, priority, assignee, and other metadata.",
+    "Retrieve a Zendesk ticket by its ID. Returns the ticket details including subject, " +
+      "description, status, priority, assignee, and other metadata.",
     {
       ticketId: z
         .number()
@@ -77,12 +78,17 @@ function createServer(
 
   server.tool(
     "search_tickets",
-    "Search for Zendesk tickets using query syntax. Returns a list of matching tickets with their details. You can search by status, priority, assignee, tags, and other fields. Query examples: 'status:open', 'priority:high', 'status:open priority:urgent', 'assignee:me', 'tags:bug'.",
+    "Search for Zendesk tickets using query syntax. Returns a list of matching tickets with their " +
+      "details. You can search by status, priority, assignee, tags, and other fields. Query " +
+      "examples: 'status:open', 'priority:high', 'status:open priority:urgent', 'assignee:me', " +
+      "'tags:bug'.",
     {
       query: z
         .string()
         .describe(
-          "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high status:pending', 'assignee:123', 'tags:bug tags:critical'. Do not include 'type:ticket' as it is automatically added."
+          "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high " +
+            "status:pending', 'assignee:123', 'tags:bug tags:critical'." +
+            "Do not include 'type:ticket'  as it is automatically added."
         ),
       sortBy: z
         .enum(["updated_at", "created_at", "priority", "status", "ticket_type"])

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
@@ -125,13 +125,11 @@ function createServer(
 
         if (result.isErr()) {
           return new Err(
-            new MCPError(
-              `Failed to search tickets: ${result.error.message}`
-            )
+            new MCPError(`Failed to search tickets: ${result.error.message}`)
           );
         }
 
-        const { results, count } = result.value;
+        const { results, count, next_page } = result.value;
 
         if (results.length === 0) {
           return new Ok([
@@ -144,17 +142,18 @@ function createServer(
 
         const ticketsText = results
           .map((ticket) => {
-            return [
-              "---",
-              renderTicket(ticket),
-            ].join("\n");
+            return ["---", renderTicket(ticket)].join("\n");
           })
           .join("\n\n");
+
+        const paginationInfo = next_page
+          ? "\n\nNote: There are more tickets available."
+          : "";
 
         return new Ok([
           {
             type: "text" as const,
-            text: `Found ${count} ticket(s):\n\n${ticketsText}`,
+            text: `Found ${count} ticket(s):\n\n${ticketsText}${paginationInfo}`,
           },
         ]);
       }

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
@@ -75,6 +75,92 @@ function createServer(
     )
   );
 
+  server.tool(
+    "search_tickets",
+    "Search for Zendesk tickets using query syntax. Returns a list of matching tickets with their details. You can search by status, priority, assignee, tags, and other fields. Query examples: 'status:open', 'priority:high', 'status:open priority:urgent', 'assignee:me', 'tags:bug'.",
+    {
+      query: z
+        .string()
+        .describe(
+          "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high status:pending', 'assignee:123', 'tags:bug tags:critical'. Do not include 'type:ticket' as it is automatically added."
+        ),
+      sortBy: z
+        .enum(["updated_at", "created_at", "priority", "status", "ticket_type"])
+        .optional()
+        .describe(
+          "Field to sort results by. Defaults to relevance if not specified."
+        ),
+      sortOrder: z
+        .enum(["asc", "desc"])
+        .optional()
+        .describe("Sort order. Defaults to 'desc' if not specified."),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: ZENDESK_TOOL_NAME,
+        agentLoopContext,
+      },
+      async ({ query, sortBy, sortOrder }, { authInfo }) => {
+        const accessToken = authInfo?.token;
+        if (!accessToken) {
+          return new Err(
+            new MCPError(
+              "No access token found. Please connect your Zendesk account."
+            )
+          );
+        }
+
+        const subdomain = authInfo?.extra?.zendesk_subdomain;
+        if (!isString(subdomain)) {
+          return new Err(
+            new MCPError(
+              "Zendesk subdomain not found in connection metadata. Please reconnect your Zendesk account."
+            )
+          );
+        }
+
+        const client = new ZendeskClient(subdomain, accessToken);
+        const result = await client.searchTickets(query, sortBy, sortOrder);
+
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to search tickets: ${result.error.message}`
+            )
+          );
+        }
+
+        const { results, count } = result.value;
+
+        if (results.length === 0) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: "No tickets found matching the search criteria.",
+            },
+          ]);
+        }
+
+        const ticketsText = results
+          .map((ticket) => {
+            return [
+              "---",
+              renderTicket(ticket),
+            ].join("\n");
+          })
+          .join("\n\n");
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Found ${count} ticket(s):\n\n${ticketsText}`,
+          },
+        ]);
+      }
+    )
+  );
+
   return server;
 }
 

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/types.ts
@@ -43,3 +43,14 @@ export const ZendeskTicketResponseSchema = z.object({
 });
 
 export type ZendeskTicketResponse = z.infer<typeof ZendeskTicketResponseSchema>;
+
+export const ZendeskSearchResponseSchema = z.object({
+  results: z.array(ZendeskTicketSchema),
+  count: z.number(),
+  next_page: z.string().nullable(),
+  previous_page: z.string().nullable(),
+});
+
+export type ZendeskSearchResponse = z.infer<
+  typeof ZendeskSearchResponseSchema
+>;

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/types.ts
@@ -51,6 +51,4 @@ export const ZendeskSearchResponseSchema = z.object({
   previous_page: z.string().nullable(),
 });
 
-export type ZendeskSearchResponse = z.infer<
-  typeof ZendeskSearchResponseSchema
->;
+export type ZendeskSearchResponse = z.infer<typeof ZendeskSearchResponseSchema>;


### PR DESCRIPTION
## Description

- This PR adds a tool to the Zendesk MCP server to search tickets based on a query.

## Tests

- Tested locally.

## Risk

- Low, behind FF.

## Deploy Plan

- Deploy front.
