### PR TITLE
Improve deploy by listing all commits since last successful build

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -46,6 +46,17 @@ inputs:
     required: false
     default: "us"
 
+outputs:
+  current_version:
+    description: "Previously deployed version"
+    value: ${{ steps.current_version.outputs.current_tag }}
+  commit_diff:
+    description: "Commit diff between versions"
+    value: ${{ steps.commit_info.outputs.commits }}
+  commit_count:
+    description: "Number of commits in diff"
+    value: ${{ steps.commit_info.outputs.commit_count }}
+
 runs:
   using: "composite"
   steps:
@@ -133,3 +144,59 @@ runs:
           ${build_args[@]} \
           --push \
           .
+
+    - name: Get current deployed version
+      id: current_version
+      shell: bash
+      run: |
+        echo "🔍 Getting current deployed version for ${{ inputs.component }} in ${{ inputs.region }}..."
+        
+        # Get all tags, exclude the current one we're building, get the most recent
+        ALL_TAGS=$(gcloud container images list-tags "${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${{ inputs.component }}" \
+          --limit=10 \
+          --sort-by=~timestamp \
+          --format="value(tags[0])" 2>/dev/null || echo "")
+        
+        # Filter out current tag and get the first remaining one
+        CURRENT_TAG=""
+        while IFS= read -r tag; do
+          if [ -n "$tag" ] && [ "$tag" != "${{ inputs.commit_sha }}" ]; then
+            CURRENT_TAG="$tag"
+            break
+          fi
+        done <<< "$ALL_TAGS"
+        
+        echo "Current deployed version: ${CURRENT_TAG:-'none found'}"
+        echo "current_tag=$CURRENT_TAG" >> $GITHUB_OUTPUT
+
+    - name: Get commit diff
+      if: steps.current_version.outputs.current_tag != ''
+      id: commit_info
+      shell: bash
+      run: |
+        CURRENT_TAG="${{ steps.current_version.outputs.current_tag }}"
+        TARGET_TAG="${{ inputs.commit_sha }}"
+        
+        echo "📋 Getting commit diff: $CURRENT_TAG → $TARGET_TAG"
+        
+        # Get commits between versions (handle case where CURRENT_TAG might not exist in git)
+        if git cat-file -e "$CURRENT_TAG" 2>/dev/null; then
+          COMMITS=$(git log --oneline --pretty=format:"%h %s (%an)" $CURRENT_TAG..$TARGET_TAG 2>/dev/null | head -10)
+        else
+          echo "Previous tag $CURRENT_TAG not found in git history, showing recent commits"
+          COMMITS=$(git log --oneline --pretty=format:"%h %s (%an)" -10 $TARGET_TAG 2>/dev/null)
+        fi
+        
+        # Count commits safely
+        if [ -n "$COMMITS" ]; then
+          COMMIT_COUNT=$(echo "$COMMITS" | wc -l | tr -d ' ')
+        else
+          COMMIT_COUNT=0
+        fi
+        
+        # Store results
+        echo "commits<<EOF" >> $GITHUB_OUTPUT
+        echo "$COMMITS" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+        
+        echo "commit_count=$COMMIT_COUNT" >> $GITHUB_OUTPUT

--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -30,6 +30,15 @@ inputs:
     description: "Whether reverting or deploying"
     required: false
     default: "false"
+  current_version:
+    description: "Current deployed version for comparison"
+    required: false
+  commit_diff:
+    description: "Commit diff information"
+    required: false
+  commit_count:
+    description: "Number of commits in the diff"
+    required: false
 
 outputs:
   thread_ts:
@@ -90,6 +99,20 @@ runs:
             • Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ inputs.image_tag }}>
             • Workflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View build>
             • Author: ${{ steps.slack_user.outputs.id != '' && format('<@{0}>', steps.slack_user.outputs.id) || format('`{0}`', steps.author.outputs.name) }}
+
+    - name: Notify Build Success
+      if: inputs.step == 'build_success'
+      uses: slackapi/slack-github-action@v2.0.0
+      with:
+        method: chat.postMessage
+        token: ${{ inputs.slack_token }}
+        payload: |
+          channel: ${{ inputs.channel }}
+          thread_ts: ${{ inputs.thread_ts }}
+          text: |
+            ✅ **${{ inputs.region }}**: Built and pushed `${{ inputs.component }}:${{ inputs.image_tag }}`
+            ${{ inputs.current_version != '' && format('📋 *Changes*: {0} → {1} ({2} commits)', inputs.current_version, inputs.image_tag, inputs.commit_count) || format('📋 *New deployment*: {0}', inputs.image_tag) }}
+            ${{ inputs.commit_diff != '' && format('```{0}```', inputs.commit_diff) || '' }}
 
     - name: Notify Deploy Failure
       if: inputs.step == 'failure'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,7 @@ jobs:
           fi
 
       - name: Build Image
+        id: build
         uses: ./.github/actions/build-image
         with:
           commit_sha_long: ${{ needs.prepare.outputs.long_sha }}
@@ -158,6 +159,20 @@ jobs:
           region: ${{ matrix.region }}
           virtuoso_license_key: ${{ secrets.VIRTUOSO_LICENSE_KEY }}
           workload_identity_provider: "projects/357744735673/locations/global/workloadIdentityPools/github-pool-apps/providers/github-provider-apps"
+
+      - name: Notify build success
+        uses: ./.github/actions/slack-notify
+        with:
+          step: "build_success"
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
+          component: ${{ inputs.component }}
+          image_tag: ${{ needs.prepare.outputs.short_sha }}
+          region: ${{ matrix.region }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          current_version: ${{ steps.build.outputs.current_version }}
+          commit_diff: ${{ steps.build.outputs.commit_diff }}
+          commit_count: ${{ steps.build.outputs.commit_count }}
 
       - name: Notify Failure
         if: failure()


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims at improving the GH action that deploys to list all commits that goes out in the deploy. We need this to be able to find quickly which deploy bundled which commit in case we need to revert. This is only the first step to improve our deploy/rollback flow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
