### PR TITLE
Remove poke connector stop/resume, and tweak strings

### DIFF
--- a/front/lib/api/poke/plugins/data_sources/operations.ts
+++ b/front/lib/api/poke/plugins/data_sources/operations.ts
@@ -10,11 +10,9 @@ import {
 } from "@app/types";
 
 const OPERATIONS = [
-  "STOP: stop workflows with intent to resume shortly after (no DB changes)",
-  "RESUME: start all stopped workflows",
-  "PAUSE: stop workflows for a longer period of time (marks Connectors DB)",
-  "UNPAUSE: use to undo PAUSE (marks Connectors DB)",
-  "SYNC: use to synchronize workflows (heavyweight, use sparingly!)",
+  "PAUSE: stop all workflows for this connector",
+  "UNPAUSE: restart any paused workflows",
+  "SYNC: perform a full data sync for this connector",
 ] as const;
 
 type OperationType = (typeof OPERATIONS)[number];
@@ -26,15 +24,11 @@ const doOperation = (op: OperationType, connectorId: string) => {
   );
 
   switch (op) {
-    case "STOP: stop workflows with intent to resume shortly after (no DB changes)":
-      return connectorsAPI.stopConnector(connectorId);
-    case "PAUSE: stop workflows for a longer period of time (marks Connectors DB)":
+    case "PAUSE: stop all workflows for this connector":
       return connectorsAPI.pauseConnector(connectorId);
-    case "UNPAUSE: use to undo PAUSE (marks Connectors DB)":
+    case "UNPAUSE: restart any paused workflows":
       return connectorsAPI.unpauseConnector(connectorId);
-    case "RESUME: start all stopped workflows":
-      return connectorsAPI.resumeConnector(connectorId);
-    case "SYNC: use to synchronize workflows (heavyweight, use sparingly!)":
+    case "SYNC: perform a full data sync for this connector":
       return connectorsAPI.syncConnector(connectorId);
     default:
       assertNever(op);

--- a/front/lib/api/poke/plugins/data_sources/operations.ts
+++ b/front/lib/api/poke/plugins/data_sources/operations.ts
@@ -10,9 +10,9 @@ import {
 } from "@app/types";
 
 const OPERATIONS = [
-  "PAUSE: stop all workflows for this connector",
-  "UNPAUSE: restart any paused workflows",
-  "SYNC: perform a full data sync for this connector",
+  "PAUSE: pause the connector",
+  "UNPAUSE: restart the connector",
+  "SYNC: perform a full data sync for the connector",
 ] as const;
 
 type OperationType = (typeof OPERATIONS)[number];
@@ -24,11 +24,11 @@ const doOperation = (op: OperationType, connectorId: string) => {
   );
 
   switch (op) {
-    case "PAUSE: stop all workflows for this connector":
+    case "PAUSE: pause the connector":
       return connectorsAPI.pauseConnector(connectorId);
-    case "UNPAUSE: restart any paused workflows":
+    case "UNPAUSE: restart the connector":
       return connectorsAPI.unpauseConnector(connectorId);
-    case "SYNC: perform a full data sync for this connector":
+    case "SYNC: perform a full data sync for the connector":
       return connectorsAPI.syncConnector(connectorId);
     default:
       assertNever(op);


### PR DESCRIPTION
## Description

Follow-up to https://github.com/dust-tt/dust/pull/18161

We decided that the difference between stop/resume and pause/unpause was too small, and was causing confusion. So only keeping pause/unpause in Poke. stop/resume are still available via CLI.

Also, tweaked strings.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front