### PR TITLE
[front] Keep runIds across workflow executions

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -203,6 +203,7 @@ export type MCPParamsEvent = {
   configurationId: string;
   messageId: string;
   action: AgentMCPActionWithOutputType;
+  runIds?: string[];
 };
 
 export type MCPSuccessEvent = {

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -18,6 +18,7 @@ import logger from "@app/logger/logger";
 import type {
   ConversationWithoutContentType,
   ToolErrorEvent,
+  UserMessageOrigin,
 } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";
@@ -196,12 +197,14 @@ export async function updateResourceAndPublishEvent(
     conversation,
     step,
     modelInteractionDurationMs,
+    userMessageOrigin,
   }: {
     event: AgentMessageEvents;
     agentMessageRow: AgentMessage;
     conversation: ConversationWithoutContentType;
     step: number;
     modelInteractionDurationMs?: number;
+    userMessageOrigin?: UserMessageOrigin | null;
   }
 ): Promise<void> {
   // Processing of events before publishing to Redis.

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -18,15 +18,13 @@ import logger from "@app/logger/logger";
 import type {
   ConversationWithoutContentType,
   ToolErrorEvent,
-  UserMessageOrigin,
 } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";
 
 export async function markAgentMessageAsFailed(
   agentMessageRow: AgentMessage,
-  error: ToolErrorEvent["error"],
-  runIds?: string[]
+  error: ToolErrorEvent["error"]
 ): Promise<void> {
   await agentMessageRow.update({
     completedAt: new Date(),
@@ -34,7 +32,6 @@ export async function markAgentMessageAsFailed(
     errorMessage: error.message,
     errorMetadata: error.metadata,
     status: "failed",
-    ...(runIds && { runIds }),
   });
 }
 
@@ -64,14 +61,21 @@ async function processEventForDatabase(
     });
   }
 
+  // Merge runIds from events that include them. This ensures runIds are persisted
+  // incrementally as events are published.
+  if ("runIds" in event && event.runIds && event.runIds.length > 0) {
+    const existingRunIds = agentMessageRow.runIds ?? [];
+    // Merge and deduplicate runIds
+    const mergedRunIds = [...new Set([...existingRunIds, ...event.runIds])];
+    await agentMessageRow.update({
+      runIds: mergedRunIds,
+    });
+  }
+
   switch (event.type) {
     case "agent_error":
-      // Store error in database with runIds from the failed LLM call.
-      await markAgentMessageAsFailed(
-        agentMessageRow,
-        event.error,
-        event.runIds
-      );
+      // Store error in database.
+      await markAgentMessageAsFailed(agentMessageRow, event.error);
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
@@ -117,9 +121,8 @@ async function processEventForDatabase(
 
     case "agent_message_success":
       await Promise.all([
-        // Store success and run IDs in database.
+        // Store success in database. runIds are already merged above.
         agentMessageRow.update({
-          runIds: event.runIds,
           status: "succeeded",
           completedAt: new Date(),
         }),
@@ -193,14 +196,12 @@ export async function updateResourceAndPublishEvent(
     conversation,
     step,
     modelInteractionDurationMs,
-    userMessageOrigin,
   }: {
     event: AgentMessageEvents;
     agentMessageRow: AgentMessage;
     conversation: ConversationWithoutContentType;
     step: number;
     modelInteractionDurationMs?: number;
-    userMessageOrigin?: UserMessageOrigin | null;
   }
 ): Promise<void> {
   // Processing of events before publishing to Redis.

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -109,12 +109,15 @@ export async function runModelAndCreateActionsActivity({
   const actionsToRun = actions.slice(0, MAX_ACTIONS_PER_STEP);
 
   // 2. Create tool actions.
+  // Include the new runId in the runIds array when creating actions
+  const currentRunIds = runId ? [...runIds, runId] : runIds;
   const createResult = await createToolActionsActivity(auth, {
     runAgentData,
     actions: actionsToRun,
     stepContexts,
     functionCallStepContentIds: updatedFunctionCallStepContentIds,
     step,
+    runIds: currentRunIds,
   });
 
   const needsApproval = createResult.actionBlobs.some((a) => a.needsApproval);

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -44,12 +44,14 @@ export async function createToolActionsActivity(
     stepContexts,
     functionCallStepContentIds,
     step,
+    runIds,
   }: {
     runAgentData: AgentLoopExecutionData;
     actions: AgentActionsEvent["actions"];
     stepContexts: StepContext[];
     functionCallStepContentIds: Record<string, ModelId>;
     step: number;
+    runIds: string[];
   }
 ): Promise<CreateToolActionsResult> {
   const { agentConfiguration, agentMessage, agentMessageRow, conversation } =
@@ -76,6 +78,7 @@ export async function createToolActionsActivity(
       stepContentId,
       stepContext: stepContexts[index],
       step,
+      runIds,
     });
 
     if (result) {
@@ -117,6 +120,7 @@ async function createActionForTool(
     stepContentId,
     stepContext,
     step,
+    runIds,
   }: {
     actionConfiguration: MCPToolConfigurationType;
     agentConfiguration: AgentConfigurationType;
@@ -126,6 +130,7 @@ async function createActionForTool(
     stepContentId: ModelId;
     stepContext: StepContext;
     step: number;
+    runIds: string[];
   }
 ): Promise<{
   actionBlob: ActionBlob;
@@ -196,7 +201,7 @@ async function createActionForTool(
     stepContext,
   });
 
-  // Publish the tool params event.
+  // Publish the tool params event with runIds so they're saved when workflow exits early.
   await updateResourceAndPublishEvent(auth, {
     event: {
       type: "tool_params",
@@ -206,6 +211,7 @@ async function createActionForTool(
       // TODO: cleanup the type field from the public API users and remove everywhere.
       // TODO: move the output field to a separate field.
       action: { ...action.toJSON(), output: null, generatedFiles: [] },
+      runIds,
     },
     agentMessageRow,
     conversation,


### PR DESCRIPTION
## Description

Store the runIds in processEventForDatabase. It's the only place where runIds are updated, and it applies to all events with runIds. Events that include runIds:

agent_message_success: runIds when generation completes
agent_error: runIds on failure
tool_params: runIds when actions are created - added here to handle early exits, if a tool need a validation, authentication, or just stops.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
