### PR TITLE
[connectors] enh(slack_bot): add slower throttle on long messages

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -44,11 +44,10 @@ const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 300; // Character threshold to switch
 
 // Dynamic throttling: longer messages get less frequent updates to reduce UX disruption
 const getThrottleDelay = (textLength: number): number => {
-  if (textLength < SLACK_MESSAGE_LONG_THRESHOLD_CHARS) {
-    return SLACK_MESSAGE_UPDATE_THROTTLE_MS;
-  } else {
+  if (textLength >= SLACK_MESSAGE_LONG_THRESHOLD_CHARS) {
     return SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS;
   }
+  return SLACK_MESSAGE_UPDATE_THROTTLE_MS;
 };
 
 export const SlackBlockIdStaticAgentConfigSchema = t.type({

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -40,7 +40,7 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 // Throttle configuration for Slack message updates
 const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000; // Base throttle: update every 1s for short messages
 const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000; // Slow throttle: update every 5s for long messages
-const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 700; // Character threshold to switch to slow throttle
+const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 300; // Character threshold to switch to slow throttle
 
 // Dynamic throttling: longer messages get less frequent updates to reduce UX disruption
 const getThrottleDelay = (textLength: number): number => {

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -37,14 +37,12 @@ import { throttleWithRedis } from "@connectors/lib/throttle";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
-// Base throttle: update every 1s for short messages.
 const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000;
-// Slow throttle: update every 5s for long messages.
 const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000;
-// Character threshold to switch to slow throttle.
 const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 300;
 
-// Dynamic throttling: longer messages get less frequent updates to reduce UX disruption
+// Dynamic throttling: longer messages get less frequent updates to reduce UX disruption when the content is expanded.
+// Posting an update on an expanded message will collapse it, frequent updates prevent users from reading the content.
 const getThrottleDelay = (textLength: number): number => {
   if (textLength >= SLACK_MESSAGE_LONG_THRESHOLD_CHARS) {
     return SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS;

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -291,7 +291,6 @@ async function streamAgentAnswerToSlack(
           break;
         }
 
-        // Dynamically adjust throttle delay based on message length
         const newThrottleDelay = getThrottleDelay(slackContent.length);
         if (newThrottleDelay !== currentThrottleDelay) {
           currentThrottleDelay = newThrottleDelay;

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -37,10 +37,12 @@ import { throttleWithRedis } from "@connectors/lib/throttle";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 
-// Throttle configuration for Slack message updates
-const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000; // Base throttle: update every 1s for short messages
-const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000; // Slow throttle: update every 5s for long messages
-const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 300; // Character threshold to switch to slow throttle
+// Base throttle: update every 1s for short messages.
+const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000;
+// Slow throttle: update every 5s for long messages.
+const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000;
+// Character threshold to switch to slow throttle.
+const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 300;
 
 // Dynamic throttling: longer messages get less frequent updates to reduce UX disruption
 const getThrottleDelay = (textLength: number): number => {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5041.
- This PR reduces the frequency of updates to slack messages when they get long. 
- Context in this [thread](https://dust4ai.slack.com/archives/C06N6P4M9F1/p1762431002620749): if the message is long and the user expands it, it will get collapsed on updates.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
