### PR TITLE
feat(front): support credentials in slack oauth provider for connection use-case

### DIFF
--- a/front/components/data_source/slack/SlackOAuthExtraConfig.tsx
+++ b/front/components/data_source/slack/SlackOAuthExtraConfig.tsx
@@ -1,0 +1,97 @@
+import { Input } from "@dust-tt/sparkle";
+import { useEffect } from "react";
+
+import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers";
+import {
+  SlackClientIdSchema,
+  SlackCredentialsStrictSchema,
+  SlackSecretSchema,
+} from "@app/types";
+
+export function SlackOAuthExtraConfig({
+  extraConfig,
+  setExtraConfig,
+  setIsExtraConfigValid,
+}: ConnectorOauthExtraConfigProps) {
+  useEffect(() => {
+    setIsExtraConfigValid(
+      SlackCredentialsStrictSchema.safeParse(extraConfig).success
+    );
+  }, [extraConfig, setIsExtraConfigValid]);
+
+  const isErrorClientId =
+    typeof extraConfig.client_id === "string" &&
+    extraConfig.client_id.length > 0 &&
+    !SlackClientIdSchema.safeParse(extraConfig.client_id).success;
+
+  const isErrorClientSecret =
+    typeof extraConfig.client_secret === "string" &&
+    extraConfig.client_secret.length > 0 &&
+    !SlackSecretSchema.safeParse(extraConfig.client_secret).success;
+
+  const isErrorSigningSecret =
+    typeof extraConfig.signing_secret === "string" &&
+    extraConfig.signing_secret.length > 0 &&
+    !SlackSecretSchema.safeParse(extraConfig.signing_secret).success;
+
+  return (
+    <>
+      <Input
+        label="Client ID"
+        message={
+          isErrorClientId
+            ? "Invalid format. Client ID must be two groups of digits separated by a dot (e.g., 1234567890.0987654321)."
+            : "Find this in your Slack app settings under 'App Credentials'."
+        }
+        name="client_id"
+        value={extraConfig.client_id ?? ""}
+        placeholder="1234567890.0987654321"
+        onChange={(e) => {
+          setExtraConfig((prev: Record<string, string>) => ({
+            ...prev,
+            client_id: e.target.value,
+          }));
+        }}
+        messageStatus={isErrorClientId ? "error" : "default"}
+      />
+      <Input
+        label="Client Secret"
+        message={
+          isErrorClientSecret
+            ? "Invalid format. Client Secret must be exactly 32 hexadecimal characters (0-9, a-f)."
+            : "Find this in your Slack app settings under 'App Credentials'."
+        }
+        name="client_secret"
+        value={extraConfig.client_secret ?? ""}
+        placeholder="a1b2c3..."
+        type="password"
+        onChange={(e) => {
+          setExtraConfig((prev: Record<string, string>) => ({
+            ...prev,
+            client_secret: e.target.value,
+          }));
+        }}
+        messageStatus={isErrorClientSecret ? "error" : "default"}
+      />
+      <Input
+        label="Signing Secret"
+        message={
+          isErrorSigningSecret
+            ? "Invalid format. Signing Secret must be exactly 32 hexadecimal characters (0-9, a-f)."
+            : "Find this in your Slack app settings under 'App Credentials'."
+        }
+        name="signing_secret"
+        value={extraConfig.signing_secret ?? ""}
+        placeholder="d4e5f6..."
+        type="password"
+        onChange={(e) => {
+          setExtraConfig((prev: Record<string, string>) => ({
+            ...prev,
+            signing_secret: e.target.value,
+          }));
+        }}
+        messageStatus={isErrorSigningSecret ? "error" : "default"}
+      />
+    </>
+  );
+}

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -26,6 +26,7 @@ import { GongOptionComponent } from "@app/components/data_source/gong/GongOption
 import { IntercomConfigView } from "@app/components/data_source/IntercomConfigView";
 import { MicrosoftOAuthExtraConfig } from "@app/components/data_source/MicrosoftOAuthExtraConfig";
 import { SalesforceOauthExtraConfig } from "@app/components/data_source/salesforce/SalesforceOAuthExtractConfig";
+import { SlackOAuthExtraConfig } from "@app/components/data_source/slack/SlackOAuthExtraConfig";
 import { SlackBotEnableView } from "@app/components/data_source/SlackBotEnableView";
 import { ZendeskConfigView } from "@app/components/data_source/ZendeskConfigView";
 import { ZendeskOAuthExtraConfig } from "@app/components/data_source/ZendeskOAuthExtraConfig";
@@ -204,7 +205,8 @@ export const CONNECTOR_CONFIGURATIONS: Record<
   slack: {
     name: "Slack",
     connectorProvider: "slack",
-    status: "built",
+    status: "rolling_out",
+    rollingOutFlag: "slack_connector_creation_enabled",
     // TODO(slack 2025-06-19): Hide the Slack connector until we publish the new app.
     hide: true,
     description:
@@ -217,6 +219,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
       return SlackLogo;
     },
     optionsComponent: SlackBotEnableView,
+    oauthExtraConfigComponent: SlackOAuthExtraConfig,
     isNested: false,
     isTitleFilterEnabled: true,
     permissions: {

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -1,4 +1,5 @@
 import * as t from "io-ts";
+import z from "zod";
 
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { validateUrl } from "@app/types/shared/utils/url_utils";
@@ -444,6 +445,14 @@ export const SalesforceCredentialsSchema = t.type({
 export type SalesforceCredentials = t.TypeOf<
   typeof SalesforceCredentialsSchema
 >;
+
+export const SlackClientIdSchema = z.string().regex(/^\d+\.\d+$/);
+export const SlackSecretSchema = z.string().regex(/^[a-f0-9]{32}$/i);
+export const SlackCredentialsStrictSchema = z.strictObject({
+  client_id: SlackClientIdSchema,
+  client_secret: SlackSecretSchema,
+  signing_secret: SlackSecretSchema,
+});
 
 export const NotionCredentialsSchema = t.type({
   integration_token: t.string,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -184,6 +184,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Slack semantic search feature",
     stage: "on_demand",
   },
+  slack_connector_creation_enabled: {
+    description: "Enabled Slack connector creation on workspace.",
+    stage: "on_demand",
+  },
   web_summarization: {
     description: "AI-powered web page summarization in the web browser tool",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -679,6 +679,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesloft_tool"
   | "show_debug_tools"
   | "slack_bot_mcp"
+  | "slack_connector_creation_enabled"
   | "slack_enhanced_default_agent"
   | "slack_files_write_scope"
   | "slack_message_splitting"


### PR DESCRIPTION
## Description

Adds support for custom Slack app credentials (client_id, client_secret, signing_secret) in the Slack OAuth provider for the `connection` use-case.

This enables enterprise customers to use their own Slack apps instead of Dust's default app, which helps mitigate rate-limiting issues. The implementation follows the same pattern as Salesforce, Gmail, and other providers that support custom credentials.

## Risk

Low

## Tests

Manually tested the OAuth flow with custom credentials for the connection use-case.


## Deploy Plan
Front.