### PR TITLE
[front] feat: PPUL - Add Stripe credit purchase api/wh

### DIFF
--- a/front/lib/credits/purchase.ts
+++ b/front/lib/credits/purchase.ts
@@ -1,0 +1,267 @@
+import type Stripe from "stripe";
+
+import { Authenticator } from "@app/lib/auth";
+import type { Subscription } from "@app/lib/models/plan";
+import {
+  attachCreditPurchaseToSubscription,
+  getCreditAmountFromInvoice,
+  getStripeSubscription,
+  isCreditPurchaseInvoice,
+  isEnterpriseSubscription,
+  makeAndMaybePayCreditPurchaseInvoice,
+} from "@app/lib/plans/stripe";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+import type { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+/**
+ * Handles credit purchase activation from a Stripe invoice for Pro subscriptions.
+ * (Enterprise subscriptions activate credits optimistically, so we skip them here.)
+ *
+ * @param invoice - The Stripe invoice that was paid
+ * @param subscription - The subscription record with workspace included
+ * @returns Result indicating success or failure
+ */
+export async function maybeStartCreditFromProOneOffInvoice({
+  invoice,
+  subscription,
+}: {
+  invoice: Stripe.Invoice;
+  subscription: Subscription & { workspace: WorkspaceModel };
+}): Promise<Result<undefined, Error>> {
+  // Check if this is a credit purchase invoice
+  if (!isCreditPurchaseInvoice(invoice)) {
+    // Not a credit purchase invoice, nothing to do
+    return new Ok(undefined);
+  }
+
+  if (typeof invoice.subscription !== "string") {
+    return new Err(
+      new Error(
+        "Credit purchase invoice does not have a valid subscription ID."
+      )
+    );
+  }
+
+  const workspace = subscription.workspace;
+  const creditAmountCents = getCreditAmountFromInvoice(invoice);
+
+  if (creditAmountCents === null) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+        creditAmountCents: invoice.metadata?.credit_amount_cents,
+      },
+      "[Credit Purchase] Invalid credit amount in invoice metadata"
+    );
+    return new Err(new Error("Invalid credit amount in invoice metadata"));
+  }
+
+  const stripeSubscription = await getStripeSubscription(invoice.subscription);
+  if (!stripeSubscription) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+      },
+      "[Credit Purchase] Subscription not found"
+    );
+    return new Err(new Error("Subscription not found"));
+  }
+  // Check if this is an Enterprise subscription
+  const isEnterprise = isEnterpriseSubscription(stripeSubscription);
+
+  if (isEnterprise) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+      },
+      "[Credit Purchase] Skipping credit activation for Enterprise (already activated optimistically)"
+    );
+    return new Ok(undefined);
+  }
+
+  // Pro accounts - activate existing credit record (created in purchase API).
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  const credit = await CreditResource.fetchByInvoiceOrLineItemId(
+    auth,
+    invoice.id
+  );
+
+  if (!credit) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+      },
+      "[Credit Purchase] Credit not found for invoice"
+    );
+    return new Err(new Error("Credit not found for invoice"));
+  }
+
+  const startResult = await credit.start();
+  if (startResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        creditAmountCents,
+        invoiceId: invoice.id,
+        creditId: credit.id,
+        expirationDate: credit.expirationDate,
+      },
+      "[Credit Purchase] Error starting credit"
+    );
+    return new Err(startResult.error);
+  }
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      creditAmountCents,
+      invoiceId: invoice.id,
+      creditId: credit.id,
+    },
+    "[Credit Purchase] Successfully activated credit for Pro subscription"
+  );
+  return new Ok(undefined);
+}
+
+/**
+ * Creates and activates a credit purchase for Enterprise subscriptions.
+ * Attaches an invoice item to the subscription and immediately activates the credit.
+ *
+ * @param auth - Authenticator for the workspace
+ * @param stripeSubscriptionId - Stripe subscription ID
+ * @param amountCents - Credit amount in cents
+ * @returns Result with credit info or error
+ */
+export async function createEnterpriseCreditPurchase({
+  auth,
+  stripeSubscriptionId,
+  amountCents,
+}: {
+  auth: Authenticator;
+  stripeSubscriptionId: string;
+  amountCents: number;
+}): Promise<Result<{ credit: CreditResource; invoiceItemId: string }, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  // Attach credit purchase to subscription
+  const attachResult = await attachCreditPurchaseToSubscription({
+    stripeSubscriptionId,
+    amountCents,
+  });
+
+  if (attachResult.isErr()) {
+    logger.error(
+      {
+        error: attachResult.error.error_message,
+        workspaceId: workspace.sId,
+        amountCents,
+      },
+      "[Credit Purchase] Failed to attach credit purchase to subscription"
+    );
+    return new Err(new Error(attachResult.error.error_message));
+  }
+
+  const invoiceItemId = attachResult.value;
+
+  // Create credit with full amount
+  const credit = await CreditResource.makeNew(auth, {
+    type: "committed",
+    initialAmount: amountCents,
+    remainingAmount: amountCents,
+    invoiceOrLineItemId: invoiceItemId,
+  });
+
+  // Activate the credit immediately (optimistic activation for Enterprise)
+  const startResult = await credit.start();
+
+  if (startResult.isErr()) {
+    logger.error(
+      {
+        error: startResult.error.message,
+        workspaceId: workspace.sId,
+        invoiceItemId,
+      },
+      "[Credit Purchase] Failed to start credit after creation"
+    );
+    return new Err(startResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      amountCents,
+      invoiceItemId,
+      expirationDate: credit.expirationDate,
+    },
+    "[Credit Purchase] Credit purchase attached to subscription and activated"
+  );
+
+  return new Ok({ credit, invoiceItemId });
+}
+
+/**
+ * Creates a credit purchase for Pro subscriptions.
+ * Creates and pays a one-off invoice. Credit will be activated via webhook when paid.
+ *
+ * @param auth - Authenticator for the workspace
+ * @param stripeSubscriptionId - Stripe subscription ID
+ * @param amountCents - Credit amount in cents
+ * @returns Result with invoice ID or error
+ */
+export async function createProCreditPurchase({
+  auth,
+  stripeSubscriptionId,
+  amountCents,
+}: {
+  auth: Authenticator;
+  stripeSubscriptionId: string;
+  amountCents: number;
+}): Promise<Result<{ invoiceId: string }, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  // Create and pay one-off invoice
+  const invoiceResult = await makeAndMaybePayCreditPurchaseInvoice({
+    stripeSubscriptionId,
+    amountCents,
+  });
+
+  if (invoiceResult.isErr()) {
+    logger.error(
+      {
+        error: invoiceResult.error.error_message,
+        workspaceId: workspace.sId,
+        amountCents,
+      },
+      "[Credit Purchase] Failed to process credit purchase"
+    );
+    return new Err(new Error(invoiceResult.error.error_message));
+  }
+
+  const invoice = invoiceResult.value;
+
+  // Create credit record (will be activated via webhook when paid)
+  await CreditResource.makeNew(auth, {
+    type: "committed",
+    initialAmount: amountCents,
+    remainingAmount: amountCents,
+    invoiceOrLineItemId: invoice.id,
+  });
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      amountCents,
+      invoiceId: invoice.id,
+    },
+    "[Credit Purchase] Credit purchase invoice created, credit will be started via webhook"
+  );
+
+  return new Ok({ invoiceId: invoice.id });
+}

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -637,6 +637,13 @@ export async function attachCreditPurchaseToSubscription({
 
     return new Ok(invoiceItem.id);
   } catch (error) {
+    logger.error(
+      {
+        stripeSubscriptionId,
+        stripeError: true,
+      },
+      "[Credit Purchase] Failed to attach line item to Stripe subscription"
+    );
     return new Err({
       error_message: `Failed to attach credit purchase to subscription: ${normalizeError(error).message}`,
     });
@@ -705,6 +712,13 @@ export async function makeAndMaybePayCreditPurchaseInvoice({
     }
     return new Ok(finalizedInvoice);
   } catch (error) {
+    logger.error(
+      {
+        stripeSubscriptionId,
+        stripeError: true,
+      },
+      "[Credit Purchase] Failed to create Stripe invoice"
+    );
     return new Err({
       error_message: `Failed to create invoice credit purchase: ${normalizeError(error).message}`,
     });

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -149,6 +149,18 @@ export class CreditResource extends BaseResource<CreditModel> {
     return row ?? null;
   }
 
+  static async fetchByInvoiceOrLineItemId(
+    auth: Authenticator,
+    invoiceOrLineItemId: string
+  ) {
+    const [row] = await this.baseFetch(auth, {
+      where: {
+        invoiceOrLineItemId,
+      },
+    });
+    return row ?? null;
+  }
+
   async consume(
     amountInCents: number,
     { transaction }: { transaction?: Transaction } = {}

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -1,0 +1,277 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { FeatureFlag } from "@app/lib/models/feature_flag";
+import {
+  attachCreditPurchaseToSubscription,
+  createAndPayCreditPurchaseInvoice,
+  getStripeClient,
+  isEnterpriseSubscription,
+} from "@app/lib/plans/stripe";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isDevelopment } from "@app/types";
+
+export const PostCreditPurchaseRequestBody = t.type({
+  amountDollars: t.number,
+});
+
+type PostCreditPurchaseResponseBody = {
+  success: boolean;
+  creditsAdded: number;
+  invoiceId: string | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostCreditPurchaseResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  // Only admins can purchase credits
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can purchase credits.",
+      },
+    });
+  }
+
+  // Check feature flag
+  const workspace = auth.getNonNullableWorkspace();
+  const featureFlag =
+    (await FeatureFlag.findOne({
+      where: {
+        workspaceId: workspace.id,
+        name: "ppul_credits_purchase_flow",
+      },
+    })) ?? isDevelopment();
+
+  if (!featureFlag) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "This feature is not enabled for your workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostCreditPurchaseRequestBody.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const { amountDollars } = bodyValidation.right;
+
+      // Validate amount is positive
+      if (amountDollars <= 0) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Amount must be greater than 0.",
+          },
+        });
+      }
+
+      // Get active subscription
+      const subscription = auth.subscription();
+      if (!subscription || !subscription.stripeSubscriptionId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "subscription_not_found",
+            message:
+              "No active Stripe subscription found. Please subscribe to a plan first.",
+          },
+        });
+      }
+
+      try {
+        // Get Stripe subscription to determine if Enterprise
+        const stripe = getStripeClient();
+        const stripeSubscription = await stripe.subscriptions.retrieve(
+          subscription.stripeSubscriptionId
+        );
+        const isEnterprise = isEnterpriseSubscription(stripeSubscription);
+
+        // Convert dollars to cents for internal storage
+        const amountCents = Math.round(amountDollars * 100);
+
+        // Orchestrate credit purchase based on subscription type
+        if (isEnterprise) {
+          // For Enterprise: attach invoice item to subscription
+          const attachResult = await attachCreditPurchaseToSubscription({
+            stripeSubscriptionId: subscription.stripeSubscriptionId,
+            amountCents,
+          });
+
+          if (attachResult.isErr()) {
+            logger.error(
+              {
+                error: attachResult.error.error_message,
+                workspaceId: workspace.sId,
+                amountDollars,
+              },
+              "Failed to attach credit purchase to subscription"
+            );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to process credit purchase.",
+              },
+            });
+          }
+
+          const invoiceItemId = attachResult.value;
+
+          // Create placeholder credit with 0/0 amounts
+          await CreditResource.makeNew(auth, {
+            initialAmount: 0,
+            remainingAmount: 0,
+            invoiceOrLineItemId: invoiceItemId,
+          });
+
+          // Immediately top-up with full amount and set expiration
+          const topUpResult = await CreditResource.topUp({
+            auth,
+            invoiceOrLineItemId: invoiceItemId,
+            amountCents,
+          });
+
+          if (topUpResult.isErr()) {
+            logger.error(
+              {
+                error: topUpResult.error.message,
+                workspaceId: workspace.sId,
+                invoiceItemId,
+              },
+              "Failed to top-up credit after creating placeholder"
+            );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to process credit purchase.",
+              },
+            });
+          }
+
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              amountCents,
+              amountDollars,
+              invoiceItemId,
+              expirationDate: topUpResult.value.expirationDate,
+            },
+            "Credit purchase attached to subscription, credits topped up with expiration"
+          );
+
+          return res.status(200).json({
+            success: true,
+            creditsAdded: amountCents,
+            invoiceId: null,
+          });
+        } else {
+          // For Pro: create and pay one-off invoice
+          const invoiceResult = await createAndPayCreditPurchaseInvoice({
+            stripeSubscriptionId: subscription.stripeSubscriptionId,
+            amountCents,
+          });
+
+          if (invoiceResult.isErr()) {
+            logger.error(
+              {
+                error: invoiceResult.error.error_message,
+                workspaceId: workspace.sId,
+                amountDollars,
+              },
+              "Failed to create and pay credit purchase invoice"
+            );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to process credit purchase.",
+              },
+            });
+          }
+
+          const invoice = invoiceResult.value;
+
+          // Create credit record with 0/0 amounts (will be updated via webhook when paid)
+          await CreditResource.makeNew(auth, {
+            initialAmount: 0,
+            remainingAmount: 0,
+            invoiceOrLineItemId: invoice.id,
+          });
+
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              amountCents,
+              amountDollars,
+              invoiceId: invoice.id,
+            },
+            "Credit purchase invoice created and paid, placeholder credit created, amounts will be updated via webhook"
+          );
+
+          return res.status(200).json({
+            success: true,
+            creditsAdded: amountCents,
+            invoiceId: invoice.id,
+          });
+        }
+      } catch (error) {
+        logger.error(
+          {
+            error,
+            workspaceId: workspace.sId,
+            amountDollars,
+          },
+          "Error while processing credit purchase"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Error while processing credit purchase.",
+          },
+        });
+      }
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler, {
+  doesNotRequireCanUseProduct: true,
+});

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -10,7 +10,7 @@ import {
   attachCreditPurchaseToSubscription,
   getStripeClient,
   isEnterpriseSubscription,
-  makeCreditPurchaseInvoice,
+  makeAndPayCreditPurchaseInvoice,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import logger from "@app/logger/logger";
@@ -191,7 +191,7 @@ async function handler(
           });
         } else {
           // For Pro: create and pay one-off invoice.
-          const invoiceResult = await makeCreditPurchaseInvoice({
+          const invoiceResult = await makeAndPayCreditPurchaseInvoice({
             stripeSubscriptionId: subscription.stripeSubscriptionId,
             amountCents,
           });

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -6,4 +6,5 @@ export function isCreditType(value: unknown): value is CreditType {
   return CREDIT_TYPES.includes(value as CreditType);
 }
 
+// Credit expiration duration in days (default: 1 year)
 export const CREDIT_EXPIRATION_DAYS = 365;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -108,6 +108,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "OpenAI tool for tracking API consumption and costs",
     stage: "on_demand",
   },
+  ppul_credits_purchase_flow: {
+    description:
+      "Purchase credits flow for workspace admins via Stripe invoices",
+    stage: "dust_only",
+  },
   salesforce_synced_queries: {
     description: "Salesforce Connection: retrieval on Synchronized queries",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -677,6 +677,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_high_reasoning_custom_assistants_feature"
   | "openai_o1_high_reasoning_feature"
   | "openai_usage_mcp"
+  | "ppul_credits_purchase_flow"
   | "salesforce_synced_queries"
   | "salesforce_tool"
   | "salesforce_tool_write"


### PR DESCRIPTION
## Description


Implements the Stripe credit purchase API endpoint and webhook handler for the PPUL (Programmatic Usage Licensing) feature. The implementation handles credit purchases differently for Enterprise and Pro subscriptions:

**Enterprise subscriptions:** Invoice items are attached to the existing subscription and credits are immediately added + started (optimistic). The item will be included in the next regular subscription invoice.

**Pro subscriptions:** A one-off invoice is created, finalized, and immediately charged. A a credit record is created, then started via the `invoice.paid` webhook.

Adds `getCreditPurchasePriceId()` helper and two new Stripe functions: `attachCreditPurchaseToSubscription()` for Enterprise flow and `createAndPayCreditPurchaseInvoice()` for Pro flow.

<details>
<summary>Flow</summary>

```mermaid
   sequenceDiagram
      participant User
      participant API as purchase.ts Handler
      participant Stripe as Stripe API
      participant Credits as CreditResource
      participant Webhook as Stripe Webhook

      Note over User,Webhook: Credit Purchase Flow - Always Create Credit Record

      User->>API: POST /api/w/[wId]/credits/purchase
      API->>Stripe: Determine if Enterprise or Pro subscription
      Stripe-->>API: Subscription details

      alt Enterprise Flow
          Note over API,Credits: Enterprise: Full Credits Immediately

          API->>Stripe: invoiceItems.create(subscription param)
          Note over Stripe: Item attached to subscription
          Stripe-->>API: Invoice Item ID

          API->>Credits: makeNew
          Note over Credits: Credit created and started
          Credits-->>API: Credit Created

          API-->>User: 200 OK (invoiceId: null)

          Note over Stripe: Later: Item included in next regular invoice
          Note over Webhook: Webhook skips Enterprise (already added)

      else Pro Flow
          Note over API,Webhook: Pro: Placeholder Credit then Webhook Update

          API->>Stripe: invoices.create(draft)
          Stripe-->>API: Draft Invoice

          API->>Stripe: invoiceItems.create(invoice param)
          Stripe-->>API: Invoice Item

          API->>Stripe: invoices.finalize()
          Stripe-->>API: Finalized Invoice

          API->>Credits: makeNew
          Note over Credits: Started upon invoice.paid received
          Credits-->>API: Placeholder Credit Created

          API-->>User: 200 OK (invoiceId: inv_xxx)

          Stripe->>Webhook: invoice.paid event
          Webhook->>Credits: start()
          Credits-->>Webhook: Credit Updated with FULL amounts
      end
```

</details>


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->


## Risk

Database schema changes were already applied in the blocking PR #18037 (migration_408.sql). This PR only adds API logic and webhook handling.

Payment failures on Pro subscriptions are handled gracefully - the placeholder credit remains startedAt = null if the webhook never fires.

## Tests

Feature is behind the `ppul_credits_purchase_flow` feature flag (dust_only stage), limiting blast radius.

## Deploy Plan

1. Ensure PR #18037 is merged and deployed (migration_408.sql must be applied)
2. Deploy this PR
3. ~~Update production Stripe price ID in `getCreditPurchasePriceId()` (currently TODO)~~

