### PR TITLE
[connectors] chore(microsoft): Remove Directory.Read.All from requested scope

### DIFF
--- a/connectors/migrations/20251113_backfill_microsoft_tenant_ids.ts
+++ b/connectors/migrations/20251113_backfill_microsoft_tenant_ids.ts
@@ -109,11 +109,18 @@ makeScript(
     }
 
     for (const connector of connectors) {
-      await backfillConnectorTenant({
-        connector,
-        execute,
-        logger: scriptLogger,
-      });
+      try {
+        await backfillConnectorTenant({
+          connector,
+          execute,
+          logger: scriptLogger,
+        });
+      } catch (error) {
+        scriptLogger.error(
+          { connectorId: connector.id, error },
+          "Error backfilling tenant id"
+        );
+      }
     }
 
     const lastProcessedId = connectors[connectors.length - 1]?.id;

--- a/connectors/migrations/20251113_backfill_microsoft_tenant_ids.ts
+++ b/connectors/migrations/20251113_backfill_microsoft_tenant_ids.ts
@@ -41,6 +41,17 @@ async function backfillConnectorTenant({
   childLogger.info({ tenantId, execute }, "Backfilling tenant id");
 
   if (execute) {
+    await config.model.update(
+      { tenantId },
+      {
+        where: {
+          id: config.id,
+        },
+        hooks: false,
+        silent: true,
+      }
+    );
+
     await config.update({ tenantId });
   }
 }

--- a/connectors/migrations/20251113_backfill_microsoft_tenant_ids.ts
+++ b/connectors/migrations/20251113_backfill_microsoft_tenant_ids.ts
@@ -1,0 +1,127 @@
+import { makeScript } from "scripts/helpers";
+import { Op } from "sequelize";
+
+import {
+  extractTenantIdFromAccessToken,
+  getMicrosoftConnectionData,
+} from "@connectors/connectors/microsoft";
+import type { Logger } from "@connectors/logger/logger";
+import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+import type { ConnectorMetadata } from "@connectors/resources/storage/models/connector_model";
+
+async function backfillConnectorTenant({
+  connector,
+  execute,
+  logger,
+}: {
+  connector: ConnectorModel;
+  execute: boolean;
+  logger: Logger;
+}) {
+  const childLogger = logger.child({ connectorId: connector.id });
+
+  const metadata = (connector.metadata ?? {}) as ConnectorMetadata;
+  if (metadata.tenantId) {
+    childLogger.info("Tenant id already present, skipping");
+    return;
+  }
+
+  try {
+    const { accessToken } = await getMicrosoftConnectionData(
+      connector.connectionId
+    );
+    const tenantId = extractTenantIdFromAccessToken(accessToken);
+
+    if (!tenantId) {
+      childLogger.warn("Unable to extract tenant id from access token");
+      return;
+    }
+
+    childLogger.info({ tenantId, execute }, "Backfilling tenant id");
+
+    if (execute) {
+      const newMetadata: ConnectorMetadata = {
+        ...metadata,
+        tenantId,
+      };
+      await connector.update({ metadata: newMetadata });
+    }
+  } catch (error) {
+    childLogger.error({ error }, "Failed to backfill tenant id");
+  }
+}
+
+makeScript(
+  {
+    connectorId: {
+      type: "number",
+      describe: "Process a single connector id",
+      required: false,
+    },
+    nextConnectorId: {
+      type: "number",
+      describe:
+        "Process connectors with id greater than the provided value (supports pagination)",
+      required: false,
+      default: 0,
+    },
+    batchSize: {
+      type: "number",
+      describe: "Maximum number of connectors to process per run",
+      required: false,
+      default: 50,
+    },
+  },
+  async ({ connectorId, nextConnectorId, batchSize, execute }, scriptLogger) => {
+    if (connectorId && connectorId > 0) {
+      const connector = await ConnectorModel.findByPk(connectorId);
+      if (!connector || connector.type !== "microsoft") {
+        scriptLogger.warn(
+          { connectorId },
+          "Connector not found or not a Microsoft connector"
+        );
+        return;
+      }
+      await backfillConnectorTenant({ connector, execute, logger: scriptLogger });
+      return;
+    }
+
+    const connectors = await ConnectorModel.findAll({
+      where: {
+        type: "microsoft",
+        id:
+          nextConnectorId && nextConnectorId > 0
+            ? {
+                [Op.gt]: nextConnectorId,
+              }
+            : {
+                [Op.gt]: 0,
+              },
+      },
+      order: [["id", "ASC"]],
+      limit: batchSize,
+    });
+
+    if (connectors.length === 0) {
+      scriptLogger.info("No Microsoft connectors matched the criteria");
+      return;
+    }
+
+    for (const connector of connectors) {
+      await backfillConnectorTenant({
+        connector,
+        execute,
+        logger: scriptLogger,
+      });
+    }
+
+    const lastProcessedId = connectors[connectors.length - 1]?.id;
+    if (lastProcessedId) {
+      scriptLogger.info(
+        { nextConnectorId: lastProcessedId },
+        "To continue, re-run the script with --nextConnectorId set to this value"
+      );
+    }
+  }
+);
+

--- a/connectors/migrations/db/migration_105.sql
+++ b/connectors/migrations/db/migration_105.sql
@@ -1,0 +1,3 @@
+-- Migration created on Nov 14, 2025
+ALTER TABLE "public"."microsoft_configurations" ADD COLUMN "tenantId" VARCHAR(255);
+

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -60,6 +60,7 @@ import type {
   ContentNodesViewType,
   DataSourceConfig,
 } from "@connectors/types";
+import { isString } from "@connectors/types/shared/utils/general";
 
 export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
   readonly provider: ConnectorProvider = "microsoft";
@@ -638,7 +639,7 @@ export function extractTenantIdFromAccessToken(
 
   try {
     const payload = decodeJwt(accessToken);
-    if (typeof payload.tid === "string") {
+    if (isString(payload.tid)) {
       return payload.tid;
     }
   } catch (e) {

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -11,6 +11,7 @@ export class MicrosoftConfigurationModel extends ConnectorBaseModel<MicrosoftCon
   declare pdfEnabled: boolean;
   declare csvEnabled: boolean;
   declare largeFilesEnabled: boolean;
+  declare tenantId: string | null;
 }
 MicrosoftConfigurationModel.init(
   {
@@ -38,6 +39,10 @@ MicrosoftConfigurationModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    tenantId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {

--- a/connectors/src/resources/storage/models/connector_model.ts
+++ b/connectors/src/resources/storage/models/connector_model.ts
@@ -11,7 +11,6 @@ import type {
 
 export interface ConnectorMetadata {
   rateLimited?: { at: Date } | null;
-  tenantId?: string;
 }
 
 export class ConnectorModel extends BaseModel<ConnectorModel> {

--- a/connectors/src/resources/storage/models/connector_model.ts
+++ b/connectors/src/resources/storage/models/connector_model.ts
@@ -11,6 +11,7 @@ import type {
 
 export interface ConnectorMetadata {
   rateLimited?: { at: Date } | null;
+  tenantId?: string;
 }
 
 export class ConnectorModel extends BaseModel<ConnectorModel> {

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -101,7 +101,7 @@ impl Provider for MicrosoftConnectionProvider {
                     "client_secret": *OAUTH_MICROSOFT_CLIENT_SECRET,
                     "code": code,
                     "redirect_uri": redirect_uri,
-                    "scope": "User.Read Sites.Read.All Directory.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
+                    "scope": "User.Read Sites.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
                 }),
             ),
         };
@@ -160,7 +160,7 @@ impl Provider for MicrosoftConnectionProvider {
                         "client_id": *OAUTH_MICROSOFT_CLIENT_ID,
                         "client_secret": *OAUTH_MICROSOFT_CLIENT_SECRET,
                         "refresh_token": refresh_token,
-                        "scope": "User.Read Sites.Read.All Directory.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
+                        "scope": "User.Read Sites.Read.All Files.Read.All Team.ReadBasic.All ChannelSettings.Read.All ChannelMessage.Read.All",
                     }),
                 )
             }

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -29,7 +29,6 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
     const scopes = [
       "User.Read",
       "Sites.Read.All",
-      "Directory.Read.All",
       "Files.Read.All",
       "Team.ReadBasic.All",
       "ChannelSettings.Read.All",


### PR DESCRIPTION
## Description

Removed scope Directory.Read.All , very broad, which was only used to get the organization name to compare it when updating the connection. Replace the check by tenantId comparison, based on token. Store the tenantId in metadata for easier comparison.

## Tests

Tested by updating and recreating the connection

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

run db migration
run backfill to fill tenantId from existing tokens
deploy connector
