### PR TITLE
[front] enh(poke): update bg color of selected command palette item

### DIFF
--- a/front/components/poke/shadcn/ui/command.tsx
+++ b/front/components/poke/shadcn/ui/command.tsx
@@ -238,7 +238,7 @@ const CommandItem = React.forwardRef<
       className={cn(
         "aria-selected:bg-accent aria-selected:text-accent-foreground relative flex cursor-pointer",
         "items-center rounded-sm px-2 py-1.5 text-sm outline-none",
-        isSelected && "bg-accent text-warning-800",
+        isSelected && "bg-faint dark:bg-faint-night",
         className
       )}
       data-index={index}


### PR DESCRIPTION
## Description

- This PR highlights the selected item in the command palette by changing its background color.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
