### PR TITLE
[front] enh(poke): add colors to search result Chips

### DIFF
--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -1,5 +1,6 @@
 import { Button, ChevronRightIcon, Chip, Logo } from "@dust-tt/sparkle";
 import Link from "next/link";
+import type { ComponentProps } from "react";
 import { useEffect, useState } from "react";
 
 import { PokeRegionDropdown } from "@app/components/poke/PokeRegionDropdown";
@@ -12,6 +13,7 @@ import {
 import type { RegionType } from "@app/lib/api/regions/config";
 import { classNames } from "@app/lib/utils";
 import { usePokeSearch } from "@app/poke/swr/search";
+import type { PokeItemBase } from "@app/types";
 import { isDevelopment } from "@app/types";
 
 const MIN_SEARCH_CHARACTERS = 2;
@@ -19,6 +21,23 @@ const MIN_SEARCH_CHARACTERS = 2;
 interface PokeNavbarProps {
   currentRegion?: RegionType;
   regionUrls?: Record<RegionType, string>;
+}
+
+function getPokeItemChipColor(
+  item: PokeItemBase
+): ComponentProps<typeof Chip>["color"] {
+  switch (item.type) {
+    case "Workspace":
+      return "blue";
+    case "Data Source":
+      return "golden";
+    case "Data Source View":
+      return "rose";
+    case "Connector":
+      return "green";
+    default:
+      return "primary";
+  }
 }
 
 function PokeNavbar({ currentRegion, regionUrls }: PokeNavbarProps) {
@@ -137,15 +156,17 @@ export function PokeSearchCommand() {
             </div>
           )}
 
-          {results.map(({ id, link, name, type }, index) => {
+          {results.map((item, index) => {
             const CommandItem = () => (
-              <PokeCommandItem value={name} index={index}>
+              <PokeCommandItem value={item.name} index={index}>
                 <div className="flex w-full items-center justify-between gap-3 px-2 text-foreground dark:text-foreground-night">
                   <div className="flex min-w-0 items-baseline gap-3">
-                    <Chip size="xs">{type}</Chip>
-                    <span className="text-sm font-medium">{name}</span>
+                    <Chip size="xs" color={getPokeItemChipColor(item)}>
+                      {item.type}
+                    </Chip>
+                    <span className="text-sm font-medium">{item.name}</span>
                     <span className="font-mono text-xs text-muted-foreground dark:text-muted-foreground-night">
-                      (id: {id})
+                      (id: {item.id})
                     </span>
                   </div>
                   <ChevronRightIcon className="h-4 w-4 flex-shrink-0" />
@@ -153,8 +174,8 @@ export function PokeSearchCommand() {
               </PokeCommandItem>
             );
 
-            return link ? (
-              <Link href={link} key={id}>
+            return item.link ? (
+              <Link href={item.link} key={item.id}>
                 <CommandItem />
               </Link>
             ) : (

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -63,7 +63,9 @@ async function searchPokeWorkspaces(
   return [];
 }
 
-async function searchConnectorModelId(searchTerm: string) {
+async function searchConnectorModelId(
+  searchTerm: string
+): Promise<PokeItemBase[] | null> {
   const connectorModelId = parseInt(searchTerm, 10);
   if (!isNaN(connectorModelId)) {
     const connectorsAPI = new ConnectorsAPI(

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -34,7 +34,9 @@ export async function dataSourceToPokeJSON(
       : null,
     name:
       (workspace ? `${workspace.name}'s ` : "") +
-      getDisplayNameForDataSource(dataSource.toJSON()),
+      (dataSource.connectorProvider
+        ? getDisplayNameForDataSource(dataSource.toJSON())
+        : `folder (${dataSource.name})`),
     type: "Data Source",
     space: spaceToPokeJSON(dataSource.space),
   };
@@ -55,7 +57,9 @@ export async function dataSourceViewToPokeJSON(
       : null,
     name:
       (workspace ? `${workspace.name}'s ` : "") +
-      getDisplayNameForDataSource(dataSourceView.dataSource.toJSON()),
+      (dataSourceView.dataSource.connectorProvider
+        ? getDisplayNameForDataSource(dataSourceView.dataSource.toJSON())
+        : `folder (${dataSourceView.dataSource.name})`),
     type: "Data Source View",
     space: spaceToPokeJSON(dataSourceView.space),
   };

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -15,11 +15,18 @@ import type { GroupType } from "../groups";
 import type { ModelId } from "../shared/model_id";
 import type { SpaceType } from "../space";
 
+type PokeItemType =
+  | "Workspace"
+  | "Data Source"
+  | "Data Source View"
+  | "Connector"
+  | "MCP Server View";
+
 export interface PokeItemBase {
   id: ModelId;
   link: string | null;
   name: string;
-  type: string;
+  type: PokeItemType;
 }
 
 export type PokeSpaceType = SpaceType & {


### PR DESCRIPTION
## Description

- Direct follow up on https://github.com/dust-tt/dust/pull/17913.
- The results from a search in poke's command palette now have chips describing what kind of content is shown.
- This PR adds distinct colors for the type of content.

<img width="501" height="135" alt="Screenshot 2025-11-14 at 7 21 54 AM" src="https://github.com/user-attachments/assets/2d60fa5d-4ba0-464b-ba26-9f307fdac3fa" />

- Also improves the names displayed for static data sources.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
