### PR TITLE
feat(oauth): support client credentials in slack oauth provider for connection use-case

### DIFF
--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -210,7 +210,7 @@ impl Credential {
                 vec!["client_id", "client_secret"]
             }
             CredentialProvider::Slack => {
-                vec!["client_id", "client_secret", "signing_secret"]
+                vec!["client_id", "client_secret"]
             }
             CredentialProvider::Microsoft => {
                 vec!["client_id", "client_secret"]

--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -54,6 +54,7 @@ impl SlackConnectionProvider {
         related_credentials: Option<Credential>,
     ) -> Result<String> {
         let (client_id, client_secret) = match app_type {
+            // related_credentials refers to customers using their own Slack app
             SlackUseCase::Connection => match related_credentials {
                 Some(credentials) => Self::get_credentials(credentials)?,
                 None => (


### PR DESCRIPTION
## Description

Adds backend support in the Rust OAuth core for handling custom Slack credentials.

When finalizing OAuth connections for the `connection` use-case, the Slack provider now extracts and uses client credentials (`client_id`, `client_secret`) from the credential system instead of falling back to environment-based credentials.

Falls back to environment-based credentials for backward compatibility with existing connections until we execute the [migration](https://github.com/dust-tt/tasks/issues/5181)

Addresses task [#5182](https://github.com/dust-tt/tasks/issues/5182)


## Risk

Low. should be backward compatible

## Tests

Manually tested the OAuth flow with custom credentials for the connection use-case.

## Deploy Plan

Core
