### PR TITLE
[front] enh(`ConnectorsPermissionModal`): add empty node label

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -897,6 +897,7 @@ export function ConnectorPermissionsModal({
                             : undefined
                         }
                         showExpand={connectorConfiguration?.isNested}
+                        emptyComponent={connectorConfiguration.emptyNodeLabel}
                       />
                     </>
                   )}

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -84,6 +84,7 @@ export type ConnectorProviderConfiguration = {
   ) => React.JSX.Element;
   guideLink: string | null;
   selectLabel?: string; // Show in the permissions modal, above the content node tree, note that a connector might not allow to select anything
+  emptyNodeLabel?: string;
   isNested: boolean;
   isTitleFilterEnabled?: boolean;
   isResourceSelectionDisabled?: boolean; // Whether the user cannot select distinct resources (everything is synced).
@@ -333,6 +334,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     mismatchError: `You cannot select another Microsoft account.\nPlease contact us at support@dust.tt if you initially selected a wrong account.`,
     guideLink: "https://docs.dust.tt/docs/microsoft-connection",
     selectLabel: "Select folders and files",
+    emptyNodeLabel: "Select the folder to enable file synchronization.",
     getLogoComponent: () => {
       return MicrosoftLogo;
     },


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5153.
- This PR adds an option per connector to add a custom label when expanding a node without children instead of "No documents".
- This will be used for Microsoft, where it's hard to tell in the connector's `retrievePermissions` whether the node has children without adding many calls.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
