### PR TITLE
Tools install in jit

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -265,41 +265,45 @@ export function ToolsPicker({
             </div>
           )}
 
-          {isAdmin && uninstalledServers.length > 0 && (
+          {isAdmin && !isServerViewsLoading && (
             <>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel label="Available to install" />
-              {uninstalledServers.map((server) => (
-                <DropdownMenuItem
-                  key={`tools-to-install-${server.sId}`}
-                  icon={() => getAvatar(server)}
-                  label={asDisplayName(server.name)}
-                  description={server.description}
-                  truncateText
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    setSetupSheetServer(server);
-                    setIsOpen(false);
-                  }}
-                />
-              ))}
-            </>
-          )}
-          {isAdmin && systemSpace && (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                icon={() => <Icon visual={ToolsIcon} size="xs" />}
-                label="Manage Tools"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  void router.push(
-                    `/w/${owner.sId}/spaces/${systemSpace.sId}/categories/actions`
-                  );
-                }}
-              />
+              {uninstalledServers.length > 0 && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel label="Available to install" />
+                  {uninstalledServers.map((server) => (
+                    <DropdownMenuItem
+                      key={`tools-to-install-${server.sId}`}
+                      icon={() => getAvatar(server)}
+                      label={asDisplayName(server.name)}
+                      description={server.description}
+                      truncateText
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        setSetupSheetServer(server);
+                        setIsOpen(false);
+                      }}
+                    />
+                  ))}
+                </>
+              )}
+              {systemSpace && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    icon={() => <Icon visual={ToolsIcon} size="xs" />}
+                    label="Manage Tools"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      void router.push(
+                        `/w/${owner.sId}/spaces/${systemSpace.sId}/categories/actions`
+                      );
+                    }}
+                  />
+                </>
+              )}
             </>
           )}
         </DropdownMenuContent>

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -11,8 +12,10 @@ import {
   LoadingBlock,
   ToolsIcon,
 } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 
+import { CreateMCPServerSheet } from "@app/components/actions/mcp/CreateMCPServerSheet";
 import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
@@ -20,15 +23,19 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
-import { useSpaces } from "@app/lib/swr/spaces";
+import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
+import {
+  useAvailableMCPServers,
+  useMCPServerViewsFromSpaces,
+} from "@app/lib/swr/mcp_servers";
+import { useSpaces, useSystemSpace } from "@app/lib/swr/spaces";
 import {
   trackEvent,
   TRACKING_ACTIONS,
   TRACKING_AREAS,
 } from "@app/lib/tracking";
 import type { WorkspaceType } from "@app/types";
+import { asDisplayName } from "@app/types";
 
 function ToolsPickerLoading({ count = 5 }: { count?: number }) {
   return (
@@ -67,14 +74,24 @@ export function ToolsPicker({
   disabled = false,
   buttonSize = "xs",
 }: ToolsPickerProps) {
+  const router = useRouter();
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
+  const [setupSheetServer, setSetupSheetServer] =
+    useState<MCPServerType | null>(null);
 
   const { spaces } = useSpaces({ workspaceId: owner.sId, disabled: !isOpen });
   const globalSpaces = useMemo(
     () => spaces.filter((s) => s.kind === "global"),
     [spaces]
   );
+
+  const isAdmin = owner.role === "admin";
+  const { systemSpace } = useSystemSpace({
+    workspaceId: owner.sId,
+    disabled: !isOpen || !isAdmin,
+  });
+
   const { serverViews, isLoading: isServerViewsLoading } =
     useMCPServerViewsFromSpaces(
       owner,
@@ -108,127 +125,202 @@ export function ToolsPicker({
     };
   }, [serverViews, searchText, selectedMCPServerViewIds]);
 
+  const { availableMCPServers } = useAvailableMCPServers({
+    owner,
+  });
+
+  // We compare by name, not sId, because names are shared between multiple instances of the same MCP server (sIds are not).
+  // We filter by manual availability to show only servers that need install step.
+  const uninstalledServers = useMemo(() => {
+    if (!availableMCPServers || !serverViews) {
+      return [];
+    }
+    const installedServerNames = new Set(serverViews.map((v) => v.server.name));
+    return availableMCPServers.filter(
+      (server) =>
+        !installedServerNames.has(server.name) &&
+        server.availability === "manual"
+    );
+  }, [availableMCPServers, serverViews]);
+
   return (
-    <DropdownMenu
-      open={isOpen}
-      onOpenChange={(open) => {
-        setIsOpen(open);
-        if (open) {
-          trackEvent({
-            area: TRACKING_AREAS.TOOLS,
-            object: "tool_picker",
-            action: TRACKING_ACTIONS.OPEN,
-          });
-          setSearchText("");
-        }
-      }}
-    >
-      <DropdownMenuTrigger asChild>
-        <Button
-          icon={ToolsIcon}
-          variant="ghost-secondary"
-          size={buttonSize}
-          tooltip="Tools"
-          disabled={disabled || isLoading}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        className="max-h-96 w-96"
-        align="start"
-        dropdownHeaders={
-          <>
-            <DropdownMenuSearchbar
-              autoFocus
-              name="search-tools"
-              placeholder="Search Tools"
-              value={searchText}
-              onChange={setSearchText}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && filteredServerViews.length > 0) {
-                  const isSelected = selectedMCPServerViewIds.includes(
-                    filteredServerViews[0].sId
-                  );
-                  if (isSelected) {
-                    trackEvent({
-                      area: TRACKING_AREAS.TOOLS,
-                      object: "tool_deselect",
-                      action: TRACKING_ACTIONS.SELECT,
-                      extra: {
-                        tool_id: filteredServerViews[0].sId,
-                        tool_name: filteredServerViews[0].server.name,
-                      },
-                    });
-                    onDeselect(filteredServerViews[0]);
-                  } else {
-                    trackEvent({
-                      area: TRACKING_AREAS.TOOLS,
-                      object: "tool_select",
-                      action: TRACKING_ACTIONS.SELECT,
-                      extra: {
-                        tool_id: filteredServerViews[0].sId,
-                        tool_name: filteredServerViews[0].server.name,
-                      },
-                    });
-                    onSelect(filteredServerViews[0]);
-                  }
-                  setSearchText("");
-                  setIsOpen(false);
-                }
-              }}
-            />
-            <DropdownMenuSeparator />
-          </>
-        }
+    <>
+      <DropdownMenu
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          if (open) {
+            trackEvent({
+              area: TRACKING_AREAS.TOOLS,
+              object: "tool_picker",
+              action: TRACKING_ACTIONS.OPEN,
+            });
+            setSearchText("");
+          }
+        }}
       >
