### PR TITLE
[Slack Bot] Improve logging for external Slack users

### DIFF
--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -311,24 +311,29 @@ export async function notifyIfSlackUserIsNotAllowed(
   } = slackUserInfo;
   const isGuest = is_restricted || is_ultra_restricted;
   const isExternal = isGuest || isStranger;
+  let isAllowed = false;
+  let externalAuthorization: { authorized: boolean; groupIds: string[] } | null =
+    null;
+
   if (isExternal) {
     // If the external user is allowed, they are allowed with a specific group id.
-    return isExternalUserAllowed(
+    externalAuthorization = await isExternalUserAllowed(
       connector,
       slackClient,
       slackUserInfo,
       slackInfos,
       whitelistedDomains
     );
+    isAllowed = externalAuthorization.authorized;
+  } else {
+    // Handle users that are not Slack external.
+    isAllowed = await isSlackUserAllowed(
+      slackUserInfo,
+      connector,
+      slackClient,
+      slackInfos
+    );
   }
-
-  // Handle users that are not Slack external.
-  const isAllowed = await isSlackUserAllowed(
-    slackUserInfo,
-    connector,
-    slackClient,
-    slackInfos
-  );
 
   if (!isAllowed) {
     logger.info(
@@ -349,5 +354,9 @@ export async function notifyIfSlackUserIsNotAllowed(
   }
 
   // If the user is part of the Dust workspace, they are allowed without any explicit group id.
+  if (isExternal && externalAuthorization) {
+    return externalAuthorization;
+  }
+
   return { authorized: isAllowed, groupIds: [] };
 }

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -312,8 +312,10 @@ export async function notifyIfSlackUserIsNotAllowed(
   const isGuest = is_restricted || is_ultra_restricted;
   const isExternal = isGuest || isStranger;
   let isAllowed = false;
-  let externalAuthorization: { authorized: boolean; groupIds: string[] } | null =
-    null;
+  let externalAuthorization: {
+    authorized: boolean;
+    groupIds: string[];
+  } | null = null;
 
   if (isExternal) {
     // If the external user is allowed, they are allowed with a specific group id.


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5056

Ensure external Slack users (guests / Slack Connect) go through `notifyIfSlackUserIsNotAllowed` so that unauthorized access attempts are logged and receive the same Slack message as internal users, while still relying on domain whitelists for authorization.

This only improves logging and error messaging for unauthorized external users; it does not change which users are considered authorized.

## Risks

Blast radius: Slack bot access control logging and error messages for external Slack users
Risk: standard

## Deploy Plan

- deploy connectors
