### PR TITLE
[front] feat(outlook): add tool to check self availability

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -821,6 +821,7 @@ The directive should be used to display a clickable version of the agent name in
       update_event: "low",
       delete_event: "low",
       check_availability: "never_ask",
+      check_self_availability: "never_ask",
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -637,62 +637,13 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
-        const blockingStatuses = [
-          "busy",
-          "tentative",
-          "oof",
-          "workingElsewhere",
-        ];
-        const blockingEvents = result.events.filter((event) => {
-          if (event.isCancelled) {
-            return false;
-          }
-          return blockingStatuses.includes(event.showAs ?? "busy");
-        });
+        const formattedText = formatAvailabilityCheck(
+          result.events,
+          startTime,
+          endTime
+        );
 
-        const available = blockingEvents.length === 0;
-
-        const lines: string[] = [];
-        if (available) {
-          lines.push("User is AVAILABLE during this time period");
-          lines.push("");
-          lines.push(`Period: ${startTime} to ${endTime}`);
-          if (result.events.length > 0) {
-            const freeEvents = result.events.filter(
-              (e) => !e.isCancelled && (e.showAs === "free" || !e.showAs)
-            );
-            if (freeEvents.length > 0) {
-              lines.push("");
-              lines.push(
-                `Note: There ${freeEvents.length === 1 ? "is" : "are"} ${freeEvents.length} event${pluralize(freeEvents.length)} during this period marked as 'free'`
-              );
-            }
-          }
-        } else {
-          lines.push("User is NOT AVAILABLE during this time period");
-          lines.push("");
-          lines.push(`Period: ${startTime} to ${endTime}`);
-          lines.push(
-            `Blocking events: ${blockingEvents.length} event${pluralize(blockingEvents.length)}`
-          );
-          lines.push("");
-          lines.push("Conflicting events:");
-          lines.push("");
-          blockingEvents.forEach((event, index) => {
-            if (index > 0) {
-              lines.push("");
-            }
-            lines.push(
-              `${index + 1}. ${event.subject || "(No title)"} - ${event.showAs ?? "busy"}`
-            );
-            lines.push(`   ${event.start.dateTime} to ${event.end.dateTime}`);
-            if (event.location?.displayName) {
-              lines.push(`   Location: ${event.location.displayName}`);
-            }
-          });
-        }
-
-        return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
+        return new Ok([{ type: "text" as const, text: formattedText }]);
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import * as OutlookApi from "@app/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper";
 import {
+  renderAvailabilityCheck,
   renderOutlookEvent,
   renderOutlookEventList,
 } from "@app/lib/actions/mcp_internal_actions/servers/outlook/rendering";
@@ -637,7 +638,7 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
-        const formattedText = formatAvailabilityCheck(
+        const formattedText = renderAvailabilityCheck(
           result.events,
           startTime,
           endTime

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -203,7 +203,7 @@ export function renderOutlookEventList(
   return lines.join("\n");
 }
 
-export function formatAvailabilityCheck(
+export function renderAvailabilityCheck(
   allEvents: OutlookEvent[],
   startTime: string,
   endTime: string

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -210,7 +210,7 @@ export function renderAvailabilityCheck(
 ): string {
   // Possible values for showAs are free, tentative, busy, oof, workingElsewhere, unknown.
   // cf. https://learn.microsoft.com/fr-fr/graph/api/resources/event?view=graph-rest-1.0
-  const blockingStatuses = ["busy", "tentative", "oof", "workingElsewhere"];
+  const blockingStatuses = ["busy", "tentative", "oof"];
   const blockingEvents = allEvents.filter((event) => {
     if (event.isCancelled) {
       return false;

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -202,3 +202,63 @@ export function renderOutlookEventList(
 
   return lines.join("\n");
 }
+
+export function formatAvailabilityCheck(
+  allEvents: OutlookEvent[],
+  startTime: string,
+  endTime: string
+): string {
+  // Possible values for showAs are free, tentative, busy, oof, workingElsewhere, unknown.
+  // cf. https://learn.microsoft.com/fr-fr/graph/api/resources/event?view=graph-rest-1.0
+  const blockingStatuses = ["busy", "tentative", "oof", "workingElsewhere"];
+  const blockingEvents = allEvents.filter((event) => {
+    if (event.isCancelled) {
+      return false;
+    }
+    return blockingStatuses.includes(event.showAs ?? "busy");
+  });
+
+  const available = blockingEvents.length === 0;
+
+  const lines: string[] = [];
+  if (available) {
+    lines.push("User is AVAILABLE during this time period");
+    lines.push("");
+    lines.push(`Period: ${startTime} to ${endTime}`);
+    if (allEvents.length > 0) {
+      const freeEvents = allEvents.filter(
+        (e) => !e.isCancelled && (e.showAs === "free" || !e.showAs)
+      );
+      if (freeEvents.length > 0) {
+        lines.push("");
+        lines.push(
+          `Note: There ${freeEvents.length === 1 ? "is" : "are"} ${freeEvents.length} event${pluralize(freeEvents.length)} during this period marked as 'free'`
+        );
+      }
+    }
+  } else {
+    lines.push("User is NOT AVAILABLE during this time period");
+    lines.push("");
+    lines.push(`Period: ${startTime} to ${endTime}`);
+    lines.push(
+      `Blocking events: ${blockingEvents.length} event${pluralize(blockingEvents.length)}`
+    );
+    lines.push("");
+    lines.push("Conflicting events:");
+    lines.push("");
+    blockingEvents.forEach((event, index) => {
+      if (index > 0) {
+        lines.push("");
+      }
+      lines.push(
+        `${index + 1}. ${event.subject ?? "(No title)"} - ${event.showAs ?? "busy"}`
+      );
+      lines.push(`   ${event.start.dateTime} to ${event.end.dateTime}`);
+      if (event.location?.displayName) {
+        lines.push(`   Location: ${event.location.displayName}`);
+      }
+    });
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/5151.
- We've observed that one use case of the outlook calendar tool was to check whether the user was available during a certain period.
- On some examples the agent struggles to parse and interpret the output of the API.
- This PR adds a tool to check the availability and return a well formatted output.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
