### PR TITLE
Add Notion webhooks support to firebase webhook-router

### DIFF
--- a/firebase-functions/webhook-router/README.md
+++ b/firebase-functions/webhook-router/README.md
@@ -69,6 +69,7 @@ npm run dev      # Start Firebase emulator
 http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/slack/events
 http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/slack/interactions
 http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/microsoft/teams/messages
+http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/notion
 ```
 
 ### Production
@@ -79,6 +80,7 @@ http://localhost:5001/dust-infra/us-central1/webhookRouter/YOUR_WEBHOOK_SECRET/m
 https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SECRET/slack/events
 https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SECRET/slack/interactions
 https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SECRET/microsoft/teams/messages
+https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SECRET/notion
 ```
 
 **Custom Domain (via Firebase Hosting):**
@@ -87,6 +89,7 @@ https://us-central1-dust-infra.cloudfunctions.net/webhookRouter/YOUR_WEBHOOK_SEC
 https://webhook.dust.tt/YOUR_WEBHOOK_SECRET/slack/events
 https://webhook.dust.tt/YOUR_WEBHOOK_SECRET/slack/interactions
 https://webhook.dust.tt/YOUR_WEBHOOK_SECRET/microsoft/teams/messages
+https://webhook.dust.tt/YOUR_WEBHOOK_SECRET/notion
 ```
 
 ## Architecture
@@ -123,6 +126,7 @@ For local development, set environment variables:
 export DUST_CONNECTORS_WEBHOOKS_SECRET="your-webhook-secret"
 export SLACK_SIGNING_SECRET="your-slack-signing-secret"
 export MICROSOFT_BOT_ID_SECRET="your-bot-app-id"
+export NOTION_SIGNING_SECRET="your-notion-signing-secret"
 ```
 
 ## Benefits over Cloud Run
@@ -143,6 +147,10 @@ export MICROSOFT_BOT_ID_SECRET="your-bot-app-id"
 ### Microsoft Teams Endpoints
 
 - `POST /:webhookSecret/microsoft/teams/messages` - Teams messages
+
+### Notion Endpoint
+
+- `POST /:webhookSecret/notion` - Teams messages
 
 ## Development
 

--- a/firebase-functions/webhook-router/README.md
+++ b/firebase-functions/webhook-router/README.md
@@ -150,7 +150,7 @@ export NOTION_SIGNING_SECRET="your-notion-signing-secret"
 
 ### Notion Endpoint
 
-- `POST /:webhookSecret/notion` - Teams messages
+- `POST /:webhookSecret/notion` - Notion events
 
 ## Development
 

