### PR TITLE
feat: add internal dust-edge global agent

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -36,10 +36,10 @@ import type {
 } from "@app/types";
 import {
   CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
+  GEMINI_3_PRO_MODEL_CONFIG,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   GLOBAL_AGENTS_SID,
-  GPT_5_1_MODEL_CONFIG,
   isProviderWhitelisted,
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
@@ -601,7 +601,7 @@ export function _getDustEdgeGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_EDGE,
     name: "dust-edge",
-    preferredModelConfiguration: GPT_5_1_MODEL_CONFIG,
+    preferredModelConfiguration: GEMINI_3_PRO_MODEL_CONFIG,
     preferredReasoningEffort: "light",
   });
 }

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -260,7 +260,8 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
       return {
         sId: GLOBAL_AGENTS_SID.DUST_EDGE,
         name: "dust-edge",
-        description: "An agent with context on your company data.",
+        description:
+          "Same as dust but on another model to experiment internally.",
         pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
       };
     case GLOBAL_AGENTS_SID.DUST:

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -256,6 +256,13 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         pictureUrl:
           "https://dust.tt/static/systemavatar/intercom_avatar_full.png",
       };
+    case GLOBAL_AGENTS_SID.DUST_EDGE:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_EDGE,
+        name: "dust-edge",
+        description: "An agent with context on your company data.",
+        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+      };
     case GLOBAL_AGENTS_SID.DUST:
       return {
         sId: GLOBAL_AGENTS_SID.DUST,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -15,7 +15,10 @@ import {
   _getDustTaskGlobalAgent,
   _getPlanningAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/deep-dive";
-import { _getDustGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
+import {
+  _getDustEdgeGlobalAgent,
+  _getDustGlobalAgent,
+} from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import { _getNoopAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/noop";
 import { _getGeminiProGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/google";
 import {
@@ -344,6 +347,22 @@ function getGlobalAgent({
         availableToolsets,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_EDGE:
+      agentConfiguration = _getDustEdgeGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        agentRouterMCPServerView,
+        webSearchBrowseMCPServerView,
+        dataSourcesFileSystemMCPServerView,
+        toolsetsMCPServerView,
+        deepDiveMCPServerView,
+        interactiveContentMCPServerView,
+        dataWarehousesMCPServerView,
+        agentMemoryMCPServerView,
+        memories,
+        availableToolsets,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
       agentConfiguration = _getDeepDiveGlobalAgent(auth, {
         settings,
@@ -559,13 +578,19 @@ export async function getGlobalAgents(
       (sId) => sId !== GLOBAL_AGENTS_SID.DEEPSEEK_R1
     );
   }
+  if (!flags.includes("dust_edge_global_agent")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.DUST_EDGE
+    );
+  }
 
   let memories: AgentMemoryResource[] = [];
   if (
     variant === "full" &&
     agentMemoryMCPServerView &&
     auth.user() &&
-    agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST)
+    (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE))
   ) {
     memories = await AgentMemoryResource.findByAgentConfigurationIdAndUser(
       auth,
@@ -579,7 +604,8 @@ export async function getGlobalAgents(
   if (
     variant === "full" &&
     toolsetsMCPServerView &&
-    agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST)
+    (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE))
   ) {
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
     availableToolsets = await MCPServerViewResource.listBySpace(

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -107,6 +107,7 @@ export function isSupportingResponseFormat(modelId: ModelIdType) {
 export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
+  DUST_EDGE = "dust-edge",
   DEEP_DIVE = "deep-dive",
   DUST_TASK = "dust-task",
   DUST_BROWSER_SUMMARY = "dust-browser-summary",
@@ -182,6 +183,7 @@ export function getGlobalAgentAuthorName(agentId: string): string {
 // Not exhaustive.
 const GLOBAL_AGENTS_SORT_ORDER: string[] = [
   GLOBAL_AGENTS_SID.DUST,
+  GLOBAL_AGENTS_SID.DUST_EDGE,
   GLOBAL_AGENTS_SID.DEEP_DIVE,
   GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET,
   GLOBAL_AGENTS_SID.GPT5,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -8,6 +8,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",
   },
+  dust_edge_global_agent: {
+    description: "Access to dust-edge global agent",
+    stage: "dust_only",
+  },
   notion_private_integration: {
     description: "Setup Notion private integration tokens",
     stage: "on_demand",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -9,7 +9,8 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
   },
   dust_edge_global_agent: {
-    description: "Access to dust-edge global agent",
+    description:
+      "Access to dust-edge global agent that we use internally to test other models on dust",
     stage: "dust_only",
   },
   notion_private_integration: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -646,6 +646,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "confluence_tool"
   | "deepseek_feature"
   | "deepseek_r1_global_agent_feature"
+  | "dust_edge_global_agent"
   | "dev_mcp_actions"
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"


### PR DESCRIPTION
## Description

goal is to have an internal version of the `@dust` global agent on which we can try a different model (here gpt 5.1 in light reasoning)

## Tests

Local

## Risk

Low

## Deploy Plan

deploy front