### PR TITLE
Filter out null agentConfigurationId when counting mentions and storing them in Reddis

### DIFF
--- a/front/lib/api/assistant/agent_usage.test.ts
+++ b/front/lib/api/assistant/agent_usage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { agentMentionsCount } from "@app/lib/api/assistant/agent_usage";
+import { Mention } from "@app/lib/models/assistant/conversation";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+
+process.env.FRONT_DATABASE_READ_REPLICA_URI =
+  process.env.FRONT_DATABASE_URI ?? process.env.TEST_FRONT_DATABASE_URI;
+
+describe("agentMentionsCount", () => {
+  it("should only count agent mentions, not user mentions", async () => {
+    const { workspace, authenticator: auth } = await createResourceTest({});
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test agent for mention counting",
+    });
+
+    // Create conversation with message
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+
+    const { messageRow } = await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "Test message",
+    });
+
+    // Create AGENT mention (agentConfigurationId NOT NULL)
+    await Mention.create({
+      workspaceId: workspace.id,
+      messageId: messageRow.id,
+      agentConfigurationId: agentConfig.sId,
+      userId: null,
+    });
+
+    // Create USER mention (agentConfigurationId IS NULL)
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await Mention.create({
+      workspaceId: workspace.id,
+      messageId: messageRow.id,
+      agentConfigurationId: null,
+      userId: user.id,
+    });
+
+    // Query should only return agent mention
+    const result = await agentMentionsCount(workspace.id);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].agentId).toBe(agentConfig.sId);
+    expect(result[0].messageCount).toBe(1); // Only agent mention, not user mention
+  });
+});

--- a/front/lib/api/assistant/agent_usage.ts
+++ b/front/lib/api/assistant/agent_usage.ts
@@ -161,6 +161,7 @@ export async function agentMentionsCount(
       WHERE
         c."workspaceId" = :workspaceId
         AND mentions."workspaceId" = :workspaceId
+        AND mentions."agentConfigurationId" IS NOT NULL
         AND mentions."createdAt" > NOW() - INTERVAL '${rankingUsageDays} days'
         AND ((:agentConfigurationId)::VARCHAR IS NULL OR mentions."agentConfigurationId" = :agentConfigurationId)
       GROUP BY mentions."agentConfigurationId"


### PR DESCRIPTION
I think since mentions V2, the mentions table can now have null agentConfigurationId as we can mention a user.
We have a workflow counting the mentions per agent and storing it in Reddis.
However, having null configuration ids means we try to store null in reddis which fails the activity.

This PR is attemps to fix this issue by removing null directly in the SQL query.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

yes

## Risk

very low

## Deploy Plan

deploy front
