### PR TITLE
feat: retry anthropic terminated errors

### DIFF
--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -8,6 +8,7 @@ export type LLMErrorType =
   | "stop_error"
   | "refusal_error"
   | "maximum_length"
+  | "terminated_error"
   // HTTP errors
   | "rate_limit_error"
   | "overloaded_error"
@@ -59,6 +60,15 @@ export function categorizeLLMError(
     typeof error.status === "number"
       ? error.status
       : undefined;
+
+  if (errorMessage === "terminated") {
+    return {
+      type: "terminated_error",
+      message: `Terminated error for ${metadata.clientId}/${metadata.modelId}. ${normalized.message}`,
+      isRetryable: true,
+      originalError: error,
+    };
+  }
 
   if (
     statusCode === 429 ||


### PR DESCRIPTION
## Description

In the LLM router logs we see mainly "terminated" error from anthropic with no additional information
These errors do not seem to affect the whole conversation and can be retried

## Tests

no

## Risk

low

## Deploy Plan

front
