### PR TITLE
[sdk] add refresh token to client side mcp transport

### DIFF
--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.1.18",
+      "version": "1.1.19",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/mcp_transport.ts
+++ b/sdks/js/src/mcp_transport.ts
@@ -8,9 +8,9 @@ const logger = console;
 
 const HEARTBEAT_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes.
 const RECONNECT_DELAY_MS = 5 * 1000; // 5 seconds.
-// Refresh EventSource connection every 1 minutes to ensure OAuth tokens are refreshed before they
+// Refresh EventSource connection every 4 minutes to ensure OAuth tokens are refreshed before they
 // expire (typical token lifetime is 5 minutes).
-const TOKEN_REFRESH_INTERVAL_MS = 60 * 1000;
+const TOKEN_REFRESH_INTERVAL_MS = 4 * 60 * 1000;
 
 /**
  * Custom transport implementation for MCP
@@ -225,7 +225,7 @@ export class DustMcpServerTransport implements Transport {
       }
     };
 
-    this.eventSource.onerror = (error: any) => {
+    this.eventSource.onerror = (error: unknown) => {
       this.logError("Error in MCP EventSource connection:", error);
       this.onerror?.(new Error(`SSE connection error: ${error}`));
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

MCP EventSource connections were failing with 401 Unauthorized after ~5 minutes because OAuth tokens expire but EventSource headers remain static after connection establishment.

This PR adds proactive token refresh to sdk's mcp_transport:

1. 4-minute refresh timer - Automatically reconnects EventSource before OAuth tokens expire (typical lifetime: 5 minutes)
2. Proper connection cleanup - Removes event handlers and adds 100ms delay before reconnecting to prevent duplicate connection errors
3. Connection state checking - Only refreshes if connection is OPEN (readyState === 1)
4. Connection tracking - Prevents old connections from triggering unnecessary reconnection attempts

How it works:
- Every 4 minutes, the transport closes the old EventSource and creates a new one
- The new connection automatically gets fresh auth headers from the client's apiKey callback
- Tokens are refreshed before expiry, preventing 401 errors

Next steps: 
Bump SDK in the CLI, and implement this.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

The CLI using those fixes in the SDK works.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, the client side mcp server is not used in itself, only in front extension. 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy SDK.