### PR TITLE
Update conversation's timestamp directly

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -118,6 +118,7 @@ export async function createConversation(
     id: conversation.id,
     owner,
     created: conversation.createdAt.getTime(),
+    updated: conversation.updatedAt.getTime(),
     sId: conversation.sId,
     title: conversation.title,
     depth: conversation.depth,
@@ -598,6 +599,8 @@ export async function postUserMessage(
         t,
       });
 
+      await ConversationResource.markAsUpdated(auth, { conversation, t });
+
       return {
         userMessage,
         agentMessages: agentMessagesResult.map(({ m }) => m),
@@ -948,6 +951,8 @@ export async function editUserMessage(
         t,
       });
 
+      await ConversationResource.markAsUpdated(auth, { conversation, t });
+
       return {
         userMessage,
         agentMessages: agentMessagesResult.map(({ m }) => m),
@@ -1113,6 +1118,8 @@ export async function retryAgentMessage(
         conversation,
         t,
       });
+
+      await ConversationResource.markAsUpdated(auth, { conversation, t });
 
       const agentMessage: AgentMessageType = {
         id: m.id,
@@ -1316,6 +1323,8 @@ export async function postNewContentFragment(
         t,
       });
     }
+
+    await ConversationResource.markAsUpdated(auth, { conversation, t });
 
     return { contentFragment, messageRow };
   });

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -123,6 +123,7 @@ export async function getConversation(
   return new Ok({
     id: conversation.id,
     created: conversation.createdAt.getTime(),
+    updated: conversation.updatedAt.getTime(),
     sId: conversation.sId,
     owner,
     title: conversation.title,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -773,7 +773,6 @@ describe("ConversationResource", () => {
       const conversationData = userConversations[0].toJSON();
 
       // Verify participation data is used in toJSON.
-      expect(conversationData.updated).toBe(participation.updatedAt.getTime());
       expect(conversationData.unread).toBe(participation.unread);
       expect(conversationData.actionRequired).toBe(
         participation.actionRequired
@@ -784,6 +783,7 @@ describe("ConversationResource", () => {
       expect(conversationData.sId).toBeDefined();
       expect(conversationData.title).toBeDefined();
       expect(conversationData.created).toBeDefined();
+      expect(conversationData.updated).toBeDefined();
       expect(Array.isArray(conversationData.requestedSpaceIds)).toBe(true);
     });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -397,6 +397,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return new Ok({
       id: conversation.id,
       created: conversation.createdAt.getTime(),
+      updated: conversation.updatedAt.getTime(),
       sId: conversation.sId,
       title: conversation.title,
       triggerId: conversation.triggerSId,
@@ -517,6 +518,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         return {
           id: c.id,
           created: c.createdAt.getTime(),
+          updated: c.updatedAt.getTime(),
           sId: c.sId,
           title: c.title,
           triggerId: triggerId,
@@ -575,6 +577,29 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
 
     return new Ok(updated);
+  }
+
+  static async markAsUpdated(
+    auth: Authenticator,
+    {
+      conversation,
+      t,
+    }: { conversation: ConversationWithoutContentType; t?: Transaction }
+  ): Promise<Result<number, Error>> {
+    const updated = await ConversationModel.update(
+      {
+        id: col("id"), // no real change
+      },
+      {
+        where: {
+          id: conversation.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction: t,
+      }
+    );
+
+    return new Ok(updated[0]);
   }
 
   static async markAsUnreadForOtherParticipants(
@@ -1076,12 +1101,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const participation = this.userParticipation ?? {
       actionRequired: false,
       unread: false,
-      updated: this.updatedAt.getTime(),
     };
 
     return {
       actionRequired: participation.actionRequired,
       created: this.createdAt.getTime(),
+      updated: this.updatedAt.getTime(),
       hasError: this.hasError,
       id: this.id,
       // TODO(REQUESTED_SPACE_IDS 2025-10-24): Stop exposing this once all logic is centralized
@@ -1095,7 +1120,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       sId: this.sId,
       title: this.title,
       unread: participation.unread,
-      updated: participation.updated,
     };
   }
 }

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -68,6 +68,7 @@ async function handler(
         return {
           id: c.id,
           created: c.createdAt.getTime(),
+          updated: c.updatedAt.getTime(),
           sId: c.sId,
           owner: auth.getNonNullableWorkspace(),
           title: c.title,

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -115,12 +115,16 @@ async function processEventForDatabase(
       break;
 
     case "agent_message_success":
-      // Store success and run IDs in database.
-      await agentMessageRow.update({
-        runIds: event.runIds,
-        status: "succeeded",
-        completedAt: new Date(),
-      });
+      await Promise.all([
+        // Store success and run IDs in database.
+        agentMessageRow.update({
+          runIds: event.runIds,
+          status: "succeeded",
+          completedAt: new Date(),
+        }),
+        // Mark the conversation as updated
+        ConversationResource.markAsUpdated(auth, { conversation }),
+      ]);
 
       break;
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -243,7 +243,7 @@ export type ConversationVisibility = "unlisted" | "deleted" | "test";
 export type ConversationWithoutContentType = {
   id: ModelId;
   created: number;
-  updated?: number;
+  updated: number;
   unread: boolean;
   actionRequired: boolean;
   hasError: boolean;


### PR DESCRIPTION
## Description

Stop using participant's updatedAt value for the conversation and update the conversation's timestamp directly.

## Tests

Local + updated.

## Risk

Low

## Deploy Plan

Deploy front