### PR TITLE
[front] - fix(AB): add option to FormProvider to not render a form tag

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -378,7 +378,7 @@ export default function AgentBuilder({
 
   return (
     <AgentBuilderFormContext.Provider value={form}>
-      <FormProvider form={form}>
+      <FormProvider form={form} asForm={false}>
         <PersonalConnectionRequiredDialog
           owner={owner}
           mcpServerViewsWithPersonalConnections={

--- a/front/components/sparkle/FormProvider.tsx
+++ b/front/components/sparkle/FormProvider.tsx
@@ -6,6 +6,8 @@ interface FormProviderProps<TFormData extends FieldValues> {
   form: UseFormReturn<TFormData>;
   onSubmit?: (data: TFormData) => void | Promise<void>;
   className?: string;
+  // When false, only provides RHF context without rendering a <form> element.
+  asForm?: boolean;
 }
 
 // You are not supposed to have nested forms. If you want to have multiple forms,
@@ -17,6 +19,7 @@ export function FormProvider<TFormData extends FieldValues>({
   form,
   onSubmit,
   className,
+  asForm = true,
 }: FormProviderProps<TFormData>) {
   const handleSubmit = async (data: TFormData) => {
     if (onSubmit) {
@@ -26,6 +29,10 @@ export function FormProvider<TFormData extends FieldValues>({
 
   // You have to call stopPropagation inside `onSubmit`, it's too late
   // if you handle it inside `handleSubmit`.
+  if (!asForm) {
+    return <ReactHookFromProvider {...form}>{children}</ReactHookFromProvider>;
+  }
+
   return (
     <ReactHookFromProvider {...form}>
       <form


### PR DESCRIPTION
## Description

Fixes nested form issue in AgentBuilder by adding an `asForm` prop to `FormProvider`. The `AgentBuilder` component uses `FormProvider` but has nested dialogs that also need form context without creating nested `<form>` elements (which is invalid HTML). When `asForm={false}`, the `FormProvider` now only provides React Hook Form context without rendering a `<form>` tag.

This fixes the "nested form" console errors.

## Risk

Moderate - breaking forms behaviour

## Tests

Locally

## Deploy Plan

Deploy front