### PR TITLE
[front] Add group by api key

### DIFF
--- a/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
+++ b/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
@@ -8,7 +8,7 @@ import { ChartTooltipCard } from "@app/components/agent_builder/observability/sh
 import { normalizeVersionLabel } from "@app/components/agent_builder/observability/shared/tooltipHelpers";
 import type { ToolChartModeType } from "@app/components/agent_builder/observability/types";
 import { isToolChartUsagePayload } from "@app/components/agent_builder/observability/types";
-import { getToolColor } from "@app/components/agent_builder/observability/utils";
+import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
 
 export interface ToolUsageTooltipProps
   extends TooltipContentProps<number, string> {
@@ -39,7 +39,7 @@ export function ChartsTooltip({
         label: toolName,
         value: count,
         percent,
-        colorClassName: getToolColor(toolName, topTools, "text"),
+        colorClassName: getIndexedColor(toolName, topTools),
       };
     });
 

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -43,7 +43,7 @@ export function SourceChart({
   const legendItems = data.map((d) => ({
     key: d.label,
     label: d.label,
-    colorClassName: getSourceColor(d.origin, "text"),
+    colorClassName: getSourceColor(d.origin),
   }));
 
   return (
@@ -72,7 +72,7 @@ export function SourceChart({
               label: d.label,
               value: d.count,
               percent: d.percent,
-              colorClassName: getSourceColor(d.origin, "text"),
+              colorClassName: getSourceColor(d.origin),
             }));
             return <ChartTooltipCard title="Source breakdown" rows={rows} />;
           }}
