### PR TITLE
[front] hootl: delete temporal schedules on manual disable

### DIFF
--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -195,16 +195,14 @@ export class TriggerResource extends BaseResource<TriggerModel> {
 
     await trigger.update(blob, transaction);
 
+    let r = null;
     if (trigger.enabled) {
-      const r = await trigger.upsertTemporalWorkflow(auth);
-      if (r.isErr()) {
-        return r;
-      }
+      r = await trigger.upsertTemporalWorkflow(auth);
     } else {
-      const r = await trigger.removeTemporalWorkflow(auth);
-      if (r.isErr()) {
-        return r;
-      }
+      r = await trigger.removeTemporalWorkflow(auth);
+    }
+    if (r.isErr()) {
+      return r;
     }
 
     return new Ok(trigger);

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -205,7 +205,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       if (r.isErr()) {
         return r;
       }
-      g;
+      gs;
     }
 
     return new Ok(trigger);

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -205,7 +205,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       if (r.isErr()) {
         return r;
       }
-      gs;
     }
 
     return new Ok(trigger);

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -64,9 +64,12 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     });
 
     const resource = new this(TriggerModel, trigger.get());
-    const r = await resource.upsertTemporalWorkflow(auth);
-    if (r.isErr()) {
-      return r;
+
+    if (resource.enabled) {
+      const r = await resource.upsertTemporalWorkflow(auth);
+      if (r.isErr()) {
+        return r;
+      }
     }
 
     return new Ok(resource);
@@ -191,9 +194,17 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     }
 
     await trigger.update(blob, transaction);
-    const r = await trigger.upsertTemporalWorkflow(auth);
-    if (r.isErr()) {
-      return r;
+
+    if (trigger.enabled) {
+      const r = await trigger.upsertTemporalWorkflow(auth);
+      if (r.isErr()) {
+        return r;
+      }
+    } else {
+      const r = await trigger.removeTemporalWorkflow(auth);
+      if (r.isErr()) {
+        return r;
+      }
     }
 
     return new Ok(trigger);

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -195,15 +195,17 @@ export class TriggerResource extends BaseResource<TriggerModel> {
 
     await trigger.update(blob, transaction);
 
-    let r: Result<undefined, Error>;
     if (trigger.enabled) {
-      r = await trigger.enable(auth);
+      const r = await trigger.upsertTemporalWorkflow(auth);
+      if (r.isErr()) {
+        return r;
+      }
     } else {
-      r = await trigger.disable(auth);
-    }
-
-    if (r.isErr()) {
-      return r;
+      const r = await trigger.removeTemporalWorkflow(auth);
+      if (r.isErr()) {
+        return r;
+      }
+      g;
     }
 
     return new Ok(trigger);

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -195,16 +195,15 @@ export class TriggerResource extends BaseResource<TriggerModel> {
 
     await trigger.update(blob, transaction);
 
+    let r: Result<undefined, Error>;
     if (trigger.enabled) {
-      const r = await trigger.upsertTemporalWorkflow(auth);
-      if (r.isErr()) {
-        return r;
-      }
+      r = await trigger.enable(auth);
     } else {
-      const r = await trigger.removeTemporalWorkflow(auth);
-      if (r.isErr()) {
-        return r;
-      }
+      r = await trigger.disable(auth);
+    }
+
+    if (r.isErr()) {
+      return r;
     }
 
     return new Ok(trigger);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR changes the update flow of a trigger.
For now, when we were updating a trigger and the enabled was set to false, we were not automatically removing the temporal workflow.
Same when the trigger was created with a disabled state, leading to creating an unwanted temporal workflow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front