### PR TITLE
chore: add Margherita to .authors

### DIFF
--- a/.authors
+++ b/.authors
@@ -50,3 +50,4 @@ Chrisjow: christophe@dust.tt
 id13: jean-david@dust.tt
 alexandre-pinon: alexandre.pinon@dust.tt
 iliasbet: ilias@dust.tt
+margherita-ops: margherita@dust.tt


### PR DESCRIPTION
## Description

- This PR adds Margherita to the `.authors` file, which maps email addresses with GitHub handles.

## Tests

## Risk

## Deploy Plan

- No deploy.