-        {filteredServerViews.length > 0 ? (
-          <>
-            {filteredServerViewsUnselected
-              .sort(mcpServerViewSortingFn)
-              .map((v) => {
-                return (
-                  <DropdownMenuItem
-                    key={`tools-picker-${v.sId}`}
-                    icon={() => getAvatar(v.server)}
-                    label={getMcpServerViewDisplayName(v)}
-                    description={getMcpServerViewDescription(v)}
-                    truncateText
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      e.preventDefault();
+        <DropdownMenuTrigger asChild>
+          <Button
+            icon={ToolsIcon}
+            variant="ghost-secondary"
+            size={buttonSize}
+            tooltip="Tools"
+            disabled={disabled || isLoading}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          className="max-h-96 w-96"
+          align="start"
+          dropdownHeaders={
+            <>
+              <DropdownMenuSearchbar
+                autoFocus
+                name="search-tools"
+                placeholder="Search Tools"
+                value={searchText}
+                onChange={setSearchText}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && filteredServerViews.length > 0) {
+                    const isSelected = selectedMCPServerViewIds.includes(
+                      filteredServerViews[0].sId
+                    );
+                    if (isSelected) {
+                      trackEvent({
+                        area: TRACKING_AREAS.TOOLS,
+                        object: "tool_deselect",
+                        action: TRACKING_ACTIONS.SELECT,
+                        extra: {
+                          tool_id: filteredServerViews[0].sId,
+                          tool_name: filteredServerViews[0].server.name,
+                        },
+                      });
+                      onDeselect(filteredServerViews[0]);
+                    } else {
                       trackEvent({
                         area: TRACKING_AREAS.TOOLS,
                         object: "tool_select",
                         action: TRACKING_ACTIONS.SELECT,
                         extra: {
-                          tool_id: v.sId,
-                          tool_name: v.server.name,
+                          tool_id: filteredServerViews[0].sId,
+                          tool_name: filteredServerViews[0].server.name,
                         },
                       });
-                      onSelect(v);
-                      setIsOpen(false);
-                    }}
-                  />
-                );
-              })}
-            {filteredServerViewsUnselected.length === 0 && (
-              <DropdownMenuItem
-                id="tools-picker-no-selected"
-                icon={() => <Icon visual={BoltIcon} size="xs" />}
-                className="italic"
-                label="No more tools to select"
-                description="All available tools are already selected"
-                disabled
+                      onSelect(filteredServerViews[0]);
+                    }
+                    setSearchText("");
+                    setIsOpen(false);
+                  }
+                }}
               />
