### PR TITLE
[front] chore: remove `WEBSEARCH_QUERY`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -363,28 +363,6 @@ export const isIncludeResultResourceType = (
 
 // Websearch results.
 
-export const WebsearchQueryResourceSchema = z.object({
-  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.WEBSEARCH_QUERY),
-  text: z.string(),
-  uri: z.literal(""),
-});
-
-export type WebsearchQueryResourceType = z.infer<
-  typeof WebsearchQueryResourceSchema
->;
-
-export const isWebsearchQueryResourceType = (
-  outputBlock: CallToolResult["content"][number]
-): outputBlock is {
-  type: "resource";
-  resource: WebsearchQueryResourceType;
-} => {
-  return (
-    outputBlock.type === "resource" &&
-    WebsearchQueryResourceSchema.safeParse(outputBlock.resource).success
-  );
-};
-
 export const WebsearchResultResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.WEBSEARCH_RESULT),
   title: z.string(),

--- a/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
@@ -93,20 +93,12 @@ export function registerWebSearchTool(
           });
         }
 
-        return new Ok([
-          ...results.map((result) => ({
+        return new Ok(
+          results.map((result) => ({
             type: "resource" as const,
             resource: result,
-          })),
-          {
-            type: "resource" as const,
-            resource: {
-              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.WEBSEARCH_QUERY,
-              text: query,
-              uri: "",
-            },
-          },
-        ]);
+          }))
+        );
       }
     )
   );

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -9,7 +9,6 @@ import {
   isRunAgentQueryResourceType,
   isToolGeneratedFile,
   isToolMarkerResourceType,
-  isWebsearchQueryResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   getAttachmentFromToolOutput,
@@ -102,7 +101,6 @@ export function rewriteContentForModel(
 
   if (
     isToolMarkerResourceType(content) ||
-    isWebsearchQueryResourceType(content) ||
     isRunAgentQueryResourceType(content)
   ) {
     return null;

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -248,28 +248,6 @@ export const isIncludeResultResourceType = (
 
 // Websearch results.
 
-export const WebsearchQueryResourceSchema = z.object({
-  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.WEBSEARCH_QUERY),
-  text: z.string(),
-  uri: z.literal(""),
-});
-
-export type WebsearchQueryResourceType = z.infer<
-  typeof WebsearchQueryResourceSchema
->;
-
-export const isWebsearchQueryResourceType = (
-  outputBlock: CallToolResult["content"][number]
-): outputBlock is {
-  type: "resource";
-  resource: WebsearchQueryResourceType;
-} => {
-  return (
-    outputBlock.type === "resource" &&
-    WebsearchQueryResourceSchema.safeParse(outputBlock.resource).success
-  );
-};
-
 export const WebsearchResultResourceSchema = z.object({
   mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.WEBSEARCH_RESULT),
   title: z.string(),


### PR DESCRIPTION
## Description

- Same as https://github.com/dust-tt/dust/pull/18100 but for the websearch query.
- This PR removes an output sent by the websearch that describes what query was sent to the websearch.
- Since https://github.com/dust-tt/dust/pull/17235 we read it from the inputs.

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
