### PR TITLE
[front] refactor(trigger): cleanup explicit Authenticator instantiation when deleting triggers

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/revoke_users.ts
+++ b/front/lib/api/poke/plugins/workspaces/revoke_users.ts
@@ -43,10 +43,7 @@ export const revokeUsersPlugin = createPlugin({
     const revokedResults = await concurrentExecutor(
       users,
       async (user) => {
-        const res = await revokeAndTrackMembership(
-          auth.getNonNullableWorkspace(),
-          user
-        );
+        const res = await revokeAndTrackMembership(auth, user);
         return {
           userId: user.sId,
           result: res,

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -351,10 +351,7 @@ export async function mergeUserIdentities({
   }
 
   if (revokeSecondaryUser) {
-    await revokeAndTrackMembership(
-      auth.getNonNullableWorkspace(),
-      secondaryUser
-    );
+    await revokeAndTrackMembership(auth, secondaryUser);
   }
 
   return new Ok({

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -25,7 +25,7 @@ import {
   deleteTriggerSchedule,
 } from "@app/lib/triggers/temporal/schedule/client";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { ModelId, Result } from "@app/types";
+import type { ModelId, Result, UserType } from "@app/types";
 import {
   assertNever,
   Err,
@@ -140,9 +140,10 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     });
   }
 
-  static async listByUserEditor(auth: Authenticator) {
-    const user = auth.getNonNullableUser();
-
+  static async listByUserEditor(
+    auth: Authenticator,
+    user: UserResource | UserType
+  ) {
     return this.baseFetch(auth, {
       where: {
         editor: user.id,
@@ -150,9 +151,11 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     });
   }
 
-  static async listByUserSubscriber(auth: Authenticator) {
+  static async listByUserSubscriber(
+    auth: Authenticator,
+    user: UserResource | UserType
+  ) {
     const workspace = auth.getNonNullableWorkspace();
-    const user = auth.getNonNullableUser();
 
     const res = await this.model.findAll({
       where: {
@@ -284,21 +287,17 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     const r = await concurrentExecutor(
       triggers,
       async (trigger) => {
-        try {
-          return await trigger.delete(auth);
-        } catch (error) {
-          return new Err(normalizeError(error));
-        }
+        return trigger.delete(auth);
       },
       {
-        concurrency: 10,
+        concurrency: 4,
       }
     );
 
-    if (r.find((res) => res.isErr())) {
+    if (r.some((res) => res.isErr())) {
       return new Err(
         new Error(
-          `Failed to delete ${r.filter((res) => res.isErr()).length} some triggers`
+          `Failed to delete ${r.filter((res) => res.isErr()).length} triggers`
         )
       );
     }
@@ -306,9 +305,11 @@ export class TriggerResource extends BaseResource<TriggerModel> {
   }
 
   static async deleteAllForUser(
-    auth: Authenticator
+    auth: Authenticator,
+    user: UserResource | UserType
   ): Promise<Result<undefined, Error>> {
-    const triggers = await this.listByUserEditor(auth);
+    const triggers = await this.listByUserEditor(auth, user);
+
     if (triggers.length === 0) {
       return new Ok(undefined);
     }
@@ -316,18 +317,14 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     const r = await concurrentExecutor(
       triggers,
       async (trigger) => {
-        try {
-          return await trigger.delete(auth);
-        } catch (error) {
-          return new Err(normalizeError(error));
-        }
+        return trigger.delete(auth);
       },
       {
-        concurrency: 10,
+        concurrency: 4,
       }
     );
 
-    if (r.find((res) => res.isErr())) {
+    if (r.some((res) => res.isErr())) {
       return new Err(
         new Error(
           `Failed to delete ${r.filter((res) => res.isErr()).length} triggers`

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -144,6 +144,11 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     auth: Authenticator,
     user: UserResource | UserType
   ) {
+    // Either have to be an admin or the user itself.
+    if (!auth.isAdmin() && auth.user()?.id !== user.id) {
+      return [];
+    }
+
     return this.baseFetch(auth, {
       where: {
         editor: user.id,
@@ -155,6 +160,11 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     auth: Authenticator,
     user: UserResource | UserType
   ) {
+    // Either have to be an admin or the user itself.
+    if (!auth.isAdmin() && auth.user()?.id !== user.id) {
+      return [];
+    }
+
     const workspace = auth.getNonNullableWorkspace();
 
     const res = await this.model.findAll({

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -58,7 +58,7 @@ async function handler(
         });
       }
 
-      const revokeResult = await revokeAndTrackMembership(owner, user);
+      const revokeResult = await revokeAndTrackMembership(auth, user);
 
       if (revokeResult.isErr()) {
         switch (revokeResult.error.type) {

--- a/front/pages/api/w/[wId]/me/triggers.ts
+++ b/front/pages/api/w/[wId]/me/triggers.ts
@@ -35,7 +35,7 @@ async function handler(
   // Get triggers where user is editor or subscriber concurrently
   const [editorTriggers, subscriberTriggers] = await Promise.all([
     TriggerResource.listByUserEditor(auth, auth.getNonNullableUser()),
-    TriggerResource.listByUserSubscriber(auth),
+    TriggerResource.listByUserSubscriber(auth, auth.getNonNullableUser()),
   ]);
 
   const editorTriggersWithAgentInfo = await concurrentExecutor(

--- a/front/pages/api/w/[wId]/me/triggers.ts
+++ b/front/pages/api/w/[wId]/me/triggers.ts
@@ -34,7 +34,7 @@ async function handler(
 
   // Get triggers where user is editor or subscriber concurrently
   const [editorTriggers, subscriberTriggers] = await Promise.all([
-    TriggerResource.listByUserEditor(auth),
+    TriggerResource.listByUserEditor(auth, auth.getNonNullableUser()),
     TriggerResource.listByUserSubscriber(auth),
   ]);
 

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -122,7 +122,7 @@ async function handler(
 
       // TODO(@fontanierh): use DELETE for revoking membership
       if (req.body.role === "revoked") {
-        const revokeResult = await revokeAndTrackMembership(owner, user);
+        const revokeResult = await revokeAndTrackMembership(auth, user);
 
         if (revokeResult.isErr()) {
           switch (revokeResult.error.type) {

--- a/front/scripts/revoke_memberships_from_csv.ts
+++ b/front/scripts/revoke_memberships_from_csv.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "fs";
 
 import { revokeAndTrackMembership } from "@app/lib/api/membership";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
 import { UserResource } from "@app/lib/resources/user_resource";
 
 import type { ArgumentSpecs } from "./helpers";
@@ -24,6 +25,8 @@ const argumentSpecs: ArgumentSpecs = {
 makeScript(
   argumentSpecs,
   async ({ csvPath, workspaceId, execute }, scriptLogger) => {
+    const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
     // Read and parse CSV file
     const fileContent = readFileSync(csvPath, "utf-8");
     const records = parse(fileContent, {
@@ -56,7 +59,7 @@ makeScript(
       }
 
       if (execute) {
-        const result = await revokeAndTrackMembership(workspace, user);
+        const result = await revokeAndTrackMembership(auth, user);
         if (result.isOk()) {
           scriptLogger.info(
             { email, role: result.value.role },

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -781,12 +781,10 @@ async function handleDeleteWorkOSUser(
     throw membershipRevokeResult.error;
   }
 
-  const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
-    user.sId,
-    workspace.sId
+  const deleteTriggerResult = await TriggerResource.deleteAllForUser(
+    auth,
+    user
   );
-
-  const deleteTriggerResult = await TriggerResource.deleteAllForUser(userAuth);
   if (deleteTriggerResult.isErr()) {
     logger.error(
       {


### PR DESCRIPTION
## Description

- When revoking a user we delete its triggers. The current implementation explicitly instantiates an Authenticator to delete the triggers for this instance.
- This PR refactors this by keeping the auth checks for permissionning checks, and having the caller of `TriggerResource.deleteAllForUser` explicitly state which user we should delete triggers for.
- The rationale here is that admins can actually delete triggers on behalf of another user.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
