### PR TITLE
[front] - chore(obs): enhance tooltip `ToolUsageChart`

### DIFF
--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -170,7 +170,7 @@ export function ToolUsageChart({
           {topTools.map((toolName) => (
             <Bar
               key={toolName}
-              dataKey={(row: ChartDatum) => row.values[toolName] ?? 0}
+              dataKey={(row: ChartDatum) => row.values[toolName]?.percent ?? 0}
               stackId="a"
               fill="currentColor"
               className={getToolColor(toolName, topTools)}

--- a/front/components/agent_builder/observability/hooks.ts
+++ b/front/components/agent_builder/observability/hooks.ts
@@ -6,6 +6,7 @@ import type { ObservabilityMode } from "@app/components/agent_builder/observabil
 import type {
   ChartDatum,
   ToolChartModeType,
+  ToolChartUsageDatum,
 } from "@app/components/agent_builder/observability/types";
 import { selectTopTools } from "@app/components/agent_builder/observability/utils";
 import type { LatencyPoint } from "@app/lib/api/assistant/observability/latency";
@@ -82,7 +83,7 @@ function createChartData(
       item.total ??
       Object.values(item.tools).reduce((acc, tool) => acc + tool.count, 0);
 
-    const values: Record<string, number> = {};
+    const values: Record<string, ToolChartUsageDatum> = {};
     let topToolsCount = 0;
     for (const toolName of displayTools) {
       if (toolName === OTHER_TOOLS_LABEL) {
@@ -92,7 +93,10 @@ function createChartData(
       const toolData = item.tools[toolName];
       const count = toolData?.count ?? 0;
       if (count > 0) {
-        values[toolName] = calculatePercentage(count, total);
+        values[toolName] = {
+          percent: calculatePercentage(count, total),
+          count,
+        };
         topToolsCount += count;
       }
     }
@@ -101,11 +105,14 @@ function createChartData(
       const othersCount = total - topToolsCount;
 
       if (othersCount > 0) {
-        values[OTHER_TOOLS_LABEL] = calculatePercentage(othersCount, total);
+        values[OTHER_TOOLS_LABEL] = {
+          percent: calculatePercentage(othersCount, total),
+          count: othersCount,
+        };
       }
     }
 
-    return { label: item.label, values };
+    return { label: item.label, values, total };
   });
 }
 

--- a/front/components/agent_builder/observability/types.ts
+++ b/front/components/agent_builder/observability/types.ts
@@ -6,7 +6,43 @@ export function isToolChartMode(mode: string): mode is ToolChartModeType {
   return TOOL_CHART_MODES.includes(mode as ToolChartModeType);
 }
 
+export type ToolChartUsageDatum = {
+  percent: number;
+  count: number;
+};
+
 export type ChartDatum = {
   label: string | number;
-  values: Record<string, number>;
+  values: Record<string, ToolChartUsageDatum>;
+  total?: number;
 };
+
+export type ToolChartUsagePayload = {
+  name?: string;
+  value?: number;
+  payload?: ChartDatum;
+};
+
+export function isChartDatum(data: unknown): data is ChartDatum {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  if (!("values" in data)) {
+    return false;
+  }
+  const v = (data as { values?: unknown }).values;
+  return !(typeof v !== "object" || v === null);
+}
+
+export function isToolChartUsagePayload(
+  d: unknown
+): d is ToolChartUsagePayload {
+  if (typeof d !== "object" || d === null) {
+    return false;
+  }
+  const o = d as Record<string, unknown>;
+  const valueOk = typeof o.value === "number";
+  const nameOk = typeof o.name === "string" || typeof o.name === "undefined";
+  const payloadOk = isChartDatum(o.payload);
+  return valueOk && nameOk && payloadOk;
+}


### PR DESCRIPTION
## Description

This PR improves the `ToolUsageChart` tooltip to display both the raw count and percentage for each tool. Previously, the tooltip only showed percentages extracted directly from the chart values. Now the tooltip displays the actual tool execution count alongside its percentage, making the data more informative and easier to interpret.
## Risk

Low - UI-only change 

## Tests

- [x] locally
- [x] front-edge

## Deploy Plan

Deploy front