### PR TITLE
feat: add script to remove reasoning tool from agents

### DIFF
--- a/front/scripts/remove_reasoning_tool.ts
+++ b/front/scripts/remove_reasoning_tool.ts
@@ -1,0 +1,176 @@
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import {
+  AgentChildAgentConfiguration,
+  AgentMCPServerConfiguration,
+} from "@app/lib/models/assistant/actions/mcp";
+import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/reasoning";
+import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+/**
+ * Deletes reasoning configurations and their associated resources for all agents.
+ * This script performs cascading deletions in the correct order to avoid foreign key constraints.
+ */
+async function deleteReasoningConfigurationAndRelatedResources(
+  reasoningConfig: AgentReasoningConfiguration & {
+    agent_mcp_server_configuration: AgentMCPServerConfiguration & {
+      agent_configuration: AgentConfiguration;
+    };
+  },
+  logger: Logger,
+  execute: boolean
+): Promise<boolean> {
+  const mcpServerConfigurationId = reasoningConfig.mcpServerConfigurationId;
+  const agent =
+    reasoningConfig.agent_mcp_server_configuration.agent_configuration;
+
+  logger.info(
+    {
+      reasoningConfigId: reasoningConfig.sId,
+      mcpServerConfigurationId,
+      agentId: agent.sId,
+      agentName: agent.name,
+      modelId: agent.modelId,
+      providerId: agent.providerId,
+    },
+    execute
+      ? "Deleting reasoning configuration and related resources"
+      : "Would delete reasoning configuration and related resources"
+  );
+
+  // If in dry run, return early.
+  if (!execute) {
+    return true;
+  }
+
+  try {
+    // Delete in the correct order to avoid foreign key constraint violations
+
+    // 1. Delete agent_data_source_configurations
+    await AgentDataSourceConfiguration.destroy({
+      where: {
+        mcpServerConfigurationId,
+      },
+    });
+
+    // 2. Delete agent_tables_query_configuration_tables
+    await AgentTablesQueryConfigurationTable.destroy({
+      where: {
+        mcpServerConfigurationId,
+      },
+    });
+
+    // 3. Delete agent_child_agent_configurations
+    await AgentChildAgentConfiguration.destroy({
+      where: {
+        mcpServerConfigurationId,
+      },
+    });
+
+    // 4. Delete agent_reasoning_configurations
+    await AgentReasoningConfiguration.destroy({
+      where: {
+        mcpServerConfigurationId,
+      },
+    });
+
+    // 5. Finally delete agent_mcp_server_configurations
+    await AgentMCPServerConfiguration.destroy({
+      where: {
+        id: mcpServerConfigurationId,
+      },
+    });
+
+    logger.info(
+      {
+        reasoningConfigId: reasoningConfig.sId,
+        mcpServerConfigurationId,
+      },
+      "Successfully deleted reasoning configuration and all related resources"
+    );
+
+    return true;
+  } catch (error) {
+    logger.error(
+      {
+        reasoningConfigId: reasoningConfig.sId,
+        mcpServerConfigurationId,
+        error,
+      },
+      "Failed to delete reasoning configuration and related resources"
+    );
+    return false;
+  }
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  logger.info(
+    { execute },
+    "Starting removal of reasoning configurations for all agents"
+  );
+
+  // Get all reasoning configurations with agent information
+
+  const reasoningConfigurations = await AgentReasoningConfiguration.findAll({
+    attributes: ["id", "sId", "mcpServerConfigurationId"],
+    include: [
+      {
+        model: AgentMCPServerConfiguration,
+        required: true,
+        include: [
+          {
+            model: AgentConfiguration,
+            required: true,
+            attributes: ["id", "sId", "name", "modelId", "providerId"],
+          },
+        ],
+      },
+    ],
+  });
+
+  if (reasoningConfigurations.length === 0) {
+    logger.info("No reasoning configurations found");
+    return;
+  }
+
+  logger.info(
+    { count: reasoningConfigurations.length },
+    `Found ${reasoningConfigurations.length} reasoning configurations for all agents`
+  );
+
+  let successCount = 0;
+  let failureCount = 0;
+
+  // Process each reasoning configuration
+  for (const reasoningConfig of reasoningConfigurations) {
+    const success = await deleteReasoningConfigurationAndRelatedResources(
+      reasoningConfig as AgentReasoningConfiguration & {
+        agent_mcp_server_configuration: AgentMCPServerConfiguration & {
+          agent_configuration: AgentConfiguration;
+        };
+      },
+      logger,
+      execute
+    );
+
+    if (success) {
+      successCount++;
+    } else {
+      failureCount++;
+    }
+  }
+
+  logger.info(
+    {
+      total: reasoningConfigurations.length,
+      successful: successCount,
+      failed: failureCount,
+      execute,
+    },
+    execute
+      ? `Finished deleting ${successCount} reasoning configurations for all agents`
+      : `Finished dry run of reasoning configuration deletion for all agents`
+  );
+});

