### PR TITLE
[front] Remove Intercom from production check on running workflows

### DIFF
--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -124,6 +124,7 @@ export const checkActiveWorkflows: CheckFunction = async (
           dataSourceId: connector.dataSourceId,
         });
       }
+      // TODO(2025-11-20 aubin): check schedules for Gong and Intercom.
     }
 
     if (missingActiveWorkflows.length > 0) {

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -6,7 +6,6 @@ import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/uti
 import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
 import type { ConnectorProvider } from "@app/types";
 import {
-  getIntercomSyncWorkflowId,
   getZendeskGarbageCollectionWorkflowId,
   getZendeskSyncWorkflowId,
   googleDriveIncrementalSyncWorkflowId,
@@ -32,11 +31,6 @@ const providersToCheck: Partial<Record<ConnectorProvider, ProviderCheck>> = {
   confluence: {
     makeIdsFn: (connector: ConnectorBlob) => [
       makeConfluenceSyncWorkflowId(connector.id),
-    ],
-  },
-  intercom: {
-    makeIdsFn: (connector: ConnectorBlob) => [
-      getIntercomSyncWorkflowId(connector.id),
     ],
   },
   google_drive: {

--- a/front/types/connectors/workflows.ts
+++ b/front/types/connectors/workflows.ts
@@ -13,10 +13,6 @@ export function getNotionWorkflowId(
   return wfName;
 }
 
-export function getIntercomSyncWorkflowId(connectorId: ModelId) {
-  return `intercom-sync-${connectorId}`;
-}
-
 export function getZendeskSyncWorkflowId(connectorId: ModelId): string {
   return `zendesk-sync-${connectorId}`;
 }

--- a/front/types/connectors/workflows.ts
+++ b/front/types/connectors/workflows.ts
@@ -50,8 +50,6 @@ export function getWorkflowIdsForConnector(
         getNotionWorkflowId(connectorId, "garbage-collector"),
         getNotionWorkflowId(connectorId, "process-database-upsert-queue"),
       ];
-    case "intercom":
-      return [getIntercomSyncWorkflowId(connectorId)];
     case "zendesk":
       return [
         getZendeskSyncWorkflowId(connectorId),


### PR DESCRIPTION
## Description

- Prior to https://github.com/dust-tt/dust/pull/18088 Intercom had a sync workflow running on a cron.
- There was a production check checking that this workflow was running.
- Not relevant anymore since it's run on a schedule, we need to check that the schedule is there instead.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
