### PR TITLE
[front] Fix case handling in agent search

### DIFF
--- a/front/components/assistant/AgentBrowser.tsx
+++ b/front/components/assistant/AgentBrowser.tsx
@@ -302,7 +302,7 @@ export function AgentBrowser({
         .sort((a, b) => {
           return (
             compareForFuzzySort(
-              assistantSearch,
+              assistantSearch.toLowerCase(),
               getAgentSearchString(a),
               getAgentSearchString(b)
             ) ||

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -199,7 +199,7 @@ export default function WorkspaceAssistants({
         )
         .sort((a, b) => {
           return compareForFuzzySort(
-            assistantSearch,
+            assistantSearch.toLowerCase(),
             getAgentSearchString(a),
             getAgentSearchString(b)
           );


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5138.
- This PR fixes the agent search in `AgentBrowser`, we compare a lower-cased string with a one that is not lower case, breaking the sorting. The filtering correctly handles this.

## Tests

- Tested locally, addressed the problem mentioned in the issue.

## Risk

- Low but changes the behavior of the search.

## Deploy Plan

- Deploy front.
