### PR TITLE
[front] enh(outlook): improve rendering for events

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -11,7 +11,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
-import { Err, Ok, pluralize } from "@app/types";
+import { Err, Ok } from "@app/types";
 
 const OUTLOOK_CALENDAR_TOOL_NAME = "outlook_calendar";
 

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import * as OutlookApi from "@app/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper";
+import {
+  renderOutlookEvent,
+  renderOutlookEventList,
+} from "@app/lib/actions/mcp_internal_actions/servers/outlook/rendering";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -186,16 +190,16 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
+        const formattedText = renderOutlookEventList(result.events, {
+          userTimezone,
+          hasMore: result.nextLink !== undefined,
+        });
+
         return new Ok([
-          { type: "text" as const, text: "Events searched successfully" },
           {
             type: "text" as const,
-            text:
-              result.events.length > 0
-                ? `Found ${result.events.length} event${pluralize(result.events.length)}`
-                : "No events found",
+            text: formattedText,
           },
-          { type: "text" as const, text: JSON.stringify(result, null, 2) },
         ]);
       }
     )
@@ -241,10 +245,9 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
-        return new Ok([
-          { type: "text" as const, text: "Event fetched successfully" },
-          { type: "text" as const, text: JSON.stringify(result, null, 2) },
-        ]);
+        const formattedText = renderOutlookEvent(result, userTimezone);
+
+        return new Ok([{ type: "text" as const, text: formattedText }]);
       }
     )
   );
@@ -350,9 +353,13 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
+        const formattedText = renderOutlookEvent(result, userTimezone);
+
         return new Ok([
-          { type: "text" as const, text: "Event created successfully" },
-          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          {
+            type: "text" as const,
+            text: `Event created successfully\n\n${formattedText}`,
+          },
         ]);
       }
     )
