### PR TITLE
feat(growth): quick replies directive

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -658,7 +658,14 @@ function AgentMessageContent({
       toolSetup: getToolSetupPlugin(owner),
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
     }),
-    [owner, conversationId, sId, agentConfiguration.sId, onQuickReplySend, isLastMessage]
+    [
+      owner,
+      conversationId,
+      sId,
+      agentConfiguration.sId,
+      onQuickReplySend,
+      isLastMessage,
+    ]
   );
 
   const additionalMarkdownPlugins: PluggableList = React.useMemo(

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -656,9 +656,9 @@ function AgentMessageContent({
       mention_user: getUserMentionPlugin(owner),
       dustimg: getImgPlugin(owner),
       toolSetup: getToolSetupPlugin(owner),
-      quickReply: getQuickReplyPlugin(onQuickReplySend),
+      quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
     }),
-    [owner, conversationId, sId, agentConfiguration.sId, onQuickReplySend]
+    [owner, conversationId, sId, agentConfiguration.sId, onQuickReplySend, isLastMessage]
   );
 
   const additionalMarkdownPlugins: PluggableList = React.useMemo(

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -156,6 +156,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               messageStreamState={data}
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}
+              handleSubmit={context.handleSubmit}
             />
           )}
         </div>

--- a/front/components/markdown/QuickReplyBlock.tsx
+++ b/front/components/markdown/QuickReplyBlock.tsx
@@ -2,12 +2,12 @@ import { Button } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 import { visit } from "unist-util-visit";
 
-type QuickReplyBlockProps = {
+interface QuickReplyBlockProps {
   label: string;
   message: string;
   disabled: boolean;
   onSend: (message: string) => Promise<void>;
-};
+}
 
 export function QuickReplyBlock({
   label,

--- a/front/components/markdown/QuickReplyBlock.tsx
+++ b/front/components/markdown/QuickReplyBlock.tsx
@@ -5,18 +5,20 @@ import { visit } from "unist-util-visit";
 type QuickReplyBlockProps = {
   label: string;
   message: string;
+  disabled: boolean;
   onSend: (message: string) => Promise<void>;
 };
 
 export function QuickReplyBlock({
   label,
   message,
+  disabled,
   onSend,
 }: QuickReplyBlockProps) {
   const [isSending, setIsSending] = useState(false);
 
   const handleClick = async () => {
-    if (isSending) {
+    if (isSending || disabled) {
       return;
     }
     setIsSending(true);
@@ -33,7 +35,7 @@ export function QuickReplyBlock({
       variant="outline"
       label={label}
       onClick={handleClick}
-      disabled={isSending}
+      disabled={disabled || isSending}
       loading={isSending}
     />
   );
@@ -56,7 +58,8 @@ export function quickReplyDirective() {
 }
 
 export function getQuickReplyPlugin(
-  onSend: (message: string) => Promise<void>
+  onSend: (message: string) => Promise<void>,
+  isLastMessage: boolean
 ) {
   function QuickReplyPlugin({
     label,
@@ -65,7 +68,14 @@ export function getQuickReplyPlugin(
     label: string;
     message: string;
   }) {
-    return <QuickReplyBlock label={label} message={message} onSend={onSend} />;
+    return (
+      <QuickReplyBlock
+        label={label}
+        message={message}
+        disabled={!isLastMessage}
+        onSend={onSend}
+      />
+    );
   }
 
   return QuickReplyPlugin;

--- a/front/components/markdown/QuickReplyBlock.tsx
+++ b/front/components/markdown/QuickReplyBlock.tsx
@@ -1,0 +1,72 @@
+import { Button } from "@dust-tt/sparkle";
+import React, { useState } from "react";
+import { visit } from "unist-util-visit";
+
+type QuickReplyBlockProps = {
+  label: string;
+  message: string;
+  onSend: (message: string) => Promise<void>;
+};
+
+export function QuickReplyBlock({
+  label,
+  message,
+  onSend,
+}: QuickReplyBlockProps) {
+  const [isSending, setIsSending] = useState(false);
+
+  const handleClick = async () => {
+    if (isSending) {
+      return;
+    }
+    setIsSending(true);
+    try {
+      await onSend(message);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      label={label}
+      onClick={handleClick}
+      disabled={isSending}
+      loading={isSending}
+    />
+  );
+}
+
+export function quickReplyDirective() {
+  return (tree: any) => {
+    visit(tree, ["textDirective"], (node) => {
+      if (node.name === "quickReply" && node.children?.[0]) {
+        const label = node.children[0].value;
+        const data = node.data || (node.data = {});
+        data.hName = "quickReply";
+        data.hProperties = {
+          label,
+          message: node.attributes?.message ?? label,
+        };
+      }
+    });
+  };
+}
+
+export function getQuickReplyPlugin(
+  onSend: (message: string) => Promise<void>
+) {
+  function QuickReplyPlugin({
+    label,
+    message,
+  }: {
+    label: string;
+    message: string;
+  }) {
+    return <QuickReplyBlock label={label} message={message} onSend={onSend} />;
+  }
+
+  return QuickReplyPlugin;
+}

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -64,7 +64,7 @@ export type LightMessageType =
  *
  */
 export type UserMessageOrigin =
-   // TODO(2025-11-24 PPUL): Remove run_agent and agent_handover from allowed origin values.
+  // TODO(2025-11-24 PPUL): Remove run_agent and agent_handover from allowed origin values.
   | "agent_handover" // soon to be removed (not a fitting origin).
   // "api" is Custom API usage, while e.g. extension, gsheets and many other origins
   // below are API usages dedicated to standard product features.


### PR DESCRIPTION
# Description

  Adds a quick reply directive system for the onboarding conversation flow. This allows the agent to present clickable
  buttons that users can tap to respond quickly.

  New directive syntax: :quickReply[Button Label]{message=The message sent when clicked}

# Changes:
  - New QuickReplyBlock.tsx component that renders as outline buttons
  - Integrated into AgentMessage.tsx - clicking a quick reply sends the message and automatically mentions the agent
  - Updated onboarding prompt to use quick replies for handling:
    - User declining to connect Gmail/Outlook ("Skip for now" / "I had an issue")
    - User wanting to see alternative tools (Slack, Notion)
    - User choosing to proceed without tools (explains web-based capabilities)

# Flow:
  1. Initial message shows tool setup card (Gmail/Outlook) + quick reply buttons
  2. If user skips → ask if they want other tools or explore on their own
  3. If user had an issue → explain common causes, offer to try different tool or proceed without
  4. If proceeding without tools → explain what Dust can do with web search (research, interactive frames)

# Tests

  Manual testing of the onboarding flow with different email providers and user responses.

# Risk

  Low risk.
  - Quick reply directive is additive - unknown directives are ignored
  - Changes are scoped to onboarding conversation only
  - Prompt changes are purely instructional, no backend logic changes

# Deploy Plan

  Standard deploy, no migrations or feature flags required.