### PR TITLE
[connectors] enh(Slack): only trigger agent tagging on word following @Dust mention

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -816,7 +816,7 @@ async function answerMessage(
   let mention: MentionMatch | undefined;
 
   // Extract all ~mentions and +mentions that appear right after the bot mention.
-  let mentionCandidates: RegExpMatchArray | [] = [];
+  let mentionCandidate: string | null = null;
   if (textAfterBotMention !== null) {
     const textAfterBotMentionWithoutMarkdown =
       removeMarkdown(textAfterBotMention);
@@ -826,7 +826,7 @@ async function answerMessage(
     );
 
     if (firstMatch?.[1]) {
-      mentionCandidates = [firstMatch[1]];
+      mentionCandidate = firstMatch[1] ?? null;
 
       // If the user tagged multiple agents, we need to show a custom message since we only support one agent at a time
       // and they will expect all agents to answer.
@@ -855,8 +855,8 @@ async function answerMessage(
       return new Err(new SlackExternalUserError("Cannot find selected agent."));
     }
     // Removing all previous mentions.
-    for (const mc of mentionCandidates) {
-      message = message.replace(mc, "");
+    if (mentionCandidate) {
+      message = message.replace(mentionCandidate, "");
     }
     mention = {
       agentId: agentConfig.sId,
@@ -866,7 +866,7 @@ async function answerMessage(
     const mentionResult = processMentions({
       message,
       activeAgentConfigurations,
-      mentionCandidates,
+      mentionCandidate,
     });
     if (mentionResult.isErr()) {
       return new Err(new SlackExternalUserError(mentionResult.error.message));

--- a/connectors/src/lib/bot/mentions.ts
+++ b/connectors/src/lib/bot/mentions.ts
@@ -13,11 +13,11 @@ const MENTION_PATTERN = /(?<!\S)[@+~]([a-zA-Z0-9_-]{1,40})(?=\s|,|\.|$|)/g;
 export function processMentions({
   message,
   activeAgentConfigurations,
-  mentionCandidates,
+  mentionCandidate,
 }: {
   message: string;
   activeAgentConfigurations: LightAgentConfigurationType[];
-  mentionCandidates: RegExpMatchArray | [];
+  mentionCandidate: string | null;
 }): Result<
   {
     mention: MentionMatch | undefined;
@@ -25,8 +25,6 @@ export function processMentions({
   },
   Error
 > {
-  const [mentionCandidate] = mentionCandidates;
-
   if (!mentionCandidate) {
     return new Ok({
       mention: undefined,
@@ -135,7 +133,7 @@ export function processMessageForMention({
   const mentionResult = processMentions({
     message,
     activeAgentConfigurations,
-    mentionCandidates,
+    mentionCandidate: mentionCandidates[0] ?? null,
   });
 
   if (mentionResult.isErr()) {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/4623.
- This PR updates the logic to find agent mentions in slack messages to only match words right after the `@Dust` mention.
- Examples can be found [here](https://casquedelumiere.slack.com/archives/C099JJPPMSA/p1763284692995989).

## Tests

- Tested locally.

## Risk

- Medium, non negligible change in behavior.

## Deploy Plan

- Deploy connectors.
