### PR TITLE
[connector] perf: Eagerly remove pages from cache on batch deletion

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -3801,6 +3801,14 @@ export async function batchDeleteResources({
       pageId,
       logger: localLogger,
     });
+    await NotionConnectorResourcesToCheckCacheEntry.destroy({
+      where: {
+        resourceType: "page",
+        notionId: pageId,
+        connectorId,
+        workflowId,
+      },
+    });
   }
 
   // Delete databases
@@ -3811,14 +3819,15 @@ export async function batchDeleteResources({
       databaseId,
       logger: localLogger,
     });
+    await NotionConnectorResourcesToCheckCacheEntry.destroy({
+      where: {
+        resourceType: "database",
+        notionId: databaseId,
+        connectorId,
+        workflowId,
+      },
+    });
   }
-
-  await NotionConnectorResourcesToCheckCacheEntry.destroy({
-    where: {
-      connectorId,
-      workflowId,
-    },
-  });
 
   return {
     deletedPages: pageIds.length,


### PR DESCRIPTION
## Description

Currently, we only delete all entry caches in batchDeleteResources when we are done. 
Given the long-running nature of this activity and the startToCloseTimeout of 10min, it can be restarted mid-way by temporal. By deleting the cache entry along the way, we reduce the number of attempts needed to go through.

## Tests

Tested locally by sending webhooks.

## Risk

Low: We're barely changing the logic.

## Deploy Plan

- [ ] Deploy connector