### PR TITLE
[LLM Router] feat: disable input schemas strict mode for openai

### DIFF
--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -138,19 +138,17 @@ export function toTool(tool: AgentActionSpecification): FunctionTool {
   const parameters: {
     type: "object";
     properties: Record<string, unknown>;
-    required: string[];
-    additionalProperties: boolean;
   } = {
     type: "object",
     properties,
-    // OpenAI requires all properties to be marked as required
-    required: Object.keys(properties),
-    additionalProperties: false,
   };
 
   return {
     type: "function",
-    strict: true,
+    // If not set to false, OpenAI requires all properties to be required,
+    // and all additionalProperties to be false.
+    // This does not fit with Notion tools that enable permissive filter properties.
+    strict: false,
     name: tool.name,
     description: tool.description,
     parameters,

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -147,7 +147,7 @@ export function toTool(tool: AgentActionSpecification): FunctionTool {
     type: "function",
     // If not set to false, OpenAI requires all properties to be required,
     // and all additionalProperties to be false.
-    // This does not fit with Notion tools that enable permissive filter properties.
+    // This does not fit with many tools that enable permissive filter properties.
     strict: false,
     name: tool.name,
     description: tool.description,


### PR DESCRIPTION
## Description

Closes https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=139073558&issue=dust-tt%7Ctasks%7C5116

Set `strict: false` on tools specifications for openai.
If not, and some object have properties that are not required (and / or no `additionalProperties` set to false), OpenAI throws an error.

## Tests

Local

## Risk

Low - this is how we did it in core

## Deploy Plan

front
