### PR TITLE
[front] chore: untrack "Data source not found" errors in `tables_filesystem_navigation`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/index.ts
@@ -332,7 +332,11 @@ function createServer(
         );
 
         if (!dataSource) {
-          return new Err(new MCPError("Data source not found"));
+          return new Err(
+            new MCPError("Data source not found", {
+              tracked: false,
+            })
+          );
         }
 
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -447,7 +451,11 @@ function createServer(
         );
 
         if (!dataSource) {
-          return new Err(new MCPError("Data source not found"));
+          return new Err(
+            new MCPError("Data source not found", {
+              tracked: false,
+            })
+          );
         }
 
         const connectorProvider = dataSource.connectorProvider;


### PR DESCRIPTION
## Description

- This PR disables the tracking on "Data source not found" errors in `tables_filesystem_navigation`.
- These errors are now almost always due to the model mixing up what a data source ID is, and we've worked quite a lot on improving the instructions around this.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
