### PR TITLE
[front] - feat(analytics): add MCP server config sId

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -70,6 +70,9 @@
           "tool_name": {
             "type": "keyword"
           },
+          "mcp_server_configuration_sid": {
+            "type": "keyword"
+          },
           "execution_time_ms": {
             "type": "integer"
           },

--- a/front/lib/analytics/migrations/20251119_add_mcp_server_configuration_sid_to_tools_used.http
+++ b/front/lib/analytics/migrations/20251119_add_mcp_server_configuration_sid_to_tools_used.http
@@ -1,0 +1,13 @@
+PUT /front.agent_message_analytics_2/_mapping
+{
+  "properties": {
+    "tools_used": {
+      "type": "nested",
+      "properties": {
+        "mcp_server_configuration_sid": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -244,7 +244,6 @@ async function collectToolUsageFromMessage(
   actionResources: AgentMCPActionResource[]
 ): Promise<AgentMessageAnalyticsToolUsed[]> {
   const workspaceId = auth.getNonNullableWorkspace().id;
-
   const uniqueConfigIds = Array.from(
     new Set(actionResources.map((a) => a.mcpServerConfigurationId))
   );
@@ -256,9 +255,9 @@ async function collectToolUsageFromMessage(
     },
   });
 
-  const configIdToSid = new Map<string, string>();
+  const configIdToSId = new Map<string, string>();
   for (const cfg of serverConfigs) {
-    configIdToSid.set(cfg.id.toString(), cfg.sId);
+    configIdToSId.set(cfg.id.toString(), cfg.sId);
   }
 
   return actionResources.map((actionResource) => {
@@ -272,7 +271,7 @@ async function collectToolUsageFromMessage(
         actionResource.functionCallName.split(TOOL_NAME_SEPARATOR).pop() ??
         actionResource.functionCallName,
       mcp_server_configuration_sid:
-        configIdToSid.get(actionResource.mcpServerConfigurationId) ?? undefined,
+        configIdToSId.get(actionResource.mcpServerConfigurationId) ?? undefined,
       execution_time_ms: actionResource.executionDurationMs,
       status: actionResource.status,
     };

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -18,6 +18,7 @@ export interface AgentMessageAnalyticsToolUsed {
   step_index: number;
   server_name: string;
   tool_name: string;
+  mcp_server_configuration_sid: string;
   execution_time_ms: number | null;
   status: string;
 }

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -18,7 +18,7 @@ export interface AgentMessageAnalyticsToolUsed {
   step_index: number;
   server_name: string;
   tool_name: string;
-  mcp_server_configuration_sid: string;
+  mcp_server_configuration_sid?: string;
   execution_time_ms: number | null;
   status: string;
 }


### PR DESCRIPTION
## Description

This PR adds the MCP server configuration sId to the tools used in the analytics index in ES.

We want to display a breakdown of tools by name (e.g. you have multiple search tools we want to breakdown by "search_1" and "search_2"). This requires storing the mcp server configuration sId to retrieve the tool name.

## Tests

Locally

## Risk

Low - adds data to the index

## Deploy Plan

- Apply migration to EU and US
- Deploy front
