### PR TITLE
[front] feat: Add credit billing logic at resource layer

### DIFF
--- a/front/lib/resources/storage/models/credits.ts
+++ b/front/lib/resources/storage/models/credits.ts
@@ -83,9 +83,9 @@ CreditModel.init(
       },
       // Unique constraint on (workspaceId, invoiceOrLineItemId) to prevent duplicate credit purchases
       {
-        fields: ["workspaceId", "invoiceOrLineItemId"],
+        fields: ["invoiceOrLineItemId"],
         unique: true,
-        name: "credits_workspace_invoice_unique_idx",
+        name: "credits_invoice_unique_idx",
         where: { invoiceOrLineItemId: { [Op.ne]: null } },
       },
       // Composite index for efficient queries on active credits

--- a/front/lib/resources/storage/models/credits.ts
+++ b/front/lib/resources/storage/models/credits.ts
@@ -15,7 +15,8 @@ export class CreditModel extends WorkspaceAwareModel<CreditModel> {
   declare updatedAt: CreationOptional<Date>;
 
   declare type: CreditType;
-  declare startDate: Date | null; // When credit becomes active (null = not yet paid/active)
+  // When credit becomes active (null = not yet paid/active).
+  declare startDate: Date | null;
   declare expirationDate: Date | null;
   declare initialAmount: number; // in cents (immutable)
   declare remainingAmount: number; // in cents

--- a/front/lib/resources/storage/models/credits.ts
+++ b/front/lib/resources/storage/models/credits.ts
@@ -15,6 +15,7 @@ export class CreditModel extends WorkspaceAwareModel<CreditModel> {
   declare expirationDate: Date | null;
   declare initialAmount: number; // in cents
   declare remainingAmount: number; // in cents
+  declare invoiceOrLineItemId: string | null; // Stripe invoice ID or line item ID for idempotency
 }
 
 CreditModel.init(
@@ -42,6 +43,11 @@ CreditModel.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
+    invoiceOrLineItemId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     modelName: "credit",
@@ -55,6 +61,13 @@ CreditModel.init(
         fields: ["workspaceId", "expirationDate"],
         name: "credits_nonzero_remaining_idx",
         where: { remainingAmount: { [Op.ne]: 0 } },
+      },
+      // Unique constraint on (workspaceId, invoiceOrLineItemId) to prevent duplicate credit purchases
+      {
+        fields: ["workspaceId", "invoiceOrLineItemId"],
+        unique: true,
+        name: "credits_workspace_invoice_unique_idx",
+        where: { invoiceOrLineItemId: { [Op.ne]: null } },
       },
     ],
   }

