### PR TITLE
[Slack Bot] Use slack_bot connector for whitelist-domains

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -229,15 +229,15 @@ export const slack = async ({
         }
       }
 
-      const connector = await ConnectorModel.findOne({
-        where: {
-          workspaceId: `${args.wId}`,
-          type: "slack",
-        },
-      });
+      const connector = await ConnectorResource.findByWorkspaceIdAndType(
+        `${args.wId}`,
+        "slack_bot"
+      );
 
       if (!connector) {
-        throw new Error(`Could not find connector for workspace ${args.wId}`);
+        throw new Error(
+          `Could not find Slack bot connector for workspace ${args.wId}`
+        );
       }
 
       const whitelistedDomainsArray = whitelistedDomains.split(",");


### PR DESCRIPTION
## Description
Update the admin slack whitelist-domains CLI command to modify the Slack bot connector configuration (slack_bot), so that domain whitelisting applies to bot conversations rather than the legacy slack connector.

## Risks
Blast radius: Slack bot domain-whitelisting behavior for external Slack users.
Risk: low

## Deploy Plan
- deploy connectors
