### PR TITLE
[front] Enforce typing, filter programmatic usages

### DIFF
--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -210,6 +210,7 @@ export async function searchAnalytics<
 ): Promise<
   Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
 > {
+  console.log("query", JSON.stringify(query, null, 2));
   return esSearch<TDocument, TAggregations>({
     index: ANALYTICS_ALIAS_NAME,
     query,

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -210,7 +210,6 @@ export async function searchAnalytics<
 ): Promise<
   Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
 > {
-  console.log("query", JSON.stringify(query, null, 2));
   return esSearch<TDocument, TAggregations>({
     index: ANALYTICS_ALIAS_NAME,
     query,

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -1,3 +1,4 @@
+import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 import type { RedisClientType } from "redis";
 
@@ -8,7 +9,19 @@ import type { Authenticator } from "@app/lib/auth";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { LightWorkspaceType } from "@app/types";
+import type { LightWorkspaceType, UserMessageOrigin } from "@app/types";
+
+export const PROGRAMMATIC_USAGE_ORIGINS: UserMessageOrigin[] = [
+  "api",
+  "gsheet",
+  "make",
+  "n8n",
+  "triggered_programmatic",
+  "zapier",
+  "zendesk",
+  "excel",
+  "powerpoint",
+];
 
 // Programmatic usage tracking: keep Redis key name for backward compatibility.
 const PROGRAMMATIC_USAGE_REMAINING_CREDITS_KEY = "public_api_remaining_credits";
@@ -20,7 +33,7 @@ function getRedisKey(workspace: LightWorkspaceType): string {
 
 function shouldTrackTokenUsageCosts(
   auth: Authenticator,
-  { userMessageOrigin }: { userMessageOrigin?: string | null } = {}
+  { userMessageOrigin }: { userMessageOrigin?: UserMessageOrigin | null } = {}
 ): boolean {
   const workspace = auth.getNonNullableWorkspace();
   const limits = getWorkspacePublicAPILimits(workspace);
@@ -30,17 +43,45 @@ function shouldTrackTokenUsageCosts(
     return false;
   }
 
-  // Track for API keys.
-  if (auth.isKey() && !auth.isSystemKey()) {
-    return true;
-  }
-
-  // Track for programmatic webhook triggers.
-  if (userMessageOrigin === "triggered_programmatic") {
+  // Track for API keys, listed programmatic origins or unspecified user message origins.
+  // This must be in sync with the getShouldTrackTokenUsageCostsESFilter function.
+  if (
+    auth.authMethod() === "api_key" ||
+    !userMessageOrigin ||
+    PROGRAMMATIC_USAGE_ORIGINS.includes(userMessageOrigin)
+  ) {
     return true;
   }
 
   return false;
+}
+
+export function getShouldTrackTokenUsageCostsESFilter(
+  auth: Authenticator
+): estypes.QueryDslQueryContainer {
+  const workspace = auth.getNonNullableWorkspace();
+
+  // Track for API keys, listed programmatic origins or unspecified user message origins.
+  // This must be in sync with the shouldTrackTokenUsageCosts function.
+  const shouldClauses: estypes.QueryDslQueryContainer[] = [
+    { term: { auth_method: "api_key" } },
+    { bool: { must_not: { exists: { field: "context_origin" } } } },
+    { terms: { context_origin: PROGRAMMATIC_USAGE_ORIGINS } },
+  ];
+
+  return {
+    bool: {
+      filter: [
+        { term: { workspace_id: workspace.sId } },
+        {
+          bool: {
+            should: shouldClauses,
+            minimum_should_match: 1,
+          },
+        },
+      ],
+    },
+  };
 }
 
 export async function hasReachedPublicAPILimits(
@@ -141,7 +182,7 @@ export async function maybeTrackTokenUsageCost(
   {
     dustRunIds,
     userMessageOrigin,
-  }: { dustRunIds: string[]; userMessageOrigin?: string | null }
+  }: { dustRunIds: string[]; userMessageOrigin?: UserMessageOrigin | null }
 ) {
   if (!shouldTrackTokenUsageCosts(auth, { userMessageOrigin })) {
     return;

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -11,17 +11,38 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { LightWorkspaceType, UserMessageOrigin } from "@app/types";
 
-export const PROGRAMMATIC_USAGE_ORIGINS: UserMessageOrigin[] = [
-  "api",
-  "gsheet",
-  "make",
-  "n8n",
-  "triggered_programmatic",
-  "zapier",
-  "zendesk",
-  "excel",
-  "powerpoint",
-];
+export const USAGE_ORIGINS_CLASSIFICATION: Record<
+  UserMessageOrigin,
+  "programmatic" | "user"
+> = {
+  agent_handover: "user",
+  api: "programmatic",
+  email: "user",
+  excel: "programmatic",
+  extension: "user",
+  "github-copilot-chat": "user",
+  gsheet: "programmatic",
+  make: "programmatic",
+  n8n: "programmatic",
+  powerpoint: "programmatic",
+  raycast: "user",
+  run_agent: "user",
+  slack: "user",
+  teams: "user",
+  transcript: "user",
+  triggered_programmatic: "programmatic",
+  triggered: "user",
+  web: "user",
+  zapier: "programmatic",
+  zendesk: "programmatic",
+};
+
+const PROGRAMMATIC_USAGE_ORIGINS = Object.keys(
+  USAGE_ORIGINS_CLASSIFICATION
+).filter(
+  (origin) =>
+    USAGE_ORIGINS_CLASSIFICATION[origin as UserMessageOrigin] === "programmatic"
+);
 
 // Programmatic usage tracking: keep Redis key name for backward compatibility.
 const PROGRAMMATIC_USAGE_REMAINING_CREDITS_KEY = "public_api_remaining_credits";
@@ -48,7 +69,7 @@ function shouldTrackTokenUsageCosts(
   if (
     auth.authMethod() === "api_key" ||
     !userMessageOrigin ||
-    PROGRAMMATIC_USAGE_ORIGINS.includes(userMessageOrigin)
+    USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic"
   ) {
     return true;
   }

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
@@ -14,6 +14,7 @@ import {
   groupTopNAndAggregateOthers,
   searchAnalytics,
 } from "@app/lib/api/elasticsearch";
+import { getShouldTrackTokenUsageCostsESFilter } from "@app/lib/api/programmatic_usage_tracking";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { CreditResource } from "@app/lib/resources/credit_resource";
@@ -107,8 +108,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-
   switch (req.method) {
     case "GET": {
       const q = QuerySchema.safeParse(req.query);
@@ -141,7 +140,7 @@ async function handler(
       const baseQuery = {
         bool: {
           filter: [
-            { term: { workspace_id: owner.sId } },
+            getShouldTrackTokenUsageCostsESFilter(auth),
             {
               range: {
                 timestamp: {

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -18,6 +18,7 @@ import logger from "@app/logger/logger";
 import type {
   ConversationWithoutContentType,
   ToolErrorEvent,
+  UserMessageOrigin,
 } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";
@@ -173,7 +174,7 @@ async function processEventForTokenUsageTracking(
   {
     event,
     userMessageOrigin,
-  }: { event: AgentMessageEvents; userMessageOrigin?: string | null }
+  }: { event: AgentMessageEvents; userMessageOrigin?: UserMessageOrigin | null }
 ) {
   if (event.type === "agent_message_success") {
     const { runIds } = event;
@@ -199,7 +200,7 @@ export async function updateResourceAndPublishEvent(
     conversation: ConversationWithoutContentType;
     step: number;
     modelInteractionDurationMs?: number;
-    userMessageOrigin?: string | null;
+    userMessageOrigin?: UserMessageOrigin | null;
   }
 ): Promise<void> {
   // Processing of events before publishing to Redis.

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -12,6 +12,7 @@ import type {
   ModelConversationTypeMultiActions,
   Ok,
   Result,
+  UserMessageOrigin,
   UserMessageType,
 } from "@app/types";
 import type {
@@ -70,7 +71,7 @@ export type GetOutputRequestParams = {
       conversation: ConversationWithoutContentType;
       step: number;
       modelInteractionDurationMs?: number;
-      userMessageOrigin?: string | null;
+      userMessageOrigin?: UserMessageOrigin | null;
     }
   ) => Promise<void>;
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -53,26 +53,26 @@ export type MessageWithContentFragmentsType =
  */
 
 export type UserMessageOrigin =
+  | "agent_handover"
   | "api"
   | "email"
+  | "excel"
   | "extension"
   | "github-copilot-chat"
   | "gsheet"
   | "make"
   | "n8n"
+  | "powerpoint"
   | "raycast"
+  | "run_agent"
   | "slack"
   | "teams"
-  | "triggered"
+  | "transcript"
   | "triggered_programmatic"
+  | "triggered"
   | "web"
   | "zapier"
-  | "zendesk"
-  | "excel"
-  | "powerpoint"
-  | "run_agent"
-  | "agent_handover"
-  | "transcript";
+  | "zendesk";
 
 export type UserMessageContext = {
   username: string;


### PR DESCRIPTION
## Description

Add filter on analytics - only shows programmatic usage. Call is considered as programmatic if : 
- is using an api key (not system)
- has no origin
- origin is part of predefined "programmatic" origin 
Sync ES filter and `shouldTrackTokenUsageCosts`

Enforce typing of UserMessageOrigin instead of string .

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
