### PR TITLE
[connector] enh(microsoft): reduce oauth scopes

### DIFF
--- a/connectors/migrations/20251113_backfill_microsoft_tenant_ids.ts
+++ b/connectors/migrations/20251113_backfill_microsoft_tenant_ids.ts
@@ -1,0 +1,127 @@
+import { makeScript } from "scripts/helpers";
+import { Op } from "sequelize";
+
+import {
+  extractTenantIdFromAccessToken,
+  getMicrosoftConnectionData,
+} from "@connectors/connectors/microsoft";
+import type { Logger } from "@connectors/logger/logger";
+import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+import type { ConnectorMetadata } from "@connectors/resources/storage/models/connector_model";
+
+async function backfillConnectorTenant({
+  connector,
+  execute,
+  logger,
+}: {
+  connector: ConnectorModel;
+  execute: boolean;
+  logger: Logger;
+}) {
+  const childLogger = logger.child({ connectorId: connector.id });
+
+  const metadata = (connector.metadata ?? {}) as ConnectorMetadata;
+  if (metadata.tenantId) {
+    childLogger.info("Tenant id already present, skipping");
+    return;
+  }
+
+  try {
+    const { accessToken } = await getMicrosoftConnectionData(
+      connector.connectionId
+    );
+    const tenantId = extractTenantIdFromAccessToken(accessToken);
+
+    if (!tenantId) {
+      childLogger.warn("Unable to extract tenant id from access token");
+      return;
+    }
+
+    childLogger.info({ tenantId, execute }, "Backfilling tenant id");
+
+    if (execute) {
+      const newMetadata: ConnectorMetadata = {
+        ...metadata,
+        tenantId,
+      };
+      await connector.update({ metadata: newMetadata });
+    }
+  } catch (error) {
+    childLogger.error({ error }, "Failed to backfill tenant id");
+  }
+}
+
+makeScript(
+  {
+    connectorId: {
+      type: "number",
+      describe: "Process a single connector id",
+      required: false,
+    },
+    nextConnectorId: {
+      type: "number",
+      describe:
+        "Process connectors with id greater than the provided value (supports pagination)",
+      required: false,
+      default: 0,
+    },
+    batchSize: {
+      type: "number",
+      describe: "Maximum number of connectors to process per run",
+      required: false,
+      default: 50,
+    },
+  },
+  async ({ connectorId, nextConnectorId, batchSize, execute }, scriptLogger) => {
+    if (connectorId && connectorId > 0) {
+      const connector = await ConnectorModel.findByPk(connectorId);
+      if (!connector || connector.type !== "microsoft") {
+        scriptLogger.warn(
+          { connectorId },
+          "Connector not found or not a Microsoft connector"
+        );
+        return;
+      }
+      await backfillConnectorTenant({ connector, execute, logger: scriptLogger });
+      return;
+    }
+
+    const connectors = await ConnectorModel.findAll({
+      where: {
+        type: "microsoft",
+        id:
+          nextConnectorId && nextConnectorId > 0
+            ? {
+                [Op.gt]: nextConnectorId,
+              }
+            : {
+                [Op.gt]: 0,
+              },
+      },
+      order: [["id", "ASC"]],
+      limit: batchSize,
+    });
+
+    if (connectors.length === 0) {
+      scriptLogger.info("No Microsoft connectors matched the criteria");
+      return;
+    }
+
+    for (const connector of connectors) {
+      await backfillConnectorTenant({
+        connector,
+        execute,
+        logger: scriptLogger,
+      });
+    }
+
+    const lastProcessedId = connectors[connectors.length - 1]?.id;
+    if (lastProcessedId) {
+      scriptLogger.info(
+        { nextConnectorId: lastProcessedId },
+        "To continue, re-run the script with --nextConnectorId set to this value"
+      );
+    }
+  }
+);
+