--- a/front/scripts/remove_reasoning_tool.ts
+++ b/front/scripts/remove_reasoning_tool.ts
@@ -1,10 +1,5 @@
-import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
-import {
-  AgentChildAgentConfiguration,
-  AgentMCPServerConfiguration,
-} from "@app/lib/models/assistant/actions/mcp";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/reasoning";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
@@ -47,36 +42,14 @@ async function deleteReasoningConfigurationAndRelatedResources(
 
   try {
     // Delete in the correct order to avoid foreign key constraint violations
-
-    // 1. Delete agent_data_source_configurations
-    await AgentDataSourceConfiguration.destroy({
-      where: {
-        mcpServerConfigurationId,
-      },
-    });
-
-    // 2. Delete agent_tables_query_configuration_tables
-    await AgentTablesQueryConfigurationTable.destroy({
-      where: {
-        mcpServerConfigurationId,
-      },
-    });
-
-    // 3. Delete agent_child_agent_configurations
-    await AgentChildAgentConfiguration.destroy({
-      where: {
-        mcpServerConfigurationId,
-      },
-    });
-
-    // 4. Delete agent_reasoning_configurations
+    // 1. Delete agent_reasoning_configurations
     await AgentReasoningConfiguration.destroy({
       where: {
         mcpServerConfigurationId,
       },
     });
 
-    // 5. Finally delete agent_mcp_server_configurations
+    // 2. Finally delete agent_mcp_server_configurations
     await AgentMCPServerConfiguration.destroy({
       where: {
         id: mcpServerConfigurationId,

--- a/front/scripts/remove_reasoning_tool.ts
+++ b/front/scripts/remove_reasoning_tool.ts
@@ -96,7 +96,14 @@ makeScript({}, async ({ execute }, logger) => {
           {
             model: AgentConfiguration,
             required: true,
-            attributes: ["id", "sId", "name", "modelId", "providerId"],
+            attributes: [
+              "id",
+              "sId",
+              "name",
+              "modelId",
+              "providerId",
+              "status",
+            ],
           },
         ],
       },
@@ -108,9 +115,21 @@ makeScript({}, async ({ execute }, logger) => {
     return;
   }
 
+  // Calculate agent counts
+  const totalAgentsImpacted = reasoningConfigurations.length;
+  const activeAgentsImpacted = reasoningConfigurations.filter(
+    (config) =>
+      // @ts-expect-error type not inferred with include clause
+      config.agent_mcp_server_configuration.agent_configuration.status ===
+      "active"
+  ).length;
+
   logger.info(
-    { count: reasoningConfigurations.length },
-    `Found ${reasoningConfigurations.length} reasoning configurations for all agents`
+    {
+      totalAgentsImpacted,
+      activeAgentsImpacted,
+    },
+    `Found ${totalAgentsImpacted} reasoning configurations impacting ${activeAgentsImpacted} active agents.`
   );
 
   let successCount = 0;


### PR DESCRIPTION
## Description

Reasoning tool is being deprecated by Duts: reasoning models initially did not support tool calls, now they do.

**Out of scope**
Migration and cleanup

## Tests

local

## Risk

low

## Deploy Plan

Communicate to relevant builders first
