### PR TITLE
[front] enh(poke): add links to DD/Temporal in stuck workflow dialog

### DIFF
--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -440,7 +440,7 @@ function StuckActivitiesModal({
         }
       }}
     >
-      <DialogContent size="lg">
+      <DialogContent size="md">
         <DialogHeader>
           <DialogTitle>Stuck Activities Details</DialogTitle>
         </DialogHeader>

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -390,7 +390,7 @@ function CheckConnectorStuck({
 
   return (
     <>
-      <StuckActivitiesModal
+      <StuckActivitiesDialog
         show={showDetailsModal}
         onClose={() => setShowDetailsModal(false)}
         result={result}
@@ -420,19 +420,19 @@ function CheckConnectorStuck({
   );
 }
 
-interface StuckActivitiesModalProps {
+interface StuckActivitiesDialogProps {
   show: boolean;
   onClose: () => void;
   result: CheckStuckResponseBody;
   temporalWorkspace: string;
 }
 
-function StuckActivitiesModal({
+function StuckActivitiesDialog({
   show,
   onClose,
   result: { workflows },
   temporalWorkspace,
-}: StuckActivitiesModalProps) {
+}: StuckActivitiesDialogProps) {
   const totalStuckActivities = workflows.reduce(
     (sum, wf) => sum + wf.stuckActivities.length,
     0

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -166,6 +166,7 @@ export function ViewDataSourceTable({
                           owner={owner}
                           dsId={dataSource.sId}
                           isRunning={isRunning}
+                          temporalWorkspace={temporalWorkspace}
                         />
                       </PokeTableCell>
                     </PokeTableRow>
@@ -342,6 +343,7 @@ function CheckConnectorStuck({
   owner,
   dsId,
   isRunning,
+  temporalWorkspace,
 }: CheckConnectorStuckProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState<CheckStuckResponseBody | null>(null);

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -481,6 +481,7 @@ function StuckActivitiesDialog({
                       size="xs"
                       className="p-2"
                       label="Workflow"
+                      target="_blank"
                     />
                   }
                 />
@@ -512,6 +513,7 @@ function StuckActivitiesDialog({
                         size="xs"
                         className="p-2"
                         label="Logs"
+                        target="_blank"
                       />
                     }
                   >


### PR DESCRIPTION
## Description

This PR improves the dialog shown for stuck workflows in poke by adding links to logs/temporal workflow.
It also contains a few cosmetic changes: full width on the content message, mono font.

<img width="475" height="292" alt="Screenshot 2025-11-14 at 8 35 28 AM" src="https://github.com/user-attachments/assets/14753027-8d65-46be-b8d6-08ed76bf27e7" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
