### PR TITLE
[front] enh(outlook): expose event count in tool_result

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -7,7 +7,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
-import { Err, Ok } from "@app/types";
+import { Err, Ok, pluralize } from "@app/types";
 
 const OUTLOOK_CALENDAR_TOOL_NAME = "outlook_calendar";
 
@@ -188,6 +188,13 @@ function createServer(
 
         return new Ok([
           { type: "text" as const, text: "Events searched successfully" },
+          {
+            type: "text" as const,
+            text:
+              result.events.length > 0
+                ? `Found ${result.events.length} event${pluralize(result.events.length)}`
+                : "No events found",
+          },
           { type: "text" as const, text: JSON.stringify(result, null, 2) },
         ]);
       }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5151.
- This PR aims at improving the rendering of events to the model by exposing the number of events matching the filters in the `list_events` tool.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
