### PR TITLE
[front] chore: lower concurrency on conversation delete

### DIFF
--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -185,7 +185,7 @@ export async function deleteAllConversations(auth: Authenticator) {
       }
     },
     {
-      concurrency: 16,
+      concurrency: 12,
     }
   );
 }


### PR DESCRIPTION
## Description

- We always delete no more than 2 conversations in parallel since this is a fairly expensive operation that puts a high load on db.
- When scrubbing a workspace we do 16 in parallel, which often caps the CPU load of the db.
- This PR lowers it to 12, we might lower it again after looking at the tendancy.

## Tests

## Risk

## Deploy Plan

- Deploy front.
