### PR TITLE
[front] - feat(obs): allow version filtering

### DIFF
--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -30,7 +30,7 @@ export function AgentFeedback({
   allowReactions,
   title = "Feedback",
 }: AgentFeedbackProps) {
-  const { period } = useObservabilityContext();
+  const { period, mode, selectedVersion } = useObservabilityContext();
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
   });
@@ -38,6 +38,7 @@ export function AgentFeedback({
     workspaceId: owner.sId,
     agentConfigurationId,
     period,
+    version: mode === "version" ? selectedVersion?.version : undefined,
   });
 
   return (

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -58,9 +58,9 @@ export function AgentObservability({
               className="h-24"
               content={
                 <div className="flex flex-col gap-1 text-2xl">
-                  {agentAnalytics?.users ? (
+                  {agentAnalytics?.activeUsers !== undefined ? (
                     <div className="truncate text-foreground dark:text-foreground-night">
-                      {agentAnalytics.users.length}
+                      {agentAnalytics.activeUsers}
                     </div>
                   ) : (
                     "-"

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -27,12 +27,13 @@ export function AgentObservability({
   agentConfigurationId,
   isCustomAgent,
 }: AgentObservabilityProps) {
-  const { period } = useObservabilityContext();
+  const { period, mode, selectedVersion } = useObservabilityContext();
 
   const { agentAnalytics, isAgentAnalyticsLoading } = useAgentAnalytics({
     workspaceId,
     agentConfigurationId,
     period,
+    version: mode === "version" ? selectedVersion?.version : undefined,
   });
 
   return (

--- a/front/lib/api/assistant/observability/overview.ts
+++ b/front/lib/api/assistant/observability/overview.ts
@@ -1,0 +1,75 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type AgentOverview = {
+  activeUsers: number;
+  conversationCount: number;
+  messageCount: number;
+  positiveFeedbacks: number;
+  negativeFeedbacks: number;
+};
+
+type OverviewAggs = {
+  active_users?: { value?: number };
+  conversations?: { value?: number };
+  total_messages?: { value?: number };
+  feedbacks?: {
+    recent?: {
+      doc_count: number;
+      up?: { doc_count: number };
+      down?: { doc_count: number };
+    };
+  };
+};
+
+export async function fetchAgentOverview(
+  baseQuery: estypes.QueryDslQueryContainer,
+  days: number
+): Promise<Result<AgentOverview, Error>> {
+  const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
+    {
+      active_users: { cardinality: { field: "user_id" } },
+      conversations: { cardinality: { field: "conversation_id" } },
+      total_messages: { value_count: { field: "message_id" } },
+      feedbacks: {
+        nested: { path: "feedbacks" },
+        aggs: {
+          recent: {
+            filter: {
+              range: { "feedbacks.created_at": { gte: `now-${days}d/d` } },
+            },
+            aggs: {
+              up: { filter: { term: { "feedbacks.thumb_direction": "up" } } },
+              down: {
+                filter: { term: { "feedbacks.thumb_direction": "down" } },
+              },
+            },
+          },
+        },
+      },
+    };
+
+  const result = await searchAnalytics<never, OverviewAggs>(baseQuery, {
+    aggregations,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const aggs = result.value.aggregations;
+
+  return new Ok({
+    activeUsers: Math.round(aggs?.active_users?.value ?? 0),
+    conversationCount: Math.round(aggs?.conversations?.value ?? 0),
+    messageCount: Math.round(aggs?.total_messages?.value ?? 0),
+    positiveFeedbacks: Math.round(aggs?.feedbacks?.recent?.up?.doc_count ?? 0),
+    negativeFeedbacks: Math.round(
+      aggs?.feedbacks?.recent?.down?.doc_count ?? 0
+    ),
+  });
+}

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -18,10 +18,10 @@ import {
 import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
-import type { GetAgentConfigurationAnalyticsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics";
 import type { GetErrorRateResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate";
 import type { GetFeedbackDistributionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution";
 import type { GetLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency";
+import type { GetAgentOverviewResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview";
 import type { GetToolExecutionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution";
 import type { GetToolStepIndexResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index";
 import type { GetUsageMetricsResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics";
@@ -426,8 +426,7 @@ export function useAgentAnalytics({
   version?: string;
   disabled?: boolean;
 }) {
-  const agentAnalyticsFetcher: Fetcher<GetAgentConfigurationAnalyticsResponseBody> =
-    fetcher;
+  const agentAnalyticsFetcher: Fetcher<GetAgentOverviewResponseBody> = fetcher;
   const fetchUrl = agentConfigurationId
     ? (() => {
         const params = new URLSearchParams({ days: String(period) });

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -417,17 +417,25 @@ export function useAgentAnalytics({
   workspaceId,
   agentConfigurationId,
   period,
+  version,
   disabled,
 }: {
   workspaceId: string;
   agentConfigurationId: string | null;
   period: number;
+  version?: string;
   disabled?: boolean;
 }) {
   const agentAnalyticsFetcher: Fetcher<GetAgentConfigurationAnalyticsResponseBody> =
     fetcher;
   const fetchUrl = agentConfigurationId
-    ? `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/analytics?period=${period}`
+    ? (() => {
+        const params = new URLSearchParams({ days: String(period) });
+        if (version) {
+          params.set("version", version);
+        }
+        return `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/overview?${params.toString()}`;
+      })()
     : null;
   const { data, error } = useSWRWithDefaults(fetchUrl, agentAnalyticsFetcher, {
     disabled,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -8,14 +8,10 @@ import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observabili
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
-import type { UserType, WithAPIErrorResponse } from "@app/types";
+import type { WithAPIErrorResponse } from "@app/types";
 
 export type GetAgentOverviewResponseBody = {
-  users: {
-    user: UserType | undefined;
-    count: number;
-    timePeriodSec: number;
-  }[];
+  activeUsers: number;
   mentions: {
     messageCount: number;
     conversationCount: number;
@@ -117,14 +113,8 @@ async function handler(
         negativeFeedbacks,
       } = overview.value;
 
-      const users = Array.from({ length: activeUsers }).map(() => ({
-        user: undefined,
-        count: 0,
-        timePeriodSec: days * 24 * 60 * 60,
-      }));
-
       return res.status(200).json({
-        users,
+        activeUsers,
         mentions: {
           messageCount,
           conversationCount,


### PR DESCRIPTION

## Description

This PR extends agent overview analytics to support version-specific filtering. The `AgentObservability` and `AgentFeedback` components now pass the selected version from the observability context to the `useAgentAnalytics` hook when in version mode. The hook constructs API requests with the new version parameter, and the backend overview endpoint (`/observability/overview`) filters analytics data accordingly using the existing `buildAgentAnalyticsBaseQuery` utility.

**References:**
- https://github.com/dust-tt/tasks/issues/5084

## Risk

Low - the change reuses existing version filtering infrastructure

## Tests

Locally

## Deploy Plan

Deploy front.
