### PR TITLE
[front] Update production check to check schedules

### DIFF
--- a/front/types/connectors/workflows.ts
+++ b/front/types/connectors/workflows.ts
@@ -39,6 +39,22 @@ export function microsoftGarbageCollectionWorkflowId(connectorId: ModelId) {
   return `microsoft-garbageCollection-${connectorId}`;
 }
 
+export function makeGongSyncScheduleId(connectorId: ModelId): string {
+  return `gong-sync-${connectorId}`;
+}
+
+export function makeIntercomHelpCenterScheduleId(
+  connectorId: ModelId
+): string {
+  return `intercom-help-center-sync-${connectorId}`;
+}
+
+export function makeIntercomConversationScheduleId(
+  connectorId: ModelId
+): string {
+  return `intercom-conversation-sync-${connectorId}`;
+}
+
 export function getWorkflowIdsForConnector(
   connectorId: ModelId,
   connectorType: ConnectorProvider

--- a/front/types/connectors/workflows.ts
+++ b/front/types/connectors/workflows.ts
@@ -43,9 +43,7 @@ export function makeGongSyncScheduleId(connectorId: ModelId): string {
   return `gong-sync-${connectorId}`;
 }
 
-export function makeIntercomHelpCenterScheduleId(
-  connectorId: ModelId
-): string {
+export function makeIntercomHelpCenterScheduleId(connectorId: ModelId): string {
   return `intercom-help-center-sync-${connectorId}`;
 }
 


### PR DESCRIPTION
## Description

The production check `check_active_workflows_for_connectors` currently only checks workflow-based connectors.
This PR extends it to also check for the existence of running schedules for Gong and Intercom.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
