### PR TITLE
[front] fix(AB): update tab title

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -242,7 +242,7 @@ export function AgentBuilderPreview() {
   const renderContent = () => {
     if (!hasContent) {
       return (
-        <TabContentLayout title="Preview">
+        <TabContentLayout title="Testing">
           <EmptyPlaceholder
             icon={TestTubeIcon}
             title="Ready to test your agent?"


### PR DESCRIPTION
## Description

- This PR fixes an inconsistent title in the Agent Builder right panel: the testing tab is named preview.

Before
<img width="747" height="441" alt="Screenshot 2025-11-13 at 3 43 00 PM" src="https://github.com/user-attachments/assets/5b19b53a-8b8a-4dbb-b3a1-3acfe55f8863" />

After
<img width="747" height="441" alt="Screenshot 2025-11-13 at 3 42 42 PM" src="https://github.com/user-attachments/assets/11183f27-7dce-4f9c-8a60-88c915d0d5ff" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
