### PR TITLE
[front] - fix(spaces): streamline space member update logic

### DIFF
--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -519,26 +519,42 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
       );
     }
 
-    // Prepare space members update request if provided.
     const spaceMembersUrl = `/api/w/${owner.sId}/spaces/${space.sId}/members`;
-    if (managementMode && isRestricted) {
-      const { memberIds, groupIds, isRestricted } = params;
 
-      updatePromises.push(
-        fetch(spaceMembersUrl, {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            memberIds,
-            groupIds,
-            managementMode,
-            isRestricted,
-          }),
-        })
-      );
+    if (isRestricted) {
+      // Restricted space: send full membership payload
+      if (managementMode === "manual") {
+        updatePromises.push(
+          fetch(spaceMembersUrl, {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              isRestricted: true,
+              managementMode,
+              memberIds: params.memberIds,
+            }),
+          })
+        );
+      } else if (managementMode === "group") {
+        updatePromises.push(
+          fetch(spaceMembersUrl, {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              isRestricted: true,
+              managementMode,
+              groupIds: params.groupIds,
+            }),
+          })
+        );
+      }
     } else {
+      // Unrestricted space: only send isRestricted flag, no
+      // members/groups needed.
       updatePromises.push(
         fetch(spaceMembersUrl, {
           method: "PATCH",
@@ -546,8 +562,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            managementMode: "manual",
-            isRestricted,
+            isRestricted: false,
           }),
         })
       );


### PR DESCRIPTION
## Description

Previously, when renaming a space we were also sending a PATCH to `/api/w/:wId/spaces/:spaceId/members` with an invalid body (missing memberIds/groupIds), which violated the `PatchSpaceMembersRequestBodySchema` and returned a
400. This meant that a successful name change could still show an “Error updating space” notification because the secondary members PATCH failed even though the primary update succeeded.

## Tests

Locally

## Risk

Medium

## Deploy Plan

Deploy front
