### PR TITLE
[front] fix gap between conversation in sidebar

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -552,11 +552,13 @@ interface InboxConversationListProps {
   owner: WorkspaceType;
 }
 
+interface ConversationListContainerProps {
+  children: React.ReactNode;
+}
+
 const ConversationListContainer = ({
   children,
-}: {
-  children: React.ReactNode;
-}) => {
+}: ConversationListContainerProps) => {
   return <div className="px-3 sm:flex sm:flex-col sm:gap-0.5">{children}</div>;
 };
 

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -552,6 +552,14 @@ interface InboxConversationListProps {
   owner: WorkspaceType;
 }
 
+const ConversationListContainer = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return <div className="px-3 sm:flex sm:flex-col sm:gap-0.5">{children}</div>;
+};
+
 const InboxConversationList = ({
   unreadConversations,
   actionRequiredConversations,
@@ -576,7 +584,7 @@ const InboxConversationList = ({
   });
 
   return (
-    <div className="px-3">
+    <ConversationListContainer>
       <div className="sticky top-0 z-10 flex items-center justify-between overflow-auto bg-background dark:bg-background-night">
         <NavigationListLabel
           label={dateLabel}
@@ -603,7 +611,7 @@ const InboxConversationList = ({
           {...props}
         />
       ))}
-    </div>
+    </ConversationListContainer>
   );
 };
 
@@ -625,7 +633,7 @@ const ConversationList = ({
   }
 
   return (
-    <div className="px-3">
+    <ConversationListContainer>
       <NavigationListLabel
         label={dateLabel}
         isSticky
@@ -639,7 +647,7 @@ const ConversationList = ({
           {...props}
         />
       ))}
-    </div>
+    </ConversationListContainer>
   );
 };
 


### PR DESCRIPTION
## Description
It was not intentional and it looks bad when you hover conversation near selected conversation 🙈

before:
<img width="602" height="172" alt="CleanShot 2025-11-20 at 14 31 04@2x" src="https://github.com/user-attachments/assets/62390a1d-8ba0-4692-be2a-5ee0819c2a07" />


after:
<img width="612" height="180" alt="CleanShot 2025-11-20 at 14 29 40@2x" src="https://github.com/user-attachments/assets/ff664349-0d8b-4cdd-94b5-d5fc0220270f" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
