### PR TITLE
[Agent Config] Two-phase publish for agent upgrades

### DIFF
--- a/front/docs/agents-two-phase-publish.md
+++ b/front/docs/agents-two-phase-publish.md
@@ -1,0 +1,73 @@
+# Two-phase publish for Agent upgrades (proposal)
+
+Context: Fixes https://github.com/dust-tt/tasks/issues/5083
+
+Problem
+- `createAgentConfiguration` currently archives the previous "active" version first, then creates
+  the new version and its actions. If action creation fails, we hard-delete the new version but the
+  previous one remains archived, making the agent unavailable until a manual restore.
+
+Goal
+- Ensure upgrades are all-or-nothing: either the new version is fully created (config + actions),
+  then atomically replaces the active one, or the system leaves the previous version untouched and
+  visible.
+
+Proposed approach (two-phase publish)
+1) Create the new version as unpublished and isolated
+   - Use the same `sId` and next `version`.
+   - Set `scope: "hidden"` (unpublished) and `status: "active"`.
+   - Keep editor group and tags creation limited to what is needed; reuse existing reserved tags
+     checks. Favor copying editors/tags after successful action creation (below) to minimize work to
+     undo.
+
+2) Create all actions for the new version
+   - Extend `createAgentActionConfiguration` to accept an optional `transaction` and reuse it when
+     provided (no nested `withTransaction`).
+   - Create action records (and data sources/tables/reasoning sub-records) inside the same
+     transaction as the agent config creation.
+
+3) Publish atomically (transaction commit boundary)
+   - Still inside the transaction:
+     - Archive all previous versions for `sId` (as today).
+     - Flip the new version to `scope: previous_scope` (usually `"published"`) and ensure `status:
+       "active"`.
+     - Copy editors and tags onto the new version (if not already done in step 1).
+
+4) Failure semantics
+   - Any error while creating actions or sub-records aborts the transaction and leaves the previous
+     active version intact and visible.
+   - No compensating "restore" step required.
+
+Notes on implementation
+- Transactions
+  - `createAgentConfiguration` already supports an optional `transaction` via `withTransaction`.
+  - Update `createAgentActionConfiguration` to accept `transaction?: Transaction` and only call
+    `withTransaction` when `!transaction`.
+  - Call both functions from a single `withTransaction` block in
+    `createOrUpgradeAgentConfiguration`.
+
+- Scope/Status
+  - We already use `scope: "hidden"` for unpublished internal agents; reuse this as a staging scope
+    while building the new version.
+
+- Editors/Tags
+  - Preserve existing reserved-tag invariants. Defer tag/editor replication to right before
+    publication (same transaction) to keep rollback trivial.
+
+- Triggers
+  - Publishing should keep current behavior (archiving disables triggers for the old version; the
+    new active version will have its triggers created/enabled as applicable by existing flows).
+
+Migration / backward compatibility
+- No schema changes. Purely behavioral change in the creation flow.
+- Existing APIs and types remain unchanged.
+
+Risks
+- Medium: touches agent creation and action creation paths; covered by endpoint functional tests.
+
+Test plan (high-level)
+- Simulate action creation failure: previous version remains active and visible; no new records
+  leaked.
+- Successful upgrade: previous version archived, new one published; actions present and callable.
+- Permission checks unchanged; reserved tags preserved.
+


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/5083

## Description
Today an upgrade archives the previous version first, then creates the new config and actions. If action creation fails, we hard-delete the new version but the previous one remains archived, temporarily taking the agent offline.

This PR proposes a two-phase publish approach so upgrades are all-or-nothing:
- Create the new version as `scope: "hidden"` inside a single transaction.
- Create all actions within the same transaction (plumb `transaction` through `createAgentActionConfiguration`).
- On success, still in-transaction, archive prior versions and flip the new one to the original scope (usually `"published"`) and keep `status: "active"`.
- On failure, the transaction aborts and the previous active version remains visible; no compensating restore is required.

A short design note is included at `front/docs/agents-two-phase-publish.md`.

## Risks
Blast radius: Agent creation/upgrade flow (config + actions)
Risk: standard

## Deploy Plan
- Deploy `front` only; no migrations.
- After merge: monitor error logs for agent creation/upgrade and any unexpected transaction rollbacks.

## Test (manual suggestions)
- Force action creation failure during upgrade: confirm previous version stays active and no partial records remain.
- Successful upgrade: previous version archived; new one visible; actions operational.
