### PR TITLE
[Analytics Export] Fill userId in user usage CSV

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -56,6 +56,7 @@ interface MessageUsageQueryResult {
 }
 
 type UserUsageQueryResult = {
+  userId: string;
   userName: string;
   userEmail: string;
   messageCount: number;
@@ -511,6 +512,7 @@ export async function getUserUsageData(
       const userId = membership.userId.toString();
 
       userUsage.push({
+        userId,
         userName: user.name || email,
         userEmail: email,
         messageCount: 0,


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5169

Ensure `getUserUsageData` includes the workspace `userId` for users that only appear via memberships (inactive users with 0 messages), so the exported user usage CSV has a consistent `userId` column for all rows and downstream analytics sheets stop breaking.

## Risks
Blast radius: workspace analytics user-usage CSV export (per-user usage export downloaded from the analytics page)
Risk: low

## Deploy Plan
- deploy front
