### PR TITLE
feat(oauth): create script to migrate existing slack connections to use credentials in OAuth DB

### DIFF
--- a/connectors/migrations/20251120_migrate_slack_connection_credentials.ts
+++ b/connectors/migrations/20251120_migrate_slack_connection_credentials.ts
@@ -1,0 +1,237 @@
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+import { makeScript } from "scripts/helpers";
+
+import { connectorsConfig } from "@connectors/connectors/shared/config";
+import { apiConfig } from "@connectors/lib/api/config";
+import { SlackConfigurationModel } from "@connectors/lib/models/slack";
+import { WebhookRouterConfigService } from "@connectors/lib/webhook_router_config";
+import type { Logger } from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import type { ModelId, OAuthAPIError } from "@connectors/types";
+import { OAuthAPI } from "@connectors/types";
+
+const PROVIDER = "slack";
+
+async function migrateSlackConnectionCredential(
+  api: OAuthAPI,
+  connector: ConnectorResource,
+  slackClientId: string,
+  slackClientSecret: string,
+  slackSigningSecret: string,
+  logger: Logger,
+  execute: boolean
+): Promise<Result<void, OAuthAPIError>> {
+  logger.info(
+    `Migrating connection credential for connector ${connector.id}, connectionId ${connector.connectionId}.`
+  );
+
+  if (!execute) {
+    logger.info(
+      `[DRY RUN] Would create credential and update connection ${connector.connectionId}.`
+    );
+    return new Ok(undefined);
+  }
+
+  // Get connection metadata to extract user_id
+  const metadataRes = await api.getConnectionMetadata({
+    connectionId: connector.connectionId,
+  });
+
+  if (metadataRes.isErr()) {
+    logger.error(
+      { error: metadataRes.error },
+      "Failed to fetch connection metadata."
+    );
+    return metadataRes;
+  }
+
+  const userId = metadataRes.value.connection.metadata.user_id;
+  const teamId = metadataRes.value.connection.metadata.team_id;
+
+  if (typeof userId !== "string" || userId.length === 0) {
+    return new Err({
+      code: "missing_user_id",
+      message: `Connection ${connector.connectionId} has no user_id in metadata.`,
+    });
+  }
+
+  if (typeof teamId !== "string" || teamId.length === 0) {
+    return new Err({
+      code: "missing_team_id",
+      message: `Connection ${connector.connectionId} has no team_id in metadata.`,
+    });
+  }
+
+  logger.info(
+    { userId, teamId },
+    "Using user_id and team_id from connection metadata."
+  );
+
+  // Create a credential record for this connection
+  const credRes = await api.postCredentials({
+    provider: PROVIDER,
+    userId,
+    workspaceId: connector.workspaceId,
+    credentials: {
+      client_id: slackClientId,
+      client_secret: slackClientSecret,
+    },
+  });
+
+  if (credRes.isErr()) {
+    return credRes;
+  }
+
+  const credentialId = credRes.value.credential.credential_id;
+  logger.info(
+    { credentialId },
+    `Created credential for connector ${connector.id}.`
+  );
+
+  // Update the connection to reference this credential and set client_id in metadata
+  const updateRes = await api.updateConnectionCredential({
+    connectionId: connector.connectionId,
+    relatedCredentialId: credentialId,
+    metadata: { client_id: slackClientId },
+  });
+
+  if (updateRes.isErr()) {
+    return updateRes;
+  }
+
+  logger.info(
+    { credentialId },
+    `Successfully updated connection ${connector.connectionId} to use credential and set client_id in metadata.`
+  );
+
+  // Store credential reference in SlackConfiguration
+  const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
+    connector.id
+  );
+
+  if (!slackConfig) {
+    return new Err({
+      code: "missing_slack_config",
+      message: `No Slack configuration found for connector ${connector.id}`,
+    });
+  }
+
+  await SlackConfigurationModel.update(
+    { privateIntegrationCredentialId: credentialId },
+    { where: { id: slackConfig.id } }
+  );
+
+  logger.info(
+    { credentialId },
+    `Updated SlackConfiguration for connector ${connector.id} with credential reference.`
+  );
+
+  // Configure webhook router
+  const webhookService = new WebhookRouterConfigService();
+  const currentRegion = connectorsConfig.getCurrentRegion();
+
+  // Get all connectors for this team to build the connector IDs list
+  const allTeamConfigs = await SlackConfigurationResource.listForTeamId(teamId);
+  const connectorIds = allTeamConfigs.map((config) => config.connectorId);
+
+  await webhookService.syncEntry(
+    PROVIDER,
+    teamId,
+    slackSigningSecret,
+    currentRegion,
+    connectorIds
+  );
+
+  logger.info(
+    { teamId, region: currentRegion, connectorIds },
+    `Updated webhook router configuration for team ${teamId} with ${connectorIds.length} connector(s).`
+  );
+
+  return new Ok(undefined);
+}
+
+async function migrateAllSlackConnections(
+  connectorId: ModelId | undefined,
+  logger: Logger,
+  execute: boolean
+) {
+  const api = new OAuthAPI(apiConfig.getOAuthAPIConfig(), logger);
+
+  // Get credentials from environment variables
+  const slackClientId = process.env.SLACK_CLIENT_ID;
+  const slackClientSecret = process.env.SLACK_CLIENT_SECRET;
+  const slackSigningSecret = process.env.SLACK_SIGNING_SECRET;
+
+  // Validate credentials upfront
+  if (!slackClientId || !slackClientSecret || !slackSigningSecret) {
+    logger.error(
+      "Missing Slack credentials. Please set SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, and SLACK_SIGNING_SECRET environment variables."
+    );
+    return;
+  }
+
+  // Fetch all Slack connectors
+  const connectors = connectorId
+    ? await ConnectorResource.fetchByIds(PROVIDER, [connectorId])
+    : await ConnectorResource.listByType(PROVIDER, {});
+
+  logger.info(`Found ${connectors.length} Slack connectors to migrate.`);
+
+  // Migrate each connector (creates one credential per connection)
+  let successCount = 0;
+  let errorCount = 0;
+
+  for (const connector of connectors) {
+    const localLogger = logger.child({
+      connectorId: connector.id,
+      workspaceId: connector.workspaceId,
+      connectionId: connector.connectionId,
+    });
+
+    const migrationRes = await migrateSlackConnectionCredential(
+      api,
+      connector,
+      slackClientId,
+      slackClientSecret,
+      slackSigningSecret,
+      localLogger,
+      execute
+    );
+
+    if (migrationRes.isErr()) {
+      errorCount++;
+      localLogger.error(
+        {
+          error: migrationRes.error,
+        },
+        "Failed to migrate connector."
+      );
+    } else {
+      successCount++;
+    }
+  }
+
+  logger.info(
+    {
+      total: connectors.length,
+      success: successCount,
+      errors: errorCount,
+    },
+    "Done migrating Slack connectors."
+  );
+}
+
+makeScript(
+  {
+    connectorId: {
+      alias: "c",
+      describe: "Connector ID (optional, for testing single connector)",
+      type: "number",
+    },
+  },
+  async ({ connectorId, execute }, logger) => {
+    await migrateAllSlackConnections(connectorId, logger, execute);
+  }
+);

