### PR TITLE
feat: add workspace id in runMultiActionsAgent context

### DIFF
--- a/front/lib/api/assistant/agent_suggestion.ts
+++ b/front/lib/api/assistant/agent_suggestion.ts
@@ -138,6 +138,7 @@ export async function getSuggestedAgentsForContent(
         operationType: "agent_suggestion",
         contextId: conversationId,
         userId: auth.user()?.sId,
+        workspaceId: owner.sId,
       },
     }
   );

--- a/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
+++ b/front/lib/api/assistant/configuration/triggers/cron_timezone.ts
@@ -84,6 +84,7 @@ export async function getCronTimezoneGeneration(
       context: {
         operationType: "trigger_cron_timezone_generator",
         userId: auth.user()?.sId,
+        workspaceId: owner.sId,
       },
     }
   );

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
@@ -310,6 +310,7 @@ export async function getWebhookFilterGeneration(
       context: {
         operationType: "trigger_webhook_filter_generator",
         userId: auth.user()?.sId,
+        workspaceId: owner.sId,
       },
     }
   );

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -164,6 +164,7 @@ async function generateConversationTitle(
         operationType: "conversation_title_suggestion",
         contextId: conversation.sId,
         userId: auth.user()?.sId,
+        workspaceId: owner.sId,
       },
     }
   );

--- a/front/lib/api/assistant/process_data_sources.ts
+++ b/front/lib/api/assistant/process_data_sources.ts
@@ -183,6 +183,7 @@ export async function processDataSources({
           context: {
             operationType: "process_data_sources",
             userId: auth.user()?.sId,
+            workspaceId: auth.getNonNullableWorkspace().sId,
           },
         }
       );

--- a/front/lib/api/assistant/suggestions/description.ts
+++ b/front/lib/api/assistant/suggestions/description.ts
@@ -75,6 +75,7 @@ export async function getBuilderDescriptionSuggestions(
       context: {
         operationType: "agent_builder_description_suggestion",
         userId: auth.user()?.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
     }
   );

--- a/front/lib/api/assistant/suggestions/emoji.ts
+++ b/front/lib/api/assistant/suggestions/emoji.ts
@@ -111,6 +111,7 @@ export async function getBuilderEmojiSuggestions(
       context: {
         operationType: "agent_builder_emoji_suggestion",
         userId: auth.user()?.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
     }
   );

--- a/front/lib/api/assistant/suggestions/instructions.ts
+++ b/front/lib/api/assistant/suggestions/instructions.ts
@@ -127,6 +127,7 @@ export async function getBuilderInstructionsSuggestions(
       context: {
         operationType: "agent_builder_instruction_suggestion",
         userId: auth.user()?.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
     }
   );

--- a/front/lib/api/assistant/suggestions/tags.ts
+++ b/front/lib/api/assistant/suggestions/tags.ts
@@ -127,6 +127,7 @@ export async function getBuilderTagSuggestions(
       context: {
         operationType: "agent_builder_tags_suggestion",
         userId: auth.user()?.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
     }
   );

--- a/front/lib/api/assistant/tag_manager.ts
+++ b/front/lib/api/assistant/tag_manager.ts
@@ -160,6 +160,7 @@ export async function getWorkspaceTagSuggestions(
       context: {
         operationType: "workspace_tags_suggestion",
         userId: auth.user()?.sId,
+        workspaceId: owner.sId,
       },
     }
   );

--- a/front/lib/api/assistant/voice_agent_finder.ts
+++ b/front/lib/api/assistant/voice_agent_finder.ts
@@ -167,6 +167,7 @@ export async function findAgentsInMessageGeneration(
       context: {
         operationType: "voice_agent_finder",
         userId: auth.user()?.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
     }
   );


### PR DESCRIPTION
## Description

In order to debug llm router for non-conversation, it is more convenient to have the workspace id in the logs

## Tests

local

## Risk

low

## Deploy Plan

front
