### PR TITLE
[front] chore: Allow CORS for office addins

### DIFF
--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -8,6 +8,7 @@ const STATIC_ALLOWED_ORIGINS = [
   "https://docs.dust.tt",
   // Microsoft Power Automate.
   "https://make.powerautomate.com",
+  "https://office-addins.dust.tt",
 ] as const;
 
 const ALLOWED_ORIGIN_PATTERNS = [

--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -105,6 +105,10 @@ function setCorsHeaders(
     return undefined;
   }
 
+  // Cannot use helper functions like isDevelopment() in Edge Runtime middleware since they are not
+  // bundled. Must check NODE_ENV directly.
+  const isDevelopment = process.env.NODE_ENV === "development";
+
   // If this is a preflight request checking headers.
   if (request.method === "OPTIONS" && requestHeaders) {
     const requestedHeaders = requestHeaders.split(",").map((h) => h.trim());
@@ -112,7 +116,7 @@ function setCorsHeaders(
       (header) => !isAllowedHeader(header)
     );
 
-    if (hasUnallowedHeader) {
+    if (hasUnallowedHeader && !isDevelopment) {
       return new NextResponse(null, {
         status: 403,
         statusText: "Forbidden: Unauthorized Headers",
@@ -121,10 +125,6 @@ function setCorsHeaders(
   }
 
   // Check if origin is allowed (prod or dev).
-
-  // Cannot use helper functions like isDevelopment() in Edge Runtime middleware since they are not
-  // bundled. Must check NODE_ENV directly.
-  const isDevelopment = process.env.NODE_ENV === "development";
   if (isDevelopment || isAllowedOrigin(origin)) {
     response.headers.set("Access-Control-Allow-Origin", origin);
     response.headers.set("Access-Control-Allow-Credentials", "true");


### PR DESCRIPTION
## Description

Add https://office-addins.dust.tt to CORS allowed hosts, also bypass allowed header in dev (useful for ngrok headers)
related to https://github.com/dust-tt/dust-labs/pull/83

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
