### PR TITLE
Add Slack files:write scope for everyone

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -328,15 +328,8 @@ async function streamAgentAnswerToSlack(
           actions
         );
 
-        const authResult = await slackClient.auth.test();
-        let filesUploaded: { file: Buffer; filename: string }[] = [];
-        if (
-          authResult.ok &&
-          authResult.response_metadata?.scopes?.includes("files:write")
-        ) {
-          const files = actions.flatMap((action) => action.generatedFiles);
-          filesUploaded = await getFilesFromDust(files, dustAPI);
-        }
+        const files = actions.flatMap((action) => action.generatedFiles);
+        const filesUploaded = await getFilesFromDust(files, dustAPI);
 
         const slackContent = slackifyMarkdown(
           normalizeContentForSlack(formattedContent)

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -282,14 +282,6 @@ export async function executePostMessage(
   );
   message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
 
-  const authResult = await slackClient.auth.test();
-  if (
-    !authResult.ok ||
-    !authResult.response_metadata?.scopes?.includes("files:write")
-  ) {
-    fileId = undefined;
-  }
-
   // If a file is provided, upload it as attachment of the original message.
   if (fileId) {
     const file = await FileResource.fetchById(auth, fileId);

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -7,7 +7,6 @@ import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
-import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -80,6 +79,7 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
             "channels:read",
             "chat:write",
             "files:read",
+            "files:write",
             "groups:history",
             "groups:read",
             "im:history",
@@ -94,15 +94,6 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
           // TODO: This is temporary until our Slack app scope is approved.
           if (extraConfig?.slack_bot_mcp_feature_flag) {
             scopes.push("reactions:read", "reactions:write");
-          }
-
-          // TODO: This is temporary until our Slack app scope is approved.
-          const currentRegion = regionsConfig.getCurrentRegion();
-          if (
-            currentRegion === "europe-west1" &&
-            extraConfig?.slack_files_write_scope_feature_flag === "true"
-          ) {
-            scopes.push("files:write");
           }
 
           return {
@@ -237,10 +228,6 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
       const config = { ...extraConfig };
       if (feature_flags.includes("slack_bot_mcp")) {
         config.slack_bot_mcp_feature_flag = "true";
-      }
-      // TODO: This is temporary until our Slack app scope is approved.
-      if (feature_flags.includes("slack_files_write_scope")) {
-        config.slack_files_write_scope_feature_flag = "true";
       }
       return config;
     }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -217,10 +217,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable mentions v2, aka mention users",
     stage: "on_demand",
   },
-  slack_files_write_scope: {
-    description: "Enable files:write scope for Slack bot and MCP server",
-    stage: "on_demand",
-  },
   notifications: {
     description: "Enable notifications",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -683,7 +683,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "show_debug_tools"
   | "slack_bot_mcp"
   | "slack_enhanced_default_agent"
-  | "slack_files_write_scope"
   | "slack_message_splitting"
   | "slack_semantic_search"
   | "slideshow"


### PR DESCRIPTION
## Description

This PR removes the `slack_files_write_scope` feature flag and give the files:write scope for everyone.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front and connectors