-            )}
-          </>
-        ) : isServerViewsLoading ? (
-          <ToolsPickerLoading />
-        ) : (
-          <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-            No results found
-          </div>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+              <DropdownMenuSeparator />
+            </>
+          }
+        >
+          {filteredServerViews.length > 0 ? (
+            <>
+              {filteredServerViewsUnselected
+                .sort(mcpServerViewSortingFn)
+                .map((v) => {
+                  return (
+                    <DropdownMenuItem
+                      key={`tools-picker-${v.sId}`}
+                      icon={() => getAvatar(v.server)}
+                      label={getMcpServerViewDisplayName(v)}
+                      description={getMcpServerViewDescription(v)}
+                      truncateText
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        trackEvent({
+                          area: TRACKING_AREAS.TOOLS,
+                          object: "tool_select",
+                          action: TRACKING_ACTIONS.SELECT,
+                          extra: {
+                            tool_id: v.sId,
+                            tool_name: v.server.name,
+                          },
+                        });
+                        onSelect(v);
+                        setIsOpen(false);
+                      }}
+                    />
+                  );
+                })}
+              {filteredServerViewsUnselected.length === 0 && (
+                <DropdownMenuItem
+                  id="tools-picker-no-selected"
+                  icon={() => <Icon visual={BoltIcon} size="xs" />}
+                  className="italic"
+                  label="No more tools to select"
+                  description="All available tools are already selected"
+                  disabled
+                />
+              )}
+            </>
+          ) : isServerViewsLoading ? (
+            <ToolsPickerLoading />
+          ) : (
+            <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+              No results found
+            </div>
+          )}
+
+          {isAdmin && uninstalledServers.length > 0 && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel label="Available to install" />
+              {uninstalledServers.map((server) => (
+                <DropdownMenuItem
+                  key={`tools-to-install-${server.sId}`}
+                  icon={() => getAvatar(server)}
+                  label={asDisplayName(server.name)}
+                  description={server.description}
+                  truncateText
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    setSetupSheetServer(server);
+                    setIsOpen(false);
+                  }}
+                />
+              ))}
+            </>
+          )}
+          {isAdmin && systemSpace && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                icon={() => <Icon visual={ToolsIcon} size="xs" />}
+                label="Manage Tools"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  void router.push(
+                    `/w/${owner.sId}/spaces/${systemSpace.sId}/categories/actions`
+                  );
+                }}
+              />
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {setupSheetServer && (
+        <CreateMCPServerSheet
+          owner={owner}
+          internalMCPServer={setupSheetServer}
+          setMCPServerToShow={() => {
+            setSetupSheetServer(null);
+          }}
+          setIsLoading={() => {}}
+          isOpen={!!setupSheetServer}
+          setIsOpen={(isOpen) => {
+            if (!isOpen) {
+              setSetupSheetServer(null);
+            }
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -29,6 +29,7 @@ import {
   useMCPServerViewsFromSpaces,
 } from "@app/lib/swr/mcp_servers";
 import { useSpaces, useSystemSpace } from "@app/lib/swr/spaces";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
   trackEvent,
   TRACKING_ACTIONS,
@@ -80,6 +81,7 @@ export function ToolsPicker({
   const [setupSheetServer, setSetupSheetServer] =
     useState<MCPServerType | null>(null);
 
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   const { spaces } = useSpaces({ workspaceId: owner.sId, disabled: !isOpen });
   const globalSpaces = useMemo(
     () => spaces.filter((s) => s.kind === "global"),
@@ -268,7 +270,7 @@ export function ToolsPicker({
             </div>
           )}
 
-          {isAdmin && !isServerViewsLoading && (
+          {isAdmin && !isServerViewsLoading && hasFeature("jit_tool_setup") && (
             <>
               {uninstalledServers.length > 0 && (
                 <>

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -225,6 +225,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable notifications",
     stage: "dust_only",
   },
+  jit_tool_setup: {
+    description: "Enable setup flow of new tools in JIT tool dropdown",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -658,6 +658,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "hootl_subscriptions"
   | "http_client_tool"
   | "index_private_slack_channel"
+  | "jit_tool_setup"
   | "labs_mcp_actions_dashboard"
   | "labs_trackers"
   | "labs_transcripts"


### PR DESCRIPTION
## Description


Display the list of tools available to install on the JIT tool dropdown. 
Note: some details I want to decide with Ed/Alex tomorrow such as what the searchbar does and if we display all tools or a limited number, but logic can be reviewed already. 

If you click on a tool you can through the install flow without reloading the current page so we do not loose the potential ongoing content in the input bar. 

<kbd>
<img width="584" height="681" alt="Screenshot 2025-11-17 at 18 33 08" src="https://github.com/user-attachments/assets/4f6eb2c7-811f-47aa-bbb3-5cf953ad01b5" />
</kbd>

Review with hidden whitespaces is advised 🙏🏻 


## Tests

Locally. 
Will test on front-edge before shipping. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 