### PR TITLE
[front] - chore(analytics): index message context origin 

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -19,6 +19,9 @@
       "user_id": {
         "type": "keyword"
       },
+      "context_origin": {
+        "type": "keyword"
+      },
       "timestamp": {
         "type": "date"
       },

--- a/front/lib/analytics/migrations/20251115_add_context_origin_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20251115_add_context_origin_to_agent_message_analytics_2.http
@@ -1,0 +1,9 @@
+PUT /front.agent_message_analytics_2/_mapping
+{
+  "properties": {
+    "context_origin": {
+      "type": "keyword"
+    }
+  }
+}
+

--- a/front/migrations/20251103_backfill_agent_analytics.ts
+++ b/front/migrations/20251103_backfill_agent_analytics.ts
@@ -163,6 +163,7 @@ async function backfillAgentAnalytics(
             agentAgentMessageRow,
             userModel: userUserMessageRow.user ?? null,
             conversationRow,
+            contextOrigin: userUserMessageRow.userContextOrigin,
           });
 
           successCount++;

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -109,6 +109,7 @@ export async function storeAgentAnalyticsActivity(
     agentAgentMessageRow,
     userModel: userUserMessageRow.user ?? null,
     conversationRow,
+    contextOrigin: userUserMessageRow.userContextOrigin,
   });
 }
 
@@ -117,18 +118,21 @@ export async function storeAgentAnalyticsActivity(
  */
 export async function storeAgentAnalytics(
   auth: Authenticator,
-  {
-    agentMessageRow,
-    agentAgentMessageRow,
-    userModel,
-    conversationRow,
-  }: {
+  params: {
     agentMessageRow: Message;
     agentAgentMessageRow: AgentMessage;
     userModel: UserModel | null;
     conversationRow: ConversationModel;
+    contextOrigin: string | null;
   }
 ): Promise<void> {
+  const {
+    agentMessageRow,
+    agentAgentMessageRow,
+    userModel,
+    conversationRow,
+    contextOrigin,
+  } = params;
   // Only index agent messages if there are no blocked actions awaiting approval.
   const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
     agentAgentMessageRow.id,
@@ -158,6 +162,7 @@ export async function storeAgentAnalytics(
     agent_id: agentAgentMessageRow.agentConfigurationId,
     agent_version: agentAgentMessageRow.agentConfigurationVersion.toString(),
     conversation_id: conversationRow.sId,
+    context_origin: contextOrigin,
     latency_ms: agentAgentMessageRow.modelInteractionDurationMs ?? 0,
     message_id: agentMessageRow.sId,
     status: agentAgentMessageRow.status,

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -37,6 +37,7 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   agent_version: string;
   conversation_id: string;
   feedbacks: AgentMessageAnalyticsFeedback[];
+  context_origin: string | null;
   latency_ms: number;
   message_id: string;
   status: AgentMessageStatus;


### PR DESCRIPTION
## Description

Adds the `context_origin` field to the `agent_message_analytics_2` Elasticsearch index to track where user messages originated from (web, slack, api, etc.). The field is passed through from the `userContextOrigin` property of user messages to the analytics data, enabling analysis of agent message patterns by user message source.

Note: we'll need to find a smart way to backfill 

## Risk

Low. The change only adds a new optional field to the analytics index without modifying existing data structures or breaking changes.

## Tests

Locally

## Deploy Plan

1. Apply the Elasticsearch mapping migration in both US and EU clusters
2. Deploy front
