### PR TITLE
[front] fix(triggers): delete user triggers on unprovisioning

### DIFF
--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -35,6 +35,7 @@ import { createOrUpdateUser } from "@app/lib/iam/users";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import mainLogger from "@app/logger/logger";
@@ -778,6 +779,23 @@ async function handleDeleteWorkOSUser(
       return;
     }
     throw membershipRevokeResult.error;
+  }
+
+  const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const deleteTriggerResult = await TriggerResource.deleteAllForUser(userAuth);
+  if (deleteTriggerResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        error: deleteTriggerResult.error,
+      },
+      "Failed to delete triggers for revoked user"
+    );
   }
 
   void ServerSideTracking.trackRevokeMembership({


### PR DESCRIPTION
## Description

- When a user is removed from provisioned group its triggers has to be deleted (example [here](https://cloud.temporal.io/namespaces/dust-agent-prod.gmnlm/schedules/agent-schedule-0ec9852c2f-trg_lPiYG5N2kT)).
- This PR implements this and prevents leaving dangling schedules that fail (the `isUser` check in the activity fails).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Delete dangling schedules from Temporal.
