### PR TITLE
feat: include cached tokens in input tokens

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -308,17 +308,18 @@ function tokenUsage(
 ): TokenUsageEvent {
   const cachedTokens = usage.cache_read_input_tokens ?? 0;
   const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
+  // In order to keep logic as it is implemented in core
+  const inputTokens =
+    (usage.input_tokens ?? 0) + cachedTokens + cacheCreationTokens;
 
   return {
     type: "token_usage",
     content: {
-      // In order to keep logic as it is implemented in core
-      inputTokens:
-        (usage.input_tokens ?? 0) + cachedTokens + cacheCreationTokens,
+      inputTokens,
       outputTokens: usage.output_tokens,
       cachedTokens,
       cacheCreationTokens,
-      totalTokens: (usage.input_tokens ?? 0) + usage.output_tokens,
+      totalTokens: inputTokens + usage.output_tokens,
     },
     metadata,
   };

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -306,13 +306,18 @@ function tokenUsage(
   usage: MessageDeltaUsage,
   metadata: LLMClientMetadata
 ): TokenUsageEvent {
+  const cachedTokens = usage.cache_read_input_tokens ?? 0;
+  const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
+
   return {
     type: "token_usage",
     content: {
-      inputTokens: usage.input_tokens ?? 0,
+      // In order to keep logic as it is implemented in core
+      inputTokens:
+        (usage.input_tokens ?? 0) + cachedTokens + cacheCreationTokens,
       outputTokens: usage.output_tokens,
-      cachedTokens: usage.cache_read_input_tokens ?? 0,
-      cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+      cachedTokens,
+      cacheCreationTokens,
       totalTokens: (usage.input_tokens ?? 0) + usage.output_tokens,
     },
     metadata,

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -308,7 +308,7 @@ function tokenUsage(
 ): TokenUsageEvent {
   const cachedTokens = usage.cache_read_input_tokens ?? 0;
   const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
-  // In order to keep logic as it is implemented in core
+  // Include all input tokens to keep consistency with core implementation
   const inputTokens =
     (usage.input_tokens ?? 0) + cachedTokens + cacheCreationTokens;
 


### PR DESCRIPTION
## Description

We were not including cached tokens count in input tokens for anthropic as we did for open ai (for which we split pricing)
This PR fixes it, we should not see negative costs for anthropic interactions anymore

## Tests


## Risk
low

## Deploy Plan

front