### PR TITLE
[LLM Router] fallback on hasFeature

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -30,7 +30,7 @@ export async function getLLM(
     temperature,
     reasoningEffort,
     responseFormat,
-    bypassFeatureFlag,
+    bypassFeatureFlag = false,
     context,
   }: LLMParameters
 ): Promise<LLM | null> {
@@ -41,7 +41,7 @@ export async function getLLM(
     return null;
   }
 
-  const hasFeature = bypassFeatureFlag ?? (await hasFeatureFlag(auth));
+  const hasFeature = bypassFeatureFlag || (await hasFeatureFlag(auth));
   if (!hasFeature) {
     return null;
   }


### PR DESCRIPTION
## Description

Now that we pass `bypassFeatureFlag: isComparisonModeEnabled` which can be `false`, we need to properly fallback to `hasFeature`

## Tests

## Risk

low

## Deploy Plan

front
