### PR TITLE
[front] enh(poke): improve command palette result display

### DIFF
--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -1,4 +1,4 @@
-import { Button, Logo } from "@dust-tt/sparkle";
+import { Button, Chip, ExternalLinkIcon, Logo } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
@@ -137,19 +137,30 @@ export function PokeSearchCommand() {
             </div>
           )}
 
-          {results.map(({ id, link, name }, index) =>
-            link ? (
+          {results.map(({ id, link, name, type }, index) => {
+            const CommandItem = () => (
+              <PokeCommandItem value={name} index={index}>
+                <div className="flex w-full items-center justify-between gap-3 px-2 text-foreground dark:text-foreground-night">
+                  <div className="flex min-w-0 items-baseline gap-3">
+                    <Chip size="xs">{type}</Chip>
+                    <span className="text-sm font-medium">{name}</span>
+                    <span className="font-mono text-xs text-muted-foreground dark:text-muted-foreground-night">
+                      (id: {id})
+                    </span>
+                  </div>
+                  <ExternalLinkIcon className="h-4 w-4 flex-shrink-0" />
+                </div>
+              </PokeCommandItem>
+            );
+
+            return link ? (
               <Link href={link} key={id}>
-                <PokeCommandItem value={name} index={index}>
-                  {name} (id: {id})
-                </PokeCommandItem>
+                <CommandItem />
               </Link>
             ) : (
-              <PokeCommandItem key={id} value={name} index={index}>
-                {name} (id: {id})
-              </PokeCommandItem>
-            )
-          )}
+              <CommandItem />
+            );
+          })}
         </PokeCommandList>
       </PokeCommandDialog>
     </>

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -94,7 +94,7 @@ export function PokeSearchCommand() {
       >
         <PokeCommandInput
           placeholder="Type a command or search..."
-          onValueChange={(value) => setSearchTerm(value)}
+          onValueChange={(value) => setSearchTerm(value.trim())}
           className="border-none focus:outline-none focus:ring-0"
         />
         <PokeCommandList>

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -1,4 +1,4 @@
-import { Button, Chip, ExternalLinkIcon, Logo } from "@dust-tt/sparkle";
+import { Button, ChevronRightIcon, Chip, Logo } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
@@ -148,7 +148,7 @@ export function PokeSearchCommand() {
                       (id: {id})
                     </span>
                   </div>
-                  <ExternalLinkIcon className="h-4 w-4 flex-shrink-0" />
+                  <ChevronRightIcon className="h-4 w-4 flex-shrink-0" />
                 </div>
               </PokeCommandItem>
             );

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -14,7 +14,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type { ConnectorType, PokeItemBase } from "@app/types";
-import { ConnectorsAPI } from "@app/types";
+import { asDisplayName, ConnectorsAPI } from "@app/types";
 
 async function searchPokeWorkspaces(
   searchTerm: string
@@ -76,10 +76,17 @@ async function searchConnectorModelId(searchTerm: string) {
         connectionId: null,
       };
 
+      const workspace = await WorkspaceResource.fetchById(
+        connector.workspaceId
+      );
+      if (!workspace) {
+        return null;
+      }
+
       return [
         {
           id: parseInt(connector.id, 10),
-          name: `Connector ${connector.id}`,
+          name: `${workspace.name}'s ${asDisplayName(connector.type)}`,
           link: `${config.getClientFacingUrl()}/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
           type: "Connector",
         },

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -24,20 +24,22 @@ async function searchPokeWorkspaces(
     return [
       {
         id: workspaceInfos.id,
-        name: `Workspace (${workspaceInfos.name})`,
+        name: workspaceInfos.name,
         link: `${config.getClientFacingUrl()}/poke/${workspaceInfos.sId}`,
+        type: "Workspace",
       },
     ];
   }
 
-  const workspaceModelId = parseInt(searchTerm);
+  const workspaceModelId = parseInt(searchTerm, 10);
   if (!isNaN(workspaceModelId)) {
     const workspaces = await unsafeGetWorkspacesByModelId([workspaceModelId]);
     if (workspaces.length > 0) {
       return workspaces.map((w) => ({
         id: w.id,
-        name: `Workspace (${w.name})`,
+        name: w.name,
         link: `${config.getClientFacingUrl()}/poke/${w.sId}`,
+        type: "Workspace",
       }));
     }
   }
@@ -49,8 +51,9 @@ async function searchPokeWorkspaces(
       return [
         {
           id: workspaceByOrgId.id,
-          name: `Workspace (${workspaceByOrgId.name})`,
+          name: workspaceByOrgId.name,
           link: `${config.getClientFacingUrl()}/poke/${workspaceByOrgId.sId}`,
+          type: "Workspace",
         },
       ];
     }
@@ -60,7 +63,7 @@ async function searchPokeWorkspaces(
 }
 
 async function searchConnectorModelId(searchTerm: string) {
-  const connectorModelId = parseInt(searchTerm);
+  const connectorModelId = parseInt(searchTerm, 10);
   if (!isNaN(connectorModelId)) {
     const connectorsAPI = new ConnectorsAPI(
       config.getConnectorsAPIConfig(),
@@ -75,9 +78,10 @@ async function searchConnectorModelId(searchTerm: string) {
 
       return [
         {
-          id: parseInt(connector.id),
-          name: "Connector",
+          id: parseInt(connector.id, 10),
+          name: `Connector ${connector.id}`,
           link: `${config.getClientFacingUrl()}/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
+          type: "Connector",
         },
       ];
     }

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -12,6 +12,7 @@ import {
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { ConnectorType, PokeItemBase } from "@app/types";
 import { asDisplayName, ConnectorsAPI } from "@app/types";

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -32,7 +32,9 @@ export async function dataSourceToPokeJSON(
     link: workspace
       ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/data_sources/${dataSource.sId}`
       : null,
-    name: getDisplayNameForDataSource(dataSource.toJSON()),
+    name:
+      (workspace ? `${workspace.name}'s ` : "") +
+      getDisplayNameForDataSource(dataSource.toJSON()),
     type: "Data Source",
     space: spaceToPokeJSON(dataSource.space),
   };
@@ -51,7 +53,9 @@ export async function dataSourceViewToPokeJSON(
     link: workspace
       ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/spaces/${dataSourceView.space.sId}/data_source_views/${dataSourceView.sId}`
       : null,
-    name: getDisplayNameForDataSource(dataSourceView.dataSource.toJSON()),
+    name:
+      (workspace ? `${workspace.name}'s ` : "") +
+      getDisplayNameForDataSource(dataSourceView.dataSource.toJSON()),
     type: "Data Source View",
     space: spaceToPokeJSON(dataSourceView.space),
   };

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -31,7 +32,7 @@ export async function dataSourceToPokeJSON(
     link: workspace
       ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/data_sources/${dataSource.sId}`
       : null,
-    name: dataSource.name,
+    name: getDisplayNameForDataSource(dataSource.toJSON()),
     type: "Data Source",
     space: spaceToPokeJSON(dataSource.space),
   };
@@ -50,7 +51,7 @@ export async function dataSourceViewToPokeJSON(
     link: workspace
       ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/spaces/${dataSourceView.space.sId}/data_source_views/${dataSourceView.sId}`
       : null,
-    name: dataSourceView.dataSource.name,
+    name: getDisplayNameForDataSource(dataSourceView.dataSource.toJSON()),
     type: "Data Source View",
     space: spaceToPokeJSON(dataSourceView.space),
   };

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -31,7 +31,8 @@ export async function dataSourceToPokeJSON(
     link: workspace
       ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/data_sources/${dataSource.sId}`
       : null,
-    name: `Data Source (${dataSource.name})`,
+    name: dataSource.name,
+    type: "Data Source",
     space: spaceToPokeJSON(dataSource.space),
   };
 }
@@ -49,7 +50,8 @@ export async function dataSourceViewToPokeJSON(
     link: workspace
       ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/spaces/${dataSourceView.space.sId}/data_source_views/${dataSourceView.sId}`
       : null,
-    name: `Data Source View (${dataSourceView.dataSource.name})`,
+    name: dataSourceView.dataSource.name,
+    type: "Data Source View",
     space: spaceToPokeJSON(dataSourceView.space),
   };
 }
@@ -68,6 +70,7 @@ export async function mcpServerViewToPokeJSON(
       ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/spaces/${mcpServerView.space.sId}/mcp_server_views/${mcpServerView.sId}`
       : null,
     name: json.server.name,
+    type: "MCP Server View",
     space: spaceToPokeJSON(mcpServerView.space),
   };
 }

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -19,6 +19,7 @@ export interface PokeItemBase {
   id: ModelId;
   link: string | null;
   name: string;
+  type: string;
 }
 
 export type PokeSpaceType = SpaceType & {


### PR DESCRIPTION
## Description

- This PR aims at improving the display of results of a search in Poke's command palette.
- It adds a Chip with the type of content and improves the displayed name by showing the workspace name + connector name for data sources and connectors instead of `Connector (id: 123)` or `Data Source (managed-xxx) (id: 123)`.
- We could add colors depending on the type.

<img width="501" height="106" alt="Screenshot 2025-11-14 at 12 19 25 AM" src="https://github.com/user-attachments/assets/7b9fb0d4-3593-4a24-b5e0-45e9fa52211d" />

<img width="501" height="106" alt="Screenshot 2025-11-14 at 12 45 07 AM" src="https://github.com/user-attachments/assets/ebeb57c2-16fd-422b-8f45-9269b02c9c32" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
