### PR TITLE
[Workspace Usage] Allow admins to export unpublished assistants

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -673,6 +673,9 @@ export async function getAssistantsUsageData(
   const wId = workspace.id;
   const includeInactiveAgents = options?.includeInactive ?? false;
   const readReplica = getFrontReplicaDbConnection();
+  // Include unpublished agents for workspace admins.
+  const scopeFilter =
+    workspace.role === "admin" ? "" : "AND ac.\"scope\" != 'hidden'";
   // eslint-disable-next-line dust/no-raw-sql -- Leggit
   const agents = await readReplica.query<AgentUsageQueryResult>(
     `
@@ -706,7 +709,7 @@ export async function getAssistantsUsageData(
              LEFT JOIN "users" u ON um."userId" = u."id"
       WHERE ac."workspaceId" = :wId
         AND ac."status" = 'active'
-        AND ac."scope" != 'hidden'
+        ${scopeFilter}
       GROUP BY ac."id"
       ORDER BY "messages" DESC, ac."name" ASC;
     `,


### PR DESCRIPTION
## Description
Context: [slack thread](https://dust4ai.slack.com/archives/C06SYAESP8R/p1762961577931189?thread_ts=1762793606.427099&cid=C06SYAESP8R)
- Include unpublished assistants (scope `hidden`) in the assistants usage export when the requester’s workspace role is `admin`.
- Implemented by conditionally removing the `ac."scope" != 'hidden'` filter in `front/lib/workspace_usage.ts#getAssistantsUsageData` based on `workspace.role`.

## Risks
Blast radius: Admin-only assistants usage export (CSV/ZIP) content.
Risk: low

## Deploy Plan
- deploy front