### PR TITLE
[front] show confirmation dialog before navigation if there is a user input

### DIFF
--- a/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
+++ b/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
@@ -1,0 +1,59 @@
+import type { NextRouter } from "next/router";
+import { useEffect } from "react";
+
+import { isDevelopment } from "@app/types";
+
+interface useHandleUnsentMessageProps {
+  getUserTextWithoutMentions: () => string;
+  router: NextRouter;
+}
+
+const THRESHOLD_TEXT_LENGTH = 20;
+
+export function useHandleUnsentMessage({
+  getUserTextWithoutMentions,
+  router,
+}: useHandleUnsentMessageProps) {
+  // This handles page reload.
+  useEffect(() => {
+    // You cannot customize the warning message for page navigation.
+    const handleBeforeReload = (e: BeforeUnloadEvent) => {
+      const userInput = getUserTextWithoutMentions();
+
+      if (!isDevelopment() && userInput.length > THRESHOLD_TEXT_LENGTH) {
+        e.preventDefault();
+        window.confirm();
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeReload);
+
+    return () => {
+      window.addEventListener("beforeunload", handleBeforeReload);
+    };
+  }, [getUserTextWithoutMentions]);
+
+  // This handles router navigation.
+  useEffect(() => {
+    // Handle custom event for shallow navigation
+    const handleBeforeNavigationChange = () => {
+      const userInput = getUserTextWithoutMentions();
+
+      if (!isDevelopment() && userInput.length > THRESHOLD_TEXT_LENGTH) {
+        const shouldProceed = window.confirm(
+          `Your message hasn't been sent. Are you sure you want to leave this conversation?`
+        );
+        if (!shouldProceed) {
+          // Not ideal but I cannot find the other way to cancel the route navigation.
+          throw "Abort route change. User cancelled navigation.";
+        }
+      }
+    };
+
+    router.events.on("beforeHistoryChange", handleBeforeNavigationChange);
+
+    return () => {
+      router.events.off("beforeHistoryChange", handleBeforeNavigationChange);
+    };
+  }, [getUserTextWithoutMentions, router]);
+}

--- a/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
+++ b/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
@@ -35,9 +35,11 @@ export function useHandleUnsentMessage({
   // This handles router navigation.
   useEffect(() => {
     // Handle custom event for shallow navigation
-    const handleBeforeNavigationChange = () => {
-      // we should do not trigger this when you post a new message (which causes the router navigation).
-      if (router.query.cId === "new") {
+    const handleBeforeNavigationChange = (url: string, { shallow }: { shallow: boolean }) => {
+      // We should do not trigger this when you post a new message (which causes the router navigation),
+      // but this also disable the confirmation dialog when you go to a different conversation from a new conversation.
+      // TODO (yuka 12th nov): fix this logic and only disable it when you post a message as a new conversation
+      if (router.query.cId === "new" && shallow) {
         return;
       }
 
@@ -48,6 +50,8 @@ export function useHandleUnsentMessage({
           `Your message hasn't been sent. Are you sure you want to leave this conversation?`
         );
         if (!shouldProceed) {
+          // We need to emit this to stop loading animation spinner
+          router.events.emit("routeChangeError");
           // Not ideal but I cannot find the other way to cancel the route navigation.
           throw "Abort route change. User cancelled navigation.";
         }

--- a/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
+++ b/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
@@ -35,7 +35,10 @@ export function useHandleUnsentMessage({
   // This handles router navigation.
   useEffect(() => {
     // Handle custom event for shallow navigation
-    const handleBeforeNavigationChange = (url: string, { shallow }: { shallow: boolean }) => {
+    const handleBeforeNavigationChange = (
+      url: string,
+      { shallow }: { shallow: boolean }
+    ) => {
       // We should do not trigger this when you post a new message (which causes the router navigation),
       // but this also disable the confirmation dialog when you go to a different conversation from a new conversation.
       // TODO (yuka 12th nov): fix this logic and only disable it when you post a message as a new conversation

--- a/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
+++ b/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 import { isDevelopment } from "@app/types";
 
-interface useHandleUnsentMessageProps {
+interface UseHandleUnsentMessageProps {
   getUserTextWithoutMentions: () => string;
   router: NextRouter;
 }
@@ -13,7 +13,7 @@ const THRESHOLD_TEXT_LENGTH = 20;
 export function useHandleUnsentMessage({
   getUserTextWithoutMentions,
   router,
-}: useHandleUnsentMessageProps) {
+}: UseHandleUnsentMessageProps) {
   // This handles page reload.
   useEffect(() => {
     // You cannot customize the warning message for page navigation.
@@ -22,14 +22,13 @@ export function useHandleUnsentMessage({
 
       if (!isDevelopment() && userInput.length > THRESHOLD_TEXT_LENGTH) {
         e.preventDefault();
-        window.confirm();
       }
     };
 
     window.addEventListener("beforeunload", handleBeforeReload);
 
     return () => {
-      window.addEventListener("beforeunload", handleBeforeReload);
+      window.removeEventListener("beforeunload", handleBeforeReload);
     };
   }, [getUserTextWithoutMentions]);
 
@@ -37,6 +36,11 @@ export function useHandleUnsentMessage({
   useEffect(() => {
     // Handle custom event for shallow navigation
     const handleBeforeNavigationChange = () => {
+      // we should do not trigger this when you post a new message (which causes the router navigation).
+      if (router.query.cId === 'new') {
+        return;
+      }
+
       const userInput = getUserTextWithoutMentions();
 
       if (!isDevelopment() && userInput.length > THRESHOLD_TEXT_LENGTH) {

--- a/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
+++ b/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
@@ -39,16 +39,18 @@ export function useHandleUnsentMessage({
       url: string,
       { shallow }: { shallow: boolean }
     ) => {
-      // We should do not trigger this when you post a new message (which causes the router navigation),
+      const cId = router.query.cId;
+
+      // We should do not trigger this when you are in AB or you post a new message (which causes the router navigation),
       // but this also disable the confirmation dialog when you go to a different conversation from a new conversation.
       // TODO (yuka 12th nov): fix this logic and only disable it when you post a message as a new conversation
-      if (router.query.cId === "new" && shallow) {
+      if (isDevelopment() || !cId || (router.query.cId === "new" && shallow)) {
         return;
       }
 
       const userInput = getUserTextWithoutMentions();
 
-      if (!isDevelopment() && userInput.length > THRESHOLD_TEXT_LENGTH) {
+      if (userInput.length > THRESHOLD_TEXT_LENGTH) {
         const shouldProceed = window.confirm(
           `Your message hasn't been sent. Are you sure you want to leave this conversation?`
         );

--- a/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
+++ b/front/components/assistant/conversation/hooks/useHandleUnsendMessage.tsx
@@ -37,7 +37,7 @@ export function useHandleUnsentMessage({
     // Handle custom event for shallow navigation
     const handleBeforeNavigationChange = () => {
       // we should do not trigger this when you post a new message (which causes the router navigation).
-      if (router.query.cId === 'new') {
+      if (router.query.cId === "new") {
         return;
       }
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -223,7 +223,6 @@ export const InputBar = React.memo(function InputBar({
     // When we are creating a new conversation, we will disable the input bar, show a loading
     // spinner and in case of error, re-enable the input bar
     if (!conversationId) {
-      debugger;
       setLoading(true);
       setDisableSendButton(true);
 
@@ -248,7 +247,6 @@ export const InputBar = React.memo(function InputBar({
       setLoading(false);
       setDisableSendButton(false);
       if (r.isOk()) {
-        debugger;
         resetEditorText();
         fileUploaderService.resetUpload();
       }
@@ -301,14 +299,14 @@ export const InputBar = React.memo(function InputBar({
           disable && "cursor-not-allowed opacity-75",
           isFloating
             ? classNames(
-              "focus-within:ring-1 dark:focus-within:ring-1",
-              "dark:focus-within:ring-highlight/30-night focus-within:ring-highlight/30",
-              "sm:focus-within:ring-2 dark:sm:focus-within:ring-2"
-            )
+                "focus-within:ring-1 dark:focus-within:ring-1",
+                "dark:focus-within:ring-highlight/30-night focus-within:ring-highlight/30",
+                "sm:focus-within:ring-2 dark:sm:focus-within:ring-2"
+              )
             : classNames(
-              "focus-within:border-highlight-300",
-              "dark:focus-within:border-highlight-300-night"
-            ),
+                "focus-within:border-highlight-300",
+                "dark:focus-within:border-highlight-300-night"
+              ),
           isAnimating ? "duration-600 animate-shake" : "duration-300"
         )}
       >

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -223,6 +223,7 @@ export const InputBar = React.memo(function InputBar({
     // When we are creating a new conversation, we will disable the input bar, show a loading
     // spinner and in case of error, re-enable the input bar
     if (!conversationId) {
+      debugger;
       setLoading(true);
       setDisableSendButton(true);
 
@@ -247,6 +248,7 @@ export const InputBar = React.memo(function InputBar({
       setLoading(false);
       setDisableSendButton(false);
       if (r.isOk()) {
+        debugger;
         resetEditorText();
         fileUploaderService.resetUpload();
       }
@@ -299,14 +301,14 @@ export const InputBar = React.memo(function InputBar({
           disable && "cursor-not-allowed opacity-75",
           isFloating
             ? classNames(
-                "focus-within:ring-1 dark:focus-within:ring-1",
-                "dark:focus-within:ring-highlight/30-night focus-within:ring-highlight/30",
-                "sm:focus-within:ring-2 dark:sm:focus-within:ring-2"
-              )
+              "focus-within:ring-1 dark:focus-within:ring-1",
+              "dark:focus-within:ring-highlight/30-night focus-within:ring-highlight/30",
+              "sm:focus-within:ring-2 dark:sm:focus-within:ring-2"
+            )
             : classNames(
-                "focus-within:border-highlight-300",
-                "dark:focus-within:border-highlight-300-night"
-              ),
+              "focus-within:border-highlight-300",
+              "dark:focus-within:border-highlight-300-night"
+            ),
           isAnimating ? "duration-600 animate-shake" : "duration-300"
         )}
       >

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -11,8 +11,8 @@ import React, {
   useState,
 } from "react";
 
-import { useHandleUnsentMessage } from "@app/assistant/conversation/hooks/useHandleUnsendMessage";
 import { AgentPicker } from "@app/components/assistant/AgentPicker";
+import { useHandleUnsentMessage } from "@app/components/assistant/conversation/hooks/useHandleUnsendMessage";
 import { MentionDropdown } from "@app/components/assistant/conversation/input_bar/editor/MentionDropdown";
 import useAgentSuggestions from "@app/components/assistant/conversation/input_bar/editor/useAgentSuggestions";
 import type { CustomEditorProps } from "@app/components/assistant/conversation/input_bar/editor/useCustomEditor";
@@ -409,25 +409,25 @@ const InputBarContainer = ({
   const { searchResultNodes, isSearchLoading } = useSpacesSearch(
     isNodeCandidate(nodeOrUrlCandidate)
       ? {
-          // NodeIdSearchParams
-          nodeIds: nodeOrUrlCandidate?.node ? [nodeOrUrlCandidate.node] : [],
-          includeDataSources: false,
-          owner,
-          viewType: "all",
-          disabled: isSpacesLoading || !nodeOrUrlCandidate,
-          spaceIds: spaces.map((s) => s.sId),
-        }
+        // NodeIdSearchParams
+        nodeIds: nodeOrUrlCandidate?.node ? [nodeOrUrlCandidate.node] : [],
+        includeDataSources: false,
+        owner,
+        viewType: "all",
+        disabled: isSpacesLoading || !nodeOrUrlCandidate,
+        spaceIds: spaces.map((s) => s.sId),
+      }
       : {
-          // TextSearchParams
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          search: nodeOrUrlCandidate?.url || "",
-          searchSourceUrls: true,
-          includeDataSources: false,
-          owner,
-          viewType: "all",
-          disabled: isSpacesLoading || !nodeOrUrlCandidate,
-          spaceIds: spaces.map((s) => s.sId),
-        }
+        // TextSearchParams
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        search: nodeOrUrlCandidate?.url || "",
+        searchSourceUrls: true,
+        includeDataSources: false,
+        owner,
+        viewType: "all",
+        disabled: isSpacesLoading || !nodeOrUrlCandidate,
+        spaceIds: spaces.map((s) => s.sId),
+      }
   );
 
   useEffect(() => {
@@ -605,26 +605,26 @@ const InputBarContainer = ({
               )}
               {(actions.includes("agents-list") ||
                 actions.includes("agents-list-with-actions")) && (
-                <AgentPicker
-                  owner={owner}
-                  size={buttonSize}
-                  onItemClick={(c) => {
-                    editorService.insertMention({
-                      type: "agent",
-                      id: c.sId,
-                      label: c.name,
-                      description: c.description,
-                      pictureUrl: c.pictureUrl,
-                    });
-                  }}
-                  agents={allAgents}
-                  showDropdownArrow={false}
-                  showFooterButtons={actions.includes(
-                    "agents-list-with-actions"
-                  )}
-                  disabled={disableTextInput}
-                />
-              )}
+                  <AgentPicker
+                    owner={owner}
+                    size={buttonSize}
+                    onItemClick={(c) => {
+                      editorService.insertMention({
+                        type: "agent",
+                        id: c.sId,
+                        label: c.name,
+                        description: c.description,
+                        pictureUrl: c.pictureUrl,
+                      });
+                    }}
+                    agents={allAgents}
+                    showDropdownArrow={false}
+                    showFooterButtons={actions.includes(
+                      "agents-list-with-actions"
+                    )}
+                    disabled={disableTextInput}
+                  />
+                )}
             </div>
             <div className="grow" />
             <div className="flex items-center gap-2 md:gap-1">

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -409,25 +409,25 @@ const InputBarContainer = ({
   const { searchResultNodes, isSearchLoading } = useSpacesSearch(
     isNodeCandidate(nodeOrUrlCandidate)
       ? {
-        // NodeIdSearchParams
-        nodeIds: nodeOrUrlCandidate?.node ? [nodeOrUrlCandidate.node] : [],
-        includeDataSources: false,
-        owner,
-        viewType: "all",
-        disabled: isSpacesLoading || !nodeOrUrlCandidate,
-        spaceIds: spaces.map((s) => s.sId),
-      }
+          // NodeIdSearchParams
+          nodeIds: nodeOrUrlCandidate?.node ? [nodeOrUrlCandidate.node] : [],
+          includeDataSources: false,
+          owner,
+          viewType: "all",
+          disabled: isSpacesLoading || !nodeOrUrlCandidate,
+          spaceIds: spaces.map((s) => s.sId),
+        }
       : {
-        // TextSearchParams
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        search: nodeOrUrlCandidate?.url || "",
-        searchSourceUrls: true,
-        includeDataSources: false,
-        owner,
-        viewType: "all",
-        disabled: isSpacesLoading || !nodeOrUrlCandidate,
-        spaceIds: spaces.map((s) => s.sId),
-      }
+          // TextSearchParams
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          search: nodeOrUrlCandidate?.url || "",
+          searchSourceUrls: true,
+          includeDataSources: false,
+          owner,
+          viewType: "all",
+          disabled: isSpacesLoading || !nodeOrUrlCandidate,
+          spaceIds: spaces.map((s) => s.sId),
+        }
   );
 
   useEffect(() => {
@@ -605,26 +605,26 @@ const InputBarContainer = ({
               )}
               {(actions.includes("agents-list") ||
                 actions.includes("agents-list-with-actions")) && (
-                  <AgentPicker
-                    owner={owner}
-                    size={buttonSize}
-                    onItemClick={(c) => {
-                      editorService.insertMention({
-                        type: "agent",
-                        id: c.sId,
-                        label: c.name,
-                        description: c.description,
-                        pictureUrl: c.pictureUrl,
-                      });
-                    }}
-                    agents={allAgents}
-                    showDropdownArrow={false}
-                    showFooterButtons={actions.includes(
-                      "agents-list-with-actions"
-                    )}
-                    disabled={disableTextInput}
-                  />
-                )}
+                <AgentPicker
+                  owner={owner}
+                  size={buttonSize}
+                  onItemClick={(c) => {
+                    editorService.insertMention({
+                      type: "agent",
+                      id: c.sId,
+                      label: c.name,
+                      description: c.description,
+                      pictureUrl: c.pictureUrl,
+                    });
+                  }}
+                  agents={allAgents}
+                  showDropdownArrow={false}
+                  showFooterButtons={actions.includes(
+                    "agents-list-with-actions"
+                  )}
+                  disabled={disableTextInput}
+                />
+              )}
             </div>
             <div className="grow" />
             <div className="flex items-center gap-2 md:gap-1">

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -16,7 +16,7 @@ import { assertNever } from "@app/types";
  * Regular expression for parsing agent mention strings.
  * Format: `:mention[name]{sId=xxx}`
  */
-const AGENT_MENTION_REGEX = /:mention\[([^\]]+)\]\{[^}]+\}/g;
+export const AGENT_MENTION_REGEX = /:mention\[([^\]]+)\]\{[^}]+\}/g;
 
 /**
  * Regular expression for parsing mention strings.


### PR DESCRIPTION
## Description
This PR is to show a confirmation dialog when you try to navigate away from your current conversation when 
- you input is a little bit longer than 20 characters (I don't think we need to show if a user input is very short? I often mistype or start typing in a wrong conversation)
- not on dev environment
- this should work when you try to go to a different conversation or reload the page 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
