### PR TITLE
[front] enh(webhooks): add signature check for Fathom webhooks

### DIFF
--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -157,15 +157,14 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     >,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
-    await WebhookSourceModel.update(updates, {
-      where: {
-        id: this.id,
-      },
-      transaction,
-    });
+    await this.update(updates, transaction);
 
     // Update the current instance
     Object.assign(this, updates);
+  }
+
+  async updateSecret(secret: WebhookSourceModel["secret"]): Promise<void> {
+    await this.update({ secret });
   }
 
   async delete(

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -158,9 +158,6 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
     await this.update(updates, transaction);
-
-    // Update the current instance
-    Object.assign(this, updates);
   }
 
   async updateSecret(

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -163,8 +163,11 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     Object.assign(this, updates);
   }
 
-  async updateSecret(secret: WebhookSourceModel["secret"]): Promise<void> {
-    await this.update({ secret });
+  async updateSecret(
+    secret: WebhookSourceModel["secret"],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.update({ secret }, transaction);
   }
 
   async delete(

--- a/front/lib/triggers/built-in-webhooks/fathom/fathom_client.ts
+++ b/front/lib/triggers/built-in-webhooks/fathom/fathom_client.ts
@@ -7,7 +7,7 @@ import type {
 
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 export type FathomWebhookConfig = {
   destinationUrl: string;
@@ -68,5 +68,22 @@ export class FathomClient {
     }
 
     return new Ok(undefined);
+  }
+
+  static verifyWebhook({
+    secret,
+    headers,
+    body,
+  }: {
+    secret: string;
+    headers: Record<string, string>;
+    body: string;
+  }): Result<void, Error> {
+    try {
+      Fathom.verifyWebhook(secret, headers, body);
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
   }
 }

--- a/front/lib/triggers/built-in-webhooks/fathom/fathom_webhook_service.ts
+++ b/front/lib/triggers/built-in-webhooks/fathom/fathom_webhook_service.ts
@@ -113,6 +113,7 @@ export class FathomWebhookService implements RemoteWebhookService<"fathom"> {
         include_action_items: webhook.includeActionItems,
         include_crm_matches: webhook.includeCrmMatches,
       },
+      secret: webhook.secret,
     });
   }
 