@@ -453,9 +460,13 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
+        const formattedText = renderOutlookEvent(result, userTimezone);
+
         return new Ok([
-          { type: "text" as const, text: "Event updated successfully" },
-          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          {
+            type: "text" as const,
+            text: `Event updated successfully\n\n${formattedText}`,
+          },
         ]);
       }
     )

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -68,6 +68,7 @@ export function renderOutlookEvent(
   const enrichedEvent = enrichEventWithDayOfWeek(event, userTimezone);
   const lines: string[] = [];
 
+  lines.push(`# ${enrichedEvent.subject ?? "Untitled event"}`);
   if (enrichedEvent.subject) {
     lines.push(`Title: ${enrichedEvent.subject}`);
   }
@@ -131,7 +132,7 @@ export function renderOutlookEvent(
         : enrichedEvent.body.content;
 
     if (bodyContent.trim()) {
-      lines.push(`Description: ${bodyContent.trim()}`);
+      lines.push(`## Description\n${bodyContent.trim()}`);
     }
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -1,0 +1,201 @@
+import type { OutlookEvent } from "@app/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper";
+import { pluralize } from "@app/types";
+
+interface EnrichedOutlookEventDateTime {
+  dateTime: string;
+  timeZone?: string;
+  eventDayOfWeek?: string;
+  isAllDay?: boolean;
+}
+
+interface EnrichedOutlookEvent extends Omit<OutlookEvent, "start" | "end"> {
+  start: EnrichedOutlookEventDateTime;
+  end: EnrichedOutlookEventDateTime;
+}
+
+function stripHtmlTags(html: string): string {
+  return html
+    .replace(/<style[^>]*>.*?<\/style>/gis, "")
+    .replace(/<script[^>]*>.*?<\/script>/gis, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n\s*\n\s*\n/g, "\n\n")
+    .trim();
+}
+
+function enrichEventWithDayOfWeek(
+  event: OutlookEvent,
+  userTimezone?: string
+): EnrichedOutlookEvent {
+  const enrichedEvent: EnrichedOutlookEvent = {
+    ...event,
+    start: {
+      dateTime: event.start.dateTime,
+      timeZone: event.start.timeZone,
+      isAllDay: event.isAllDay ?? false,
+    },
+    end: {
+      dateTime: event.end.dateTime,
+      timeZone: event.end.timeZone,
+      isAllDay: event.isAllDay ?? false,
+    },
+  };
+
+  const startDate = new Date(event.start.dateTime);
+  enrichedEvent.start.eventDayOfWeek = startDate.toLocaleDateString("en-US", {
+    weekday: "long",
+    timeZone: userTimezone ?? event.start.timeZone ?? undefined,
+  });
+
+  const endDate = new Date(event.end.dateTime);
+  enrichedEvent.end.eventDayOfWeek = endDate.toLocaleDateString("en-US", {
+    weekday: "long",
+    timeZone: userTimezone ?? event.end.timeZone ?? undefined,
+  });
+
+  return enrichedEvent;
+}
+
+export function renderOutlookEvent(
+  event: OutlookEvent,
+  userTimezone?: string
+): string {
+  const enrichedEvent = enrichEventWithDayOfWeek(event, userTimezone);
+  const lines: string[] = [];
+
+  if (enrichedEvent.subject) {
+    lines.push(`Title: ${enrichedEvent.subject}`);
+  }
+
+  if (enrichedEvent.start) {
+    const start = enrichedEvent.start;
+    if (start.isAllDay) {
+      const startDate = new Date(start.dateTime);
+      const dateStr = startDate.toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      });
+      lines.push(`Date: ${start.eventDayOfWeek}, ${dateStr} (All day)`);
+    } else {
+      const startDate = new Date(start.dateTime);
+      const timeStr = startDate.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+        timeZone: userTimezone ?? start.timeZone ?? undefined,
+      });
+      const dateStr = startDate.toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone: userTimezone ?? start.timeZone ?? undefined,
+      });
+      lines.push(
+        `Start: ${start.eventDayOfWeek}, ${dateStr} at ${timeStr}${start.timeZone ? ` (${start.timeZone})` : ""}`
+      );
+    }
+  }
+
+  if (enrichedEvent.end && !enrichedEvent.isAllDay) {
+    const end = enrichedEvent.end;
+    const endDate = new Date(end.dateTime);
+    const timeStr = endDate.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: userTimezone ?? end.timeZone ?? undefined,
+    });
+    const dateStr = endDate.toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      timeZone: userTimezone ?? end.timeZone ?? undefined,
+    });
+    lines.push(
+      `End: ${end.eventDayOfWeek}, ${dateStr} at ${timeStr}${end.timeZone ? ` (${end.timeZone})` : ""}`
+    );
+  }
+
+  if (enrichedEvent.location?.displayName) {
+    lines.push(`Location: ${enrichedEvent.location.displayName}`);
+  }
+
+  if (enrichedEvent.body?.content) {
+    const bodyContent =
+      enrichedEvent.body.contentType === "html"
+        ? stripHtmlTags(enrichedEvent.body.content)
+        : enrichedEvent.body.content;
+
+    if (bodyContent.trim()) {
+      lines.push(`Description: ${bodyContent}`);
+    }
+  }
+
+  if (enrichedEvent.organizer) {
+    const organizer = enrichedEvent.organizer.emailAddress.name
+      ? `${enrichedEvent.organizer.emailAddress.name} (${enrichedEvent.organizer.emailAddress.address})`
+      : enrichedEvent.organizer.emailAddress.address;
+    lines.push(`Organizer: ${organizer}`);
+  }
+
+  if (enrichedEvent.attendees && enrichedEvent.attendees.length > 0) {
+    const attendeeList = enrichedEvent.attendees
+      .map((a) => {
+        const name = a.emailAddress.name ?? a.emailAddress.address ?? "Unknown";
+        const status = a.status.response ? ` (${a.status.response})` : "";
+        return `${name}${status}`;
+      })
+      .join(", ");
+    lines.push(`Attendees: ${attendeeList}`);
+  }
+
+  if (enrichedEvent.importance && enrichedEvent.importance !== "normal") {
+    lines.push(`Importance: ${enrichedEvent.importance}`);
+  }
+
+  if (enrichedEvent.showAs) {
+    lines.push(`Show as: ${enrichedEvent.showAs}`);
+  }
+
+  if (enrichedEvent.isCancelled) {
+    lines.push("Status: Cancelled");
+  }
+
+  if (enrichedEvent.id) {
+    lines.push(`Event ID: ${enrichedEvent.id}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function renderOutlookEventList(
+  events: OutlookEvent[],
+  {
+    userTimezone,
+    hasMore,
+  }: {
+    userTimezone?: string;
+    hasMore: boolean;
+  }
+): string {
+  if (events.length === 0) {
+    return "No event found.";
+  }
+
+  const eventCount = events.length;
+
+  const lines: string[] = [
+    `Found ${eventCount} event${pluralize(eventCount)}${hasMore ? " (more available)" : ""}`,
+  ];
+
+  for (const event of events) {
+    lines.push("\n---\n");
+    lines.push(renderOutlookEvent(event, userTimezone));
+  }
+
+  return lines.join("\n");
+}

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -131,7 +131,7 @@ export function renderOutlookEvent(
         : enrichedEvent.body.content;
 
     if (bodyContent.trim()) {
-      lines.push(`Description: ${bodyContent}`);
+      lines.push(`Description: ${bodyContent.trim()}`);
     }
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -195,7 +195,7 @@ export function renderOutlookEventList(
   ];
 
   for (const event of events) {
-    lines.push("\n---\n");
+    lines.push("\n---");
     lines.push(renderOutlookEvent(event, userTimezone));
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -146,7 +146,9 @@ export function renderOutlookEvent(
     const attendeeList = enrichedEvent.attendees
       .map((a) => {
         const name = a.emailAddress.name ?? a.emailAddress.address ?? "Unknown";
-        const status = a.status.response ? ` (${a.status.response})` : "";
+        const status = a.status.response
+          ? ` (response: ${a.status.response})`
+          : "";
         return `${name}${status}`;
       })
       .join(", ");

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import type {
   Attributes,
   CreationAttributes,
@@ -144,10 +145,10 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     auth: Authenticator,
     user: UserResource | UserType
   ) {
-    // Either have to be an admin or the user itself.
-    if (!auth.isAdmin() && auth.user()?.id !== user.id) {
-      return [];
-    }
+    assert(
+      auth.isAdmin() || auth.user()?.id === user.id,
+      "Triggers can only be listed by admins or by their editor."
+    );
 
     return this.baseFetch(auth, {
       where: {
@@ -160,10 +161,10 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     auth: Authenticator,
     user: UserResource | UserType
   ) {
-    // Either have to be an admin or the user itself.
-    if (!auth.isAdmin() && auth.user()?.id !== user.id) {
-      return [];
-    }
+    assert(
+      auth.isAdmin() || auth.user()?.id === user.id,
+      "Triggers can only be listed by admins or by their editor."
+    );
 
     const workspace = auth.getNonNullableWorkspace();
 

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -163,7 +163,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
   ) {
     assert(
       auth.isAdmin() || auth.user()?.id === user.id,
-      "Triggers can only be listed by admins or by their editor."
+      "Triggers can only be listed by admins or by the subscribed user."
     );
 
     const workspace = auth.getNonNullableWorkspace();


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/5151.
- This PR improves how Outlook events are rendered to the model.
- Instead of showing a stringified JSON (example [here](https://eu.dust.tt/poke/UUQVDrWpp6/conversation/F2tU3vR1wh)), events are rendered as a Markdown text.
- Notably, the HTML content of the event's body is stripped.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
