### PR TITLE
feat(llm): add a comparison mode

### DIFF
--- a/front/temporal/agent_loop/lib/compare_outputs.ts
+++ b/front/temporal/agent_loop/lib/compare_outputs.ts
@@ -1,0 +1,135 @@
+import type { GetOutputResponse } from "@app/temporal/agent_loop/lib/types";
+
+export type ComparisonResult = {
+  // Structural comparisons (should be identical)
+  sameActionsCount: boolean;
+  sameActionNames: boolean;
+  sameContentStructure: boolean;
+
+  // Output type comparison (critical)
+  bothAreActions: boolean;
+  bothAreGenerations: boolean;
+  outputTypeMismatch: boolean;
+
+  // Length comparisons (with tolerance for LLM variance)
+  generationLengthRatio: number | null; // null if no generation
+  generationLengthDifferencePercent: number | null;
+
+  // Summary
+  hasCriticalDifferences: boolean;
+  summary: string;
+};
+
+/**
+ * Compare two LLM outputs to detect significant structural differences.
+ * Since LLM outputs are non-deterministic, we focus on structural and behavioral differences
+ * rather than exact text matching.
+ */
+export function compareOutputs(
+  coreOutput: PromiseSettledResult<GetOutputResponse>,
+  llmOutput: PromiseSettledResult<GetOutputResponse>
+): ComparisonResult | null {
+  // if either response is rejected, we can't compare
+  if (coreOutput.status === "rejected" || llmOutput.status === "rejected") {
+    return null;
+  }
+
+  // If either output is an error, we can't compare
+
+  if (coreOutput.value.isErr() || llmOutput.value.isErr()) {
+    return null;
+  }
+
+  const core = coreOutput.value.value;
+  const llm = llmOutput.value.value;
+
+  // 1. Compare action count
+  const sameActionsCount =
+    core.output.actions.length === llm.output.actions.length;
+
+  // 2. Compare action names (tools called)
+  const sameActionNames = core.output.actions.every(
+    (action, idx) => llm.output.actions[idx]?.name === action.name
+  );
+
+  // 3. Compare content structure (types and count)
+  const sameContentStructure =
+    core.output.contents.length === llm.output.contents.length &&
+    core.output.contents.every(
+      (content, idx) => llm.output.contents[idx]?.type === content.type
+    );
+
+  // 4. Determine output type
+  const coreIsAction = core.output.actions.length > 0;
+  const llmIsAction = llm.output.actions.length > 0;
+  const bothAreActions = coreIsAction && llmIsAction;
+  const bothAreGenerations = !coreIsAction && !llmIsAction;
+  const outputTypeMismatch = coreIsAction !== llmIsAction;
+
+  // 5. Compare generation lengths (only if both are generations)
+  let generationLengthRatio: number | null = null;
+  let generationLengthDifferencePercent: number | null = null;
+
+  if (bothAreGenerations) {
+    const coreGenLength = (core.output.generation ?? "").length;
+    const llmGenLength = (llm.output.generation ?? "").length;
+
+    if (coreGenLength > 0 || llmGenLength > 0) {
+      const maxLength = Math.max(coreGenLength, llmGenLength);
+      const minLength = Math.min(coreGenLength, llmGenLength);
+
+      if (maxLength > 0) {
+        generationLengthRatio = minLength / maxLength;
+        const lengthDiff = Math.abs(coreGenLength - llmGenLength);
+        generationLengthDifferencePercent = (lengthDiff / maxLength) * 100;
+      }
+    }
+  }
+
+  // 6. Determine critical differences
+  const hasCriticalDifferences =
+    outputTypeMismatch || // One returned actions, the other didn't
+    (bothAreActions && !sameActionNames) || // Different tools called
+    (bothAreGenerations &&
+      generationLengthDifferencePercent !== null &&
+      generationLengthDifferencePercent > 50); // Generation length differs by >50%
+
+  // 7. Generate summary
+  let summary = "";
+  if (outputTypeMismatch) {
+    summary = coreIsAction
+      ? "core returned actions, llm returned generation"
+      : "core returned generation, llm returned actions";
+  } else if (bothAreActions) {
+    if (!sameActionsCount) {
+      summary = `Actions count differs: core=${core.output.actions.length}, llm=${llm.output.actions.length}`;
+    } else if (!sameActionNames) {
+      summary = `Different tools called: core=[${core.output.actions.map((a) => a.name).join(", ")}], llm=[${llm.output.actions.map((a) => a.name).join(", ")}]`;
+    } else {
+      summary = "Same tools called in same order";
+    }
+  } else if (bothAreGenerations) {
+    if (generationLengthDifferencePercent !== null) {
+      summary = `Both generated text. Length difference: ${generationLengthDifferencePercent.toFixed(1)}%`;
+    } else {
+      summary = "Both generated empty text";
+    }
+  }
+
+  if (!sameContentStructure && !hasCriticalDifferences) {
+    summary += " (content structure differs)";
+  }
+
+  return {
+    sameActionsCount,
+    sameActionNames,
+    sameContentStructure,
+    bothAreActions,
+    bothAreGenerations,
+    outputTypeMismatch,
+    generationLengthRatio,
+    generationLengthDifferencePercent,
+    hasCriticalDifferences,
+    summary,
+  };
+}