--- a/firebase-functions/webhook-router/src/config.ts
+++ b/firebase-functions/webhook-router/src/config.ts
@@ -17,6 +17,9 @@ export const CONFIG = {
   // Microsoft Bot environment secrets.
   MICROSOFT_BOT_ID_SECRET: process.env.MICROSOFT_BOT_ID_SECRET,
 
+  // Notion environment secrets.
+  NOTION_SIGNING_SECRET: process.env.NOTION_SIGNING_SECRET,
+
   // Endpoints.
   US_CONNECTOR_URL: "https://connectors.dust.tt",
   EU_CONNECTOR_URL: "https://eu.connectors.dust.tt",
@@ -29,6 +32,9 @@ export const CONFIG = {
 
   // Microsoft Bot related secrets.
   MICROSOFT_BOT_ID_SECRET_NAME: "MICROSOFT_BOT_ID_SECRET",
+
+  // Notion related secrets.
+  NOTION_SIGNING_SECRET_NAME: "NOTION_SIGNING_SECRET",
 } as const;
 
 // Runtime getters for Firebase params.

--- a/firebase-functions/webhook-router/src/notion/routes.ts
+++ b/firebase-functions/webhook-router/src/notion/routes.ts
@@ -1,0 +1,52 @@
+import type { RequestHandler } from "express";
+import express from "express";
+
+import { WebhookForwarder } from "../forwarder.js";
+import type { SecretManager } from "../secrets.js";
+
+export function createNotionRoutes(
+  secretManager: SecretManager,
+  notionVerification: RequestHandler
+) {
+  const router = express.Router();
+
+  // Notion webhook endpoint with Notion verification only (webhook secret already validated)
+  router.post("/", notionVerification, async (req, res) => {
+    await handleNotionWebhook(req, res, "notion", secretManager);
+  });
+
+  return router;
+}
+
+async function handleNotionWebhook(
+  req: express.Request,
+  res: express.Response,
+  endpoint: string,
+  secretManager: SecretManager
+): Promise<void> {
+  try {
+    // Respond immediately to Notion.
+    res.status(200).send();
+
+    // Get secrets for forwarding (already validated by middleware).
+    const secrets = await secretManager.getSecrets();
+
+    // Forward to regions asynchronously.
+    await new WebhookForwarder(secrets).forwardToRegions({
+      body: req.body,
+      endpoint,
+      headers: req.headers,
+      method: req.method,
+    });
+  } catch (error) {
+    console.error("Notion webhook router error", {
+      component: "notion-routes",
+      endpoint,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    if (!res.headersSent) {
+      res.status(200).send();
+    }
+  }
+}

--- a/firebase-functions/webhook-router/src/notion/verification.ts
+++ b/firebase-functions/webhook-router/src/notion/verification.ts
@@ -69,7 +69,8 @@ export function createNotionVerificationMiddleware(
       const stringBody = await parseExpressRequestRawBody(req);
 
       // Verify Notion signature.
-      const signature = req.headers["X-Notion-Signature"];
+      // Even though it's documented as "X-Notion-Signature", the actual header name is lowercase in practice.
+      const signature = req.headers["x-notion-signature"];
 
       if (typeof signature !== "string") {
         throw new ReceiverAuthenticityError(

--- a/firebase-functions/webhook-router/src/notion/verification.ts
+++ b/firebase-functions/webhook-router/src/notion/verification.ts
@@ -65,6 +65,16 @@ export function createNotionVerificationMiddleware(
       // Get secrets for Notion signature verification (webhook secret already validated)
       const secrets = await secretManager.getSecrets();
 
+      // Skip verification if signing secret missing or empty.
+      // This is expected when we first set up the webhook and are waiting for
+      // Notion to send the verification_token.
+      if (!secrets.notionSigningSecret || secrets.notionSigningSecret === "") {
+        console.warn(
+          "Notion signing secret is missing or empty, skipping verification. This should only happen during initial setup."
+        );
+        return next();
+      }
+
       // Get the raw body for Notion signature verification.
       const stringBody = await parseExpressRequestRawBody(req);
 

--- a/firebase-functions/webhook-router/src/notion/verification.ts
+++ b/firebase-functions/webhook-router/src/notion/verification.ts
@@ -30,7 +30,8 @@ function verifyRequestSignature({
   hmac.update(body);
 
   // Use crypto.timingSafeEqual for timing-safe comparison.
-  const expectedHash = hmac.digest("hex");
+  const expectedHash = `sha256=${hmac.digest("hex")}`;
+
   if (signature.length !== expectedHash.length) {
     throw new ReceiverAuthenticityError(
       "Notion request signing verification failed. Signature mismatch."

--- a/firebase-functions/webhook-router/src/notion/verification.ts
+++ b/firebase-functions/webhook-router/src/notion/verification.ts
@@ -1,0 +1,108 @@
+import crypto from "crypto";
+import type { Request, RequestHandler } from "express";
+import rawBody from "raw-body";
+
+import type { SecretManager } from "../secrets.js";
+
+class ReceiverAuthenticityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReceiverAuthenticityError";
+  }
+}
+
+function verifyRequestSignature({
+  body,
+  signature,
+  signingSecret,
+}: {
+  body: string;
+  signature: string | undefined;
+  signingSecret: string;
+}): void {
+  if (signature === undefined) {
+    throw new ReceiverAuthenticityError(
+      "Notion request signing verification failed. Signature header is missing."
+    );
+  }
+
+  const hmac = crypto.createHmac("sha256", signingSecret);
+  hmac.update(body);
+
+  // Use crypto.timingSafeEqual for timing-safe comparison.
+  const expectedHash = hmac.digest("hex");
+  if (signature.length !== expectedHash.length) {
+    throw new ReceiverAuthenticityError(
+      "Notion request signing verification failed. Signature mismatch."
+    );
+  }
+
+  const signatureBuffer = Buffer.from(signature, "hex");
+  const expectedHashBuffer = Buffer.from(expectedHash, "hex");
+
+  if (!crypto.timingSafeEqual(signatureBuffer, expectedHashBuffer)) {
+    throw new ReceiverAuthenticityError(
+      "Notion request signing verification failed. Signature mismatch."
+    );
+  }
+}
+
+// On Firebase Functions and GCP, req.rawBody is provided for signature verification.
+async function parseExpressRequestRawBody(req: Request): Promise<string> {
+  if (req !== null && "rawBody" in req && req.rawBody) {
+    return Promise.resolve(req.rawBody.toString());
+  }
+
+  return (await rawBody(req)).toString();
+}
+
+// Creates middleware that verifies Notion signature.
+export function createNotionVerificationMiddleware(
+  secretManager: SecretManager
+): RequestHandler {
+  return async (req, res, next): Promise<void> => {
+    try {
+      // Get secrets for Notion signature verification (webhook secret already validated)
+      const secrets = await secretManager.getSecrets();
+
+      // Get the raw body for Notion signature verification.
+      const stringBody = await parseExpressRequestRawBody(req);
+
+      // Verify Notion signature.
+      const signature = req.headers["X-Notion-Signature"];
+
+      if (typeof signature !== "string") {
+        throw new ReceiverAuthenticityError(
+          "Notion request signing verification failed. Signature header is invalid."
+        );
+      }
+
+      verifyRequestSignature({
+        body: stringBody,
+        signature,
+        signingSecret: secrets.notionSigningSecret,
+      });
+
+      // Parse body as JSON for routes to access the object.
+      req.body = JSON.parse(stringBody);
+
+      return next();
+    } catch (error) {
+      if (error instanceof ReceiverAuthenticityError) {
+        console.error("Notion request verification failed", {
+          component: "notion-verification",
+          error: error.message,
+        });
+        res.status(401).send();
+        return;
+      }
+
+      console.error("Notion request verification failed", {
+        component: "notion-verification",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      res.status(400).send();
+      return;
+    }
+  };
+}

--- a/firebase-functions/webhook-router/src/routes.ts
+++ b/firebase-functions/webhook-router/src/routes.ts
@@ -2,6 +2,8 @@ import express from "express";
 
 import { createTeamsRoutes } from "./microsoft/routes.js";
 import { createTeamsVerificationMiddleware } from "./microsoft/verification.js";
+import { createNotionRoutes } from "./notion/routes.js";
+import { createNotionVerificationMiddleware } from "./notion/verification.js";
 import type { SecretManager } from "./secrets.js";
 import { createSlackRoutes } from "./slack/routes.js";
 import { createSlackVerificationMiddleware } from "./slack/verification.js";
@@ -45,6 +47,7 @@ export function createRoutes(secretManager: SecretManager) {
   // Create platform-specific verification middlewares (without webhook secret validation)
   const slackVerification = createSlackVerificationMiddleware(secretManager);
   const teamsVerification = createTeamsVerificationMiddleware(secretManager);
+  const notionVerification = createNotionVerificationMiddleware(secretManager);
 
   // Mount platform routes with webhook secret validation first
   const slackRoutes = createSlackRoutes(secretManager, slackVerification);
@@ -52,6 +55,9 @@ export function createRoutes(secretManager: SecretManager) {
 
   const teamsRoutes = createTeamsRoutes(secretManager, teamsVerification);
   router.use("/:webhookSecret/microsoft", webhookSecretValidation, teamsRoutes);
+
+  const notionRoutes = createNotionRoutes(secretManager, notionVerification);
+  router.use("/:webhookSecret/notion", webhookSecretValidation, notionRoutes);
 
   return router;
 }

--- a/firebase-functions/webhook-router/src/secrets.ts
+++ b/firebase-functions/webhook-router/src/secrets.ts
@@ -8,6 +8,7 @@ export interface Secrets {
   usSecret: string;
   webhookSecret: string;
   microsoftBotId?: string;
+  notionSigningSecret: string;
 }
 
 export class SecretManager {
@@ -44,6 +45,7 @@ export class SecretManager {
         euSecret: CONFIG.DUST_CONNECTORS_WEBHOOKS_SECRET,
         microsoftBotId: CONFIG.MICROSOFT_BOT_ID_SECRET,
         slackSigningSecret: CONFIG.SLACK_SIGNING_SECRET ?? "",
+        notionSigningSecret: CONFIG.NOTION_SIGNING_SECRET ?? "",
         usSecret: CONFIG.DUST_CONNECTORS_WEBHOOKS_SECRET,
         webhookSecret: CONFIG.DUST_CONNECTORS_WEBHOOKS_SECRET,
       };
@@ -72,6 +74,7 @@ export class SecretManager {
         euSecretResponse,
         slackSigningSecretResponse,
         microsoftBotIdResponse,
+        notionSigningSecretResponse,
       ] = await Promise.all([
         this.client.accessSecretVersion({
           name: `projects/${GCP_GLOBAL_PROJECT_ID}/secrets/${CONFIG.SECRET_NAME}/versions/latest`,
@@ -88,6 +91,9 @@ export class SecretManager {
         this.client.accessSecretVersion({
           name: `projects/${GCP_GLOBAL_PROJECT_ID}/secrets/${CONFIG.MICROSOFT_BOT_ID_SECRET_NAME}/versions/latest`,
         }),
+        this.client.accessSecretVersion({
+          name: `projects/${GCP_GLOBAL_PROJECT_ID}/secrets/${CONFIG.NOTION_SIGNING_SECRET_NAME}/versions/latest`,
+        }),
       ]);
 
       return {
@@ -98,6 +104,8 @@ export class SecretManager {
         euSecret: euSecretResponse[0].payload?.data?.toString() || "",
         slackSigningSecret:
           slackSigningSecretResponse[0].payload?.data?.toString() || "",
+        notionSigningSecret:
+          notionSigningSecretResponse[0].payload?.data?.toString() || "",
       };
     } catch (error) {
       console.error("Failed to load secrets from Secret Manager", {


### PR DESCRIPTION
## Description

The Notion support is quite similar to what we do for Slack, except that we need to deal with the initial setup that gives us the `verification_token`.

Fixes https://github.com/dust-tt/tasks/issues/5100

## Tests

Manual

## Risk

At worst we don't get the webhooks, which is not terrible.

## Deploy Plan

- Firebase router deploy
- Set up new webhook in Notion
- Get `verification_token`
- Set it as a firebase secret (named `NOTION_SIGNING_SECRET `)
- Also set as NOTION_SIGNING_SECRET in connector secret in both region, if we decide to verify signature there as well (in future PR)