### PR TITLE
[hootl] Use upsert on WebhookRequestTriggerModel to avoid duplicate key

### DIFF
--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -69,7 +69,8 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     status: WebhookRequestTriggerStatus;
     errorMessage?: string;
   }) {
-    await WebhookRequestTriggerModel.create({
+    // Use upsert as we might be retrying for the same request/trigger combination
+    await WebhookRequestTriggerModel.upsert({
       workspaceId: this.workspaceId,
       webhookRequestId: this.id,
       triggerId: trigger.id,

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -69,14 +69,31 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     status: WebhookRequestTriggerStatus;
     errorMessage?: string;
   }) {
-    // Use upsert as we might be retrying for the same request/trigger combination
-    await WebhookRequestTriggerModel.upsert({
-      workspaceId: this.workspaceId,
-      webhookRequestId: this.id,
-      triggerId: trigger.id,
-      status,
-      errorMessage,
+    // Check if the record already exists (for retry scenarios)
+    const existing = await WebhookRequestTriggerModel.findOne({
+      where: {
+        workspaceId: this.workspaceId,
+        webhookRequestId: this.id,
+        triggerId: trigger.id,
+      },
     });
+
+    if (existing) {
+      // Update existing record
+      await existing.update({
+        status,
+        errorMessage,
+      });
+    } else {
+      // Create new record
+      await WebhookRequestTriggerModel.create({
+        workspaceId: this.workspaceId,
+        webhookRequestId: this.id,
+        triggerId: trigger.id,
+        status,
+        errorMessage,
+      });
+    }
   }
 
   static async makeNew(


### PR DESCRIPTION
## Description

Make the operation itempotent

Should fix stuck workflows like this one: https://cloud.temporal.io/namespaces/dust-agent-prod.gmnlm/workflows/agent-trigger-webhook-17027-0ec9852c2f-1763109898394

## Tests


## Risk

low

## Deploy Plan

deploy front
