### PR TITLE
[front] Add custom component for JIT cat

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -25,6 +25,7 @@ import {
   MCPAgentMemoryRetrieveActionDetails,
 } from "@app/components/actions/mcp/details/MCPAgentMemoryActionDetails";
 import { MCPBrowseActionDetails } from "@app/components/actions/mcp/details/MCPBrowseActionDetails";
+import { MCPConversationCatFileDetails } from "@app/components/actions/mcp/details/MCPConversationFilesActionDetails";
 import {
   DataSourceNodeContentDetails,
   FilesystemPathDetails,
@@ -41,6 +42,7 @@ import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPTool
 import { MCPToolsetsEnableActionDetails } from "@app/components/actions/mcp/details/MCPToolsetsEnableActionDetails";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
+import { DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME } from "@app/lib/actions/constants";
 import {
   DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME,
   DATA_WAREHOUSES_FIND_TOOL_NAME,
@@ -304,6 +306,12 @@ export function MCPActionDetails({
     }
     if (toolName === DATA_WAREHOUSES_QUERY_TOOL_NAME) {
       return <MCPTablesQueryActionDetails {...toolOutputDetailsProps} />;
+    }
+  }
+
+  if (isInternalMCPServerOfName(mcpServerId, "conversation_files")) {
+    if (toolName === DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME) {
+      return <MCPConversationCatFileDetails {...toolOutputDetailsProps} />;
     }
   }
 

--- a/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
@@ -62,10 +62,7 @@ export function MCPConversationCatFileDetails({
             }
             contentChildren={
               <div className="py-2">
-                <CodeBlock
-                  className="language-text max-h-32 overflow-y-auto"
-                  wrapLongLines={true}
-                >
+                <CodeBlock className="language-text max-h-32 overflow-y-auto">
                   {truncatedContent}
                 </CodeBlock>
               </div>

--- a/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
@@ -1,0 +1,73 @@
+import {
+  CodeBlock,
+  CollapsibleComponent,
+  DocumentIcon,
+} from "@dust-tt/sparkle";
+
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+
+const MAX_SNIPPET_LENGTH = 200;
+
+export function MCPConversationCatFileDetails({
+  toolOutput,
+  viewType,
+}: ToolExecutionDetailsProps) {
+  const contentBlock = toolOutput?.find(isTextContent);
+  const content = contentBlock?.text ?? null;
+
+  if (!content) {
+    return (
+      <ActionDetailsWrapper
+        viewType={viewType}
+        actionName={
+          viewType === "conversation"
+            ? "Reading conversation file"
+            : "Read conversation file"
+        }
+        visual={DocumentIcon}
+      />
+    );
+  }
+
+  const snippet =
+    content.length > MAX_SNIPPET_LENGTH
+      ? content.slice(0, MAX_SNIPPET_LENGTH) + "..."
+      : content;
+
+  return (
+    <ActionDetailsWrapper
+      viewType={viewType}
+      actionName={
+        viewType === "conversation"
+          ? "Reading conversation file"
+          : "Read conversation file"
+      }
+      visual={DocumentIcon}
+    >
+      {viewType === "sidebar" && (
+        <div className="flex flex-col gap-4 pl-6 pt-4">
+          <CollapsibleComponent
+            rootProps={{ defaultOpen: false }}
+            triggerChildren={
+              <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                Preview
+              </span>
+            }
+            contentChildren={
+              <div className="py-2">
+                <CodeBlock
+                  className="language-text max-h-32 overflow-y-auto"
+                  wrapLongLines={true}
+                >
+                  {snippet}
+                </CodeBlock>
+              </div>
+            }
+          />
+        </div>
+      )}
+    </ActionDetailsWrapper>
+  );
+}

--- a/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
@@ -8,7 +8,7 @@ import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapp
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
-const MAX_SNIPPET_LENGTH = 200;
+const MAX_PREVIEW_LINES = 10;
 
 export function MCPConversationCatFileDetails({
   toolOutput,
@@ -27,13 +27,18 @@ export function MCPConversationCatFileDetails({
             : "Read conversation file"
         }
         visual={DocumentIcon}
-      />
+      >
+        <></>
+      </ActionDetailsWrapper>
     );
   }
 
-  const snippet =
-    content.length > MAX_SNIPPET_LENGTH
-      ? content.slice(0, MAX_SNIPPET_LENGTH) + "..."
+  // Skip the first line with the XML tag.
+  const lines = content.split("\n").slice(1);
+  const truncatedContent =
+    lines.length > MAX_PREVIEW_LINES
+      ? lines.join("\n") +
+        `\n... (${lines.length - MAX_PREVIEW_LINES} more lines)`
       : content;
 
   return (
@@ -61,7 +66,7 @@ export function MCPConversationCatFileDetails({
                   className="language-text max-h-32 overflow-y-auto"
                   wrapLongLines={true}
                 >
-                  {snippet}
+                  {truncatedContent}
                 </CodeBlock>
               </div>
             }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5137.
- This PR adds a custom component for the JIT cat tool's details, both in the conversation and in the sidebar.
- This change improves the display in the conversation, replacing `Running a tool: Conversation Files Cat` with `Reading conversation file`.

<img width="424" height="820" alt="Screenshot 2025-11-17 at 10 34 29 AM" src="https://github.com/user-attachments/assets/cb146764-f3e5-4cae-ba5a-4e18d1596235" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
