### PR TITLE
Add warning banner to Notion poke page + clarify actions

### DIFF
--- a/front/lib/api/poke/plugins/data_sources/operations.ts
+++ b/front/lib/api/poke/plugins/data_sources/operations.ts
@@ -9,7 +9,13 @@ import {
   Ok,
 } from "@app/types";
 
-const OPERATIONS = ["STOP", "PAUSE", "UNPAUSE", "RESUME", "SYNC"] as const;
+const OPERATIONS = [
+  "STOP: stop workflows with intent to resume shortly after (no DB changes)",
+  "RESUME: start all stopped workflows",
+  "PAUSE: stop workflows for a longer period of time (marks Connectors DB)",
+  "UNPAUSE: use to undo PAUSE (marks Connectors DB)",
+  "SYNC: use to synchronize workflows (heavyweight, use sparingly!)",
+] as const;
 
 type OperationType = (typeof OPERATIONS)[number];
 
@@ -20,15 +26,15 @@ const doOperation = (op: OperationType, connectorId: string) => {
   );
 
   switch (op) {
-    case "STOP":
+    case "STOP: stop workflows with intent to resume shortly after (no DB changes)":
       return connectorsAPI.stopConnector(connectorId);
-    case "PAUSE":
+    case "PAUSE: stop workflows for a longer period of time (marks Connectors DB)":
       return connectorsAPI.pauseConnector(connectorId);
-    case "UNPAUSE":
+    case "UNPAUSE: use to undo PAUSE (marks Connectors DB)":
       return connectorsAPI.unpauseConnector(connectorId);
-    case "RESUME":
+    case "RESUME: start all stopped workflows":
       return connectorsAPI.resumeConnector(connectorId);
-    case "SYNC":
+    case "SYNC: use to synchronize workflows (heavyweight, use sparingly!)":
       return connectorsAPI.syncConnector(connectorId);
     default:
       assertNever(op);

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -24,6 +24,10 @@ import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { PokePermissionTree } from "@app/components/poke/PokeConnectorPermissionsTree";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { SlackChannelPatternInput } from "@app/components/poke/PokeSlackChannelPatternInput";
+import {
+  PokeAlert,
+  PokeAlertDescription,
+} from "@app/components/poke/shadcn/ui/alert";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -562,6 +566,22 @@ const DataSourcePage = ({
           {owner.name}
         </a>
       </h3>
+      {dataSource.connectorProvider === "notion" && (
+        <PokeAlert variant="destructive" className="my-4">
+          <PokeAlertDescription>
+            Please read{" "}
+            <a
+              href="http://go/poke-notion"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold underline hover:no-underline"
+            >
+              go/poke-notion
+            </a>{" "}
+            before using any Notion plugin!
+          </PokeAlertDescription>
+        </PokeAlert>
+      )}
       {dataSource.connectorProvider && (
         <p>
           The data displayed here is fetched from <b>connectors</b>, please


### PR DESCRIPTION
## Description

Add a warning banner in the Notion datasource page. Also, add longer strings to clarify what maintenance ops do:

<img width="438" height="77" alt="Screenshot 2025-11-21 at 15 24 28" src="https://github.com/user-attachments/assets/96410070-3b3e-47f7-9ba3-ad336f2f887e" />
<img width="583" height="439" alt="Screenshot 2025-11-21 at 15 24 42" src="https://github.com/user-attachments/assets/314bd489-0e40-4d7e-abf4-5fee00ea7334" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Front