### PR TITLE
[Slack MCP] rm semantic search status cached in redis

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -306,9 +306,11 @@ function isSlackTokenRevoked(error: unknown): boolean {
 // 'disconnected' is expected when we don't have a Slack connection yet.
 type SlackAIStatus = "enabled" | "disabled" | "disconnected";
 
-async function getSlackAIEnablementStatus(
-  accessToken: string
-): Promise<SlackAIStatus> {
+async function getSlackAIEnablementStatus({
+  accessToken,
+}: {
+  accessToken: string;
+}): Promise<SlackAIStatus> {
   try {
     // Use assistant.search.info to detect if Slack AI is enabled at workspace level
     // This endpoint requires search:read.public scope and returns is_ai_search_enabled boolean
@@ -355,7 +357,7 @@ async function createServer(
   });
 
   const slackAIStatus: SlackAIStatus = c
-    ? await getSlackAIEnablementStatus(c.access_token)
+    ? await getSlackAIEnablementStatus({ accessToken: c.access_token })
     : "disconnected";
 
   localLogger.info(

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -30,7 +30,6 @@ import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { TimeFrame } from "@app/types";
 import {
@@ -307,19 +306,12 @@ function isSlackTokenRevoked(error: unknown): boolean {
 // 'disconnected' is expected when we don't have a Slack connection yet.
 type SlackAIStatus = "enabled" | "disabled" | "disconnected";
 
-const SLACK_AI_STATUS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-
-type GetSlackAIEnablementStatusArgs = {
-  mcpServerId: string;
-  accessToken: string;
-};
-
-const _getSlackAIEnablementStatus = async ({
-  accessToken,
-}: {
-  accessToken: string;
-}): Promise<SlackAIStatus> => {
+async function getSlackAIEnablementStatus(
+  accessToken: string
+): Promise<SlackAIStatus> {
   try {
+    // Use assistant.search.info to detect if Slack AI is enabled at workspace level
+    // This endpoint requires search:read.public scope and returns is_ai_search_enabled boolean
     const assistantSearchInfo = await fetch(
       "https://slack.com/api/assistant.search.info",
       {
@@ -335,27 +327,20 @@ const _getSlackAIEnablementStatus = async ({
       return "disconnected";
     }
 
-    const assistantSearchInfoJson = await assistantSearchInfo.json();
+    const data = await assistantSearchInfo.json();
 
-    const status = assistantSearchInfoJson.is_ai_search_enabled
-      ? "enabled"
-      : "disabled";
+    // Check both HTTP ok and Slack API ok for robustness
+    if (!data.ok) {
+      return "disconnected";
+    }
+
+    const status = data.is_ai_search_enabled ? "enabled" : "disabled";
 
     return status;
   } catch (e) {
     return "disconnected";
   }
-};
-
-// Cache the result as this involves a call to the Slack API.
-// We use a hash of the access token as the cache key to avoid storing sensitive information directly.
-const getCachedSlackAIEnablementStatus = cacheWithRedis(
-  _getSlackAIEnablementStatus,
-  ({ mcpServerId }: GetSlackAIEnablementStatusArgs) => mcpServerId,
-  {
-    ttlMs: SLACK_AI_STATUS_CACHE_TTL_MS,
-  }
-);
+}
 
 async function createServer(
   auth: Authenticator,
@@ -370,10 +355,7 @@ async function createServer(
   });
 
   const slackAIStatus: SlackAIStatus = c
-    ? await getCachedSlackAIEnablementStatus({
-        mcpServerId,
-        accessToken: c.access_token,
-      })
+    ? await getSlackAIEnablementStatus(c.access_token)
     : "disconnected";
 
   localLogger.info(


### PR DESCRIPTION
## Description
Removes Redis caching for Slack AI enablement status detection. The `assistant.search.info` endpoint is now called directly on each server initialization without caching. The function was simplified from a cached implementation to a straightforward async function with improved error handling that checks both HTTP response status and Slack API `ok` field.

## Risk
Low. The `assistant.search.info` call is lightweight and only occurs during MCP server initialization.

## Tests
Tested locally with whitelisted Slack app to verify AI search detection works correctly.

## Deploy Plan
