### PR TITLE
[front] - feat(obs): display median in `LatencyChart`

### DIFF
--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -25,18 +25,21 @@ import {
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { VersionMarkersDots } from "@app/components/agent_builder/observability/shared/VersionMarkers";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
+import type { LatencyPoint } from "@app/lib/api/assistant/observability/latency";
 import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
 import { formatShortDate } from "@app/lib/utils/timestamps";
 
-interface LatencyData {
-  timestamp: number;
+interface LatencyData extends LatencyPoint {
   date: string;
-  messages: number;
-  average: number;
 }
 
 function isLatencyData(data: unknown): data is LatencyData {
-  return typeof data === "object" && data !== null && "average" in data;
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "average" in data &&
+    "median" in data
+  );
 }
 
 function zeroFactory(timestamp: number) {
@@ -44,6 +47,7 @@ function zeroFactory(timestamp: number) {
     timestamp,
     messages: 0,
     average: 0,
+    median: 0,
   };
 }
 
@@ -68,6 +72,11 @@ function LatencyTooltip(
           label: "Average time",
           value: `${row.average}s`,
           colorClassName: LATENCY_PALETTE.average,
+        },
+        {
+          label: "Median time",
+          value: `${row.median}s`,
+          colorClassName: LATENCY_PALETTE.median,
         },
       ]}
     />
@@ -120,7 +129,7 @@ export function LatencyChart({
   return (
     <ChartContainer
       title="Latency"
-      description="Average time to complete output (seconds). Lower is better."
+      description="Average and median time to complete output (seconds). Lower is better."
       isLoading={isLoading}
       errorMessage={errorMessage}
     >
@@ -183,6 +192,14 @@ export function LatencyChart({
             name="Average time to complete output"
             className={LATENCY_PALETTE.average}
             fill="url(#fillAverage)"
+            stroke="currentColor"
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="median"
+            name="Median time to complete output"
+            className={LATENCY_PALETTE.median}
             stroke="currentColor"
             dot={false}
           />

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -18,10 +18,12 @@ export const USAGE_METRICS_LEGEND = [
 
 export const LATENCY_PALETTE = {
   average: "text-blue-400 dark:text-blue-400-night",
+  median: "text-violet-300 dark:text-violet-300-night",
 } as const;
 
 export const LATENCY_LEGEND = [
   { key: "average", label: "Average time to complete output" },
+  { key: "median", label: "Median time to complete output" },
 ] as const;
 
 export const CHART_HEIGHT = 260;

--- a/front/components/agent_builder/observability/hooks.ts
+++ b/front/components/agent_builder/observability/hooks.ts
@@ -8,6 +8,7 @@ import type {
   ToolChartModeType,
 } from "@app/components/agent_builder/observability/types";
 import { selectTopTools } from "@app/components/agent_builder/observability/utils";
+import type { LatencyPoint } from "@app/lib/api/assistant/observability/latency";
 import type { ToolExecutionByVersion } from "@app/lib/api/assistant/observability/tool_execution";
 import type { ToolStepIndexByStep } from "@app/lib/api/assistant/observability/tool_step_index";
 import {
@@ -46,11 +47,7 @@ type ErrorRateDataResult = {
 };
 
 type LatencyDataResult = {
-  data: {
-    timestamp: number;
-    messages: number;
-    average: number;
-  }[];
+  data: LatencyPoint[];
   isLoading: boolean;
   errorMessage: string | undefined;
 };


### PR DESCRIPTION
## Description

This PR adds a median line to the `LatencyChart` in observability.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front