### PR TITLE
Improve screen when trying to access a conversation we don't have the…

### DIFF
--- a/front/components/assistant/conversation/ConversationError.tsx
+++ b/front/components/assistant/conversation/ConversationError.tsx
@@ -34,7 +34,7 @@ function ConversationAccessRestricted() {
       title="Permission Required"
       message={[
         "This conversation contains protected information.",
-        "Request access to view it.",
+        "You don't have permission to view it.",
       ]}
     />
   );

--- a/front/components/assistant/conversation/ConversationError.tsx
+++ b/front/components/assistant/conversation/ConversationError.tsx
@@ -1,4 +1,10 @@
-import { Icon, StopSignIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  ExclamationCircleIcon,
+  Icon,
+  LoginIcon,
+} from "@dust-tt/sparkle";
+import Link from "next/link";
 import type { ComponentType } from "react";
 
 import type { ConversationError } from "@app/types";
@@ -30,12 +36,9 @@ export function ConversationErrorDisplay({ error }: ConversationErrorProps) {
 function ConversationAccessRestricted() {
   return (
     <ErrorDisplay
-      icon={StopSignIcon}
-      title="Permission Required"
-      message={[
-        "This conversation contains protected information.",
-        "You don't have permission to view it.",
-      ]}
+      icon={ExclamationCircleIcon}
+      title="You don't have access to this page"
+      message={["This conversation may include restricted data."]}
     />
   );
 }
@@ -43,9 +46,9 @@ function ConversationAccessRestricted() {
 function ConversationNotFound() {
   return (
     <ErrorDisplay
+      icon={ExclamationCircleIcon}
       title="Conversation Not Found"
-      message="It looks like the conversation you're looking for doesn't exist or may
-        have been deleted."
+      message="This conversation may have been deleted or moved."
     />
   );
 }
@@ -72,11 +75,11 @@ interface ErrorDisplayProps {
 
 export function ErrorDisplay({ icon, message, title }: ErrorDisplayProps) {
   return (
-    <div className="h-dvh flex flex-col items-center justify-center gap-1">
+    <div className="h-dvh flex flex-col items-center justify-center gap-3">
       {icon && (
         <Icon
           visual={icon}
-          className="text-warning-400 dark:text-warning-400-night"
+          className="dark:text-golder-400-night text-golden-400"
           size="lg"
         />
       )}
@@ -90,6 +93,9 @@ export function ErrorDisplay({ icon, message, title }: ErrorDisplayProps) {
           <p>{message}</p>
         )}
       </p>
+      <Link href="/">
+        <Button variant="outline" label="Back to homepage" icon={LoginIcon} />
+      </Link>
     </div>
   );
 }

--- a/front/components/assistant/conversation/ConversationError.tsx
+++ b/front/components/assistant/conversation/ConversationError.tsx
@@ -9,7 +9,7 @@ interface ConversationErrorProps {
 }
 
 export function ConversationErrorDisplay({ error }: ConversationErrorProps) {
-  const errorMessageRes = safeParseJSON(error.message);
+  const errorMessageRes = safeParseJSON(JSON.stringify(error));
 
   if (errorMessageRes.isErr() || !isAPIErrorResponse(errorMessageRes.value)) {
     return <ConversationGenericError />;

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -215,7 +215,9 @@ function ConversationInnerLayout({
         >
           <ResizablePanel defaultSize={100}>
             <div className="flex h-full flex-col">
-              {activeConversationId && <ConversationTitle owner={owner} />}
+              {activeConversationId && !conversationError && (
+                <ConversationTitle owner={owner} />
+              )}
               {conversationError ? (
                 <ConversationErrorDisplay error={conversationError} />
               ) : (

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -141,11 +141,16 @@ export async function updateConversationTitle(
     title: string;
   }
 ): Promise<Result<undefined, ConversationError>> {
-  const conversation = await ConversationResource.fetchById(
+  const conversationRes = await ConversationResource.fetchById(
     auth,
     conversationId
   );
 
+  if (conversationRes.isErr()) {
+    return conversationRes;
+  }
+
+  const conversation = conversationRes.value;
   if (!conversation) {
     return new Err(new ConversationError("conversation_not_found"));
   }
@@ -168,7 +173,7 @@ export async function deleteOrLeaveConversation(
     conversationId: string;
   }
 ): Promise<Result<{ success: true }, Error>> {
-  const conversation = await ConversationResource.fetchById(
+  const conversationRes = await ConversationResource.fetchById(
     auth,
     conversationId,
     {
@@ -176,6 +181,11 @@ export async function deleteOrLeaveConversation(
     }
   );
 
+  if (conversationRes.isErr()) {
+    return conversationRes;
+  }
+
+  const conversation = conversationRes.value;
   if (!conversation) {
     return new Err(new ConversationError("conversation_not_found"));
   }

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -205,13 +205,13 @@ export async function destroyConversation(
 
   await destroyConversationDataSource(auth, { conversation });
 
-  const c = await ConversationResource.fetchById(auth, conversation.sId, {
+  const cRes = await ConversationResource.fetchById(auth, conversation.sId, {
     includeDeleted: true,
     includeTest: true,
     dangerouslySkipPermissionFiltering: true,
   });
-  if (c) {
-    await c.delete(auth);
+  if (cRes.isOk() && cRes.value) {
+    await cRes.value.delete(auth);
   }
 
   return new Ok(undefined);

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -27,12 +27,17 @@ export async function getConversation(
 ): Promise<Result<ConversationType, ConversationError>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const conversation = await ConversationResource.fetchById(
+  const conversationRes = await ConversationResource.fetchById(
     auth,
     conversationId,
     { includeDeleted }
   );
 
+  if (conversationRes.isErr()) {
+    return conversationRes;
+  }
+
+  const conversation = conversationRes.value;
   if (!conversation) {
     return new Err(new ConversationError("conversation_not_found"));
   }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -676,11 +676,16 @@ export async function fetchConversationMessages(
     return new Err(new Error("Unexpected `auth` without `workspace`."));
   }
 
-  const conversation = await ConversationResource.fetchById(
+  const conversationRes = await ConversationResource.fetchById(
     auth,
     conversationId
   );
 
+  if (conversationRes.isErr()) {
+    return conversationRes;
+  }
+
+  const conversation = conversationRes.value;
   if (!conversation) {
     return new Err(new ConversationError("conversation_not_found"));
   }

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -201,13 +201,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   ): Promise<BlockedToolExecution[]> {
     const owner = auth.getNonNullableWorkspace();
 
-    const conversation = await ConversationResource.fetchById(
+    const conversationRes = await ConversationResource.fetchById(
       auth,
       conversationId
     );
-    if (!conversation) {
+    if (conversationRes.isErr() || !conversationRes.value) {
       return [];
     }
+    const conversation = conversationRes.value;
 
     const latestAgentMessages =
       await conversation.getLatestAgentMessageIdByRank(auth);

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -97,10 +97,12 @@ describe("FileResource", () => {
       assert(token, "Share token should be defined");
 
       // Soft-delete the conversation.
-      const conversationResource = await ConversationResource.fetchById(
+      const conversationRes = await ConversationResource.fetchById(
         auth,
         conversation.sId
       );
+      assert(conversationRes.isOk(), "Failed to fetch conversation");
+      const conversationResource = conversationRes.value;
       assert(conversationResource, "Conversation resource should be defined");
       await conversationResource.updateVisibilityToDeleted();
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -177,12 +177,12 @@ export class FileResource extends BaseResource<FileModel> {
       // conversation exists, but internalBuilderForWorkspace only has global group
       // access and can't see agents from other groups that this conversation might reference.
       // Skip permission filtering since share token provides its own authorization.
-      const conversation = await ConversationResource.fetchById(
+      const conversationRes = await ConversationResource.fetchById(
         auth,
         conversationId,
         { dangerouslySkipPermissionFiltering: true }
       );
-      if (!conversation) {
+      if (conversationRes.isErr() || !conversationRes.value) {
         return null;
       }
     }

--- a/front/pages/404.tsx
+++ b/front/pages/404.tsx
@@ -1,42 +1,32 @@
-import { Button, LogoutIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  ExclamationCircleIcon,
+  Icon,
+  LoginIcon,
+} from "@dust-tt/sparkle";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 
 export default function Custom404() {
-  const [currentURL, setCurrentURL] = useState("");
-
-  useEffect(() => {
-    // Only set the URL on the client-side
-    if (typeof window !== "undefined") {
-      setCurrentURL(window.location.href);
-    }
-  }, []);
-
   return (
     <div className="h-dvh flex items-center justify-center">
       <div className="flex flex-col gap-3 text-center">
-        <div>
-          <span className="text-4xl leading-10 text-foreground dark:text-foreground-night">
-            ☕️
-          </span>
+        <div className="flex flex-col items-center">
+          <div>
+            <Icon
+              visual={ExclamationCircleIcon}
+              size="lg"
+              className="dark:text-golder-400-night text-golden-400"
+            />
+          </div>
           <p className="heading-xl leading-7 text-foreground dark:text-foreground-night">
             404: Page not found
           </p>
           <p className="copy-sm leading-tight text-muted-foreground dark:text-muted-foreground-night">
             Looks like this page took an unscheduled coffee break.
           </p>
-          {currentURL && (
-            <p className="mt-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
-              Attempted URL: {currentURL}
-            </p>
-          )}
         </div>
         <Link href="/">
-          <Button
-            variant="highlight"
-            label="Back to homepage"
-            icon={LogoutIcon}
-          />
+          <Button variant="outline" label="Back to homepage" icon={LoginIcon} />
         </Link>
       </div>
     </div>

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -129,12 +129,13 @@ async function handler(
   let isParticipant = false;
 
   if (user && conversationId) {
-    const conversationResource = await ConversationResource.fetchById(
+    const conversationRes = await ConversationResource.fetchById(
       auth,
       conversationId
     );
 
-    if (user && conversationResource) {
+    if (conversationRes.isOk() && conversationRes.value && user) {
+      const conversationResource = conversationRes.value;
       isParticipant =
         await conversationResource.isConversationParticipant(user);
     }

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -78,11 +78,11 @@ async function handler(
     file.useCaseMetadata?.conversationId
   ) {
     // For conversation files, check if the user has access to the conversation
-    const conversation = await ConversationResource.fetchById(
+    const conversationRes = await ConversationResource.fetchById(
       auth,
       file.useCaseMetadata.conversationId
     );
-    if (!conversation) {
+    if (conversationRes.isErr() || !conversationRes.value) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {

--- a/front/pages/api/v1/w/[wId]/files/fileId.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/fileId.test.ts
@@ -7,7 +7,10 @@ import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_
 
 vi.mock("@app/lib/resources/file_resource", () => ({
   FileResource: {
-    fetchById: vi.fn(),
+    fetchById: vi.fn().mockResolvedValue({
+      isErr: () => false,
+      value: { id: "test-file-id" },
+    }),
   },
 }));
 
@@ -50,7 +53,10 @@ vi.mock("@app/lib/api/data_sources", () => ({
 
 vi.mock("@app/lib/resources/conversation_resource", () => ({
   ConversationResource: {
-    fetchById: vi.fn().mockResolvedValue({ id: "test-conversation-id" }),
+    fetchById: vi.fn().mockResolvedValue({
+      isErr: () => false,
+      value: { id: "test-conversation-id" },
+    }),
   },
 }));
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -62,7 +62,9 @@ async function handler(
   switch (req.method) {
     case "GET": {
       const conversationRes =
-        await ConversationResource.fetchConversationWithoutContent(auth, cId);
+        await ConversationResource.fetchConversationWithoutContent(auth, cId, {
+          alertIfNoAccessible: true,
+        });
 
       if (conversationRes.isErr()) {
         return apiErrorForConversation(req, res, conversationRes.error);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -42,9 +42,9 @@ async function handler(
     });
   }
 
-  const conversation = await ConversationResource.fetchById(auth, cId);
+  const conversationRes = await ConversationResource.fetchById(auth, cId);
 
-  if (!conversation) {
+  if (conversationRes.isErr() || !conversationRes.value) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -53,6 +53,8 @@ async function handler(
       },
     });
   }
+
+  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
@@ -44,7 +44,10 @@ vi.mock("@app/lib/api/data_sources", () => ({
 
 vi.mock("@app/lib/resources/conversation_resource", () => ({
   ConversationResource: {
-    fetchById: vi.fn().mockResolvedValue({ id: "test-conversation-id" }),
+    fetchById: vi.fn().mockResolvedValue({
+      isErr: () => false,
+      value: { id: "test-conversation-id" },
+    }),
   },
 }));
 

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -122,11 +122,11 @@ async function handler(
     isConversationFileUseCase(file.useCase) &&
     file.useCaseMetadata?.conversationId
   ) {
-    const conversation = await ConversationResource.fetchById(
+    const conversationRes = await ConversationResource.fetchById(
       auth,
       file.useCaseMetadata.conversationId
     );
-    if (!conversation) {
+    if (conversationRes.isErr() || !conversationRes.value) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {

--- a/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
@@ -64,12 +64,12 @@ async function handler(
 
   // Check permissions based on useCase and useCaseMetadata.
   if (isConversationFileUseCase(useCase) && useCaseMetadata?.conversationId) {
-    const conversation = await ConversationResource.fetchById(
+    const conversationRes = await ConversationResource.fetchById(
       auth,
       useCaseMetadata.conversationId
     );
 
-    if (!conversation) {
+    if (conversationRes.isErr() || !conversationRes.value) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -55,11 +55,11 @@ async function handler(
     file.useCaseMetadata?.conversationId
   ) {
     // For conversation files, check if the user has access to the conversation.
-    const conversation = await ConversationResource.fetchById(
+    const conversationRes = await ConversationResource.fetchById(
       auth,
       file.useCaseMetadata.conversationId
     );
-    if (!conversation) {
+    if (conversationRes.isErr() || !conversationRes.value) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {

--- a/front/scripts/debug_conversation_accessibility.ts
+++ b/front/scripts/debug_conversation_accessibility.ts
@@ -41,13 +41,15 @@ makeScript(
 
     // Step 1: Check if conversation exists (bypass permissions)
     logger.info("STEP 1: Checking if conversation exists...");
-    const conversationWithoutPermCheck = await ConversationResource.fetchById(
-      auth,
-      conversationId,
-      { dangerouslySkipPermissionFiltering: true }
-    );
+    const conversationWithoutPermCheckRes =
+      await ConversationResource.fetchById(auth, conversationId, {
+        dangerouslySkipPermissionFiltering: true,
+      });
 
-    if (!conversationWithoutPermCheck) {
+    if (
+      conversationWithoutPermCheckRes.isErr() ||
+      !conversationWithoutPermCheckRes.value
+    ) {
       logger.error(
         "✗ Conversation not found in this workspace (or doesn't exist)"
       );
@@ -60,6 +62,8 @@ makeScript(
       return;
     }
 
+    const conversationWithoutPermCheck = conversationWithoutPermCheckRes.value;
+
     logger.info("✓ Conversation exists", {
       conversationId: conversationWithoutPermCheck.sId,
       visibility: conversationWithoutPermCheck.visibility,
@@ -71,12 +75,13 @@ makeScript(
 
     // Step 2: Check if user has access (with permission filtering)
     logger.info("STEP 2: Checking user access (with permission filtering)...");
-    const conversation = await ConversationResource.fetchById(
+    const conversationRes = await ConversationResource.fetchById(
       auth,
       conversationId
     );
 
-    if (conversation) {
+    if (conversationRes.isOk() && conversationRes.value) {
+      const conversation = conversationRes.value;
       logger.info("✓ USER HAS ACCESS TO CONVERSATION", {
         conversationExists: true,
         userHasAccess: true,

--- a/front/temporal/agent_loop/activities/notification.ts
+++ b/front/temporal/agent_loop/activities/notification.ts
@@ -51,18 +51,20 @@ export async function conversationUnreadNotificationActivity(
   await new Promise((resolve) => setTimeout(resolve, NOTIFICATION_DELAY_MS));
 
   // Get conversation participants
-  const conversation = await ConversationResource.fetchById(
+  const conversationRes = await ConversationResource.fetchById(
     auth,
     agentLoopArgs.conversationId
   );
 
-  if (!conversation) {
+  if (conversationRes.isErr() || !conversationRes.value) {
     logger.warn(
       { conversationId: agentLoopArgs.conversationId },
       "Conversation not found after delay"
     );
     return;
   }
+
+  const conversation = conversationRes.value;
 
   // Skip any sub-conversations.
   if (conversation.depth > 0) {


### PR DESCRIPTION
## Description

Frontend: A screen already exists when the user doesn't have access to a conversation but the errors handling was broken.
Backend: Return the right error (`conversation_access_restricted` instead of `conversation_not_found`)

## Tests

- In a workspace, create a new private space, add a data source in this space and link an agent to this data source
- Start a conversation with this agent
- Copy the link of this conversation
- Log in with another user and try to go to the conversation
- You should see an error message 
<img width="1417" height="1315" alt="image" src="https://github.com/user-attachments/assets/dc6e043a-22d4-4712-884e-30d24c5a7297" />

## Risk

Low

## Deploy Plan

Deploy front
