### PR TITLE
[connectors] Rename assistant into agent in mention type

### DIFF
--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -5,6 +5,7 @@ import type { Activity } from "botbuilder";
 import type { MessageFootnotes } from "@connectors/lib/bot/citations";
 import { convertUrlsToMarkdown } from "@connectors/lib/bot/citations";
 import { makeDustAppUrl } from "@connectors/lib/bot/conversation_utils";
+import type { MentionMatch } from "@connectors/lib/bot/mentions";
 
 const DUST_URL = "https://dust.tt/home";
 
@@ -13,7 +14,7 @@ const DUST_URL = "https://dust.tt/home";
  */
 export function createResponseAdaptiveCard({
   response,
-  assistant,
+  mentionedAgent,
   conversationUrl,
   workspaceId,
   footnotes,
@@ -22,7 +23,7 @@ export function createResponseAdaptiveCard({
   originalMessage,
 }: {
   response: string;
-  assistant: { assistantName: string; assistantId: string };
+  mentionedAgent: MentionMatch;
   conversationUrl: string | null;
   workspaceId: string;
   footnotes?: MessageFootnotes;
@@ -31,7 +32,7 @@ export function createResponseAdaptiveCard({
   originalMessage: string;
 }): Partial<Activity> {
   const currentAgent = agentConfigurations.find(
-    (agent) => agent.sId === assistant.assistantId
+    (agent) => agent.sId === mentionedAgent.agentId
   );
 
   const feedbackActions =
@@ -120,7 +121,7 @@ export function createResponseAdaptiveCard({
       {
         type: "TextBlock",
         text: createFooterText({
-          assistantName: assistant.assistantName,
+          agentName: mentionedAgent.agentName,
           conversationUrl,
           workspaceId,
           isError,
@@ -144,7 +145,7 @@ export function createResponseAdaptiveCard({
           {
             type: "Input.ChoiceSet",
             id: "selectedAgent",
-            value: assistant.assistantName,
+            value: mentionedAgent.agentName,
             choices: agentConfigurations.map((agent) => ({
               title: agent.name,
               value: agent.name,
@@ -202,7 +203,7 @@ export function createStreamingAdaptiveCard({
   response,
 }: {
   response: string;
-  assistantName: string;
+  agentName: string;
   conversationUrl: string | null;
   workspaceId: string;
 }): Partial<Activity> {
@@ -540,28 +541,28 @@ export function createWelcomeAdaptiveCard(): Partial<Activity> {
 }
 
 function createFooterText({
-  assistantName,
+  agentName,
   conversationUrl,
   workspaceId,
   isError = false,
 }: {
-  assistantName?: string;
+  agentName?: string;
   conversationUrl?: string | null;
   workspaceId: string;
   isError?: boolean;
 }): string {
-  const assistantsUrl = makeDustAppUrl(`/w/${workspaceId}/assistant/new`);
+  const agentsUrl = makeDustAppUrl(`/w/${workspaceId}/agent/new`);
 
   let attribution = "";
-  if (assistantName) {
+  if (agentName) {
     if (isError) {
-      attribution = `**${assistantName}** encountered an error | `;
+      attribution = `**${agentName}** encountered an error | `;
     } else {
-      attribution = `Answered by **${assistantName}** | `;
+      attribution = `Answered by **${agentName}** | `;
     }
   }
 
-  const baseLinks = `[Browse agents](${assistantsUrl}) | [Learn more](${DUST_URL})`;
+  const baseLinks = `[Browse agents](${agentsUrl}) | [Learn more](${DUST_URL})`;
 
   return conversationUrl
     ? `${attribution}[Go to full conversation](${conversationUrl}) | ${baseLinks}`

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -12,12 +12,13 @@ import type { Activity, TurnContext } from "botbuilder";
 import removeMarkdown from "remove-markdown";
 
 import { processFileAttachments } from "@connectors/api/webhooks/teams/content_fragments";
-import { getMicrosoftClient } from "@connectors/connectors/microsoft/index";
+import { getMicrosoftClient } from "@connectors/connectors/microsoft";
 import { getMessagesFromConversation } from "@connectors/connectors/microsoft/lib/graph_api";
 import { apiConfig } from "@connectors/lib/api/config";
 import type { MessageFootnotes } from "@connectors/lib/bot/citations";
 import { annotateCitations } from "@connectors/lib/bot/citations";
 import { makeConversationUrl } from "@connectors/lib/bot/conversation_utils";
+import type { MentionMatch } from "@connectors/lib/bot/mentions";
 import { processMessageForMention } from "@connectors/lib/bot/mentions";
 import { MicrosoftBotMessage } from "@connectors/lib/models/microsoft_bot";
 import { getActionName } from "@connectors/lib/tools_utils";
@@ -152,7 +153,7 @@ export async function botAnswerMessage(
 
   const messageReqBody: PublicPostMessagesRequestBody = {
     content: message,
-    mentions: [{ configurationId: mention.assistantId }],
+    mentions: [{ configurationId: mention.agentId }],
     context: {
       timezone: "UTC", // Teams doesn't provide timezone info easily
       username: displayName,
@@ -282,7 +283,7 @@ export async function botAnswerMessage(
 
   const finalCard = createResponseAdaptiveCard({
     response: formattedContent,
-    assistant: mention,
+    mentionedAgent: mention,
     conversationUrl: makeConversationUrl(
       connector.workspaceId,
       conversation.sId
@@ -313,7 +314,7 @@ async function streamAgentResponse({
   dustAPI: DustAPI;
   conversation: ConversationPublicType;
   userMessage: UserMessageType;
-  mention: { assistantName: string; assistantId: string };
+  mention: MentionMatch;
   connector: ConnectorResource;
   agentActivityId: string;
   localLogger: Logger;
@@ -389,7 +390,7 @@ async function streamAgentResponse({
 
             const streamingCard = createStreamingAdaptiveCard({
               response: formattedContent,
-              assistantName: mention.assistantName,
+              agentName: mention.agentName,
               conversationUrl: null,
               workspaceId: connector.workspaceId,
             });
@@ -411,7 +412,7 @@ async function streamAgentResponse({
         const action = getActionName(event.action);
         const streamingCard = createStreamingAdaptiveCard({
           response: action,
-          assistantName: mention.assistantName,
+          agentName: mention.agentName,
           conversationUrl: null,
           workspaceId: connector.workspaceId,
         });

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -808,7 +808,7 @@ async function answerMessage(
   // Remove markdown to extract mentions.
   const messageWithoutMarkdown = removeMarkdown(message);
 
-  let mention: { assistantName: string; assistantId: string } | undefined;
+  let mention: { agentName: string; agentId: string } | undefined;
 
   // Extract all ~mentions and +mentions
   const mentionCandidates =
@@ -828,8 +828,8 @@ async function answerMessage(
       message = message.replace(mc, "");
     }
     mention = {
-      assistantId: agentConfig.sId,
-      assistantName: agentConfig.name,
+      agentId: agentConfig.sId,
+      agentName: agentConfig.name,
     };
   } else {
     if (mentionCandidates.length > 1) {
@@ -872,8 +872,8 @@ async function answerMessage(
 
     if (agentConfigurationToMention) {
       mention = {
-        assistantId: agentConfigurationToMention.sId,
-        assistantName: agentConfigurationToMention.name,
+        agentId: agentConfigurationToMention.sId,
+        agentName: agentConfigurationToMention.name,
       };
     } else {
       // If no mention is found and no channel-based routing rule is found, we use the default agent.
@@ -895,8 +895,8 @@ async function answerMessage(
         );
       }
       mention = {
-        assistantId: defaultAssistant.sId,
-        assistantName: defaultAssistant.name,
+        agentId: defaultAssistant.sId,
+        agentName: defaultAssistant.name,
       };
     }
   }
@@ -911,14 +911,14 @@ async function answerMessage(
     const isRestrictedRes = await isAgentAccessingRestrictedSpace(
       dustAPI,
       activeAgentConfigurations,
-      mention.assistantId
+      mention.agentId
     );
 
     if (isRestrictedRes.isErr()) {
       logger.error(
         {
           error: isRestrictedRes.error,
-          agentId: mention.assistantId,
+          agentId: mention.agentId,
           connectorId: connector.id,
         },
         "Error determining if agent is from restricted space"
@@ -947,7 +947,7 @@ async function answerMessage(
 
   const mainMessage = await slackClient.chat.postMessage({
     ...makeMessageUpdateBlocksAndText(null, connector.workspaceId, {
-      assistantName: mention.assistantName,
+      assistantName: mention.agentName,
       agentConfigurations: mostPopularAgentConfigurations,
       isThinking: true,
     }),
@@ -991,12 +991,12 @@ async function answerMessage(
 
   if (!message.includes(":mention")) {
     // if the message does not contain the mention, we add it as a prefix.
-    message = `:mention[${mention.assistantName}]{sId=${mention.assistantId}} ${message}`;
+    message = `:mention[${mention.agentName}]{sId=${mention.agentId}} ${message}`;
   }
 
   const messageReqBody: PublicPostMessagesRequestBody = {
     content: message,
-    mentions: [{ configurationId: mention.assistantId }],
+    mentions: [{ configurationId: mention.agentId }],
     context: {
       timezone: slackChatBotMessage.slackTimezone || "Europe/Paris",
       username: slackChatBotMessage.slackUserName,
@@ -1090,7 +1090,7 @@ async function answerMessage(
   }
 
   const streamRes = await streamConversationToSlack(dustAPI, {
-    assistantName: mention.assistantName,
+    assistantName: mention.agentName,
     connector,
     conversation,
     mainMessage,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -53,6 +53,7 @@ import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { makeConversationUrl } from "@connectors/lib/bot/conversation_utils";
+import type { MentionMatch } from "@connectors/lib/bot/mentions";
 import { processMentions } from "@connectors/lib/bot/mentions";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import { sectionFullText } from "@connectors/lib/data_sources";
@@ -808,7 +809,7 @@ async function answerMessage(
   // Remove markdown to extract mentions.
   const messageWithoutMarkdown = removeMarkdown(message);
 
-  let mention: { agentName: string; agentId: string } | undefined;
+  let mention: MentionMatch | undefined;
 
   // Extract all ~mentions and +mentions
   const mentionCandidates =

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -877,16 +877,16 @@ async function answerMessage(
       };
     } else {
       // If no mention is found and no channel-based routing rule is found, we use the default agent.
-      let defaultAssistant: LightAgentConfigurationType | undefined = undefined;
+      let defaultAgent: LightAgentConfigurationType | undefined = undefined;
       for (const agent of DEFAULT_AGENTS) {
-        defaultAssistant = activeAgentConfigurations.find(
+        defaultAgent = activeAgentConfigurations.find(
           (ac) => ac.sId === agent && ac.status === "active"
         );
-        if (defaultAssistant) {
+        if (defaultAgent) {
           break;
         }
       }
-      if (!defaultAssistant) {
+      if (!defaultAgent) {
         return new Err(
           // not actually reachable, gpt-4 cannot be disabled.
           new SlackExternalUserError(
@@ -895,8 +895,8 @@ async function answerMessage(
         );
       }
       mention = {
-        agentId: defaultAssistant.sId,
-        agentName: defaultAssistant.name,
+        agentId: defaultAgent.sId,
+        agentName: defaultAgent.name,
       };
     }
   }

--- a/connectors/src/lib/bot/mentions.ts
+++ b/connectors/src/lib/bot/mentions.ts
@@ -3,8 +3,8 @@ import { Err, Ok } from "@dust-tt/client";
 import jaroWinkler from "talisman/metrics/jaro-winkler";
 
 type MentionMatch = {
-  assistantId: string;
-  assistantName: string;
+  agentId: string;
+  agentName: string;
 };
 
 // Pattern to match @mention, +mention, and ~mention.
@@ -35,8 +35,8 @@ export function processMentions({
   }
 
   let bestCandidate: {
-    assistantId: string;
-    assistantName: string;
+    agentId: string;
+    agentName: string;
     distance: number;
   } | null = null;
 
@@ -50,8 +50,8 @@ export function processMentions({
 
     if (bestCandidate === null || bestCandidate.distance > distance) {
       bestCandidate = {
-        assistantId: agentConfiguration.sId,
-        assistantName: agentConfiguration.name,
+        agentId: agentConfiguration.sId,
+        agentName: agentConfiguration.name,
         distance: distance,
       };
     }
@@ -64,12 +64,12 @@ export function processMentions({
   }
 
   const mention = {
-    assistantId: bestCandidate.assistantId,
-    assistantName: bestCandidate.assistantName,
+    agentId: bestCandidate.agentId,
+    agentName: bestCandidate.agentName,
   };
   const processedMessage = message.replace(
     mentionCandidate,
-    `:mention[${bestCandidate.assistantName}]{sId=${bestCandidate.assistantId}}`
+    `:mention[${bestCandidate.agentName}]{sId=${bestCandidate.agentId}}`
   );
 
   return new Ok({
@@ -164,14 +164,14 @@ export function processMessageForMention({
       return new Err(new Error("No agent has been configured to reply."));
     }
     mention = {
-      assistantId: defaultAssistant.sId,
-      assistantName: defaultAssistant.name,
+      agentId: defaultAssistant.sId,
+      agentName: defaultAssistant.name,
     };
   }
 
   if (!processedMessage.includes(":mention")) {
     // if the message does not contain the mention, we add it as a prefix.
-    processedMessage = `:mention[${mention.assistantName}]{sId=${mention.assistantId}} ${processedMessage}`;
+    processedMessage = `:mention[${mention.agentName}]{sId=${mention.agentId}} ${processedMessage}`;
   }
 
   return new Ok({

--- a/connectors/src/lib/bot/mentions.ts
+++ b/connectors/src/lib/bot/mentions.ts
@@ -2,7 +2,7 @@ import type { LightAgentConfigurationType, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import jaroWinkler from "talisman/metrics/jaro-winkler";
 
-type MentionMatch = {
+export type MentionMatch = {
   agentId: string;
   agentName: string;
 };

--- a/connectors/src/lib/bot/mentions.ts
+++ b/connectors/src/lib/bot/mentions.ts
@@ -58,9 +58,7 @@ export function processMentions({
   }
 
   if (!bestCandidate) {
-    return new Err(
-      new Error(`Assistant ${mentionCandidate} has not been found.`)
-    );
+    return new Err(new Error(`Agent ${mentionCandidate} has not been found.`));
   }
 
   const mention = {
@@ -151,21 +149,21 @@ export function processMessageForMention({
 
   if (!mention) {
     // Use default agent if no mention found
-    let defaultAssistant: LightAgentConfigurationType | undefined = undefined;
+    let defaultAgent: LightAgentConfigurationType | undefined = undefined;
     for (const agentId of fallbackAgentIds) {
-      defaultAssistant = activeAgentConfigurations.find(
+      defaultAgent = activeAgentConfigurations.find(
         (ac) => ac.sId === agentId && ac.status === "active"
       );
-      if (defaultAssistant) {
+      if (defaultAgent) {
         break;
       }
     }
-    if (!defaultAssistant) {
+    if (!defaultAgent) {
       return new Err(new Error("No agent has been configured to reply."));
     }
     mention = {
-      agentId: defaultAssistant.sId,
-      agentName: defaultAssistant.name,
+      agentId: defaultAgent.sId,
+      agentName: defaultAgent.name,
     };
   }
 

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -25,7 +25,6 @@ import {
   MCPAgentMemoryRetrieveActionDetails,
 } from "@app/components/actions/mcp/details/MCPAgentMemoryActionDetails";
 import { MCPBrowseActionDetails } from "@app/components/actions/mcp/details/MCPBrowseActionDetails";
-import { MCPConversationCatFileDetails } from "@app/components/actions/mcp/details/MCPConversationFilesActionDetails";
 import {
   DataSourceNodeContentDetails,
   FilesystemPathDetails,
@@ -42,7 +41,6 @@ import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPTool
 import { MCPToolsetsEnableActionDetails } from "@app/components/actions/mcp/details/MCPToolsetsEnableActionDetails";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
-import { DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME } from "@app/lib/actions/constants";
 import {
   DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME,
   DATA_WAREHOUSES_FIND_TOOL_NAME,
@@ -306,12 +304,6 @@ export function MCPActionDetails({
     }
     if (toolName === DATA_WAREHOUSES_QUERY_TOOL_NAME) {
       return <MCPTablesQueryActionDetails {...toolOutputDetailsProps} />;
-    }
-  }
-
-  if (isInternalMCPServerOfName(mcpServerId, "conversation_files")) {
-    if (toolName === DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME) {
-      return <MCPConversationCatFileDetails {...toolOutputDetailsProps} />;
     }
   }
 

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -25,6 +25,7 @@ import {
   MCPAgentMemoryRetrieveActionDetails,
 } from "@app/components/actions/mcp/details/MCPAgentMemoryActionDetails";
 import { MCPBrowseActionDetails } from "@app/components/actions/mcp/details/MCPBrowseActionDetails";
+import { MCPConversationCatFileDetails } from "@app/components/actions/mcp/details/MCPConversationFilesActionDetails";
 import {
   DataSourceNodeContentDetails,
   FilesystemPathDetails,
@@ -41,6 +42,7 @@ import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPTool
 import { MCPToolsetsEnableActionDetails } from "@app/components/actions/mcp/details/MCPToolsetsEnableActionDetails";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
+import { DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME } from "@app/lib/actions/constants";
 import {
   DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME,
   DATA_WAREHOUSES_FIND_TOOL_NAME,
@@ -304,6 +306,12 @@ export function MCPActionDetails({
     }
     if (toolName === DATA_WAREHOUSES_QUERY_TOOL_NAME) {
       return <MCPTablesQueryActionDetails {...toolOutputDetailsProps} />;
+    }
+  }
+
+  if (isInternalMCPServerOfName(mcpServerId, "conversation_files")) {
+    if (toolName === DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME) {
+      return <MCPConversationCatFileDetails {...toolOutputDetailsProps} />;
     }
   }
 


### PR DESCRIPTION
## Description

- This PR renames `assistant` into `agent` in the implementation of the code handling bots, specifically for mentions.
- Prepares for a follow up PR, where the diff will potentially be horrible if mixed with this PR.
- No behavior change, except for the fallback message displayed when a user mentions multiple agents at once.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
