### PR TITLE
fix(front): mention dropdown in input bar

### DIFF
--- a/front/lib/mentions/ui/MentionDisplay.tsx
+++ b/front/lib/mentions/ui/MentionDisplay.tsx
@@ -26,6 +26,18 @@ interface MentionDisplayProps {
   showTooltip?: boolean;
 }
 
+interface MentionTriggerProps {
+  mention: RichMention;
+}
+
+function MentionTrigger({ mention }: MentionTriggerProps) {
+  return (
+    <span className="inline-block cursor-pointer font-medium text-highlight-500">
+      @{mention.label}
+    </span>
+  );
+}
+
 /**
  * Displays a mention as a styled badge with optional tooltip and dropdown.
  *
@@ -39,31 +51,27 @@ export function MentionDisplay({
   owner,
   showTooltip = true,
 }: MentionDisplayProps) {
-  const trigger = (
-    <span className="inline-block cursor-pointer font-medium text-highlight-500">
-      @{mention.label}
-    </span>
-  );
-
   // If interactive and owner is provided, wrap with dropdown.
   if (interactive && owner) {
     // If tooltip is requested and description exists, wrap with tooltip.
     if (showTooltip && mention.description) {
       return (
         <TooltipProvider>
-          <MentionDropdown mention={mention} owner={owner}>
-            <TooltipRoot>
-              <TooltipTrigger asChild>{trigger}</TooltipTrigger>
-              <TooltipContent>{mention.description}</TooltipContent>
-            </TooltipRoot>
-          </MentionDropdown>
+          <TooltipRoot>
+            <TooltipTrigger asChild>
+              <MentionDropdown mention={mention} owner={owner}>
+                <MentionTrigger mention={mention} />
+              </MentionDropdown>
+            </TooltipTrigger>
+            <TooltipContent>{mention.description}</TooltipContent>
+          </TooltipRoot>
         </TooltipProvider>
       );
     }
 
     return (
       <MentionDropdown mention={mention} owner={owner}>
-        {trigger}
+        <MentionTrigger mention={mention} />
       </MentionDropdown>
     );
   }
@@ -73,12 +81,14 @@ export function MentionDisplay({
     return (
       <TooltipProvider>
         <TooltipRoot>
-          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipTrigger asChild>
+            <MentionTrigger mention={mention} />
+          </TooltipTrigger>
           <TooltipContent>{mention.description}</TooltipContent>
         </TooltipRoot>
       </TooltipProvider>
     );
   }
 
-  return trigger;
+  return <MentionTrigger mention={mention} />;
 }

--- a/front/lib/mentions/ui/MentionDropdown.tsx
+++ b/front/lib/mentions/ui/MentionDropdown.tsx
@@ -35,11 +35,10 @@ interface MentionDropdownProps {
  * - Agent mentions: start a conversation or view details
  * - User mentions: view user profile
  */
-export function MentionDropdown({
-  mention,
-  owner,
-  children,
-}: MentionDropdownProps) {
+export const MentionDropdown = React.forwardRef<
+  HTMLDivElement,
+  MentionDropdownProps
+>(({ mention, owner, children }, ref) => {
   const router = useRouter();
   const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");
 
@@ -58,7 +57,9 @@ export function MentionDropdown({
 
     return (
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+        <DropdownMenuTrigger asChild>
+          <div ref={ref}>{children}</div>
+        </DropdownMenuTrigger>
         <DropdownMenuContent side="bottom" align="start">
           <DropdownMenuItem
             onClick={handleStartConversation}
@@ -79,7 +80,9 @@ export function MentionDropdown({
   if (isRichUserMention(mention)) {
     return (
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+        <DropdownMenuTrigger asChild>
+          <div ref={ref}>{children}</div>
+        </DropdownMenuTrigger>
         <DropdownMenuContent side="bottom" align="start">
           <DropdownMenuItem
             icon={UserIcon}
@@ -91,5 +94,7 @@ export function MentionDropdown({
   }
 
   // Unsupported mention type, render children without dropdown.
-  return <>{children}</>;
-}
+  return <div ref={ref}>{children}</div>;
+});
+
+MentionDropdown.displayName = "MentionDropdown";


### PR DESCRIPTION
## Description

Claude code fixed the ref forwarding issue that was preventing the mention dropdown from working. The problem was with how React refs were being passed through nested Radix UI components.

**Root Cause**

When asChild is used in Radix UI components (like DropdownMenuTrigger and TooltipTrigger), they try to pass refs to their
  children. When these are nested, you get conflicts because:
  1. DropdownMenuTrigger asChild tries to pass a ref to its child
  2. TooltipTrigger asChild also tries to pass a ref to its child
  3. The plain <span> element at the bottom can't receive multiple refs
  4. Function components without forwardRef can't receive refs at all

_Note: I don't understand this fix, it was made by claude code and it works_

## Tests

<img width="341" height="162" alt="image" src="https://github.com/user-attachments/assets/fe1efa4e-51b0-4b87-9e4b-cc5ea4340004" />

<img width="428" height="257" alt="image" src="https://github.com/user-attachments/assets/5bb2731b-2733-484e-af9d-d35555cd2254" />


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
