### PR TITLE
[Connectors][Slack] Upgrade permission on add-channel-to-sync for existing channels

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -642,7 +642,10 @@ export const slack = async ({
 
       // If the channel already existed with a non-indexed permission (e.g. "write"),
       // upgrade it to "read_write" so the sync actually indexes content.
-      if (!(["read", "read_write"] as const).includes(channel.permission)) {
+      if (
+        channel.permission !== "read" &&
+        channel.permission !== "read_write"
+      ) {
         const existing = await SlackChannel.findOne({
           where: {
             connectorId: connector.id,

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -640,6 +640,20 @@ export const slack = async ({
         },
       });
 
+      // If the channel already existed with a non-indexed permission (e.g. "write"),
+      // upgrade it to "read_write" so the sync actually indexes content.
+      if (!(["read", "read_write"] as const).includes(channel.permission)) {
+        const existing = await SlackChannel.findOne({
+          where: {
+            connectorId: connector.id,
+            slackChannelId: args.channelId,
+          },
+        });
+        if (existing) {
+          await existing.update({ permission: "read_write" });
+        }
+      }
+
       const workflowRes = await launchSlackSyncWorkflow(connector.id, null, [
         channel.slackId,
       ]);


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/4360

When add-channel-to-sync is used on a channel that already exists in connectors DB with permission write, the CLI previously did not upgrade the permission, and sync activities would no-op ("Channel is not indexed, skipping"). This change upgrades existing channels to read_write before launching the sync, ensuring indexing proceeds.

## Risks
Blast radius: Slack admin CLI add-channel-to-sync flow for existing channels
Risk: low

## Deploy Plan
- deploy connectors
