### PR TITLE
[front] disable keyboard option for dropzone to allow keyboard navigation inside the conversation layout

### DIFF
--- a/front/components/misc/DropzoneContainer.tsx
+++ b/front/components/misc/DropzoneContainer.tsx
@@ -24,6 +24,7 @@ export function DropzoneContainer({
 
   const { getRootProps, isDragActive } = useDropzone({
     onDrop,
+    noKeyboard: true, // To avoid stealing focus when you try to scroll page by arrow keys.
     noClick: true, // Prevent default click behavior.
   });
 


### PR DESCRIPTION
## Description
This PR is to remove tabIndex from `DropzoneContainer` so that it doesn't get focused when you press keys when you are not focusing on inputs.

### How I investigated it:
Usually the first thing I would do when I have to deal with focusing issue is that checking which element is [activeElement](https://html.spec.whatwg.org/multipage/interaction.html#dom-documentorshadowroot-activeelement-dev) (you can find it by typing `document.activeElement` in console). This is almost same as focused element, from what I see is that if you press any keys it will receive events, and if it doesn't have focus ring it will show one (and perform events if there is any key event listener attach), but I haven't read the spec to understand how browser decides to show focus ring so it's purely based on my observation. 

So if you go to prod and click somewhere inside the conversation, and press any keys, the focus ring will appear. From there you can navigate to another focusable elements (buttons, links or any elements with tabIndex 0) with tab/shift + tab. 

### Why react-dropzone has tabIndex=0 by default?
When you add `tabIndex=0`, non natively focusable elements will be focusable (you can read more [here](https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute). If I understand it correctly react-dropzone adds `tabIndex=0` by default so that you can open a native file selection by pressing space or enter key (when it  is activeElement, it can receive key events):

https://github.com/user-attachments/assets/6604c6f5-49f2-4d55-8a85-4f6b2d7ded27

which makes sense because usually you will have an area you can drag and drop files like in the recording. But in our case you can drag and drop anywhere inside the conversation layout so we don't really need this.  If you remove tabIndex, `activeElement` will be `body` which you can now scroll into 🎉

We talked about adding tabIndex=0 somewhere so you can still focus the conversation itself. I checked ChatGPT and Claude but they both don't have it. I'm not an a11y expert but from what I test you can still read the conversation so I think it's okay to not be able to focus the conversation itself. 

But I don't know if I'm right, better to read the spec if you want to know the truth 🙈

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