--- a/connectors/migrations/20251120_migrate_slack_connection_credentials.ts
+++ b/connectors/migrations/20251120_migrate_slack_connection_credentials.ts
@@ -133,8 +133,11 @@ async function migrateSlackConnectionCredential(
   const currentRegion = connectorsConfig.getCurrentRegion();
 
   // Get all connectors for this team to build the connector IDs list
-  const allTeamConfigs = await SlackConfigurationResource.listForTeamId(teamId);
-  const connectorIds = allTeamConfigs.map((config) => config.connectorId);
+  const allTeamSlackConfigs = await SlackConfigurationResource.listForTeamId(
+    teamId,
+    PROVIDER
+  );
+  const connectorIds = allTeamSlackConfigs.map((config) => config.connectorId);
 
   await webhookService.syncEntry(
     PROVIDER,

--- a/connectors/src/types/oauth/lib.ts
+++ b/connectors/src/types/oauth/lib.ts
@@ -88,6 +88,7 @@ export const CREDENTIALS_PROVIDERS = [
   "snowflake",
   "bigquery",
   "salesforce",
+  "slack",
   "notion",
   // Labs
   "modjo",
@@ -201,6 +202,12 @@ export type SalesforceCredentials = t.TypeOf<
   typeof SalesforceCredentialsSchema
 >;
 
+export const SlackCredentialsSchema = t.type({
+  client_id: t.string,
+  client_secret: t.string,
+});
+export type SlackCredentials = t.TypeOf<typeof SlackCredentialsSchema>;
+
 export const NotionCredentialsSchema = t.type({
   integration_token: t.string,
 });
@@ -211,6 +218,7 @@ export type ConnectionCredentials =
   | ModjoCredentials
   | BigQueryCredentialsWithLocation
   | SalesforceCredentials
+  | SlackCredentials
   | NotionCredentials;
 
 export function isSnowflakeCredentials(

--- a/connectors/src/types/oauth/oauth_api.ts
+++ b/connectors/src/types/oauth/oauth_api.ts
@@ -202,6 +202,44 @@ export class OAuthAPI {
     return this._resultFromResponse(response);
   }
 
+  async getConnectionMetadata({
+    connectionId,
+  }: {
+    connectionId: string;
+  }): Promise<OAuthAPIResponse<{ connection: OAuthConnectionType }>> {
+    const response = await this._fetchWithError(
+      `${this._url}/connections/${connectionId}/metadata`
+    );
+    return this._resultFromResponse(response);
+  }
+
+  async updateConnectionCredential({
+    connectionId,
+    relatedCredentialId,
+    metadata,
+  }: {
+    connectionId: string;
+    relatedCredentialId: string;
+    metadata: Record<string, unknown>;
+  }): Promise<
+    OAuthAPIResponse<{ connection: Pick<OAuthConnectionType, "connection_id"> }>
+  > {
+    const response = await this._fetchWithError(
+      `${this._url}/connections/${connectionId}/credential`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          related_credential_id: relatedCredentialId,
+          metadata,
+        }),
+      }
+    );
+    return this._resultFromResponse(response);
+  }
+
   private async _fetchWithError(
     url: string,
     init?: RequestInit


### PR DESCRIPTION
## Description

Creates a migration script to backfill credentials for all existing Slack connections (~300 connections) in the OAuth database.

This script performs a complete migration for each Slack connection:
- Creates a credential record containing `client_id` and `client_secret`
- Links the credential by updating the connection's `related_credential_id` field
- Sets `client_id` in the connection metadata (extends PATCH endpoint to accept metadata)
- Persists the credential reference in `SlackConfiguration.privateIntegrationCredentialId`
- Configures the webhook router with `team_id`, `signing_secret`, and current region

**Core changes:**
- Extended PATCH `/connections/:id/credential` endpoint to accept and merge metadata

Addresses task [#5181](https://github.com/dust-tt/tasks/issues/5181)

## Risk

Medium - affects slack oauth connection of clients

## Tests

Tested locally with environment variables:

- **Dry run:**
```bash
npx tsx migrations/20251120_migrate_slack_connection_credentials.ts

{"msg":"Found 4 Slack connectors to migrate."}
{"msg":"[DRY RUN] Would create credential and update connection con_CvSgrmZotf-..."}
{"msg":"[DRY RUN] Would create credential and update connection con_Td1RnNxQaM-..."}
{"msg":"[DRY RUN] Would create credential and update connection con_p5kel3gnfV-..."}
{"msg":"[DRY RUN] Would create credential and update connection con_W10jrC6izk-..."}
{"msg":"Done migrating Slack connectors.","total":4,"success":4,"errors":0}
```

- **Single connector:**
```bash
npx tsx migrations/20251120_migrate_slack_connection_credentials.ts --connectorId 6 --execute

{"msg":"Found 1 Slack connectors to migrate."}
{"msg":"Migrating connection credential for connector 6, connectionId con_CvSgrmZotf-..."}
{"msg":"Using user_id and team_id from connection metadata.","userId":"1X6jaTQiEf","teamId":"T05GT3SDN7P"}
{"msg":"Created credential for connector 6.","credentialId":"cred_mlxO3bHds9-..."}
{"msg":"Successfully updated connection con_CvSgrmZotf-... to use credential and set client_id in metadata.","credentialId":"cred_mlxO3bHds9-..."}
{"msg":"Updated SlackConfiguration for connector 6 with credential reference.","credentialId":"cred_mlxO3bHds9-..."}
{"msg":"Successfully sync webhook router entry","provider":"slack","providerWorkspaceId":"T05GT3SDN7P"}
{"msg":"Updated webhook router configuration for team T05GT3SDN7P with 4 connector(s).","teamId":"T05GT3SDN7P","region":"us-central1","connectorIds":[7,9,8,6]}
{"msg":"Done migrating Slack connectors.","total":1,"success":1,"errors":0}
```

- **All connectors:**
```bash
npx tsx migrations/20251120_migrate_slack_connection_credentials.ts --execute

{"msg":"Found 4 Slack connectors to migrate."}

# Connector 6
{"msg":"Using user_id and team_id from connection metadata.","userId":"1X6jaTQiEf","teamId":"T05GT3SDN7P"}
{"msg":"Created credential for connector 6.","credentialId":"cred_SmIOsHq43B-..."}
{"msg":"Successfully updated connection con_CvSgrmZotf-... to use credential and set client_id in metadata."}
{"msg":"Updated SlackConfiguration for connector 6 with credential reference."}
{"msg":"Updated webhook router configuration for team T05GT3SDN7P with 4 connector(s).","connectorIds":[7,9,8,6]}

# Connector 9
{"msg":"Using user_id and team_id from connection metadata.","userId":"1X6jaTQiEf","teamId":"T05GT3SDN7P"}
{"msg":"Created credential for connector 9.","credentialId":"cred_eH6wlj03ED-..."}
{"msg":"Successfully updated connection con_Td1RnNxQaM-... to use credential and set client_id in metadata."}
{"msg":"Updated SlackConfiguration for connector 9 with credential reference."}
{"msg":"Updated webhook router configuration for team T05GT3SDN7P with 4 connector(s).","connectorIds":[7,8,6,9]}

# Connector 8
{"msg":"Using user_id and team_id from connection metadata.","userId":"1X6jaTQiEf","teamId":"T05GT3SDN7P"}
{"msg":"Created credential for connector 8.","credentialId":"cred_eH6wlZ03ED-..."}
{"msg":"Successfully updated connection con_p5kel3gnfV-... to use credential and set client_id in metadata."}
{"msg":"Updated SlackConfiguration for connector 8 with credential reference."}
{"msg":"Updated webhook router configuration for team T05GT3SDN7P with 4 connector(s).","connectorIds":[7,6,9,8]}

# Connector 7
{"msg":"Using user_id and team_id from connection metadata.","userId":"1X6jaTQiEf","teamId":"T05GT3SDN7P"}
{"msg":"Created credential for connector 7.","credentialId":"cred_HbVDtljoX0-..."}
{"msg":"Successfully updated connection con_W10jrC6izk-... to use credential and set client_id in metadata."}
{"msg":"Updated SlackConfiguration for connector 7 with credential reference."}
{"msg":"Updated webhook router configuration for team T05GT3SDN7P with 4 connector(s).","connectorIds":[6,9,8,7]}

{"msg":"Done migrating Slack connectors.","total":4,"success":4,"errors":0}
```


## Deploy Plan

1. Deploy core (Rust) changes to extend the PATCH endpoint
2. Deploy connectors code with new migration script and OAuthAPI methods
3. Run migration with single connector ID first (Dust workspace):
   ```bash
   SLACK_CLIENT_ID=xxx SLACK_CLIENT_SECRET=yyy SLACK_SIGNING_SECRET=zzz \
   npx tsx migrations/20251120_migrate_slack_connection_credentials.ts --connectorId <dust_workspace_connector_id> --execute
   ```
4. Verify the test connector works correctly
5. Run migration for all Slack connections in both regions US & EU:
   ```bash
   SLACK_CLIENT_ID=xxx SLACK_CLIENT_SECRET=yyy SLACK_SIGNING_SECRET=zzz \
   npx tsx migrations/20251120_migrate_slack_connection_credentials.ts --execute
   ```
