### PR TITLE
[front] feat: Add image editing tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -183,7 +183,8 @@ export const INTERNAL_MCP_SERVERS = {
     serverInfo: {
       name: "image_generation",
       version: "1.0.0",
-      description: "Create visual content from text descriptions.",
+      description:
+        "Create or edit visual content from text descriptions and images.",
       icon: "ActionImageIcon",
       authorization: null,
       documentationUrl: null,

--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -40,11 +40,6 @@ const MAX_FILE_SIZE_FOR_GREP = 20 * 1024 * 1024; // 20MB.
 
 /**
  * MCP server for handling conversation file operations.
- *
- * This server is designed to replace the legacy conversation_include_file action
- * when JIT actions are migrated to use MCP. Currently, JIT actions still use
- * the legacy action system, but this server provides the MCP implementation
- * for future migration.
  */
 
 function createServer(

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -5,14 +5,21 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { streamToBuffer } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { dustManagedCredentials, Err, Ok } from "@app/types";
 import { GEMINI_2_5_FLASH_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
+import {
+  fileSizeToHumanReadable,
+  isSupportedImageContentType,
+  MAX_FILE_SIZES,
+} from "@app/types/files";
 
 const IMAGE_GENERATION_RATE_LIMITER_KEY = "image_generation";
 const IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS = 60 * 60 * 24 * 7; // 1 week.
@@ -41,6 +48,158 @@ function isValidGeminiInlineDataPart(
   part: unknown
 ): part is GeminiInlineDataPart {
   return GeminiInlineDataPartSchema.safeParse(part).success;
+}
+
+// Helper functions for image generation tools.
+
+async function sendImageProgressNotification(
+  sendNotification: (
+    notification: MCPProgressNotificationType
+  ) => Promise<void>,
+  progressToken: string | number | undefined,
+  label: string
+): Promise<void> {
+  if (!progressToken) {
+    return;
+  }
+
+  const notification: MCPProgressNotificationType = {
+    method: "notifications/progress",
+    params: {
+      progress: 0,
+      total: 1,
+      progressToken,
+      data: {
+        label,
+        output: {
+          type: "image",
+          mimeType: DEFAULT_IMAGE_MIME_TYPE,
+        },
+      },
+    },
+  };
+
+  await sendNotification(notification);
+}
+
+async function checkImageGenerationRateLimit(
+  auth: Authenticator,
+  workspace: { sId: string }
+): Promise<Ok<void> | Err<MCPError>> {
+  const { limits } = auth.getNonNullablePlan();
+  const { maxImagesPerWeek } = limits.capabilities.images;
+
+  const remaining = await rateLimiter({
+    key: `${IMAGE_GENERATION_RATE_LIMITER_KEY}_${workspace.sId}`,
+    maxPerTimeframe: maxImagesPerWeek,
+    timeframeSeconds: IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS,
+    logger,
+  });
+
+  if (remaining <= 0) {
+    const statsDClient = getStatsDClient();
+    statsDClient.increment("tools.image_generation.rate_limit_hit", 1, [
+      "provider:gemini",
+    ]);
+
+    return new Err(
+      new MCPError(
+        `Rate limit of ${maxImagesPerWeek} requests per week exceeded. Contact your ` +
+          "administrator to increase the limit.",
+        {
+          tracked: false,
+        }
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+function validateGeminiImageResponse(
+  response: any,
+  operationType: "generation" | "editing",
+  promptText: string
+): Ok<GeminiInlineDataPart[]> | Err<MCPError> {
+  // Check for empty candidates.
+  if (!response.candidates || response.candidates.length === 0) {
+    if (response.promptFeedback?.blockReason) {
+      logger.error(
+        {
+          blockReason: response.promptFeedback.blockReason,
+          safetyRatings: response.promptFeedback.safetyRatings,
+          prompt: promptText,
+        },
+        `Gemini image ${operationType}: Prompt blocked by safety filters`
+      );
+      return new Err(
+        new MCPError(
+          `Image ${operationType} blocked by safety filters: ${response.promptFeedback.blockReason}`
+        )
+      );
+    }
+    return new Err(new MCPError("No image generated."));
+  }
+
+  // Validate content structure.
+  const content = response.candidates[0].content;
+  if (!content || !content.parts) {
+    return new Err(new MCPError("No image data in response"));
+  }
+
+  // Extract valid image parts.
+  const imageParts = content.parts.filter(isValidGeminiInlineDataPart);
+  if (imageParts.length === 0) {
+    return new Err(new MCPError("No image data in response."));
+  }
+
+  return new Ok(imageParts);
+}
+
+function trackGeminiTokenUsage(
+  response: any,
+  statsDClient: ReturnType<typeof getStatsDClient>
+): void {
+  statsDClient.increment(
+    "tools.image_generation.usage.input_tokens",
+    response.usageMetadata?.promptTokenCount ?? 0,
+    ["provider:gemini"]
+  );
+  statsDClient.increment(
+    "tools.image_generation.usage.output_tokens",
+    response.usageMetadata?.candidatesTokenCount ?? 0,
+    ["provider:gemini"]
+  );
+}
+
+function formatImageResponse(
+  imageParts: GeminiInlineDataPart[],
+  fileName: string
+): Ok<
+  Array<{
+    type: "image";
+    mimeType: string;
+    data: string;
+    name: string;
+  }>
+> {
+  const outputFileName = `${fileName}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
+
+  return new Ok(
+    imageParts.map((part) => ({
+      type: "image" as const,
+      mimeType: part.inlineData.mimeType ?? DEFAULT_IMAGE_MIME_TYPE,
+      data: part.inlineData.data,
+      name: outputFileName,
+    }))
+  );
+}
+
+function createGeminiClient(): GoogleGenAI {
+  const credentials = dustManagedCredentials();
+  return new GoogleGenAI({
+    apiKey: credentials.GOOGLE_AI_STUDIO_API_KEY,
+  });
 }
 
 function createServer(
@@ -89,67 +248,29 @@ function createServer(
       async ({ prompt, name, quality, size }, { sendNotification, _meta }) => {
         const workspace = auth.getNonNullableWorkspace();
 
-        if (_meta?.progressToken) {
-          const notification: MCPProgressNotificationType = {
-            method: "notifications/progress",
-            params: {
-              progress: 0,
-              total: 1,
-              progressToken: _meta?.progressToken,
-              data: {
-                label: "Generating image...",
-                output: {
-                  type: "image",
-                  mimeType: DEFAULT_IMAGE_MIME_TYPE,
-                },
-              },
-            },
-          };
-
-          // Send a notification to the MCP Client, to display a placeholder for the image.
-          await sendNotification(notification);
-        }
-
-        const { limits } = auth.getNonNullablePlan();
-        const { maxImagesPerWeek } = limits.capabilities.images;
-
-        // Check current usage for the week.
-        const remaining = await rateLimiter({
-          key: `${IMAGE_GENERATION_RATE_LIMITER_KEY}_${workspace.sId}`,
-          maxPerTimeframe: maxImagesPerWeek,
-          timeframeSeconds: IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS,
-          logger,
-        });
+        await sendImageProgressNotification(
+          sendNotification,
+          _meta?.progressToken,
+          "Generating image..."
+        );
 
         const statsDClient = getStatsDClient();
         statsDClient.increment("tools.image_generation.generated", 1, [
           `quality:${quality}`,
           `size:${size}`,
-          `provider:gemini`,
+          "provider:gemini",
         ]);
 
-        if (remaining <= 0) {
-          statsDClient.increment("tools.image_generation.rate_limit_hit", 1, [
-            `provider:gemini`,
-          ]);
-
-          return new Err(
-            new MCPError(
-              `Rate limit of ${maxImagesPerWeek} requests per week exceeded. Contact your ` +
-                "administrator to increase the limit.",
-              {
-                tracked: false,
-              }
-            )
-          );
+        const rateLimitResult = await checkImageGenerationRateLimit(
+          auth,
+          workspace
+        );
+        if (rateLimitResult.isErr()) {
+          return rateLimitResult;
         }
 
         try {
-          const credentials = dustManagedCredentials();
-
-          const gemini = new GoogleGenAI({
-            apiKey: credentials.GOOGLE_AI_STUDIO_API_KEY,
-          });
+          const gemini = createGeminiClient();
 
           const aspectRatio =
             SIZE_TO_ASPECT_RATIO[size] || SIZE_TO_ASPECT_RATIO["1024x1024"];
@@ -167,59 +288,20 @@ function createServer(
             },
           });
 
-          if (!response.candidates || response.candidates.length === 0) {
-            // Check if prompt was blocked by safety filters
-            if (response.promptFeedback?.blockReason) {
-              logger.error(
-                {
-                  blockReason: response.promptFeedback.blockReason,
-                  safetyRatings: response.promptFeedback.safetyRatings,
-                  prompt,
-                },
-                "Gemini image generation: Prompt blocked by safety filters"
-              );
-              return new Err(
-                new MCPError(
-                  `Image generation blocked by safety filters: ${response.promptFeedback.blockReason}`
-                )
-              );
-            }
-            return new Err(new MCPError("No image generated."));
+          const validationResult = validateGeminiImageResponse(
+            response,
+            "generation",
+            prompt
+          );
+          if (validationResult.isErr()) {
+            return validationResult;
           }
 
-          const content = response.candidates[0].content;
+          const imageParts = validationResult.value;
 
-          if (!content || !content.parts) {
-            return new Err(new MCPError("No image data in response"));
-          }
+          trackGeminiTokenUsage(response, statsDClient);
 
-          const imageParts = content.parts.filter(isValidGeminiInlineDataPart);
-
-          if (imageParts.length === 0) {
-            return new Err(new MCPError("No image data in response."));
-          }
-
-          statsDClient.increment(
-            "tools.image_generation.usage.input_tokens",
-            response.usageMetadata?.promptTokenCount ?? 0,
-            [`provider:gemini`]
-          );
-          statsDClient.increment(
-            "tools.image_generation.usage.output_tokens",
-            response.usageMetadata?.candidatesTokenCount ?? 0,
-            [`provider:gemini`]
-          );
-
-          const fileName = `${name}.${DEFAULT_IMAGE_OUTPUT_FORMAT}`;
-
-          return new Ok(
-            imageParts.map((part) => ({
-              type: "image" as const,
-              mimeType: part.inlineData.mimeType ?? DEFAULT_IMAGE_MIME_TYPE,
-              data: part.inlineData.data,
-              name: fileName,
-            }))
-          );
+          return formatImageResponse(imageParts, name);
         } catch (error) {
           logger.error(
             {
@@ -228,6 +310,230 @@ function createServer(
             "Error generating image."
           );
           return new Err(new MCPError("Error generating image."));
+        }
+      }
+    )
+  );
+
+  server.tool(
+    "edit_image",
+    "Edit an existing image using text instructions. Provide the file ID of an image from Dust" +
+      " file storage and describe the changes you want to make. The tool preserves the original" +
+      " image's aspect ratio by default, but you can optionally change it.",
+    {
+      imageFileId: z
+        .string()
+        .describe(
+          "The ID of the image file to edit (e.g. fil_abc1234) from conversation attachments. Must be a valid image file (PNG, JPEG, etc.)."
+        ),
+      editPrompt: z
+        .string()
+        .max(4000)
+        .describe(
+          "A text description of the desired edits. Be specific about what should change and what should remain unchanged. The maximum length is 4000 characters."
+        ),
+      outputName: z
+        .string()
+        .max(64)
+        .describe(
+          "The filename that will be used to save the edited image. Must be 64 characters or less."
+        ),
+      quality: z
+        .enum(["auto", "low", "medium", "high"])
+        .optional()
+        .default("auto")
+        .describe(
+          "The quality of the edited image. Must be one of auto, low, medium, or high. Auto" +
+            " will automatically choose the best quality."
+        ),
+      aspectRatio: z
+        .enum(["1:1", "3:2", "2:3"])
+        .optional()
+        .describe(
+          "Optional aspect ratio override for the edited image. If not specified, preserves the" +
+            " original image's aspect ratio. Must be one of 1:1, 3:2, or 2:3."
+        ),
+    },
+    withToolLogging(
+      auth,
+      { toolNameForMonitoring: "edit_image", agentLoopContext },
+      async (
+        {
+          imageFileId: inputImageFileId,
+          editPrompt: editImageInstructions,
+          outputName: outputImageFileName,
+          quality,
+          aspectRatio,
+        },
+        { sendNotification, _meta }
+      ) => {
+        const workspace = auth.getNonNullableWorkspace();
+        const statsDClient = getStatsDClient();
+
+        await sendImageProgressNotification(
+          sendNotification,
+          _meta?.progressToken,
+          "Editing image..."
+        );
+
+        // Check if agentLoopContext is available (required for conversation validation)
+        if (!agentLoopContext?.runContext) {
+          return new Err(
+            new MCPError("No conversation context available for file access", {
+              tracked: false,
+            })
+          );
+        }
+
+        // Fetch the file resource
+        const fileResource = await FileResource.fetchById(
+          auth,
+          inputImageFileId
+        );
+        if (!fileResource) {
+          return new Err(
+            new MCPError(`File not found: ${inputImageFileId}`, {
+              tracked: false,
+            })
+          );
+        }
+
+        // Validate file belongs to the current conversation
+        const conversationId = agentLoopContext.runContext.conversation.sId;
+        const belongsResult =
+          fileResource.belongsToConversation(conversationId);
+        if (belongsResult.isErr() || !belongsResult.value) {
+          return new Err(
+            new MCPError(`File does not belong to this conversation`, {
+              tracked: false,
+            })
+          );
+        }
+
+        const maxImageSize = MAX_FILE_SIZES.image;
+        if (fileResource.fileSize > maxImageSize) {
+          logger.warn(
+            {
+              fileId: fileResource.sId,
+              fileSize: fileResource.fileSize,
+              maxFileSize: maxImageSize,
+              workspaceId: workspace.sId,
+            },
+            "edit_image: File size exceeds maximum allowed size"
+          );
+
+          statsDClient.increment(
+            "tools.image_generation.file_size_limit_exceeded",
+            1,
+            ["provider:gemini"]
+          );
+
+          return new Err(
+            new MCPError(
+              `Image file too large for editing. Maximum allowed size is ${fileSizeToHumanReadable(maxImageSize, 0)}, but file is ${fileSizeToHumanReadable(fileResource.fileSize, 0)}.`,
+              {
+                tracked: false,
+              }
+            )
+          );
+        }
+
+        // Get file content as buffer
+        const readStream = fileResource.getReadStream({
+          auth,
+          version: "original",
+        });
+        const bufferResult = await streamToBuffer(readStream);
+        if (bufferResult.isErr()) {
+          return new Err(
+            new MCPError(`Failed to read file: ${bufferResult.error}`, {
+              tracked: false,
+            })
+          );
+        }
+
+        const buffer = bufferResult.value;
+        const contentType = fileResource.contentType;
+
+        if (!isSupportedImageContentType(fileResource.contentType)) {
+          return new Err(
+            new MCPError(
+              `File is not a supported image type. Got: ${fileResource.contentType}. Supported types: PNG, JPEG, WebP, HEIC, HEIF.`,
+              {
+                tracked: false,
+              }
+            )
+          );
+        }
+
+        statsDClient.increment("tools.image_generation.edited", 1, [
+          `quality:${quality}`,
+          `aspect_ratio:${aspectRatio ?? "original"}`,
+          "provider:gemini",
+        ]);
+
+        const rateLimitResult = await checkImageGenerationRateLimit(
+          auth,
+          workspace
+        );
+        if (rateLimitResult.isErr()) {
+          return rateLimitResult;
+        }
+
+        const imageBase64 = buffer.toString("base64");
+
+        try {
+          const gemini = createGeminiClient();
+
+          // Call Gemini API with image inline data and edit prompt.
+          // The contents array includes both the image and the text prompt.
+          const response = await gemini.models.generateContent({
+            model: GEMINI_2_5_FLASH_IMAGE_MODEL_ID,
+            contents: [
+              {
+                parts: [
+                  {
+                    inlineData: {
+                      data: imageBase64,
+                      mimeType: contentType,
+                    },
+                  },
+                  {
+                    text: editImageInstructions,
+                  },
+                ],
+              },
+            ],
+            config: {
+              temperature: 0.7,
+              responseModalities: ["IMAGE"],
+              candidateCount: 1,
+              imageConfig: aspectRatio ? { aspectRatio } : undefined,
+            },
+          });
+
+          const validationResult = validateGeminiImageResponse(
+            response,
+            "editing",
+            editImageInstructions
+          );
+          if (validationResult.isErr()) {
+            return validationResult;
+          }
+
+          const imageParts = validationResult.value;
+
+          trackGeminiTokenUsage(response, statsDClient);
+
+          return formatImageResponse(imageParts, outputImageFileName);
+        } catch (error) {
+          logger.error(
+            {
+              error,
+            },
+            "Error editing image."
+          );
+          return new Err(new MCPError("Error editing image."));
         }
       }
     )

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -41,6 +41,7 @@ export async function getFileFromConversationAttachment(
       buffer: Buffer;
       filename: string;
       contentType: string;
+      fileResource: FileResource;
     },
     string
   >
@@ -119,6 +120,7 @@ export async function getFileFromConversationAttachment(
     buffer: bufferResult.value,
     filename: sanitizeFilename(attachment.title || `attachment-${fileId}`),
     contentType: attachment.contentType || "application/octet-stream",
+    fileResource,
   });
 }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -450,6 +450,31 @@ export class FileResource extends BaseResource<FileModel> {
     return ["upsert_document", "upsert_table"].includes(this.useCase);
   }
 
+  /**
+   * Check if this file belongs to a specific conversation by comparing the
+   * conversationId stored in useCaseMetadata.
+   *
+   * @param requestedConversationId The conversation ID to check against
+   * @returns Ok(true) if file belongs to the conversation, Ok(false) if it belongs
+   *          to a different conversation, Err if file is not associated with any conversation
+   */
+  belongsToConversation(
+    requestedConversationId: string
+  ): Result<boolean, Error> {
+    const { useCaseMetadata } = this;
+
+    if (!useCaseMetadata?.conversationId) {
+      return new Err(new Error("File is not associated with a conversation"));
+    }
+
+    // Direct access, file belongs to the requested conversation.
+    if (useCaseMetadata.conversationId === requestedConversationId) {
+      return new Ok(true);
+    }
+
+    return new Ok(false);
+  }
+
   getBucketForVersion(version: FileVersion) {
     if (version === "public") {
       return getPublicUploadBucket();

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -156,7 +156,7 @@ export function asDisplayToolName(name?: string | null) {
   }
 
   if (name === "image_generation") {
-    return "Create Images";
+    return "Create / Update Images";
   }
 
   if (name === "file_generation") {


### PR DESCRIPTION

## Description

This PR adds an `edit_image` tool to the existing image generation MCP server, allowing users to edit existing images from Dust file storage using text instructions. The tool leverages Gemini 2.5 Flash Image's multimodal capabilities by sending both the original image (as base64 inline data) and edit instructions in a single API call.

The implementation follows the same patterns as the existing `generate_image` tool: rate limiting, progress notifications, safety filter handling, and metrics tracking. The tool preserves the original image's aspect ratio by default, with optional override support (1:1, 3:2, 2:3).

## Risk

Low. The new tool is additive and follows established patterns from the existing `generate_image` tool. It follows file upload size validation (5MB max) and the same rate limiting applies to both generation and editing operations.

## Tests

Manually tested image editing with various prompts and aspect ratios.

## Deploy Plan

- [x] Deploy front-edge
- [x] Deploy front
