### PR TITLE
[front] fix(Ashby): only retrieve feedback for most recent application

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1243,7 +1243,7 @@ The directive should be used to display a clickable version of the agent name in
     tools_stakes: {
       search_candidates: "never_ask",
       get_report_data: "never_ask",
-      get_latest_interview_feedback: "never_ask",
+      get_interview_feedback: "never_ask",
       create_candidate_note: "high",
     },
     tools_retry_policies: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/client.ts
@@ -5,6 +5,7 @@ import type {
   AshbyApplicationFeedbackListRequest,
   AshbyCandidateCreateNoteRequest,
   AshbyCandidateSearchRequest,
+  AshbyFeedbackSubmission,
   AshbyReportSynchronousRequest,
 } from "@app/lib/actions/mcp_internal_actions/servers/ashby/types";
 import {
@@ -138,12 +139,19 @@ export class AshbyClient {
     );
   }
 
-  async listApplicationFeedback(request: AshbyApplicationFeedbackListRequest) {
-    return this.postRequest(
+  async listApplicationFeedback(
+    request: AshbyApplicationFeedbackListRequest
+  ): Promise<Result<AshbyFeedbackSubmission[], Error>> {
+    const response = await this.postRequest(
       "applicationFeedback.list",
       request,
       AshbyApplicationFeedbackListResponseSchema
     );
+    if (response.isErr()) {
+      return response;
+    }
+
+    return new Ok(response.value.results);
   }
 
   async createCandidateNote(request: AshbyCandidateCreateNoteRequest) {

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/client.ts
@@ -138,7 +138,7 @@ export class AshbyClient {
     );
   }
 
-  async getApplicationFeedback(request: AshbyApplicationFeedbackListRequest) {
+  async listApplicationFeedback(request: AshbyApplicationFeedbackListRequest) {
     return this.postRequest(
       "applicationFeedback.list",
       request,

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
@@ -43,7 +43,7 @@ function createServer(
 
   server.tool(
     "search_candidates",
-    "Search for candidates in Ashby ATS by name and/or email. " +
+    "Search for candidates by name and/or email. " +
       `Returns up to ${DEFAULT_SEARCH_LIMIT} matching candidates by default.`,
     CandidateSearchInputSchema.shape,
     withToolLogging(
@@ -118,7 +118,7 @@ function createServer(
 
   server.tool(
     "get_report_data",
-    "Retrieve report data from Ashby ATS synchronously and save as a CSV file.",
+    "Retrieve report data and save it as a CSV file.",
     {
       reportUrl: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
@@ -226,9 +226,9 @@ function createServer(
 
   server.tool(
     "get_interview_feedback",
-    "Retrieve all interview feedback for a candidate. " +
+    "Retrieve interview feedback for a candidate. " +
       "This tool will search for the candidate by name or email and return all submitted " +
-      "interview feedback, sorted by most recent first.",
+      "interview feedback for the most recent application.",
     CandidateSearchInputSchema.shape,
     withToolLogging(
       auth,
@@ -304,12 +304,6 @@ function createServer(
             )
           );
         }
-
-        latestApplicationFeedback.sort((a, b) => {
-          const dateA = new Date(a.submittedAt!);
-          const dateB = new Date(b.submittedAt!);
-          return dateB.getTime() - dateA.getTime();
-        });
 
         const recapText = renderInterviewFeedbackRecap(
           candidate,

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
@@ -282,14 +282,14 @@ function createServer(
           }
 
           // We consider the max date across all feedback for the application.
-          for (const feedback of feedbackResult.value.results) {
+          for (const feedback of feedbackResult.value) {
             if (!feedback.submittedAt) {
               continue;
             }
             const submittedAt = new Date(feedback.submittedAt);
             if (!latestApplicationDate || submittedAt > latestApplicationDate) {
               latestApplicationDate = submittedAt;
-              latestApplicationFeedback = feedbackResult.value.results;
+              latestApplicationFeedback = feedbackResult.value;
             }
           }
         }

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
@@ -233,7 +233,7 @@ function createServer(
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: "ashby_get_latest_interview_feedback",
+        toolNameForMonitoring: "ashby_get_interview_feedback",
         agentLoopContext,
       },
       async ({ email, name }) => {


### PR DESCRIPTION
## Description

- In the Ashby internal MCP server there's a tool to retrieve feedback for a candidate.
- This tool retrieves feedback for all applications.
- This PR fixes that to take only the feedback for the most recent one, assuming there aren't multiple applications in parallel.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
