### PR TITLE
feat(connectors): migrate first types from io-ts to zod (PR #1)

### DIFF
--- a/connectors/IO_TS_TO_ZOD_MIGRATION_STRATEGY.md
+++ b/connectors/IO_TS_TO_ZOD_MIGRATION_STRATEGY.md
@@ -1,0 +1,344 @@
+# Migration Strategy: io-ts → zod
+
+This document outlines a step-by-step strategy to migrate from io-ts to zod in the `@connectors` package, broken down into small, reviewable PRs.
+
+## Overview
+
+The migration will be done incrementally, allowing the codebase to work with both libraries during the transition. Each PR will focus on a specific area to make reviews manageable.
+
+## Current State
+
+- **io-ts** is used in ~30+ files across the codebase
+- Main usage patterns:
+  - Schema definitions (`t.type()`, `t.union()`, `t.literal()`, etc.)
+  - Type extraction (`t.TypeOf<>`)
+  - Validation (`codec.decode()` with `isLeft()` from fp-ts)
+  - Error reporting (`io-ts-reporters`)
+  - Custom codecs and branded types
+  - Utility functions in `src/types/shared/utils/iots_utils.ts`
+
+## Migration Strategy (Multiple PRs)
+
+### Phase 1: First Migration (PR #1)
+
+**Goal**: Add zod dependency and migrate first simple types
+
+**Changes**:
+
+1. Add `zod` to `package.json` dependencies (first PR using zod)
+2. Create `src/types/shared/utils/zod_utils.ts` with equivalent utilities:
+   - `zodEnum()` - equivalent to `ioTsEnum()`
+   - `zodParsePayload()` - equivalent to `ioTsParsePayload()`
+   - `createRangeCodec()` - equivalent using zod's `refine()`
+   - `SlugifiedString` - equivalent using zod's `brand()`
+   - `NumberAsStringCodec` - equivalent custom refinement
+3. Migrate first simple type files:
+   - `src/types/webcrawler.ts`
+   - `src/types/discord_bot.ts`
+   - `src/types/slack.ts`
+4. Update imports in files that use these types
+5. Keep `iots_utils.ts` intact (will be removed in final PR)
+
+**Files to create/modify**:
+
+- `package.json` (add zod)
+- `src/types/shared/utils/zod_utils.ts` (new)
+- `src/types/shared/utils/zod_utils.test.ts` (new, if tests exist)
+- `src/types/webcrawler.ts`
+- `src/types/discord_bot.ts`
+- `src/types/slack.ts`
+- Files that import these types
+
+**Review focus**: zod dependency addition, utility functions correctness, schema equivalence
+
+---
+
+### Phase 2: Migrate Simple Type Files (PRs #2-4)
+
+**Goal**: Migrate remaining standalone type definition files that have minimal dependencies
+
+**PR #2: Migrate OAuth Types (Part 1)**
+
+- Migrate simple schemas in `src/types/oauth/lib.ts`:
+  - `SnowflakeCredentialsSchema` and related
+  - `BigQueryCredentialsSchema` and related
+  - `ApiKeyCredentialsSchema`
+  - `SalesforceCredentialsSchema`
+  - `NotionCredentialsSchema`
+- Keep type guards and helper functions unchanged initially
+
+**PR #3: Migrate Configuration Types**
+
+- `src/types/configuration.ts`
+- Update `src/api/create_connector.ts` to use zod schemas
+- Update `src/api/update_connector.ts` to use zod schemas
+
+**PR #4: Migrate Remaining Simple Types**
+
+- `src/types/notion.ts`
+- `src/types/content_nodes.ts`
+- `src/types/admin/cli.ts`
+
+**Review focus**: Schema equivalence, type extraction correctness
+
+---
+
+### Phase 3: Migrate API Handlers (PRs #5-8)
+
+**Goal**: Migrate API request/response validation
+
+**PR #5: Migrate Connector API Handlers**
+
+- `src/api/create_connector.ts`
+- `src/api/update_connector.ts`
+- `src/api/connector_config.ts`
+- `src/api/set_connector_permissions.ts`
+- Replace `codec.decode()` with `zodSchema.safeParse()`
+- Replace `reporter.formatValidationErrors()` with zod error formatting
+
+**PR #6: Migrate Webhook Handlers (Part 1)**
+
+- `src/api/webhooks/webhook_slack_interaction.ts`
+- `src/api/webhooks/webhook_slack_bot_interaction.ts`
+- `src/api/webhooks/webhook_slack_bot.ts`
+
+**PR #7: Migrate Webhook Handlers (Part 2)**
+
+- `src/api/webhooks/webhook_github.ts`
+- `src/api/webhooks/webhook_notion.ts`
+- `src/api/webhooks/webhook_intercom.ts`
+- `src/api/webhooks/webhook_discord_app.ts`
+- `src/api/webhooks/webhook_teams.ts`
+- `src/api/webhooks/webhook_firecrawl.ts`
+
+**PR #8: Migrate Remaining API Handlers**
+
+- `src/api/slack_channels_linked_with_agent.ts`
+- `src/api/admin.ts`
+- `src/admin/cli.ts`
+
+**Review focus**: Validation logic correctness, error handling
+
+---
+
+### Phase 4: Migrate Connector-Specific Code (PRs #9-13)
+
+**Goal**: Migrate connector implementation files
+
+**PR #9: Migrate Shared Connector Utilities**
+
+- `src/lib/cli.ts`
+- `src/connectors/microsoft/lib/cli.ts`
+- `src/lib/remote_databases/utils.ts`
+
+**PR #10: Migrate GitHub Connector**
+
+- `src/connectors/github/lib/github_api.ts`
+- `src/connectors/github/lib/github_graphql.ts`
+- `src/connectors/github/lib/github_webhooks.ts`
+
+**PR #11: Migrate Snowflake & BigQuery Connectors**
+
+- `src/connectors/snowflake/lib/snowflake_api.ts`
+- Any BigQuery-related validation code
+
+**PR #12: Migrate Gong & Confluence Connectors**
+
+- `src/connectors/gong/lib/gong_api.ts`
+- `src/connectors/gong/lib/oauth.ts`
+- `src/connectors/confluence/lib/confluence_client.ts`
+
+**PR #13: Migrate Remaining Connectors**
+
+- `src/connectors/notion/lib/utils.ts`
+- `src/connectors/slack/chat/stream_conversation_handler.ts`
+- Any other connector-specific validation
+
+**Review focus**: Connector-specific validation logic
+
+---
+
+### Phase 5: Migrate Complex Types & Utilities (PR #14)
+
+**Goal**: Migrate remaining complex type definitions
+
+**Changes**:
+
+- `src/types/oauth/lib.ts` - remaining complex schemas
+- `src/types/shared/text_extraction/index.ts`
+- `src/lib/data_sources.ts` (if it uses io-ts types)
+
+**Review focus**: Complex schema migrations, edge cases
+
+---
+
+### Phase 6: Cleanup (PR #15)
+
+**Goal**: Remove io-ts dependencies and old utilities
+
+**Changes**:
+
+1. Remove `io-ts`, `io-ts-reporters`, `io-ts-types` from `package.json`
+2. Delete `src/types/shared/utils/iots_utils.ts`
+3. Remove all `import * as t from "io-ts"` statements
+4. Remove all `import * as reporter from "io-ts-reporters"` statements
+5. Remove `isLeft` imports from `fp-ts/lib/Either` (if only used for io-ts)
+6. Update any remaining references
+7. Run full test suite
+
+**Review focus**: No remaining io-ts references, all tests pass
+
+---
+
+## Key Migration Patterns
+
+### Schema Definition
+
+```typescript
+// io-ts
+const Schema = t.type({
+  name: t.string,
+  age: t.number,
+  email: t.union([t.string, t.undefined]),
+});
+
+// zod
+const Schema = z.object({
+  name: z.string(),
+  age: z.number(),
+  email: z.string().optional(),
+});
+```
+
+### Type Extraction
+
+```typescript
+// io-ts
+type MyType = t.TypeOf<typeof Schema>;
+
+// zod
+type MyType = z.infer<typeof Schema>;
+```
+
+### Validation
+
+```typescript
+// io-ts
+const result = Schema.decode(data);
+if (isLeft(result)) {
+  const errors = reporter.formatValidationErrors(result.left);
+  return Err(errors);
+}
+return Ok(result.right);
+
+// zod
+const result = Schema.safeParse(data);
+if (!result.success) {
+  return Err(result.error.errors.map((e) => e.message));
+}
+return Ok(result.data);
+```
+
+### Union Types
+
+```typescript
+// io-ts
+const UnionSchema = t.union([t.string, t.number]);
+
+// zod
+const UnionSchema = z.union([z.string(), z.number()]);
+```
+
+### Literal Types
+
+```typescript
+// io-ts
+const LiteralSchema = t.union([t.literal("option1"), t.literal("option2")]);
+
+// zod
+const LiteralSchema = z.enum(["option1", "option2"]);
+// or
+const LiteralSchema = z.union([z.literal("option1"), z.literal("option2")]);
+```
+
+### Branded Types
+
+```typescript
+// io-ts
+const BrandedString = t.brand(
+  t.string,
+  (s): s is t.Branded<string, Brand> => /^[a-z]+$/.test(s),
+  "Brand"
+);
+
+// zod
+const BrandedString = z
+  .string()
+  .refine((s) => /^[a-z]+$/.test(s))
+  .brand<"Brand">();
+```
+
+### Custom Codecs
+
+```typescript
+// io-ts
+const NumberAsString = new t.Type<string, string, unknown>(
+  "NumberAsString",
+  (u): u is string => typeof u === "number",
+  (u, c) => {
+    if (typeof u === "number") {
+      return t.success(u.toString());
+    }
+    return t.failure(u, c, "Value must be a number");
+  },
+  t.identity
+);
+
+// zod
+const NumberAsString = z
+  .union([z.number().transform((n) => n.toString()), z.string()])
+  .refine((val) => !isNaN(Number(val)), {
+    message: "Value must be a number",
+  });
+```
+
+## Testing Strategy
+
+1. **Unit Tests**: Ensure zod utilities match io-ts behavior
+2. **Integration Tests**: Test each migrated API endpoint
+3. **Type Tests**: Ensure TypeScript types are correctly inferred
+4. **Regression Tests**: Run full test suite after each PR
+
+## Rollback Plan
+
+If issues arise:
+
+1. Each PR should be independently revertible
+2. Keep io-ts in dependencies until final cleanup PR
+3. Can run both validations side-by-side during transition if needed
+
+## Success Criteria
+
+- ✅ All io-ts imports removed
+- ✅ All tests passing
+- ✅ No runtime behavior changes
+- ✅ Type safety maintained
+- ✅ Error messages remain clear and helpful
+
+## Estimated Timeline
+
+- **PR #1**: 2-3 days (add zod dependency + utilities + first type migrations)
+- **PRs #2-4**: 2-3 days each (type migrations)
+- **PRs #5-8**: 2-3 days each (API handlers)
+- **PRs #9-13**: 1-2 days each (connectors)
+- **PR #14**: 2-3 days (complex types)
+- **PR #15**: 1 day (cleanup)
+
+**Total**: ~5-7 weeks with proper review cycles (15 PRs total)
+
+## Notes
+
+- Each PR should be small enough to review in <30 minutes
+- Focus on one logical area per PR
+- Maintain backward compatibility during transition
+- Update this document as migration progresses

--- a/connectors/IO_TS_TO_ZOD_QUICK_REFERENCE.md
+++ b/connectors/IO_TS_TO_ZOD_QUICK_REFERENCE.md
@@ -1,0 +1,304 @@
+# io-ts → zod Quick Reference Guide
+
+This is a quick reference for common io-ts to zod migration patterns found in the codebase.
+
+## Basic Types
+
+| io-ts         | zod                              |
+| ------------- | -------------------------------- |
+| `t.string`    | `z.string()`                     |
+| `t.number`    | `z.number()`                     |
+| `t.boolean`   | `z.boolean()`                    |
+| `t.null`      | `z.null()`                       |
+| `t.undefined` | `.optional()` or `z.undefined()` |
+| `t.any`       | `z.any()`                        |
+| `t.unknown`   | `z.unknown()`                    |
+
+## Complex Types
+
+| io-ts                                       | zod                                    |
+| ------------------------------------------- | -------------------------------------- |
+| `t.type({ a: t.string })`                   | `z.object({ a: z.string() })`          |
+| `t.array(t.string)`                         | `z.array(z.string())`                  |
+| `t.union([t.string, t.number])`             | `z.union([z.string(), z.number()])`    |
+| `t.intersection([A, B])`                    | `A.merge(B)` or `z.intersection(A, B)` |
+| `t.record(t.string, t.string)`              | `z.record(z.string(), z.string())`     |
+| `t.literal("value")`                        | `z.literal("value")`                   |
+| `t.union([t.literal("a"), t.literal("b")])` | `z.enum(["a", "b"])`                   |
+
+## Optional & Nullable
+
+| io-ts                                      | zod                     |
+| ------------------------------------------ | ----------------------- |
+| `t.union([t.string, t.undefined])`         | `z.string().optional()` |
+| `t.union([t.string, t.null])`              | `z.string().nullable()` |
+| `t.union([t.string, t.null, t.undefined])` | `z.string().nullish()`  |
+
+## Type Extraction
+
+| io-ts                              | zod                               |
+| ---------------------------------- | --------------------------------- |
+| `type T = t.TypeOf<typeof Schema>` | `type T = z.infer<typeof Schema>` |
+
+## Validation
+
+### io-ts Pattern
+
+```typescript
+import { isLeft } from "fp-ts/lib/Either";
+import * as reporter from "io-ts-reporters";
+
+const result = Schema.decode(data);
+if (isLeft(result)) {
+  const errors = reporter.formatValidationErrors(result.left);
+  return Err(errors);
+}
+return Ok(result.right);
+```
+
+### zod Pattern
+
+```typescript
+const result = Schema.safeParse(data);
+if (!result.success) {
+  const errors = result.error.errors.map(
+    (e) => `${e.path.join(".")}: ${e.message}`
+  );
+  return Err(errors);
+}
+return Ok(result.data);
+```
+
+## Custom Codecs
+
+### Enum Codec
+
+**io-ts:**
+
+```typescript
+export function ioTsEnum<EnumType>(
+  enumValues: readonly string[],
+  enumName?: string
+) {
+  const isEnumValue = (input: unknown): input is EnumType =>
+    enumValues.includes(input as string);
+
+  return new t.Type<EnumType>(
+    enumName || uuidv4(),
+    isEnumValue,
+    (input, context) =>
+      isEnumValue(input) ? t.success(input) : t.failure(input, context),
+    t.identity
+  );
+}
+```
+
+**zod:**
+
+```typescript
+export function zodEnum<EnumType extends string>(
+  enumValues: readonly EnumType[],
+  enumName?: string
+) {
+  return z.enum(enumValues as [EnumType, ...EnumType[]], {
+    errorMap: () => ({
+      message: `${enumName || "Value"} must be one of: ${enumValues.join(", ")}`,
+    }),
+  });
+}
+```
+
+### Branded Types
+
+**io-ts:**
+
+```typescript
+const SlugifiedString = t.brand(
+  t.string,
+  (s): s is t.Branded<string, SlugifiedStringBrand> => /^[a-z0-9_]+$/.test(s),
+  "SlugifiedString"
+);
+```
+
+**zod:**
+
+```typescript
+const SlugifiedString = z
+  .string()
+  .refine((s) => /^[a-z0-9_]+$/.test(s), {
+    message:
+      "Must be a slugified string (lowercase letters, numbers, underscores only)",
+  })
+  .brand<"SlugifiedString">();
+```
+
+### Range Codec
+
+**io-ts:**
+
+```typescript
+export function createRangeCodec(min: number, max: number) {
+  return t.brand(
+    t.number,
+    (n): n is t.Branded<number, BrandedRange> => n >= min && n <= max,
+    "Range"
+  );
+}
+```
+
+**zod:**
+
+```typescript
+export function createRangeCodec(min: number, max: number) {
+  return z.number().min(min).max(max).brand<"Range">();
+}
+```
+
+### Number as String Codec
+
+**io-ts:**
+
+```typescript
+export const NumberAsStringCodec = new t.Type<string, string, unknown>(
+  "NumberAsString",
+  (u): u is string => typeof u === "number",
+  (u, c) => {
+    if (typeof u === "number") {
+      return t.success(u.toString());
+    }
+    return t.failure(u, c, "Value must be a number");
+  },
+  t.identity
+);
+```
+
+**zod:**
+
+```typescript
+export const NumberAsStringCodec = z.union([
+  z.number().transform((n) => n.toString()),
+  z.string().refine((s) => !isNaN(Number(s)), {
+    message: "Value must be a number",
+  }),
+]);
+```
+
+## Error Formatting
+
+### io-ts-reporters
+
+```typescript
+import * as reporter from "io-ts-reporters";
+const errors = reporter.formatValidationErrors(validation.left);
+// Returns: string[]
+```
+
+### zod (custom formatter)
+
+```typescript
+function formatZodErrors(error: z.ZodError): string[] {
+  return error.errors.map((e) => {
+    const path = e.path.join(".");
+    return path ? `${path}: ${e.message}` : e.message;
+  });
+}
+```
+
+## Common Patterns in Codebase
+
+### Configuration Schema
+
+```typescript
+// io-ts
+const ConfigSchema = t.type({
+  name: t.string,
+  enabled: t.boolean,
+  options: t.union([t.array(t.string), t.undefined]),
+});
+
+// zod
+const ConfigSchema = z.object({
+  name: z.string(),
+  enabled: z.boolean(),
+  options: z.array(z.string()).optional(),
+});
+```
+
+### Union with Null
+
+```typescript
+// io-ts
+const Schema = t.union([SomeTypeSchema, t.null]);
+
+// zod
+const Schema = z.union([SomeTypeSchema, z.null()]);
+```
+
+### Intersection Types
+
+```typescript
+// io-ts
+const BaseSchema = t.type({ a: t.string });
+const ExtendedSchema = t.intersection([BaseSchema, t.type({ b: t.number })]);
+
+// zod
+const BaseSchema = z.object({ a: z.string() });
+const ExtendedSchema = BaseSchema.extend({ b: z.number() });
+// or
+const ExtendedSchema = z.intersection(BaseSchema, z.object({ b: z.number() }));
+```
+
+### Record Types
+
+```typescript
+// io-ts
+const HeadersSchema = t.record(t.string, t.string);
+
+// zod
+const HeadersSchema = z.record(z.string(), z.string());
+```
+
+### Catch-All Pattern (Allowing Unknown Properties)
+
+This pattern is used in Gong and Confluence connectors to allow extra properties:
+
+**io-ts:**
+
+```typescript
+const CatchAllCodec = t.record(t.string, t.unknown);
+const Schema = t.intersection([t.type({ known: t.string }), CatchAllCodec]);
+```
+
+**zod:**
+
+```typescript
+const Schema = z
+  .object({
+    known: z.string(),
+  })
+  .passthrough(); // Allows unknown properties
+// or
+const Schema = z
+  .object({
+    known: z.string(),
+  })
+  .catchall(z.unknown()); // Explicitly catch unknown properties
+```
+
+## Testing Migration
+
+When migrating a file:
+
+1. **Create zod schema** alongside io-ts schema
+2. **Test both schemas** with same inputs
+3. **Compare outputs** - should be identical
+4. **Update imports** and usage
+5. **Remove io-ts schema** once verified
+
+## Notes
+
+- zod schemas are more concise
+- zod has better TypeScript inference
+- zod error messages are more detailed by default
+- zod supports `.transform()` for data transformation
+- zod `.refine()` replaces custom codec validation logic

--- a/connectors/MIGRATION_SUMMARY.md
+++ b/connectors/MIGRATION_SUMMARY.md
@@ -1,0 +1,133 @@
+# io-ts → zod Migration Summary
+
+## Overview
+
+This migration will replace `io-ts` with `zod` for runtime type validation and schema definition in the `@connectors` package. The migration is designed to be done incrementally across **16 small PRs** to ensure easy review and minimal risk.
+
+## Documentation
+
+- **[Migration Strategy](./IO_TS_TO_ZOD_MIGRATION_STRATEGY.md)**: Detailed step-by-step plan with PR breakdown
+- **[Quick Reference](./IO_TS_TO_ZOD_QUICK_REFERENCE.md)**: Code pattern translations and examples
+
+## Why Migrate?
+
+- **Better TypeScript integration**: zod has superior TypeScript inference
+- **More concise syntax**: Less boilerplate than io-ts
+- **Better error messages**: More detailed and user-friendly by default
+- **Active maintenance**: zod is actively maintained and widely adopted
+- **Easier to learn**: More intuitive API for new team members
+
+## Migration Approach
+
+### Key Principles
+
+1. **Incremental**: Each PR focuses on one logical area
+2. **Non-breaking**: Code works with both libraries during transition
+3. **Testable**: Each PR can be tested independently
+4. **Reviewable**: Small PRs (<500 lines) for easy review
+
+### PR Breakdown
+
+| Phase       | PRs   | Focus Area                        | Estimated Time |
+| ----------- | ----- | --------------------------------- | -------------- |
+| **Phase 1** | #1    | Add zod + Utilities + First Types | 2-3 days       |
+| **Phase 2** | #2-4  | Simple Type Files                 | 2-3 days each  |
+| **Phase 3** | #5-8  | API Handlers                      | 2-3 days each  |
+| **Phase 4** | #9-13 | Connector-Specific Code           | 1-2 days each  |
+| **Phase 5** | #14   | Complex Types                     | 2-3 days       |
+| **Phase 6** | #15   | Cleanup                           | 1 day          |
+
+**Total Estimated Time**: 5-7 weeks with proper review cycles (15 PRs total)
+
+**Note**: zod dependency is added in PR #1 (the first PR that uses it)
+
+## Current Usage
+
+- **~30+ files** use io-ts
+- **Main patterns**:
+  - Schema definitions (`t.type()`, `t.union()`, `t.literal()`)
+  - Type extraction (`t.TypeOf<>`)
+  - Validation (`codec.decode()` with `isLeft()`)
+  - Error reporting (`io-ts-reporters`)
+  - Custom codecs and branded types
+
+## Quick Start
+
+### For Reviewers
+
+1. Read the [Migration Strategy](./IO_TS_TO_ZOD_MIGRATION_STRATEGY.md) to understand the overall plan
+2. Use the [Quick Reference](./IO_TS_TO_ZOD_QUICK_REFERENCE.md) to verify pattern translations
+3. Focus on:
+   - Schema equivalence (same validation rules)
+   - Type correctness (TypeScript types match)
+   - Error handling (errors are properly formatted)
+
+### For Implementers
+
+1. Start with **PR #1**: Set up zod utilities
+2. Follow the PR order in the [Migration Strategy](./IO_TS_TO_ZOD_MIGRATION_STRATEGY.md)
+3. Use the [Quick Reference](./IO_TS_TO_ZOD_QUICK_REFERENCE.md) for pattern translations
+4. Test thoroughly before submitting PR
+
+## Common Patterns
+
+### Schema Definition
+
+```typescript
+// Before (io-ts)
+const Schema = t.type({
+  name: t.string,
+  age: t.number,
+});
+
+// After (zod)
+const Schema = z.object({
+  name: z.string(),
+  age: z.number(),
+});
+```
+
+### Type Extraction
+
+```typescript
+// Before
+type MyType = t.TypeOf<typeof Schema>;
+
+// After
+type MyType = z.infer<typeof Schema>;
+```
+
+### Validation
+
+```typescript
+// Before
+const result = Schema.decode(data);
+if (isLeft(result)) {
+  const errors = reporter.formatValidationErrors(result.left);
+  return Err(errors);
+}
+return Ok(result.right);
+
+// After
+const result = Schema.safeParse(data);
+if (!result.success) {
+  return Err(result.error.errors.map((e) => e.message));
+}
+return Ok(result.data);
+```
+
+See [Quick Reference](./IO_TS_TO_ZOD_QUICK_REFERENCE.md) for more patterns.
+
+## Success Criteria
+
+- ✅ All io-ts imports removed
+- ✅ All tests passing
+- ✅ No runtime behavior changes
+- ✅ Type safety maintained
+- ✅ Error messages remain clear
+
+## Questions?
+
+- Check the [Migration Strategy](./IO_TS_TO_ZOD_MIGRATION_STRATEGY.md) for detailed plans
+- Refer to [Quick Reference](./IO_TS_TO_ZOD_QUICK_REFERENCE.md) for code examples
+- Review existing zod migrations in the codebase for patterns

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -72,7 +72,9 @@
         "tweetnacl": "^1.0.3",
         "undici": "^6.21.1",
         "uuid": "^9.0.0",
-        "yargs": "^17.7.2"
+        "yargs": "^17.7.2",
+        "zod": "^3.25.76",
+        "zod-validation-error": "^3.5.4"
       },
       "devDependencies": {
         "@types/eslint": "^8.56.10",
@@ -19081,7 +19083,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -19093,6 +19094,17 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
+      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.24.4"
       }
     },
     "node_modules/zwitch": {

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -83,7 +83,9 @@
     "tweetnacl": "^1.0.3",
     "undici": "^6.21.1",
     "uuid": "^9.0.0",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^3.25.76",
+    "zod-validation-error": "^3.5.4"
   },
   "devDependencies": {
     "@types/eslint": "^8.56.10",

--- a/connectors/src/api/configuration.ts
+++ b/connectors/src/api/configuration.ts
@@ -11,8 +11,8 @@ import type {
 } from "@connectors/types";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
 import {
-  ioTsParsePayload,
   WebCrawlerConfigurationTypeSchema,
+  zodParsePayload,
 } from "@connectors/types";
 
 type PatchConnectorConfigurationResBody =
@@ -40,7 +40,7 @@ const _patchConnectorConfiguration = async (
   let patchRes: Result<void, Error> | null = null;
   switch (connector.type) {
     case "webcrawler": {
-      const parseRes = ioTsParsePayload(
+      const parseRes = zodParsePayload(
         req.body.configuration,
         WebCrawlerConfigurationTypeSchema
       );
@@ -48,7 +48,7 @@ const _patchConnectorConfiguration = async (
         return apiError(req, res, {
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid configuration: ${parseRes.error.join(", ")}`,
+            message: `Invalid configuration: ${parseRes.error}`,
           },
           status_code: 400,
         });

--- a/connectors/src/api/create_connector.ts
+++ b/connectors/src/api/create_connector.ts
@@ -1,9 +1,7 @@
 import type { Result } from "@dust-tt/client";
 import { assertNever, isConnectorProvider } from "@dust-tt/client";
 import type { Request, Response } from "express";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
+import { z } from "zod";
 
 import { createConnector } from "@connectors/connectors";
 import type {
@@ -18,18 +16,18 @@ import type { ConnectorType } from "@connectors/types";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
 import {
   DiscordBotConfigurationTypeSchema,
-  ioTsParsePayload,
   SlackConfigurationTypeSchema,
   WebCrawlerConfigurationTypeSchema,
+  zodParsePayload,
 } from "@connectors/types";
 import { ConnectorConfigurationTypeSchema } from "@connectors/types";
 import { normalizeError } from "@connectors/types";
 
-const ConnectorCreateRequestBodySchema = t.type({
-  workspaceAPIKey: t.string,
-  dataSourceId: t.string,
-  workspaceId: t.string,
-  connectionId: t.string,
+const ConnectorCreateRequestBodySchema = z.object({
+  workspaceAPIKey: z.string(),
+  dataSourceId: z.string(),
+  workspaceId: z.string(),
+  connectionId: z.string(),
   configuration: ConnectorConfigurationTypeSchema,
 });
 
@@ -40,15 +38,16 @@ const _createConnectorAPIHandler = async (
   res: Response<ConnectorCreateResBody>
 ) => {
   try {
-    const bodyValidation = ConnectorCreateRequestBodySchema.decode(req.body);
-    if (isLeft(bodyValidation)) {
-      const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+    const bodyValidation = zodParsePayload(
+      req.body,
+      ConnectorCreateRequestBodySchema
+    );
+    if (bodyValidation.isErr()) {
       return apiError(req, res, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: `Invalid request body: ${pathError}`,
+          message: `Invalid request body: ${bodyValidation.error}`,
         },
       });
     }
@@ -69,7 +68,7 @@ const _createConnectorAPIHandler = async (
       dataSourceId,
       connectionId,
       configuration,
-    } = bodyValidation.right;
+    } = bodyValidation.value;
 
     let connectorRes: Result<
       string,
@@ -78,7 +77,7 @@ const _createConnectorAPIHandler = async (
 
     switch (req.params.connector_provider) {
       case "webcrawler": {
-        const configurationRes = ioTsParsePayload(
+        const configurationRes = zodParsePayload(
           configuration,
           WebCrawlerConfigurationTypeSchema
         );
@@ -108,7 +107,7 @@ const _createConnectorAPIHandler = async (
 
       case "slack":
       case "slack_bot": {
-        const configurationRes = ioTsParsePayload(
+        const configurationRes = zodParsePayload(
           configuration,
           SlackConfigurationTypeSchema
         );
@@ -137,7 +136,7 @@ const _createConnectorAPIHandler = async (
       }
 
       case "discord_bot": {
-        const configurationRes = ioTsParsePayload(
+        const configurationRes = zodParsePayload(
           configuration,
           DiscordBotConfigurationTypeSchema
         );

--- a/connectors/src/types/configuration.ts
+++ b/connectors/src/types/configuration.ts
@@ -1,4 +1,4 @@
-import * as t from "io-ts";
+import { z } from "zod";
 
 import type { DiscordBotConfigurationType } from "./discord_bot";
 import { DiscordBotConfigurationTypeSchema } from "./discord_bot";
@@ -7,18 +7,18 @@ import { SlackConfigurationTypeSchema } from "./slack";
 import type { WebCrawlerConfigurationType } from "./webcrawler";
 import { WebCrawlerConfigurationTypeSchema } from "./webcrawler";
 
-export const ConnectorConfigurationTypeSchema = t.union([
+export const ConnectorConfigurationTypeSchema = z.union([
   WebCrawlerConfigurationTypeSchema,
   SlackConfigurationTypeSchema,
   DiscordBotConfigurationTypeSchema,
-  t.null,
+  z.null(),
 ]);
 
-const UpdateConnectorConfigurationTypeSchema = t.type({
+const UpdateConnectorConfigurationTypeSchema = z.object({
   configuration: ConnectorConfigurationTypeSchema,
 });
 
-export type UpdateConnectorConfigurationType = t.TypeOf<
+export type UpdateConnectorConfigurationType = z.infer<
   typeof UpdateConnectorConfigurationTypeSchema
 >;
 

--- a/connectors/src/types/discord_bot.ts
+++ b/connectors/src/types/discord_bot.ts
@@ -1,9 +1,9 @@
-import * as t from "io-ts";
+import { z } from "zod";
 
-export const DiscordBotConfigurationTypeSchema = t.type({
-  botEnabled: t.boolean,
+export const DiscordBotConfigurationTypeSchema = z.object({
+  botEnabled: z.boolean(),
 });
 
-export type DiscordBotConfigurationType = t.TypeOf<
+export type DiscordBotConfigurationType = z.infer<
   typeof DiscordBotConfigurationTypeSchema
 >;

--- a/connectors/src/types/index.ts
+++ b/connectors/src/types/index.ts
@@ -30,6 +30,7 @@ export * from "./shared/utils/iots_utils";
 export * from "./shared/utils/string_utils";
 export * from "./shared/utils/structured_data";
 export * from "./shared/utils/url_utils";
+export * from "./shared/utils/zod_utils";
 export * from "./slack";
 export * from "./snowflake";
 export * from "./webcrawler";

--- a/connectors/src/types/shared/utils/zod_utils.ts
+++ b/connectors/src/types/shared/utils/zod_utils.ts
@@ -1,0 +1,38 @@
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+/**
+ * Creates a zod enum schema from an array of string values.
+ * Equivalent to ioTsEnum().
+ */
+export function zodEnum<EnumType extends string>(
+  enumValues: readonly EnumType[],
+  enumName?: string
+): z.ZodEnum<[EnumType, ...EnumType[]]> {
+  return z.enum(enumValues as [EnumType, ...EnumType[]], {
+    errorMap: () => ({
+      message: `${enumName || "Value"} must be one of: ${enumValues.join(", ")}`,
+    }),
+  });
+}
+
+/**
+ * Parses a payload using a zod schema and returns a Result.
+ * Equivalent to ioTsParsePayload().
+ * Uses zod-validation-error for better error formatting, consistent with @front.
+ */
+export function zodParsePayload<T>(
+  payload: unknown,
+  schema: z.ZodSchema<T>
+): Result<T, string> {
+  const result = schema.safeParse(payload);
+  if (!result.success) {
+    // Use zod-validation-error for better error formatting, consistent with @front
+    const formattedError = fromError(result.error).toString();
+    return new Err(formattedError);
+  }
+
+  return new Ok(result.data);
+}

--- a/connectors/src/types/slack.ts
+++ b/connectors/src/types/slack.ts
@@ -1,32 +1,33 @@
-import * as t from "io-ts";
+import { z } from "zod";
 
 // Auto-read patterns.
 
-const SlackAutoReadPatternSchema = t.type({
-  pattern: t.string,
-  spaceId: t.string,
+const SlackAutoReadPatternSchema = z.object({
+  pattern: z.string(),
+  spaceId: z.string(),
 });
-export const SlackAutoReadPatternsSchema = t.array(SlackAutoReadPatternSchema);
+export const SlackAutoReadPatternsSchema = z.array(SlackAutoReadPatternSchema);
 
-export type SlackAutoReadPattern = t.TypeOf<typeof SlackAutoReadPatternSchema>;
+export type SlackAutoReadPattern = z.infer<typeof SlackAutoReadPatternSchema>;
 
 export function isSlackAutoReadPatterns(
   v: unknown[]
 ): v is SlackAutoReadPattern[] {
-  return SlackAutoReadPatternsSchema.is(v);
+  const result = SlackAutoReadPatternsSchema.safeParse(v);
+  return result.success;
 }
 
 // Configuration.
 
-export const SlackConfigurationTypeSchema = t.type({
-  botEnabled: t.boolean,
-  whitelistedDomains: t.union([t.array(t.string), t.undefined]),
+export const SlackConfigurationTypeSchema = z.object({
+  botEnabled: z.boolean(),
+  whitelistedDomains: z.array(z.string()).optional(),
   autoReadChannelPatterns: SlackAutoReadPatternsSchema,
-  restrictedSpaceAgentsEnabled: t.union([t.boolean, t.undefined]),
-  feedbackVisibleToAuthorOnly: t.union([t.boolean, t.undefined]),
+  restrictedSpaceAgentsEnabled: z.boolean().optional(),
+  feedbackVisibleToAuthorOnly: z.boolean().optional(),
 });
 
-export type SlackConfigurationType = t.TypeOf<
+export type SlackConfigurationType = z.infer<
   typeof SlackConfigurationTypeSchema
 >;
 

--- a/connectors/src/types/webcrawler.ts
+++ b/connectors/src/types/webcrawler.ts
@@ -1,4 +1,4 @@
-import * as t from "io-ts";
+import { z } from "zod";
 
 export const WEBCRAWLER_MAX_DEPTH = 5;
 export const WEBCRAWLER_MAX_PAGES = 1024;
@@ -16,36 +16,32 @@ export type CrawlingFrequency = (typeof CrawlingFrequencies)[number];
 
 export const DepthOptions = [0, 1, 2, 3, 4, 5] as const;
 export type DepthOption = (typeof DepthOptions)[number];
-export type WebCrawlerConfigurationType = t.TypeOf<
-  typeof WebCrawlerConfigurationTypeSchema
->;
 
 export function isDepthOption(value: unknown): value is DepthOption {
   return DepthOptions.includes(value as DepthOption);
 }
 
-export const WebCrawlerConfigurationTypeSchema = t.type({
-  url: t.string,
-  depth: t.union([
-    t.literal(0),
-    t.literal(1),
-    t.literal(2),
-    t.literal(3),
-    t.literal(4),
-    t.literal(5),
+export const WebCrawlerConfigurationTypeSchema = z.object({
+  url: z.string(),
+  depth: z.union([
+    z.literal(0),
+    z.literal(1),
+    z.literal(2),
+    z.literal(3),
+    z.literal(4),
+    z.literal(5),
   ]),
-  maxPageToCrawl: t.number,
-  crawlMode: t.union([t.literal("child"), t.literal("website")]),
-  crawlFrequency: t.union([
-    t.literal("never"),
-    t.literal("daily"),
-    t.literal("weekly"),
-    t.literal("monthly"),
-  ]),
-  headers: t.record(t.string, t.string),
+  maxPageToCrawl: z.number(),
+  crawlMode: z.enum(["child", "website"]),
+  crawlFrequency: z.enum(["never", "daily", "weekly", "monthly"]),
+  headers: z.record(z.string(), z.string()),
 });
 
-export type WebCrawlerConfiguration = t.TypeOf<
+export type WebCrawlerConfigurationType = z.infer<
+  typeof WebCrawlerConfigurationTypeSchema
+>;
+
+export type WebCrawlerConfiguration = z.infer<
   typeof WebCrawlerConfigurationTypeSchema
 >;
 


### PR DESCRIPTION
## Description

- Add zod and zod-validation-error dependencies
- Create zod_utils.ts with equivalent utilities to ioTsEnum, ioTsParsePayload, etc.
- Migrate webcrawler, discord_bot, and slack type definitions to zod
- Update configuration.ts to use zod schemas
- Update create_connector.ts and configuration.ts API handlers to use zod validation
- Use zod-validation-error for better error formatting (consistent with @front)
- Add migration strategy documentation for incremental migration

This is the first PR in a series to migrate from io-ts to zod incrementally.

## Tests

Local

## Risk

Medium but should be straightforward to review.

## Deploy Plan

Deploy connectors.