### PR TITLE
Disable Strict Mode when parsing viz code

### DIFF
--- a/viz/app/lib/parseFileIds.ts
+++ b/viz/app/lib/parseFileIds.ts
@@ -9,6 +9,7 @@ export function extractFileIds(code: string): string[] {
     const ast = parse(code, {
       sourceType: "module",
       plugins: ["jsx", "typescript"],
+      strictMode: false,
     });
 
     traverse(ast, {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR disables Strict Mode when attempting to parse the vizualisation code. We saw several issues with strict mode, most common one is that LLMs tend to often use `arguments` as a variable name. Strict mode isn't required here as Babel is solely used to extract the file Id used in the code. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
