### PR TITLE
fix: strip function call without tool output before title generation

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -70,7 +70,7 @@ export async function ensureConversationTitle(
 
   const titleRes = await generateConversationTitle(auth, {
     ...conversation,
-    content: [...conversation.content, [userMessage]],
+    content: [...conversationContent, [userMessage]],
   });
 
   if (titleRes.isErr()) {


### PR DESCRIPTION
## Description

Remaining llm router errors are from title generation which tries to infer a title from the conversation.
Sometimes the conversation is ongoing and the agent requested a tool call without getting the output, which makes the model throw an error.
This PR strips the last messages if they are function calls.

## Tests

locally

## Risk

low

## Deploy Plan

front