--- a/front/lib/triggers/temporal/webhook/activities.ts
+++ b/front/lib/triggers/temporal/webhook/activities.ts
@@ -218,7 +218,7 @@ export async function runTriggerWebhookActivity({
       configuration: { event, filter },
     } = trigger;
 
-    if (event && event !== receivedEventValue) {
+    if (event && receivedEventValue && event !== receivedEventValue) {
       // Received event doesn't match the trigger's event, skip this trigger
       await webhookRequest.markRelatedTrigger({
         trigger,

--- a/front/lib/triggers/temporal/webhook/activities.ts
+++ b/front/lib/triggers/temporal/webhook/activities.ts
@@ -103,14 +103,6 @@ export async function runTriggerWebhookActivity({
 
   // Validate webhook signature if secret is configured
   if (secret) {
-    if (!signatureHeader || !signatureAlgorithm) {
-      const errorMessage =
-        "Webhook source is missing header or algorithm configuration.";
-      await webhookRequest.markAsFailed(errorMessage);
-      logger.error({ workspaceId, webhookRequestId }, errorMessage);
-      throw new TriggerNonRetryableError(errorMessage);
-    }
-
     const r = checkSignature({
       headerName: signatureHeader,
       algorithm: signatureAlgorithm,

--- a/front/lib/triggers/temporal/webhook/activities.ts
+++ b/front/lib/triggers/temporal/webhook/activities.ts
@@ -103,7 +103,7 @@ export async function runTriggerWebhookActivity({
 
   // Validate webhook signature if secret is configured
   if (secret) {
-    const r = checkSignature({
+    const signatureCheckResult = checkSignature({
       headerName: signatureHeader,
       algorithm: signatureAlgorithm,
       secret,
@@ -112,8 +112,8 @@ export async function runTriggerWebhookActivity({
       provider,
     });
 
-    if (r.isErr()) {
-      const errorMessage = r.error.message;
+    if (signatureCheckResult.isErr()) {
+      const { message: errorMessage } = signatureCheckResult.error;
       await webhookRequest.markAsFailed(errorMessage);
       logger.error({ workspaceId, webhookRequestId }, errorMessage);
       throw new TriggerNonRetryableError(errorMessage);

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -8,6 +8,7 @@ import type { WebhookRequestTriggerStatus } from "@app/lib/models/assistant/trig
 import { WebhookRequestTriggerModel } from "@app/lib/models/assistant/triggers/webhook_request_trigger";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
+import { FathomClient } from "@app/lib/triggers/built-in-webhooks/fathom/fathom_client";
 import { launchAgentTriggerWebhookWorkflow } from "@app/lib/triggers/temporal/webhook/client";
 import {
   getTimeframeSecondsFromLiteral,
@@ -18,7 +19,10 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok, removeNulls } from "@app/types";
 import type { TriggerType } from "@app/types/assistant/triggers";
-import type { WebhookSourceForAdminType } from "@app/types/triggers/webhooks";
+import type {
+  WebhookProvider,
+  WebhookSourceForAdminType,
+} from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
 
 const WORKSPACE_MESSAGE_LIMIT_MULTIPLIER = 0.5; // 50% of workspace message limit
@@ -26,11 +30,15 @@ const WORKSPACE_MESSAGE_LIMIT_MULTIPLIER = 0.5; // 50% of workspace message limi
 /**
  * To avoid storing sensitive information, only these headers are allowed to be stored in GCS.
  */
-const HEADERS_ALLOWED_LIST = removeNulls(
-  Object.values(WEBHOOK_PRESETS)
-    .filter((preset) => preset.eventCheck?.type === "headers")
-    .map((preset) => preset.eventCheck?.field.toLowerCase())
-);
+const HEADERS_ALLOWED_LIST = [
+  ...removeNulls(
+    Object.values(WEBHOOK_PRESETS)
+      .filter((preset) => preset.eventCheck?.type === "headers")
+      .map((preset) => preset.eventCheck?.field.toLowerCase())
+  ),
+  // Header used by Fathom.
+  "webhook-signature",
+];
 
 export function checkSignature({
   headerName,
@@ -38,16 +46,53 @@ export function checkSignature({
   secret,
   headers,
   body,
+  provider,
 }: {
-  headerName: string;
-  algorithm: "sha1" | "sha256" | "sha512";
+  headerName: string | null;
+  algorithm: "sha1" | "sha256" | "sha512" | null;
   secret: string;
   headers: Record<string, string>;
   body: unknown;
+  provider: WebhookProvider | null;
 }): Result<
   void,
   Omit<DustError, "code"> & { code: "invalid_signature_error" }
 > {
+  if (provider === "fathom") {
+    const verifyRes = FathomClient.verifyWebhook({
+      secret,
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (verifyRes.isErr()) {
+      return new Err({
+        name: "dust_error",
+        code: "invalid_signature_error",
+        message: `Invalid Fathom webhook signature: ${verifyRes.error.message}`,
+      });
+    }
+
+    return new Ok(undefined);
+  }
+
+  if (!secret) {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_signature_error",
+      message: "Missing secret for webhook verification",
+    });
+  }
+
+  if (!headerName || !algorithm) {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_signature_error",
+      message:
+        "Missing headerName or algorithm for custom webhook verification",
+    });
+  }
+
   const signature = headers[headerName.toLowerCase()] as string;
 
   if (!signature) {

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -76,14 +76,6 @@ export function checkSignature({
     return new Ok(undefined);
   }
 
-  if (!secret) {
-    return new Err({
-      name: "dust_error",
-      code: "invalid_signature_error",
-      message: "Missing secret for webhook verification",
-    });
-  }
-
   if (!headerName || !algorithm) {
     return new Err({
       name: "dust_error",

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
@@ -339,11 +339,6 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(500);
-
-    const responseData = res._getJSONData();
-    expect(responseData).toEqual({
-      success: true,
-    });
   });
 
   it("should return 404 when webhook source does not exist", async () => {

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.test.ts
@@ -326,7 +326,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
     expect(updatedWebhookSource?.oauthConnectionId).toBe("valid-connection");
   });
 
-  it("should return 200 with empty body (no updates)", async () => {
+  it("should return 500 on empty body (no updates)", async () => {
     const { req, res, workspace } = await setupTest("admin", "PATCH");
 
     const webhookSource = await createWebhookSource(
@@ -338,7 +338,7 @@ describe("PATCH /api/w/[wId]/webhook_sources/[webhookSourceId]", () => {
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(200);
+    expect(res._getStatusCode()).toBe(500);
 
     const responseData = res._getJSONData();
     expect(responseData).toEqual({

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -239,11 +239,17 @@ async function handler(
         }
 
         // Update the webhook source with the id of the webhook
-        const updatedRemoteMetadata = result.value.updatedRemoteMetadata;
+        const { updatedRemoteMetadata, secret: secretFromRemote } =
+          result.value;
+
         await webhookSource.updateRemoteMetadata({
           remoteMetadata: updatedRemoteMetadata,
           oauthConnectionId: connectionId,
         });
+
+        if (secretFromRemote) {
+          await webhookSource.updateSecret(secretFromRemote);
+        }
       }
 
       return res.status(201).json({

--- a/front/types/triggers/remote_webhook_service.ts
+++ b/front/types/triggers/remote_webhook_service.ts
@@ -26,6 +26,7 @@ export interface RemoteWebhookService<
     Result<
       {
         updatedRemoteMetadata: Record<string, unknown>;
+        secret?: string;
         errors?: string[];
       },
       Error


### PR DESCRIPTION
## Description

- This PR adds a signature check on webhooks received from Fathom, as detailed in https://developers.fathom.ai/webhooks#verifying-webhooks.
- This check is based on a secret received upon creating the webhook on Fathom.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
