### PR TITLE
feat(growth): onboarding conversation

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -138,4 +138,8 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
     label: "Zendesk",
     color: "text-blue-800 dark:text-blue-800-night",
   },
+  onboarding_conversation: {
+    label: "Onboarding",
+    color: "info-muted dark:info-muted-night",
+  },
 };

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -16,7 +16,10 @@ import type {
   VirtuosoMessage,
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
-import { isUserMessage } from "@app/components/assistant/conversation/types";
+import {
+  isHiddenContextOrigin,
+  isUserMessage,
+} from "@app/components/assistant/conversation/types";
 import { useCancelMessage, useConversation } from "@app/lib/swr/conversations";
 import { emptyArray } from "@app/lib/swr/swr";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -59,7 +62,7 @@ export const AgentInputBar = ({
         isUserMessage(m) &&
         m.user?.id === context.user.id &&
         m.visibility !== "deleted" &&
-        m.context.origin !== "agent_handover"
+        !isHiddenContextOrigin(m.context.origin)
     );
 
   const agentMentions = useMemo(() => {

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -25,6 +25,7 @@ import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideP
 import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import { useURLSheet } from "@app/hooks/useURLSheet";
+import { ONBOARDING_CONVERSATION_ENABLED } from "@app/lib/onboarding";
 import { useConversation } from "@app/lib/swr/conversations";
 import type {
   ConversationError,
@@ -115,7 +116,12 @@ const ConversationLayoutContent = ({
     useWelcomeTourGuide();
 
   const shouldDisplayWelcomeTourGuide = useMemo(() => {
-    return router.query.welcome === "true" && !activeConversationId;
+    // Only show the welcome tour guide if onboarding chat is disabled.
+    return (
+      router.query.welcome === "true" &&
+      !activeConversationId &&
+      !ONBOARDING_CONVERSATION_ENABLED
+    );
   }, [router.query.welcome, activeConversationId]);
 
   const onTourGuideEnd = () => {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -31,6 +31,7 @@ import type {
 import {
   areSameRank,
   getMessageRank,
+  isHiddenContextOrigin,
   isMessageTemporayState,
   isUserMessage,
   makeInitialMessageStreamState,
@@ -182,9 +183,13 @@ export const ConversationViewer = ({
     // Switch to conversation B, wait till A is done streaming, then switch back to A.
     // Without waiting for revalidation, we would use whatever data was in the swr cache and see the last message as "streaming" (old data, no more streaming events).
     if (!initialListData && messages.length > 0 && !isValidating) {
-      const messagesToRender = convertLightMessageTypeToVirtuosoMessages(
-        messages.flatMap((m) => m.messages)
-      );
+      const raw = messages
+        .flatMap((m) => m.messages)
+        .filter((m) =>
+          isUserMessageType(m) ? !isHiddenContextOrigin(m.context.origin) : true
+        );
+
+      const messagesToRender = convertLightMessageTypeToVirtuosoMessages(raw);
 
       setInitialListData(messagesToRender);
     }
@@ -209,8 +214,11 @@ export const ConversationViewer = ({
     );
 
     if (olderMessagesFromBackend.length > 0) {
+      const filtered = olderMessagesFromBackend.filter((m) =>
+        isUserMessageType(m) ? !isHiddenContextOrigin(m.context.origin) : true
+      );
       ref.current.data.prepend(
-        convertLightMessageTypeToVirtuosoMessages(olderMessagesFromBackend)
+        convertLightMessageTypeToVirtuosoMessages(filtered)
       );
     }
 
@@ -277,6 +285,9 @@ export const ConversationViewer = ({
         switch (event.type) {
           case "user_message_new":
             if (ref.current) {
+              if (isHiddenContextOrigin(event.message.context.origin)) {
+                break;
+              }
               const userMessage: VirtuosoMessage = {
                 ...event.message,
                 contentFragments: [],

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -89,9 +89,7 @@ export const isTriggeredOrigin = (origin?: UserMessageOrigin | null) => {
 export const isHiddenContextOrigin = (
   origin?: UserMessageOrigin | null
 ): boolean => {
-  return (
-    origin === "onboarding_conversation" || origin === "agent_handover"
-  );
+  return origin === "onboarding_conversation" || origin === "agent_handover";
 };
 
 export const isUserMessage = (

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -84,6 +84,14 @@ export const isTriggeredOrigin = (origin?: UserMessageOrigin | null) => {
   );
 };
 
+// Central helper to control which user message origins should be hidden in the UI.
+// Extend this list as we introduce more bootstrap/system user messages.
+export const isHiddenContextOrigin = (
+  origin?: UserMessageOrigin | null
+): boolean => {
+  return origin === "onboarding_conversation";
+};
+
 export const isUserMessage = (
   msg: VirtuosoMessage
 ): msg is UserMessageType & { contentFragments: ContentFragmentType[] } =>

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -89,7 +89,9 @@ export const isTriggeredOrigin = (origin?: UserMessageOrigin | null) => {
 export const isHiddenContextOrigin = (
   origin?: UserMessageOrigin | null
 ): boolean => {
-  return origin === "onboarding_conversation";
+  return (
+    origin === "onboarding_conversation" || origin === "agent_handover"
+  );
 };
 
 export const isUserMessage = (

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -33,6 +33,7 @@ import {
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
 import { triggerConversationUnreadNotifications } from "@app/lib/notifications/workflows/conversation-unread";
+import { ONBOARDING_CONVERSATION_ENABLED } from "@app/lib/onboarding";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -77,6 +78,7 @@ import {
   assertNever,
   ConversationError,
   Err,
+  GLOBAL_AGENTS_SID,
   isAgentMention,
   isContentFragmentInputWithContentNode,
   isContentFragmentType,
@@ -274,6 +276,129 @@ export async function getMessageConversationId(
     conversationId: messageRow?.conversation?.sId ?? null,
     messageId: messageRow?.sId ?? null,
   };
+}
+
+export async function createOnboardingConversationIfNeeded(
+  auth: Authenticator,
+  { force }: { force?: boolean } = { force: false }
+): Promise<Result<string | null, APIErrorWithStatusCode>> {
+  const owner = auth.workspace();
+  const subscription = auth.subscription();
+  const user = auth.user();
+
+  if (!owner || !subscription || !user) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Cannot create onboarding conversation without workspace, user and subscription.",
+      },
+    });
+  }
+
+  if (!force && !ONBOARDING_CONVERSATION_ENABLED) {
+    return new Ok(null);
+  }
+
+  // Only create onboarding conversation for brand-new workspaces (only one member,
+  // no conversations) unless force flag is set.
+  if (!force) {
+    const existingMetadata = await user.getMetadata("onboarding:conversation");
+
+    if (existingMetadata?.value) {
+      // User already has an onboarding conversation.
+      return new Ok(null);
+    }
+
+    const { total: membersTotal } =
+      await MembershipResource.getMembershipsForWorkspace({
+        workspace: owner,
+      });
+
+    if (membersTotal > 1) {
+      return new Ok(null);
+    }
+
+    const conversationsCount =
+      await ConversationResource.countForWorkspace(auth);
+
+    if (conversationsCount > 0) {
+      return new Ok(null);
+    }
+  }
+
+  const conversation = await createConversation(auth, {
+    title: null,
+    visibility: "unlisted",
+  });
+
+  const gmailToolDirective = ":toolSetup[Connect Gmail]{sId=gmail}";
+
+  const onboardingSystemMessage = `<dust_system>
+You are onboarding a brand-new user to Dust.
+
+FOR YOUR INITIAL MESSAGE IN THIS CONVERSATION: respond very quickly, do NOT use long or step-by-step "thinking" or analysis, and keep your reply short and direct. Your first line MUST be a level-1 markdown heading that starts with the text "Welcome to Dust" followed by at least one emoji, for example:
+
+# Welcome to Dust 👋
+
+In this very first reply, you MUST (1) briefly explain what Dust is and a couple of things it can do, (2) mention that Dust works even better when it has access to tools like Gmail, (3) explicitly reference that the user is using a Google email address and propose connecting Gmail, and (4) end with the Gmail markdown directive described below. Your first reply MUST include between 1 and 3 emojis in total (not 0 and not more than 3).
+
+Dust is the product. The user has a workspace on Dust where they can use and create AI agents, connect tools (like email, calendar, docs), and invite their teammates to collaborate. You are the user’s first guide in this workspace. In your first message, you should not ask the user what they want to achieve yet; instead, focus on a concise explanation of Dust’s capabilities and why connecting Gmail is useful. You can ask follow-up questions about their goals in later turns, after the first reply.
+
+The user signed up with a Google-hosted email address, so they very likely use Gmail as their primary inbox. Explicitly mention that you noticed they are using a Google email address and that, because of this, connecting Gmail is a highly recommended first step so you can, for example, search emails, summarize threads, and help draft replies on their behalf.
+
+Dust supports a special markdown directive that lets you show a visual card to help users set up tools like Gmail. When rendered, this directive becomes an interactive card with a title, description, and a button to activate the tool.
+
+For Gmail, the directive syntax is:
+
+${gmailToolDirective}
+
+Where:
+- \`toolSetup\` identifies the tool-setup directive.
+- \`Connect Gmail\` is the label the user will see on the card.
+- \`sId=gmail\` selects the internal Gmail tool.
+
+In this onboarding conversation, your initial message MUST:
+1. Very briefly explain Dust (1–2 short sentences).
+2. Immediately explain, in one or two short sentences, why connecting Gmail will make Dust more helpful.
+3. Then add a blank line and a final line containing only the directive:
+
+${gmailToolDirective}
+
+Do NOT wrap this directive in a code block or quotes; it must appear as raw markdown on its own line at the end of your message so the UI can render the setup card correctly. In later messages, only repeat the directive if the user seems interested in Gmail or asks how to connect email again.
+</dust_system>`;
+
+  const userJson = user.toJSON();
+
+  const context: UserMessageContext = {
+    username: userJson.username,
+    fullName: userJson.fullName,
+    email: userJson.email,
+    profilePictureUrl: userJson.image,
+    timezone: "UTC",
+    origin: "onboarding_conversation",
+  };
+
+  const postRes = await postUserMessage(auth, {
+    conversation,
+    content: onboardingSystemMessage,
+    mentions: [
+      {
+        configurationId: GLOBAL_AGENTS_SID.DUST,
+      },
+    ],
+    context,
+    skipToolsValidation: false,
+  });
+
+  if (postRes.isErr()) {
+    return postRes;
+  }
+
+  await user.setMetadata("onboarding:conversation", conversation.sId);
+
+  return new Ok(conversation.sId);
 }
 
 export async function getLastUserMessage(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -331,6 +331,7 @@ export async function createOnboardingConversationIfNeeded(
   const conversation = await createConversation(auth, {
     title: null,
     visibility: "unlisted",
+    spaceId: null,
   });
 
   const gmailToolDirective = ":toolSetup[Connect Gmail]{sId=gmail}";

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -17,6 +17,7 @@ export * from "./rename_workspace";
 export * from "./reset_message_rate_limit";
 export * from "./restore_conversation";
 export * from "./revoke_users";
+export * from "./send_onboarding_conversation";
 export * from "./set_public_api_limits";
 export * from "./sync_missing_transcripts_date_range";
 export * from "./toggle_auto_create_space";

--- a/front/lib/api/poke/plugins/workspaces/send_onboarding_conversation.ts
+++ b/front/lib/api/poke/plugins/workspaces/send_onboarding_conversation.ts
@@ -1,0 +1,77 @@
+import { createOnboardingConversationIfNeeded } from "@app/lib/api/assistant/conversation";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { Authenticator } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { Err, Ok } from "@app/types";
+
+export const sendOnboardingConversationPlugin = createPlugin({
+  manifest: {
+    id: "send-onboarding-conversation",
+    name: "Send onboarding conversation",
+    description:
+      "Create and send the onboarding conversation to a specific user in this workspace.",
+    warning:
+      "This overwrites the user's onboarding metadata and may recreate the conversation even if one exists.",
+    resourceTypes: ["workspaces"],
+    args: {
+      userSId: {
+        type: "string",
+        label: "User sId",
+        description:
+          "Target user stable id (e.g., usr_xxx) belonging to this workspace.",
+      },
+    },
+  },
+  execute: async (auth, _resource, args) => {
+    const workspace = auth.workspace();
+    if (!workspace) {
+      return new Err(new Error("Workspace not found in auth context."));
+    }
+
+    const targetUser = await UserResource.fetchById(args.userSId);
+    if (!targetUser) {
+      return new Err(new Error("User not found."));
+    }
+
+    const role = await MembershipResource.getActiveRoleForUserInWorkspace({
+      user: targetUser,
+      workspace: renderLightWorkspaceType({ workspace }),
+    });
+
+    if (role === "none") {
+      return new Err(new Error("User is not a member of this workspace."));
+    }
+
+    const targetAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      targetUser.sId,
+      workspace.sId
+    );
+
+    const convoRes = await createOnboardingConversationIfNeeded(targetAuth, {
+      force: true,
+    });
+
+    if (convoRes.isErr()) {
+      return new Err(new Error(convoRes.error.api_error.message));
+    }
+
+    const conversationId = convoRes.value;
+
+    if (!conversationId) {
+      return new Ok({
+        display: "text",
+        value: "Onboarding conversation was not created (conditions not met).",
+      });
+    }
+
+    return new Ok({
+      display: "textWithLink",
+      value: `Onboarding conversation ${conversationId} created.`,
+      link: `/w/${workspace.sId}/conversation/${conversationId}`,
+      linkText: "Open conversation",
+    });
+  },
+  isApplicableTo: () => true,
+});

--- a/front/lib/api/poke/plugins/workspaces/send_onboarding_conversation.ts
+++ b/front/lib/api/poke/plugins/workspaces/send_onboarding_conversation.ts
@@ -40,8 +40,8 @@ export const sendOnboardingConversationPlugin = createPlugin({
       workspace: renderLightWorkspaceType({ workspace }),
     });
 
-    if (role === "none") {
-      return new Err(new Error("User is not a member of this workspace."));
+    if (role === "admin") {
+      return new Err(new Error("User is not an admin of this workspace."));
     }
 
     const targetAuth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -34,6 +34,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   web: "user",
   zapier: "programmatic",
   zendesk: "programmatic",
+  onboarding_conversation: "user",
 };
 
 const PROGRAMMATIC_USAGE_ORIGINS = Object.keys(

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -40,6 +40,9 @@ export const shouldSendNotificationForAgentAnswer = (
     case "agent_handover":
     case "extension":
       return true;
+    case "onboarding_conversation":
+      // Internal bootstrap conversations shouldn't trigger unread notifications.
+      return false;
     case "api":
     case "email":
     case "excel":

--- a/front/lib/onboarding.ts
+++ b/front/lib/onboarding.ts
@@ -1,0 +1,4 @@
+// Central switch controlling whether new users get the onboarding conversation
+// experience.
+// TODO(growth): enable it once ready
+export const ONBOARDING_CONVERSATION_ENABLED = false;

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -119,6 +119,21 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
   }
 
+  static async countForWorkspace(
+    auth: Authenticator,
+    options?: FetchConversationOptions
+  ): Promise<number> {
+    const workspace = auth.getNonNullableWorkspace();
+    const { where } = this.getOptions(options);
+
+    return this.model.count({
+      where: {
+        ...where,
+        workspaceId: workspace.id,
+      },
+    });
+  }
+
   private static getOptions(
     options?: FetchConversationOptions
   ): ResourceFindOptions<ConversationModel> {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -72,7 +72,8 @@ export type UserMessageOrigin =
   | "triggered"
   | "web"
   | "zapier"
-  | "zendesk";
+  | "zendesk"
+  | "onboarding_conversation";
 
 export type UserMessageContext = {
   username: string;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -322,6 +322,7 @@ const UserMessageOriginSchema = FlexibleEnumSchema<
   | "web"
   | "zapier"
   | "zendesk"
+  | "onboarding_conversation"
 >()
   .or(z.null())
   .or(z.undefined());


### PR DESCRIPTION
## Description

Adds the onboarding conversation setup.

Users creating a new workspace automatically get the onboarding conversation if `ONBOARDING_CONVERSATION_ENABLED` is true (it's currently false)

There's also a poke plugin to send it to any user.

## Tests

Local

## Risk

Low

## Deploy Plan

deploy front