### PR TITLE
Log conversations that are using the new LLM router

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -128,10 +128,10 @@ export async function renderConversationForModel(
 
   // prune previous interactions.
   previousInteractions = prunePreviousInteractions(
-      previousInteractions,
-      availableTokens,
-      PREVIOUS_INTERACTIONS_TO_PRESERVE
-    );
+    previousInteractions,
+    availableTokens,
+    PREVIOUS_INTERACTIONS_TO_PRESERVE
+  );
 
   const prunedInteractions = [...previousInteractions, currentInteraction];
 

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -101,23 +101,9 @@ export async function renderConversationForModel(
 
   let availableTokens = allowedTokenCount - baseTokens;
 
-  let isContextWindowHit = false;
-  function logContextWindowHit(interactionsCount: number) {
-    logger.info(
-      {
-        workspaceId: conversation.owner.sId,
-        conversationId: conversation.sId,
-        interactionsCount, // Number of interactions before hitting the context window
-      },
-      "Conversation hit context window"
-    );
-  }
-
   if (currentInteractionTokens > availableTokens) {
     // The last interaction does not fit within the token budget.
     // We apply progressive pruning to that interaction until it fits within the token budget.
-    logContextWindowHit(1);
-    isContextWindowHit = true;
     currentInteraction = progressivelyPruneInteraction(
       currentInteraction,
       availableTokens
@@ -138,24 +124,16 @@ export async function renderConversationForModel(
     availableTokens -= currentInteractionTokens;
   }
 
-  const previousInteractions = interactions.slice(0, -1);
+  let previousInteractions = interactions.slice(0, -1);
 
   // prune previous interactions.
-  const { interactions: prunedPreviousInteractions, contextWindowHitPosition } =
-    prunePreviousInteractions(
+  previousInteractions = prunePreviousInteractions(
       previousInteractions,
       availableTokens,
       PREVIOUS_INTERACTIONS_TO_PRESERVE
     );
-  if (!isContextWindowHit && contextWindowHitPosition > 0) {
-    logContextWindowHit(contextWindowHitPosition + 1); // we add 1 to include the current interaction
-    isContextWindowHit = true;
-  }
 
-  const prunedInteractions = [
-    ...prunedPreviousInteractions,
-    currentInteraction,
-  ];
+  const prunedInteractions = [...previousInteractions, currentInteraction];
 
   // Select interactions that fit within token budget.
   const selected: MessageWithTokens[] = [];
@@ -170,9 +148,6 @@ export async function renderConversationForModel(
       tokensUsed += interactionTokens;
       selected.unshift(...interaction.messages);
     } else {
-      if (!isContextWindowHit) {
-        logContextWindowHit(prunedInteractions.length - i);
-      }
       break;
     }
   }

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -108,10 +108,9 @@ export function prunePreviousInteractions(
   inputInteractions: InteractionWithTokens[],
   maxTokens: number,
   interactionsToPreserve: number
-): { interactions: InteractionWithTokens[]; contextWindowHitPosition: number } {
+): InteractionWithTokens[] {
   const interactions = [...inputInteractions];
 
-  let contextWindowHitPosition = 0;
   let shouldPrune = false;
   let availableTokens = maxTokens;
   for (let i = interactions.length - 1; i >= 0; i--) {
@@ -138,7 +137,6 @@ export function prunePreviousInteractions(
       interactions[i] = pruneAllToolResults(interaction);
       interactionTokens = getInteractionTokenCount(interaction);
       shouldPrune = true;
-      contextWindowHitPosition = interactions.length - i; // contextWindowHitPosition is the number of interactions before hitting the context window
     } else {
       // Interaction fits within the token budget.
       // We keep it as-is
@@ -148,8 +146,5 @@ export function prunePreviousInteractions(
     availableTokens -= interactionTokens;
   }
 
-  return {
-    interactions,
-    contextWindowHitPosition,
-  };
+  return interactions;
 }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -465,9 +465,12 @@ export async function runModelActivity(
   } else {
     if (userMessage.rank === 0) {
       // Log conversations that are using the new LLM router (log only once when the conversation starts)
-      localLogger.info({
-        conversationId: conversation.sId,
-      }, "Running model with the new LLM router");
+      localLogger.info(
+        {
+          conversationId: conversation.sId,
+        },
+        "Running model with the new LLM router"
+      );
     }
     getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
       modelConversationRes,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -463,6 +463,12 @@ export async function runModelActivity(
       prompt,
     });
   } else {
+    if (userMessage.rank === 0) {
+      // Log conversations that are using the new LLM router (log only once when the conversation starts)
+      localLogger.info({
+        conversationId: conversation.sId,
+      }, "Running model with the new LLM router");
+    }
     getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
       modelConversationRes,
       conversation,

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1504,14 +1504,6 @@ export class CoreAPI {
     providerId: string;
   }): Promise<CoreAPIResponse<{ counts: number[] }>> {
     const credentials = dustManagedCredentials();
-    this._logger.info(
-      {
-        textsLength: texts.length,
-        modelId,
-        providerId,
-      },
-      "Calling core API tokenizer batch count endpoint"
-    );
 
     const response = await this._fetchWithError(
       `${this._url}/tokenize/batch/count`,


### PR DESCRIPTION
## Description

This PR:
- removes the logs created to monitor the context window hits and tokenizer rate limits
- adds a log to track the number of conversations that use the new LLM router

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
