### PR TITLE
Fix: stall conversation messages & conversation loading visual

### DIFF
--- a/front/components/assistant/ConversationViewerEmptyState.tsx
+++ b/front/components/assistant/ConversationViewerEmptyState.tsx
@@ -1,9 +1,36 @@
-import { Spinner } from "@dust-tt/sparkle";
+import { LoadingBlock } from "@dust-tt/sparkle";
 
 export function ConversationViewerEmptyState() {
   return (
-    <div className="flex h-full w-full flex-1 flex-col items-center justify-center">
-      <Spinner variant="color" size="xl" />
+    <div className="mx-auto flex h-full w-full min-w-60 max-w-3xl flex-col pt-6 md:pt-10">
+      <FakeUserMessage />
+      <FakeAgentMessage />
+    </div>
+  );
+}
+
+function FakeUserMessage() {
+  return (
+    <div className="min-w-60 max-w-full self-end">
+      <LoadingBlock className="h-[125px] w-[350px] rounded-xl" />
+    </div>
+  );
+}
+
+function FakeAgentMessage() {
+  return (
+    <div className="mt-8">
+      <div className="flex flex-col space-y-3">
+        <div className="mb-2 flex flex-row items-center gap-x-2">
+          <LoadingBlock className="h-[36px] w-[36px]" />
+          <LoadingBlock className="h-4 w-[120px]" />
+        </div>
+        <LoadingBlock className="h-4 w-[450px]" />
+        <LoadingBlock className="h-4 w-[475px]" />
+        <LoadingBlock className="h-4 w-[350px]" />
+        <LoadingBlock className="h-4 w-[450px]" />
+        <LoadingBlock className="h-4 w-[375px]" />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

Fix a potential loading issue with conversation.
Rework the loading state (https://github.com/orgs/dust-tt/projects/2/views/1?filterQuery=assignee%3AFraggle&pane=issue&itemId=136238783&issue=dust-tt%7Ctasks%7C4919)

## Tests

Local

https://github.com/user-attachments/assets/9d6913b3-b4c1-4ffb-a007-95ce15cd0073



## Risk

It will delay slightly the loading of previous conversations you might already have navigated too without reloading (shallow nav)

## Deploy Plan

Deploy front