### PR TITLE
[front] Bump number of concurrent webhook trigger activities

### DIFF
--- a/front/lib/triggers/temporal/webhook/worker.ts
+++ b/front/lib/triggers/temporal/webhook/worker.ts
@@ -15,7 +15,7 @@ export async function runAgentTriggerWebhookWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 2,
+    maxConcurrentActivityTaskExecutions: 8,
     connection,
     namespace,
     interceptors: {

--- a/front/lib/triggers/temporal/webhook/worker.ts
+++ b/front/lib/triggers/temporal/webhook/worker.ts
@@ -15,7 +15,7 @@ export async function runAgentTriggerWebhookWorker() {
     workflowsPath: require.resolve("./workflows"),
     activities,
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 8,
+    maxConcurrentActivityTaskExecutions: 4,
     connection,
     namespace,
     interceptors: {


### PR DESCRIPTION
## Description

- This PR bumps the number of activities processed concurrently for webhook triggers.
- IIUC the activities for this worker are very lightweight and only check the signature + rate limit before launching an agent loop.

## Tests

## Risk

- Will have to monitor front-worker pods.

## Deploy Plan

- Deploy front.
