### PR TITLE
[connectors] enh(Intercom): add `continueAsNew` on `intercomAllConversationsSyncWorkflow`

### DIFF
--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -6,7 +6,6 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
-import type { IntercomSyncAllConversationsStatus } from "@connectors/connectors/intercom/lib/types";
 import type * as activities from "@connectors/connectors/intercom/temporal/activities";
 import type { IntercomUpdateSignal } from "@connectors/connectors/intercom/temporal/signals";
 import type { ModelId } from "@connectors/types";

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -1,10 +1,12 @@
 import {
+  continueAsNew,
   executeChild,
   proxyActivities,
   setHandler,
   workflowInfo,
 } from "@temporalio/workflow";
 
+import type { IntercomSyncAllConversationsStatus } from "@connectors/connectors/intercom/lib/types";
 import type * as activities from "@connectors/connectors/intercom/temporal/activities";
 import type { IntercomUpdateSignal } from "@connectors/connectors/intercom/temporal/signals";
 import type { ModelId } from "@connectors/types";
@@ -47,6 +49,9 @@ const {
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "1 minute",
 });
+
+const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 40_000;
+const TEMPORAL_WORKFLOW_MAX_HISTORY_SIZE_MB = 40;
 
 /**
  * Sync Workflow for Intercom.
@@ -359,15 +364,17 @@ export async function intercomHourlyConversationSyncWorkflow({
 export async function intercomAllConversationsSyncWorkflow({
   connectorId,
   currentSyncMs,
+  initialCursor = null,
 }: {
   connectorId: ModelId;
   currentSyncMs: number;
+  initialCursor?: string | null;
 }) {
   const syncAllConvosStatus = await getSyncAllConversationsStatusActivity({
     connectorId,
   });
 
-  let cursor = null;
+  let cursor = initialCursor;
   let convosIdsToDelete = [];
 
   switch (syncAllConvosStatus) {
@@ -377,7 +384,9 @@ export async function intercomAllConversationsSyncWorkflow({
       break;
     case "scheduled_activate":
       // Upserts teams with permission "none" if not already in db and syncs them with data_sources_folders/nodes.
-      await syncAllTeamsActivity({ connectorId, currentSyncMs });
+      if (!initialCursor) {
+        await syncAllTeamsActivity({ connectorId, currentSyncMs });
+      }
       // We loop over the conversations to sync them all.
       do {
         const { conversationIds, nextPageCursor } =
@@ -391,6 +400,20 @@ export async function intercomAllConversationsSyncWorkflow({
           currentSyncMs,
         });
         cursor = nextPageCursor;
+
+        if (
+          cursor &&
+          (workflowInfo().historyLength >
+            TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH ||
+            workflowInfo().historySize >
+              TEMPORAL_WORKFLOW_MAX_HISTORY_SIZE_MB * 1024 * 1024)
+        ) {
+          await continueAsNew<typeof intercomAllConversationsSyncWorkflow>({
+            connectorId,
+            currentSyncMs,
+            initialCursor: cursor,
+          });
+        }
       } while (cursor);
       // We mark the status as activated.
       await setSyncAllConversationsStatusActivity({


### PR DESCRIPTION
## Description

- This PR implements a `continueAsNew` to allow the `intercomAllConversationsSyncWorkflow` workflow to not be limited by Temporal's history limits.
- We've had the issue [here](https://cloud.temporal.io/namespaces/eu-dust-prod.gmnlm/workflows/intercom-sync-809-all-conversations/019a95f3-141d-7672-8188-b42613ea96ae/history). Also looks like we've had it a while ago [here](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/intercom-sync-31514-all-conversations/019a2b41-d90e-7a89-8192-bdc5150ec472/history).
- No non-deterministic error expected, the workflow is not run often (no running ones now).

## Tests

- Tested locally (with a much lower limit on the history length).

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
