### PR TITLE
[front] - fix(obs): display zero for message / users

### DIFF
--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -74,9 +74,9 @@ export function AgentObservability({
               className="h-24"
               content={
                 <div className="flex flex-row gap-2 text-2xl">
-                  {agentAnalytics?.mentions
+                  {agentAnalytics?.mentions && agentAnalytics.activeUsers > 0
                     ? `${Math.round(agentAnalytics.mentions.messageCount / agentAnalytics.activeUsers)}`
-                    : "-"}
+                    : 0}
                 </div>
               }
             />


### PR DESCRIPTION
## Description

This PR ensures the message count ratio displays "0" instead of "-" or `NaN` when there are no active users

## Tests

Low

## Risk

Low

## Deploy Plan

Deploy front