--- a/connectors/src/connectors/microsoft/lib/content_nodes.ts
+++ b/connectors/src/connectors/microsoft/lib/content_nodes.ts
@@ -1,9 +1,4 @@
-import type {
-  Channel,
-  Drive,
-  Site,
-  Team,
-} from "@microsoft/microsoft-graph-types";
+import type { Drive, Site } from "@microsoft/microsoft-graph-types";
 
 import {
   getDriveInternalId,
@@ -11,16 +6,13 @@ import {
   getSiteAPIPath,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
-import {
-  internalIdFromTypeAndPath,
-  typeAndPathFromInternalId,
-} from "@connectors/connectors/microsoft/lib/utils";
+import { internalIdFromTypeAndPath } from "@connectors/connectors/microsoft/lib/utils";
 import type { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
 import type { ContentNode, ContentNodeType } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 export function getRootNodes(): ContentNode[] {
-  return [getSitesRootAsContentNode(), getTeamsRootAsContentNode()];
+  return [getSitesRootAsContentNode()];
 }
 
 export function getSitesRootAsContentNode(): ContentNode {
@@ -33,41 +25,6 @@ export function getSitesRootAsContentNode(): ContentNode {
     type: "folder",
     title: "Sites",
     sourceUrl: null,
-    lastUpdatedAt: null,
-    preventSelection: true,
-    expandable: true,
-    permission: "none",
-    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
-  };
-}
-
-export function getTeamsRootAsContentNode(): ContentNode {
-  return {
-    internalId: internalIdFromTypeAndPath({
-      itemAPIPath: "",
-      nodeType: "teams-root",
-    }),
-    parentInternalId: null,
-    type: "folder",
-    title: "Teams",
-    sourceUrl: null,
-    lastUpdatedAt: null,
-    preventSelection: true,
-    expandable: true,
-    permission: "none",
-    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
-  };
-}
-export function getTeamAsContentNode(team: Team): ContentNode {
-  return {
-    internalId: internalIdFromTypeAndPath({
-      itemAPIPath: `/teams/${team.id}`,
-      nodeType: "team",
-    }),
-    parentInternalId: null,
-    type: "folder",
-    title: team.displayName || "unnamed",
-    sourceUrl: team.webUrl ?? null,
     lastUpdatedAt: null,
     preventSelection: true,
     expandable: true,
@@ -96,35 +53,6 @@ export function getSiteAsContentNode(
     lastUpdatedAt: null,
     preventSelection: true,
     expandable: true,
-    permission: "none",
-    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
-  };
-}
-
-export function getChannelAsContentNode(
-  channel: Channel,
-  parentInternalId: string
-): ContentNode {
-  if (!channel.id) {
-    // Unexpected, unreachable
-    throw new Error("Channel id is required");
-  }
-  const { nodeType } = typeAndPathFromInternalId(parentInternalId);
-  if (nodeType !== "team") {
-    throw new Error(`Invalid parent nodeType: ${nodeType}`);
-  }
-
-  return {
-    internalId: internalIdFromTypeAndPath({
-      itemAPIPath: `/teams/${parentInternalId}/channels/${channel.id}`,
-      nodeType: "channel",
-    }),
-    parentInternalId,
-    type: "folder",
-    title: channel.displayName || "unnamed",
-    sourceUrl: channel.webUrl ?? null,
-    lastUpdatedAt: null,
-    expandable: false,
     permission: "none",
     mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
   };

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -337,35 +337,6 @@ export async function getWorksheetContent(
   return res;
 }
 
-export async function getMessages(
-  logger: LoggerInterface,
-  client: Client,
-  parentInternalId: string,
-  nextLink?: string
-): Promise<{ results: ChatMessage[]; nextLink?: string }> {
-  const { nodeType, itemAPIPath: parentResourcePath } =
-    typeAndPathFromInternalId(parentInternalId);
-
-  if (nodeType !== "channel") {
-    throw new Error(
-      `Invalid node type: ${nodeType} for getMessages, expected channel`
-    );
-  }
-
-  const res = nextLink
-    ? await clientApiGet(logger, client, nextLink)
-    : await clientApiGet(logger, client, parentResourcePath);
-
-  if ("@odata.nextLink" in res) {
-    return {
-      results: res.value,
-      nextLink: res["@odata.nextLink"],
-    };
-  }
-
-  return { results: res.value };
-}
-
 export async function getMessagesFromConversation(
   logger: LoggerInterface,
   client: Client,

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -4,20 +4,20 @@ import type { Client } from "@microsoft/microsoft-graph-client";
 import { GraphError } from "@microsoft/microsoft-graph-client";
 import type {
   BaseItem,
-  Channel,
   ChatMessage,
   Drive,
   Entity,
   ItemReference,
   Organization,
   Site,
-  Team,
   WorkbookRange,
   WorkbookWorksheet,
 } from "@microsoft/microsoft-graph-types";
 
-import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
-import type { MicrosoftNode } from "@connectors/connectors/microsoft/lib/types";
+import type {
+  DriveItem,
+  MicrosoftNode,
+} from "@connectors/connectors/microsoft/lib/types";
 import { DRIVE_ITEM_EXPANDS_AND_SELECTS } from "@connectors/connectors/microsoft/lib/types";
 import {
   internalIdFromTypeAndPath,
@@ -337,54 +337,6 @@ export async function getWorksheetContent(
   return res;
 }
 
-export async function getTeams(
-  logger: LoggerInterface,
-  client: Client,
-  nextLink?: string
-): Promise<{ results: Team[]; nextLink?: string }> {
-  const res = nextLink
-    ? await clientApiGet(logger, client, nextLink)
-    : await clientApiGet(logger, client, "/me/joinedTeams");
-
-  if ("@odata.nextLink" in res) {
-    return {
-      results: res.value,
-      nextLink: res["@odata.nextLink"],
-    };
-  }
-
-  return { results: res.value };
-}
-
-export async function getChannels(
-  logger: LoggerInterface,
-  client: Client,
-  parentInternalId: string,
-  nextLink?: string
-): Promise<{ results: Channel[]; nextLink?: string }> {
-  const { nodeType, itemAPIPath: parentResourcePath } =
-    typeAndPathFromInternalId(parentInternalId);
-
-  if (nodeType !== "team") {
-    throw new Error(
-      `Invalid node type: ${nodeType} for getChannels, expected team`
-    );
-  }
-
-  const res = nextLink
-    ? await clientApiGet(logger, client, nextLink)
-    : await clientApiGet(logger, client, `${parentResourcePath}/channels`);
-
-  if ("@odata.nextLink" in res) {
-    return {
-      results: res.value,
-      nextLink: res["@odata.nextLink"],
-    };
-  }
-
-  return { results: res.value };
-}
-
 export async function getMessages(
   logger: LoggerInterface,
   client: Client,
@@ -467,10 +419,8 @@ type MicrosoftEntity = {
   folder: DriveItem;
   drive: Drive;
   site: Site;
-  team: Team;
   file: DriveItem;
   page: DriveItem;
-  channel: Channel;
   message: ChatMessage;
   worksheet: WorkbookWorksheet;
 };
@@ -538,8 +488,6 @@ export function itemToMicrosoftNode<T extends keyof MicrosoftEntityMapping>(
         webUrl: item.webUrl ?? null,
       };
     }
-    case "team":
-    case "channel":
     case "message":
     case "worksheet":
     case "page":

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -26,14 +26,11 @@ export const DRIVE_ITEM_EXPANDS_AND_SELECTS =
 
 export const MICROSOFT_NODE_TYPES = [
   "sites-root",
-  "teams-root",
   "site",
-  "team",
   "drive",
   "folder",
   "file",
   "page",
-  "channel",
   "message",
   "worksheet",
 ] as const;

--- a/connectors/src/connectors/microsoft/lib/utils.ts
+++ b/connectors/src/connectors/microsoft/lib/utils.ts
@@ -20,12 +20,8 @@ export function internalIdFromTypeAndPath({
   nodeType: MicrosoftNodeType;
   itemAPIPath: string;
 }): string {
-  let stringId = "";
-  if (nodeType === "sites-root" || nodeType === "teams-root") {
-    stringId = nodeType;
-  } else {
-    stringId = `${nodeType}/${itemAPIPath}`;
-  }
+  const stringId =
+    nodeType === "sites-root" ? nodeType : `${nodeType}/${itemAPIPath}`;
   // encode to base64url so the internal id is URL-friendly
   return "microsoft-" + Buffer.from(stringId).toString("base64url");
 }
@@ -44,7 +40,7 @@ export function typeAndPathFromInternalId(internalId: string): {
     "base64url"
   ).toString();
 
-  if (decodedId === "sites-root" || decodedId === "teams-root") {
+  if (decodedId === "sites-root") {
     return { nodeType: decodedId, itemAPIPath: "" };
   }
 

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -48,10 +48,10 @@ MicrosoftConfigurationModel.init(
   }
 );
 
-// MicrosoftRoot stores the drive/folders/channels selected by the user to sync.
+// MicrosoftRoot stores the sites/drives selected by the user to sync.
 // In order to be able to uniquely identify each node, we store the GET path
-// to the item in the itemApiPath field (e.g. /drives/{drive-id}), except for the toplevel
-// sites-root and teams-root, which are stored as "sites-root" and "teams-root" respectively.
+// to the item in the itemApiPath field (e.g. /drives/{drive-id}), except for the top-level
+// sites-root, which is stored as "sites-root".
 export class MicrosoftRootModel extends ConnectorBaseModel<MicrosoftRootModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;

--- a/connectors/src/resources/storage/models/connector_model.ts
+++ b/connectors/src/resources/storage/models/connector_model.ts
@@ -11,6 +11,7 @@ import type {
 
 export interface ConnectorMetadata {
   rateLimited?: { at: Date } | null;
+  tenantId?: string;
 }
 
 export class ConnectorModel extends BaseModel<ConnectorModel> {

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -101,7 +101,7 @@ impl Provider for MicrosoftConnectionProvider {
                     "client_secret": *OAUTH_MICROSOFT_CLIENT_SECRET,
                     "code": code,
                     "redirect_uri": redirect_uri,
-                    "scope": "User.Read Sites.Read.All Directory.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
+                    "scope": "User.Read Sites.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
                 }),
             ),
         };
@@ -160,7 +160,7 @@ impl Provider for MicrosoftConnectionProvider {
                         "client_id": *OAUTH_MICROSOFT_CLIENT_ID,
                         "client_secret": *OAUTH_MICROSOFT_CLIENT_SECRET,
                         "refresh_token": refresh_token,
-                        "scope": "User.Read Sites.Read.All Directory.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
+                        "scope": "User.Read Sites.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
                     }),
                 )
             }

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -101,7 +101,7 @@ impl Provider for MicrosoftConnectionProvider {
                     "client_secret": *OAUTH_MICROSOFT_CLIENT_SECRET,
                     "code": code,
                     "redirect_uri": redirect_uri,
-                    "scope": "User.Read Sites.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
+                    "scope": "User.Read Sites.Read.All Files.Read.All",
                 }),
             ),
         };
