### PR TITLE
client_secret optional for mcp_static

### DIFF
--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -229,8 +229,9 @@ export const getProviderRequiredOAuthCredentialInputs = async ({
           client_secret: {
             label: "OAuth Client Secret",
             value: undefined,
-            helpMessage: "The client secret from your MCP server.",
-            validator: isValidClientIdOrSecret,
+            helpMessage:
+              "The client secret from your MCP server (optional for PKCE flows).",
+            validator: isValidOptionalClientSecret,
           },
           token_endpoint: {
             label: "OAuth Token Endpoint",
@@ -307,6 +308,11 @@ export function isValidSalesforceDomain(s: unknown): s is string {
 
 export function isValidClientIdOrSecret(s: unknown): s is string {
   return typeof s === "string" && s.trim().length > 0;
+}
+
+export function isValidOptionalClientSecret(s: unknown): s is string {
+  // Allow empty strings for optional client secrets (e.g., PKCE flows)
+  return typeof s === "string";
 }
 
 export function isValidUrl(s: unknown): s is string {


### PR DESCRIPTION
## Description

Attempt to solve https://github.com/dust-tt/tasks/issues/4045

client_secret is optional in the [backend](https://github.com/dust-tt/dust/blob/c199e9688c20a317bbf8861ee38088dcdd2c6e96/front/lib/api/oauth/providers/mcp.ts#L35) but the interface forces users to input one. 



## Risk

Low/none

## Deploy Plan

Front only
