### PR TITLE
[LLM Router] fix: adds line breaks between reasoning parts

### DIFF
--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -194,6 +194,13 @@ function toEvents({
       return [reasoningDelta(event.delta, metadata)];
     case "response.completed":
       return responseCompleted(event.response, metadata);
+    case "response.reasoning_summary_part.added": {
+      if (event.summary_index === 0) {
+        return [];
+      }
+
+      return [reasoningDelta("\n\n", metadata)];
+    }
     default:
       return [];
   }

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
@@ -22,6 +22,16 @@ export const reasoningLLMEvents = [
   {
     type: "reasoning_delta",
     content: {
+      delta: "\n\n",
+    },
+    metadata: {
+      clientId: "openai_responses",
+      modelId: "gpt-5",
+    },
+  },
+  {
+    type: "reasoning_delta",
+    content: {
       delta: "**Solving the Quadratic**\n\nTo solve ",
     },
     metadata: {


### PR DESCRIPTION
## Description

When OpenAI reasons in multiple "parts", we concatenate the streamed chunks with no separation, which leads to weird ui.
This PR fixes it

<img width="790" height="697" alt="Screenshot 2025-11-12 at 16 58 03" src="https://github.com/user-attachments/assets/4a005b83-9dae-4e97-a3a4-a825322a1781" />


## Tests

Locally

## Risk

Low

## Deploy Plan

Front
