### PR TITLE
[front] - feat(obs): observability summary

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -206,8 +206,9 @@ export function ToolsPicker({
     hasFeature,
     isAdmin,
     isDataReady,
-    availableMCPServers,
+    shouldFetchToolsData,
     serverViews,
+    availableMCPServers,
     searchText,
   ]);
 

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -50,17 +50,13 @@ export function AgentObservability({
     agentAnalytics.activeUsers > 0 &&
     agentAnalytics.mentions.messageCount > 0;
 
-  const {
-    summaryText,
-    isSummaryLoading,
-    isSummaryError,
-    refetchSummary,
-  } = useAgentObservabilitySummary({
-    workspaceId,
-    agentConfigurationId,
-    days: period,
-    disabled: !isTimeRangeMode,
-  });
+  const { summaryText, isSummaryLoading, isSummaryError, refetchSummary } =
+    useAgentObservabilitySummary({
+      workspaceId,
+      agentConfigurationId,
+      days: period,
+      disabled: !isTimeRangeMode,
+    });
 
   return (
     <TabContentLayout
@@ -76,7 +72,7 @@ export function AgentObservability({
         {isTimeRangeMode && (
           <div className="mb-4">
             {isSummaryLoading ? (
-              <div className="rounded-lg border border-border bg-card p-4 dark:border-border-night">
+              <div className="bg-card rounded-lg border border-border p-4 dark:border-border-night">
                 <div className="mb-2 flex items-center justify-between">
                   <LoadingBlock className="h-5 w-24" />
                 </div>

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -4,6 +4,7 @@ import {
   ContentMessage,
   HandThumbDownIcon,
   HandThumbUpIcon,
+  LoadingBlock,
   Separator,
   Spinner,
   ValueCard,
@@ -74,42 +75,50 @@ export function AgentObservability({
       <TabContentChildSectionLayout title="Overview">
         {isTimeRangeMode && (
           <div className="mb-4">
-            <ContentMessage
-              title="Summary"
-              variant="primary"
-              size="lg"
-              className="w-full"
-            >
-              {isSummaryLoading ? (
-                <div className="flex items-center gap-2">
-                  <Spinner size="xs" />
-                  <span>Generating summary for this time range…</span>
+            {isSummaryLoading ? (
+              <div className="rounded-lg border border-border bg-card p-4 dark:border-border-night">
+                <div className="mb-2 flex items-center justify-between">
+                  <LoadingBlock className="h-5 w-24" />
                 </div>
-              ) : isSummaryError ? (
-                <div className="flex flex-col gap-2">
-                  <span>
-                    We couldn&apos;t generate a summary for this time range.
-                  </span>
-                  <div>
-                    <Button
-                      label="Try again"
-                      size="xs"
-                      variant="outline"
-                      onClick={() => {
-                        void refetchSummary();
-                      }}
-                    />
+                <div className="space-y-2">
+                  <LoadingBlock className="h-4 w-full" />
+                  <LoadingBlock className="h-4 w-11/12" />
+                  <LoadingBlock className="h-4 w-10/12" />
+                </div>
+              </div>
+            ) : (
+              <ContentMessage
+                title="Summary"
+                variant="primary"
+                size="lg"
+                className="w-full"
+              >
+                {isSummaryError ? (
+                  <div className="flex flex-col gap-2">
+                    <span>
+                      We couldn&apos;t generate a summary for this time range.
+                    </span>
+                    <div>
+                      <Button
+                        label="Try again"
+                        size="xs"
+                        variant="outline"
+                        onClick={() => {
+                          void refetchSummary();
+                        }}
+                      />
+                    </div>
                   </div>
-                </div>
-              ) : summaryText ? (
-                <p>{summaryText}</p>
-              ) : (
-                <p>
-                  There is not enough activity in this time range to generate a
-                  summary yet.
-                </p>
-              )}
-            </ContentMessage>
+                ) : summaryText ? (
+                  <p>{summaryText}</p>
+                ) : (
+                  <p>
+                    There is not enough activity in this time range to generate
+                    a summary yet.
+                  </p>
+                )}
+              </ContentMessage>
+            )}
           </div>
         )}
 

--- a/front/lib/api/assistant/observability/summary.ts
+++ b/front/lib/api/assistant/observability/summary.ts
@@ -1,6 +1,5 @@
 import type { estypes } from "@elastic/elasticsearch";
 
-import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { MessageMetricsPoint } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
@@ -29,8 +28,6 @@ const SUMMARY_METRICS = [
   "failedMessages",
   "errorRate",
 ] as const satisfies readonly (keyof MessageMetricsPoint)[];
-
-const SUMMARY_SPECIFICATIONS: AgentActionSpecification[] = [];
 
 function hasAnyActivity(
   overview: AgentOverview,
@@ -114,8 +111,8 @@ export async function generateAgentObservabilitySummary({
   };
 
   const prompt =
-    "You are an analytics assistant for Dust. " +
-    "You are given time-series metrics about how an AI agent is used over a given time range. " +
+    "You are an analytics assistant. " +
+    `You are given time-series metrics about how an AI agent called '${agentName}' is used over a given time range. ` +
     "Write a short natural language summary (2-4 sentences) describing the most important trends, " +
     "including notable spikes or drops, usage changes, latency, and error-rate patterns. " +
     "Focus on the big picture and unusual behavior rather than listing every number. " +
@@ -148,7 +145,7 @@ export async function generateAgentObservabilitySummary({
     {
       conversation,
       prompt,
-      specifications: SUMMARY_SPECIFICATIONS,
+      specifications: [],
     },
     {
       context: {

--- a/front/lib/api/assistant/observability/summary.ts
+++ b/front/lib/api/assistant/observability/summary.ts
@@ -113,7 +113,7 @@ export async function generateAgentObservabilitySummary({
   const prompt =
     "You are an analytics assistant. " +
     `You are given time-series metrics about how an AI agent called '${agentName}' is used over a given time range. ` +
-    "Write a short natural language summary (2-4 sentences) describing the most important trends, " +
+    "Write a short natural language summary (2-3 short sentences) describing the most important trends, " +
     "including notable spikes or drops, usage changes, latency, and error-rate patterns. " +
     "Focus on the big picture and unusual behavior rather than listing every number. " +
     "If the data is noisy or inconclusive, say so explicitly.";

--- a/front/lib/api/assistant/observability/summary.ts
+++ b/front/lib/api/assistant/observability/summary.ts
@@ -7,7 +7,7 @@ import type { AgentOverview } from "@app/lib/api/assistant/observability/overvie
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
-import { Err, GEMINI_2_5_FLASH_MODEL_ID, Ok } from "@app/types";
+import { Err, GPT_4_1_MINI_MODEL_ID, Ok } from "@app/types";
 
 export type AgentObservabilitySummaryInput = {
   auth: Authenticator;
@@ -136,8 +136,8 @@ export async function generateAgentObservabilitySummary({
   const res = await runMultiActionsAgent(
     auth,
     {
-      modelId: GEMINI_2_5_FLASH_MODEL_ID,
-      providerId: "google_ai_studio",
+      modelId: GPT_4_1_MINI_MODEL_ID,
+      providerId: "openai",
     },
     {
       conversation,

--- a/front/lib/api/assistant/observability/summary.ts
+++ b/front/lib/api/assistant/observability/summary.ts
@@ -1,0 +1,178 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
+import {
+  fetchMessageMetrics,
+  type MessageMetricsPoint,
+} from "@app/lib/api/assistant/observability/messages_metrics";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types";
+import { Err, GPT_4_1_MINI_MODEL_ID, Ok } from "@app/types";
+
+export type AgentObservabilitySummaryInput = {
+  auth: Authenticator;
+  baseQuery: estypes.QueryDslQueryContainer;
+  days: number;
+  agentName: string;
+};
+
+export type AgentObservabilitySummaryResult = {
+  summaryText: string;
+};
+
+const SUMMARY_METRICS = [
+  "conversations",
+  "activeUsers",
+  "costCents",
+  "avgLatencyMs",
+  "percentilesLatencyMs",
+  "failedMessages",
+  "errorRate",
+] as const satisfies readonly (keyof MessageMetricsPoint)[];
+
+function hasAnyActivity(
+  overview: Awaited<ReturnType<typeof fetchAgentOverview>>["value"],
+  points: Pick<
+    MessageMetricsPoint,
+    (typeof SUMMARY_METRICS)[number] | "timestamp"
+  >[]
+) {
+  if (
+    overview.activeUsers > 0 ||
+    overview.conversationCount > 0 ||
+    overview.messageCount > 0
+  ) {
+    return true;
+  }
+
+  return points.some(
+    (p) =>
+      (p.conversations ?? 0) > 0 ||
+      (p.activeUsers ?? 0) > 0 ||
+      (p.costCents ?? 0) > 0 ||
+      (p.failedMessages ?? 0) > 0
+  );
+}
+
+export async function generateAgentObservabilitySummary({
+  auth,
+  baseQuery,
+  days,
+  agentName,
+}: AgentObservabilitySummaryInput): Promise<
+  Result<AgentObservabilitySummaryResult, Error>
+> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const overviewResult = await fetchAgentOverview(baseQuery, days);
+  if (overviewResult.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to retrieve agent overview for summary: ${overviewResult.error.message}`
+      )
+    );
+  }
+
+  const usageMetricsResult = await fetchMessageMetrics(
+    baseQuery,
+    "day",
+    SUMMARY_METRICS
+  );
+
+  if (usageMetricsResult.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to retrieve usage metrics for summary: ${usageMetricsResult.error.message}`
+      )
+    );
+  }
+
+  const overview = overviewResult.value;
+  const points = usageMetricsResult.value;
+
+  if (!hasAnyActivity(overview, points)) {
+    return new Ok({
+      summaryText:
+        "There is not enough activity in this time range to generate a meaningful summary yet.",
+    });
+  }
+
+  const metricsPayload = {
+    days,
+    agentName,
+    overview,
+    usage: points.map((p) => ({
+      timestamp: p.timestamp,
+      conversations: p.conversations,
+      activeUsers: p.activeUsers,
+      costCents: p.costCents,
+      avgLatencyMs: p.avgLatencyMs,
+      p50LatencyMs: p.percentilesLatencyMs,
+      failedMessages: p.failedMessages,
+      errorRate: p.errorRate,
+    })),
+  };
+
+  const prompt =
+    "You are an analytics assistant for Dust. " +
+    "You are given time-series metrics about how an AI agent is used over a given time range. " +
+    "Write a short natural language summary (2-4 sentences) describing the most important trends, " +
+    "including notable spikes or drops, usage changes, latency, and error-rate patterns. " +
+    "Focus on the big picture and unusual behavior rather than listing every number. " +
+    "If the data is noisy or inconclusive, say so explicitly.";
+
+  const conversation = {
+    messages: [
+      {
+        role: "user" as const,
+        name: "",
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(metricsPayload),
+          },
+        ],
+      },
+    ],
+  };
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      functionCall: null,
+      modelId: GPT_4_1_MINI_MODEL_ID,
+      providerId: "openai",
+      temperature: 0.3,
+      useCache: false,
+    },
+    {
+      conversation,
+      prompt,
+    },
+    {
+      context: {
+        operationType: "agent_observability_summary",
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  const raw = res.value.generation?.trim() ?? "";
+  if (!raw) {
+    return new Err(
+      new Error("LLM did not return any text for observability summary.")
+    );
+  }
+
+  // Keep summary relatively short to avoid overflowing the UI.
+  const summaryText =
+    raw.length > 1_000 ? `${raw.slice(0, 1_000).trim()}…` : raw;
+
+  return new Ok({ summaryText });
+}
+

--- a/front/lib/api/assistant/observability/summary.ts
+++ b/front/lib/api/assistant/observability/summary.ts
@@ -7,7 +7,7 @@ import type { AgentOverview } from "@app/lib/api/assistant/observability/overvie
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
-import { Err, GPT_4_1_MINI_MODEL_ID, Ok } from "@app/types";
+import { Err, GEMINI_2_5_FLASH_MODEL_ID, Ok } from "@app/types";
 
 export type AgentObservabilitySummaryInput = {
   auth: Authenticator;
@@ -136,11 +136,8 @@ export async function generateAgentObservabilitySummary({
   const res = await runMultiActionsAgent(
     auth,
     {
-      functionCall: null,
-      modelId: GPT_4_1_MINI_MODEL_ID,
-      providerId: "openai",
-      temperature: 0.3,
-      useCache: false,
+      modelId: GEMINI_2_5_FLASH_MODEL_ID,
+      providerId: "google_ai_studio",
     },
     {
       conversation,

--- a/front/lib/api/assistant/observability/summary.ts
+++ b/front/lib/api/assistant/observability/summary.ts
@@ -1,5 +1,6 @@
 import type { estypes } from "@elastic/elasticsearch";
 
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
 import {
@@ -30,6 +31,8 @@ const SUMMARY_METRICS = [
   "failedMessages",
   "errorRate",
 ] as const satisfies readonly (keyof MessageMetricsPoint)[];
+
+const SUMMARY_SPECIFICATIONS: AgentActionSpecification[] = [];
 
 function hasAnyActivity(
   overview: Awaited<ReturnType<typeof fetchAgentOverview>>["value"],
@@ -149,6 +152,7 @@ export async function generateAgentObservabilitySummary({
     {
       conversation,
       prompt,
+      specifications: SUMMARY_SPECIFICATIONS,
     },
     {
       context: {
@@ -175,4 +179,3 @@ export async function generateAgentObservabilitySummary({
 
   return new Ok({ summaryText });
 }
-

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -1,5 +1,9 @@
 import type { TokenUsage, ToolCall } from "@app/lib/api/llm/types/events";
-import type { ModelConversationTypeMultiActions, ModelIdType, ReasoningEffort } from "@app/types";
+import type {
+  ModelConversationTypeMultiActions,
+  ModelIdType,
+  ReasoningEffort,
+} from "@app/types";
 
 /**
  * Context information for LLM operations to aid in debugging and discovery

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -1,9 +1,5 @@
 import type { TokenUsage, ToolCall } from "@app/lib/api/llm/types/events";
-import type {
-  ModelConversationTypeMultiActions,
-  ModelIdType,
-  ReasoningEffort,
-} from "@app/types";
+import type { ModelConversationTypeMultiActions, ModelIdType, ReasoningEffort } from "@app/types";
 
 /**
  * Context information for LLM operations to aid in debugging and discovery
@@ -24,7 +20,8 @@ export interface LLMTraceContext {
     | "trigger_cron_timezone_generator"
     | "trigger_webhook_filter_generator"
     | "voice_agent_finder"
-    | "workspace_tags_suggestion";
+    | "workspace_tags_suggestion"
+    | "agent_observability_summary";
 
   /** Context-specific identifier (e.g., agentConfigId, conversationId, etc.) */
   contextId?: string;

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -22,6 +22,7 @@ import type { GetErrorRateResponse } from "@app/pages/api/w/[wId]/assistant/agen
 import type { GetFeedbackDistributionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution";
 import type { GetLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency";
 import type { GetAgentOverviewResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview";
+import type { GetAgentSummaryResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary";
 import type { GetContextOriginResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source";
 import type { GetToolExecutionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution";
 import type { GetToolStepIndexResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index";
@@ -445,6 +446,34 @@ export function useAgentAnalytics({
     agentAnalytics: data ? data : null,
     isAgentAnalyticsLoading: !error && !data && !disabled,
     isAgentAnalyticsError: error,
+  };
+}
+
+export function useAgentObservabilitySummary({
+  workspaceId,
+  agentConfigurationId,
+  days = DEFAULT_PERIOD_DAYS,
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  disabled?: boolean;
+}) {
+  const summaryFetcher: Fetcher<GetAgentSummaryResponseBody> = fetcher;
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/summary?days=${days}`;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    disabled ? null : key,
+    summaryFetcher
+  );
+
+  return {
+    summaryText: data?.summaryText ?? null,
+    isSummaryLoading: !error && !data && !disabled,
+    isSummaryError: error,
+    isSummaryValidating: isValidating,
+    refetchSummary: mutate,
   };
 }
 

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -22,8 +22,8 @@ import type { GetErrorRateResponse } from "@app/pages/api/w/[wId]/assistant/agen
 import type { GetFeedbackDistributionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution";
 import type { GetLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency";
 import type { GetAgentOverviewResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview";
-import type { GetAgentSummaryResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary";
 import type { GetContextOriginResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source";
+import type { GetAgentSummaryResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary";
 import type { GetToolExecutionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution";
 import type { GetToolStepIndexResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index";
 import type { GetUsageMetricsResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
@@ -23,6 +23,8 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetAgentSummaryResponseBody>>,
   auth: Authenticator
 ) {
+  const owner = auth.getNonNullableWorkspace();
+
   if (typeof req.query.aId !== "string") {
     return apiError(req, res, {
       status_code: 400,
@@ -72,7 +74,6 @@ async function handler(
       }
 
       const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
-      const owner = auth.getNonNullableWorkspace();
 
       const baseQuery = buildAgentAnalyticsBaseQuery({
         workspaceId: owner.sId,
@@ -114,4 +115,3 @@ async function handler(
 }
 
 export default withSessionAuthenticationForWorkspace(handler);
-

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
@@ -1,0 +1,117 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { generateAgentObservabilitySummary } from "@app/lib/api/assistant/observability/summary";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type GetAgentSummaryResponseBody = {
+  summaryText: string;
+};
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional(),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetAgentSummaryResponseBody>>,
+  auth: Authenticator
+) {
+  if (typeof req.query.aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent configuration ID.",
+      },
+    });
+  }
+
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: req.query.aId,
+    variant: "light",
+  });
+
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  if (!assistant.canEdit && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only editors can get agent observability.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        agentId: assistant.sId,
+        days,
+      });
+
+      const summaryResult = await generateAgentObservabilitySummary({
+        auth,
+        baseQuery,
+        days,
+        agentName: assistant.name,
+      });
+
+      if (summaryResult.isErr()) {
+        const e = summaryResult.error;
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to generate observability summary: ${e.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        summaryText: summaryResult.value.summaryText,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);
+


### PR DESCRIPTION
## Description
This PR adds an LLM-powered summary feature to the agent observability insights tab. When viewing agent analytics in time-range mode, a natural language summary is now automatically generated from the metrics data (active users, conversations, latency, error rates, etc.). The summary uses GPT-4.1 Mini to analyze the time-series metrics and highlights important trends, usage patterns, and notable anomalies. The feature only generates summaries when there's sufficient activity in the selected time period.

## Risk

Low

## Tests

- [x] locally
- [ ] front-edge

## Deploy Plan
Deploy front