--- a/front/temporal/agent_loop/lib/utils.ts
+++ b/front/temporal/agent_loop/lib/utils.ts
@@ -1,10 +1,18 @@
 import type { Logger } from "pino";
 
+import {
+  AgentMessageContentParser,
+  getDelimitersConfiguration,
+} from "@app/lib/api/assistant/agent_message_content_parser";
+import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { Authenticator } from "@app/lib/auth";
+import type { AgentMessage } from "@app/lib/models/assistant/conversation";
+import { compareOutputs } from "@app/temporal/agent_loop/lib/compare_outputs";
 import { getOutputFromAction } from "@app/temporal/agent_loop/lib/get_output_from_action";
 import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_from_llm";
 import type { GetOutputRequestParams } from "@app/temporal/agent_loop/lib/types";
+import type { ConversationWithoutContentType } from "@app/types";
 
 export async function getOutputFromLLM(
   auth: Authenticator,
@@ -75,4 +83,155 @@ export async function getOutputFromLLM(
       updateResourceAndPublishEvent,
     });
   }
+}
+
+const noopUpdateResourceAndPublishEvent = (
+  _auth: Authenticator,
+  _: {
+    event: AgentMessageEvents;
+    agentMessageRow: AgentMessage;
+    conversation: ConversationWithoutContentType;
+    step: number;
+    modelInteractionDurationMs?: number;
+    userMessageOrigin?: string | null;
+  }
+): Promise<void> => {
+  return Promise.resolve();
+};
+
+const noopPublishAgentError = (_error: {
+  code: string;
+  message: string;
+  metadata: Record<string, string | number | boolean> | null;
+}): Promise<void> => {
+  return Promise.resolve();
+};
+
+export async function getOutputFromLLMWithParallelComparisonMode(
+  auth: Authenticator,
+  localLogger: Logger,
+  {
+    modelConversationRes,
+    conversation,
+    userMessage,
+    specifications,
+    flushParserTokens,
+    contentParser,
+    agentMessageRow,
+    step,
+    agentConfiguration,
+    agentMessage,
+    model,
+    prompt,
+    llm,
+    runConfig,
+    publishAgentError,
+    updateResourceAndPublishEvent,
+  }: GetOutputRequestParams & { llm: LLM }
+) {
+  // Comparison mode: run both implementations in parallel
+  localLogger.info(
+    {
+      conversationId: conversation.sId,
+      step,
+    },
+    "Running LLM comparison mode: executing both core and llm implementations in parallel"
+  );
+
+  // We need to create a separate content parser for the new implementation
+  // to avoid conflicts with the old implementation's parser
+  const newContentParser = new AgentMessageContentParser(
+    agentConfiguration,
+    agentMessage.sId,
+    getDelimitersConfiguration({ agentConfiguration })
+  );
+
+  // Helper function to flush tokens for the new parser (we won't publish these events)
+  async function flushNewParserTokens(): Promise<void> {
+    // Consume tokens but don't publish them
+    for await (const _tokenEvent of newContentParser.flushTokens()) {
+      // Silently discard
+    }
+  }
+
+  const [coreResponse, llmResponse] = await Promise.allSettled([
+    getOutputFromAction(auth, {
+      modelConversationRes,
+      conversation,
+      userMessage,
+      runConfig,
+      specifications,
+      flushParserTokens,
+      contentParser,
+      agentMessageRow,
+      step,
+      agentConfiguration,
+      agentMessage,
+      model,
+      publishAgentError,
+      prompt,
+      updateResourceAndPublishEvent,
+    }),
+    getOutputFromLLMStream(auth, {
+      modelConversationRes,
+      conversation,
+      userMessage,
+      runConfig,
+      specifications,
+      agentMessageRow,
+      step,
+      agentConfiguration,
+      agentMessage,
+      model,
+      prompt,
+      llm,
+      // we don't want to have any side effect from the new implementation in comparison mode, so we pass a noop functions
+      updateResourceAndPublishEvent: noopUpdateResourceAndPublishEvent,
+      publishAgentError: noopPublishAgentError,
+      flushParserTokens: flushNewParserTokens,
+      contentParser: newContentParser,
+    }),
+  ]);
+
+  // Compare the outputs
+  const comparisonResult = compareOutputs(coreResponse, llmResponse);
+
+  if (comparisonResult) {
+    const logLevel = comparisonResult.hasCriticalDifferences ? "warn" : "info";
+    localLogger[logLevel](
+      {
+        conversationId: conversation.sId,
+        step,
+        comparison: {
+          summary: comparisonResult.summary,
+          sameActionsCount: comparisonResult.sameActionsCount,
+          sameActionNames: comparisonResult.sameActionNames,
+          sameContentStructure: comparisonResult.sameContentStructure,
+          outputTypeMismatch: comparisonResult.outputTypeMismatch,
+          generationLengthDifferencePercent:
+            comparisonResult.generationLengthDifferencePercent,
+          hasCriticalDifferences: comparisonResult.hasCriticalDifferences,
+        },
+      },
+      `LLM comparison: ${comparisonResult.summary}`
+    );
+  } else {
+    localLogger.warn(
+      {
+        conversationId: conversation.sId,
+        step,
+        coreResponseIsErr:
+          coreResponse.status === "rejected" || coreResponse.value.isErr(),
+        llmResponseIsErr:
+          llmResponse.status === "rejected" || llmResponse.value.isErr(),
+      },
+      "LLM comparison mode: could not compare outputs (one or both failed)"
+    );
+  }
+
+  if (coreResponse.status === "rejected") {
+    return Promise.reject(coreResponse.reason);
+  }
+
+  return coreResponse.value;
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -205,6 +205,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Use direct LLM call over Dust app run in a conversation.",
     stage: "on_demand",
   },
+  llm_comparison_mode_enabled: {
+    description: "Enable LLM comparison mode.",
+    stage: "on_demand",
+  },
   use_requested_space_ids: {
     description: "Use requested spaces Ids for permissions checking.",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -660,6 +660,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_trackers"
   | "labs_transcripts"
   | "legacy_dust_apps"
+  | "llm_comparison_mode_enabled"
   | "llm_router_direct_requests"
   | "mentions_v2"
   | "monday_tool"


### PR DESCRIPTION
## Description

Enable a comparison mode between the old and new LLM implementations. 

For now it just outputs stuff in the logs

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
