### PR TITLE
Add script to send email on reasoning tool sunset

### DIFF
--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -63,9 +63,7 @@ async function sendReasoningToolRemovalEmail(
     throw new Error("DUST_CLIENT_FACING_URL is not defined");
   }
 
-  let body = `<p>Hi ${record.author_first_name},</p>
-
-<p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on Friday, November 28th.</p>
+  let body = `<p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on Friday, November 28th.</p>
 
 <ul>
 ${agentList

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -54,10 +54,7 @@ const sendReasoningToolRemovalEmail = async (
   const agentList = record.agent_list.trim();
   const minReasoningEffort = record.min_reasoning_effort.trim().toLowerCase();
 
-  // TODO: get first name.
-  const firstName = email.split("@")[0];
-
-  let body = `<p>Hi ${firstName},</p>
+  let body = `<p>Hi ${record.first_name},</p>
 
 <p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on [DATE].</p>
 

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -165,10 +165,10 @@ The Dust Team</p>`;
       };
     }
 
-    childLogger.info("Successfully sent email");
+    childLogger.info({ email }, "Successfully sent email");
     return { success: true };
   } else {
-    childLogger.info({ minReasoningEffort }, "Would send email");
+    childLogger.info({ email, body }, "Would send email");
     return { success: true };
   }
 }

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -43,11 +43,11 @@ async function readCsvFile(
   return parseResult.data;
 }
 
-const sendReasoningToolRemovalEmail = async (
+async function sendReasoningToolRemovalEmail(
   record: CsvRecord,
   execute: boolean,
   logger: Logger
-): Promise<{ success: boolean; error?: string }> => {
+): Promise<{ success: boolean; error?: string }> {
   const childLogger = logger.child({ email: record.email });
 
   const email = record.email.trim().toLowerCase();
@@ -165,7 +165,7 @@ The Dust Team</p>`;
     childLogger.info({ minReasoningEffort }, "Would send email");
     return { success: true };
   }
-};
+}
 
 makeScript(
   {

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -11,10 +11,11 @@ import { z } from "zod";
 const MAIL_CONCURRENCY = 5;
 
 const CsvRecordSchema = z.object({
-  first_name: z.string(),
+  author_first_name: z.string(),
   email: z.string(),
   agent_list: z.string(),
   min_reasoning_effort: z.string(),
+  workspace_id: z.string(),
 });
 
 type CsvRecord = z.infer<typeof CsvRecordSchema>;
@@ -54,7 +55,7 @@ async function sendReasoningToolRemovalEmail(
   const agentList = record.agent_list.trim();
   const minReasoningEffort = record.min_reasoning_effort.trim().toLowerCase();
 
-  let body = `<p>Hi ${record.first_name},</p>
+  let body = `<p>Hi ${record.author_first_name},</p>
 
 <p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on Friday, November 28th.</p>
 
@@ -182,18 +183,6 @@ makeScript(
 
     if (records.length === 0) {
       throw new Error("CSV file is empty");
-    }
-
-    const firstRecord = records[0];
-    if (
-      !firstRecord ||
-      !("email" in firstRecord) ||
-      !("agent_list" in firstRecord) ||
-      !("min_reasoning_effort" in firstRecord)
-    ) {
-      throw new Error(
-        "CSV file must have 'email', 'agent_list', and 'min_reasoning_effort' columns"
-      );
     }
 
     const validRecords = records.filter((record) => {

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -73,7 +73,7 @@ ${agentList
   .map((agent) => {
     const [agentId, agentName] = agent.trim().split("|");
     const agentUrl = `${baseUrl}/w/${workspaceId}/builder/agents/${agentId}`;
-    return `  <li><a href="${agentUrl.replace('"', "")}">${agentName}</a></li>`;
+    return `  <li><a href=${agentUrl}>${agentName}</a></li>`;
   })
   .join("\n")}
 </ul>

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -126,7 +126,7 @@ ${agentList
   body += `
 <h3>Questions?</h3>
 
-<p>If you have any concerns, please reach out to our support team.</p>
+<p>If you have any concerns, please reach out to us at support@dust.tt</p>
 
 <p>Thank you for building with Dust!</p>
 

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -152,7 +152,7 @@ The Dust Team</p>`;
         name: "Dust team",
         email: "team@dust.tt",
       },
-      subject: "[Dust] Update: Reasoning Tool Removal",
+      subject: "Reasoning tool removal on November 28th",
       body,
     });
 

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -44,6 +44,7 @@ const sendReasoningToolRemovalEmail = async (
   const agentList = record.agent_list.trim();
   const minReasoningEffort = record.min_reasoning_effort.trim().toLowerCase();
 
+  // TODO: get first name.
   const firstName = email.split("@")[0];
 
   let body = `<p>Hi ${firstName},</p>
@@ -53,6 +54,7 @@ const sendReasoningToolRemovalEmail = async (
 <ul>
 ${agentList
   .split(",")
+  // TODO: get agent name + sId, make it clickable.
   .map((agent) => `  <li>${agent.trim()}</li>`)
   .join("\n")}
 </ul>

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -46,61 +46,7 @@ const sendReasoningToolRemovalEmail = async (
 
   const firstName = email.split("@")[0];
 
-  const isVersionA =
-    minReasoningEffort === "medium" || minReasoningEffort === "high";
-
-  let body: string;
-
-  if (isVersionA) {
-    body = `<p>Hi ${firstName},</p>
-
-<p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on [DATE]:</p>
-
-<ul>
-${agentList
-  .split(",")
-  .map((agent) => `  <li>${agent.trim()}</li>`)
-  .join("\n")}
-</ul>
-
-<h3>Why we're making this change</h3>
-
-<p>When we introduced the Reasoning tool in early 2025, it was designed to give you access to pure reasoning models like o1 and DeepSeek R1. These models excelled at deep, step-by-step thinking, but they could <em>only</em> reason, they could not use any tools. So we turned them into a tool themselves, allowing you to combine their reasoning capabilities with other models that <em>could</em> search your company data, browse the web, or query databases. This was the beginning of us exploring the potential of sub-agents: agents that could leverage deep reasoning <em>plus</em> take actions.</p>
-
-<p>Today, modern reasoning models like GPT-5, o3, o4-mini, and Claude Sonnet 4.5 combine the best of both worlds. They can think deeply <em>while simultaneously</em> using tools—searching your data, browsing the web, querying databases, and more. Using these as your agent's base model delivers better performance with lower latency.</p>
-
-<h3>What happens next</h3>
-
-<p>Good news: You're already set up for success!</p>
-
-<p>Your agent is already configured with medium or high reasoning effort, which means you're already leveraging the full reasoning capabilities of your base model. When we remove the Reasoning tool on [DATE]:</p>
-
-<ul>
-  <li>Your agents will continue working normally with their current strong reasoning capabilities</li>
-  <li>No action required from you</li>
-  <li>Your agent will continue reasoning deeply while using all its tools</li>
-</ul>
-
-<p>The Reasoning tool will simply be removed automatically, and your agent's performance will remain great, or even improve slightly due to reduced overhead.</p>
-
-<h3>Timeline</h3>
-
-<ul>
-  <li>[DATE]: Reasoning tool removed from all agents</li>
-  <li>No action needed: Your agents are already optimized</li>
-</ul>
-
-<h3>Questions?</h3>
-
-<p>If you have any concerns, please reach out to our support team or reply to this email.</p>
-
-<p>Thank you for building with Dust!</p>
-
-<p>Best regards,<br>
-[Your Name]<br>
-The Dust Team</p>`;
-  } else {
-    body = `<p>Hi ${firstName},</p>
+  let body = `<p>Hi ${firstName},</p>
 
 <p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on [DATE].</p>
 
@@ -116,7 +62,34 @@ ${agentList
 <p>When we introduced the Reasoning tool in early 2025, it was designed to give you access to pure reasoning models like o1 and DeepSeek R1. These models excelled at deep, step-by-step thinking, but they could <em>only</em> reason, they could not use any tools. So we turned them into a tool themselves, allowing you to combine their reasoning capabilities with other models that <em>could</em> search your company data, browse the web, or query databases. This was the beginning of us exploring the potential of sub-agents: agents that could leverage deep reasoning <em>plus</em> take actions.</p>
 
 <p>Today, modern reasoning models like GPT-5, o3, o4-mini, and Claude Sonnet 4.5 combine the best of both worlds. They can think deeply <em>while simultaneously</em> using tools—searching your data, browsing the web, querying databases, and more. Using these as your agent's base model delivers better performance with lower latency.</p>
+`;
 
+  // Next steps.
+  if (minReasoningEffort === "medium" || minReasoningEffort === "high") {
+    body += `
+<h3>What happens next</h3>
+
+<p>Good news: You're already set up for success!</p>
+
+<p>Your agents are already configured with medium or high reasoning effort, which means you're already leveraging the full reasoning capabilities of your base model. When we remove the Reasoning tool on [DATE]:</p>
+
+<ul>
+  <li>Your agents will continue working normally with their current strong reasoning capabilities</li>
+  <li>No action required from you</li>
+  <li>Your agent will continue reasoning deeply while using all its tools</li>
+</ul>
+
+<p>The Reasoning tool will simply be removed automatically, and your agent's performance will remain great, or even improve slightly due to reduced overhead.</p>
+
+<h3>Timeline</h3>
+
+<ul>
+  <li>[DATE]: Reasoning tool removed from all agents</li>
+  <li>No action needed: Your agents are already optimized</li>
+</ul>
+`;
+  } else {
+    body = `
 <h3>What happens next</h3>
 
 <p><strong>Automatic migration (no action required):</strong></p>
@@ -143,17 +116,20 @@ ${agentList
   <li>[DATE]: Reasoning tool removed from all agents</li>
   <li>Before [DATE]: Optionally adjust your agent's reasoning configuration</li>
 </ul>
+`;
+  }
 
+  // Footer.
+  body += `
 <h3>Questions?</h3>
 
-<p>If you have any concerns, please reach out to our support team or reply to this email.</p>
+<p>If you have any concerns, please reach out to our support team.</p>
 
 <p>Thank you for building with Dust!</p>
 
 <p>Best regards,<br>
 [Your Name]<br>
 The Dust Team</p>`;
-  }
 
   if (execute) {
     const emailResult = await sendEmailWithTemplate({
@@ -177,7 +153,7 @@ The Dust Team</p>`;
     childLogger.info("Successfully sent email");
     return { success: true };
   } else {
-    childLogger.info({ version: isVersionA ? "A" : "B" }, "Would send email");
+    childLogger.info({ minReasoningEffort }, "Would send email");
     return { success: true };
   }
 };

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -1,0 +1,271 @@
+import { parse } from "csv-parse";
+import * as fs from "fs";
+
+import { sendEmailWithTemplate } from "@app/lib/api/email";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { isString, normalizeError } from "@app/types";
+
+const MAIL_CONCURRENCY = 5;
+
+interface CsvRecord {
+  email: string;
+  agent_list: string;
+  min_reasoning_effort: string;
+}
+
+const readCsvFile = async (filePath: string): Promise<CsvRecord[]> => {
+  const parser = parse({
+    delimiter: ",",
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+  });
+
+  const records: CsvRecord[] = [];
+  fs.createReadStream(filePath).pipe(parser);
+
+  for await (const record of parser) {
+    records.push(record);
+  }
+
+  return records;
+};
+
+const sendReasoningToolRemovalEmail = async (
+  record: CsvRecord,
+  execute: boolean,
+  logger: Logger
+): Promise<{ success: boolean; error?: string }> => {
+  const childLogger = logger.child({ email: record.email });
+
+  const email = record.email.trim().toLowerCase();
+  const agentList = record.agent_list.trim();
+  const minReasoningEffort = record.min_reasoning_effort.trim().toLowerCase();
+
+  const firstName = email.split("@")[0];
+
+  const isVersionA =
+    minReasoningEffort === "medium" || minReasoningEffort === "high";
+
+  let body: string;
+
+  if (isVersionA) {
+    body = `<p>Hi ${firstName},</p>
+
+<p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on [DATE]:</p>
+
+<ul>
+${agentList
+  .split(",")
+  .map((agent) => `  <li>${agent.trim()}</li>`)
+  .join("\n")}
+</ul>
+
+<h3>Why we're making this change</h3>
+
+<p>When we introduced the Reasoning tool in early 2025, it was designed to give you access to pure reasoning models like o1 and DeepSeek R1. These models excelled at deep, step-by-step thinking, but they could <em>only</em> reason, they could not use any tools. So we turned them into a tool themselves, allowing you to combine their reasoning capabilities with other models that <em>could</em> search your company data, browse the web, or query databases. This was the beginning of us exploring the potential of sub-agents: agents that could leverage deep reasoning <em>plus</em> take actions.</p>
+
+<p>Today, modern reasoning models like GPT-5, o3, o4-mini, and Claude Sonnet 4.5 combine the best of both worlds. They can think deeply <em>while simultaneously</em> using tools—searching your data, browsing the web, querying databases, and more. Using these as your agent's base model delivers better performance with lower latency.</p>
+
+<h3>What happens next</h3>
+
+<p>Good news: You're already set up for success!</p>
+
+<p>Your agent is already configured with medium or high reasoning effort, which means you're already leveraging the full reasoning capabilities of your base model. When we remove the Reasoning tool on [DATE]:</p>
+
+<ul>
+  <li>Your agents will continue working normally with their current strong reasoning capabilities</li>
+  <li>No action required from you</li>
+  <li>Your agent will continue reasoning deeply while using all its tools</li>
+</ul>
+
+<p>The Reasoning tool will simply be removed automatically, and your agent's performance will remain great, or even improve slightly due to reduced overhead.</p>
+
+<h3>Timeline</h3>
+
+<ul>
+  <li>[DATE]: Reasoning tool removed from all agents</li>
+  <li>No action needed: Your agents are already optimized</li>
+</ul>
+
+<h3>Questions?</h3>
+
+<p>If you have any concerns, please reach out to our support team or reply to this email.</p>
+
+<p>Thank you for building with Dust!</p>
+
+<p>Best regards,<br>
+[Your Name]<br>
+The Dust Team</p>`;
+  } else {
+    body = `<p>Hi ${firstName},</p>
+
+<p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on [DATE].</p>
+
+<ul>
+${agentList
+  .split(",")
+  .map((agent) => `  <li>${agent.trim()}</li>`)
+  .join("\n")}
+</ul>
+
+<h3>Why we're making this change</h3>
+
+<p>When we introduced the Reasoning tool in early 2025, it was designed to give you access to pure reasoning models like o1 and DeepSeek R1. These models excelled at deep, step-by-step thinking, but they could <em>only</em> reason, they could not use any tools. So we turned them into a tool themselves, allowing you to combine their reasoning capabilities with other models that <em>could</em> search your company data, browse the web, or query databases. This was the beginning of us exploring the potential of sub-agents: agents that could leverage deep reasoning <em>plus</em> take actions.</p>
+
+<p>Today, modern reasoning models like GPT-5, o3, o4-mini, and Claude Sonnet 4.5 combine the best of both worlds. They can think deeply <em>while simultaneously</em> using tools—searching your data, browsing the web, querying databases, and more. Using these as your agent's base model delivers better performance with lower latency.</p>
+
+<h3>What happens next</h3>
+
+<p><strong>Automatic migration (no action required):</strong></p>
+
+<ul>
+  <li>On [DATE], we'll automatically remove the Reasoning tool from all agents</li>
+  <li>Your agents will continue working normally</li>
+  <li>No configuration changes needed from you</li>
+</ul>
+
+<p><strong>Recommended: Maintain strong reasoning capabilities</strong></p>
+
+<p>Since your agent currently uses the Reasoning tool and has ${minReasoningEffort} reasoning effort configured, we recommend one of these options to maintain strong reasoning:</p>
+
+<p><strong>Option 1: Increase reasoning effort</strong> - Edit your agent and set <code>reasoningEffort</code> to "medium" or "high" in the model settings of Agent Builder</p>
+
+<p><strong>Option 2: Switch to a reasoning model</strong> - Change your base model to GPT-5 or Claude Sonnet 4.5 with "medium" or "high" reasoning effort</p>
+
+<p><strong>Option 3: Do nothing</strong> - For simpler use cases, your current setup may work fine without the Reasoning tool</p>
+
+<h3>Timeline</h3>
+
+<ul>
+  <li>[DATE]: Reasoning tool removed from all agents</li>
+  <li>Before [DATE]: Optionally adjust your agent's reasoning configuration</li>
+</ul>
+
+<h3>Questions?</h3>
+
+<p>If you have any concerns, please reach out to our support team or reply to this email.</p>
+
+<p>Thank you for building with Dust!</p>
+
+<p>Best regards,<br>
+[Your Name]<br>
+The Dust Team</p>`;
+  }
+
+  if (execute) {
+    const emailResult = await sendEmailWithTemplate({
+      to: email,
+      from: {
+        name: "Dust team",
+        email: "team@dust.tt",
+      },
+      subject: "[Dust] Important Update: Reasoning Tool Removal",
+      body,
+    });
+
+    if (emailResult.isErr()) {
+      childLogger.error({ error: emailResult.error }, "Failed to send email");
+      return {
+        success: false,
+        error: normalizeError(emailResult.error).message,
+      };
+    }
+
+    childLogger.info("Successfully sent email");
+    return { success: true };
+  } else {
+    childLogger.info({ version: isVersionA ? "A" : "B" }, "Would send email");
+    return { success: true };
+  }
+};
+
+makeScript(
+  {
+    csvPath: {
+      alias: "csv",
+      describe:
+        "Path to the CSV file containing email, agent_list, and min_reasoning_effort",
+      type: "string",
+      demandOption: true,
+    },
+  },
+  async ({ csvPath, execute }, logger) => {
+    logger.info(
+      { csvPath, execute },
+      "Starting reasoning tool removal email script"
+    );
+
+    const records: CsvRecord[] = await readCsvFile(csvPath);
+    logger.info(`Read ${records.length} records from CSV file`);
+
+    if (records.length === 0) {
+      throw new Error("CSV file is empty");
+    }
+
+    const firstRecord = records[0];
+    if (
+      !firstRecord ||
+      !("email" in firstRecord) ||
+      !("agent_list" in firstRecord) ||
+      !("min_reasoning_effort" in firstRecord)
+    ) {
+      throw new Error(
+        "CSV file must have 'email', 'agent_list', and 'min_reasoning_effort' columns"
+      );
+    }
+
+    const validRecords = records.filter((record) => {
+      if (
+        !isString(record.email) ||
+        !isString(record.agent_list) ||
+        !isString(record.min_reasoning_effort)
+      ) {
+        logger.warn({ record }, "Skipping record with invalid data");
+        return false;
+      }
+      return true;
+    });
+
+    logger.info(`Processing ${validRecords.length} valid records`);
+
+    const results = await concurrentExecutor(
+      validRecords,
+      async (record) => {
+        const result = await sendReasoningToolRemovalEmail(
+          record,
+          execute,
+          logger
+        );
+        return { email: record.email, ...result };
+      },
+      { concurrency: MAIL_CONCURRENCY }
+    );
+
+    const successful = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success).length;
+
+    logger.info(
+      {
+        total: results.length,
+        successful,
+        failed,
+        execute,
+      },
+      "Reasoning tool removal email script completed"
+    );
+
+    const failures = results.filter((r) => !r.success);
+    if (failures.length > 0) {
+      logger.warn({ failures }, "Some operations failed");
+    }
+
+    if (execute) {
+      logger.info(`Successfully sent ${successful} emails`);
+    } else {
+      logger.info(`Would send ${successful} emails`);
+    }
+  }
+);

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -73,7 +73,7 @@ ${agentList
   .map((agent) => {
     const [agentId, agentName] = agent.trim().split("|");
     const agentUrl = `${baseUrl}/w/${workspaceId}/builder/agents/${agentId}`;
-    return `  <li><a href="${agentUrl}">${agentName}</a></li>`;
+    return `  <li><a href="${agentUrl.replace('"', "")}">${agentName}</a></li>`;
   })
   .join("\n")}
 </ul>

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -104,7 +104,7 @@ ${agentList
 </ul>
 `;
   } else {
-    body = `
+    body += `
 <h3>What happens next</h3>
 
 <p><strong>Automatic migration (no action required):</strong></p>

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -143,7 +143,6 @@ ${agentList
 <p>Thank you for building with Dust!</p>
 
 <p>Best regards,<br>
-[Your Name]<br>
 The Dust Team</p>`;
 
   if (execute) {

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -80,13 +80,7 @@ ${agentList
 
 <p>Good news: You're already set up for success!</p>
 
-<p>Your agents are already configured with medium or high reasoning effort, which means you're already leveraging the full reasoning capabilities of your base model. When we remove the Reasoning tool on Friday, November 28th:</p>
-
-<ul>
-  <li>Your agents will continue working normally with their current strong reasoning capabilities</li>
-  <li>No action required from you</li>
-  <li>Your agent will continue reasoning deeply while using all its tools</li>
-</ul>
+<p>Your agents are already configured with medium or high reasoning effort, which means you're already leveraging the full reasoning capabilities of your base model.</p>
 
 <p>The Reasoning tool will simply be removed automatically, and your agent's performance will remain great, or even improve slightly due to reduced overhead.</p>
 
@@ -111,9 +105,9 @@ ${agentList
 
 <p><strong>Recommended: Maintain strong reasoning capabilities</strong></p>
 
-<p>Since your agent currently uses the Reasoning tool and has ${minReasoningEffort} reasoning effort configured, we recommend one of these options to maintain strong reasoning:</p>
+<p>Since your agent currently uses the Reasoning tool and has ${minReasoningEffort === "none" ? "no" : minReasoningEffort} reasoning effort configured, we recommend one of these options to maintain strong reasoning:</p>
 
-<p><strong>Option 1: Increase reasoning effort</strong> - Edit your agent and set <code>reasoningEffort</code> to "medium" or "high" in the model settings of Agent Builder</p>
+<p><strong>Option 1: Increase reasoning effort</strong> - Edit your agent and set <code>reasoningEffort</code> to "medium" or "high" in the model settings of Agent Builder if the underlying model supports it</p>
 
 <p><strong>Option 2: Switch to a reasoning model</strong> - Change your base model to GPT-5 or Claude Sonnet 4.5 with "medium" or "high" reasoning effort</p>
 

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -15,7 +15,7 @@ const { DUST_CLIENT_FACING_URL } = process.env;
 const CsvRecordSchema = z.object({
   author_first_name: z.string(),
   email: z.string(),
-  agent_list: z.string(),
+  agents: z.string(),
   min_reasoning_effort: z.string().optional(),
   workspace_id: z.string(),
 });
@@ -54,7 +54,7 @@ async function sendReasoningToolRemovalEmail(
   const childLogger = logger.child({ email: record.email });
 
   const email = record.email.trim().toLowerCase();
-  const agentList = record.agent_list.trim();
+  const agentList = record.agents.trim();
   const minReasoningEffort = record.min_reasoning_effort?.trim().toLowerCase();
   const workspaceId = record.workspace_id.trim();
 
@@ -177,7 +177,7 @@ makeScript(
     csvPath: {
       alias: "csv",
       describe:
-        "Path to the CSV file containing email, agent_list, and min_reasoning_effort",
+        "Path to the CSV file containing email, agents, and min_reasoning_effort",
       type: "string",
       demandOption: true,
     },
@@ -198,7 +198,7 @@ makeScript(
     const validRecords = records.filter((record) => {
       if (
         !isString(record.email) ||
-        !isString(record.agent_list) ||
+        !isString(record.agents) ||
         !isString(record.min_reasoning_effort)
       ) {
         logger.warn({ record }, "Skipping record with invalid data");

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -14,7 +14,7 @@ const { DUST_CLIENT_FACING_URL } = process.env;
 
 const CsvRecordSchema = z.object({
   author_first_name: z.string(),
-  email: z.string(),
+  author_email: z.string(),
   agents: z.string(),
   min_reasoning_effort: z.string().optional(),
   workspace_id: z.string(),
@@ -51,9 +51,9 @@ async function sendReasoningToolRemovalEmail(
   execute: boolean,
   logger: Logger
 ): Promise<{ success: boolean; error?: string }> {
-  const childLogger = logger.child({ email: record.email });
+  const childLogger = logger.child({ email: record.author_email });
 
-  const email = record.email.trim().toLowerCase();
+  const email = record.author_email.trim().toLowerCase();
   const agentList = record.agents.trim();
   const minReasoningEffort = record.min_reasoning_effort?.trim().toLowerCase();
   const workspaceId = record.workspace_id.trim();
@@ -197,7 +197,7 @@ makeScript(
 
     const validRecords = records.filter((record) => {
       if (
-        !isString(record.email) ||
+        !isString(record.author_email) ||
         !isString(record.agents) ||
         !isString(record.min_reasoning_effort)
       ) {
@@ -217,7 +217,7 @@ makeScript(
           execute,
           logger
         );
-        return { email: record.email, ...result };
+        return { email: record.author_email, ...result };
       },
       { concurrency: MAIL_CONCURRENCY }
     );

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -136,7 +136,6 @@ ${agentList
 
   // Footer.
   body += `
-<h3>Questions?</h3>
 
 <p>If you have any concerns, please reach out to us at support@dust.tt</p>
 

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -16,7 +16,7 @@ const CsvRecordSchema = z.object({
   author_first_name: z.string(),
   email: z.string(),
   agent_list: z.string(),
-  min_reasoning_effort: z.string(),
+  min_reasoning_effort: z.string().optional(),
   workspace_id: z.string(),
 });
 
@@ -55,7 +55,7 @@ async function sendReasoningToolRemovalEmail(
 
   const email = record.email.trim().toLowerCase();
   const agentList = record.agent_list.trim();
-  const minReasoningEffort = record.min_reasoning_effort.trim().toLowerCase();
+  const minReasoningEffort = record.min_reasoning_effort?.trim().toLowerCase();
   const workspaceId = record.workspace_id.trim();
 
   const baseUrl = DUST_CLIENT_FACING_URL;
@@ -117,7 +117,7 @@ ${agentList
 
 <p><strong>Recommended: Maintain strong reasoning capabilities</strong></p>
 
-<p>Since your agent currently uses the Reasoning tool and has ${minReasoningEffort === "none" ? "no" : minReasoningEffort} reasoning effort configured, we recommend one of these options to maintain strong reasoning:</p>
+<p>Since your agent currently uses the Reasoning tool${minReasoningEffort ? ` and has ${minReasoningEffort === "none" ? "no" : minReasoningEffort} reasoning effort configured` : ""}, we recommend one of these options to maintain strong reasoning:</p>
 
 <p><strong>Option 1: Increase reasoning effort</strong> - Edit your agent and set <code>reasoningEffort</code> to "medium" or "high" in the model settings of Agent Builder if the underlying model supports it</p>
 

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -140,10 +140,9 @@ ${agentList
 
 <p>If you have any concerns, please reach out to us at support@dust.tt</p>
 
-<p>Thank you for building with Dust!</p>
+<p>Thank you for building with Dust!</p><br/>
 
-<p>Best regards,<br>
-The Dust Team</p>`;
+<p>Best regards,`;
 
   if (execute) {
     const emailResult = await sendEmailWithTemplate({

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -153,7 +153,7 @@ The Dust Team</p>`;
         name: "Dust team",
         email: "team@dust.tt",
       },
-      subject: "[Dust] Important Update: Reasoning Tool Removal",
+      subject: "[Dust] Update: Reasoning Tool Removal",
       body,
     });
 

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -82,7 +82,7 @@ ${agentList
 
 <p>When we introduced the Reasoning tool in early 2025, it was designed to give you access to pure reasoning models like o1 and DeepSeek R1. These models excelled at deep, step-by-step thinking, but they could <em>only</em> reason, they could not use any tools. So we turned them into a tool themselves, allowing you to combine their reasoning capabilities with other models that <em>could</em> search your company data, browse the web, or query databases. This was the beginning of us exploring the potential of sub-agents: agents that could leverage deep reasoning <em>plus</em> take actions.</p>
 
-<p>Today, modern reasoning models like GPT-5, o3, o4-mini, and Claude Sonnet 4.5 combine the best of both worlds. They can think deeply <em>while simultaneously</em> using tools—searching your data, browsing the web, querying databases, and more. Using these as your agent's base model delivers better performance with lower latency.</p>
+<p>Today, modern reasoning models like GPT-5, o3, o4-mini, and Claude Sonnet 4.5 combine the best of both worlds. They can think deeply <em>while simultaneously</em> using tools: searching your data, browsing the web, querying databases, and more. Using these as your agent's base model delivers better performance with lower latency.</p>
 `;
 
   // Next steps.

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -17,6 +17,8 @@ const CsvRecordSchema = z.object({
   min_reasoning_effort: z.string(),
 });
 
+type CsvRecord = z.infer<typeof CsvRecordSchema>;
+
 async function readCsvFile(
   filePath: string
 ): Promise<z.infer<typeof CsvRecordSchema>[]> {

--- a/front/migrations/20251120_email_sunset_reasoning_tool.ts
+++ b/front/migrations/20251120_email_sunset_reasoning_tool.ts
@@ -56,7 +56,7 @@ const sendReasoningToolRemovalEmail = async (
 
   let body = `<p>Hi ${record.first_name},</p>
 
-<p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on [DATE].</p>
+<p>We're reaching out because you've built the following agents that use the Reasoning tool, which we'll be removing from Dust on Friday, November 28th.</p>
 
 <ul>
 ${agentList
@@ -80,7 +80,7 @@ ${agentList
 
 <p>Good news: You're already set up for success!</p>
 
-<p>Your agents are already configured with medium or high reasoning effort, which means you're already leveraging the full reasoning capabilities of your base model. When we remove the Reasoning tool on [DATE]:</p>
+<p>Your agents are already configured with medium or high reasoning effort, which means you're already leveraging the full reasoning capabilities of your base model. When we remove the Reasoning tool on Friday, November 28th:</p>
 
 <ul>
   <li>Your agents will continue working normally with their current strong reasoning capabilities</li>
@@ -93,7 +93,7 @@ ${agentList
 <h3>Timeline</h3>
 
 <ul>
-  <li>[DATE]: Reasoning tool removed from all agents</li>
+  <li>Friday, November 28th: Reasoning tool removed from all agents</li>
   <li>No action needed: Your agents are already optimized</li>
 </ul>
 `;
@@ -104,7 +104,7 @@ ${agentList
 <p><strong>Automatic migration (no action required):</strong></p>
 
 <ul>
-  <li>On [DATE], we'll automatically remove the Reasoning tool from all agents</li>
+  <li>On Friday, November 28th, we'll automatically remove the Reasoning tool from all agents</li>
   <li>Your agents will continue working normally</li>
   <li>No configuration changes needed from you</li>
 </ul>
@@ -122,8 +122,8 @@ ${agentList
 <h3>Timeline</h3>
 
 <ul>
-  <li>[DATE]: Reasoning tool removed from all agents</li>
-  <li>Before [DATE]: Optionally adjust your agent's reasoning configuration</li>
+  <li>Friday, November 28th: Reasoning tool removed from all agents</li>
+  <li>Before Friday, November 28th: Optionally adjust your agent's reasoning configuration</li>
 </ul>
 `;
   }


### PR DESCRIPTION
## Description

- Thread on the topic [here](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1763566238058979).
- This PR adds a script to send emails to users, warning them about the sunset of the reasoning tool.

Query used to obtain the data:
```sql
SELECT
    u.email as author_email,
    u."firstName" as author_first_name,
    STRING_AGG(DISTINCT ac."sId" || '|' || ac.name, ',') as agents,
    CASE MIN(
        CASE arc."reasoningEffort"
            WHEN 'none' THEN 0
            WHEN 'light' THEN 1
            WHEN 'medium' THEN 2
            WHEN 'high' THEN 3
        END
    )
        WHEN 0 THEN 'none'
        WHEN 1 THEN 'light'
        WHEN 2 THEN 'medium'
        WHEN 3 THEN 'high'
    END as min_reasoning_effort,
	MIN(w."sId") as workspace_id
FROM agent_configurations ac
JOIN users u
    ON ac."authorId" = u.id
JOIN workspaces w
    ON ac."workspaceId" = w.id
JOIN agent_mcp_server_configurations amsc
    ON ac.id = amsc."agentConfigurationId"
JOIN agent_reasoning_configurations arc
    ON amsc.id = arc."mcpServerConfigurationId"
WHERE ac.status = 'active'
GROUP BY u.email, u."firstName";
```

## Tests

## Risk

- None.

## Deploy Plan

- No deploy.
