### PR TITLE
[connectors] enh(Intercom): split sync workflow, run convo sync on a schedule

### DIFF
--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -41,7 +41,12 @@ const _webhookIntercomAPIHandler = async (
   res: Response<IntercomWebhookResBody>
 ) => {
   const event = req.body;
-  logger.info("Received Intercom webhook", { event });
+  logger.info(
+    {
+      event,
+    },
+    "Received Intercom webhook"
+  );
 
   if (event.topic !== "conversation.admin.closed") {
     logger.error(

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -1,10 +1,7 @@
 import type { Request, Response } from "express";
 
 import type { IntercomConversationWithPartsType } from "@connectors/connectors/intercom/lib/types";
-import {
-  stopIntercomFullSyncWorkflow,
-  stopIntercomScheduledWorkflows,
-} from "@connectors/connectors/intercom/temporal/client";
+import { stopIntercomWorkflows } from "@connectors/connectors/intercom/temporal/client";
 import { syncConversation } from "@connectors/connectors/intercom/temporal/sync_conversation";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
@@ -226,26 +223,14 @@ const _webhookIntercomUninstallAPIHandler = async (
   }
 
   // Stop the underlying sync workflows to avoid churning.
-  const stopSchedulesRes = await stopIntercomScheduledWorkflows(connector);
-  if (stopSchedulesRes.isErr()) {
+  const stopRes = await stopIntercomWorkflows(connector);
+  if (stopRes.isErr()) {
     logger.error(
       {
         connectorId: connector.id,
-        error: stopSchedulesRes.error,
+        error: stopRes.error,
       },
-      "Failed to stop Intercom scheduled workflows (intercom uninstall webhook)"
-    );
-    return res.status(200).end();
-  }
-
-  const stopFullSyncRes = await stopIntercomFullSyncWorkflow(connector.id);
-  if (stopFullSyncRes.isErr()) {
-    logger.error(
-      {
-        connectorId: connector.id,
-        error: stopFullSyncRes.error,
-      },
-      "Failed to stop Intercom full sync workflow (intercom uninstall webhook)"
+      "Failed to stop Intercom workflows (intercom uninstall webhook)"
     );
     return res.status(200).end();
   }

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -23,12 +23,12 @@ const logger = mainLogger.child(
   }
 );
 
-type IntercomWebhookResBody = WithConnectorsAPIErrorReponse<null>;
+type IntercombWebhookResBody = WithConnectorsAPIErrorReponse<null>;
 
 const _webhookIntercomAPIHandler = async (
   req: Request<
     Record<string, string>,
-    IntercomWebhookResBody,
+    IntercombWebhookResBody,
     {
       topic?: string;
       type: "notification_event";
@@ -38,7 +38,7 @@ const _webhookIntercomAPIHandler = async (
       };
     }
   >,
-  res: Response<IntercomWebhookResBody>
+  res: Response<IntercombWebhookResBody>
 ) => {
   const event = req.body;
   logger.info(
@@ -177,12 +177,12 @@ export const webhookIntercomAPIHandler = withLogging(
 const _webhookIntercomUninstallAPIHandler = async (
   req: Request<
     Record<string, string>,
-    IntercomWebhookResBody,
+    IntercombWebhookResBody,
     {
       app_id: string; // That's the Intercom workspace id
     }
   >,
-  res: Response<IntercomWebhookResBody>
+  res: Response<IntercombWebhookResBody>
 ) => {
   const event = req.body;
   logger.info({ event }, "Received Intercom uninstall webhook");

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -18,7 +18,9 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
 
 const logger = mainLogger.child(
-  { provider: "intercom" },
+  {
+    provider: "intercom",
+  },
   {
     msgPrefix: "[Intercom] ",
   }

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -81,12 +81,12 @@ const _webhookIntercomAPIHandler = async (
   }
 
   // Find IntercomWorkspace
-  const intercomWorkspace = await IntercomWorkspaceModel.findOne({
+  const intercomWorskpace = await IntercomWorkspaceModel.findOne({
     where: {
       intercomWorkspaceId,
     },
   });
-  if (!intercomWorkspace) {
+  if (!intercomWorskpace) {
     logger.error(
       {
         event,
@@ -98,7 +98,7 @@ const _webhookIntercomAPIHandler = async (
 
   // Find Connector
   const connector = await ConnectorResource.fetchById(
-    intercomWorkspace.connectorId
+    intercomWorskpace.connectorId
   );
 
   if (!connector || connector.type !== "intercom") {
@@ -122,7 +122,7 @@ const _webhookIntercomAPIHandler = async (
   }
 
   const isSelectedAllConvos =
-    intercomWorkspace.syncAllConversations === "activated";
+    intercomWorskpace.syncAllConversations === "activated";
 
   if (!isSelectedAllConvos) {
     if (!conversation.team_assignee_id) {
@@ -198,12 +198,12 @@ const _webhookIntercomUninstallAPIHandler = async (
     return res.status(200).end();
   }
 
-  const intercomWorkspace = await IntercomWorkspaceModel.findOne({
+  const intercomWorskpace = await IntercomWorkspaceModel.findOne({
     where: {
       intercomWorkspaceId,
     },
   });
-  if (!intercomWorkspace) {
+  if (!intercomWorskpace) {
     logger.error(
       {
         event,
@@ -215,7 +215,7 @@ const _webhookIntercomUninstallAPIHandler = async (
 
   // Find Connector
   const connector = await ConnectorResource.fetchById(
-    intercomWorkspace.connectorId
+    intercomWorskpace.connectorId
   );
   if (!connector || connector.type !== "intercom") {
     logger.error(

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -248,17 +248,14 @@ const _webhookIntercomUninstallAPIHandler = async (
   // Mark the connector as errored so that the user is notified.
   await syncFailed(connector.id, "oauth_token_revoked");
 
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const loggerArgs = {
-    workspaceId: dataSourceConfig.workspaceId,
-    connectorId: connector.id,
-    provider: "intercom",
-    dataSourceId: dataSourceConfig.dataSourceId,
-    intercomWorkspaceId,
-  };
-
   logger.info(
-    loggerArgs,
+    {
+      workspaceId: connector.workspaceId,
+      connectorId: connector.id,
+      provider: "intercom",
+      dataSourceId: connector.dataSourceId,
+      intercomWorkspaceId,
+    },
     "[Intercom] Errored connector from uninstall webhook"
   );
 

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 
 import type { IntercomConversationWithPartsType } from "@connectors/connectors/intercom/lib/types";
-import { stopIntercomWorkflows } from "@connectors/connectors/intercom/temporal/client";
+import { stopIntercomSchedulesAndWorkflows } from "@connectors/connectors/intercom/temporal/client";
 import { syncConversation } from "@connectors/connectors/intercom/temporal/sync_conversation";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
@@ -228,7 +228,7 @@ const _webhookIntercomUninstallAPIHandler = async (
   }
 
   // Stop the underlying sync workflows to avoid churning.
-  const stopRes = await stopIntercomWorkflows(connector);
+  const stopRes = await stopIntercomSchedulesAndWorkflows(connector);
   if (stopRes.isErr()) {
     logger.error(
       {

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -243,16 +243,16 @@ const _webhookIntercomUninstallAPIHandler = async (
   // Mark the connector as errored so that the user is notified.
   await syncFailed(connector.id, "oauth_token_revoked");
 
-  logger.info(
-    {
-      workspaceId: connector.workspaceId,
-      connectorId: connector.id,
-      provider: "intercom",
-      dataSourceId: connector.dataSourceId,
-      intercomWorkspaceId,
-    },
-    "Errored connector from uninstall webhook"
-  );
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const loggerArgs = {
+    workspaceId: dataSourceConfig.workspaceId,
+    connectorId: connector.id,
+    provider: "intercom",
+    dataSourceId: dataSourceConfig.dataSourceId,
+    intercomWorkspaceId,
+  };
+
+  logger.info(loggerArgs, "Errored connector from uninstall webhook");
 
   return res.status(200).end();
 };

--- a/connectors/src/api/webhooks/webhook_intercom.ts
+++ b/connectors/src/api/webhooks/webhook_intercom.ts
@@ -14,14 +14,7 @@ import { withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
 
-const logger = mainLogger.child(
-  {
-    provider: "intercom",
-  },
-  {
-    msgPrefix: "[Intercom] ",
-  }
-);
+const logger = mainLogger.child({ provider: "intercom" });
 
 type IntercombWebhookResBody = WithConnectorsAPIErrorReponse<null>;
 
@@ -41,19 +34,14 @@ const _webhookIntercomAPIHandler = async (
   res: Response<IntercombWebhookResBody>
 ) => {
   const event = req.body;
-  logger.info(
-    {
-      event,
-    },
-    "Received Intercom webhook"
-  );
+  logger.info("[Intercom] Received Intercom webhook", { event });
 
   if (event.topic !== "conversation.admin.closed") {
     logger.error(
       {
         event,
       },
-      "Received Intercom webhook with unknown topic"
+      "[Intercom] Received Intercom webhook with unknown topic"
     );
     return res.status(200).end();
   }
@@ -64,7 +52,7 @@ const _webhookIntercomAPIHandler = async (
       {
         event,
       },
-      "Received Intercom webhook with no workspace id"
+      "[Intercom] Received Intercom webhook with no workspace id"
     );
     return res.status(200).end();
   }
@@ -75,7 +63,7 @@ const _webhookIntercomAPIHandler = async (
       {
         event,
       },
-      "Received Intercom webhook with no conversation"
+      "[Intercom] Received Intercom webhook with no conversation"
     );
     return res.status(200).end();
   }
@@ -91,7 +79,7 @@ const _webhookIntercomAPIHandler = async (
       {
         event,
       },
-      "Received Intercom webhook for unknown workspace"
+      "[Intercom] Received Intercom webhook for unknown workspace"
     );
     return res.status(200).end();
   }
@@ -106,7 +94,7 @@ const _webhookIntercomAPIHandler = async (
       {
         event,
       },
-      "Received Intercom webhook for unknown connector"
+      "[Intercom] Received Intercom webhook for unknown connector"
     );
     return res.status(200).end();
   }
@@ -116,7 +104,7 @@ const _webhookIntercomAPIHandler = async (
       {
         connectorId: connector.id,
       },
-      "Received webhook for paused connector, skipping."
+      "[Intercom] Received webhook for paused connector, skipping."
     );
     return res.status(200).end();
   }
@@ -127,7 +115,9 @@ const _webhookIntercomAPIHandler = async (
   if (!isSelectedAllConvos) {
     if (!conversation.team_assignee_id) {
       // Check we have the permissions to sync this conversation
-      logger.info("Received webhook for conversation without team, skipping.");
+      logger.info(
+        "[Intercom] Received webhook for conversation without team, skipping."
+      );
       return res.status(200).end();
     } else {
       const team = await IntercomTeamModel.findOne({
@@ -138,7 +128,7 @@ const _webhookIntercomAPIHandler = async (
       });
       if (!team || team.permission !== "read") {
         logger.info(
-          "Received webhook for conversation attached to team without read permission, skipping."
+          "[Intercom] Received webhook for conversation attached to team without read permission, skipping."
         );
         return res.status(200).end();
       }
@@ -165,7 +155,7 @@ const _webhookIntercomAPIHandler = async (
     loggerArgs,
   });
 
-  logger.info(loggerArgs, "Upserted conversation from webhook");
+  logger.info(loggerArgs, "[Intercom] Upserted conversation from webhook");
 
   return res.status(200).end();
 };
@@ -185,7 +175,7 @@ const _webhookIntercomUninstallAPIHandler = async (
   res: Response<IntercombWebhookResBody>
 ) => {
   const event = req.body;
-  logger.info({ event }, "Received Intercom uninstall webhook");
+  logger.info({ event }, "[Intercom] Received Intercom uninstall webhook");
 
   const intercomWorkspaceId = event.app_id;
   if (!intercomWorkspaceId) {
@@ -193,7 +183,7 @@ const _webhookIntercomUninstallAPIHandler = async (
       {
         event,
       },
-      "Received Intercom uninstall webhook with no workspace id"
+      "[Intercom] Received Intercom uninstall webhook with no workspace id"
     );
     return res.status(200).end();
   }
@@ -208,7 +198,7 @@ const _webhookIntercomUninstallAPIHandler = async (
       {
         event,
       },
-      "Received Intercom uninstall webhook for unknown workspace"
+      "[Intercom] Received Intercom uninstall webhook for unknown workspace"
     );
     return res.status(200).end();
   }
@@ -222,7 +212,7 @@ const _webhookIntercomUninstallAPIHandler = async (
       {
         event,
       },
-      "Received Intercom uninstall webhook for unknown connector"
+      "[Intercom] Received Intercom uninstall webhook for unknown connector"
     );
     return res.status(200).end();
   }
@@ -252,7 +242,10 @@ const _webhookIntercomUninstallAPIHandler = async (
     intercomWorkspaceId,
   };
 
-  logger.info(loggerArgs, "Errored connector from uninstall webhook");
+  logger.info(
+    loggerArgs,
+    "[Intercom] Errored connector from uninstall webhook"
+  );
 
   return res.status(200).end();
 };

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -24,7 +24,7 @@ import {
 } from "@connectors/connectors/intercom/lib/utils";
 import {
   launchIntercomFullSyncWorkflow,
-  launchIntercomScheduledWorkflows,
+  launchIntercomSchedules,
   stopIntercomWorkflows,
 } from "@connectors/connectors/intercom/temporal/client";
 import type {
@@ -96,7 +96,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       intercomConfigurationBlob
     );
 
-    const schedulesStarted = await launchIntercomScheduledWorkflows(connector);
+    const schedulesStarted = await launchIntercomSchedules(connector);
 
     if (schedulesStarted.isErr()) {
       await connector.delete();
@@ -249,7 +249,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
 
-    const schedulesRes = await launchIntercomScheduledWorkflows(connector);
+    const schedulesRes = await launchIntercomSchedules(connector);
     if (schedulesRes.isErr()) {
       return schedulesRes;
     }

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -583,17 +583,17 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
           },
           attributes: ["teamId"],
         });
-        const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
-        const r = await launchIntercomFullSyncWorkflow({
+
+        const fullSyncStartResult = await launchIntercomFullSyncWorkflow({
           connectorId: this.connectorId,
-          teamIds: toBeSignaledTeamIds,
+          teamIds: teamsIds.map((team) => team.teamId),
           forceResync: true,
         });
-        if (r.isErr()) {
-          return r;
+        if (fullSyncStartResult.isErr()) {
+          return fullSyncStartResult;
         }
 
-        return new Ok(void 0);
+        return new Ok(undefined);
       }
 
       default: {

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -25,7 +25,7 @@ import {
 import {
   launchIntercomFullSyncWorkflow,
   launchIntercomSchedules,
-  stopIntercomWorkflows,
+  stopIntercomSchedulesAndWorkflows,
 } from "@connectors/connectors/intercom/temporal/client";
 import type {
   CreateConnectorErrorCode,
@@ -230,7 +230,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
 
-    const res = await stopIntercomWorkflows(connector);
+    const res = await stopIntercomSchedulesAndWorkflows(connector);
     if (res.isErr()) {
       return res;
     }

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -292,7 +292,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     if (!connector) {
       logger.error(
         { connectorId: this.connectorId },
-        "Notion connector not found."
+        "Intercom connector not found."
       );
       return new Err(new Error("Connector not found"));
     }

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -105,7 +105,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
           workspaceId: dataSourceConfig.workspaceId,
           error: schedulesStarted.error,
         },
-        "[Intercom] Error creating connector Could not launch scheduled workflows."
+        "[Intercom] Error creating connector, could not launch scheduled workflows."
       );
       throw schedulesStarted.error;
     }

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -43,7 +43,7 @@ import {
   IntercomTeamModel,
   IntercomWorkspaceModel,
 } from "@connectors/lib/models/intercom";
-import logger from "@connectors/logger/logger";
+import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type {
   ConnectorPermission,
@@ -51,6 +51,15 @@ import type {
   ContentNodesViewType,
   DataSourceConfig,
 } from "@connectors/types";
+
+const logger = mainLogger.child(
+  {
+    provider: "intercom",
+  },
+  {
+    msgPrefix: "[Intercom] ",
+  }
+);
 
 export class IntercomConnectorManager extends BaseConnectorManager<null> {
   readonly provider: ConnectorProvider = "intercom";
@@ -104,7 +113,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
           workspaceId: dataSourceConfig.workspaceId,
           error: schedulesStarted.error,
         },
-        "[Intercom] Error creating connector, could not launch scheduled workflows."
+        "Error creating connector, could not launch schedules."
       );
       throw schedulesStarted.error;
     }
@@ -119,10 +128,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
   }): Promise<Result<string, ConnectorManagerError<UpdateConnectorErrorCode>>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
-      logger.error(
-        { connectorId: this.connectorId },
-        "[Intercom] Connector not found."
-      );
+      logger.error({ connectorId: this.connectorId }, "Connector not found.");
       throw new Error(`Connector ${this.connectorId} not found`);
     }
 
@@ -241,10 +247,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
   async resume(): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
-      logger.error(
-        { connectorId: this.connectorId },
-        "[Intercom] Connector not found."
-      );
+      logger.error({ connectorId: this.connectorId }, "Connector not found.");
       return new Err(new Error("Connector not found"));
     }
 
@@ -330,10 +333,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
   > {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
-      logger.error(
-        { connectorId: this.connectorId },
-        "[Intercom] Connector not found."
-      );
+      logger.error({ connectorId: this.connectorId }, "Connector not found.");
       return new Err(
         new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
       );
@@ -392,10 +392,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
   }): Promise<Result<void, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
-      logger.error(
-        { connectorId: this.connectorId },
-        "[Intercom] Connector not found."
-      );
+      logger.error({ connectorId: this.connectorId }, "Connector not found.");
       return new Err(new Error("Connector not found"));
     }
 
@@ -407,7 +404,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     if (!intercomWorkspace) {
       logger.error(
         { connectorId: this.connectorId },
-        "[Intercom] IntercomWorkspace not found. Cannot set permissions."
+        "IntercomWorkspace not found. Cannot set permissions."
       );
       return new Err(new Error("IntercomWorkspace not found"));
     }
@@ -535,11 +532,11 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       }
 
       return new Ok(undefined);
-    } catch (e) {
+    } catch (error) {
       logger.error(
         {
           connectorId: this.connectorId,
-          error: e,
+          error,
         },
         "Error setting connector permissions."
       );

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -316,7 +316,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       forceResync: true,
     });
     if (sendSignalToWorkflowResult.isErr()) {
-      return new Err(sendSignalToWorkflowResult.error);
+      return sendSignalToWorkflowResult;
     }
     return new Ok(connector.id.toString());
   }
@@ -533,7 +533,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
           }
         );
         if (sendSignalToWorkflowResult.isErr()) {
-          return new Err(sendSignalToWorkflowResult.error);
+          return sendSignalToWorkflowResult;
         }
       }
 

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -25,8 +25,7 @@ import {
 import {
   launchIntercomFullSyncWorkflow,
   launchIntercomScheduledWorkflows,
-  stopIntercomFullSyncWorkflow,
-  stopIntercomScheduledWorkflows,
+  stopIntercomWorkflows,
 } from "@connectors/connectors/intercom/temporal/client";
 import type {
   CreateConnectorErrorCode,
@@ -232,14 +231,9 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
 
-    const schedulesRes = await stopIntercomScheduledWorkflows(connector);
-    if (schedulesRes.isErr()) {
-      return schedulesRes;
-    }
-
-    const fullSyncRes = await stopIntercomFullSyncWorkflow(this.connectorId);
-    if (fullSyncRes.isErr()) {
-      return fullSyncRes;
+    const res = await stopIntercomWorkflows(connector);
+    if (res.isErr()) {
+      return res;
     }
 
     return new Ok(undefined);

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -305,20 +305,16 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       attributes: ["teamId"],
     });
 
-    const toBeSignaledHelpCenterIds = helpCentersIds.map(
-      (hc) => hc.helpCenterId
-    );
-    const toBeSignaledTeamIds = teamsIds.map((team) => team.teamId);
-
     const sendSignalToWorkflowResult = await launchIntercomFullSyncWorkflow({
       connectorId: this.connectorId,
-      helpCenterIds: toBeSignaledHelpCenterIds,
-      teamIds: toBeSignaledTeamIds,
+      helpCenterIds: helpCentersIds.map((hc) => hc.helpCenterId),
+      teamIds: teamsIds.map((team) => team.teamId),
       forceResync: true,
     });
     if (sendSignalToWorkflowResult.isErr()) {
       return sendSignalToWorkflowResult;
     }
+
     return new Ok(connector.id.toString());
   }
 

--- a/connectors/src/connectors/intercom/temporal/activities.ts
+++ b/connectors/src/connectors/intercom/temporal/activities.ts
@@ -570,12 +570,12 @@ export async function getNextConversationBatchToSyncActivity({
   connectorId,
   teamId,
   cursor,
-  lastHourOnly,
+  closedAfterTimeWindowMinutes,
 }: {
   connectorId: ModelId;
   teamId?: string;
   cursor: string | null;
-  lastHourOnly?: boolean;
+  closedAfterTimeWindowMinutes?: number;
 }): Promise<{ conversationIds: string[]; nextPageCursor: string | null }> {
   const connector = await _getIntercomConnectorOrRaise(connectorId);
 
@@ -591,8 +591,8 @@ export async function getNextConversationBatchToSyncActivity({
   let result;
 
   const accessToken = await getIntercomAccessToken(connector.connectionId);
-  const closedAfter = lastHourOnly
-    ? Math.floor((Date.now() - 1 * 60 * 60 * 1000) / 1000)
+  const closedAfter = closedAfterTimeWindowMinutes
+    ? Math.floor((Date.now() - closedAfterTimeWindowMinutes * 60 * 1000) / 1000)
     : undefined;
 
   if (teamId) {

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -134,16 +134,16 @@ export async function stopIntercomSchedulesAndWorkflows(
     const handle: WorkflowHandle<typeof intercomFullSyncWorkflow> =
       client.workflow.getHandle(workflowId);
     await handle.terminate();
-  } catch (e) {
-    if (!(e instanceof WorkflowNotFoundError)) {
+  } catch (error) {
+    if (!(error instanceof WorkflowNotFoundError)) {
       logger.error(
         {
           workflowId,
-          error: e,
+          error,
         },
         "[Intercom] Failed to stop full sync workflow."
       );
-      return new Err(normalizeError(e));
+      return new Err(normalizeError(error));
     }
   }
 

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -115,7 +115,7 @@ export async function stopIntercomWorkflows(
   });
 
   if (helpCenterResult.isErr()) {
-    return new Err(helpCenterResult.error);
+    return helpCenterResult;
   }
 
   const conversationResult = await deleteSchedule({
@@ -124,7 +124,7 @@ export async function stopIntercomWorkflows(
   });
 
   if (conversationResult.isErr()) {
-    return new Err(conversationResult.error);
+    return conversationResult;
   }
 
   const client = await getTemporalClient();
@@ -176,7 +176,7 @@ export async function launchIntercomScheduledWorkflows(
   });
 
   if (helpCenterResult.isErr()) {
-    return new Err(helpCenterResult.error);
+    return helpCenterResult;
   }
 
   const conversationResult = await createSchedule({
@@ -206,9 +206,8 @@ export async function launchIntercomScheduledWorkflows(
   });
 
   if (conversationResult.isErr()) {
-    return new Err(conversationResult.error);
+    return conversationResult;
   }
 
   return new Ok(undefined);
 }
-

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -1,19 +1,35 @@
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import type { WorkflowHandle } from "@temporalio/client";
-import { WorkflowNotFoundError } from "@temporalio/client";
+import {
+  ScheduleOverlapPolicy,
+  WorkflowNotFoundError,
+} from "@temporalio/client";
 
 import { QUEUE_NAME } from "@connectors/connectors/intercom/temporal/config";
 import type { IntercomUpdateSignal } from "@connectors/connectors/intercom/temporal/signals";
 import { intercomUpdatesSignal } from "@connectors/connectors/intercom/temporal/signals";
-import { intercomSyncWorkflow } from "@connectors/connectors/intercom/temporal/workflows";
+import {
+  intercomFullSyncWorkflow,
+  intercomScheduledConversationSyncWorkflow,
+  intercomScheduledHelpCenterSyncWorkflow,
+} from "@connectors/connectors/intercom/temporal/workflows";
 import { getTemporalClient } from "@connectors/lib/temporal";
+import {
+  createSchedule,
+  deleteSchedule,
+} from "@connectors/lib/temporal_schedules";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
-import { getIntercomSyncWorkflowId, normalizeError } from "@connectors/types";
+import {
+  getIntercomFullSyncWorkflowId,
+  makeIntercomConversationScheduleId,
+  makeIntercomHelpCenterScheduleId,
+  normalizeError,
+} from "@connectors/types";
 
-export async function launchIntercomSyncWorkflow({
+export async function launchIntercomFullSyncWorkflow({
   connectorId,
   fromTs = null,
   helpCenterIds = [],
@@ -40,7 +56,7 @@ export async function launchIntercomSyncWorkflow({
     );
   }
 
-  const workflowId = getIntercomSyncWorkflowId(connectorId);
+  const workflowId = getIntercomFullSyncWorkflowId(connectorId);
   const signaledHelpCenterIds: IntercomUpdateSignal[] = helpCenterIds.map(
     (helpCenterId) => ({
       type: "help_center",
@@ -69,9 +85,8 @@ export async function launchIntercomSyncWorkflow({
     ...signaledHasUpdatedSelectAllConvos,
   ];
 
-  // When the workflow is inactive, we omit passing helpCenterIds as they are only used to signal modifications within a currently active full sync workflow.
   try {
-    await client.workflow.signalWithStart(intercomSyncWorkflow, {
+    await client.workflow.signalWithStart(intercomFullSyncWorkflow, {
       args: [{ connectorId: connector.id }],
       taskQueue: QUEUE_NAME,
       workflowId,
@@ -83,7 +98,6 @@ export async function launchIntercomSyncWorkflow({
       memo: {
         connectorId,
       },
-      cronSchedule: "30 * * * *", // Every hour, at 30 of the hour.
     });
   } catch (err) {
     return new Err(normalizeError(err));
@@ -92,7 +106,7 @@ export async function launchIntercomSyncWorkflow({
   return new Ok(workflowId);
 }
 
-export async function stopIntercomSyncWorkflow(
+export async function stopIntercomFullSyncWorkflow(
   connectorId: ModelId
 ): Promise<Result<void, Error>> {
   const client = await getTemporalClient();
@@ -103,27 +117,111 @@ export async function stopIntercomSyncWorkflow(
     );
   }
 
-  const workflowId = getIntercomSyncWorkflowId(connectorId);
+  const workflowId = getIntercomFullSyncWorkflowId(connectorId);
 
   try {
-    const handle: WorkflowHandle<typeof intercomSyncWorkflow> =
+    const handle: WorkflowHandle<typeof intercomFullSyncWorkflow> =
       client.workflow.getHandle(workflowId);
-    try {
-      await handle.terminate();
-    } catch (e) {
-      if (!(e instanceof WorkflowNotFoundError)) {
-        throw e;
-      }
-    }
+    await handle.terminate();
     return new Ok(undefined);
   } catch (e) {
-    logger.error(
-      {
-        workflowId,
-        error: e,
-      },
-      "[Intercom] Failed stopping workflow."
-    );
-    return new Err(normalizeError(e));
+    if (!(e instanceof WorkflowNotFoundError)) {
+      logger.error(
+        {
+          workflowId,
+          error: e,
+        },
+        "[Intercom] Failed stopping full sync workflow."
+      );
+      return new Err(normalizeError(e));
+    }
   }
+
+  return new Ok(undefined);
+}
+
+export async function launchIntercomScheduledWorkflows(
+  connector: ConnectorResource
+): Promise<Result<void, Error>> {
+  const helpCenterResult = await createSchedule({
+    connector,
+    action: {
+      type: "startWorkflow",
+      workflowType: intercomScheduledHelpCenterSyncWorkflow,
+      args: [{ connectorId: connector.id }],
+      taskQueue: QUEUE_NAME,
+    },
+    scheduleId: makeIntercomHelpCenterScheduleId(connector),
+    policies: {
+      catchupWindow: "1 day",
+      overlap: ScheduleOverlapPolicy.BUFFER_ONE,
+    },
+    spec: {
+      intervals: [
+        {
+          every: "1 day",
+        },
+      ],
+    },
+  });
+
+  if (helpCenterResult.isErr()) {
+    return new Err(helpCenterResult.error);
+  }
+
+  const conversationResult = await createSchedule({
+    connector,
+    action: {
+      type: "startWorkflow",
+      workflowType: intercomScheduledConversationSyncWorkflow,
+      args: [
+        {
+          connectorId: connector.id,
+        },
+      ],
+      taskQueue: QUEUE_NAME,
+    },
+    scheduleId: makeIntercomConversationScheduleId(connector),
+    policies: {
+      catchupWindow: "1 day",
+      overlap: ScheduleOverlapPolicy.BUFFER_ONE,
+    },
+    spec: {
+      intervals: [
+        {
+          every: "20 minutes",
+        },
+      ],
+    },
+  });
+
+  if (conversationResult.isErr()) {
+    return new Err(conversationResult.error);
+  }
+
+  return new Ok(undefined);
+}
+
+export async function stopIntercomScheduledWorkflows(
+  connector: ConnectorResource
+): Promise<Result<void, Error>> {
+  const helpCenterResult = await deleteSchedule({
+    scheduleId: makeIntercomHelpCenterScheduleId(connector),
+    connector,
+  });
+
+  if (helpCenterResult.isErr()) {
+    return new Err(helpCenterResult.error);
+  }
+
+  const conversationResult = await deleteSchedule({
+    scheduleId: makeIntercomConversationScheduleId(connector),
+    connector,
+  });
+
+  if (conversationResult.isErr()) {
+    return new Err(conversationResult.error);
+  }
+
+  return new Ok(undefined);
 }

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -158,7 +158,11 @@ export async function launchIntercomSchedules(
     action: {
       type: "startWorkflow",
       workflowType: intercomHelpCenterSyncWorkflow,
-      args: [{ connectorId: connector.id }],
+      args: [
+        {
+          connectorId: connector.id,
+        },
+      ],
       taskQueue: QUEUE_NAME,
     },
     scheduleId: makeIntercomHelpCenterScheduleId(connector),

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -150,7 +150,7 @@ export async function stopIntercomWorkflows(
   return new Ok(undefined);
 }
 
-export async function launchIntercomScheduledWorkflows(
+export async function launchIntercomSchedules(
   connector: ConnectorResource
 ): Promise<Result<void, Error>> {
   const helpCenterResult = await createSchedule({

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -106,7 +106,7 @@ export async function launchIntercomFullSyncWorkflow({
   return new Ok(workflowId);
 }
 
-export async function stopIntercomWorkflows(
+export async function stopIntercomSchedulesAndWorkflows(
   connector: ConnectorResource
 ): Promise<Result<void, Error>> {
   const helpCenterResult = await deleteSchedule({

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -56,7 +56,7 @@ export async function launchIntercomFullSyncWorkflow({
     );
   }
 
-  const workflowId = getIntercomFullSyncWorkflowId(connectorId);
+  const workflowId = getIntercomFullSyncWorkflowId(connector);
   const signaledHelpCenterIds: IntercomUpdateSignal[] = helpCenterIds.map(
     (helpCenterId) => ({
       type: "help_center",
@@ -128,7 +128,7 @@ export async function stopIntercomSchedulesAndWorkflows(
   }
 
   const client = await getTemporalClient();
-  const workflowId = getIntercomFullSyncWorkflowId(connector.id);
+  const workflowId = getIntercomFullSyncWorkflowId(connector);
 
   try {
     const handle: WorkflowHandle<typeof intercomFullSyncWorkflow> =

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -141,7 +141,7 @@ export async function stopIntercomSchedulesAndWorkflows(
           workflowId,
           error: e,
         },
-        "[Intercom] Failed stopping full sync workflow."
+        "[Intercom] Failed to stop full sync workflow."
       );
       return new Err(normalizeError(e));
     }

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -11,8 +11,8 @@ import type { IntercomUpdateSignal } from "@connectors/connectors/intercom/tempo
 import { intercomUpdatesSignal } from "@connectors/connectors/intercom/temporal/signals";
 import {
   intercomFullSyncWorkflow,
-  intercomScheduledConversationSyncWorkflow,
-  intercomScheduledHelpCenterSyncWorkflow,
+  intercomConversationSyncWorkflow,
+  intercomHelpCenterSyncWorkflow,
 } from "@connectors/connectors/intercom/temporal/workflows";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import {
@@ -147,7 +147,7 @@ export async function launchIntercomScheduledWorkflows(
     connector,
     action: {
       type: "startWorkflow",
-      workflowType: intercomScheduledHelpCenterSyncWorkflow,
+      workflowType: intercomHelpCenterSyncWorkflow,
       args: [{ connectorId: connector.id }],
       taskQueue: QUEUE_NAME,
     },
@@ -173,7 +173,7 @@ export async function launchIntercomScheduledWorkflows(
     connector,
     action: {
       type: "startWorkflow",
-      workflowType: intercomScheduledConversationSyncWorkflow,
+      workflowType: intercomConversationSyncWorkflow,
       args: [
         {
           connectorId: connector.id,

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -180,6 +180,9 @@ export async function intercomFullSyncWorkflow({
   await saveIntercomConnectorSuccessSync({ connectorId });
 }
 
+/**
+ * This workflow runs on a schedule and syncs the Help Center.
+ */
 export async function intercomHelpCenterSyncWorkflow({
   connectorId,
 }: {
@@ -203,6 +206,7 @@ export async function intercomHelpCenterSyncWorkflow({
   const currentSyncMs = new Date().getTime();
 
   for (const helpCenterId of helpCenterIds) {
+    // We full sync the Help Center, we don't have incremental sync here.
     await executeChild(intercomHelpCenterFullSyncWorkflow, {
       workflowId: `${workflowId}-help-center-${helpCenterId}`,
       searchAttributes: parentSearchAttributes,
@@ -221,6 +225,9 @@ export async function intercomHelpCenterSyncWorkflow({
   await saveIntercomConnectorSuccessSync({ connectorId });
 }
 
+/**
+ * This workflow runs on a schedule and syncs conversations closed over the last CONVERSATION_SYNC_WINDOW_MINUTES.
+ */
 export async function intercomConversationSyncWorkflow({
   connectorId,
 }: {
@@ -292,9 +299,8 @@ export async function intercomConversationSyncWorkflow({
 }
 
 /**
- * Sync Workflow for a Help Center.
- * Launched by the IntercomFullSyncWorkflow, it will sync a given help center.
- * We sync a HelpCenter by fetching all the Collections and Articles.
+ * This workflow is called as a child workflow, it will sync a given Help Center.
+ * We sync a Help Center by fetching all the Collections and Articles.
  */
 export async function intercomHelpCenterFullSyncWorkflow({
   connectorId,
@@ -348,8 +354,7 @@ export async function intercomHelpCenterFullSyncWorkflow({
 }
 
 /**
- * Sync Workflow for a Team.
- * Launched by the IntercomFullSyncWorkflow, it will sync a given Team.
+ * This workflow is called as a child workflow of intercomFullSyncWorkflow, it will sync conversations for a team.
  * We sync a Team by fetching the conversations attached to this team.
  */
 export async function intercomTeamFullSyncWorkflow({
@@ -397,9 +402,8 @@ export async function intercomTeamFullSyncWorkflow({
 }
 
 /**
- * Sync Workflow for All Conversations.
- * Launched by the IntercomFullSyncWorkflow if a signal is received, meaning the admin updated the permissions and
- * ticked or unticked the "All Conversations" checkbox.
+ * This workflow is called as a child workflow of intercomFullSyncWorkflow, it will sync conversations for all teams.
+ * It is triggered when the admin updated the permissions and ticked or unticked the "All Conversations" checkbox.
  */
 export async function intercomAllConversationsFullSyncWorkflow({
   connectorId,

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -293,7 +293,7 @@ export async function intercomConversationSyncWorkflow({
     } while (cursor);
   }
 
-  await intercomOutdatedConversationsCleanup({
+  await cleanupOutdatedConversations({
     connectorId,
   });
 
@@ -490,10 +490,7 @@ export async function intercomAllConversationsFullSyncWorkflow({
   }
 }
 
-/**
- * Cleaning Workflow to remove old convos.
- */
-export async function intercomOutdatedConversationsCleanup({
+async function cleanupOutdatedConversations({
   connectorId,
 }: {
   connectorId: ModelId;

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -161,7 +161,7 @@ export async function intercomFullSyncWorkflow({
   }
 
   if (hasUpdatedSelectAllConvos) {
-    await executeChild(intercomAllConversationsSyncWorkflow, {
+    await executeChild(intercomAllConversationsFullSyncWorkflow, {
       workflowId: `${workflowId}-all-conversations`,
       searchAttributes: parentSearchAttributes,
       args: [
@@ -258,7 +258,7 @@ export async function intercomConversationSyncWorkflow({
     } while (cursor);
   }
 
-  await intercomOldConversationsCleanup({
+  await intercomOutdatedConversationsCleanup({
     connectorId,
   });
 
@@ -375,7 +375,7 @@ export async function intercomTeamFullSyncWorkflow({
  * Launched by the IntercomFullSyncWorkflow if a signal is received, meaning the admin updated the permissions and
  * ticked or unticked the "All Conversations" checkbox.
  */
-export async function intercomAllConversationsSyncWorkflow({
+export async function intercomAllConversationsFullSyncWorkflow({
   connectorId,
   currentSyncMs,
   initialCursor = null,
@@ -422,7 +422,7 @@ export async function intercomAllConversationsSyncWorkflow({
             workflowInfo().historySize >
               TEMPORAL_WORKFLOW_MAX_HISTORY_SIZE_MB * 1024 * 1024)
         ) {
-          await continueAsNew<typeof intercomAllConversationsSyncWorkflow>({
+          await continueAsNew<typeof intercomAllConversationsFullSyncWorkflow>({
             connectorId,
             currentSyncMs,
             initialCursor: cursor,
@@ -461,7 +461,7 @@ export async function intercomAllConversationsSyncWorkflow({
 /**
  * Cleaning Workflow to remove old convos.
  */
-export async function intercomOldConversationsCleanup({
+export async function intercomOutdatedConversationsCleanup({
   connectorId,
 }: {
   connectorId: ModelId;

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -293,17 +293,9 @@ export async function intercomConversationSyncWorkflow({
     } while (cursor);
   }
 
-  // Cleanup old conversations.
-  let conversationIds = [];
-  do {
-    conversationIds = await getNextOldConversationsBatchToDeleteActivity({
-      connectorId,
-    });
-    await deleteConversationBatchActivity({
-      connectorId,
-      conversationIds,
-    });
-  } while (conversationIds.length > 0);
+  await intercomOutdatedConversationsCleanup({
+    connectorId,
+  });
 
   await saveIntercomConnectorSuccessSync({ connectorId });
 }
@@ -496,4 +488,24 @@ export async function intercomAllConversationsFullSyncWorkflow({
       });
       break;
   }
+}
+
+/**
+ * Cleaning Workflow to remove old convos.
+ */
+export async function intercomOutdatedConversationsCleanup({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}) {
+  let conversationIds = [];
+  do {
+    conversationIds = await getNextOldConversationsBatchToDeleteActivity({
+      connectorId,
+    });
+    await deleteConversationBatchActivity({
+      connectorId,
+      conversationIds,
+    });
+  } while (conversationIds.length > 0);
 }

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -52,7 +52,7 @@ const {
 const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 40_000;
 const TEMPORAL_WORKFLOW_MAX_HISTORY_SIZE_MB = 40;
 
-// We sync conversations over the last 30 minutes, which is 1.5 times the frequency of the schedule.
+// We sync conversations over the last 30 minutes, a bit more than the schedule frequency to allow for some overlap.
 const CONVERSATION_SYNC_WINDOW_MINUTES = 30;
 
 /**

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -55,7 +55,7 @@ const TEMPORAL_WORKFLOW_MAX_HISTORY_SIZE_MB = 40;
 /**
  * Sync Workflow for Intercom.
  * This workflow is responsible for syncing all the help centers for a given connector.
- * Lauched on a cron schedule every hour, it will sync all the help centers that are in DB.
+ * Launched on a cron schedule every hour, it will sync all the help centers that are in DB.
  * If a signal is received, it will sync the help centers that were modified.
  */
 export async function intercomSyncWorkflow({

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -291,9 +291,17 @@ export async function intercomConversationSyncWorkflow({
     } while (cursor);
   }
 
-  await intercomOutdatedConversationsCleanup({
-    connectorId,
-  });
+  // Cleanup old conversations.
+  let conversationIds = [];
+  do {
+    conversationIds = await getNextOldConversationsBatchToDeleteActivity({
+      connectorId,
+    });
+    await deleteConversationBatchActivity({
+      connectorId,
+      conversationIds,
+    });
+  } while (conversationIds.length > 0);
 
   await saveIntercomConnectorSuccessSync({ connectorId });
 }
@@ -486,24 +494,4 @@ export async function intercomAllConversationsFullSyncWorkflow({
       });
       break;
   }
-}
-
-/**
- * Cleaning Workflow to remove old convos.
- */
-export async function intercomOutdatedConversationsCleanup({
-  connectorId,
-}: {
-  connectorId: ModelId;
-}) {
-  let conversationIds = [];
-  do {
-    conversationIds = await getNextOldConversationsBatchToDeleteActivity({
-      connectorId,
-    });
-    await deleteConversationBatchActivity({
-      connectorId,
-      conversationIds,
-    });
-  } while (conversationIds.length > 0);
 }

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -261,6 +261,29 @@ export async function intercomConversationSyncWorkflow({
     } while (cursor);
   }
 
+  const syncAllConvosStatus = await getSyncAllConversationsStatusActivity({
+    connectorId,
+  });
+  if (syncAllConvosStatus === "activated") {
+    let cursor = null;
+    do {
+      const { conversationIds, nextPageCursor } =
+        await getNextConversationBatchToSyncActivity({
+          connectorId,
+          cursor,
+          closedAfterTimeWindowMinutes: CONVERSATION_SYNC_WINDOW_MINUTES,
+        });
+
+      await syncConversationBatchActivity({
+        connectorId,
+        conversationIds,
+        currentSyncMs,
+      });
+
+      cursor = nextPageCursor;
+    } while (cursor);
+  }
+
   await intercomOutdatedConversationsCleanup({
     connectorId,
   });

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -244,6 +244,7 @@ export async function intercomConversationSyncWorkflow({
 
   const currentSyncMs = new Date().getTime();
 
+  // Sync conversations for each team.
   for (const teamId of teamIds) {
     let cursor = null;
 
@@ -268,6 +269,7 @@ export async function intercomConversationSyncWorkflow({
     } while (cursor);
   }
 
+  // If we sync all conversations, we need to check for conversations that are not assign to a team.
   const syncAllConvosStatus = await getSyncAllConversationsStatusActivity({
     connectorId,
   });

--- a/connectors/src/connectors/intercom/temporal/workflows.ts
+++ b/connectors/src/connectors/intercom/temporal/workflows.ts
@@ -52,6 +52,9 @@ const {
 const TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH = 40_000;
 const TEMPORAL_WORKFLOW_MAX_HISTORY_SIZE_MB = 40;
 
+// We sync conversations over the last 30 minutes, which is 1.5 times the frequency of the schedule.
+const CONVERSATION_SYNC_WINDOW_MINUTES = 30;
+
 /**
  * This workflow is triggered by signals when permissions are updated or when a full sync is triggered.
  * It processes help centers, teams, and "all conversations" based on the signals received.
@@ -244,7 +247,7 @@ export async function intercomConversationSyncWorkflow({
           connectorId,
           teamId,
           cursor,
-          lastHourOnly: true,
+          closedAfterTimeWindowMinutes: CONVERSATION_SYNC_WINDOW_MINUTES,
         });
 
       await syncConversationBatchActivity({

--- a/connectors/src/types/intercom.ts
+++ b/connectors/src/types/intercom.ts
@@ -1,8 +1,7 @@
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ModelId } from "@connectors/types";
 
-export function getIntercomFullSyncWorkflowId(connectorId: ModelId) {
-  return `intercom-full-sync-${connectorId}`;
+export function getIntercomFullSyncWorkflowId(connector: ConnectorResource) {
+  return `intercom-full-sync-${connector.id}`;
 }
 
 export function makeIntercomHelpCenterScheduleId(

--- a/connectors/src/types/intercom.ts
+++ b/connectors/src/types/intercom.ts
@@ -8,11 +8,11 @@ export function getIntercomFullSyncWorkflowId(connectorId: ModelId) {
 export function makeIntercomHelpCenterScheduleId(
   connector: ConnectorResource
 ): string {
-  return `intercom-help-center-schedule-${connector.id}`;
+  return `intercom-help-center-sync-${connector.id}`;
 }
 
 export function makeIntercomConversationScheduleId(
   connector: ConnectorResource
 ): string {
-  return `intercom-conversation-schedule-${connector.id}`;
+  return `intercom-conversation-sync-${connector.id}`;
 }

--- a/connectors/src/types/intercom.ts
+++ b/connectors/src/types/intercom.ts
@@ -1,5 +1,18 @@
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-export function getIntercomSyncWorkflowId(connectorId: ModelId) {
-  return `intercom-sync-${connectorId}`;
+export function getIntercomFullSyncWorkflowId(connectorId: ModelId) {
+  return `intercom-full-sync-${connectorId}`;
+}
+
+export function makeIntercomHelpCenterScheduleId(
+  connector: ConnectorResource
+): string {
+  return `intercom-help-center-schedule-${connector.id}`;
+}
+
+export function makeIntercomConversationScheduleId(
+  connector: ConnectorResource
+): string {
+  return `intercom-conversation-schedule-${connector.id}`;
 }


### PR DESCRIPTION
## Description

Current state
- The sync for Intercom connectors is currently handled by the workflow `intercomSyncWorkflow`, which runs on a cron schedule and can receive signals. It has two modes: if we're on the hourly execution it syncs the Help Center entirely (no way using their API to efficiently retrieve exactly a diff from a given date), and if not we full sync the content that was passed as signals.
- Conversations are synced via webhooks, and hourly since https://github.com/dust-tt/dust/pull/16704

Goal
- End game is to remove webhooks and only rely on an incremental sync, webhooks are sync (not retried in a Temporal workflow) and can lead us to lose conversations for good if the webhook fails.
- We don't need to sync the Help Center as often as conversations (Help Center quite static), however having a sync frequency too slow will lead us to lose the instantaneity of webhooks for conversations.

Content of this PR
- This PR splits the two syncs and sets distinct frequencies.
- To go one step further, the Help Center sync is separated from the main workflow, which is now a full sync workflow that does not run on a schedule.

Next steps
- Remove webhooks.
- Split the full sync workflow + its children workflows in a separate file. Won't do here because it will create a horrible diff.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Stop all Intercom connectors.
- Deploy connectors.
- Resume all Intercom connectors.
