### PR TITLE
Ignore conversation not found in runToolActivity (for real)

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -12,7 +12,7 @@ import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activiti
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type { ModelId } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever, ConversationError } from "@app/types";
 import type { AgentLoopArgsWithTiming } from "@app/types/assistant/agent_run";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";
 
@@ -36,7 +36,10 @@ export async function runToolActivity(
   const runAgentDataRes = await getAgentLoopData(authType, runAgentArgs);
   if (runAgentDataRes.isErr()) {
     // If the conversation is not found, we cannot run the tool and should stop execution here.
-    if (runAgentDataRes.error.message === "conversation_not_found") {
+    if (
+      runAgentDataRes.error instanceof ConversationError &&
+      runAgentDataRes.error.type === "conversation_not_found"
+    ) {
       logger.warn(
         {
           actionId,


### PR DESCRIPTION
## Description

Really fix what we tried to fix [here](https://github.com/dust-tt/dust/pull/17002/files)

## Tests

[No logs with the warning](https://app.datadoghq.eu/logs?query=%22conversation_not_found%20while%20running%20tool%2C%20stopping%20execution%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1762988888680&to_ts=1763161688680&live=true), yet still [a lot of errors](https://app.datadoghq.eu/logs?query=service%3Afront-agent-loop-worker%20status%3Aerror%20%40error.type%3AConversationError&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1760354719591&to_ts=1762946719591&live=true)

## Risk

Low

## Deploy Plan

Deploy connectors.