### PR TITLE
Increase Notion GC runs to an hour

### DIFF
--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -1,12 +1,13 @@
 const WORKFLOW_VERSION = 52;
 export const QUEUE_NAME = `notion-queue-v${WORKFLOW_VERSION}`;
-export const GARBAGE_COLLECT_QUEUE_NAME = `notion-gc-queue-v${WORKFLOW_VERSION}`;
+const GC_WORKFLOW_VERSION = 52;
+export const GARBAGE_COLLECT_QUEUE_NAME = `notion-gc-queue-v${GC_WORKFLOW_VERSION}`;
 
 // Notion's "last edited" timestamp is precise to the minute
 export const SYNC_PERIOD_DURATION_MS = 60_000;
 
 // How long to wait before checking for new pages again
-export const INTERVAL_BETWEEN_SYNCS_MS = 60_000; // 1 minute
+export const INTERVAL_BETWEEN_GC_SYNCS_MS = 60_000; // 1 minute
 
 export const MAX_CONCURRENT_CHILD_WORKFLOWS = 1;
 export const MAX_PAGE_IDS_PER_CHILD_WORKFLOW = 64;

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -6,8 +6,11 @@ export const GARBAGE_COLLECT_QUEUE_NAME = `notion-gc-queue-v${GC_WORKFLOW_VERSIO
 // Notion's "last edited" timestamp is precise to the minute
 export const SYNC_PERIOD_DURATION_MS = 60_000;
 
-// How long to wait before checking for new pages again
-export const INTERVAL_BETWEEN_GC_SYNCS_MS = 60_000; // 1 minute
+// How long to wait before running the incremental sync again
+export const INTERVAL_BETWEEN_SYNCS_MS = 60_000; // 1 minute
+
+// How long to wait before running the GC sync again
+export const INTERVAL_BETWEEN_GC_SYNCS_MS = 1000 * 60 * 60; // 1 hour
 
 export const MAX_CONCURRENT_CHILD_WORKFLOWS = 1;
 export const MAX_PAGE_IDS_PER_CHILD_WORKFLOW = 64;

--- a/connectors/src/connectors/notion/temporal/workflows/garbage_collection.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/garbage_collection.ts
@@ -8,7 +8,7 @@ import PQueue from "p-queue";
 
 import type * as activities from "@connectors/connectors/notion/temporal/activities";
 import {
-  INTERVAL_BETWEEN_SYNCS_MS,
+  INTERVAL_BETWEEN_GC_SYNCS_MS,
   MAX_CONCURRENT_CHILD_WORKFLOWS,
   MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES,
   MAX_SEARCH_PAGE_GARBAGE_COLLECTION_INDEX,
@@ -241,7 +241,7 @@ export async function notionGarbageCollectionWorkflow({
   // Once done, clear all the redis keys used for garbage collection
   await completeGarbageCollectionRun(connectorId, nbOfBatches);
 
-  await sleep(INTERVAL_BETWEEN_SYNCS_MS);
+  await sleep(INTERVAL_BETWEEN_GC_SYNCS_MS);
 
   await continueAsNew<typeof notionGarbageCollectionWorkflow>({
     connectorId,

--- a/connectors/src/connectors/notion/temporal/workflows/garbage_collection.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/garbage_collection.ts
@@ -1,5 +1,6 @@
 import {
   continueAsNew,
+  patched,
   proxyActivities,
   sleep,
   workflowInfo,
@@ -9,6 +10,7 @@ import PQueue from "p-queue";
 import type * as activities from "@connectors/connectors/notion/temporal/activities";
 import {
   INTERVAL_BETWEEN_GC_SYNCS_MS,
+  INTERVAL_BETWEEN_SYNCS_MS,
   MAX_CONCURRENT_CHILD_WORKFLOWS,
   MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES,
   MAX_SEARCH_PAGE_GARBAGE_COLLECTION_INDEX,
@@ -241,7 +243,11 @@ export async function notionGarbageCollectionWorkflow({
   // Once done, clear all the redis keys used for garbage collection
   await completeGarbageCollectionRun(connectorId, nbOfBatches);
 
-  await sleep(INTERVAL_BETWEEN_GC_SYNCS_MS);
+  if (patched("one-hour-gc-interval")) {
+    await sleep(INTERVAL_BETWEEN_GC_SYNCS_MS);
+  } else {
+    await sleep(INTERVAL_BETWEEN_SYNCS_MS);
+  }
 
   await continueAsNew<typeof notionGarbageCollectionWorkflow>({
     connectorId,


### PR DESCRIPTION
## Description

This change increases the Notion GC sync interval from one minute to an hour, since we have better ways of detecting add/deletes.

It also decouples the queue and sync interval of the Notion GC workflow from that of the regular workflow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low, but need to monitor

## Deploy Plan

Connectors