### PR TITLE
Tools: fix sorting & various small updates

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -12,7 +12,6 @@ import {
   LoadingBlock,
   ToolsIcon,
 } from "@dust-tt/sparkle";
-import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 
 import { CreateMCPServerSheet } from "@app/components/actions/mcp/CreateMCPServerSheet";
@@ -31,7 +30,7 @@ import {
   useAvailableMCPServers,
   useMCPServerViewsFromSpaces,
 } from "@app/lib/swr/mcp_servers";
-import { useSpaces, useSystemSpace } from "@app/lib/swr/spaces";
+import { useSpaces } from "@app/lib/swr/spaces";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
   trackEvent,
@@ -78,7 +77,6 @@ export function ToolsPicker({
   disabled = false,
   buttonSize = "xs",
 }: ToolsPickerProps) {
-  const router = useRouter();
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [setupSheetServer, setSetupSheetServer] =
@@ -104,10 +102,6 @@ export function ToolsPicker({
   );
 
   const isAdmin = owner.role === "admin";
-  const { systemSpace } = useSystemSpace({
-    workspaceId: owner.sId,
-    disabled: !isOpen || !isAdmin,
-  });
 
   const {
     serverViews,
@@ -251,63 +245,45 @@ export function ToolsPicker({
           align="start"
           dropdownHeaders={
             <>
-              <div className="flex items-center">
-                <div className="flex-1">
-                  <DropdownMenuSearchbar
-                    autoFocus
-                    name="search-tools"
-                    placeholder="Search Tools"
-                    value={searchText}
-                    onChange={setSearchText}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" && filteredServerViews.length > 0) {
-                        const isSelected = selectedMCPServerViewIds.includes(
-                          filteredServerViews[0].sId
-                        );
-                        if (isSelected) {
-                          trackEvent({
-                            area: TRACKING_AREAS.TOOLS,
-                            object: "tool_deselect",
-                            action: TRACKING_ACTIONS.SELECT,
-                            extra: {
-                              tool_id: filteredServerViews[0].sId,
-                              tool_name: filteredServerViews[0].server.name,
-                            },
-                          });
-                          onDeselect(filteredServerViews[0]);
-                        } else {
-                          trackEvent({
-                            area: TRACKING_AREAS.TOOLS,
-                            object: "tool_select",
-                            action: TRACKING_ACTIONS.SELECT,
-                            extra: {
-                              tool_id: filteredServerViews[0].sId,
-                              tool_name: filteredServerViews[0].server.name,
-                            },
-                          });
-                          onSelect(filteredServerViews[0]);
-                        }
-                        setSearchText("");
-                        setIsOpen(false);
-                      }
-                    }}
-                  />
-                </div>
-                {systemSpace && (
-                  <Button
-                    icon={ToolsIcon}
-                    variant="outline"
-                    label="Manage"
-                    onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                      e.stopPropagation();
-                      e.preventDefault();
-                      void router.push(
-                        `/w/${owner.sId}/spaces/${systemSpace.sId}/categories/actions`
-                      );
-                    }}
-                  />
-                )}
-              </div>
+              <DropdownMenuSearchbar
+                autoFocus
+                name="search-tools"
+                placeholder="Search Tools"
+                value={searchText}
+                onChange={setSearchText}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && filteredServerViews.length > 0) {
+                    const isSelected = selectedMCPServerViewIds.includes(
+                      filteredServerViews[0].sId
+                    );
+                    if (isSelected) {
+                      trackEvent({
+                        area: TRACKING_AREAS.TOOLS,
+                        object: "tool_deselect",
+                        action: TRACKING_ACTIONS.SELECT,
+                        extra: {
+                          tool_id: filteredServerViews[0].sId,
+                          tool_name: filteredServerViews[0].server.name,
+                        },
+                      });
+                      onDeselect(filteredServerViews[0]);
+                    } else {
+                      trackEvent({
+                        area: TRACKING_AREAS.TOOLS,
+                        object: "tool_select",
+                        action: TRACKING_ACTIONS.SELECT,
+                        extra: {
+                          tool_id: filteredServerViews[0].sId,
+                          tool_name: filteredServerViews[0].server.name,
+                        },
+                      });
+                      onSelect(filteredServerViews[0]);
+                    }
+                    setSearchText("");
+                    setIsOpen(false);
+                  }
+                }}
+              />
               <DropdownMenuSeparator />
             </>
           }

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -19,6 +19,7 @@ import { CreateMCPServerSheet } from "@app/components/actions/mcp/CreateMCPServe
 import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
+  mcpServersSortingFn,
   mcpServerViewSortingFn,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
