### PR TITLE
feat(oauth): create temporary endpoint to update connection's related credential id

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -960,7 +960,7 @@ impl Connection {
             .update_connection_related_credential_id(self)
             .await
             .map_err(|e| {
-                error!(error = ?e, "Failed to update related_credential_id");
+                error!(error = %e, "Failed to update related_credential_id");
                 ConnectionError {
                     code: ConnectionErrorCode::InternalError,
                     message: "Failed to update related_credential_id".to_string(),

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -925,7 +925,7 @@ impl Connection {
     ) -> Result<(), ConnectionError> {
         match store.retrieve_credential(&related_credential_id).await {
             Err(e) => {
-                error!(error = ?e, "Failed to retrieve credential");
+                error!(error = %e, "Failed to retrieve credential");
                 return Err(ConnectionError {
                     code: ConnectionErrorCode::InternalError,
                     message: "Failed to retrieve credential".to_string(),

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -18,6 +18,7 @@ pub enum CredentialProvider {
     Snowflake,
     Bigquery,
     Salesforce,
+    Slack,
     Microsoft,
     MicrosoftTools,
     Modjo,
@@ -38,6 +39,7 @@ impl From<ConnectionProvider> for CredentialProvider {
             ConnectionProvider::Microsoft => CredentialProvider::Microsoft,
             ConnectionProvider::MicrosoftTools => CredentialProvider::MicrosoftTools,
             ConnectionProvider::Salesforce => CredentialProvider::Salesforce,
+            ConnectionProvider::Slack => CredentialProvider::Slack,
             ConnectionProvider::Gmail => CredentialProvider::Gmail,
             ConnectionProvider::Jira => CredentialProvider::Jira,
             ConnectionProvider::Mcp => CredentialProvider::Mcp,
@@ -206,6 +208,9 @@ impl Credential {
             }
             CredentialProvider::Salesforce => {
                 vec!["client_id", "client_secret"]
+            }
+            CredentialProvider::Slack => {
+                vec!["client_id", "client_secret", "signing_secret"]
             }
             CredentialProvider::Microsoft => {
                 vec!["client_id", "client_secret"]

--- a/core/src/oauth/store.rs
+++ b/core/src/oauth/store.rs
@@ -28,6 +28,7 @@ pub trait OAuthStore {
     async fn update_connection_secrets(&self, connection: &Connection) -> Result<()>;
     async fn update_connection_status(&self, connection: &Connection) -> Result<()>;
     async fn update_connection_metadata(&self, connection: &Connection) -> Result<()>;
+    async fn update_connection_related_credential_id(&self, connection: &Connection) -> Result<()>;
 
     async fn create_credential(
         &self,
@@ -287,6 +288,27 @@ impl OAuthStore for PostgresOAuthStore {
             "UPDATE connections SET metadata = $1 WHERE id = $2 AND provider = $3 AND secret = $4",
             &[
                 &connection.metadata(),
+                &row_id,
+                &connection.provider().to_string(),
+                &secret,
+            ],
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn update_connection_related_credential_id(&self, connection: &Connection) -> Result<()> {
+        let (row_id, secret) =
+            Connection::row_id_and_secret_from_connection_id(&connection.connection_id())?;
+
+        let pool = self.pool.clone();
+        let c = pool.get().await?;
+
+        c.execute(
+            "UPDATE connections SET related_credential_id = $1 WHERE id = $2 AND provider = $3 AND secret = $4",
+            &[
+                &connection.related_credential_id(),
                 &row_id,
                 &connection.provider().to_string(),
                 &secret,


### PR DESCRIPTION
## Description

Related issue: [#5188](https://github.com/dust-tt/tasks/issues/5188)

Add a new temporary endpoint for the migration of the current slack connections to support credentials

## Tests

Tested with script :

before executing :
<img width="817" height="99" alt="image" src="https://github.com/user-attachments/assets/17256a2e-a3d5-4a51-9589-cf4fd490f5c5" />

command :
<img width="2516" height="348" alt="image" src="https://github.com/user-attachments/assets/7f466334-46b3-4bc7-9115-f4c53ac5603f" />

after executing :
<img width="798" height="97" alt="image" src="https://github.com/user-attachments/assets/802b6038-1c00-4077-af83-89e360004582" />


## Risk

None. should not be called except for the migration of defined in [#5188](https://github.com/dust-tt/tasks/issues/5181)

## Deploy Plan

Core
