### PR TITLE
[front] enh(poke): add examples in command palette

### DIFF
--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -14,6 +14,8 @@ import { classNames } from "@app/lib/utils";
 import { usePokeSearch } from "@app/poke/swr/search";
 import { isDevelopment } from "@app/types";
 
+const MIN_SEARCH_CHARACTERS = 2;
+
 interface PokeNavbarProps {
   currentRegion?: RegionType;
   regionUrls?: Record<RegionType, string>;
@@ -59,8 +61,8 @@ export function PokeSearchCommand() {
   const [searchTerm, setSearchTerm] = useState("");
 
   const { isError, isLoading, results } = usePokeSearch({
-    // Disable search until the user has typed at least 2 characters.
-    disabled: searchTerm.length < 2,
+    // Disable search until the user has typed at least MIN_SEARCH_CHARACTERS characters.
+    disabled: searchTerm.length < MIN_SEARCH_CHARACTERS,
     search: searchTerm,
   });
 
@@ -98,14 +100,14 @@ export function PokeSearchCommand() {
         <PokeCommandList>
           {isLoading && <div className="p-4 text-sm">Searching...</div>}
           {searchTerm &&
-            searchTerm.length >= 2 &&
+            searchTerm.length >= MIN_SEARCH_CHARACTERS &&
             !isError &&
             !isLoading &&
             results.length === 0 && (
               <div className="p-4 text-sm">No results found.</div>
             )}
           {isError && <div className="p-4 text-sm">Something went wrong.</div>}
-          {searchTerm.length < 2 && (
+          {searchTerm.length < MIN_SEARCH_CHARACTERS && (
             <div className="p-4 text-sm">
               <div className="mb-3 text-muted-foreground dark:text-muted-foreground-night">
                 Search for resources by:

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -112,10 +112,6 @@ export function PokeSearchCommand() {
               </div>
               <div className="space-y-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
                 <div>
-                  <span className="font-medium">Workspace name:</span>{" "}
-                  <span className="font-mono">acme</span>
-                </div>
-                <div>
                   <span className="font-medium">Workspace ID:</span>{" "}
                   <span className="font-mono">123456</span>
                 </div>

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -106,7 +106,37 @@ export function PokeSearchCommand() {
             )}
           {isError && <div className="p-4 text-sm">Something went wrong.</div>}
           {searchTerm.length < 2 && (
-            <div className="p-4 text-sm">Enter at least 2 characters...</div>
+            <div className="p-4 text-sm">
+              <div className="mb-3 text-muted-foreground dark:text-muted-foreground-night">
+                Search for resources by:
+              </div>
+              <div className="space-y-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                <div>
+                  <span className="font-medium">Workspace name:</span>{" "}
+                  <span className="font-mono">acme</span>
+                </div>
+                <div>
+                  <span className="font-medium">Workspace ID:</span>{" "}
+                  <span className="font-mono">123456</span>
+                </div>
+                <div>
+                  <span className="font-medium">WorkOS org ID:</span>{" "}
+                  <span className="font-mono">org_01AB</span>
+                </div>
+                <div>
+                  <span className="font-medium">Data source view:</span>{" "}
+                  <span className="font-mono">dsv_abc123</span>
+                </div>
+                <div>
+                  <span className="font-medium">Data source:</span>{" "}
+                  <span className="font-mono">dts_abc123</span>
+                </div>
+                <div>
+                  <span className="font-medium">Connector ID:</span>{" "}
+                  <span className="font-mono">78901</span>
+                </div>
+              </div>
+            </div>
           )}
 
           {results.map(({ id, link, name }, index) =>

--- a/front/components/poke/plugins/PluginList.tsx
+++ b/front/components/poke/plugins/PluginList.tsx
@@ -23,7 +23,7 @@ function PluginCard({ onClick, plugin }: PluginCardProps) {
       className="flex h-20 w-44 cursor-pointer hover:bg-gray-100 dark:hover:bg-muted/10"
       onClick={onClick}
     >
-      <PokeCardHeader className="flex space-y-1.5 overflow-hidden p-2 text-left">
+      <PokeCardHeader className="flex space-y-2 overflow-hidden p-2 text-left">
         <PokeCardTitle className="text-sm font-medium">
           {plugin.name}
         </PokeCardTitle>

--- a/front/components/poke/shadcn/ui/command.tsx
+++ b/front/components/poke/shadcn/ui/command.tsx
@@ -140,11 +140,11 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <MagnifyingGlassIcon className="mb-3 mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <MagnifyingGlassIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "mb-3 flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none",
+        "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none",
         "placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         "dark:placeholder:text-muted-foreground-night",
         className

--- a/front/components/poke/shadcn/ui/table.tsx
+++ b/front/components/poke/shadcn/ui/table.tsx
@@ -152,7 +152,7 @@ const TableCellWithCopy = React.forwardRef<
       <div className="flex items-center space-x-2">
         <Label>{label}</Label>
         <Button
-          size="sm"
+          size="xs"
           variant="outline"
           onClick={handleCopy}
           icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -65,7 +65,7 @@ export function WorkspaceInfoTable({
   };
 
   return (
-    <div className="mt-3 flex justify-between gap-3">
+    <div className="flex justify-between gap-3">
       <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4 pb-2">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-md flex-grow pb-4 font-bold">Workspace info</h2>

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -101,7 +101,7 @@ export function WorkspaceInfoTable({
                     target="_blank"
                     className="text-xs text-highlight-400"
                   >
-                    Organization
+                    {owner.workOSOrganizationId}
                   </Link>
                 )}
               </PokeTableCell>
@@ -147,14 +147,6 @@ export function WorkspaceInfoTable({
                 {extensionConfig?.blacklistedDomains.length
                   ? extensionConfig.blacklistedDomains.join(", ")
                   : "None"}
-              </PokeTableCell>
-            </PokeTableRow>
-            <PokeTableRow>
-              <PokeTableCell className="max-w-48">
-                WorkOS organization
-              </PokeTableCell>
-              <PokeTableCell>
-                {owner.workOSOrganizationId ?? "None"}
               </PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -231,7 +231,7 @@ const WorkspacePage = ({
         <div className="flex flex-col space-y-8">
           <div className="mt-4 flex flex-row items-stretch gap-3">
             <Tabs defaultValue="workspace" className="min-w-[512px]">
-              <TabsList>
+              <TabsList className="mb-3">
                 <TabsTrigger value="workspace" label="Workspace" />
                 <TabsTrigger value="subscriptions" label="Subscriptions" />
                 <TabsTrigger value="planlimitations" label="Plan Limitations" />

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -13,8 +13,7 @@ export function usePokeSearch({
   const workspacesFetcher: Fetcher<GetPokeSearchItemsResponseBody> = fetcher;
 
   const queryParams = new URLSearchParams({
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    search: search || "",
+    search: search ?? "",
   });
 
   const { data, error } = useSWRWithDefaults(


### PR DESCRIPTION
## Description

- This PR enhances Poke's command palette by adding some examples of what can be searched when empty. Not necessarily very pretty but exhaustive.

<img width="514" height="235" alt="Screenshot 2025-11-13 at 11 58 21 PM" src="https://github.com/user-attachments/assets/5606759c-5bab-4162-9ad1-3597e5bbd1ab" />

- This PR also contains a few miscellaneous cosmetic changes: in the workspace table it merges the two rows workOS organization ID and workOS organization (the one with the link) and uniformizes the margins below the tabs between workspace, subscription and plan.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
