### PR TITLE
[front] chore: add log on google drive production check start 

### DIFF
--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -29,6 +29,14 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   await concurrentExecutor(
     GdriveDataSources,
     async (ds) => {
+      logger.info(
+        {
+          reportPayload: {
+            connectorId: ds.connectorId,
+          },
+        },
+        "Check started"
+      );
       heartbeat();
 
       // Retrieve all documents from the connector (first) in batches using an id cursor


### PR DESCRIPTION
## Description

- This PR adds a log to track the start of a google drive gc check production check.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
