### PR TITLE
[poke] delete group membership before deleting workspace

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -45,6 +45,7 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
 import { Provider } from "@app/lib/resources/storage/models/apps";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import {
   LabsTranscriptsConfigurationModel,
   LabsTranscriptsHistoryModel,
@@ -590,6 +591,9 @@ export async function deleteWorkspaceActivity({
   await FileResource.deleteAllForWorkspace(auth);
   await RunResource.deleteAllForWorkspace(auth);
   await MembershipResource.deleteAllForWorkspace(auth);
+  await GroupMembershipModel.destroy({
+    where: { workspaceId: workspace.id },
+  });
   await WorkspaceHasDomainModel.destroy({
     where: { workspaceId: workspace.id },
   });


### PR DESCRIPTION
## Description

Currently the deleteWorkspaceWorkflow fails with this error:
> update or delete on table \"workspaces\" violates foreign key constraint \"group_memberships_workspaceId_fkey\" on table \"group_memberships\"


## Tests

no

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
