### PR TITLE
[front] Move maybeTrackTokenUsageCost into analytics activity

### DIFF
--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -179,14 +179,12 @@ export async function updateResourceAndPublishEvent(
     conversation,
     step,
     modelInteractionDurationMs,
-    userMessageOrigin,
   }: {
     event: AgentMessageEvents;
     agentMessageRow: AgentMessage;
     conversation: ConversationWithoutContentType;
     step: number;
     modelInteractionDurationMs?: number;
-    userMessageOrigin?: UserMessageOrigin | null;
   }
 ): Promise<void> {
   // Processing of events before publishing to Redis.

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -17,7 +17,6 @@ import logger from "@app/logger/logger";
 import type {
   ConversationWithoutContentType,
   ToolErrorEvent,
-  UserMessageOrigin,
 } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";

--- a/front/temporal/agent_loop/activities/usage_tracking.ts
+++ b/front/temporal/agent_loop/activities/usage_tracking.ts
@@ -1,0 +1,74 @@
+import { maybeTrackTokenUsageCost } from "@app/lib/api/programmatic_usage_tracking";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessage,
+  Message,
+  UserMessage,
+} from "@app/lib/models/assistant/conversation";
+import type { AgentMessageStatus } from "@app/types";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+const AGENT_MESSAGE_STATUSES_TO_TRACK: AgentMessageStatus[] = [
+  "succeeded",
+  "cancelled",
+];
+
+export async function trackUsageActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  const auth = await Authenticator.fromJSON(authType);
+  const workspace = auth.getNonNullableWorkspace();
+
+  const { agentMessageId, userMessageId } = agentLoopArgs;
+
+  // Query the Message/AgentMessage/Conversation rows.
+  const agentMessageRow = await Message.findOne({
+    where: {
+      sId: agentMessageId,
+      workspaceId: workspace.id,
+    },
+    include: [
+      {
+        model: AgentMessage,
+        as: "agentMessage",
+        required: true,
+      },
+    ],
+  });
+
+  const agentMessage = agentMessageRow?.agentMessage;
+
+  // Query the UserMessage row to get user.
+  const userMessageRow = await Message.findOne({
+    where: {
+      sId: userMessageId,
+      workspaceId: workspace.id,
+    },
+    include: [
+      {
+        model: UserMessage,
+        as: "userMessage",
+        required: true,
+      },
+    ],
+  });
+
+  const userMessage = userMessageRow?.userMessage;
+
+  if (!agentMessage || !userMessage) {
+    throw new Error("Agent message or user message not found");
+  }
+
+  if (
+    AGENT_MESSAGE_STATUSES_TO_TRACK.includes(agentMessage.status) &&
+    agentMessage.runIds
+  ) {
+    // Track token usage cost for programmatic usage.
+    await maybeTrackTokenUsageCost(auth, {
+      dustRunIds: agentMessage.runIds,
+      userMessageOrigin: userMessage.userContextOrigin ?? null,
+    });
+  }
+}

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -604,7 +604,6 @@ export async function runModelActivity(
       step,
       modelInteractionDurationMs:
         modelInteractionEndDate - modelInteractionStartDate,
-      userMessageOrigin: userMessage.context.origin,
     });
     localLogger.info("Agent message generation succeeded");
 

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -64,14 +64,12 @@ export type GetOutputRequestParams = {
       conversation,
       step,
       modelInteractionDurationMs,
-      userMessageOrigin,
     }: {
       event: AgentMessageEvents;
       agentMessageRow: AgentMessage;
       conversation: ConversationWithoutContentType;
       step: number;
       modelInteractionDurationMs?: number;
-      userMessageOrigin?: UserMessageOrigin | null;
     }
   ) => Promise<void>;
 };

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -12,7 +12,6 @@ import type {
   ModelConversationTypeMultiActions,
   Ok,
   Result,
-  UserMessageOrigin,
   UserMessageType,
 } from "@app/types";
 import type {

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -21,6 +21,7 @@ import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
+import { trackUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 
@@ -47,6 +48,7 @@ export async function runAgentLoopWorker() {
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,
       runToolActivity,
+      trackUsageActivity,
     },
     taskQueue: QUEUE_NAME,
     connection,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -21,6 +21,7 @@ import type * as notificationActivities from "@app/temporal/agent_loop/activitie
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
+import type * as usageTrackingActivities from "@app/temporal/agent_loop/activities/usage_tracking";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import { cancelAgentLoopSignal } from "@app/temporal/agent_loop/signals";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
@@ -103,6 +104,13 @@ const { ensureConversationTitleActivity } = proxyActivities<
 const { notifyWorkflowError, finalizeCancellationActivity } = proxyActivities<
   typeof commonActivities
 >({
+  startToCloseTimeout: "2 minutes",
+  retry: {
+    maximumAttempts: 5,
+  },
+});
+
+const { trackUsageActivity } = proxyActivities<typeof usageTrackingActivities>({
   startToCloseTimeout: "2 minutes",
   retry: {
     maximumAttempts: 5,
@@ -237,6 +245,7 @@ export async function agentLoopWorkflow({
       await CancellationScope.nonCancellable(async () => {
         await Promise.all([
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
+          trackUsageActivity(authType, agentLoopArgs),
           conversationUnreadNotificationActivity(authType, agentLoopArgs),
         ]);
       });
@@ -254,6 +263,7 @@ export async function agentLoopWorkflow({
         // Ensure analytics runs even when workflow is cancelled
         await Promise.all([
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
+          trackUsageActivity(authType, agentLoopArgs),
           finalizeCancellationActivity(authType, agentLoopArgs),
         ]);
         return;
@@ -261,6 +271,7 @@ export async function agentLoopWorkflow({
         // Ensure analytics runs even when workflow errors
         await Promise.all([
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
+          trackUsageActivity(authType, agentLoopArgs),
           notifyWorkflowError(authType, {
             conversationId: agentLoopArgs.conversationId,
             agentMessageId: agentLoopArgs.agentMessageId,

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -2,7 +2,6 @@ import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import { updateAnalyticsFeedback } from "@app/lib/analytics/feedback";
 import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
-import { maybeTrackTokenUsageCost } from "@app/lib/api/programmatic_usage_tracking";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
@@ -104,14 +103,6 @@ export async function storeAgentAnalyticsActivity(
 
   if (!userUserMessageRow) {
     throw new Error("User message not found");
-  }
-
-  // Track token usage cost for programmatic usage.
-  if (agentAgentMessageRow.runIds) {
-    await maybeTrackTokenUsageCost(auth, {
-      dustRunIds: agentAgentMessageRow.runIds,
-      userMessageOrigin: userUserMessageRow.userContextOrigin,
-    });
   }
 
   await storeAgentAnalytics(auth, {


### PR DESCRIPTION
## Description

Consistently call cost tracking at the end of agent loop to avoid missing tracking and discrepancies with analytics

Ensure the workflow is executed in all cases, even when the agent loop is cancelled or in error.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk


## Deploy Plan

deploy front