@@ -160,7 +160,7 @@ impl Provider for MicrosoftConnectionProvider {
                         "client_id": *OAUTH_MICROSOFT_CLIENT_ID,
                         "client_secret": *OAUTH_MICROSOFT_CLIENT_SECRET,
                         "refresh_token": refresh_token,
-                        "scope": "User.Read Sites.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
+                        "scope": "User.Read Sites.Read.All Files.Read.All",
                     }),
                 )
             }

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -30,9 +30,6 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
       "User.Read",
       "Sites.Read.All",
       "Files.Read.All",
-      "Team.ReadBasic.All",
-      "ChannelSettings.Read.All",
-      "ChannelMessage.Read.All",
       "offline_access",
     ];
     if (relatedCredential) {

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -29,7 +29,6 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
     const scopes = [
       "User.Read",
       "Sites.Read.All",
-      "Directory.Read.All",
       "Files.Read.All",
       "Team.ReadBasic.All",
       "ChannelSettings.Read.All",


### PR DESCRIPTION
## Description

Cleaned unused code and removed unused scopes. Mainly the Directory.Read.All , very broad,  which was only used to get the organization name to compare it when updating the connection. Replace the check by tenantId comparison, based on token. Store the tenantId in metadata for easier comparison.

Removed all stuff related to teams/channels as it has never been implemented/used so far.

<img width="404" height="389" alt="Screenshot 2025-11-13 at 21 27 20" src="https://github.com/user-attachments/assets/fc48bd30-756d-475b-af37-e21f2f6fc361" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

run backfill to fill tenantId from existing tokens
deploy connector
clean up permissions in prod app ( 04c0e2b8-9852-4fad-9a5c-b97b29e95492 )
