### PR TITLE
[Assistant Config] Run unsafeHardDeleteAgentConfiguration destroys in a single transaction

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1034,23 +1034,30 @@ export async function unsafeHardDeleteAgentConfiguration(
 ): Promise<void> {
   const workspaceId = auth.getNonNullableWorkspace().id;
 
-  await TagAgentModel.destroy({
-    where: {
-      agentConfigurationId: agentConfiguration.id,
-      workspaceId,
-    },
-  });
-  await GroupAgentModel.destroy({
-    where: {
-      agentConfigurationId: agentConfiguration.id,
-      workspaceId,
-    },
-  });
-  await AgentConfiguration.destroy({
-    where: {
-      id: agentConfiguration.id,
-      workspaceId,
-    },
+  await withTransaction(async (t) => {
+    await TagAgentModel.destroy({
+      where: {
+        agentConfigurationId: agentConfiguration.id,
+        workspaceId,
+      },
+      transaction: t,
+    });
+
+    await GroupAgentModel.destroy({
+      where: {
+        agentConfigurationId: agentConfiguration.id,
+        workspaceId,
+      },
+      transaction: t,
+    });
+
+    await AgentConfiguration.destroy({
+      where: {
+        id: agentConfiguration.id,
+        workspaceId,
+      },
+      transaction: t,
+    });
   });
 }
 


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/5083

Wraps the three destroy operations in `unsafeHardDeleteAgentConfiguration` (`TagAgentModel`, `GroupAgentModel`, `AgentConfiguration`) into a single SQL transaction via `withTransaction`. Ensures atomic cleanup and avoids partial deletions when failures occur during agent creation error handling.

## Risks
Blast radius: Agent cleanup after failed agent configuration creation/hard-delete path
Risk: low

## Deploy Plan
- deploy front