@@ -96,7 +96,7 @@ export function SourceChart({
           {data.map((entry) => (
             <Cell
               key={entry.origin}
-              className={getSourceColor(entry.origin, "text")}
+              className={getSourceColor(entry.origin)}
               fill="currentColor"
             />
           ))}

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -21,7 +21,7 @@ import type {
   ChartDatum,
   ToolChartModeType,
 } from "@app/components/agent_builder/observability/types";
-import { getToolColor } from "@app/components/agent_builder/observability/utils";
+import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
 
 export function ToolUsageChart({
   workspaceId,
@@ -54,7 +54,7 @@ export function ToolUsageChart({
       topTools.map((t) => ({
         key: t,
         label: t,
-        colorClassName: getToolColor(t, topTools, "text"),
+        colorClassName: getIndexedColor(t, topTools),
       })),
     [topTools]
   );
@@ -150,7 +150,7 @@ export function ToolUsageChart({
             dataKey={(row: ChartDatum) => row.values[toolName]?.percent ?? 0}
             stackId="a"
             fill="currentColor"
-            className={getToolColor(toolName, topTools, "text")}
+            className={getIndexedColor(toolName, topTools)}
             name={toolName}
             shape={
               <RoundedTopBarShape toolName={toolName} stackOrder={topTools} />

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -47,10 +47,15 @@ export const INDEXED_COLORS = [
 
 export const MAX_TOOLS_DISPLAYED = 5;
 
-export const OTHER_LABEL = "Others";
-export const OTHER_COLOR = "text-blue-300 dark:text-blue-300-night";
-export const UNKNOWN_LABEL = "Unknown";
-export const UNKNOWN_COLOR = "text-gray-400 dark:text-gray-400-night";
+export const OTHER_LABEL = {
+  label: "Others",
+  color: "text-blue-300 dark:text-blue-300-night",
+};
+
+export const UNKNOWN_LABEL = {
+  label: "Unknown",
+  color: "text-gray-400 dark:text-gray-400-night",
+};
 
 export const FEEDBACK_DISTRIBUTION_PALETTE = {
   positive: "text-green-400 dark:text-green-400-night",

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -31,24 +31,26 @@ export const LATENCY_LEGEND = [
 export const COST_PALETTE = {
   costCents: "text-blue-400 dark:text-blue-400-night",
   totalCredits: "text-green-500 dark:text-green-500-night",
-  unknown: "text-gray-400 dark:text-gray-400-night",
 } as const;
 
 export const COST_LEGEND = [{ key: "costCents", label: "Cost" }] as const;
 
 export const CHART_HEIGHT = 260;
 
-export const TOOL_COLORS = [
-  "orange-300 dark:orange-300-night",
-  "golden-200 dark:golden-200-night",
-  "green-200 dark:green-200-night",
-  "violet-300 dark:violet-300-night",
-  "rose-300 dark:rose-300-night",
+export const INDEXED_COLORS = [
+  "text-orange-300 dark:text-orange-300-night",
+  "text-golden-200 dark:text-golden-200-night",
+  "text-green-200 dark:text-green-200-night",
+  "text-violet-300 dark:text-violet-300-night",
+  "text-rose-300 dark:text-rose-300-night",
 ] as const;
 
 export const MAX_TOOLS_DISPLAYED = 5;
 
-export const OTHER_TOOLS_LABEL = "Others";
+export const OTHER_LABEL = "Others";
+export const OTHER_COLOR = "text-blue-300 dark:text-blue-300-night";
+export const UNKNOWN_LABEL = "Unknown";
+export const UNKNOWN_COLOR = "text-gray-400 dark:text-gray-400-night";
 
 export const FEEDBACK_DISTRIBUTION_PALETTE = {
   positive: "text-green-400 dark:text-green-400-night",
@@ -66,28 +68,34 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
 > = {
   "github-copilot-chat": {
     label: "GitHub Copilot Chat",
-    color: "blue-500 dark:blue-500-night",
+    color: "text-blue-500 dark:text-blue-500-night",
   },
   agent_handover: {
     label: "Agent handover",
-    color: "gray-300 dark:gray-300-night",
+    color: "text-gray-300 dark:text-gray-300-night",
   },
-  api: { label: "API", color: "blue-300 dark:blue-300-night" },
-  email: { label: "Email", color: "violet-300 dark:violet-300-night" },
-  excel: { label: "Excel", color: "rose-300 dark:rose-300-night" },
+  api: { label: "API", color: "text-blue-300 dark:text-blue-300-night" },
+  email: {
+    label: "Email",
+    color: "text-violet-300 dark:text-violet-300-night",
+  },
+  excel: { label: "Excel", color: "text-rose-300 dark:text-rose-300-night" },
   extension: {
     label: "Chrome extension",
-    color: "golden-300 dark:golden-300-night",
+    color: "text-golden-300 dark:text-golden-300-night",
   },
   gsheet: {
     label: "Google Sheets",
-    color: "green-300 dark:green-300-night",
+    color: "text-green-300 dark:text-green-300-night",
   },
-  make: { label: "Make", color: "gray-600 dark:gray-600-night" },
-  n8n: { label: "n8n", color: "success-muted dark:success-muted-night" },
+  make: { label: "Make", color: "text-gray-600 dark:text-gray-600-night" },
+  n8n: {
+    label: "n8n",
+    color: "text-success-muted dark:text-success-muted-night",
+  },
   powerpoint: {
     label: "PowerPoint",
-    color: "violet-500 dark:violet-500-night",
+    color: "text-violet-500 dark:text-violet-500-night",
   },
   raycast: {
     label: "Raycast",
@@ -95,29 +103,32 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
   },
   run_agent: {
     label: "Sub-agent",
-    color: "golden-500 dark:golden-500-night",
+    color: "text-golden-500 dark:text-golden-500-night",
   },
-  slack: { label: "Slack", color: "green-500 dark:green-500-night" },
+  slack: { label: "Slack", color: "text-green-500 dark:text-green-500-night" },
   teams: {
     label: "Teams",
-    color: "highlight-muted dark:highlight-muted-night",
+    color: "text-highlight-muted dark:text-highlight-muted-night",
   },
   transcript: {
     label: "Transcript",
-    color: "warning-muted dark:warning-muted-night",
+    color: "text-warning-muted dark:text-warning-muted-night",
   },
   triggered_programmatic: {
     label: "Trigger",
-    color: "info-muted dark:info-muted-night",
+    color: "text-info-muted dark:text-info-muted-night",
   },
   triggered: {
     label: "Trigger",
-    color: "info-muted dark:info-muted-night",
+    color: "text-info-muted dark:text-info-muted-night",
   },
-  web: { label: "Conversation", color: "blue-500 dark:blue-500-night" },
-  zapier: { label: "Zapier", color: "blue-800 dark:blue-800-night" },
+  web: {
+    label: "Conversation",
+    color: "text-blue-500 dark:text-blue-500-night",
+  },
+  zapier: { label: "Zapier", color: "text-blue-800 dark:text-blue-800-night" },
   zendesk: {
     label: "Zendesk",
-    color: "blue-800 dark:blue-800-night",
+    color: "text-blue-800 dark:text-blue-800-night",
   },
 };

--- a/front/components/agent_builder/observability/hooks.ts
+++ b/front/components/agent_builder/observability/hooks.ts
@@ -92,7 +92,7 @@ function createChartData(
     const values: Record<string, ToolChartUsageDatum> = {};
     let topToolsCount = 0;
     for (const toolName of displayTools) {
-      if (toolName === OTHER_LABEL) {
+      if (toolName === OTHER_LABEL.label) {
         continue;
       }
 
@@ -111,7 +111,7 @@ function createChartData(
       const othersCount = total - topToolsCount;
 
       if (othersCount > 0) {
-        values[OTHER_LABEL] = {
+        values[OTHER_LABEL.label] = {
           percent: calculatePercentage(othersCount, total),
           count: othersCount,
         };
@@ -177,7 +177,7 @@ function processToolUsageData(
   const selectedTools = selectTopTools(counts, MAX_TOOLS_DISPLAYED);
   const includeOthers = counts.size > MAX_TOOLS_DISPLAYED;
   const topTools = includeOthers
-    ? [...selectedTools, OTHER_LABEL]
+    ? [...selectedTools, OTHER_LABEL.label]
     : selectedTools;
   const chartData = createChartData(data, topTools, includeOthers);
 

--- a/front/components/agent_builder/observability/hooks.ts
+++ b/front/components/agent_builder/observability/hooks.ts
@@ -1,6 +1,6 @@
 import {
   MAX_TOOLS_DISPLAYED,
-  OTHER_TOOLS_LABEL,
+  OTHER_LABEL,
 } from "@app/components/agent_builder/observability/constants";
 import type { ObservabilityMode } from "@app/components/agent_builder/observability/ObservabilityContext";
 import type {
@@ -92,7 +92,7 @@ function createChartData(
     const values: Record<string, ToolChartUsageDatum> = {};
     let topToolsCount = 0;
     for (const toolName of displayTools) {
-      if (toolName === OTHER_TOOLS_LABEL) {
+      if (toolName === OTHER_LABEL) {
         continue;
       }
 
@@ -111,7 +111,7 @@ function createChartData(
       const othersCount = total - topToolsCount;
 
       if (othersCount > 0) {
-        values[OTHER_TOOLS_LABEL] = {
+        values[OTHER_LABEL] = {
           percent: calculatePercentage(othersCount, total),
           count: othersCount,
         };
@@ -177,7 +177,7 @@ function processToolUsageData(
   const selectedTools = selectTopTools(counts, MAX_TOOLS_DISPLAYED);
   const includeOthers = counts.size > MAX_TOOLS_DISPLAYED;
   const topTools = includeOthers
-    ? [...selectedTools, OTHER_TOOLS_LABEL]
+    ? [...selectedTools, OTHER_LABEL]
     : selectedTools;
   const chartData = createChartData(data, topTools, includeOthers);
 

--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -1,8 +1,6 @@
 import {
   INDEXED_COLORS,
-  OTHER_COLOR,
   OTHER_LABEL,
-  UNKNOWN_COLOR,
   UNKNOWN_LABEL,
   USER_MESSAGE_ORIGIN_LABELS,
 } from "@app/components/agent_builder/observability/constants";
@@ -35,10 +33,10 @@ export function getSourceColor(source: UserMessageOrigin) {
  * "Other" and "Unknown" are special cases that have their own colors.
  */
 export function getIndexedColor(label: string, allLabels: string[]): string {
-  if (label === OTHER_LABEL) {
-    return OTHER_COLOR;
-  } else if (label === UNKNOWN_LABEL) {
-    return UNKNOWN_COLOR;
+  if (label === OTHER_LABEL.label) {
+    return OTHER_LABEL.color;
+  } else if (label === UNKNOWN_LABEL.label) {
+    return UNKNOWN_LABEL.color;
   }
 
   const idx = allLabels.indexOf(label);

--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -1,6 +1,9 @@
 import {
-  OTHER_TOOLS_LABEL,
-  TOOL_COLORS,
+  INDEXED_COLORS,
+  OTHER_COLOR,
+  OTHER_LABEL,
+  UNKNOWN_COLOR,
+  UNKNOWN_LABEL,
   USER_MESSAGE_ORIGIN_LABELS,
 } from "@app/components/agent_builder/observability/constants";
 import type { ObservabilityMode } from "@app/components/agent_builder/observability/ObservabilityContext";
@@ -15,37 +18,31 @@ export type ValuesPayload = { values: Record<string, number> };
 
 export type SourceBucket = { origin: string; count: number };
 
-function addPrefixToColor(color: string, prefix: "text" | "bg"): string {
-  return `${prefix}-${color.replace("dark:", `dark:${prefix}-`)}`;
-}
-
 export function isUserMessageOrigin(
   origin?: string | null
 ): origin is UserMessageOrigin {
   return !!origin && origin in USER_MESSAGE_ORIGIN_LABELS;
 }
 
-export function getSourceColor(
-  source: UserMessageOrigin,
-  prefix: "text" | "bg"
-) {
-  return addPrefixToColor(USER_MESSAGE_ORIGIN_LABELS[source].color, prefix);
+export function getSourceColor(source: UserMessageOrigin) {
+  return USER_MESSAGE_ORIGIN_LABELS[source].color;
 }
 
-export function getToolColor(
-  toolName: string,
-  topTools: string[],
-  prefix: "text" | "bg"
-): string {
-  if (toolName === OTHER_TOOLS_LABEL) {
-    return addPrefixToColor("blue-300", prefix);
+/**
+ * Returns a unique color from TOOL_COLORS based on the label's index in allLabels,
+ * cycling through the array in a rolling ribbon fashion to ensure distinct but repeating colors.
+ * Useful for consistently coloring a set of values.
+ * "Other" and "Unknown" are special cases that have their own colors.
+ */
+export function getIndexedColor(label: string, allLabels: string[]): string {
+  if (label === OTHER_LABEL) {
+    return OTHER_COLOR;
+  } else if (label === UNKNOWN_LABEL) {
+    return UNKNOWN_COLOR;
   }
 
-  const idx = topTools.indexOf(toolName);
-  return addPrefixToColor(
-    TOOL_COLORS[(idx >= 0 ? idx : 0) % TOOL_COLORS.length],
-    prefix
-  );
+  const idx = allLabels.indexOf(label);
+  return INDEXED_COLORS[(idx >= 0 ? idx : 0) % INDEXED_COLORS.length];
 }
 
 export function buildSourceChartData(

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -30,13 +30,12 @@ import {
   getSourceColor,
   isUserMessageOrigin,
 } from "@app/components/agent_builder/observability/utils";
+import type { GroupByType } from "@app/lib/swr/workspaces";
 import { useWorkspaceProgrammaticCost } from "@app/lib/swr/workspaces";
 
 interface ProgrammaticCostChartProps {
   workspaceId: string;
 }
-
-type GroupByOptionValue = "global" | "agent" | "origin" | "apiKey";
 
 type ChartDataPoint = {
   date: string;
@@ -47,7 +46,7 @@ type ChartDataPoint = {
 };
 
 const GROUP_BY_OPTIONS: {
-  value: GroupByOptionValue;
+  value: "global" | GroupByType;
   label: string;
 }[] = [
   { value: "global", label: "Global" },
@@ -57,7 +56,7 @@ const GROUP_BY_OPTIONS: {
 ];
 
 function getColorClassName(
-  groupBy: "agent" | "origin" | "apiKey" | undefined,
+  groupBy: GroupByType | undefined,
   groupName: string,
   groups: string[]
 ): string {
@@ -73,7 +72,7 @@ function getColorClassName(
 // Custom tooltip for grouped view
 function GroupedTooltip(
   props: TooltipContentProps<number, string>,
-  groupBy: "agent" | "origin" | "apiKey" | undefined,
+  groupBy: GroupByType | undefined,
   groups: string[]
 ): JSX.Element | null {
   const { active, payload } = props;
@@ -122,9 +121,7 @@ function GroupedTooltip(
 export function ProgrammaticCostChart({
   workspaceId,
 }: ProgrammaticCostChartProps) {
-  const [groupBy, setGroupBy] = useState<
-    "agent" | "origin" | "apiKey" | undefined
-  >(undefined);
+  const [groupBy, setGroupBy] = useState<GroupByType | undefined>(undefined);
 
   const {
     programmaticCostData,

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -26,8 +26,8 @@ import {
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import {
+  getIndexedColor,
   getSourceColor,
-  getToolColor,
   isUserMessageOrigin,
 } from "@app/components/agent_builder/observability/utils";
 import { useWorkspaceProgrammaticCost } from "@app/lib/swr/workspaces";
@@ -57,25 +57,23 @@ const GROUP_BY_OPTIONS: {
 ];
 
 function getColorClassName(
-  groupBy: "agent" | "origin" | undefined,
+  groupBy: "agent" | "origin" | "apiKey" | undefined,
   groupName: string,
   groups: string[]
 ): string {
-  if (groupBy === "origin" && isUserMessageOrigin(groupName)) {
-    return getSourceColor(groupName, "text");
-  } else if (groupBy === "agent" || groupBy === "apiKey") {
-    return getToolColor(groupName, groups, "text");
-  } else if (!groupBy) {
+  if (!groupBy) {
     return COST_PALETTE.costCents;
+  } else if (groupBy === "origin" && isUserMessageOrigin(groupName)) {
+    return getSourceColor(groupName);
   } else {
-    return COST_PALETTE.unknown;
+    return getIndexedColor(groupName, groups);
   }
 }
 
 // Custom tooltip for grouped view
 function GroupedTooltip(
   props: TooltipContentProps<number, string>,
-  groupBy: "agent" | "origin" | undefined,
+  groupBy: "agent" | "origin" | "apiKey" | undefined,
   groups: string[]
 ): JSX.Element | null {
   const { active, payload } = props;
@@ -124,9 +122,9 @@ function GroupedTooltip(
 export function ProgrammaticCostChart({
   workspaceId,
 }: ProgrammaticCostChartProps) {
-  const [groupBy, setGroupBy] = useState<"agent" | "origin" | undefined>(
-    undefined
-  );
+  const [groupBy, setGroupBy] = useState<
+    "agent" | "origin" | "apiKey" | undefined
+  >(undefined);
 
   const {
     programmaticCostData,

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -36,7 +36,7 @@ interface ProgrammaticCostChartProps {
   workspaceId: string;
 }
 
-type GroupByOptionValue = "global" | "agent" | "origin";
+type GroupByOptionValue = "global" | "agent" | "origin" | "apiKey";
 
 type ChartDataPoint = {
   date: string;
@@ -53,6 +53,7 @@ const GROUP_BY_OPTIONS: {
   { value: "global", label: "Global" },
   { value: "agent", label: "By Agent" },
   { value: "origin", label: "By Source" },
+  { value: "apiKey", label: "By Api Key" },
 ];
 
 function getColorClassName(
@@ -62,7 +63,7 @@ function getColorClassName(
 ): string {
   if (groupBy === "origin" && isUserMessageOrigin(groupName)) {
     return getSourceColor(groupName, "text");
-  } else if (groupBy === "agent") {
+  } else if (groupBy === "agent" || groupBy === "apiKey") {
     return getToolColor(groupName, groups, "text");
   } else if (!groupBy) {
     return COST_PALETTE.costCents;

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -155,7 +155,7 @@ export function useWorkspaceProgrammaticCost({
   disabled,
 }: {
   workspaceId: string;
-  groupBy?: "agent" | "origin";
+  groupBy?: "agent" | "origin" | "apiKey";
   disabled?: boolean;
 }) {
   const fetcherFn: Fetcher<GetWorkspaceProgrammaticCostResponse> = fetcher;

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -149,13 +149,15 @@ export function useFeatureFlags({
   };
 }
 
+export type GroupByType = "agent" | "origin" | "apiKey";
+
 export function useWorkspaceProgrammaticCost({
   workspaceId,
   groupBy,
   disabled,
 }: {
   workspaceId: string;
-  groupBy?: "agent" | "origin" | "apiKey";
+  groupBy?: GroupByType;
   disabled?: boolean;
 }) {
   const fetcherFn: Fetcher<GetWorkspaceProgrammaticCostResponse> = fetcher;

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
@@ -21,7 +21,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
 const QuerySchema = z.object({
-  groupBy: z.enum(["agent", "origin"]).optional(),
+  groupBy: z.enum(["agent", "origin", "apiKey"]).optional(),
 });
 
 export type WorkspaceProgrammaticCostPoint = {
@@ -185,8 +185,19 @@ async function handler(
           groupValues["total"]?.set(point.timestamp, point.costCents);
         });
       } else {
+        let groupField: string;
         // Grouped view (agent or origin)
-        const groupField = groupBy === "agent" ? "agent_id" : "context_origin";
+        switch (groupBy) {
+          case "agent":
+            groupField = "agent_id";
+            break;
+          case "origin":
+            groupField = "context_origin";
+            break;
+          case "apiKey":
+            groupField = "api_key_name";
+            break;
+        }
 
         // Use the extracted helper to build metric aggregates
         const metricAggregates = buildMetricAggregates(["costCents"]);


### PR DESCRIPTION
## Description

Add a group by apiKey name in endpoint and graph.
Restored simplified color handling (we finally always use text- classes) and renamed method for reuse ( getToolColor  was already used for other stuff than tools - now also using for api key names )

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front

