### PR TITLE
[LLM Router] Hotfix Mistral websearch

### DIFF
--- a/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
+++ b/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
@@ -13,12 +13,30 @@ import type {
   Content,
   ModelMessageTypeMultiActionsWithoutContentFragment,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever, safeParseJSON } from "@app/types";
 import type {
   AgentFunctionCallContentType,
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
+
+function removeReferenceKeys(obj: any): any {
+  if (obj === null || typeof obj !== "object") {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(removeReferenceKeys);
+  }
+
+  const result: any = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (key !== "reference") {
+      result[key] = removeReferenceKeys(value);
+    }
+  }
+  return result;
+}
 
 function toContentChunk(
   content: Content | AgentTextContentType | AgentReasoningContentType
@@ -103,6 +121,31 @@ export function toMessage(
       };
     }
     case "function": {
+      if (typeof message.content === "string") {
+        const parsedContentRes = safeParseJSON(message.content);
+        if (
+          parsedContentRes.isErr() ||
+          message.name !== "web_search_browse__websearch"
+        ) {
+          return {
+            role: "tool",
+            content: message.content,
+            name: message.name,
+            toolCallId: message.function_call_id,
+          };
+        }
+
+        // There is a conflict with Mistral web search tool that is supposed to send back reference ids as number
+        // But we send to mistral string references which makes the Mistral client invalidate the event it send back
+        const cleanedContent = removeReferenceKeys(parsedContentRes.value);
+        return {
+          role: "tool",
+          content: JSON.stringify(cleanedContent),
+          name: message.name,
+          toolCallId: message.function_call_id,
+        };
+      }
+
       return {
         role: "tool",
         content:


### PR DESCRIPTION
## Description

Seems to be a conflict between our websearch and Mistral's websearch. If I remove reference keys from websearch browse tool content, we don't have the problem.
This is a hotfix

## Tests

local

## Risk

low

## Deploy Plan

front
