### PR TITLE
fix: put text and reasoning events before tool call

### DIFF
--- a/front/lib/api/llm/clients/google/utils/test/google_to_events.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/google_to_events.test.ts
@@ -209,6 +209,13 @@ const functionCallLLMEvents = [
     metadata,
   },
   {
+    type: "text_generated",
+    content: {
+      text: "Hi !",
+    },
+    metadata,
+  },
+  {
     type: "tool_call",
     content: {
       id: "DdHr7L197",
@@ -218,17 +225,12 @@ const functionCallLLMEvents = [
     metadata,
   },
   {
-    type: "text_generated",
-    content: {
-      text: "Hi !",
-    },
-    metadata,
-  },
-  {
     type: "token_usage",
     content: {
+      cachedTokens: undefined,
       inputTokens: 1766,
       outputTokens: 128,
+      reasoningTokens: undefined,
       totalTokens: 1894,
     },
     metadata,
@@ -237,18 +239,18 @@ const functionCallLLMEvents = [
     type: "success",
     aggregated: [
       {
+        type: "text_generated",
+        content: {
+          text: "Hi !",
+        },
+        metadata,
+      },
+      {
         type: "tool_call",
         content: {
           id: "DdHr7L197",
           name: "web_search_browse__websearch",
           arguments: { query: "Paris France weather forecast October 23 2025" },
-        },
-        metadata,
-      },
-      {
-        type: "text_generated",
-        content: {
-          text: "Hi !",
         },
         metadata,
       },


### PR DESCRIPTION
## Description

There was an issue when creating a conversation with tool calls with gemini, and then invoking an Anthropic model in the same conversation because a tool output was not following a tool call. 
This PR fixes it by updating Gemini llm event order

## Tests

Local

## Risk

low

## Deploy Plan

front
