### PR TITLE
[front] GA Zendesk tool and trigger

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1593,9 +1593,7 @@ The directive should be used to display a clickable version of the agent name in
     id: 42,
     availability: "manual",
     allowMultipleInstances: true,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("zendesk_features");
-    },
+    isRestricted: undefined,
     isPreview: false,
     tools_stakes: {
       get_ticket: "never_ask",

--- a/front/lib/triggers/built-in-webhooks/zendesk/preset.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/preset.ts
@@ -15,7 +15,6 @@ export const ZENDESK_WEBHOOK_PRESET: PresetWebhook<"zendesk"> = {
   icon: "ZendeskLogo",
   description:
     "Receive events from Zendesk such as ticket creation or modification",
-  featureFlag: "zendesk_features",
   webhookService: new ZendeskWebhookService(),
   components: {
     detailsComponent: WebhookSourceZendeskDetails,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -226,10 +226,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable notifications",
     stage: "dust_only",
   },
-  zendesk_features: {
-    description: "Zendesk MCP tool and webhook triggers",
-    stage: "rolling_out",
-  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -683,7 +683,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "use_requested_space_ids"
   | "web_summarization"
   | "xai_feature"
-  | "zendesk_features"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

- This PR removes the `zendesk_features` feature flag on the MCP tools and the webhook triggers.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