@@ -348,38 +349,42 @@ export function ToolsPicker({
 
           {isDataReady && filteredUninstalledServers.length > 0 && (
             <>
-              {filteredUninstalledServers.map((server) => (
-                <DropdownMenuItem
-                  key={`tools-to-install-${server.sId}`}
-                  icon={() => getAvatar(server)}
-                  label={asDisplayName(server.name)}
-                  description={server.description}
-                  truncateText
-                  endComponent={
-                    <Chip size="xs" color="golden" label="Activate" />
-                  }
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-
-                    const remoteMcpServerConfig =
-                      getDefaultRemoteMCPServerByName(server.name);
-
-                    if (remoteMcpServerConfig) {
-                      // Remote servers always use the remote flow, even if they have OAuth.
-                      setSetupSheetServer(null);
-                      setSetupSheetRemoteServerConfig(remoteMcpServerConfig);
-                    } else {
-                      // Internal servers (with or without OAuth)
-                      setSetupSheetServer(server);
-                      setSetupSheetRemoteServerConfig(null);
+              {filteredUninstalledServers
+                .sort((a, b) =>
+                  mcpServersSortingFn({ mcpServer: a }, { mcpServer: b })
+                )
+                .map((server) => (
+                  <DropdownMenuItem
+                    key={`tools-to-install-${server.sId}`}
+                    icon={() => getAvatar(server)}
+                    label={asDisplayName(server.name)}
+                    description={server.description}
+                    truncateText
+                    endComponent={
+                      <Chip size="xs" color="golden" label="Configure" />
                     }
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
 
-                    setIsSettingUpServer(true);
-                    setIsOpen(false);
-                  }}
-                />
-              ))}
+                      const remoteMcpServerConfig =
+                        getDefaultRemoteMCPServerByName(server.name);
+
+                      if (remoteMcpServerConfig) {
+                        // Remote servers always use the remote flow, even if they have OAuth.
+                        setSetupSheetServer(null);
+                        setSetupSheetRemoteServerConfig(remoteMcpServerConfig);
+                      } else {
+                        // Internal servers (with or without OAuth)
+                        setSetupSheetServer(server);
+                        setSetupSheetRemoteServerConfig(null);
+                      }
+
+                      setIsSettingUpServer(true);
+                      setIsOpen(false);
+                    }}
+                  />
+                ))}
             </>
           )}
 

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -97,18 +97,18 @@ export function ToolSetupCard({ toolName, toolId, owner }: ToolSetupCardProps) {
 
   const getButtonLabel = () => {
     if (!isAdmin) {
-      return "Admin only can activate tools";
+      return "Admin only can configure tools";
     }
     if (isActivating) {
-      return "Activating...";
+      return "Configuring...";
     }
     if (isToolActivatedInGlobalSpace) {
-      return "Activated";
+      return "Configured";
     }
     if (isToolActivatedInSystemSpace) {
       return "Add to Company Data";
     }
-    return "Activate";
+    return "Configure";
   };
 
   const getButtonClickHandler = () => {

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -97,7 +97,7 @@ export function ToolSetupCard({ toolName, toolId, owner }: ToolSetupCardProps) {
 
   const getButtonLabel = () => {
     if (!isAdmin) {
-      return "Admin only can configure tools";
+      return "Only admins can configure tools";
     }
     if (isActivating) {
       return "Configuring...";

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   MCPServerType,
+  MCPServerTypeWithViews,
   MCPServerViewType,
   RemoteMCPServerType,
 } from "@app/lib/api/mcp";
@@ -103,8 +104,8 @@ export const mcpServerViewSortingFn = (
 };
 
 export const mcpServersSortingFn = (
-  a: { mcpServer: MCPServerType },
-  b: { mcpServer: MCPServerType }
+  a: { mcpServer: MCPServerType | MCPServerTypeWithViews },
+  b: { mcpServer: MCPServerType | MCPServerTypeWithViews }
 ) => {
   const { serverType: aServerType } = getServerTypeAndIdFromSId(
     a.mcpServer.sId
@@ -113,7 +114,9 @@ export const mcpServersSortingFn = (
     b.mcpServer.sId
   );
   if (aServerType === bServerType) {
-    return a.mcpServer.name.localeCompare(b.mcpServer.name);
+    const aDisplayName = getMcpServerDisplayName(a.mcpServer);
+    const bDisplayName = getMcpServerDisplayName(b.mcpServer);
+    return aDisplayName.localeCompare(bDisplayName);
   }
   return aServerType < bServerType ? -1 : 1;
 };
@@ -148,7 +151,7 @@ export function getMcpServerDisplayName(
     | AgentBuilderMCPConfiguration
     | AgentBuilderAction
     | MCPServerConfigurationType
-) {
+): string {
   // Unreleased internal servers are displayed with a suffix in the UI.
   const res = getInternalMCPServerNameAndWorkspaceId(server.sId);
   let displayName = asDisplayToolName(server.name);

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -156,7 +156,7 @@ export function asDisplayToolName(name?: string | null) {
   }
 
   if (name === "image_generation") {
-    return "Create / Update Images";
+    return "Create Images";
   }
 
   if (name === "file_generation") {
@@ -168,7 +168,7 @@ export function asDisplayToolName(name?: string | null) {
   }
 
   if (name === "deep_dive") {
-    return `Go deep`;
+    return "Go deep";
   }
 
   return formatAsDisplayName(name);
@@ -179,7 +179,7 @@ export function asDisplayName(name?: string | null) {
     return "";
   }
 
-  return formatAsDisplayName(name);
+  return asDisplayToolName(name);
 }
 
 // Replace lone surrogates (actual Unicode surrogates, not escaped ones) with placeholder


### PR DESCRIPTION
## Description

- Change wording from "Activate" to "Configure" on the JIT tool list & on the toolSetup markdown directive. 
- Fix sorting of tools to use the displayName (currently the sorting on prod is 🤯 ). I did not change the fact that we sort first per server type then by server name (even if that could look odd to users). 
- Rename tool `"Create / Update Images"`to "Create Images" because whether it's images or frames we can edit and yet the name for Frames was "Create Frames" so trying to be consistent here. 

Review with hidden whitespaces advised! 

Ok I just added a second commit to remove the button "Manage", since we're not really explaining to the user where they are going!

<kbd>
<img width="598" height="714" alt="Screenshot 2025-11-21 at 15 04 23" src="https://github.com/user-attachments/assets/91e0e79f-8d84-4d0d-9cb5-a0eba6518740" />
</kbd>



## Tests

Locally. 


## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 