### PR TITLE
Make Salesforce query format LLM friendly

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/salesforce/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce/index.ts
@@ -6,6 +6,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   downloadSalesforceContent,
   extractTextFromSalesforceAttachment,
+  formatRecords,
   getAllSalesforceAttachments,
 } from "@app/lib/actions/mcp_internal_actions/servers/salesforce/salesforce_api_helper";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -57,9 +58,26 @@ function createServer(
 
         const result = await conn.query(query);
 
+        const formattedRecords = formatRecords(result.records);
+
+        const summaryParts = [
+          `Query returned ${result.totalSize ?? result.records.length} record(s).`,
+        ];
+
+        if (!result.done) {
+          summaryParts.push(
+            "More records are available. Refine the query or paginate to retrieve remaining records."
+          );
+        }
+
+        const summary = summaryParts.join(" ");
+
         return new Ok([
-          { type: "text" as const, text: "Operation completed successfully" },
-          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          { type: "text" as const, text: summary },
+          {
+            type: "text" as const,
+            text: formattedRecords,
+          },
         ]);
       }
     )

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce/salesforce_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce/salesforce_api_helper.ts
@@ -244,6 +244,60 @@ export async function extractTextFromSalesforceAttachment(
   return extractTextFromBuffer(downloadResult.value, mimeType);
 }
 
+function sanitizeRecord(
+  record: Record<string, unknown>
+): Record<string, unknown> {
+  return Object.entries(record).reduce<Record<string, unknown>>(
+    (acc, [key, value]) => {
+      if (key === "attributes") {
+        return acc;
+      }
+      acc[key] = value;
+      return acc;
+    },
+    {}
+  );
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0 ? "[]" : JSON.stringify(value);
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+export function formatRecords(records: Record<string, unknown>[]): string {
+  if (records.length === 0) {
+    return "No records returned.";
+  }
+
+  return records
+    .map((record, index) => {
+      const sanitizedRecord = sanitizeRecord(record);
+      const fieldLines = Object.entries(sanitizedRecord).map(
+        ([key, value]) => `  - ${key}: ${formatValue(value)}`
+      );
+      return `Record ${index + 1}:\n${fieldLines.join("\n")}`;
+    })
+    .join("\n\n");
+}
+
 function getMimeType(fileType: string): string {
   const type = fileType?.toUpperCase();
 


### PR DESCRIPTION
## Description

* Improve bad performance for agents handling Salesforce query responses by formatting the records to text from JSON

## Tests
```
Record 1:
Id: 005Qy000009jOk9IAE
Name: Alban Dumouilla
Username: [accounts@dust.tt](mailto:accounts@dust.tt)
Email: [accounts@dust.tt](mailto:accounts@dust.tt)
IsActive: true
ProfileId: 00eQy000008uz8OIAQ
Record 2:
Id: 005Qy00000EdQVdIAN
Name: Bob Tracker
Username: [dev@dust.tt](mailto:dev@dust.tt)
Email: [dev@dust.tt](mailto:dev@dust.tt)
IsActive: true
ProfileId: 00eQy000008uz8XIAQ
Record 3:
Id: 005Qy000009jISmIAM
Name: Platform Integration User
Username: cloud@00dqy00000fujhmmap
Email: noreply@00dqy00000fujhmmap
IsActive: true
ProfileId: 00eQy000008uz8MIAQ
Record 4:
Id: 005Qy000009jISnIAM
Name: Data.com Clean
Username: automatedclean@00dqy00000fujhmmap
Email: noreply@00dqy00000fujhmmap
IsActive: true
ProfileId: 00eQy000008uz8NIAQ
Record 5:
Id: 005Qy000009jISjIAM
Name: Integration User
Username: [integration@00dqy00000fujhmmap.com](mailto:integration@00dqy00000fujhmmap.com)
Email: [noreply@example.com](mailto:noreply@example.com)
IsActive: true
ProfileId: 00eQy000008uz8QIAQ
```

## Risk

* Low

## Deploy Plan

* Deploy front