### PR TITLE
[front] Untrack "data source not found" errors in validateTables

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/helpers.ts
@@ -297,7 +297,9 @@ export async function validateTables(
   const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
   if (!dataSource) {
     return new Err(
-      new MCPError(`Data source not found for ID: ${dataSourceId}`)
+      new MCPError(`Data source not found for ID: ${dataSourceId}`, {
+        tracked: false,
+      })
     );
   }
 

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -132,7 +132,9 @@ export function registerListTool(
 
           if (!dataSourceConfig) {
             return new Err(
-              new MCPError(`Data source not found for ID: ${dataSourceId}`)
+              new MCPError(`Data source not found for ID: ${dataSourceId}`, {
+                tracked: false,
+              })
             );
           }
 


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/17983.
- We still have tracked errors coming from the tables validation.
- Untracking these for now but keeping the log so that we can iterate on it without having alerting.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
