### PR TITLE
Fix Gemini 2.5 Pro

### DIFF
--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -56,7 +56,7 @@ export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   isLatest: true,
   generationTokensCount: 64_000,
   supportsVision: true,
-  minimumReasoningEffort: "none",
+  minimumReasoningEffort: "light",
   maximumReasoningEffort: "high",
-  defaultReasoningEffort: "none",
+  defaultReasoningEffort: "light",
 };


### PR DESCRIPTION
## Description

Gemini 2.5 Pro was not working.
Get this error:
`Budget 0 is invalid. This model only works in thinking mode`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
