### PR TITLE
[Agent Config] Restore previous version after failed upgrade

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -385,7 +385,7 @@ export async function createOrUpgradeAgentConfiguration({
             agentConfigurationRes.value.sId
           );
           if (!restored) {
-            logger.warn(
+            logger.error(
               {
                 workspaceId: auth.getNonNullableWorkspace().sId,
                 agentConfigurationId: agentConfigurationRes.value.sId,


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/5083

## Description
When upgrading an agent, the previous version is archived first. If creating an action for the new version fails, we hard-delete the new version but leave the previous one archived, making the agent unavailable if the user leaves the builder without a successful save.

This change restores the previously archived version back to `active` status after we hard-delete the just-created version on failure. It preserves availability of the assistant in upgrade failure scenarios.

## Risks
Blast radius: Agent upgrade failure path (error handling around action creation)
Risk: low

## Deploy Plan
- Deploy `front` only; no migrations.

## Test (manual suggestions)
- Trigger an action creation failure during agent upgrade; the previous version should remain visible as `active` after the request completes.
