### PR TITLE
[front] enh(poke): improve support for Temporal Schedules in Poke

### DIFF
--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -506,7 +506,7 @@ function StuckActivitiesDialog({
                         href={
                           "https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20%40dd.service%3Aconnectors-worker" +
                           `%20%40activityType%3A${encodeURIComponent(activity.activityType)}` +
-                          `%20%40workflowId%3A${encodeURIComponent(workflow.workflowId)}` +
+                          `%20%40workflowId%3A${encodeURIComponent(workflow.workflowId.replaceAll(":", "\\:"))}` +
                           "&agg_m=count&agg_m_source=base&agg_t=count&cols=%40workflowId&" +
                           "fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&" +
                           "stream_sort=time%2Cdesc&viz=stream"

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -66,6 +66,11 @@ export function ViewDataSourceTable({
 
   const isPaused = connector && !!connector.pausedAt;
   const isRunning = temporalRunningWorkflows.length > 0;
+  const isScheduleBased =
+    dataSource.connectorProvider === "gong" ||
+    dataSource.connectorProvider === "intercom"
+      ? "schedules"
+      : "workflows";
 
   return (
     <>
@@ -132,13 +137,9 @@ export function ViewDataSourceTable({
                   <PokeTableCell>Logs</PokeTableCell>
                   <PokeTableCell>
                     <Link
-                      href={
-                        dataSource.connectorProvider === "gong"
-                          ? // Gong is schedule-based, linking the schedule page that has the list
-                            // of all workflow runs.
-                            `https://cloud.temporal.io/namespaces/${temporalWorkspace}/schedules/gong-sync-${dataSource.connectorId}`
-                          : `https://cloud.temporal.io/namespaces/${temporalWorkspace}/workflows?query=connectorId%3D%22${dataSource.connectorId}%22`
-                      }
+                      href={`https://cloud.temporal.io/namespaces/${temporalWorkspace}/${
+                        isScheduleBased ? "schedules" : "workflows"
+                      }?query=connectorId%3D%22${dataSource.connectorId}%22`}
                       target="_blank"
                       className="text-sm text-highlight-400"
                     >

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
@@ -71,7 +71,7 @@ async function getWorkflowIdsFromSchedule(
 async function getWorkflowIdsForConnector(
   connectorId: ModelId,
   connectorType: ConnectorProvider
-): Promise<string[]> {
+): Promise<string[] | null> {
   switch (connectorType) {
     case "notion":
       return [
@@ -113,7 +113,7 @@ async function getWorkflowIdsForConnector(
       return [...helpCenterWorkflows, ...conversationWorkflows];
     }
     default:
-      return [];
+      return null;
   }
 }
 
@@ -289,7 +289,7 @@ async function handler(
         dataSource.connectorProvider
       );
 
-      if (workflowIds.length === 0) {
+      if (workflowIds === null) {
         return res.status(200).json({
           isStuck: false,
           workflows: [],

--- a/front/types/connectors/workflows.ts
+++ b/front/types/connectors/workflows.ts
@@ -1,4 +1,4 @@
-import type { ConnectorProvider, ModelId } from "@app/types";
+import type { ModelId } from "@app/types";
 
 export function getNotionWorkflowId(
   connectorId: ModelId,
@@ -51,34 +51,4 @@ export function makeIntercomConversationScheduleId(
   connectorId: ModelId
 ): string {
   return `intercom-conversation-sync-${connectorId}`;
-}
-
-export function getWorkflowIdsForConnector(
-  connectorId: ModelId,
-  connectorType: ConnectorProvider
-): string[] {
-  switch (connectorType) {
-    case "notion":
-      return [
-        getNotionWorkflowId(connectorId, "sync"),
-        getNotionWorkflowId(connectorId, "garbage-collector"),
-        getNotionWorkflowId(connectorId, "process-database-upsert-queue"),
-      ];
-    case "zendesk":
-      return [
-        getZendeskSyncWorkflowId(connectorId),
-        getZendeskGarbageCollectionWorkflowId(connectorId),
-      ];
-    case "google_drive":
-      return [googleDriveIncrementalSyncWorkflowId(connectorId)];
-    case "confluence":
-      return [makeConfluenceSyncWorkflowId(connectorId)];
-    case "microsoft":
-      return [
-        microsoftIncrementalSyncWorkflowId(connectorId),
-        microsoftGarbageCollectionWorkflowId(connectorId),
-      ];
-    default:
-      return [];
-  }
 }


### PR DESCRIPTION
## Description

This PR does 3 things:
- Extend the "Check stuck" button to retrieve workflows triggered by schedules (previously showed a Chip saying `Workflow checking not implemented for connector type xxx`).
<img width="561" height="330" alt="Screenshot 2025-11-21 at 10 28 29 AM" src="https://github.com/user-attachments/assets/a0054d52-6a14-4d98-94b0-bb6970a95dc2" />
- Fix the link to datadog (escape `:`).
- Update the Temporal link for Intercom to show the schedules.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
