### PR TITLE
[fix] front: add a (preview) in the not-GA webhooks

### DIFF
--- a/front/components/triggers/AddTriggerMenu.tsx
+++ b/front/components/triggers/AddTriggerMenu.tsx
@@ -49,7 +49,7 @@ export const AddTriggerMenu = ({
           .map(([provider, preset]) => (
             <DropdownMenuItem
               key={`trigger-${provider}`}
-              label={preset.name}
+              label={preset.name + (!!preset.featureFlag ? " (Preview)" : "")}
               icon={getIcon(preset.icon)}
               onClick={() =>
                 isWebhookProvider(provider) && createWebhook(provider)

--- a/front/components/triggers/AddTriggerMenu.tsx
+++ b/front/components/triggers/AddTriggerMenu.tsx
@@ -49,7 +49,7 @@ export const AddTriggerMenu = ({
           .map(([provider, preset]) => (
             <DropdownMenuItem
               key={`trigger-${provider}`}
-              label={preset.name + (!!preset.featureFlag ? " (Preview)" : "")}
+              label={preset.name + (preset.featureFlag ? " (Preview)" : "")}
               icon={getIcon(preset.icon)}
               onClick={() =>
                 isWebhookProvider(provider) && createWebhook(provider)


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR adds this (preview) text on non-GA webhook sources.
<img width="197" height="295" alt="Capture d’écran 2025-11-18 à 23 57 32" src="https://github.com/user-attachments/assets/80f2f73e-139a-4a37-8523-ab1149bd6217" />

This is QOL + we have this for mcp servers so might as well do it here.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front