### PR TITLE
Do not render expired content fragment as rendering fails

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -508,6 +508,10 @@ async function batchRenderContentFragment(
   return Promise.all(
     messagesWithContentFragment.map(async (message: Message) => {
       const contentFragment = ContentFragmentResource.fromMessage(message);
+      if (contentFragment.expiredReason) {
+        // ignore expired content fragments
+        return null;
+      }
       const render = await contentFragment.renderFromMessage({
         auth,
         conversationId,
@@ -516,7 +520,7 @@ async function batchRenderContentFragment(
 
       return render;
     })
-  );
+  ).then((results) => removeNulls(results));
 }
 
 /**


### PR DESCRIPTION
## Description

Trying to avoid error while rendering the conversation by removing the expired content fragment

Another solution might be to render it as expired, but it requires to change the output type and message type to handle a ExpiredContentFragment with less fields

## Tests

no

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front