### PR TITLE
Implement full flow from tool markdown to setup tool from conversation

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -54,7 +54,7 @@ import {
 import { getImgPlugin, imgDirective } from "@app/components/markdown/Image";
 import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import {
-  getToolPlugin,
+  getToolSetupPlugin,
   toolDirective,
 } from "@app/components/markdown/tool/tool";
 import {
@@ -607,7 +607,7 @@ function AgentMessageContent({
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
       dustimg: getImgPlugin(owner),
-      tool: getToolPlugin(owner),
+      toolSetup: getToolSetupPlugin(owner),
     }),
     [owner, conversationId, sId, agentConfiguration.sId]
   );

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -54,6 +54,10 @@ import {
 import { getImgPlugin, imgDirective } from "@app/components/markdown/Image";
 import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import {
+  getToolPlugin,
+  toolDirective,
+} from "@app/components/markdown/tool/tool";
+import {
   getVisualizationPlugin,
   sanitizeVisualizationContent,
   visualizationDirective,
@@ -603,6 +607,7 @@ function AgentMessageContent({
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
       dustimg: getImgPlugin(owner),
+      tool: getToolPlugin(owner),
     }),
     [owner, conversationId, sId, agentConfiguration.sId]
   );
@@ -613,6 +618,7 @@ function AgentMessageContent({
       getCiteDirective(),
       visualizationDirective,
       imgDirective,
+      toolDirective,
     ],
     []
   );

--- a/front/components/markdown/tool/ToolCard.tsx
+++ b/front/components/markdown/tool/ToolCard.tsx
@@ -1,0 +1,185 @@
+/**
+ * Tool directive card component.
+ *
+ * Renders a card for tool directives in markdown content.
+ * Displays tool information with logo, description, and action buttons.
+ */
+
+import { Button, ContentMessage } from "@dust-tt/sparkle";
+import React, { useMemo, useState } from "react";
+
+import { CreateMCPServerSheet } from "@app/components/actions/mcp/CreateMCPServerSheet";
+import { getIcon } from "@app/components/resources/resources_icons";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { isInternalMCPServerOfName } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  useAddMCPServerToSpace,
+  useAvailableMCPServers,
+  useMCPServers,
+} from "@app/lib/swr/mcp_servers";
+import { useSpaces, useSpacesAsAdmin } from "@app/lib/swr/spaces";
+import type { WorkspaceType } from "@app/types";
+import { asDisplayToolName } from "@app/types";
+
+interface ToolCardProps {
+  toolName: string;
+  toolId: InternalMCPServerNameType;
+  owner: WorkspaceType;
+}
+
+export function ToolCard({ toolName, toolId, owner }: ToolCardProps) {
+  const [isActivating, setIsActivating] = useState(false);
+  const [isSetupSheetOpen, setIsSetupSheetOpen] = useState(false);
+  const isAdmin = owner.role === "admin";
+
+  const { spaces: spacesAsUser } = useSpaces({
+    workspaceId: owner.sId,
+    disabled: isAdmin,
+  });
+  const { spaces: spacesAsAdmin } = useSpacesAsAdmin({
+    workspaceId: owner.sId,
+    disabled: !isAdmin,
+  });
+  const spaces = isAdmin ? spacesAsAdmin : spacesAsUser;
+  const { addToSpace } = useAddMCPServerToSpace(owner);
+
+  const globalSpace = useMemo(() => {
+    return spaces.find((space) => space.kind === "global");
+  }, [spaces]);
+
+  // Get available MCPServers (servers that can be installed but aren't yet).
+  const { availableMCPServers } = useAvailableMCPServers({
+    owner,
+  });
+
+  // Get all installed MCP servers with their views across all spaces.
+  const { mcpServers, mutateMCPServers } = useMCPServers({
+    owner,
+  });
+
+  // Find the macthing MCP server for the tool we want to activate.
+  const matchingMCPServer = useMemo(() => {
+    const installedServer = mcpServers.find((s) =>
+      isInternalMCPServerOfName(s.sId, toolId)
+    );
+    if (installedServer) {
+      return installedServer;
+    }
+    return availableMCPServers.find((server) =>
+      isInternalMCPServerOfName(server.sId, toolId)
+    );
+  }, [mcpServers, availableMCPServers, toolId]);
+
+  // Check if the tool is installed at workspace level.
+  // A tool is installed if it exists in mcpServers (installed servers list).
+  const isToolActivatedInSystemSpace = useMemo(() => {
+    if (!matchingMCPServer) {
+      return false;
+    }
+    return mcpServers.some((s) => s.sId === matchingMCPServer.sId);
+  }, [matchingMCPServer, mcpServers]);
+
+  // Check if the tool is in global space.
+  // A tool is in global space if it has a view in the global space.
+  const isToolActivatedInGlobalSpace = useMemo(() => {
+    if (!globalSpace || !matchingMCPServer || !matchingMCPServer.views) {
+      return false;
+    }
+    return matchingMCPServer.views.some(
+      (view) => view.spaceId === globalSpace.sId
+    );
+  }, [matchingMCPServer, globalSpace]);
+
+  // Don't render the card at all if the tool does not exist.
+  if (!matchingMCPServer || !globalSpace) {
+    return null;
+  }
+
+  const getButtonLabel = () => {
+    if (!isAdmin) {
+      return "Admin only can activate tools";
+    }
+    if (isActivating) {
+      return "Activating...";
+    }
+    if (isToolActivatedInGlobalSpace) {
+      return "Activated";
+    }
+    if (isToolActivatedInSystemSpace) {
+      return "Add to Company Data";
+    }
+    return "Activate";
+  };
+
+  const getButtonClickHandler = () => {
+    return isToolActivatedInSystemSpace
+      ? handleAddToGlobalSpace
+      : handleActivateClick;
+  };
+
+  const handleAddToGlobalSpace = async () => {
+    setIsActivating(true);
+    await addToSpace(matchingMCPServer, globalSpace);
+    await mutateMCPServers();
+    setIsActivating(false);
+  };
+
+  const handleActivateClick = async () => {
+    setIsSetupSheetOpen(true);
+  };
+
+  const handleSetupComplete = async () => {
+    setIsSetupSheetOpen(false);
+    setIsActivating(true);
+    await mutateMCPServers();
+    setIsActivating(false);
+  };
+
+  return (
+    <>
+      <ContentMessage
+        title={`${asDisplayToolName(toolId) || toolName} Tool`}
+        icon={getIcon(matchingMCPServer.icon)}
+        variant="primary"
+        size="sm"
+      >
+        <div className="flex flex-col gap-3">
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {matchingMCPServer.description}
+          </span>
+          <div className="flex justify-end gap-2">
+            {matchingMCPServer.documentationUrl && (
+              <Button
+                variant="outline"
+                size="sm"
+                label="About"
+                href={matchingMCPServer.documentationUrl}
+                target="_blank"
+              />
+            )}
+            <Button
+              variant="highlight"
+              size="sm"
+              label={getButtonLabel()}
+              onClick={getButtonClickHandler()}
+              disabled={
+                !isAdmin || isToolActivatedInGlobalSpace || isActivating
+              }
+            />
+          </div>
+        </div>
+      </ContentMessage>
+
+      {matchingMCPServer && (
+        <CreateMCPServerSheet
+          owner={owner}
+          internalMCPServer={matchingMCPServer}
+          setMCPServerToShow={handleSetupComplete}
+          setIsLoading={setIsActivating}
+          isOpen={isSetupSheetOpen}
+          setIsOpen={setIsSetupSheetOpen}
+        />
+      )}
+    </>
+  );
+}

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -21,13 +21,13 @@ import { useSpaces, useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import type { WorkspaceType } from "@app/types";
 import { asDisplayToolName } from "@app/types";
 
-interface ToolCardProps {
+interface ToolSetupCardProps {
   toolName: string;
   toolId: InternalMCPServerNameType;
   owner: WorkspaceType;
 }
 
-export function ToolCard({ toolName, toolId, owner }: ToolCardProps) {
+export function ToolSetupCard({ toolName, toolId, owner }: ToolSetupCardProps) {
   const [isActivating, setIsActivating] = useState(false);
   const [isSetupSheetOpen, setIsSetupSheetOpen] = useState(false);
   const isAdmin = owner.role === "admin";

--- a/front/components/markdown/tool/tool.tsx
+++ b/front/components/markdown/tool/tool.tsx
@@ -8,7 +8,7 @@
 import React from "react";
 import { visit } from "unist-util-visit";
 
-import { ToolCard } from "@app/components/markdown/tool/ToolCard";
+import { ToolSetupCard } from "@app/components/markdown/tool/ToolSetupCard";
 import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { WorkspaceType } from "@app/types";
 
@@ -21,9 +21,9 @@ import type { WorkspaceType } from "@app/types";
 export function toolDirective() {
   return (tree: any) => {
     visit(tree, ["textDirective"], (node) => {
-      if (node.name === "tool" && node.children[0]) {
+      if (node.name === "toolSetup" && node.children[0]) {
         const data = node.data || (node.data = {});
-        data.hName = "tool";
+        data.hName = "toolSetup";
         data.hProperties = {
           toolId: node.attributes.sId,
           toolName: node.children[0].value,
@@ -42,8 +42,8 @@ export function toolDirective() {
  * @param owner - The workspace context for tool interactions
  * @returns A React component for rendering tool cards
  */
-export function getToolPlugin(owner: WorkspaceType) {
-  const ToolPlugin = ({
+export function getToolSetupPlugin(owner: WorkspaceType) {
+  const ToolSetupPlugin = ({
     toolName,
     toolId,
   }: {
@@ -53,8 +53,8 @@ export function getToolPlugin(owner: WorkspaceType) {
     if (!toolId || !isInternalMCPServerName(toolId)) {
       return null;
     }
-    return <ToolCard toolName={toolName} toolId={toolId} owner={owner} />;
+    return <ToolSetupCard toolName={toolName} toolId={toolId} owner={owner} />;
   };
 
-  return ToolPlugin;
+  return ToolSetupPlugin;
 }

--- a/front/components/markdown/tool/tool.tsx
+++ b/front/components/markdown/tool/tool.tsx
@@ -1,0 +1,60 @@
+/**
+ * Markdown directive plugin for tools.
+ *
+ * This module provides remark-directive plugins for parsing and rendering
+ * tool directives in markdown content, enabling the :tool[name]{sId=xxx} syntax.
+ */
+
+import React from "react";
+import { visit } from "unist-util-visit";
+
+import { ToolCard } from "@app/components/markdown/tool/ToolCard";
+import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { WorkspaceType } from "@app/types";
+
+/**
+ * Remark directive plugin for parsing tool directives.
+ *
+ * Transforms `:tool[name]{sId=xxx}` into a custom HTML element
+ * that can be rendered by the tool button component.
+ */
+export function toolDirective() {
+  return (tree: any) => {
+    visit(tree, ["textDirective"], (node) => {
+      if (node.name === "tool" && node.children[0]) {
+        const data = node.data || (node.data = {});
+        data.hName = "tool";
+        data.hProperties = {
+          toolId: node.attributes.sId,
+          toolName: node.children[0].value,
+        };
+      }
+    });
+  };
+}
+
+/**
+ * Creates a React component plugin for rendering tools in markdown.
+ *
+ * This function returns a component that can be used as a custom component
+ * in ReactMarkdown to render the tool HTML elements.
+ *
+ * @param owner - The workspace context for tool interactions
+ * @returns A React component for rendering tool cards
+ */
+export function getToolPlugin(owner: WorkspaceType) {
+  const ToolPlugin = ({
+    toolName,
+    toolId,
+  }: {
+    toolName: string;
+    toolId: string;
+  }) => {
+    if (!toolId || !isInternalMCPServerName(toolId)) {
+      return null;
+    }
+    return <ToolCard toolName={toolName} toolId={toolId} owner={owner} />;
+  };
+
+  return ToolPlugin;
+}


### PR DESCRIPTION
## Description

New tool directive: `tool[Gmail]{sId=gmail}`. 
Actually renamed to -> `toolSetup[Gmail]{sId=gmail}`


When the tool is not yet on the workspace: 
<kbd>
<img width="797" height="541" alt="Screenshot 2025-11-14 at 15 55 44" src="https://github.com/user-attachments/assets/1d0b0826-a350-4393-b461-c2491e6502a0" />
</kbd>

When the tool was activated: 
<kbd>
<img width="868" height="560" alt="Screenshot 2025-11-14 at 15 55 24" src="https://github.com/user-attachments/assets/81f9cf36-57c1-4a91-9ddb-09828f77b3fa" />
</kbd>

If the was activated in the workspace but not in Company Data: 
<kbd>
<img width="788" height="496" alt="Screenshot 2025-11-14 at 15 58 23" src="https://github.com/user-attachments/assets/58695bab-751c-40c6-afad-3ac7e62a4c69" />
</kbd>

## Tests

Locally. 

## Risk

Directive unused yet, can be rolled back. 

## Deploy Plan

Deploy front.