### PR TITLE
[Poke Plugins] Fix Update Agent Editors search

### DIFF
--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -83,7 +83,7 @@ export function EnumSelect({
                 const isSelected = values?.includes(option.value);
                 return (
                   <PokeCommandItem
-                    value={option.value}
+                    value={option.label}
                     key={option.value}
                     onSelect={() => {
                       onValuesChange([option.value]);


### PR DESCRIPTION
## Description
Fixes issue in the "Update Agent Editors" Poke plugin where the member search field did not match on member names/emails, because the enum select items used the internal value (ID) as the searchable string instead of the human-readable label. The fix makes the Poke enum select search over option labels, restoring search for this plugin and any other enum-based plugins.

## Risks
Blast radius: Poke UI enum select search behavior for all plugins that use async/sync enum args (search now matches labels instead of internal IDs).
Risk: low

## Deploy Plan
- deploy front
