### PR TITLE
[LLM Router] Fix gpt-5 reasoning effort

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/index.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.test.ts
@@ -6,8 +6,8 @@ import {
 } from "@app/lib/api/llm/clients/anthropic/utils";
 
 describe("toThinkingConfig", () => {
-  it('returns undefined for "light" when native light reasoning is false', () => {
-    expect(toThinkingConfig("light", false)).toBeUndefined();
+  it('returns disabled for "light" when native light reasoning is false', () => {
+    expect(toThinkingConfig("light", false)).toEqual({ type: "disabled" });
   });
 
   it('returns configured budget tokens for "medium"', () => {

--- a/front/lib/api/llm/clients/anthropic/utils/index.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.ts
@@ -12,9 +12,14 @@ export function toThinkingConfig(
   reasoningEffort: ReasoningEffort | null,
   useNativeLightReasoning?: boolean
 ): ThinkingConfigParam | undefined {
-  if (!reasoningEffort || reasoningEffort === "none") {
+  if (!reasoningEffort) {
     return undefined;
   }
+
+  if (reasoningEffort === "none") {
+    return { type: "disabled" };
+  }
+
   if (reasoningEffort !== "light") {
     return {
       type: "enabled",
@@ -30,5 +35,5 @@ export function toThinkingConfig(
     };
   }
 
-  return undefined;
+  return { type: "disabled" };
 }

--- a/front/lib/api/llm/clients/google/utils/to_thinking.ts
+++ b/front/lib/api/llm/clients/google/utils/to_thinking.ts
@@ -15,9 +15,14 @@ export function toThinkingConfig(
   reasoningEffort: ReasoningEffort | null,
   useNativeLightReasoning?: boolean
 ): ThinkingConfig | undefined {
-  if (!reasoningEffort || reasoningEffort === "none") {
+  if (!reasoningEffort) {
     return undefined;
   }
+
+  if (reasoningEffort === "none") {
+    return { includeThoughts: false, thinkingBudget: 0 };
+  }
+
   if (reasoningEffort !== "light") {
     return {
       includeThoughts: true,
@@ -34,5 +39,5 @@ export function toThinkingConfig(
     };
   }
 
-  return undefined;
+  return { includeThoughts: false, thinkingBudget: 0 };
 }

--- a/front/lib/api/llm/clients/openai/__test__/openai.test.ts
+++ b/front/lib/api/llm/clients/openai/__test__/openai.test.ts
@@ -1,13 +1,11 @@
 import { vi } from "vitest";
 
 import type {
+  ModelConfig,
   OpenAIModelFamily,
   OpenAIWhitelistedModelId,
 } from "@app/lib/api/llm/clients/openai/types";
-import {
-  OPENAI_MODEL_FAMILIES,
-  OPENAI_MODEL_FAMILY_CONFIGS,
-} from "@app/lib/api/llm/clients/openai/types";
+import { OPENAI_MODEL_FAMILY_CONFIGS } from "@app/lib/api/llm/clients/openai/types";
 import {
   TEST_CONVERSATIONS,
   TEST_STRUCTURED_OUTPUT_CONVERSATIONS,
@@ -111,15 +109,16 @@ vi.mock("@app/lib/api/regions/config", async (importOriginal) => {
 function getOpenAIModelFamilyFromModelId(
   modelId: OpenAIWhitelistedModelId
 ): OpenAIModelFamily {
-  const family = OPENAI_MODEL_FAMILIES.find((family) =>
-    new Set(OPENAI_MODEL_FAMILY_CONFIGS[family].modelIds).has(modelId)
-  );
+  const family = Object.entries(OPENAI_MODEL_FAMILY_CONFIGS).find(
+    ([_family, config]: [string, ModelConfig]) =>
+      config.modelIds.includes(modelId)
+  )?.[0];
   if (!family) {
     throw new Error(
       `Model ID ${modelId} does not belong to any OpenAI model family`
     );
   }
-  return family;
+  return family as OpenAIModelFamily;
 }
 
 /**

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -76,7 +76,7 @@ export class OpenAIResponsesLLM extends LLM {
       };
     }
 
-    // In this case, use CoT
+    // In this case, use CoT meta prompt
     return {
       effort: "none",
       summary: "auto",

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -1,8 +1,14 @@
 import { APIError, OpenAI } from "openai";
+import type { Reasoning } from "openai/resources/shared";
 
 import type { OpenAIWhitelistedModelId } from "@app/lib/api/llm/clients/openai/types";
-import { overwriteLLMParameters } from "@app/lib/api/llm/clients/openai/types";
+import { DEFAULT_REASONING_EFFORT_MAPPING } from "@app/lib/api/llm/clients/openai/types";
+import {
+  getModelConfig,
+  overwriteLLMParameters,
+} from "@app/lib/api/llm/clients/openai/utils";
 import { LLM } from "@app/lib/api/llm/llm";
+import { handleGenericError } from "@app/lib/api/llm/types/errors";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type {
   LLMClientMetadata,
@@ -12,15 +18,13 @@ import type {
 import { handleError } from "@app/lib/api/llm/utils/openai_like/errors";
 import {
   toInput,
-  toReasoning,
   toResponseFormat,
   toTool,
 } from "@app/lib/api/llm/utils/openai_like/responses/conversation_to_openai";
 import { streamLLMEvents } from "@app/lib/api/llm/utils/openai_like/responses/openai_to_events";
 import type { Authenticator } from "@app/lib/auth";
+import type { ReasoningEffort } from "@app/types";
 import { dustManagedCredentials } from "@app/types";
-
-import { handleGenericError } from "../../types/errors";
 
 export class OpenAIResponsesLLM extends LLM {
   private client: OpenAI;
@@ -46,17 +50,52 @@ export class OpenAIResponsesLLM extends LLM {
     });
   }
 
+  toResponsesReasoning(
+    reasoningEffort: ReasoningEffort | null,
+    useNativeLightReasoning?: boolean
+  ): Reasoning | null {
+    if (!reasoningEffort) {
+      // This is for non-reasoning models
+      // For reasoning, setting to null defaults to medium
+      // So we enforce a default value for each reasoning model
+      return null;
+    }
+
+    const { reasoningEffortMappingOverwrites } = getModelConfig(this.modelId);
+
+    const reasoningEffortMapping = {
+      ...DEFAULT_REASONING_EFFORT_MAPPING,
+      // Specific to gpt-5 which is the only model supporting "minimal"
+      ...reasoningEffortMappingOverwrites,
+    };
+
+    if (reasoningEffort !== "light" || useNativeLightReasoning) {
+      return {
+        effort: reasoningEffortMapping[reasoningEffort],
+        summary: "auto",
+      };
+    }
+
+    // In this case, use CoT
+    return {
+      effort: "none",
+      summary: "auto",
+    };
+  }
+
   async *internalStream({
     conversation,
     prompt,
     specifications,
   }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     try {
-      const reasoning = toReasoning(
+      const reasoning = this.toResponsesReasoning(
         this.reasoningEffort,
         this.modelConfig.useNativeLightReasoning
       );
+
       const events = await this.client.responses.create({
+        ...getModelConfig(this.modelId).inputDefaults,
         model: this.modelId,
         input: toInput(prompt, conversation),
         stream: true,
@@ -64,8 +103,6 @@ export class OpenAIResponsesLLM extends LLM {
         reasoning,
         tools: specifications.map(toTool),
         text: { format: toResponseFormat(this.responseFormat) },
-        // Only models supporting reasoning can do encrypted content for reasoning.
-        include: reasoning !== null ? ["reasoning.encrypted_content"] : [],
       });
 
       yield* streamLLMEvents(events, this.metadata);

--- a/front/lib/api/llm/clients/openai/types.ts
+++ b/front/lib/api/llm/clients/openai/types.ts
@@ -1,8 +1,14 @@
 import flatMap from "lodash/flatMap";
+import type {
+  ResponseCreateParamsStreaming,
+  ResponseIncludable,
+} from "openai/resources/responses/responses";
+import type { ReasoningEffort as OpenAIReasoningEffort } from "openai/resources/shared";
 
 import type { LLMParameters } from "@app/lib/api/llm/types/options";
-import type { ModelIdType } from "@app/types";
+import type { ModelIdType, ReasoningEffort } from "@app/types";
 import {
+  ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES,
   GPT_3_5_TURBO_MODEL_ID,
   GPT_4_1_MINI_MODEL_ID,
   GPT_4_1_MODEL_ID,
@@ -20,34 +26,51 @@ import {
   O4_MINI_MODEL_ID,
 } from "@app/types";
 
-export const OPENAI_MODEL_FAMILIES = [
-  "o3",
-  "o3-no-vision",
-  "no-vision",
-  "non-reasoning",
-  "reasoning",
-] as const;
-export type OpenAIModelFamily = (typeof OPENAI_MODEL_FAMILIES)[number];
+export type ModelConfig = {
+  modelIds: ModelIdType[];
+  overwrites?: Partial<LLMParameters & { modelId: never }>;
+  defaults?: Partial<Exclude<LLMParameters, "modelId">>;
+  inputDefaults?: Partial<ResponseCreateParamsStreaming>;
+  include?: ResponseIncludable[];
+  reasoningEffortMappingOverwrites?: Partial<
+    Record<ReasoningEffort, OpenAIReasoningEffort>
+  >;
+};
 
 export const OPENAI_MODEL_FAMILY_CONFIGS = {
   o3: {
     modelIds: [O3_MODEL_ID],
     overwrites: { temperature: null },
+    defaults: { reasoningEffort: "medium" },
+    inputDefaults: { include: ["reasoning.encrypted_content"] },
   },
   "o3-no-vision": {
     modelIds: [O3_MINI_MODEL_ID],
     overwrites: { temperature: null },
+    defaults: { reasoningEffort: "medium" },
+    inputDefaults: { include: ["reasoning.encrypted_content"] },
   },
   reasoning: {
-    modelIds: [
-      O1_MODEL_ID,
-      O4_MINI_MODEL_ID,
-      GPT_5_1_MODEL_ID,
-      GPT_5_MODEL_ID,
-      GPT_5_MINI_MODEL_ID,
-      GPT_5_NANO_MODEL_ID,
-    ],
+    modelIds: [O1_MODEL_ID, O4_MINI_MODEL_ID],
     overwrites: { temperature: null },
+    // For reasoning, setting to null defaults to medium
+    // So we should make sure to enforce a default value
+    // To avoid unexpected behaviors
+    defaults: { reasoningEffort: "medium" },
+    inputDefaults: { include: ["reasoning.encrypted_content"] },
+  },
+  "gpt-5": {
+    modelIds: [GPT_5_MODEL_ID, GPT_5_MINI_MODEL_ID, GPT_5_NANO_MODEL_ID],
+    overwrites: { temperature: null },
+    defaults: { reasoningEffort: "medium" },
+    inputDefaults: { include: ["reasoning.encrypted_content"] },
+    reasoningEffortMappingOverwrites: { none: "minimal" },
+  },
+  "gpt-5.1": {
+    modelIds: [GPT_5_1_MODEL_ID],
+    overwrites: { temperature: null },
+    inputDefaults: { include: ["reasoning.encrypted_content"] },
+    defaults: { reasoningEffort: "medium" },
   },
   "non-reasoning": {
     modelIds: [
@@ -59,18 +82,25 @@ export const OPENAI_MODEL_FAMILY_CONFIGS = {
       GPT_4O_20240806_MODEL_ID,
     ],
     overwrites: { reasoningEffort: null },
+    defaults: { temperature: ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES.balanced },
   },
   "no-vision": {
     modelIds: [GPT_3_5_TURBO_MODEL_ID],
     overwrites: { reasoningEffort: null },
+    defaults: { temperature: ASSISTANT_CREATIVITY_LEVEL_TEMPERATURES.balanced },
   },
-} as const satisfies Record<
-  OpenAIModelFamily,
-  {
-    modelIds: ModelIdType[];
-    overwrites: Partial<LLMParameters>;
-  }
->;
+} as const satisfies Record<OpenAIModelFamily, ModelConfig>;
+
+export const OPENAI_MODEL_FAMILIES = [
+  "o3",
+  "o3-no-vision",
+  "no-vision",
+  "non-reasoning",
+  "reasoning",
+  "gpt-5",
+  "gpt-5.1",
+] as const;
+export type OpenAIModelFamily = (typeof OPENAI_MODEL_FAMILIES)[number];
 
 export type OpenAIWhitelistedModelId = {
   [K in OpenAIModelFamily]: (typeof OPENAI_MODEL_FAMILY_CONFIGS)[K]["modelIds"][number];
@@ -79,40 +109,11 @@ export const OPENAI_WHITELISTED_MODEL_IDS = flatMap<OpenAIWhitelistedModelId>(
   Object.values(OPENAI_MODEL_FAMILY_CONFIGS).map((config) => config.modelIds)
 );
 
-export function isOpenAIResponsesWhitelistedModelId(
-  modelId: ModelIdType
-): modelId is OpenAIWhitelistedModelId {
-  return new Set<string>(OPENAI_WHITELISTED_MODEL_IDS).has(modelId);
-}
-
-export function getOpenAIModelFamilyFromModelId(
-  modelId: OpenAIWhitelistedModelId
-): OpenAIModelFamily {
-  const family = OPENAI_MODEL_FAMILIES.find((family) =>
-    new Set(OPENAI_MODEL_FAMILY_CONFIGS[family].modelIds).has(modelId)
-  );
-  if (!family) {
-    throw new Error(
-      `Model ID ${modelId} does not belong to any OpenAI model family`
-    );
-  }
-  return family;
-}
-
-export function overwriteLLMParameters(
-  llMParameters: LLMParameters & {
-    modelId: OpenAIWhitelistedModelId;
-  }
-): LLMParameters & { modelId: OpenAIWhitelistedModelId } & {
-  clientId: "openai";
-} {
-  const config = Object.values(OPENAI_MODEL_FAMILY_CONFIGS).find((config) =>
-    new Set<string>(config.modelIds).has(llMParameters.modelId)
-  );
-
-  return {
-    ...llMParameters,
-    ...config?.overwrites,
-    clientId: "openai" as const,
-  };
-}
+export const DEFAULT_REASONING_EFFORT_MAPPING: {
+  [key in ReasoningEffort]: OpenAIReasoningEffort;
+} = {
+  none: "none",
+  light: "low",
+  medium: "medium",
+  high: "high",
+};

--- a/front/lib/api/llm/clients/openai/utils.ts
+++ b/front/lib/api/llm/clients/openai/utils.ts
@@ -1,0 +1,53 @@
+import type {
+  ModelConfig,
+  OpenAIWhitelistedModelId,
+} from "@app/lib/api/llm/clients/openai/types";
+import {
+  OPENAI_MODEL_FAMILY_CONFIGS,
+  OPENAI_WHITELISTED_MODEL_IDS,
+} from "@app/lib/api/llm/clients/openai/types";
+import type { LLMParameters } from "@app/lib/api/llm/types/options";
+import type { ModelIdType } from "@app/types";
+
+export function isOpenAIResponsesWhitelistedModelId(
+  modelId: ModelIdType
+): modelId is OpenAIWhitelistedModelId {
+  return new Set<string>(OPENAI_WHITELISTED_MODEL_IDS).has(modelId);
+}
+
+export function overwriteLLMParameters(
+  llMParameters: LLMParameters & {
+    modelId: OpenAIWhitelistedModelId;
+  }
+): LLMParameters & { modelId: OpenAIWhitelistedModelId } & {
+  clientId: "openai";
+} {
+  const { defaults = {}, overwrites = {} } = getModelConfig(
+    llMParameters.modelId
+  );
+
+  return {
+    ...defaults,
+    ...llMParameters,
+    ...overwrites,
+    clientId: "openai" as const,
+  };
+}
+
+export function getModelConfig(modelId: ModelIdType): ModelConfig {
+  if (!isOpenAIResponsesWhitelistedModelId(modelId)) {
+    throw new Error(
+      `Model ID ${modelId} is not a whitelisted OpenAI Responses model ID`
+    );
+  }
+
+  const config = Object.values(OPENAI_MODEL_FAMILY_CONFIGS).find((config) =>
+    new Set<string>(config.modelIds).has(modelId)
+  );
+
+  if (!config) {
+    throw new Error(`Model ID ${modelId} is not a whitelisted OpenAI model ID`);
+  }
+
+  return config;
+}

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -9,7 +9,7 @@ import { isMistralWhitelistedModelId } from "@app/lib/api/llm/clients/mistral/ty
 import { NoopLLM } from "@app/lib/api/llm/clients/noop";
 import { isNoopWhitelistedModelId } from "@app/lib/api/llm/clients/noop/types";
 import { OpenAIResponsesLLM } from "@app/lib/api/llm/clients/openai";
-import { isOpenAIResponsesWhitelistedModelId } from "@app/lib/api/llm/clients/openai/types";
+import { isOpenAIResponsesWhitelistedModelId } from "@app/lib/api/llm/clients/openai/utils";
 import { XaiLLM } from "@app/lib/api/llm/clients/xai";
 import { isXaiWhitelistedModelId } from "@app/lib/api/llm/clients/xai/types";
 import type { LLM } from "@app/lib/api/llm/llm";

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -25481,9 +25481,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.8.1.tgz",
-      "integrity": "sha512-ACifslrVgf+maMz9vqwMP4+v9qvx5Yzssydizks8n+YUJ6YwUoxj51sKRQ8HYMfR6wgKLSIlaI108ZwCk+8yig==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.9.1.tgz",
+      "integrity": "sha512-vQ5Rlt0ZgB3/BNmTa7bIijYFhz3YBceAA3Z4JuoMSBftBF9YqFHIEhZakSs+O/Ad7EaoEimZvHxD5ylRjN11Lg==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -207,7 +207,8 @@ export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   isLatest: true,
   generationTokensCount: 128_000,
   supportsVision: true,
-  minimumReasoningEffort: "none",
+  // Does not support "none", lowest reasoning effort is "minimal" which can be misleading for user
+  minimumReasoningEffort: "light",
   maximumReasoningEffort: "high",
   defaultReasoningEffort: "medium",
   useNativeLightReasoning: true,


### PR DESCRIPTION
## Description

There was a misunderstanding of the `reasoning: null` in the codebase. In this case, OpenAI reasoning models default to "medium", and in this case we were not including encrypted_content.

This might be related to an issue brought by customer.

**Out of scope**
Fixing  XAI (based on OpenAI Responses)

## Tests

Local

## Risk

Low

## Deploy Plan

Front
