### PR TITLE
feat: call new llm router in dust apps

### DIFF
--- a/front/lib/api/assistant/agent_suggestion.ts
+++ b/front/lib/api/assistant/agent_suggestion.ts
@@ -1,3 +1,4 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { LightAgentConfigurationType, Result } from "@app/types";
@@ -40,7 +41,7 @@ You must always use the field from the "id" attribute of the agent.
 Here is the list of available agents:
 `;
 
-const SUGGEST_AGENTS_FUNCTION_SPECIFICATIONS = [
+const SUGGEST_AGENTS_FUNCTION_SPECIFICATIONS: AgentActionSpecification[] = [
   {
     name: "suggest_agents",
     description:
@@ -119,12 +120,25 @@ export async function getSuggestedAgentsForContent(
       useCache: true,
     },
     {
-      conversation: { messages: [{ role: "user", content: content.trim() }] },
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: content.trim() }],
+            name: "",
+          },
+        ],
+      },
       prompt: `${INSTRUCTIONS}${formattedAgents}`,
       specifications: SUGGEST_AGENTS_FUNCTION_SPECIFICATIONS,
     },
     {
       tracingRecords,
+      context: {
+        operationType: "agent_suggestion",
+        contextId: conversationId,
+        userId: auth.user()?.sId,
+      },
     }
   );
 

--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -10,14 +10,12 @@ import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import logger from "@app/logger/logger";
 import type { ModelIdType, Result } from "@app/types";
-import { Err, isReasoningEffort, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 export interface LLMConfig {
   functionCall?: string | null;
   modelId: ModelIdType;
   providerId: ModelProviderIdType;
-  reasoningEffort?: string;
-  responseFormat?: string;
   temperature?: number;
   useCache?: boolean;
   useStream?: boolean;
@@ -55,15 +53,9 @@ export async function runMultiActionsAgent(
   input: LLMStreamParameters,
   options: LLMOptions = {}
 ): Promise<Result<LLMOutput, Error>> {
-  const reasoningEffort = config.reasoningEffort ?? "none";
-
   const llm = await getLLM(auth, {
     modelId: config.modelId,
     temperature: config.temperature,
-    reasoningEffort: isReasoningEffort(reasoningEffort)
-      ? reasoningEffort
-      : "none",
-    responseFormat: config.responseFormat,
     context: options.context,
   });
 

--- a/front/lib/api/assistant/call_llm.ts
+++ b/front/lib/api/assistant/call_llm.ts
@@ -2,12 +2,15 @@ import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 import { runActionStreamed } from "@app/lib/actions/server";
+import { getLLM } from "@app/lib/api/llm";
+import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import logger from "@app/logger/logger";
 import type { ModelIdType, Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, isReasoningEffort, Ok } from "@app/types";
 
 export interface LLMConfig {
   functionCall?: string | null;
@@ -20,18 +23,9 @@ export interface LLMConfig {
   useStream?: boolean;
 }
 
-export interface LLMInput {
-  conversation: unknown;
-  prompt: string;
-  specifications?: Array<{
-    name: string;
-    description: string;
-    inputSchema: any;
-  }>;
-}
-
 export interface LLMOptions {
   tracingRecords?: Record<string, string>;
+  context?: LLMTraceContext;
 }
 
 // Zod schema to validate runActionStreamed output.
@@ -58,66 +52,105 @@ export type LLMOutput = z.infer<typeof LLMOutputSchema>;
 export async function runMultiActionsAgent(
   auth: Authenticator,
   config: LLMConfig,
-  input: LLMInput,
+  input: LLMStreamParameters,
   options: LLMOptions = {}
 ): Promise<Result<LLMOutput, Error>> {
-  // Clone base config and apply overrides.
-  const runConfig = cloneBaseConfig(
-    getDustProdAction("assistant-v2-multi-actions-agent").config
-  );
+  const reasoningEffort = config.reasoningEffort ?? "none";
 
-  // Override model configuration.
-  runConfig.MODEL.provider_id = config.providerId;
-  runConfig.MODEL.model_id = config.modelId;
-  runConfig.MODEL.temperature = config.temperature ?? 0;
-  runConfig.MODEL.function_call = config.functionCall ?? null;
-  runConfig.MODEL.use_cache = config.useCache ?? false;
-  runConfig.MODEL.use_stream = config.useStream ?? true;
+  const llm = await getLLM(auth, {
+    modelId: config.modelId,
+    temperature: config.temperature,
+    reasoningEffort: isReasoningEffort(reasoningEffort)
+      ? reasoningEffort
+      : "none",
+    responseFormat: config.responseFormat,
+    context: options.context,
+  });
 
-  const res = await runActionStreamed(
-    auth,
-    "assistant-v2-multi-actions-agent",
-    runConfig,
-    [input],
-    options.tracingRecords ?? {}
-  );
+  if (llm) {
+    const actions: NonNullable<LLMOutput["actions"]> = [];
+    let generation = "";
 
-  if (res.isErr()) {
-    return new Err(new Error(`LLM execution failed: ${res.error.message}`));
-  }
-
-  const { eventStream } = res.value;
-
-  for await (const event of eventStream) {
-    if (event.type === "error") {
-      return new Err(new Error(`LLM error: ${event.content.message}`));
-    }
-
-    if (event.type === "block_execution") {
-      const e = event.content.execution[0][0];
-      if (e.error) {
-        return new Err(new Error(`Block execution error: ${e.error}`));
+    for await (const event of llm.stream(input)) {
+      if (event.type === "error") {
+        return new Err(new Error(`LLM error: ${event.content.message}`));
       }
 
-      if (event.content.block_name === "OUTPUT" && e.value) {
-        const parseResult = LLMOutputSchema.safeParse(e.value);
-        if (!parseResult.success) {
-          logger.error(
-            {
-              error: fromError(parseResult.error).toString(),
-            },
-            "Invalid LLM output schema"
-          );
+      if (event.type === "text_generated") {
+        generation += event.content.text;
+      }
 
-          return new Err(
-            new Error(`Invalid LLM output schema: ${parseResult.error.message}`)
-          );
+      if (event.type === "tool_call") {
+        actions.push({
+          name: event.content.name,
+          functionCallId: event.content.id,
+          arguments: event.content.arguments,
+        });
+      }
+    }
+
+    return new Ok({ actions, generation });
+  } else {
+    // Clone base config and apply overrides.
+    const runConfig = cloneBaseConfig(
+      getDustProdAction("assistant-v2-multi-actions-agent").config
+    );
+
+    // Override model configuration.
+    runConfig.MODEL.provider_id = config.providerId;
+    runConfig.MODEL.model_id = config.modelId;
+    runConfig.MODEL.temperature = config.temperature ?? 0;
+    runConfig.MODEL.function_call = config.functionCall ?? null;
+    runConfig.MODEL.use_cache = config.useCache ?? false;
+    runConfig.MODEL.use_stream = config.useStream ?? true;
+
+    const res = await runActionStreamed(
+      auth,
+      "assistant-v2-multi-actions-agent",
+      runConfig,
+      [input],
+      options.tracingRecords ?? {}
+    );
+
+    if (res.isErr()) {
+      return new Err(new Error(`LLM execution failed: ${res.error.message}`));
+    }
+
+    const { eventStream } = res.value;
+
+    for await (const event of eventStream) {
+      if (event.type === "error") {
+        return new Err(new Error(`LLM error: ${event.content.message}`));
+      }
+
+      if (event.type === "block_execution") {
+        const e = event.content.execution[0][0];
+        if (e.error) {
+          return new Err(new Error(`Block execution error: ${e.error}`));
         }
 
-        return new Ok(parseResult.data);
+        if (event.content.block_name === "OUTPUT" && e.value) {
+          const parseResult = LLMOutputSchema.safeParse(e.value);
+          if (!parseResult.success) {
+            logger.error(
+              {
+                error: fromError(parseResult.error).toString(),
+              },
+              "Invalid LLM output schema"
+            );
+
+            return new Err(
+              new Error(
+                `Invalid LLM output schema: ${parseResult.error.message}`
+              )
+            );
+          }
+
+          return new Ok(parseResult.data);
+        }
       }
     }
-  }
 
-  return new Err(new Error("No output found in LLM response"));
+    return new Err(new Error("No output found in LLM response"));
+  }
 }

--- a/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
+++ b/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
@@ -1,3 +1,4 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
@@ -6,7 +7,7 @@ import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
 const SET_SCHEDULE_FUNCTION_NAME = "set_schedule";
 const SET_TIMEZONE_FUNCTION_NAME = "set_tz";
 
-const specifications = [
+const specifications: AgentActionSpecification[] = [
   {
     name: SET_SCHEDULE_FUNCTION_NAME,
     description: "Setup a schedule for triggering an assistant",
@@ -63,7 +64,8 @@ export async function getCronTimezoneGeneration(
         messages: [
           {
             role: "user",
-            content: JSON.stringify(inputs),
+            content: [{ type: "text", text: JSON.stringify(inputs) }],
+            name: "",
           },
         ],
       },
@@ -74,8 +76,15 @@ export async function getCronTimezoneGeneration(
         "For the timezone generation (set_tz):\n" +
         "You must interpret the description, get the requested timezone from the user, and call set_tz with the timezone as an argument.\n" +
         "If no timezone is specified in the naturalDescription, return the defaultTimezone.\n" +
-        "ALWAYS use IANA Timezone such as Europe/Paris, or America/New_York.",
+        "ALWAYS use IANA Timezone such as Europe/Paris, or America/New_York.\n" +
+        "ALWAYS call both tools",
       specifications,
+    },
+    {
+      context: {
+        operationType: "trigger_cron_timezone_generator",
+        userId: auth.user()?.sId,
+      },
     }
   );
 

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -1,3 +1,4 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
@@ -86,7 +87,7 @@ const MODEL_ID: ModelIdType = GPT_4O_MINI_MODEL_ID;
 
 const FUNCTION_NAME = "update_title";
 
-const specifications = [
+const specifications: AgentActionSpecification[] = [
   {
     name: FUNCTION_NAME,
     description: "Update the title of the conversation",
@@ -157,6 +158,13 @@ async function generateConversationTitle(
         "Generate a concise conversation title (3-8 words) based on the user's message and context. " +
         "The title should capture the main topic or request without being too generic.",
       specifications,
+    },
+    {
+      context: {
+        operationType: "conversation_title_suggestion",
+        contextId: conversation.sId,
+        userId: auth.user()?.sId,
+      },
     }
   );
 

--- a/front/lib/api/assistant/json_schema_generator.ts
+++ b/front/lib/api/assistant/json_schema_generator.ts
@@ -68,7 +68,7 @@ export async function getBuilderJsonSchemaGenerator(
   };
 
   const traceContext: LLMTraceContext = {
-    operationType: "schema_generator",
+    operationType: "process_schema_generator",
     userId: auth.user()?.sId,
   };
   const llm = await getLLM(auth, {

--- a/front/lib/api/assistant/suggestions/description.ts
+++ b/front/lib/api/assistant/suggestions/description.ts
@@ -1,12 +1,17 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
 import type { Authenticator } from "@app/lib/auth";
-import type { BuilderSuggestionInputType, Result } from "@app/types";
+import type {
+  BuilderSuggestionInputType,
+  ModelConversationTypeMultiActions,
+  Result,
+} from "@app/types";
 import { Err, GPT_3_5_TURBO_MODEL_ID, Ok } from "@app/types";
 
 const FUNCTION_NAME = "send_suggestion";
 
-const specifications = [
+const specifications: AgentActionSpecification[] = [
   {
     name: FUNCTION_NAME,
     description: "Send a suggestion of description for the assistant",
@@ -25,7 +30,9 @@ const specifications = [
   },
 ];
 
-function getConversationContext(inputs: BuilderSuggestionInputType) {
+function getConversationContext(
+  inputs: BuilderSuggestionInputType
+): ModelConversationTypeMultiActions {
   const instructions = "instructions" in inputs ? inputs.instructions : "";
 
   const instructionsText = instructions
@@ -36,7 +43,8 @@ function getConversationContext(inputs: BuilderSuggestionInputType) {
     messages: [
       {
         role: "user",
-        content: instructionsText,
+        content: [{ type: "text", text: instructionsText }],
+        name: "",
       },
     ],
   };
@@ -62,6 +70,12 @@ export async function getBuilderDescriptionSuggestions(
         "The assistant has been given instructions by the user. Based on the provided " +
         "instructions suggest a short description of the assistant.",
       specifications,
+    },
+    {
+      context: {
+        operationType: "agent_builder_description_suggestion",
+        userId: auth.user()?.sId,
+      },
     }
   );
 

--- a/front/lib/api/assistant/suggestions/emoji.ts
+++ b/front/lib/api/assistant/suggestions/emoji.ts
@@ -1,9 +1,14 @@
 import { isLeft } from "fp-ts/lib/Either";
 
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
 import type { Authenticator } from "@app/lib/auth";
-import type { BuilderSuggestionInputType, Result } from "@app/types";
+import type {
+  BuilderSuggestionInputType,
+  ModelConversationTypeMultiActions,
+  Result,
+} from "@app/types";
 import {
   BuilderEmojiSuggestionsResponseBodySchema,
   Err,
@@ -13,7 +18,7 @@ import {
 
 const FUNCTION_NAME = "send_suggestions";
 
-const specifications = [
+const specifications: AgentActionSpecification[] = [
   {
     name: FUNCTION_NAME,
     description: "Send suggestions of names for the assistants",
@@ -49,6 +54,7 @@ const specifications = [
               },
             },
             required: ["emoji", "backgroundColor"],
+            additionalProperties: false,
           },
           description: "Suggest one to three emojis for the assistant",
         },
@@ -58,7 +64,9 @@ const specifications = [
   },
 ];
 
-function getConversationContext(inputs: BuilderSuggestionInputType) {
+function getConversationContext(
+  inputs: BuilderSuggestionInputType
+): ModelConversationTypeMultiActions {
   const instructions = "instructions" in inputs ? inputs.instructions : "";
 
   const instructionsText = instructions
@@ -73,7 +81,8 @@ function getConversationContext(inputs: BuilderSuggestionInputType) {
     messages: [
       {
         role: "user",
-        content: initialPrompt + instructionsText,
+        content: [{ type: "text", text: initialPrompt + instructionsText }],
+        name: "",
       },
     ],
   };
@@ -97,6 +106,12 @@ export async function getBuilderEmojiSuggestions(
       prompt:
         "Task Overview: Assist in the customization of a virtual assistant’s visual identity by selecting an emoji for its avatar. The assistant's design and purpose will be described in each message you receive.\n\nObjective: Your main responsibility is to choose an emoji that captures the essence of the assistant, reflecting its unique functions, personality, or the context in which it will be used.\n\nGuidelines:\n- Broaden Your Choices: Consider a wide range of emojis to find one that uniquely represents the assistant's qualities or use case. Avoid defaulting to common choices unless they are the best fit. Try to avoid the generic 🤖 that could work for all assistants, unless the topic is truly about robots.\n- Relevance is Key: Select emojis that directly relate to the assistant’s described characteristics or intended environment. For instance, a 🎨 might suit a creative design tool, while a 📚 could represent a learning aid.\n- Compatibility Consideration: Ensure that your choices adhere to the Unicode standard to guarantee that the emoji displays correctly across all platforms.",
       specifications,
+    },
+    {
+      context: {
+        operationType: "agent_builder_emoji_suggestion",
+        userId: auth.user()?.sId,
+      },
     }
   );
 

--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -100,7 +100,7 @@ export async function getBuilderNameSuggestions(
   const conversation: ModelConversationTypeMultiActions =
     getConversationContext(inputs);
   const traceContext: LLMTraceContext = {
-    operationType: "name_suggestion",
+    operationType: "agent_builder_name_suggestion",
     userId: auth.user()?.sId,
   };
   const llm = await getLLM(auth, {

--- a/front/lib/api/assistant/suggestions/tags.ts
+++ b/front/lib/api/assistant/suggestions/tags.ts
@@ -1,12 +1,17 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
 import type { Authenticator } from "@app/lib/auth";
-import type { BuilderSuggestionInputType, Result } from "@app/types";
+import type {
+  BuilderSuggestionInputType,
+  ModelConversationTypeMultiActions,
+  Result,
+} from "@app/types";
 import { Err, GPT_4_1_MINI_MODEL_ID, Ok } from "@app/types";
 
 const FUNCTION_NAME = "send_suggestions";
 
-const specifications = [
+const specifications: AgentActionSpecification[] = [
   {
     name: FUNCTION_NAME,
     description: "Send suggestions of tags for the agent",
@@ -27,7 +32,9 @@ const specifications = [
   },
 ];
 
-function getConversationContext(inputs: BuilderSuggestionInputType) {
+function getConversationContext(
+  inputs: BuilderSuggestionInputType
+): ModelConversationTypeMultiActions {
   const instructions = "instructions" in inputs ? inputs.instructions : "";
   const description = "description" in inputs ? inputs.description : "";
   const tags = "tags" in inputs ? inputs.tags : [];
@@ -50,7 +57,13 @@ function getConversationContext(inputs: BuilderSuggestionInputType) {
     messages: [
       {
         role: "user",
-        content: initialPrompt + descriptionText + instructionsText + tagsText,
+        content: [
+          {
+            type: "text",
+            text: initialPrompt + descriptionText + instructionsText + tagsText,
+          },
+        ],
+        name: "",
       },
     ],
   };
@@ -109,6 +122,12 @@ export async function getBuilderTagSuggestions(
       conversation: getConversationContext(inputs),
       prompt: auth.isAdmin() && isAdminInput ? ADMIN_PROMPT : USER_PROMPT,
       specifications,
+    },
+    {
+      context: {
+        operationType: "agent_builder_tags_suggestion",
+        userId: auth.user()?.sId,
+      },
     }
   );
 

--- a/front/lib/api/assistant/tag_manager.ts
+++ b/front/lib/api/assistant/tag_manager.ts
@@ -2,6 +2,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import { formatValidationErrors } from "io-ts-reporters";
 
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
@@ -22,7 +23,7 @@ const WorkspaceTagSuggestionsResponseSchema = t.type({
   ]),
 });
 
-const specifications = [
+const specifications: AgentActionSpecification[] = [
   {
     name: SEND_TAGS_FUNCTION_NAME,
     description: "Send tagging plan for the assistant",
@@ -147,12 +148,19 @@ export async function getWorkspaceTagSuggestions(
         messages: [
           {
             role: "user",
-            content: "Please suggest tags.",
+            content: [{ type: "text", text: "Please suggest tags." }],
+            name: "",
           },
         ],
       },
       prompt: instructionsWithAgents,
       specifications,
+    },
+    {
+      context: {
+        operationType: "workspace_tags_suggestion",
+        userId: auth.user()?.sId,
+      },
     }
   );
 

--- a/front/lib/api/assistant/voice_agent_finder.ts
+++ b/front/lib/api/assistant/voice_agent_finder.ts
@@ -2,6 +2,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
@@ -24,7 +25,7 @@ const VoiceAgentFinderResponseSchema = t.type({
   ),
 });
 
-const specifications = [
+const specifications: AgentActionSpecification[] = [
   {
     name: FIND_AGENTS_AND_TOOLS_FUNCTION_NAME,
     description: "Find agents and tools in a message",
@@ -154,12 +155,19 @@ export async function findAgentsInMessageGeneration(
         messages: [
           {
             role: "user",
-            content: inputs.message.trim(),
+            content: [{ type: "text", text: inputs.message.trim() }],
+            name: "",
           },
         ],
       },
       prompt: instructionsWithAgents,
       specifications,
+    },
+    {
+      context: {
+        operationType: "voice_agent_finder",
+        userId: auth.user()?.sId,
+      },
     }
   );
 

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -14,7 +14,7 @@ import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
-  StreamParameters,
+  LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -49,7 +49,7 @@ export class AnthropicLLM extends LLM {
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     try {
       const messages = conversation.messages.map(toMessage);
 

--- a/front/lib/api/llm/clients/fireworks/index.ts
+++ b/front/lib/api/llm/clients/fireworks/index.ts
@@ -7,7 +7,7 @@ import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
-  StreamParameters,
+  LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import {
   toMessages,
@@ -44,7 +44,7 @@ export class FireworksLLM extends LLM {
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     try {
       const tools =
         specifications.length > 0 ? toTools(specifications) : undefined;

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -15,7 +15,7 @@ import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
-  StreamParameters,
+  LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { dustManagedCredentials } from "@app/types";
@@ -58,7 +58,7 @@ export class GoogleLLM extends LLM {
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     try {
       const modelFamily = getGoogleModelFamilyFromModelId(this.modelId);
 

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -13,7 +13,7 @@ import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
-  StreamParameters,
+  LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { dustManagedCredentials } from "@app/types";
@@ -52,7 +52,7 @@ export class MistralLLM extends LLM {
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     try {
       const messages = [
         {

--- a/front/lib/api/llm/clients/noop/index.ts
+++ b/front/lib/api/llm/clients/noop/index.ts
@@ -6,7 +6,7 @@ import type {
 } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
-  StreamParameters,
+  LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 
@@ -64,7 +64,7 @@ export class NoopLLM extends LLM {
   async *internalStream({
     conversation: _conversation,
     prompt: _prompt,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     // Emit a simple flow of event:
     // 1. text delta "Soup"
     // 2. text delta "inou!"

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -7,7 +7,7 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMClientMetadata,
   LLMParameters,
-  StreamParameters,
+  LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { handleError } from "@app/lib/api/llm/utils/openai_like/errors";
 import {
@@ -50,7 +50,7 @@ export class OpenAIResponsesLLM extends LLM {
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     try {
       const events = await this.client.responses.create({
         model: this.modelId,

--- a/front/lib/api/llm/clients/xai/index.ts
+++ b/front/lib/api/llm/clients/xai/index.ts
@@ -7,7 +7,7 @@ import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
-  StreamParameters,
+  LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { handleError } from "@app/lib/api/llm/utils/openai_like/errors";
 import {
@@ -44,7 +44,7 @@ export class XaiLLM extends LLM {
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     try {
       const events = await this.client.responses.create({
         model: this.modelId,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -11,7 +11,7 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMClientMetadata,
   LLMParameters,
-  StreamParameters,
+  LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { RunResource } from "@app/lib/resources/run_resource";
@@ -63,7 +63,7 @@ export abstract class LLM {
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     if (!this.context) {
       yield* this.internalStream({ conversation, prompt, specifications });
       return;
@@ -152,7 +152,7 @@ export abstract class LLM {
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent> {
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     yield* this.streamWithTracing({
       conversation,
       prompt,
@@ -164,5 +164,5 @@ export abstract class LLM {
     conversation,
     prompt,
     specifications,
-  }: StreamParameters): AsyncGenerator<LLMEvent>;
+  }: LLMStreamParameters): AsyncGenerator<LLMEvent>;
 }

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -11,14 +11,22 @@ import type {
 export interface LLMTraceContext {
   /** Type of operation that triggered the LLM call */
   operationType:
+    | "agent_builder_description_suggestion"
+    | "agent_builder_emoji_suggestion"
+    | "agent_builder_instruction_suggestion"
+    | "agent_builder_name_suggestion"
+    | "agent_builder_tags_suggestion"
     | "agent_conversation"
-    | "builder_suggestion"
-    | "agent_preview"
-    | "name_suggestion"
-    | "schema_generator"
-    | "other";
+    | "agent_suggestion"
+    | "conversation_title_suggestion"
+    | "process_data_sources"
+    | "process_schema_generator"
+    | "trigger_cron_timezone_generator"
+    | "trigger_webhook_filter_generator"
+    | "voice_agent_finder"
+    | "workspace_tags_suggestion";
 
-  /** Context-specific identifier (e.g., agentConfigId, userId, etc.) */
+  /** Context-specific identifier (e.g., agentConfigId, conversationId, etc.) */
   contextId?: string;
 
   /** User who triggered the operation */

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -20,7 +20,7 @@ export type LLMClientMetadata = {
   modelId: ModelIdType;
 };
 
-export interface StreamParameters {
+export interface LLMStreamParameters {
   conversation: ModelConversationTypeMultiActions;
   prompt: string;
   specifications: AgentActionSpecification[];


### PR DESCRIPTION




## Description

This PR updates `runMultiActionsAgent` to support the new LLM router infrastructure.

The function now attempts to use `getLLM` first (when available), and falls back to the legacy `assistant-v2-multi-actions-agent` dust app if the LLM router is not available for the requested model.

All callers are updated to pass properly structured conversation messages with the new `ModelConversationTypeMultiActions` format and include trace context for observability.

## Risk

Low

## Tests

Tested locally

## Deploy

Deploy Front.
