### PR TITLE
[connectors] chore: remove `node-zendesk` dependency

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -25,7 +25,6 @@
         "@types/express": "^4.17.17",
         "@types/fs-extra": "^11.0.1",
         "@types/minimist": "^1.2.2",
-        "@types/node-zendesk": "^2.0.15",
         "@types/remove-markdown": "^0.3.4",
         "@types/uuid": "^9.0.2",
         "axios": "^1.7.9",
@@ -6140,15 +6139,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@types/node-zendesk": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@types/node-zendesk/-/node-zendesk-2.0.15.tgz",
-      "integrity": "sha512-8Kk7ceoSUiBst5+jX/121QBD8f69F5j9CqvLA1Ka+24vo+B6sPINnqPwfBJAs4/9jBpCLh7h2SH9hUbABiuZXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -36,7 +36,6 @@
     "@types/express": "^4.17.17",
     "@types/fs-extra": "^11.0.1",
     "@types/minimist": "^1.2.2",
-    "@types/node-zendesk": "^2.0.15",
     "@types/remove-markdown": "^0.3.4",
     "@types/uuid": "^9.0.2",
     "axios": "^1.7.9",

--- a/connectors/src/connectors/zendesk/lib/errors.ts
+++ b/connectors/src/connectors/zendesk/lib/errors.ts
@@ -1,12 +1,3 @@
-/**
- * Errors returned by the library node-zendesk.
- * Check out https://github.com/blakmatrix/node-zendesk/blob/fa069d927bd418ee2058bb7bb913f9414e395110/src/clients/helpers.js#L262
- */
-interface NodeZendeskError extends Error {
-  statusCode: number;
-  result: string | null;
-}
-
 export class ZendeskApiError extends Error {
   readonly status?: number;
   readonly data?: object;
@@ -16,17 +7,6 @@ export class ZendeskApiError extends Error {
     this.status = status;
     this.data = data;
   }
-}
-
-export function isNodeZendeskForbiddenError(
-  err: unknown
-): err is NodeZendeskError {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "statusCode" in err &&
-    err.statusCode === 403
-  );
 }
 
 export function isZendeskForbiddenError(err: unknown): err is ZendeskApiError {
@@ -65,13 +45,4 @@ export function isZendeskNotFoundError(
   err: unknown
 ): err is ZendeskApiError & boolean {
   return err instanceof ZendeskApiError && err.status === 404;
-}
-
-export function isNodeZendeskEpipeError(err: unknown): err is NodeZendeskError {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    err.code === "EPIPE"
-  );
 }

--- a/connectors/src/connectors/zendesk/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/zendesk/temporal/cast_known_errors.ts
@@ -5,15 +5,12 @@ import type {
 } from "@temporalio/worker";
 
 import {
-  isNodeZendeskEpipeError,
-  isNodeZendeskForbiddenError,
   isZendeskExpiredCursorError,
   isZendeskForbiddenError,
 } from "@connectors/connectors/zendesk/lib/errors";
 import {
   DustConnectorWorkflowError,
   ExternalOAuthTokenError,
-  ProviderWorkflowError,
 } from "@connectors/lib/error";
 
 export class ZendeskCastKnownErrorsInterceptor
@@ -26,19 +23,12 @@ export class ZendeskCastKnownErrorsInterceptor
     try {
       return await next(input);
     } catch (err: unknown) {
-      if (isNodeZendeskForbiddenError(err) || isZendeskForbiddenError(err)) {
+      if (isZendeskForbiddenError(err)) {
         throw new ExternalOAuthTokenError(err);
       } else if (isZendeskExpiredCursorError(err)) {
         throw new DustConnectorWorkflowError(
           "Cursor expired",
           "unhandled_internal_activity_error",
-          err
-        );
-      } else if (isNodeZendeskEpipeError(err)) {
-        throw new ProviderWorkflowError(
-          "zendesk",
-          "EPIPE",
-          "transient_upstream_activity_error",
           err
         );
       }


### PR DESCRIPTION
## Description

- At the very beginning of the implementation of the Zendesk connector we used a lib called `node-zendesk`.
- We're not using it anymore, this PR cleans up the remaining typeguards around errors coming from this lib + the dependency.

## Tests

- Tested locally.

## Risk

- Low to medium: technically removes a lot of code via the dependency.

## Deploy Plan

- Deploy connectors.
