### PR TITLE
[connectors] Add workflow search attributes when creating schedules

### DIFF
--- a/connectors/src/lib/temporal_schedules.ts
+++ b/connectors/src/lib/temporal_schedules.ts
@@ -71,7 +71,13 @@ export async function createSchedule({
 
   try {
     const scheduleHandle = await client.schedule.create({
-      action,
+      action: {
+        ...action,
+        searchAttributes: {
+          ...action.searchAttributes,
+          connectorId: connector ? [connector?.id] : undefined,
+        },
+      },
       scheduleId,
       policies,
       spec,

--- a/connectors/src/lib/temporal_schedules.ts
+++ b/connectors/src/lib/temporal_schedules.ts
@@ -73,6 +73,7 @@ export async function createSchedule({
     const scheduleHandle = await client.schedule.create({
       action: {
         ...action,
+        // Workflow-level search attributes.
         searchAttributes: {
           ...action.searchAttributes,
           connectorId: connector ? [connector?.id] : undefined,
@@ -81,6 +82,7 @@ export async function createSchedule({
       scheduleId,
       policies,
       spec,
+      // Schedule-level search attributes.
       searchAttributes: {
         connectorId: connector ? [connector?.id] : undefined,
       },


### PR DESCRIPTION
## Description

- We don't have a search attribute on the connector ID on workflows created by schedules for Intercom, only search attributes on schedules.
- This PR fixes that.
- Won't backfill the existing schedules, won't have search attributes but not a huge deal. This PR is mostly about making sure we do it right from now on.

## Tests

- Tested locally (`temporal describe workflow`).

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
