### PR TITLE
[front] feat(Zendesk): add custom fields in ticket rendering

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/rendering.ts
@@ -54,6 +54,15 @@ export function renderTicket(ticket: ZendeskTicket): string {
   lines.push(`\nCreated: ${new Date(ticket.created_at).toISOString()}`);
   lines.push(`Updated: ${new Date(ticket.updated_at).toISOString()}`);
 
+  if (ticket.custom_fields) {
+    lines.push("\nCustom Fields:");
+    for (const field of ticket.custom_fields) {
+      if (field.value && typeof field.value !== "boolean") {
+        lines.push(`${field.value}`);
+      }
+    }
+  }
+
   return lines.join("\n");
 }
 


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5172.
- This PR adds support for custom fields in the Zendesk internal MCP server.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
