### PR TITLE
triggers: do not retry trigger if we have reached the rate limit

### DIFF
--- a/front/lib/triggers/temporal/common/client.ts
+++ b/front/lib/triggers/temporal/common/client.ts
@@ -11,10 +11,12 @@ export async function launchAgentTriggerWorkflow({
   auth,
   trigger,
   contentFragment,
+  webhookRequestId,
 }: {
   auth: Authenticator;
   trigger: TriggerType;
   contentFragment?: ContentFragmentInputWithFileIdType;
+  webhookRequestId?: number;
 }): Promise<Result<undefined, Error>> {
   const client = await getTemporalClientForAgentNamespace();
 
@@ -31,6 +33,7 @@ export async function launchAgentTriggerWorkflow({
         workspaceId: auth.getNonNullableWorkspace().sId,
         triggerId: trigger.sId,
         contentFragment,
+        webhookRequestId,
       },
     ],
     taskQueue: QUEUE_NAME,

--- a/front/lib/triggers/temporal/common/workflows.ts
+++ b/front/lib/triggers/temporal/common/workflows.ts
@@ -16,16 +16,19 @@ export async function agentTriggerWorkflow({
   workspaceId,
   triggerId,
   contentFragment,
+  webhookRequestId,
 }: {
   userId: string;
   workspaceId: string;
   triggerId: string;
   contentFragment?: ContentFragmentInputWithFileIdType;
+  webhookRequestId?: number;
 }) {
   await runTriggeredAgentsActivity({
     userId,
     workspaceId,
     triggerId,
     contentFragment,
+    webhookRequestId,
   });
 }

--- a/front/lib/triggers/temporal/webhook/activities.ts
+++ b/front/lib/triggers/temporal/webhook/activities.ts
@@ -479,6 +479,7 @@ export async function runTriggerWebhookActivity({
           auth,
           trigger,
           contentFragment,
+          webhookRequestId,
         });
 
         if (result.isErr()) {


### PR DESCRIPTION
## Description

If the error is hitting the conversation rate limite, then we should not retry as we will hit it again until next day
We should throw a non retryiable error and mark the trigger request as failed.

This won't fix the stuck workflows as their webhookId will still be null, but should work for future workflows

Should fix https://github.com/dust-tt/tasks/issues/4994#issuecomment-3547863959

## Tests

no

## Risk



## Deploy Plan

deploy front
