### PR TITLE
[front] fix(triggers): fix missing icon in Agent Builder card grid

### DIFF
--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -97,7 +97,23 @@ export const TriggerCard = ({
     >
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
-          <Avatar visual={getTriggerIcon(trigger)} size="xs" />
+          <Avatar
+            visual={
+              webhookSourceView?.provider
+                ? (() => {
+                    const IconComponent = getIcon(
+                      normalizeWebhookIcon(
+                        WEBHOOK_PRESETS[webhookSourceView.provider].icon
+                      )
+                    );
+                    return (
+                      <IconComponent className="h-4 w-4 text-foreground" />
+                    );
+                  })()
+                : getTriggerIcon(trigger)
+            }
+            size="xs"
+          />
           <span className="truncate">{trigger.name}</span>
         </div>
         <span className="text-muted-foreground dark:text-muted-foreground-night">


### PR DESCRIPTION
## Description

- This PR fixes missing icon for webhook trigger in the `CardGrid` for triggers in Agent Builder.

Before
<img width="791" height="186" alt="Screenshot 2025-11-12 at 11 40 34 PM" src="https://github.com/user-attachments/assets/99880319-d21f-48b5-8bbc-e550e1ccd711" />

After
<img width="791" height="186" alt="Screenshot 2025-11-12 at 11 41 39 PM" src="https://github.com/user-attachments/assets/ef2d719a-8459-4096-89b5-61703c47d408" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
