### PR TITLE
[front] enh(Zendesk): add custom field name to tool result

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
@@ -5,16 +5,39 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   ZendeskSearchResponse,
   ZendeskTicket,
+  ZendeskTicketField,
   ZendeskTicketMetrics,
 } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
 import {
   ZendeskSearchResponseSchema,
+  ZendeskTicketFieldsResponseSchema,
   ZendeskTicketMetricsResponseSchema,
   ZendeskTicketResponseSchema,
 } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, isValidZendeskSubdomain, Ok } from "@app/types";
+
+const MAX_CUSTOM_FIELDS_TO_FETCH = 50;
+
+export function getUniqueCustomFieldIds(
+  tickets: ZendeskTicket | ZendeskTicket[]
+): number[] {
+  const ticketsArray = Array.isArray(tickets) ? tickets : [tickets];
+  const fieldIds = new Set<number>();
+
+  for (const ticket of ticketsArray) {
+    if (ticket.custom_fields) {
+      for (const field of ticket.custom_fields) {
+        if (field.value !== null && field.value !== "") {
+          fieldIds.add(field.id);
+        }
+      }
+    }
+  }
+
+  return Array.from(fieldIds).slice(0, MAX_CUSTOM_FIELDS_TO_FETCH);
+}
 
 export function getZendeskClient(
   authInfo: AuthInfo | undefined
@@ -186,5 +209,25 @@ class ZendeskClient {
     }
 
     return new Ok(result.value.ticket);
+  }
+
+  async getTicketFieldsByIds(
+    fieldIds: number[]
+  ): Promise<Result<ZendeskTicketField[], Error>> {
+    if (fieldIds.length === 0) {
+      return new Ok([]);
+    }
+
+    const idsParam = fieldIds.join(",");
+    const result = await this.request(
+      `ticket_fields/show_many?ids=${idsParam}`,
+      ZendeskTicketFieldsResponseSchema
+    );
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    return new Ok(result.value.ticket_fields.filter((f) => f.active));
   }
 }

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
@@ -69,12 +69,8 @@ function createServer(
 
         const fieldIds = getUniqueCustomFieldIds(ticket);
         const ticketFieldsResult = await client.getTicketFieldsByIds(fieldIds);
-        const ticketFields = ticketFieldsResult.isOk()
-          ? ticketFieldsResult.value
-          : undefined;
-        // TODO: add disclaimer to tool result saying that we were not able to pull the custom fields.
 
-        let ticketText = renderTicket(ticket, ticketFields);
+        let ticketText = renderTicket(ticket, ticketFieldsResult);
 
         if (includeMetrics) {
           const metricsResult = await client.getTicketMetrics(ticketId);
@@ -110,7 +106,7 @@ function createServer(
       query: z
         .string()
         .describe(
-          "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high " +
+          "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high' " +
             "status:pending', 'assignee:123', 'tags:bug tags:critical'." +
             "Do not include 'type:ticket' as it is automatically added."
         ),
@@ -159,15 +155,10 @@ function createServer(
 
         const fieldIds = getUniqueCustomFieldIds(results);
         const ticketFieldsResult = await client.getTicketFieldsByIds(fieldIds);
-        const ticketFields = ticketFieldsResult.isOk()
-          ? ticketFieldsResult.value
-          : undefined;
-
-        // TODO: same todo as above.
 
         const ticketsText = results
           .map((ticket) => {
-            return ["---", renderTicket(ticket, ticketFields)].join("\n");
+            return ["---", renderTicket(ticket, ticketFieldsResult)].join("\n");
           })
           .join("\n\n");
 

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/rendering.ts
@@ -69,6 +69,7 @@ export function renderTicket(
         ticketFieldsResult.value.map((f) => [f.id, f.title])
       );
       const fieldsWithNames: string[] = [];
+      let fieldsAreMissing = false;
 
       for (const field of ticket.custom_fields) {
         if (field.value !== null && field.value !== "") {
@@ -78,6 +79,8 @@ export function renderTicket(
               ? field.value.join(", ")
               : String(field.value);
             fieldsWithNames.push(`- ${fieldName}: ${valueStr}`);
+          } else {
+            fieldsAreMissing = true;
           }
         }
       }
@@ -85,6 +88,10 @@ export function renderTicket(
       if (fieldsWithNames.length > 0) {
         lines.push("\nCustom Fields:");
         lines.push(...fieldsWithNames);
+      }
+
+      if (fieldsAreMissing) {
+        lines.push("\nNote: Some custom fields could not be displayed.");
       }
     }
   }

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/types.ts
@@ -119,3 +119,25 @@ export type ZendeskTicketMetrics = z.infer<typeof ZendeskTicketMetricsSchema>;
 export const ZendeskTicketMetricsResponseSchema = z.object({
   ticket_metric: ZendeskTicketMetricsSchema,
 });
+
+export type ZendeskTicketMetricsResponse = z.infer<
+  typeof ZendeskTicketMetricsResponseSchema
+>;
+
+export const ZendeskTicketFieldSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  active: z.boolean(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export type ZendeskTicketField = z.infer<typeof ZendeskTicketFieldSchema>;
+
+export const ZendeskTicketFieldsResponseSchema = z.object({
+  ticket_fields: z.array(ZendeskTicketFieldSchema),
+});
+
+export type ZendeskTicketFieldsResponse = z.infer<
+  typeof ZendeskTicketFieldsResponseSchema
+>;


### PR DESCRIPTION
## Description

- This PR exposes the name of the custom field to rendered tickets.
- Currently only the value is exposed.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
