### PR TITLE
[front] - fix(obs): conditional logic in tabs 

### DIFF
--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -128,13 +128,15 @@ export function AgentDetails({
   );
 
   const showPerformanceTabs =
-    (agentConfiguration?.canEdit ?? isAdmin(owner)) &&
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    (agentConfiguration?.canEdit || isAdmin(owner)) &&
     agentId != null &&
     !isGlobalAgent;
 
   const showInsightsTabs =
     agentId != null &&
-    (agentConfiguration?.canEdit ?? isAdmin(owner)) &&
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    (agentConfiguration?.canEdit || isAdmin(owner)) &&
     !isGlobalAgent &&
     hasFeature("agent_builder_observability");
 


### PR DESCRIPTION
## Description

Fix conditional logic for tab visibility in `AgentDetails` by replacing nullish coalescing operators (`??`) with logical OR (`||`). This makes the permission checks more explicit and clearer when determining whether to show the Performance and Insights tabs based on `agentConfiguration?.canEdit` or `isAdmin(owner)`.

## Risk
None

## Tests
Locally

## Deploy Plan
Deploy front