### PR TITLE
chore: remove GEN6 rule on comments

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -51,52 +51,6 @@ function addItem(items: string[], newItem: string) {
 }
 ```
 
-### [GEN6] Comments must be sentences and properly wrapped
-
-Comments must be full sentences (generally starting with a capital letter and ending with a period)
-and must be consistently wrapped (see examples below).
-
-Example:
-
-```
-// BAD
-// new function
-// does something
-// interesting
-
-// BAD
-// this is a comment that is neither a full sentence nor wrapped at 100 characters (clearly higher) / it should be wrapped because otherwise it's really hard to read
-
-// BAD
-// This comment is a valid sentence but it
-// is wrapped at a much lower character count than
-// 100. It should be wrapped at ~100 characters.
-
-// BAD
-// Check if the current tag is the page selector.
-// If it is, we are inside a page.
-// This assumes that we don't have nested pages.
-
-// GOOD
-// This function is new and does something interesting.
-// TODO(xxx): improve the efficiency of this.
-
-// GOOD
-// This is a comment that is a full sentence and is wrapped at 100 characters. It is easy to read
-// and supports consistency of our code style.
-
-// GOOD
-// Permissions:
-// - "never_ask": Automatically approved
-// - "low": Ask user for approval and allow to automatically approve next time
-// - "high": Ask for approval each time
-// - undefined: Use default permission ("never_ask" for default tools, "high" for other tools)
-
-// GOOD
-// Check if the current tag is the page selector. If it is, we are inside a page. This assumes that
-// we don't have nested pages.
-```
-
 ### [GEN7] Avoid loops with quadratic or worse complexity
 
 Loops with quadratic O(n²) or worse cubic O(n³) complexity can severely hurt performance as data
@@ -168,7 +122,9 @@ When quadratic complexity cannot be avoided:
 
 ### [GEN8] Do not use console.log, console.error, etc. — always use the app logger
 
-Direct calls to `console.log`, `console.error`, `console.warn`, `console.info`, or similar console methods are prohibited in the codebase. Always use the application logger for all logging, debugging, and error reporting purposes. This ensures consistent log formatting, proper log routing, and easier log management across environments.
+Direct calls to `console.log`, `console.error`, `console.warn`, `console.info`, or similar console methods are
+prohibited in the codebase. Always use the application logger for all logging, debugging, and error reporting purposes.
+This ensures consistent log formatting, proper log routing, and easier log management across environments.
 
 Example:
 


### PR DESCRIPTION
## Description

As seen [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1763047455349879), removing GEN6 rule as it brings more noise than value

I tried [vale](https://vale.sh/), even if it's very nice, it adds a tons of errors, and it segfault on our code base (unless we target it to very specific directories).

So I believe we could just remove the rule. Also we already have an eslint plugin for jsdoc 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
