### PR TITLE
JIT tool searchbar search into installed and non installed servers

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -86,12 +86,12 @@ export function ToolsPicker({
 
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
-  const shouldKeepHooksActive =
+  const shouldFetchToolsData =
     isOpen || isSettingUpServer || !!pendingServerToAdd;
 
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
-    disabled: !shouldKeepHooksActive,
+    disabled: !shouldFetchToolsData,
   });
   const globalSpaces = useMemo(
     () => spaces.filter((s) => s.kind === "global"),
@@ -109,7 +109,7 @@ export function ToolsPicker({
     isLoading: isServerViewsLoading,
     mutateServerViews,
   } = useMCPServerViewsFromSpaces(owner, globalSpaces, {
-    disabled: !shouldKeepHooksActive,
+    disabled: !shouldFetchToolsData,
   });
 
   const selectedMCPServerViewIds = useMemo(
@@ -166,7 +166,7 @@ export function ToolsPicker({
   const { availableMCPServers, isAvailableMCPServersLoading } =
     useAvailableMCPServers({
       owner,
-      disabled: !shouldKeepHooksActive,
+      disabled: !shouldFetchToolsData,
     });
 
   const isDataReady = !isServerViewsLoading && !isAvailableMCPServersLoading;
@@ -175,7 +175,12 @@ export function ToolsPicker({
   // - We filter by manual availability to show only servers that need install step, and by search text if present.
   // - We don't compute uninstalled servers until BOTH data sources have loaded to prevent flicker.
   const filteredUninstalledServers = useMemo(() => {
-    if (!hasFeature("jit_tool_setup") || !isAdmin || !isDataReady) {
+    if (
+      !hasFeature("jit_tool_setup") ||
+      !isAdmin ||
+      !isDataReady ||
+      !shouldFetchToolsData
+    ) {
       return [];
     }
 
@@ -363,8 +368,16 @@ export function ToolsPicker({
                 id="tools-picker-no-selected"
                 icon={() => <Icon visual={BoltIcon} size="xs" />}
                 className="italic"
-                label="No more tools to select"
-                description="All available tools are already selected"
+                label={
+                  searchText.length > 0
+                    ? "No result"
+                    : "No more tools to select"
+                }
+                description={
+                  searchText.length > 0
+                    ? "No tools found matching your search."
+                    : "All available tools are already selected."
+                }
                 disabled
               />
             )}

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -163,32 +163,48 @@ export function ToolsPicker({
     };
   }, [serverViews, searchText, selectedMCPServerViewIds]);
 
-  const { availableMCPServers } = useAvailableMCPServers({
-    owner,
-  });
+  const { availableMCPServers, isAvailableMCPServersLoading } =
+    useAvailableMCPServers({
+      owner,
+      disabled: !shouldKeepHooksActive,
+    });
 
-  // We compare by name, not sId, because names are shared between multiple instances of the same MCP server (sIds are not).
-  // We filter by manual availability to show only servers that need install step.
-  const uninstalledServers = useMemo(() => {
-    if (!availableMCPServers || !serverViews) {
+  const isDataReady = !isServerViewsLoading && !isAvailableMCPServersLoading;
+
+  // - We compare by name, not sId, because names are shared between multiple instances of the same MCP server (sIds are not).
+  // - We filter by manual availability to show only servers that need install step, and by search text if present.
+  // - We don't compute uninstalled servers until BOTH data sources have loaded to prevent flicker.
+  const filteredUninstalledServers = useMemo(() => {
+    if (!hasFeature("jit_tool_setup") || !isAdmin || !isDataReady) {
       return [];
     }
+
     const installedServerNames = new Set(serverViews.map((v) => v.server.name));
-    return availableMCPServers.filter(
+    const uninstalled = availableMCPServers.filter(
       (server) =>
         !installedServerNames.has(server.name) &&
         server.availability === "manual"
     );
-  }, [availableMCPServers, serverViews]);
 
-  const displayToolsToInstall = useMemo(() => {
-    return (
-      isAdmin &&
-      !isServerViewsLoading &&
-      hasFeature("jit_tool_setup") &&
-      uninstalledServers.length > 0
+    if (searchText.length === 0) {
+      return uninstalled;
+    }
+
+    return uninstalled.filter(
+      (server) =>
+        asDisplayName(server.name)
+          .toLowerCase()
+          .includes(searchText.toLowerCase()) ||
+        server.description.toLowerCase().includes(searchText.toLowerCase())
     );
-  }, [isAdmin, isServerViewsLoading, hasFeature, uninstalledServers]);
+  }, [
+    hasFeature,
+    isAdmin,
+    isDataReady,
+    availableMCPServers,
+    serverViews,
+    searchText,
+  ]);
 
   return (
     <>
@@ -281,7 +297,9 @@ export function ToolsPicker({
             </>
           }
         >
-          {filteredServerViews.length > 0 ? (
+          {!isDataReady && <ToolsPickerLoading />}
+
+          {isDataReady && filteredServerViews.length > 0 && (
             <>
               {filteredServerViewsUnselected
                 .sort(mcpServerViewSortingFn)
@@ -311,28 +329,12 @@ export function ToolsPicker({
                     />
                   );
                 })}
-              {filteredServerViewsUnselected.length === 0 && (
-                <DropdownMenuItem
-                  id="tools-picker-no-selected"
-                  icon={() => <Icon visual={BoltIcon} size="xs" />}
-                  className="italic"
-                  label="No more tools to select"
-                  description="All available tools are already selected"
-                  disabled
-                />
-              )}
             </>
-          ) : isServerViewsLoading ? (
-            <ToolsPickerLoading />
-          ) : (
-            <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-              No results found
-            </div>
           )}
 
-          {displayToolsToInstall && (
+          {isDataReady && filteredUninstalledServers.length > 0 && (
             <>
-              {uninstalledServers.map((server) => (
+              {filteredUninstalledServers.map((server) => (
                 <DropdownMenuItem
                   key={`tools-to-install-${server.sId}`}
                   icon={() => getAvatar(server)}
@@ -353,6 +355,19 @@ export function ToolsPicker({
               ))}
             </>
           )}
+
+          {isDataReady &&
+            filteredServerViewsUnselected.length === 0 &&
+            filteredUninstalledServers.length === 0 && (
+              <DropdownMenuItem
+                id="tools-picker-no-selected"
+                icon={() => <Icon visual={BoltIcon} size="xs" />}
+                className="italic"
+                label="No more tools to select"
+                description="All available tools are already selected"
+                disabled
+              />
+            )}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -136,9 +136,11 @@ export function useMCPServer({
 export function useAvailableMCPServers({
   owner,
   space,
+  disabled = false,
 }: {
   owner: LightWorkspaceType;
   space?: SpaceType;
+  disabled?: boolean;
 }) {
   const configFetcher: Fetcher<GetMCPServersResponseBody> = fetcher;
 
@@ -146,7 +148,9 @@ export function useAvailableMCPServers({
     ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp/available`
     : `/api/w/${owner.sId}/mcp/available`;
 
-  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher);
+  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
+    disabled,
+  });
 
   const availableMCPServers = useMemo(
     () =>
@@ -160,7 +164,7 @@ export function useAvailableMCPServers({
 
   return {
     availableMCPServers,
-    isAvailableMCPServersLoading: !error && !data,
+    isAvailableMCPServersLoading: !disabled && !error && !data,
     isAvailableMCPServersError: error,
     mutateAvailableMCPServers: mutate,
   };


### PR DESCRIPTION
## Description

Rework the search on the JIT tool dropdown so it searched on both installed and not installed tools. 
Make sure we display non installed tools only when the installed one are loaded. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 