### PR TITLE
[connectors] fix(Intercom): stop running workflows when stopping connector

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -29,7 +29,7 @@ import {
   deleteSchedule,
   pauseSchedule,
   scheduleExists,
-  triggerSchedule,
+  unpauseAndTriggerSchedule,
 } from "@connectors/lib/temporal_schedules";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -233,7 +233,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
         return new Err(creationRes.error);
       }
     } else {
-      const result = await triggerSchedule({
+      const result = await unpauseAndTriggerSchedule({
         connector,
         scheduleId,
       });
@@ -265,7 +265,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const result = await triggerSchedule({
+    const result = await unpauseAndTriggerSchedule({
       connector,
       scheduleId: makeGongSyncScheduleId(connector),
     });

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -26,6 +26,7 @@ import {
   launchIntercomFullSyncWorkflow,
   launchIntercomSchedules,
   stopIntercomSchedulesAndWorkflows,
+  unpauseIntercomSchedules,
 } from "@connectors/connectors/intercom/temporal/client";
 import type {
   CreateConnectorErrorCode,
@@ -251,7 +252,7 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
 
-    const schedulesRes = await launchIntercomSchedules(connector);
+    const schedulesRes = await unpauseIntercomSchedules(connector);
     if (schedulesRes.isErr()) {
       return schedulesRes;
     }

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -23,6 +23,7 @@ import {
   isInternalIdForAllTeams,
 } from "@connectors/connectors/intercom/lib/utils";
 import {
+  deleteIntercomSchedules,
   launchIntercomFullSyncWorkflow,
   launchIntercomSchedules,
   stopIntercomSchedulesAndWorkflows,
@@ -218,6 +219,8 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
         "Error uninstalling Intercom, continuing..."
       );
     }
+
+    await deleteIntercomSchedules(connector);
 
     const res = await connector.delete();
     if (res.isErr()) {

--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -90,13 +90,12 @@ async function queryIntercomAPI({
         `405 - ${isCaptchaError ? "Captcha error" : text}`,
         "transient_upstream_activity_error"
       );
-    } else {
-      logger.info(
-        { path, response: text, status: rawResponse.status },
-        "Failed to parse Intercom JSON response."
-      );
-      throw e;
     }
+    logger.info(
+      { path, response: text, status: rawResponse.status },
+      "Failed to parse Intercom JSON response."
+    );
+    throw e;
   }
 }
 

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -17,6 +17,7 @@ import {
 import { getTemporalClient } from "@connectors/lib/temporal";
 import {
   createSchedule,
+  deleteSchedule,
   pauseSchedule,
   unpauseAndTriggerSchedule,
 } from "@connectors/lib/temporal_schedules";
@@ -232,6 +233,32 @@ export async function unpauseIntercomSchedules(
     scheduleId: makeIntercomConversationScheduleId(connector),
     connector,
   });
+  if (conversationResult.isErr()) {
+    return conversationResult;
+  }
+
+  return new Ok(undefined);
+}
+
+export async function deleteIntercomSchedules(
+  connector: ConnectorResource
+): Promise<Result<void, Error>> {
+  await stopIntercomSchedulesAndWorkflows(connector);
+
+  const helpCenterResult = await deleteSchedule({
+    scheduleId: makeIntercomHelpCenterScheduleId(connector),
+    connector,
+  });
+
+  if (helpCenterResult.isErr()) {
+    return helpCenterResult;
+  }
+
+  const conversationResult = await deleteSchedule({
+    scheduleId: makeIntercomConversationScheduleId(connector),
+    connector,
+  });
+
   if (conversationResult.isErr()) {
     return conversationResult;
   }

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -17,7 +17,8 @@ import {
 import { getTemporalClient } from "@connectors/lib/temporal";
 import {
   createSchedule,
-  deleteSchedule,
+  pauseSchedule,
+  unpauseAndTriggerSchedule,
 } from "@connectors/lib/temporal_schedules";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -109,7 +110,7 @@ export async function launchIntercomFullSyncWorkflow({
 export async function stopIntercomSchedulesAndWorkflows(
   connector: ConnectorResource
 ): Promise<Result<void, Error>> {
-  const helpCenterResult = await deleteSchedule({
+  const helpCenterResult = await pauseSchedule({
     scheduleId: makeIntercomHelpCenterScheduleId(connector),
     connector,
   });
@@ -118,7 +119,7 @@ export async function stopIntercomSchedulesAndWorkflows(
     return helpCenterResult;
   }
 
-  const conversationResult = await deleteSchedule({
+  const conversationResult = await pauseSchedule({
     scheduleId: makeIntercomConversationScheduleId(connector),
     connector,
   });
@@ -209,6 +210,28 @@ export async function launchIntercomSchedules(
     },
   });
 
+  if (conversationResult.isErr()) {
+    return conversationResult;
+  }
+
+  return new Ok(undefined);
+}
+
+export async function unpauseIntercomSchedules(
+  connector: ConnectorResource
+): Promise<Result<void, Error>> {
+  const helpCenterResult = await unpauseAndTriggerSchedule({
+    scheduleId: makeIntercomHelpCenterScheduleId(connector),
+    connector,
+  });
+  if (helpCenterResult.isErr()) {
+    return helpCenterResult;
+  }
+
+  const conversationResult = await unpauseAndTriggerSchedule({
+    scheduleId: makeIntercomConversationScheduleId(connector),
+    connector,
+  });
   if (conversationResult.isErr()) {
     return conversationResult;
   }

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -11,7 +11,7 @@ import { getTemporalClient } from "@connectors/lib/temporal";
 import {
   createSchedule,
   scheduleExists,
-  triggerSchedule,
+  unpauseAndTriggerSchedule,
 } from "@connectors/lib/temporal_schedules";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -133,7 +133,7 @@ export async function launchCrawlWebsiteScheduler() {
   });
   // If the schedule already exists, trigger it.
   if (scheduleAlreadyExists) {
-    return triggerSchedule({
+    return unpauseAndTriggerSchedule({
       scheduleId,
     });
   }

--- a/connectors/src/lib/temporal_schedules.ts
+++ b/connectors/src/lib/temporal_schedules.ts
@@ -136,7 +136,7 @@ export async function deleteSchedule({
 /**
  * Unpauses the schedule if paused and triggers the schedule to start the workflow immediately.
  */
-export async function triggerSchedule({
+export async function unpauseAndTriggerSchedule({
   scheduleId,
   connector,
 }: {


### PR DESCRIPTION
## Description

- In https://github.com/dust-tt/dust/pull/18088 the workflows for the Intercom connector were split in workflows and schedules.
- In `IntercomConnectorManager.stop` we stopped the schedules but not the running workflows.
- This PR fixes that.

## Tests

- Tested locally (by adding sleeps in the activities, workflows complete too fast to test it otherwise).

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
