### PR TITLE
feat: add traceId in logs

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -115,6 +115,7 @@ export abstract class LLM {
             message: currentEvent.content.message,
             modelId: this.modelId,
             context: this.context,
+            traceId: this.traceId,
           },
           "LLM Error"
         );
@@ -124,6 +125,7 @@ export abstract class LLM {
             llmEventType: "success",
             modelId: this.modelId,
             context: this.context,
+            traceId: this.traceId,
           },
           "LLM Success"
         );
@@ -134,6 +136,7 @@ export abstract class LLM {
             lastEventType: currentEvent?.type,
             modelId: this.modelId,
             context: this.context,
+            traceId: this.traceId,
           },
           "LLM uncategorized"
         );


### PR DESCRIPTION
## Description

Add traceId in llm router logs so we can retrieve the trace for non-conversations

## Tests



## Risk

low

## Deploy Plan

front
