### PR TITLE
fix(front): enable debugging vitest

### DIFF
--- a/.run/Template Vitest.run.xml
+++ b/.run/Template Vitest.run.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="JavaScriptTestRunnerVitest">
+    <config value="$PROJECT_DIR$/front/vite.config.mjs" />
+    <node-interpreter value="project" />
+    <envs>
+      <env name="VITEST_DEBUG" value="1" />
+      <env name="CONNECTORS_DATABASE_URI" value="postgres://dev:dev@localhost:5432/dust_front_test" />
+      <env name="FRONT_DATABASE_URI" value="postgres://dev:dev@localhost:5432/dust_front_test" />
+      <env name="NODE_ENV" value="test" />
+    </envs>
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/front/TESTING.md
+++ b/front/TESTING.md
@@ -1,0 +1,34 @@
+Debugging Vitest tests in the front package
+
+This repository is configured so you can reliably hit breakpoints when running tests under a debugger, while keeping the default behavior optimized for isolation and performance in CI and regular runs.
+
+How it works
+
+- By default, Vitest runs with a pool of forked processes so each test file is isolated and can rely on CLS-based transaction isolation.
+- When a debugger is detected, Vitest automatically switches to a single-threaded worker pool so the Node inspector can attach to the worker running your tests and breakpoints will hit.
+
+Ways to enable debug mode
+
+- Option A: Set an environment variable.
+  - VITEST_DEBUG=1 pnpm --filter front test:watch
+  - Or: VITEST_DEBUG=1 pnpm --filter front vitest --inspect-brk
+
+- Option B: Start Vitest with Node’s inspector flags.
+  - node --inspect-brk $(pnpm bin)/vitest --watch
+  - Or configure your IDE to run Vitest with --inspect or --inspect-brk.
+
+Behavior summary
+
+- Debug mode ON (via VITEST_DEBUG=1 or --inspect/--inspect-brk):
+  - pool: "threads"
+  - singleThread: true
+  - Breakpoints in tests will stop reliably.
+
+- Debug mode OFF (default):
+  - pool: "forks"
+  - Multiple forks for parallelism and isolation remain enabled, matching CI.
+
+Notes
+
+- CI behavior is unchanged; it continues using forks for isolation and performance.
+- No application runtime behavior is affected outside of test runs.

--- a/front/vite.config.mjs
+++ b/front/vite.config.mjs
@@ -10,14 +10,36 @@ export default defineConfig({
     setupFiles: "./vite.setup.ts",
     globalSetup: "./vite.globalSetup.ts",
 
-    // We uses forks instead of threads to isolate tests in separate processes that can rely on CLS for transactions isolation.
-    pool: "forks",
-    poolOptions: {
-      forks: {
-        singleFork: false, // Use multiple forks for parallelism
-        isolate: true, // Each test file gets its own proces
-      },
-    },
+    // We use forks by default to isolate tests in separate processes that can rely on CLS for
+    // transactions isolation. However, when a debugger is attached (Node --inspect), we switch to
+    // a single-threaded pool so breakpoints hit reliably. Vitest runs workers in separate
+    // processes/threads and the Node inspector only attaches to the main process by default.
+    // Detect an attached debugger by checking execArgv and a dedicated env var for flexibility.
+    ...(function resolvePoolForDebug() {
+      const isDebug =
+        process.env.VITEST_DEBUG === "1" ||
+        process.execArgv?.some((a) => a.includes("--inspect")) === true;
+
+      if (isDebug) {
+        return {
+          pool: "threads",
+          poolOptions: {
+            threads: {
+              singleThread: true, // Run everything in a single worker to allow debugger attach.
+            },
+          },
+        };
+      }
+      return {
+        pool: "forks",
+        poolOptions: {
+          forks: {
+            singleFork: false, // Use multiple forks for parallelism
+            isolate: true, // Each test file gets its own process
+          },
+        },
+      };
+    })(),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Description

We couldn't debug vitest tests, now we can. I also added the run for intelliJ
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