--- a/front/lib/resources/storage/models/credits.ts
+++ b/front/lib/resources/storage/models/credits.ts
@@ -18,7 +18,8 @@ export class CreditModel extends WorkspaceAwareModel<CreditModel> {
   // When credit becomes active (null = not yet paid/active).
   declare startDate: Date | null;
   declare expirationDate: Date | null;
-  declare initialAmount: number; // in cents (immutable)
+  // Amount in cents (immutable after creation).
+  declare initialAmount: number;
   declare remainingAmount: number; // in cents
   // Stripe invoice ID or line item ID for idempotency.
   declare invoiceOrLineItemId: string | null;

--- a/front/lib/resources/storage/models/credits.ts
+++ b/front/lib/resources/storage/models/credits.ts
@@ -20,7 +20,8 @@ export class CreditModel extends WorkspaceAwareModel<CreditModel> {
   declare expirationDate: Date | null;
   declare initialAmount: number; // in cents (immutable)
   declare remainingAmount: number; // in cents
-  declare invoiceOrLineItemId: string | null; // Stripe invoice ID or line item ID for idempotency
+  // Stripe invoice ID or line item ID for idempotency.
+  declare invoiceOrLineItemId: string | null;
 }
 
 CreditModel.init(

--- a/front/migrations/db/migration_408.sql
+++ b/front/migrations/db/migration_408.sql
@@ -3,6 +3,17 @@
 -- This column stores either a Stripe invoice ID (for Pro subscriptions) or a Stripe invoice line item ID (for Enterprise subscriptions)
 ALTER TABLE "public"."credits" ADD COLUMN "invoiceOrLineItemId" VARCHAR(255);
 
+-- Add type column to distinguish between credit types (free, payg, committed)
+-- Validation enforced at application level in CreditResource.makeNew() and CreditModel
+ALTER TABLE "public"."credits" ADD COLUMN "type" VARCHAR(16) NOT NULL;
+
+-- Add startDate column to track when a credit becomes active/consumable
+-- Credits with null startDate are not yet paid/active and cannot be consumed
+ALTER TABLE "public"."credits" ADD COLUMN "startDate" TIMESTAMP WITH TIME ZONE;
+
 -- Create unique index on (workspaceId, invoiceOrLineItemId) to prevent duplicate credit purchases
 -- Uses partial index to only enforce uniqueness for non-null values
 CREATE UNIQUE INDEX "credits_workspace_invoice_unique_idx" ON "public"."credits" ("workspaceId", "invoiceOrLineItemId") WHERE "invoiceOrLineItemId" IS NOT NULL;
+
+-- Create composite index for efficient queries on active credits
+CREATE INDEX "credits_workspace_start_expiration_idx" ON "public"."credits" ("workspaceId", "startDate", "expirationDate");

--- a/front/migrations/db/migration_408.sql
+++ b/front/migrations/db/migration_408.sql
@@ -13,7 +13,7 @@ ALTER TABLE "public"."credits" ADD COLUMN "startDate" TIMESTAMP WITH TIME ZONE;
 
 -- Create unique index on (workspaceId, invoiceOrLineItemId) to prevent duplicate credit purchases
 -- Uses partial index to only enforce uniqueness for non-null values
-CREATE UNIQUE INDEX "credits_workspace_invoice_unique_idx" ON "public"."credits" ("workspaceId", "invoiceOrLineItemId") WHERE "invoiceOrLineItemId" IS NOT NULL;
+CREATE UNIQUE INDEX "credits_invoice_unique_idx" ON "public"."credits" ("invoiceOrLineItemId") WHERE "invoiceOrLineItemId" IS NOT NULL;
 
 -- Create composite index for efficient queries on active credits
 CREATE INDEX "credits_workspace_start_expiration_idx" ON "public"."credits" ("workspaceId", "startDate", "expirationDate");

--- a/front/migrations/db/migration_408.sql
+++ b/front/migrations/db/migration_408.sql
@@ -1,0 +1,8 @@
+-- Migration created on Nov 18, 2025
+-- Add invoiceOrLineItemId column to credits table for idempotency in credit purchase flow
+-- This column stores either a Stripe invoice ID (for Pro subscriptions) or a Stripe invoice line item ID (for Enterprise subscriptions)
+ALTER TABLE "public"."credits" ADD COLUMN "invoiceOrLineItemId" VARCHAR(255);
+
+-- Create unique index on (workspaceId, invoiceOrLineItemId) to prevent duplicate credit purchases
+-- Uses partial index to only enforce uniqueness for non-null values
+CREATE UNIQUE INDEX "credits_workspace_invoice_unique_idx" ON "public"."credits" ("workspaceId", "invoiceOrLineItemId") WHERE "invoiceOrLineItemId" IS NOT NULL;

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -1,0 +1,9 @@
+export const CREDIT_TYPES = ["free", "payg", "committed"] as const;
+
+export type CreditType = (typeof CREDIT_TYPES)[number];
+
+export function isCreditType(value: unknown): value is CreditType {
+  return CREDIT_TYPES.includes(value as CreditType);
+}
+
+export const CREDIT_EXPIRATION_DAYS = 365;


### PR DESCRIPTION
## Description

Add 3 new fields to credit model
- `startDate`
- `type: "free" | "payg" | "commited"`  
- `invoiceOrLineItemId`

And a `start` method that sets the startDate of a customer to now(). Only credit with non null startDate can be consumed (considered active)


<details>
<summary>Flow</summary>

```mermaid
   sequenceDiagram
      participant User
      participant API as purchase.ts Handler
      participant Stripe as Stripe API
      participant Credits as CreditResource
      participant Webhook as Stripe Webhook

      Note over User,Webhook: Credit Purchase Flow - Always Create Credit Record

      User->>API: POST /api/w/[wId]/credits/purchase
      API->>Stripe: Determine if Enterprise or Pro subscription
      Stripe-->>API: Subscription details

      alt Enterprise Flow
          Note over API,Credits: Enterprise: Full Credits Immediately

          API->>Stripe: invoiceItems.create(subscription param)
          Note over Stripe: Item attached to subscription
          Stripe-->>API: Invoice Item ID

          API->>Credits: makeNew(initialAmount=FULL, remainingAmount=FULL)
          Note over Credits: Credit created with FULL amounts
          Credits-->>API: Credit Created

          API-->>User: 200 OK (invoiceId: null)

          Note over Stripe: Later: Item included in next regular invoice
          Note over Webhook: Webhook skips Enterprise (already added)

      else Pro Flow
          Note over API,Webhook: Pro: Placeholder Credit then Webhook Update

          API->>Stripe: invoices.create(draft)
          Stripe-->>API: Draft Invoice

          API->>Stripe: invoiceItems.create(invoice param)
          Stripe-->>API: Invoice Item

          API->>Stripe: invoices.finalize()
          Stripe-->>API: Finalized Invoice

          API->>Stripe: invoices.pay()
          Stripe-->>API: Paid Invoice

          API->>Credits: makeNew(initialAmount=0, remainingAmount=0)
          Note over Credits: Placeholder credit with 0/0 amounts
          Credits-->>API: Placeholder Credit Created

          API-->>User: 200 OK (invoiceId: inv_xxx)

          Stripe->>Webhook: invoice.paid event
          Webhook->>Credits: topUp(amount=FULL)
          Note over Credits: Update only if amounts are 0/0 (idempotency)
          Credits-->>Webhook: Credit Updated with FULL amounts
      end
```

</details>


## Risk

Database schema migration adds a new column and unique index to the `credits` table.

## Tests

Tested manually with both Enterprise and Pro subscription flows, including webhook delivery for Pro invoices.

## Deploy Plan

1. Apply database migration (`migration_408.sql`) to add `invoiceOrLineItemId` column and unique index
2. Deploy code changes