### PR TITLE
[front] feat(Zendesk): add tool to draft a reply

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1600,6 +1600,7 @@ The directive should be used to display a clickable version of the agent name in
     tools_stakes: {
       get_ticket: "never_ask",
       search_tickets: "never_ask",
+      draft_reply: "low", // Low because it's a draft.
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/api/oauth/providers/zendesk.ts
+++ b/front/lib/api/oauth/providers/zendesk.ts
@@ -19,9 +19,21 @@ export class ZendeskOAuthProvider implements BaseOAuthStrategyProvider {
     useCase: OAuthUseCase;
   }) {
     // Webhooks require write scope to create/manage webhooks
-    const scopes = useCase === "webhooks" ? ["webhooks:write"] : ["read"];
+    let scopes;
+    switch (useCase) {
+      case "webhooks":
+        scopes = ["webhooks:write"];
+        break;
+      case "platform_actions":
+      case "personal_actions":
+        scopes = ["read", "write"];
+        break;
+      default:
+        scopes = ["read"];
+        break;
+    }
     if (!isValidZendeskSubdomain(connection.metadata.zendesk_subdomain)) {
-      throw "Invalid Zendesk subdomain";
+      throw new Error("Invalid Zendesk subdomain");
     }
     return (
       `https://${connection.metadata.zendesk_subdomain}.zendesk.com/oauth/authorizations/new?` +


### PR DESCRIPTION
## Description

- This PR adds a tool to the Zendesk MCP server to draft a reply to a ticket.

## Tests

- Tested locally [here](https://d3v-dust.zendesk.com/agent/tickets/35).

## Risk

- Low.

## Deploy Plan

- Deploy front.
