### PR TITLE
[front] chore(http_client): untrack fetch errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/http_client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/http_client.ts
@@ -213,22 +213,20 @@ function createServer(
         } catch (error) {
           clearTimeout(timeoutId);
 
-          if (error instanceof Error) {
-            if (error.name === "AbortError") {
-              return new Err(
-                new MCPError(`Request timed out after ${timeoutMs}ms`)
-              );
-            }
+          if (error instanceof Error && error.name === "AbortError") {
             return new Err(
-              new MCPError(
-                `HTTP request failed: ${normalizeError(error).message}`
-              )
+              new MCPError(`Request timed out after ${timeoutMs}ms`, {
+                tracked: false,
+              })
             );
           }
 
           return new Err(
             new MCPError(
-              `HTTP request failed: ${normalizeError(error).message}`
+              `HTTP request failed: ${normalizeError(error).message}`,
+              {
+                tracked: false,
+              }
             )
           );
         }


### PR DESCRIPTION
## Description

- This PR untracks generic fetch errors in the `http_client` MCP server.
- Logs will be kept (warn instead of error) and this will disable alerting.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
