### PR TITLE
Move models-tokenizers mapping to front

### DIFF
--- a/core/src/api/tokenize.rs
+++ b/core/src/api/tokenize.rs
@@ -84,7 +84,7 @@ async fn tokenize_batch_internal(
     if let Some(c) = payload.credentials {
         llm.initialize(c).await?;
     }
-    
+
     // Initialize the tokenizer from the config
     llm.set_tokenizer_from_config(payload.tokenizer);
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -55,6 +55,9 @@ pub mod project;
 pub mod run;
 pub mod search_filter;
 pub mod utils;
+pub mod types {
+    pub mod tokenizer;
+}
 pub mod providers {
     pub mod azure_openai;
     pub mod chat_messages;

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -16,6 +16,7 @@ use crate::providers::provider::{ModelError, ModelErrorRetryOptions, Provider, P
 use crate::providers::tiktoken::tiktoken::anthropic_base_singleton;
 use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, decode_async, encode_async};
 use crate::run::Credentials;
+use crate::types::tokenizer::TokenizerConfig;
 use crate::utils;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -332,8 +333,8 @@ impl LLM for AnthropicLLM {
         }
     }
 
-    fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
-        self.tokenizer = TokenizerSingleton::from_config(config.clone());
+    fn set_tokenizer_from_config(&mut self, config: TokenizerConfig) {
+        self.tokenizer = TokenizerSingleton::from_config(&config);
     }
 
     async fn generate(

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -357,24 +357,27 @@ impl LLM for AnthropicLLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn chat(

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -59,7 +59,11 @@ impl AnthropicLLM {
             api_key: None,
             user_id: None,
             backend: Box::new(DirectAnthropicBackend::new()),
-            tokenizer,
+            tokenizer: tokenizer.or_else(|| {
+                TokenizerSingleton::from_config(&TokenizerConfig::Tiktoken {
+                    base: TiktokenTokenizerBase::AnthropicBase,
+                })
+            }),
         }
     }
 

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -215,16 +215,9 @@ impl LLM for AzureOpenAILLM {
     fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
         self.tokenizer = match self.model_id.as_ref() {
             Some(model_id) => match model_id.as_str() {
-                "code_davinci-002" | "code-cushman-001" => {
-                    Some(TokenizerSingleton::Tiktoken(p50k_base_singleton()))
-                }
-                "text-davinci-002" | "text-davinci-003" => {
-                    Some(TokenizerSingleton::Tiktoken(p50k_base_singleton()))
-                }
-                _ => match model_id.starts_with("gpt-3.5-turbo") || model_id.starts_with("gpt-4") {
-                    true => Some(TokenizerSingleton::Tiktoken(cl100k_base_singleton())),
-                    false => TokenizerSingleton::from_config(&config),
-                },
+                "code_davinci-002" | "code-cushman-001" | "text-davinci-002"
+                | "text-davinci-003" => Some(TokenizerSingleton::Tiktoken(p50k_base_singleton())),
+                _ => TokenizerSingleton::from_config(&config),
             },
             None => TokenizerSingleton::from_config(&config),
         };

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -126,7 +126,7 @@ pub struct AzureOpenAILLM {
 impl AzureOpenAILLM {
     pub fn new(deployment_id: String, tokenizer: Option<TokenizerSingleton>) -> Self {
         AzureOpenAILLM {
-            deployment_id: deployment_id.clone(),
+            deployment_id,
             model_id: None,
             endpoint: None,
             api_key: None,

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -223,10 +223,10 @@ impl LLM for AzureOpenAILLM {
                 }
                 _ => match model_id.starts_with("gpt-3.5-turbo") || model_id.starts_with("gpt-4") {
                     true => Some(TokenizerSingleton::Tiktoken(cl100k_base_singleton())),
-                    false => TokenizerSingleton::from_config(config),
+                    false => TokenizerSingleton::from_config(&config),
                 },
             },
-            None => TokenizerSingleton::from_config(config),
+            None => TokenizerSingleton::from_config(&config),
         };
     }
 

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -224,24 +224,27 @@ impl LLM for AzureOpenAILLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn generate(

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -9,9 +9,7 @@ use crate::providers::openai::streamed_completion;
 use crate::providers::openai::{completion, REMAINING_TOKENS_MARGIN};
 use crate::providers::provider::{Provider, ProviderID};
 use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, decode_async, encode_async};
-use crate::providers::tiktoken::tiktoken::{
-    cl100k_base_singleton, CoreBPE, p50k_base_singleton,
-};
+use crate::providers::tiktoken::tiktoken::{cl100k_base_singleton, p50k_base_singleton, CoreBPE};
 use crate::run::Credentials;
 use crate::utils;
 use anyhow::{anyhow, Result};
@@ -155,7 +153,6 @@ impl AzureOpenAILLM {
         )
         .parse::<Uri>()?)
     }
-
 }
 
 #[async_trait]
@@ -218,8 +215,12 @@ impl LLM for AzureOpenAILLM {
     fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
         self.tokenizer = match self.model_id.as_ref() {
             Some(model_id) => match model_id.as_str() {
-                "code_davinci-002" | "code-cushman-001" => Some(TokenizerSingleton::Tiktoken(p50k_base_singleton())),
-                "text-davinci-002" | "text-davinci-003" => Some(TokenizerSingleton::Tiktoken(p50k_base_singleton())),
+                "code_davinci-002" | "code-cushman-001" => {
+                    Some(TokenizerSingleton::Tiktoken(p50k_base_singleton()))
+                }
+                "text-davinci-002" | "text-davinci-003" => {
+                    Some(TokenizerSingleton::Tiktoken(p50k_base_singleton()))
+                }
                 _ => match model_id.starts_with("gpt-3.5-turbo") || model_id.starts_with("gpt-4") {
                     true => Some(TokenizerSingleton::Tiktoken(cl100k_base_singleton())),
                     false => TokenizerSingleton::from_config(config),

--- a/core/src/providers/deepseek.rs
+++ b/core/src/providers/deepseek.rs
@@ -5,7 +5,7 @@ use crate::providers::llm::TokenizerSingleton;
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLM};
 use crate::providers::provider::{Provider, ProviderID};
 use crate::run::Credentials;
-use crate::types::tokenizer::{TokenizerConfig, TiktokenTokenizerBase};
+use crate::types::tokenizer::{TiktokenTokenizerBase, TokenizerConfig};
 use crate::utils;
 
 use anyhow::{anyhow, Result};
@@ -33,7 +33,11 @@ impl DeepseekLLM {
         DeepseekLLM {
             id,
             api_key: None,
-            tokenizer,
+            tokenizer: tokenizer.or_else(|| {
+                TokenizerSingleton::from_config(&TokenizerConfig::Tiktoken {
+                    base: TiktokenTokenizerBase::O200kBase,
+                })
+            }),
         }
     }
 
@@ -75,7 +79,6 @@ impl LLM for DeepseekLLM {
     fn context_size(&self) -> usize {
         Self::deepseek_context_size(self.id.as_str())
     }
-
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
         self.tokenizer

--- a/core/src/providers/deepseek.rs
+++ b/core/src/providers/deepseek.rs
@@ -80,24 +80,27 @@ impl LLM for DeepseekLLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn generate(

--- a/core/src/providers/deepseek.rs
+++ b/core/src/providers/deepseek.rs
@@ -76,7 +76,7 @@ impl LLM for DeepseekLLM {
     }
 
     fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
-        self.tokenizer = TokenizerSingleton::from_config(config);
+        self.tokenizer = TokenizerSingleton::from_config(&config);
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {

--- a/core/src/providers/deepseek.rs
+++ b/core/src/providers/deepseek.rs
@@ -1,19 +1,15 @@
-use std::sync::Arc;
-
 use crate::providers::chat_messages::ChatMessage;
 use crate::providers::embedder::Embedder;
 use crate::providers::llm::ChatFunction;
+use crate::providers::llm::TokenizerSingleton;
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLM};
 use crate::providers::provider::{Provider, ProviderID};
-use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, o200k_base_singleton, CoreBPE};
-use crate::providers::tiktoken::tiktoken::{decode_async, encode_async};
 use crate::run::Credentials;
 use crate::utils;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use hyper::Uri;
-use parking_lot::RwLock;
 use serde_json::Value;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -28,20 +24,20 @@ const MODEL_IDS_WITH_TOOLS_SUPPORT: &[&str] = &["deepseek-chat"];
 pub struct DeepseekLLM {
     id: String,
     api_key: Option<String>,
+    tokenizer: Option<TokenizerSingleton>,
 }
 
 impl DeepseekLLM {
     pub fn new(id: String) -> Self {
-        DeepseekLLM { id, api_key: None }
+        DeepseekLLM {
+            id,
+            api_key: None,
+            tokenizer: None,
+        }
     }
 
     fn chat_uri(&self) -> Result<Uri> {
         Ok(format!("https://api.deepseek.com/v1/chat/completions",).parse::<Uri>()?)
-    }
-
-    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
-        // TODO(@fontanierh): TBD
-        o200k_base_singleton()
     }
 
     pub fn deepseek_context_size(_model_id: &str) -> usize {
@@ -79,16 +75,29 @@ impl LLM for DeepseekLLM {
         Self::deepseek_context_size(self.id.as_str())
     }
 
+    fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
+        self.tokenizer = TokenizerSingleton::from_config(config);
+    }
+
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        encode_async(self.tokenizer(), text).await
+        match &self.tokenizer {
+            Some(t) => t.encode(text).await,
+            None => Err(anyhow!("Tokenizer not initialized")),
+        }
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        decode_async(self.tokenizer(), tokens).await
+        match &self.tokenizer {
+            Some(t) => t.decode(tokens).await,
+            None => Err(anyhow!("Tokenizer not initialized")),
+        }
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        batch_tokenize_async(self.tokenizer(), texts).await
+        match &self.tokenizer {
+            Some(t) => t.tokenize(texts).await,
+            None => Err(anyhow!("Tokenizer not initialized")),
+        }
     }
 
     async fn generate(

--- a/core/src/providers/fireworks.rs
+++ b/core/src/providers/fireworks.rs
@@ -83,7 +83,7 @@ impl LLM for FireworksLLM {
     }
 
     fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
-        self.tokenizer = TokenizerSingleton::from_config(config);
+        self.tokenizer = TokenizerSingleton::from_config(&config);
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {

--- a/core/src/providers/fireworks.rs
+++ b/core/src/providers/fireworks.rs
@@ -1,19 +1,16 @@
 use crate::providers::chat_messages::ChatMessage;
 use crate::providers::embedder::Embedder;
 use crate::providers::llm::ChatFunction;
+use crate::providers::llm::TokenizerSingleton;
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLM};
 use crate::providers::provider::{Provider, ProviderID};
-use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, o200k_base_singleton, CoreBPE};
-use crate::providers::tiktoken::tiktoken::{decode_async, encode_async};
 use crate::run::Credentials;
 use crate::utils;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use hyper::Uri;
-use parking_lot::RwLock;
 use serde_json::Value;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::helpers::strip_tools_from_chat_history;
@@ -34,20 +31,20 @@ const MODEL_IDS_WITH_TOOLS_SUPPORT: &[&str] = &[
 pub struct FireworksLLM {
     id: String,
     api_key: Option<String>,
+    tokenizer: Option<TokenizerSingleton>,
 }
 
 impl FireworksLLM {
     pub fn new(id: String) -> Self {
-        FireworksLLM { id, api_key: None }
+        FireworksLLM {
+            id,
+            api_key: None,
+            tokenizer: None,
+        }
     }
 
     fn chat_uri(&self) -> Result<Uri> {
         Ok(format!("https://api.fireworks.ai/inference/v1/chat/completions",).parse::<Uri>()?)
-    }
-
-    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
-        // TODO(@fontanierh): TBD
-        o200k_base_singleton()
     }
 
     pub fn fireworks_context_size(_model_id: &str) -> usize {
@@ -85,16 +82,29 @@ impl LLM for FireworksLLM {
         Self::fireworks_context_size(self.id.as_str())
     }
 
+    fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
+        self.tokenizer = TokenizerSingleton::from_config(config);
+    }
+
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        encode_async(self.tokenizer(), text).await
+        match &self.tokenizer {
+            Some(t) => t.encode(text).await,
+            None => Err(anyhow!("Tokenizer not initialized")),
+        }
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        decode_async(self.tokenizer(), tokens).await
+        match &self.tokenizer {
+            Some(t) => t.decode(tokens).await,
+            None => Err(anyhow!("Tokenizer not initialized")),
+        }
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        batch_tokenize_async(self.tokenizer(), texts).await
+        match &self.tokenizer {
+            Some(t) => t.tokenize(texts).await,
+            None => Err(anyhow!("Tokenizer not initialized")),
+        }
     }
 
     async fn generate(

--- a/core/src/providers/fireworks.rs
+++ b/core/src/providers/fireworks.rs
@@ -87,24 +87,27 @@ impl LLM for FireworksLLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn generate(

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -94,24 +94,27 @@ impl LLM for GoogleAiStudioLLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn generate(

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -7,6 +7,7 @@ use super::{
     openai_compatible_helpers::{openai_compatible_chat_completion, TransformSystemMessages},
     provider::{Provider, ProviderID},
 };
+use crate::types::tokenizer::{TiktokenTokenizerBase, TokenizerConfig};
 use crate::{run::Credentials, utils};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -60,7 +61,11 @@ impl GoogleAiStudioLLM {
         Self {
             id,
             api_key: None,
-            tokenizer,
+            tokenizer: tokenizer.or_else(|| {
+                TokenizerSingleton::from_config(&TokenizerConfig::Tiktoken {
+                    base: TiktokenTokenizerBase::Cl100kBase,
+                })
+            }),
         }
     }
 
@@ -88,7 +93,6 @@ impl LLM for GoogleAiStudioLLM {
     fn context_size(&self) -> usize {
         1_000_000
     }
-
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
         self.tokenizer

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -90,7 +90,7 @@ impl LLM for GoogleAiStudioLLM {
     }
 
     fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
-        self.tokenizer = TokenizerSingleton::from_config(config);
+        self.tokenizer = TokenizerSingleton::from_config(&config);
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -40,8 +40,8 @@ impl Provider for GoogleAiStudioProvider {
         ))
     }
 
-    fn llm(&self, id: String) -> Box<dyn LLM + Sync + Send> {
-        Box::new(GoogleAiStudioLLM::new(id))
+    fn llm(&self, id: String, tokenizer: Option<TokenizerSingleton>) -> Box<dyn LLM + Sync + Send> {
+        Box::new(GoogleAiStudioLLM::new(id, tokenizer))
     }
 
     fn embedder(&self, _id: String) -> Box<dyn Embedder + Sync + Send> {
@@ -56,11 +56,11 @@ pub struct GoogleAiStudioLLM {
 }
 
 impl GoogleAiStudioLLM {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: String, tokenizer: Option<TokenizerSingleton>) -> Self {
         Self {
             id,
             api_key: None,
-            tokenizer: None,
+            tokenizer,
         }
     }
 
@@ -89,9 +89,6 @@ impl LLM for GoogleAiStudioLLM {
         1_000_000
     }
 
-    fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
-        self.tokenizer = TokenizerSingleton::from_config(&config);
-    }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
         self.tokenizer

--- a/core/src/providers/google_ai_studio.rs
+++ b/core/src/providers/google_ai_studio.rs
@@ -2,8 +2,8 @@ use super::{
     chat_messages::ChatMessage,
     embedder::Embedder,
     helpers::{convert_message_images_to_base64, fetch_and_encode_images_from_messages},
-    llm::{ChatFunction, LLMChatGeneration, LLMGeneration, LLM},
     llm::TokenizerSingleton,
+    llm::{ChatFunction, LLMChatGeneration, LLMGeneration, LLM},
     openai_compatible_helpers::{openai_compatible_chat_completion, TransformSystemMessages},
     provider::{Provider, ProviderID},
 };
@@ -67,7 +67,6 @@ impl GoogleAiStudioLLM {
     fn model_endpoint(&self) -> Uri {
         Uri::from_static("https://generativelanguage.googleapis.com/v1beta/openai/chat/completions")
     }
-
 }
 
 #[async_trait]

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -36,7 +36,7 @@ pub enum TokenizerSingleton {
 }
 
 impl TokenizerSingleton {
-    pub fn from_config(config: TokenizerConfig) -> Option<Self> {
+    pub fn from_config(config: &TokenizerConfig) -> Option<Self> {
         match config {
             TokenizerConfig::Tiktoken { base } => match base {
                 TiktokenTokenizerBase::O200kBase => {

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -221,8 +221,6 @@ pub trait LLM {
 
     fn context_size(&self) -> usize;
 
-    fn set_tokenizer_from_config(&mut self, config: TokenizerConfig);
-
     async fn encode(&self, text: &str) -> Result<Vec<usize>>;
     async fn decode(&self, tokens: Vec<usize>) -> Result<String>;
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>>;
@@ -358,7 +356,7 @@ impl LLMRequest {
         event_sender: Option<UnboundedSender<Value>>,
         run_id: String,
     ) -> Result<LLMGeneration> {
-        let mut llm = provider(self.provider_id).llm(self.model_id.clone());
+        let mut llm = provider(self.provider_id).llm(self.model_id.clone(), None);
         llm.initialize(credentials).await?;
 
         let out = with_retryable_back_off(
@@ -584,7 +582,7 @@ impl LLMChatRequest {
         event_sender: Option<UnboundedSender<Value>>,
         run_id: String,
     ) -> Result<LLMChatGeneration> {
-        let mut llm = provider(self.provider_id).llm(self.model_id.clone());
+        let mut llm = provider(self.provider_id).llm(self.model_id.clone(), None);
         llm.initialize(credentials).await?;
 
         let out = with_retryable_back_off(

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -4,6 +4,7 @@ use crate::providers::chat_messages::{AssistantChatMessage, AssistantContentItem
 use crate::providers::provider::{provider, with_retryable_back_off, ProviderID};
 use crate::run::Credentials;
 use crate::stores::store::Store;
+use crate::types::tokenizer::TokenizerConfig;
 use crate::utils::ParseError;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -13,6 +14,93 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, info};
+
+use crate::providers::sentencepiece::sentencepiece::{
+    mistral_instruct_tokenizer_240216_model_v2_base_singleton,
+    mistral_instruct_tokenizer_240216_model_v3_base_singleton,
+    mistral_tokenizer_model_v1_base_singleton,
+};
+use crate::providers::tiktoken::tiktoken::CoreBPE;
+use crate::providers::tiktoken::tiktoken::{
+    anthropic_base_singleton, cl100k_base_singleton, o200k_base_singleton, p50k_base_singleton, r50k_base_singleton,
+};
+use crate::types::tokenizer::{SentencePieceTokenizerBase, TiktokenTokenizerBase};
+use parking_lot::RwLock;
+use sentencepiece::SentencePieceProcessor;
+use std::sync::Arc;
+
+pub enum TokenizerSingleton {
+    Tiktoken(Arc<RwLock<CoreBPE>>),
+    SentencePiece(Arc<RwLock<SentencePieceProcessor>>),
+}
+
+impl TokenizerSingleton {
+    pub fn from_config(config: TokenizerConfig) -> Option<Self> {
+        match config {
+            TokenizerConfig::Tiktoken { base } => match base {
+                TiktokenTokenizerBase::O200kBase => {
+                    Some(TokenizerSingleton::Tiktoken(o200k_base_singleton()))
+                }
+                TiktokenTokenizerBase::Cl100kBase => {
+                    Some(TokenizerSingleton::Tiktoken(cl100k_base_singleton()))
+                }
+                TiktokenTokenizerBase::P50kBase => {
+                    Some(TokenizerSingleton::Tiktoken(p50k_base_singleton()))
+                }
+                TiktokenTokenizerBase::R50kBase => {
+                    Some(TokenizerSingleton::Tiktoken(r50k_base_singleton()))
+                }
+                TiktokenTokenizerBase::AnthropicBase => {
+                    Some(TokenizerSingleton::Tiktoken(anthropic_base_singleton()))
+                }
+            },
+            TokenizerConfig::SentencePiece { base } => match base {
+                SentencePieceTokenizerBase::ModelV1 => Some(TokenizerSingleton::SentencePiece(
+                    mistral_tokenizer_model_v1_base_singleton(),
+                )),
+                SentencePieceTokenizerBase::ModelV2 => Some(TokenizerSingleton::SentencePiece(
+                    mistral_instruct_tokenizer_240216_model_v2_base_singleton(),
+                )),
+                SentencePieceTokenizerBase::ModelV3 => Some(TokenizerSingleton::SentencePiece(
+                    mistral_instruct_tokenizer_240216_model_v3_base_singleton(),
+                )),
+            },
+        }
+    }
+
+    pub async fn encode(&self, text: &str) -> Result<Vec<usize>> {
+        match self {
+            TokenizerSingleton::Tiktoken(bpe) => {
+                crate::providers::tiktoken::tiktoken::encode_async(bpe.clone(), text).await
+            }
+            TokenizerSingleton::SentencePiece(spp) => {
+                crate::providers::sentencepiece::sentencepiece::encode_async(spp.clone(), text).await
+            }
+        }
+    }
+
+    pub async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
+        match self {
+            TokenizerSingleton::Tiktoken(bpe) => {
+                crate::providers::tiktoken::tiktoken::decode_async(bpe.clone(), tokens).await
+            }
+            TokenizerSingleton::SentencePiece(spp) => {
+                crate::providers::sentencepiece::sentencepiece::decode_async(spp.clone(), tokens).await
+            }
+        }
+    }
+
+    pub async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        match self {
+            TokenizerSingleton::Tiktoken(bpe) => {
+                crate::providers::tiktoken::tiktoken::batch_tokenize_async(bpe.clone(), texts).await
+            }
+            TokenizerSingleton::SentencePiece(spp) => {
+                crate::providers::sentencepiece::sentencepiece::batch_tokenize_async(spp.clone(), texts).await
+            }
+        }
+    }
+}
 
 #[derive(Debug, Serialize, PartialEq, Clone, Deserialize)]
 pub struct Tokens {
@@ -125,6 +213,8 @@ pub trait LLM {
     async fn initialize(&mut self, credentials: Credentials) -> Result<()>;
 
     fn context_size(&self) -> usize;
+
+    fn set_tokenizer_from_config(&mut self, config: TokenizerConfig);
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>>;
     async fn decode(&self, tokens: Vec<usize>) -> Result<String>;

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -22,7 +22,8 @@ use crate::providers::sentencepiece::sentencepiece::{
 };
 use crate::providers::tiktoken::tiktoken::CoreBPE;
 use crate::providers::tiktoken::tiktoken::{
-    anthropic_base_singleton, cl100k_base_singleton, o200k_base_singleton, p50k_base_singleton, r50k_base_singleton,
+    anthropic_base_singleton, cl100k_base_singleton, o200k_base_singleton, p50k_base_singleton,
+    r50k_base_singleton,
 };
 use crate::types::tokenizer::{SentencePieceTokenizerBase, TiktokenTokenizerBase};
 use parking_lot::RwLock;
@@ -74,7 +75,8 @@ impl TokenizerSingleton {
                 crate::providers::tiktoken::tiktoken::encode_async(bpe.clone(), text).await
             }
             TokenizerSingleton::SentencePiece(spp) => {
-                crate::providers::sentencepiece::sentencepiece::encode_async(spp.clone(), text).await
+                crate::providers::sentencepiece::sentencepiece::encode_async(spp.clone(), text)
+                    .await
             }
         }
     }
@@ -85,7 +87,8 @@ impl TokenizerSingleton {
                 crate::providers::tiktoken::tiktoken::decode_async(bpe.clone(), tokens).await
             }
             TokenizerSingleton::SentencePiece(spp) => {
-                crate::providers::sentencepiece::sentencepiece::decode_async(spp.clone(), tokens).await
+                crate::providers::sentencepiece::sentencepiece::decode_async(spp.clone(), tokens)
+                    .await
             }
         }
     }
@@ -96,7 +99,11 @@ impl TokenizerSingleton {
                 crate::providers::tiktoken::tiktoken::batch_tokenize_async(bpe.clone(), texts).await
             }
             TokenizerSingleton::SentencePiece(spp) => {
-                crate::providers::sentencepiece::sentencepiece::batch_tokenize_async(spp.clone(), texts).await
+                crate::providers::sentencepiece::sentencepiece::batch_tokenize_async(
+                    spp.clone(),
+                    texts,
+                )
+                .await
             }
         }
     }

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -933,24 +933,27 @@ impl LLM for MistralAILLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn chat(

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -920,12 +920,14 @@ impl LLM for MistralAILLM {
             || self.id.starts_with("open-mistral-7b")
             || self.id.starts_with("open-mixtral-8x7b")
         {
-            self.tokenizer = Some(TokenizerSingleton::SentencePiece(mistral_tokenizer_model_v1_base_singleton()));
-        }
-        else if self.id.starts_with("open-mixtral-8x22b") {
-            self.tokenizer = Some(TokenizerSingleton::SentencePiece(mistral_instruct_tokenizer_240216_model_v3_base_singleton()));
-        }
-        else {
+            self.tokenizer = Some(TokenizerSingleton::SentencePiece(
+                mistral_tokenizer_model_v1_base_singleton(),
+            ));
+        } else if self.id.starts_with("open-mixtral-8x22b") {
+            self.tokenizer = Some(TokenizerSingleton::SentencePiece(
+                mistral_instruct_tokenizer_240216_model_v3_base_singleton(),
+            ));
+        } else {
             self.tokenizer = TokenizerSingleton::from_config(config);
         }
     }

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -928,7 +928,7 @@ impl LLM for MistralAILLM {
                 mistral_instruct_tokenizer_240216_model_v3_base_singleton(),
             ));
         } else {
-            self.tokenizer = TokenizerSingleton::from_config(config);
+            self.tokenizer = TokenizerSingleton::from_config(&config);
         }
     }
 

--- a/core/src/providers/noop.rs
+++ b/core/src/providers/noop.rs
@@ -45,24 +45,27 @@ impl LLM for NoopLLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn generate(

--- a/core/src/providers/noop.rs
+++ b/core/src/providers/noop.rs
@@ -41,7 +41,7 @@ impl LLM for NoopLLM {
     }
 
     fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
-        self.tokenizer = TokenizerSingleton::from_config(config);
+        self.tokenizer = TokenizerSingleton::from_config(&config);
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {

--- a/core/src/providers/noop.rs
+++ b/core/src/providers/noop.rs
@@ -1,8 +1,8 @@
 use crate::providers::chat_messages::AssistantContentItem::TextContent;
 use crate::providers::chat_messages::{AssistantChatMessage, ChatMessage};
 use crate::providers::embedder::Embedder;
-use crate::providers::llm::{ChatFunction, ChatMessageRole, Tokens};
 use crate::providers::llm::TokenizerSingleton;
+use crate::providers::llm::{ChatFunction, ChatMessageRole, Tokens};
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLM};
 use crate::providers::provider::{Provider, ProviderID};
 use crate::run::Credentials;
@@ -24,7 +24,6 @@ impl NoopLLM {
             tokenizer: None,
         }
     }
-
 }
 
 #[async_trait]

--- a/core/src/providers/noop.rs
+++ b/core/src/providers/noop.rs
@@ -18,10 +18,10 @@ pub struct NoopLLM {
 }
 
 impl NoopLLM {
-    pub fn new(id: String) -> Self {
+    pub fn new(id: String, tokenizer: Option<TokenizerSingleton>) -> Self {
         NoopLLM {
             id,
-            tokenizer: None,
+            tokenizer,
         }
     }
 }
@@ -40,9 +40,6 @@ impl LLM for NoopLLM {
         1_000_000
     }
 
-    fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
-        self.tokenizer = TokenizerSingleton::from_config(&config);
-    }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
         self.tokenizer
@@ -184,8 +181,8 @@ impl Provider for NoopProvider {
         Ok(())
     }
 
-    fn llm(&self, id: String) -> Box<dyn LLM + Sync + Send> {
-        Box::new(NoopLLM::new(id))
+    fn llm(&self, id: String, tokenizer: Option<TokenizerSingleton>) -> Box<dyn LLM + Sync + Send> {
+        Box::new(NoopLLM::new(id, tokenizer))
     }
 
     fn embedder(&self, _id: String) -> Box<dyn Embedder + Sync + Send> {

--- a/core/src/providers/noop.rs
+++ b/core/src/providers/noop.rs
@@ -6,6 +6,7 @@ use crate::providers::llm::{ChatFunction, ChatMessageRole, Tokens};
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLM};
 use crate::providers::provider::{Provider, ProviderID};
 use crate::run::Credentials;
+use crate::types::tokenizer::{TiktokenTokenizerBase, TokenizerConfig};
 use crate::utils;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -21,7 +22,11 @@ impl NoopLLM {
     pub fn new(id: String, tokenizer: Option<TokenizerSingleton>) -> Self {
         NoopLLM {
             id,
-            tokenizer,
+            tokenizer: tokenizer.or_else(|| {
+                TokenizerSingleton::from_config(&TokenizerConfig::Tiktoken {
+                    base: TiktokenTokenizerBase::O200kBase,
+                })
+            }),
         }
     }
 }
@@ -39,7 +44,6 @@ impl LLM for NoopLLM {
     fn context_size(&self) -> usize {
         1_000_000
     }
-
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
         self.tokenizer

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -809,8 +809,12 @@ impl LLM for OpenAILLM {
 
     fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
         self.tokenizer = match self.id.as_str() {
-            "code_davinci-002" | "code-cushman-001" => Some(TokenizerSingleton::Tiktoken(p50k_base_singleton())),
-            "text-davinci-002" | "text-davinci-003" => Some(TokenizerSingleton::Tiktoken(p50k_base_singleton())),
+            "code_davinci-002" | "code-cushman-001" => {
+                Some(TokenizerSingleton::Tiktoken(p50k_base_singleton()))
+            }
+            "text-davinci-002" | "text-davinci-003" => {
+                Some(TokenizerSingleton::Tiktoken(p50k_base_singleton()))
+            }
             _ => TokenizerSingleton::from_config(config),
         };
     }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -10,7 +10,7 @@ use crate::providers::tiktoken::tiktoken::{
 };
 use crate::providers::tiktoken::tiktoken::{decode_async, encode_async};
 use crate::run::Credentials;
-use crate::types::tokenizer::{TokenizerConfig, TiktokenTokenizerBase};
+use crate::types::tokenizer::{TiktokenTokenizerBase, TokenizerConfig};
 use crate::utils;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -703,7 +703,11 @@ impl OpenAILLM {
             host: None,
             use_eu_endpoint: false,
             api_key: None,
-            tokenizer,
+            tokenizer: tokenizer.or_else(|| {
+                TokenizerSingleton::from_config(&TokenizerConfig::Tiktoken {
+                    base: TiktokenTokenizerBase::R50kBase,
+                })
+            }),
         }
     }
 
@@ -807,7 +811,6 @@ impl LLM for OpenAILLM {
     fn context_size(&self) -> usize {
         Self::openai_context_size(self.id.as_str())
     }
-
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
         self.tokenizer

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -815,7 +815,7 @@ impl LLM for OpenAILLM {
             "text-davinci-002" | "text-davinci-003" => {
                 Some(TokenizerSingleton::Tiktoken(p50k_base_singleton()))
             }
-            _ => TokenizerSingleton::from_config(config),
+            _ => TokenizerSingleton::from_config(&config),
         };
     }
 

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -820,24 +820,27 @@ impl LLM for OpenAILLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn generate(

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -2,7 +2,7 @@ use crate::providers::anthropic::anthropic::AnthropicProvider;
 use crate::providers::azure_openai::AzureOpenAIProvider;
 use crate::providers::embedder::Embedder;
 use crate::providers::google_ai_studio::GoogleAiStudioProvider;
-use crate::providers::llm::LLM;
+use crate::providers::llm::{TokenizerSingleton, LLM};
 use crate::providers::mistral::MistralProvider;
 use crate::providers::noop::NoopProvider;
 use crate::providers::openai::OpenAIProvider;
@@ -161,7 +161,7 @@ pub trait Provider {
     fn setup(&self) -> Result<()>;
     async fn test(&self) -> Result<()>;
 
-    fn llm(&self, id: String) -> Box<dyn LLM + Sync + Send>;
+    fn llm(&self, id: String, tokenizer: Option<TokenizerSingleton>) -> Box<dyn LLM + Sync + Send>;
     fn embedder(&self, id: String) -> Box<dyn Embedder + Sync + Send>;
 }
 

--- a/core/src/providers/togetherai.rs
+++ b/core/src/providers/togetherai.rs
@@ -1,19 +1,16 @@
 use crate::providers::chat_messages::ChatMessage;
 use crate::providers::embedder::Embedder;
 use crate::providers::llm::ChatFunction;
+use crate::providers::llm::TokenizerSingleton;
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLM};
 use crate::providers::provider::{Provider, ProviderID};
-use crate::providers::tiktoken::tiktoken::{batch_tokenize_async, o200k_base_singleton, CoreBPE};
-use crate::providers::tiktoken::tiktoken::{decode_async, encode_async};
 use crate::run::Credentials;
 use crate::utils;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use hyper::Uri;
-use parking_lot::RwLock;
 use serde_json::Value;
-use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::helpers::strip_tools_from_chat_history;
@@ -33,21 +30,21 @@ const MODEL_IDS_WITH_TOOLS_SUPPORT: &[&str] = &[
 
 pub struct TogetherAILLM {
     id: String,
+    tokenizer: Option<TokenizerSingleton>,
     api_key: Option<String>,
 }
 
 impl TogetherAILLM {
     pub fn new(id: String) -> Self {
-        TogetherAILLM { id, api_key: None }
+        TogetherAILLM {
+            id,
+            tokenizer: None,
+            api_key: None,
+        }
     }
 
     fn chat_uri(&self) -> Result<Uri> {
         Ok(format!("https://api.together.xyz/v1/chat/completions",).parse::<Uri>()?)
-    }
-
-    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
-        // TODO(@fontanierh): TBD
-        o200k_base_singleton()
     }
 
     pub fn togetherai_context_size(_model_id: &str) -> usize {
@@ -85,16 +82,29 @@ impl LLM for TogetherAILLM {
         Self::togetherai_context_size(self.id.as_str())
     }
 
+    fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
+        self.tokenizer = TokenizerSingleton::from_config(config);
+    }
+
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        encode_async(self.tokenizer(), text).await
+        match &self.tokenizer {
+            Some(t) => t.encode(text).await,
+            None => Err(anyhow!("Tokenizer not initialized")),
+        }
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        decode_async(self.tokenizer(), tokens).await
+        match &self.tokenizer {
+            Some(t) => t.decode(tokens).await,
+            None => Err(anyhow!("Tokenizer not initialized")),
+        }
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        batch_tokenize_async(self.tokenizer(), texts).await
+        match &self.tokenizer {
+            Some(t) => t.tokenize(texts).await,
+            None => Err(anyhow!("Tokenizer not initialized")),
+        }
     }
 
     async fn generate(

--- a/core/src/providers/togetherai.rs
+++ b/core/src/providers/togetherai.rs
@@ -87,24 +87,27 @@ impl LLM for TogetherAILLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn generate(

--- a/core/src/providers/togetherai.rs
+++ b/core/src/providers/togetherai.rs
@@ -83,7 +83,7 @@ impl LLM for TogetherAILLM {
     }
 
     fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
-        self.tokenizer = TokenizerSingleton::from_config(config);
+        self.tokenizer = TokenizerSingleton::from_config(&config);
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {

--- a/core/src/providers/xai.rs
+++ b/core/src/providers/xai.rs
@@ -5,7 +5,7 @@ use crate::providers::llm::TokenizerSingleton;
 use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLM};
 use crate::providers::provider::{Provider, ProviderID};
 use crate::run::Credentials;
-use crate::types::tokenizer::{TokenizerConfig, TiktokenTokenizerBase};
+use crate::types::tokenizer::{TiktokenTokenizerBase, TokenizerConfig};
 use crate::utils;
 
 use anyhow::{anyhow, Result};
@@ -28,7 +28,11 @@ impl XaiLLM {
     pub fn new(id: String, tokenizer: Option<TokenizerSingleton>) -> Self {
         XaiLLM {
             id,
-            tokenizer,
+            tokenizer: tokenizer.or_else(|| {
+                TokenizerSingleton::from_config(&TokenizerConfig::Tiktoken {
+                    base: TiktokenTokenizerBase::O200kBase,
+                })
+            }),
             api_key: None,
         }
     }
@@ -68,7 +72,6 @@ impl LLM for XaiLLM {
     fn context_size(&self) -> usize {
         Self::xai_context_size(self.id.as_str())
     }
-
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
         self.tokenizer

--- a/core/src/providers/xai.rs
+++ b/core/src/providers/xai.rs
@@ -73,24 +73,27 @@ impl LLM for XaiLLM {
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {
-        match &self.tokenizer {
-            Some(t) => t.encode(text).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .encode(text)
+            .await
     }
 
     async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
-        match &self.tokenizer {
-            Some(t) => t.decode(tokens).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .decode(tokens)
+            .await
     }
 
     async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
-        match &self.tokenizer {
-            Some(t) => t.tokenize(texts).await,
-            None => Err(anyhow!("Tokenizer not initialized")),
-        }
+        self.tokenizer
+            .as_ref()
+            .ok_or_else(|| anyhow!("Tokenizer not initialized"))?
+            .tokenize(texts)
+            .await
     }
 
     async fn generate(

--- a/core/src/providers/xai.rs
+++ b/core/src/providers/xai.rs
@@ -69,7 +69,7 @@ impl LLM for XaiLLM {
     }
 
     fn set_tokenizer_from_config(&mut self, config: crate::types::tokenizer::TokenizerConfig) {
-        self.tokenizer = TokenizerSingleton::from_config(config);
+        self.tokenizer = TokenizerSingleton::from_config(&config);
     }
 
     async fn encode(&self, text: &str) -> Result<Vec<usize>> {

--- a/core/src/types/tokenizer.rs
+++ b/core/src/types/tokenizer.rs
@@ -3,34 +3,24 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TiktokenTokenizerBase {
-    #[serde(rename = "o200k_base")]
     O200kBase,
-    #[serde(rename = "cl100k_base")]
     Cl100kBase,
-    #[serde(rename = "p50k_base")]
     P50kBase,
-    #[serde(rename = "r50k_base")]
     R50kBase,
-    #[serde(rename = "anthropic_base")]
     AnthropicBase,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SentencePieceTokenizerBase {
-    #[serde(rename = "model_v1")]
     ModelV1,
-    #[serde(rename = "model_v2")]
     ModelV2,
-    #[serde(rename = "model_v3")]
     ModelV3,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TokenizerConfig {
-    #[serde(rename = "tiktoken")]
     Tiktoken { base: TiktokenTokenizerBase },
-    #[serde(rename = "sentencepiece")]
     SentencePiece { base: SentencePieceTokenizerBase },
 }

--- a/core/src/types/tokenizer.rs
+++ b/core/src/types/tokenizer.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TiktokenTokenizerBase {
+    #[serde(rename = "o200k_base")]
+    O200kBase,
+    #[serde(rename = "cl100k_base")]
+    Cl100kBase,
+    #[serde(rename = "p50k_base")]
+    P50kBase,
+    #[serde(rename = "r50k_base")]
+    R50kBase,
+    #[serde(rename = "anthropic_base")]
+    AnthropicBase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SentencePieceTokenizerBase {
+    #[serde(rename = "model_v1")]
+    ModelV1,
+    #[serde(rename = "model_v2")]
+    ModelV2,
+    #[serde(rename = "model_v3")]
+    ModelV3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TokenizerConfig {
+    #[serde(rename = "tiktoken")]
+    Tiktoken { base: TiktokenTokenizerBase },
+    #[serde(rename = "sentencepiece")]
+    SentencePiece { base: SentencePieceTokenizerBase },
+}

--- a/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
@@ -276,6 +276,7 @@ export function registerWebBrowserTool(
           const tokensRes = await tokenCountForTexts([contentText ?? ""], {
             providerId: "openai",
             modelId: "gpt-4o",
+            tokenizer: { type: "tiktoken", base: "o200k_base" },
           });
 
           if (tokensRes.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
@@ -35,6 +35,7 @@ import { webSearch } from "@app/lib/utils/websearch";
 import { Err, GLOBAL_AGENTS_SID, GPT_4O_MODEL_CONFIG, Ok } from "@app/types";
 
 const BROWSE_MAX_TOKENS_LIMIT = 32_000;
+const DEFAULT_WEBSEARCH_MODEL_CONFIG = GPT_4O_MODEL_CONFIG;
 
 export function registerWebSearchTool(
   auth: Authenticator,
@@ -274,9 +275,9 @@ export function registerWebBrowserTool(
           const contentText = format === "html" ? html : markdown;
 
           const tokensRes = await tokenCountForTexts([contentText ?? ""], {
-            providerId: GPT_4O_MODEL_CONFIG.providerId,
-            modelId: GPT_4O_MODEL_CONFIG.modelId,
-            tokenizer: GPT_4O_MODEL_CONFIG.tokenizer,
+            providerId: DEFAULT_WEBSEARCH_MODEL_CONFIG.providerId,
+            modelId: DEFAULT_WEBSEARCH_MODEL_CONFIG.modelId,
+            tokenizer: DEFAULT_WEBSEARCH_MODEL_CONFIG.tokenizer,
           });
 
           if (tokensRes.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
@@ -32,7 +32,7 @@ import {
   isBrowseScrapeSuccessResponse,
 } from "@app/lib/utils/webbrowse";
 import { webSearch } from "@app/lib/utils/websearch";
-import { Err, GLOBAL_AGENTS_SID, Ok } from "@app/types";
+import { Err, GLOBAL_AGENTS_SID, GPT_4O_MODEL_CONFIG, Ok } from "@app/types";
 
 const BROWSE_MAX_TOKENS_LIMIT = 32_000;
 
@@ -274,9 +274,9 @@ export function registerWebBrowserTool(
           const contentText = format === "html" ? html : markdown;
 
           const tokensRes = await tokenCountForTexts([contentText ?? ""], {
-            providerId: "openai",
-            modelId: "gpt-4o",
-            tokenizer: { type: "tiktoken", base: "o200k_base" },
+            providerId: GPT_4O_MODEL_CONFIG.providerId,
+            modelId: GPT_4O_MODEL_CONFIG.modelId,
+            tokenizer: GPT_4O_MODEL_CONFIG.tokenizer,
           });
 
           if (tokensRes.isErr()) {

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -104,6 +104,7 @@ export async function generateSnippet(
       text: content,
       providerId: model.providerId,
       modelId: model.modelId,
+      tokenizer: model.tokenizer,
     });
 
     if (resTokenize.isErr()) {

--- a/front/lib/tokenization.ts
+++ b/front/lib/tokenization.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { Result } from "@app/types";
+import type { Result, TokenizerConfig } from "@app/types";
 import {
   CoreAPI,
   DEFAULT_TOKEN_COUNT_ADJUSTMENT,
@@ -22,7 +22,12 @@ const TOKENIZATION_CONCURRENCY = 3;
 
 export async function tokenCountForTexts(
   texts: string[],
-  model: { providerId: string; modelId: string; tokenCountAdjustment?: number }
+  model: {
+    providerId: string;
+    modelId: string;
+    tokenCountAdjustment?: number;
+    tokenizer: TokenizerConfig;
+  }
 ): Promise<Result<Array<number>, Error>> {
   try {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -36,6 +41,7 @@ export async function tokenCountForTexts(
           texts: batch,
           providerId: model.providerId,
           modelId: model.modelId,
+          tokenizer: model.tokenizer,
         }),
       { concurrency: TOKENIZATION_CONCURRENCY }
     );
@@ -65,7 +71,7 @@ export async function tokenCountForTexts(
 
 export async function tokenSplit(
   text: string,
-  model: { providerId: string; modelId: string },
+  model: { providerId: string; modelId: string; tokenizer: TokenizerConfig },
   splitAt: number
 ): Promise<Result<string, Error>> {
   try {
@@ -74,6 +80,7 @@ export async function tokenSplit(
       text,
       providerId: model.providerId,
       modelId: model.modelId,
+      tokenizer: model.tokenizer,
     });
     if (res.isErr()) {
       return new Err(

--- a/front/temporal/tracker/activities.ts
+++ b/front/temporal/tracker/activities.ts
@@ -19,7 +19,13 @@ import type {
   Result,
   TrackerIdWorkspaceId,
 } from "@app/types";
-import { CoreAPI, Err, GPT_4O_MODEL_CONFIG, Ok } from "@app/types";
+import {
+  CoreAPI,
+  Err,
+  GPT_3_5_TURBO_MODEL_CONFIG,
+  GPT_4O_MODEL_CONFIG,
+  Ok,
+} from "@app/types";
 import { withRetries } from "@app/types";
 
 // If a diff is less than this number of characters, we don't run the tracker.
@@ -178,9 +184,9 @@ export async function trackersGenerationActivity(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const tokensInDiff = await coreAPI.tokenize({
     text: diffString,
-    providerId: "openai",
-    modelId: "gpt-3.5-turbo",
-    tokenizer: { type: "tiktoken", base: "cl100k_base" },
+    providerId: GPT_3_5_TURBO_MODEL_CONFIG.providerId,
+    modelId: GPT_3_5_TURBO_MODEL_CONFIG.modelId,
+    tokenizer: GPT_3_5_TURBO_MODEL_CONFIG.tokenizer,
   });
   if (tokensInDiff.isErr()) {
     throw tokensInDiff.error;

--- a/front/temporal/tracker/activities.ts
+++ b/front/temporal/tracker/activities.ts
@@ -180,6 +180,7 @@ export async function trackersGenerationActivity(
     text: diffString,
     providerId: "openai",
     modelId: "gpt-3.5-turbo",
+    tokenizer: { type: "tiktoken", base: "cl100k_base" },
   });
   if (tokensInDiff.isErr()) {
     throw tokensInDiff.error;

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -66,6 +66,7 @@ export const CLAUDE_4_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   featureFlag: "claude_4_opus_feature",
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -87,6 +88,7 @@ export const CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -109,6 +111,7 @@ export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsPromptCaching: true,
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -129,6 +132,7 @@ export const CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -149,6 +153,7 @@ export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -170,6 +175,7 @@ export const CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   nativeReasoningMetaPrompt: CLAUDE_4_NATIVE_REASONING_META_PROMPT,
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 
 /**

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -200,6 +200,7 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_3_5_SONNET_20240620_DEPRECATED_MODEL_CONFIG: ModelConfigurationType =
   {
@@ -220,6 +221,7 @@ export const CLAUDE_3_5_SONNET_20240620_DEPRECATED_MODEL_CONFIG: ModelConfigurat
     maximumReasoningEffort: "light",
     defaultReasoningEffort: "light",
     tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+    tokenizer: { type: "tiktoken", base: "anthropic_base" },
   };
 export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -239,6 +241,7 @@ export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };
 export const CLAUDE_3_7_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -258,4 +261,5 @@ export const CLAUDE_3_7_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
 };

--- a/front/types/assistant/models/deepseek.ts
+++ b/front/types/assistant/models/deepseek.ts
@@ -20,6 +20,7 @@ export const DEEPSEEK_CHAT_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   featureFlag: "deepseek_feature",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const DEEPSEEK_REASONER_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "deepseek",
@@ -39,4 +40,5 @@ export const DEEPSEEK_REASONER_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   featureFlag: "deepseek_feature",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };

--- a/front/types/assistant/models/fireworks.ts
+++ b/front/types/assistant/models/fireworks.ts
@@ -22,6 +22,7 @@ export const FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const FIREWORKS_KIMI_K2_INSTRUCT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
@@ -40,4 +41,5 @@ export const FIREWORKS_KIMI_K2_INSTRUCT_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "light",
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -23,6 +23,7 @@ export const GEMINI_2_5_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
+  tokenizer: { type: "tiktoken", base: "cl100k_base" },
 };
 export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -41,6 +42,7 @@ export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
+  tokenizer: { type: "tiktoken", base: "cl100k_base" },
 };
 export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -59,4 +61,5 @@ export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "light",
   maximumReasoningEffort: "high",
   defaultReasoningEffort: "light",
+  tokenizer: { type: "tiktoken", base: "cl100k_base" },
 };

--- a/front/types/assistant/models/mistral.ts
+++ b/front/types/assistant/models/mistral.ts
@@ -21,7 +21,7 @@ export const MISTRAL_LARGE_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  tokenizer: { type: "sentencepiece", base: "model_v2" },
+  tokenizer: { type: "sentence_piece", base: "model_v2" },
 };
 export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -40,7 +40,7 @@ export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  tokenizer: { type: "sentencepiece", base: "model_v2" },
+  tokenizer: { type: "sentence_piece", base: "model_v2" },
 };
 export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -59,7 +59,7 @@ export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  tokenizer: { type: "sentencepiece", base: "model_v2" },
+  tokenizer: { type: "sentence_piece", base: "model_v2" },
 };
 export const MISTRAL_CODESTRAL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -79,5 +79,5 @@ export const MISTRAL_CODESTRAL_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
-  tokenizer: { type: "sentencepiece", base: "model_v2" },
+  tokenizer: { type: "sentence_piece", base: "model_v2" },
 };

--- a/front/types/assistant/models/mistral.ts
+++ b/front/types/assistant/models/mistral.ts
@@ -21,6 +21,7 @@ export const MISTRAL_LARGE_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
+  tokenizer: { type: "sentencepiece", base: "model_v2" },
 };
 export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -39,6 +40,7 @@ export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
+  tokenizer: { type: "sentencepiece", base: "model_v2" },
 };
 export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -57,6 +59,7 @@ export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
+  tokenizer: { type: "sentencepiece", base: "model_v2" },
 };
 export const MISTRAL_CODESTRAL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -76,4 +79,5 @@ export const MISTRAL_CODESTRAL_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
+  tokenizer: { type: "sentencepiece", base: "model_v2" },
 };

--- a/front/types/assistant/models/noop.ts
+++ b/front/types/assistant/models/noop.ts
@@ -20,4 +20,5 @@ export const NOOP_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
   featureFlag: "noop_model_feature",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -233,6 +233,7 @@ export const GPT_5_1_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
+  tokenizer: { type: "tiktoken", base: "r50k_base" },
 };
 export const GPT_5_MINI_NO_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -38,6 +38,7 @@ export const GPT_3_5_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
+  tokenizer: { type: "tiktoken", base: "cl100k_base" },
 };
 export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -58,6 +59,7 @@ export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
+  tokenizer: { type: "tiktoken", base: "cl100k_base" },
 };
 export const GPT_4O_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -77,6 +79,7 @@ export const GPT_4O_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: true,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GPT_4_1_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -96,6 +99,7 @@ export const GPT_4_1_MINI_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: true,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GPT_4_1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -115,6 +119,7 @@ export const GPT_4_1_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: true,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GPT_4O_20240806_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -134,6 +139,7 @@ export const GPT_4O_20240806_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: true,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GPT_4O_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -154,6 +160,7 @@ export const GPT_4O_MINI_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const OPENAI_FORMATTING_META_PROMPT = `# Response Formats
 SYSTEM STYLE: Rich Markdown by default
@@ -203,6 +210,7 @@ export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
+  tokenizer: { type: "tiktoken", base: "r50k_base" },
 };
 export const GPT_5_1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -248,6 +256,7 @@ export const GPT_5_MINI_NO_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
+  tokenizer: { type: "tiktoken", base: "r50k_base" },
 };
 export const GPT_5_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -271,6 +280,7 @@ export const GPT_5_MINI_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
+  tokenizer: { type: "tiktoken", base: "r50k_base" },
 };
 export const GPT_5_NANO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -293,6 +303,7 @@ export const GPT_5_NANO_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
+  tokenizer: { type: "tiktoken", base: "r50k_base" },
 };
 export const O1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -315,6 +326,7 @@ export const O1_MODEL_CONFIG: ModelConfigurationType = {
   featureFlag: "openai_o1_feature",
   customAssistantFeatureFlag: "openai_o1_custom_assistants_feature",
   supportsResponseFormat: false,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const O1_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -336,6 +348,7 @@ export const O1_MINI_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   customAssistantFeatureFlag: "openai_o1_custom_assistants_feature",
   supportsResponseFormat: false,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const O3_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -358,6 +371,7 @@ export const O3_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const O3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -380,6 +394,7 @@ export const O3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const O4_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -401,4 +416,5 @@ export const O4_MINI_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };

--- a/front/types/assistant/models/togetherai.ts
+++ b/front/types/assistant/models/togetherai.ts
@@ -31,6 +31,7 @@ export const TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_CONFIG: ModelConfigur
     minimumReasoningEffort: "none",
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
+    tokenizer: { type: "tiktoken", base: "o200k_base" },
   };
 export const TOGETHERAI_QWEN_2_5_CODER_32B_INSTRUCT_MODEL_CONFIG: ModelConfigurationType =
   {
@@ -50,6 +51,7 @@ export const TOGETHERAI_QWEN_2_5_CODER_32B_INSTRUCT_MODEL_CONFIG: ModelConfigura
     minimumReasoningEffort: "none",
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
+    tokenizer: { type: "tiktoken", base: "o200k_base" },
   };
 export const TOGETHERAI_QWEN_QWQ_32B_PREVIEW_MODEL_CONFIG: ModelConfigurationType =
   {
@@ -69,6 +71,7 @@ export const TOGETHERAI_QWEN_QWQ_32B_PREVIEW_MODEL_CONFIG: ModelConfigurationTyp
     minimumReasoningEffort: "none",
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
+    tokenizer: { type: "tiktoken", base: "o200k_base" },
   };
 export const TOGETHERAI_QWEN_72B_INSTRUCT_MODEL_CONFIG: ModelConfigurationType =
   {
@@ -88,6 +91,7 @@ export const TOGETHERAI_QWEN_72B_INSTRUCT_MODEL_CONFIG: ModelConfigurationType =
     minimumReasoningEffort: "none",
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
+    tokenizer: { type: "tiktoken", base: "o200k_base" },
   };
 export const TOGETHERAI_DEEPSEEK_V3_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "togetherai",
@@ -106,6 +110,7 @@ export const TOGETHERAI_DEEPSEEK_V3_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const TOGETHERAI_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "togetherai",
@@ -124,4 +129,5 @@ export const TOGETHERAI_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -8,6 +8,7 @@ import type {
   MODEL_PROVIDER_IDS,
   REASONING_EFFORTS,
   SUPPORTED_MODEL_CONFIGS,
+  TokenizerConfig,
   WhitelistableFeature,
 } from "@app/types";
 
@@ -60,6 +61,9 @@ export type ModelConfigurationType = {
 
   featureFlag?: WhitelistableFeature;
   customAssistantFeatureFlag?: WhitelistableFeature;
+
+  // Tokenizer configuration for the model
+  tokenizer: TokenizerConfig;
 };
 
 export type ModelConfig = (typeof SUPPORTED_MODEL_CONFIGS)[number];

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -62,7 +62,6 @@ export type ModelConfigurationType = {
   featureFlag?: WhitelistableFeature;
   customAssistantFeatureFlag?: WhitelistableFeature;
 
-  // Tokenizer configuration for the model
   tokenizer: TokenizerConfig;
 };
 

--- a/front/types/assistant/models/xai.ts
+++ b/front/types/assistant/models/xai.ts
@@ -27,6 +27,7 @@ export const GROK_3_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
   featureFlag: "xai_feature",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GROK_3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "xai",
@@ -47,6 +48,7 @@ export const GROK_3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
   featureFlag: "xai_feature",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 
 export const GROK_4_MODEL_CONFIG: ModelConfigurationType = {
@@ -68,6 +70,7 @@ export const GROK_4_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
   featureFlag: "xai_feature",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GROK_4_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "xai",
@@ -88,6 +91,7 @@ export const GROK_4_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
   featureFlag: "xai_feature",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };
 export const GROK_4_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "xai",
@@ -108,4 +112,5 @@ export const GROK_4_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
   featureFlag: "xai_feature",
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
 };

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -35,6 +35,7 @@ import type { LoggerInterface } from "@app/types/shared/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { errorToString } from "@app/types/shared/utils/error_utils";
+import type { TokenizerConfig } from "@app/types/tokenizer";
 import type { LightWorkspaceType } from "@app/types/user";
 
 export const MAX_CHUNK_SIZE = 512;
@@ -1444,10 +1445,12 @@ export class CoreAPI {
     text,
     modelId,
     providerId,
+    tokenizer,
   }: {
     text: string;
     modelId: string;
     providerId: string;
+    tokenizer: TokenizerConfig;
   }): Promise<CoreAPIResponse<{ tokens: CoreAPITokenType[] }>> {
     const credentials = dustManagedCredentials();
     const response = await this._fetchWithError(`${this._url}/tokenize`, {
@@ -1461,6 +1464,7 @@ export class CoreAPI {
         model_id: modelId,
         provider_id: providerId,
         credentials,
+        tokenizer,
       }),
     });
 
@@ -1498,13 +1502,15 @@ export class CoreAPI {
     texts,
     modelId,
     providerId,
+    tokenizer,
   }: {
     texts: string[];
     modelId: string;
     providerId: string;
+    tokenizer: TokenizerConfig;
   }): Promise<CoreAPIResponse<{ counts: number[] }>> {
     const credentials = dustManagedCredentials();
-
+    
     const response = await this._fetchWithError(
       `${this._url}/tokenize/batch/count`,
       {
@@ -1516,6 +1522,7 @@ export class CoreAPI {
         body: JSON.stringify({
           texts,
           model_id: modelId,
+          tokenizer,
           provider_id: providerId,
           credentials,
         }),

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1510,7 +1510,7 @@ export class CoreAPI {
     tokenizer: TokenizerConfig;
   }): Promise<CoreAPIResponse<{ counts: number[] }>> {
     const credentials = dustManagedCredentials();
-    
+
     const response = await this._fetchWithError(
       `${this._url}/tokenize/batch/count`,
       {

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -94,6 +94,7 @@ export * from "./shared/utils/time_frame";
 export * from "./shared/utils/url_utils";
 export * from "./sheets";
 export * from "./space";
+export * from "./tokenizer";
 export * from "./tracker";
 export * from "./user";
 export * from "./website";

--- a/front/types/tokenizer.ts
+++ b/front/types/tokenizer.ts
@@ -12,9 +12,6 @@ const SENTENCEPIECE_BASE = ["model_v1", "model_v2", "model_v3"] as const;
 
 export type SentencePieceTokenizerBase = (typeof SENTENCEPIECE_BASE)[number];
 
-export const TOKENIZER_TYPES = ["tiktoken", "sentencepiece"] as const;
-export type TokenizerType = (typeof TOKENIZER_TYPES)[number];
-
 export type TokenizerConfig =
   | { type: "tiktoken"; base: TiktokenTokenizerBase }
   | { type: "sentencepiece"; base: SentencePieceTokenizerBase };

--- a/front/types/tokenizer.ts
+++ b/front/types/tokenizer.ts
@@ -14,4 +14,4 @@ export type SentencePieceTokenizerBase = (typeof SENTENCEPIECE_BASE)[number];
 
 export type TokenizerConfig =
   | { type: "tiktoken"; base: TiktokenTokenizerBase }
-  | { type: "sentencepiece"; base: SentencePieceTokenizerBase };
+  | { type: "sentence_piece"; base: SentencePieceTokenizerBase };

--- a/front/types/tokenizer.ts
+++ b/front/types/tokenizer.ts
@@ -1,0 +1,20 @@
+const TIKTOKEN_TOKENIZER_BASE = [
+  "o200k_base",
+  "cl100k_base",
+  "p50k_base",
+  "r50k_base",
+  "anthropic_base",
+] as const;
+
+export type TiktokenTokenizerBase = (typeof TIKTOKEN_TOKENIZER_BASE)[number];
+
+const SENTENCEPIECE_BASE = ["model_v1", "model_v2", "model_v3"] as const;
+
+export type SentencePieceTokenizerBase = (typeof SENTENCEPIECE_BASE)[number];
+
+export const TOKENIZER_TYPES = ["tiktoken", "sentencepiece"] as const;
+export type TokenizerType = (typeof TOKENIZER_TYPES)[number];
+
+export type TokenizerConfig =
+  | { type: "tiktoken"; base: TiktokenTokenizerBase }
+  | { type: "sentencepiece"; base: SentencePieceTokenizerBase };


### PR DESCRIPTION
## Description

This PR moves the model-to-tokenizer mapping from Core (Rust) to Front (TypeScript).
This change centralizes model configuration management in Front, where all model definitions already live. When adding a new model to Dust, the tokenizer configuration is now defined alongside other model properties (context size, provider ID, etc.) rather than requiring changes in multiple places.

## Tests

Started a conversation with al the models and checked that they are properly working.
Not sure how to check if the number of tokens returned bu the Core api is correct

## Risk

Medium

## Deploy Plan

Deploy front and core
