### PR TITLE
[front] - feat(obs): context origin chart

### DIFF
--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -9,6 +9,10 @@ import { ChartContainer } from "@app/components/agent_builder/observability/shar
 import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { useAgentContextOrigin } from "@app/lib/swr/assistants";
+import {
+  isUserMessageOrigin,
+  USER_MESSAGE_ORIGIN_LABELS,
+} from "@app/types/assistant/conversation";
 
 interface SourceChartProps {
   workspaceId: string;
@@ -33,15 +37,21 @@ export function SourceChart({
 
   const total = contextOrigin.total;
 
-  const data = contextOrigin.buckets.map((b) => ({
-    origin: b.origin,
-    count: b.count,
-    percent: Math.round((b.count / total) * 100),
-  }));
+  const data = contextOrigin.buckets.map((b) => {
+    const label = isUserMessageOrigin(b.origin)
+      ? USER_MESSAGE_ORIGIN_LABELS[b.origin]
+      : b.origin;
+    return {
+      origin: b.origin,
+      label,
+      count: b.count,
+      percent: Math.round((b.count / total) * 100),
+    };
+  });
 
   const legendItems = data.map((d, index) => ({
     key: d.origin,
-    label: d.origin,
+    label: d.label,
     colorClassName: getSourceColor(index),
   }));
 
@@ -67,7 +77,7 @@ export function SourceChart({
                 return null;
               }
               const rows = data.map((d, index) => ({
-                label: d.origin,
+                label: d.label,
                 value: d.count,
                 percent: d.percent,
                 colorClassName: getSourceColor(index),

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -72,7 +72,7 @@ export function SourceChart({
           <Tooltip
             cursor={false}
             wrapperStyle={{ outline: "none" }}
-            content={({ active, payload }) => {
+            content={({ active }) => {
               if (!active || data.length === 0) {
                 return null;
               }

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -1,0 +1,143 @@
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+
+import { CHART_HEIGHT } from "@app/components/agent_builder/observability/constants";
+import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
+import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
+import { ChartLegend } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { useAgentContextOrigin } from "@app/lib/swr/assistants";
+
+type SourceDatum = {
+  origin: string;
+  count: number;
+  percent: number;
+};
+
+const SOURCE_COLORS = [
+  "text-pink-300 dark:text-pink-300-night",
+  "text-blue-400 dark:text-blue-400-night",
+  "text-rose-400 dark:text-rose-400-night",
+  "text-amber-400 dark:text-amber-400-night",
+  "text-violet-300 dark:text-violet-300-night",
+  "text-slate-300 dark:text-slate-300-night",
+] as const;
+
+function getSourceColor(index: number) {
+  return SOURCE_COLORS[index % SOURCE_COLORS.length];
+}
+
+export function SourceChart({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}) {
+  const { period, mode, selectedVersion } = useObservabilityContext();
+
+  const { contextOrigin, isContextOriginLoading, isContextOriginError } =
+    useAgentContextOrigin({
+      workspaceId,
+      agentConfigurationId,
+      days: period,
+      version: mode === "version" ? selectedVersion?.version : undefined,
+      disabled:
+        !workspaceId ||
+        !agentConfigurationId ||
+        (mode === "version" && !selectedVersion),
+    });
+
+  const total = contextOrigin.total ?? 0;
+
+  const data: SourceDatum[] =
+    total === 0
+      ? []
+      : contextOrigin.buckets.map((b) => ({
+          origin: b.origin,
+          count: b.count,
+          percent: Math.round((b.count / total) * 100),
+        }));
+
+  const legendItems = data.map((d, index) => ({
+    key: d.origin,
+    label: d.origin,
+    colorClassName: getSourceColor(index),
+  }));
+
+  return (
+    <ChartContainer
+      title="Source"
+      description="Message volume broken down by source."
+      isLoading={isContextOriginLoading}
+      errorMessage={
+        isContextOriginError ? "Failed to load source breakdown." : undefined
+      }
+      emptyMessage={
+        data.length === 0 ? "No messages for this selection." : undefined
+      }
+    >
+      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+        <PieChart>
+          <Tooltip
+            cursor={false}
+            wrapperStyle={{ outline: "none" }}
+            content={({ active, payload }) => {
+              if (!active || !payload || payload.length === 0) {
+                return null;
+              }
+              const p = payload[0].payload as SourceDatum;
+              return (
+                <ChartTooltipCard
+                  title={p.origin}
+                  rows={[
+                    { label: "Messages", value: p.count },
+                    { label: "Share", value: `${p.percent}%` },
+                  ]}
+                />
+              );
+            }}
+            contentStyle={{
+              background: "transparent",
+              border: "none",
+              padding: 0,
+              boxShadow: "none",
+            }}
+          />
+          <Pie
+            data={data}
+            dataKey="count"
+            nameKey="origin"
+            innerRadius="60%"
+            outerRadius="80%"
+            paddingAngle={3}
+            strokeWidth={0}
+          >
+            {data.map((entry, index) => (
+              <Cell
+                key={entry.origin}
+                className={getSourceColor(index)}
+                fill="currentColor"
+              />
+            ))}
+          </Pie>
+          {/* Center label */}
+          {total > 0 && (
+            <text
+              x="50%"
+              y="50%"
+              textAnchor="middle"
+              dominantBaseline="middle"
+              className="fill-foreground dark:fill-foreground-night"
+            >
+              <tspan className="text-2xl font-semibold">{total}</tspan>
+              <tspan x="50%" dy="1.2em" className="text-sm">
+                Messages
+              </tspan>
+            </text>
+          )}
+        </PieChart>
+      </ResponsiveContainer>
+      <ChartLegend items={legendItems} />
+    </ChartContainer>
+  );
+}

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -63,19 +63,17 @@ export function SourceChart({
             cursor={false}
             wrapperStyle={{ outline: "none" }}
             content={({ active, payload }) => {
-              if (!active || !payload || payload.length === 0) {
+              if (!active || data.length === 0) {
                 return null;
               }
-              const p = payload[0].payload;
-              return (
-                <ChartTooltipCard
-                  title={p.origin}
-                  rows={[
-                    { label: "Messages", value: p.count },
-                    { label: "Share", value: `${p.percent}%` },
-                  ]}
-                />
-              );
+              const rows = data.map((d, index) => ({
+                label: d.origin,
+                value: d.count,
+                percent: d.percent,
+                colorClassName: getSourceColor(index),
+              }));
+
+              return <ChartTooltipCard title="Source breakdown" rows={rows} />;
             }}
             contentStyle={{
               background: "transparent",

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -49,3 +49,16 @@ export const FEEDBACK_DISTRIBUTION_LEGEND = [
   { key: "positive", label: "Positive" },
   { key: "negative", label: "Negative" },
 ] as const;
+
+const SOURCE_COLORS = [
+  "text-pink-300 dark:text-pink-300-night",
+  "text-blue-400 dark:text-blue-400-night",
+  "text-rose-400 dark:text-rose-400-night",
+  "text-amber-400 dark:text-amber-400-night",
+  "text-violet-300 dark:text-violet-300-night",
+  "text-slate-300 dark:text-slate-300-night",
+] as const;
+
+export function getSourceColor(index: number) {
+  return SOURCE_COLORS[index % SOURCE_COLORS.length];
+}

--- a/front/components/agent_builder/observability/types.ts
+++ b/front/components/agent_builder/observability/types.ts
@@ -23,6 +23,12 @@ export type ToolChartUsagePayload = {
   payload?: ChartDatum;
 };
 
+export type SourceChartDatum = {
+  origin: string;
+  count: number;
+  percent: number;
+};
+
 export function isChartDatum(data: unknown): data is ChartDatum {
   if (typeof data !== "object" || data === null) {
     return false;

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -8,6 +8,7 @@ import {
 } from "@dust-tt/sparkle";
 
 import { LatencyChart } from "@app/components/agent_builder/observability/charts/LatencyChart";
+import { SourceChart } from "@app/components/agent_builder/observability/charts/SourceChart";
 import { ToolUsageChart } from "@app/components/agent_builder/observability/charts/ToolUsageChart";
 import { UsageMetricsChart } from "@app/components/agent_builder/observability/charts/UsageMetricsChart";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
@@ -107,6 +108,11 @@ export function AgentObservability({
 
       <TabContentChildSectionLayout title="Details">
         <UsageMetricsChart
+          workspaceId={workspaceId}
+          agentConfigurationId={agentConfigurationId}
+        />
+        <Separator />
+        <SourceChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
         />

--- a/front/lib/api/assistant/observability/context_origin.ts
+++ b/front/lib/api/assistant/observability/context_origin.ts
@@ -1,0 +1,52 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type ContextOriginBucket = {
+  origin: string;
+  count: number;
+};
+
+type ContextOriginAggs = {
+  by_origin?: estypes.AggregationsMultiBucketAggregateBase<{
+    key: string;
+    doc_count: number;
+  }>;
+};
+
+export async function fetchContextOriginBreakdown(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Result<ContextOriginBucket[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_origin: {
+      terms: {
+        field: "context_origin",
+        size: 20,
+        missing: "unknown",
+      },
+    },
+  };
+
+  const result = await searchAnalytics<never, ContextOriginAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const buckets = bucketsToArray<{
+    key: string;
+    doc_count: number;
+  }>(result.value.aggregations?.by_origin?.buckets);
+
+  const mapped: ContextOriginBucket[] = buckets.map((b) => ({
+    origin: String(b.key),
+    count: b.doc_count ?? 0,
+  }));
+
+  return new Ok(mapped);
+}

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -22,6 +22,7 @@ import type { GetErrorRateResponse } from "@app/pages/api/w/[wId]/assistant/agen
 import type { GetFeedbackDistributionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution";
 import type { GetLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency";
 import type { GetAgentOverviewResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview";
+import type { GetContextOriginResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source";
 import type { GetToolExecutionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution";
 import type { GetToolStepIndexResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index";
 import type { GetUsageMetricsResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics";
@@ -811,6 +812,37 @@ export function useAgentUsageMetrics({
     isUsageMetricsLoading: !error && !data && !disabled,
     isUsageMetricsError: error,
     isUsageMetricsValidating: isValidating,
+  };
+}
+
+export function useAgentContextOrigin(params: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  version?: string;
+  disabled?: boolean;
+}) {
+  const {
+    workspaceId,
+    agentConfigurationId,
+    days = DEFAULT_PERIOD_DAYS,
+    version,
+    disabled,
+  } = params;
+  const fetcherFn: Fetcher<GetContextOriginResponse> = fetcher;
+  const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/source?days=${days}${versionParam}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    contextOrigin: data ?? { total: 0, buckets: emptyArray() },
+    isContextOriginLoading: !error && !data && !disabled,
+    isContextOriginError: error,
+    isContextOriginValidating: isValidating,
   };
 }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
@@ -1,0 +1,121 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { fetchContextOriginBreakdown } from "@app/lib/api/assistant/observability/context_origin";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional(),
+  version: z.string().optional(),
+});
+
+export type GetContextOriginResponse = {
+  total: number;
+  buckets: {
+    origin: string;
+    count: number;
+  }[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetContextOriginResponse>>,
+  auth: Authenticator
+) {
+  if (typeof req.query.aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent configuration ID.",
+      },
+    });
+  }
+
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: req.query.aId,
+    variant: "light",
+  });
+
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  if (!assistant.canEdit && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only editors can get agent observability.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        agentId: assistant.sId,
+        days,
+        version: q.data.version,
+      });
+
+      const result = await fetchContextOriginBreakdown(baseQuery);
+
+      if (result.isErr()) {
+        const e = result.error;
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve source breakdown: ${e.message}`,
+          },
+        });
+      }
+
+      const buckets = result.value;
+      const total = buckets.reduce((acc, b) => acc + b.count, 0);
+
+      return res.status(200).json({
+        total,
+        buckets,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -73,6 +73,34 @@ export type UserMessageOrigin =
   | "run_agent"
   | "agent_handover";
 
+export const USER_MESSAGE_ORIGIN_LABELS: Record<UserMessageOrigin, string> = {
+  api: "API",
+  email: "Email",
+  extension: "Chrome extension",
+  "github-copilot-chat": "GitHub Copilot Chat",
+  gsheet: "Google Sheets",
+  make: "Make",
+  n8n: "n8n",
+  raycast: "Raycast",
+  slack: "Slack",
+  teams: "Teams",
+  triggered: "Triggered",
+  triggered_programmatic: "Programmatic trigger",
+  web: "App",
+  zapier: "Zapier",
+  zendesk: "Zendesk",
+  excel: "Excel",
+  powerpoint: "PowerPoint",
+  run_agent: "Agent run",
+  agent_handover: "Agent handover",
+};
+
+export function isUserMessageOrigin(
+  origin: string
+): origin is UserMessageOrigin {
+  return origin in USER_MESSAGE_ORIGIN_LABELS;
+}
+
 export type UserMessageContext = {
   username: string;
   timezone: string;


### PR DESCRIPTION

## Description

Adds a "Source" chart to agent observability that displays message volume breakdown by user context origin (web, slack, api, etc.). This builds on top of PR #17947 which added the `context_origin` field to the analytics index. Implements the full observability pipeline: a new API endpoint to fetch context origin aggregations from Elasticsearch, a new SWR hook to consume the data, and a pie chart component with custom tooltip to visualize the breakdown.

## Risk

Low. This is a new additive feature that only introduces a new chart component and endpoint. No existing functionality is modified.

## Tests

- [ ] Locally
- [ ] Front-edge

## Deploy Plan

Deploy front
