### PR TITLE
Fix console error Missing resize handle for PanelGroup

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -40,10 +40,12 @@ export default function ConversationSidePanelContainer({
 
   return (
     <>
-      {/* Resizable Handle for Panels - Only show on desktop */}
-      {currentPanel && !isMobile && (
-        <ResizableHandle withHandle className="z-50" />
-      )}
+      {/* Resizable Handle for Panels - Always render but control visibility */}
+      <ResizableHandle
+        withHandle={currentPanel && !isMobile}
+        disabled={!currentPanel || isMobile}
+        className="z-50"
+      />
       {/* Panel Container - either Interactive Content or Actions */}
       <ResizablePanel
         ref={panelRef}


### PR DESCRIPTION
## Description

Should fix a warning we have on the console in the convo page: 
```
installHook.js:1 WARNING: Missing resize handle for PanelGroup ":rg:" Error Component Stack
    at forwardRef(PanelGroup) (<anonymous>)
    at ErrorBoundary (ErrorBoundary.tsx:17:5)
    at ConversationInnerLayout (ConversationLayout.tsx:203:3)
    at ConversationSidePanelProvider (ConversationSidePanelContext.tsx:60:3)
    at div (<anonymous>)
    at div (<anonymous>)
    at AppContentLayout (AppContentLayout.tsx:62:3)
    at InputBarProvider (InputBarContext.tsx:19:36)
    at BlockedActionsProvider (BlockedActionsProvider.tsx:141:3)
    at ConversationLayoutContent (ConversationLayout.tsx:82:3)
    at ConversationsNavigationProvider (ConversationsNavigationProvider.tsx:15:3)
    at ConversationLayout (ConversationLayout.tsx:49:3)
    at DesktopNavigationProvider (DesktopNavigationContext.tsx:25:3)
    at WelcomeTourGuideProvider (WelcomeTourGuideProvider.tsx:13:3)
    at ThemeProvider (ThemeContext.tsx:93:33)
    at AppRootLayout (AppRootLayout.tsx:23:3)
    at ConfirmPopupArea (Confirm.tsx:24:36)
    at NavigationLoadingProvider (NavigationLoadingContext.tsx:23:3)
    at SidebarProvider (SidebarContext.tsx:18:3)
    at RootLayout (RootLayout.tsx:69:3)
    at PostHogTracker (PostHogTracker.tsx:28:34)
    at App (_app.tsx:48:31)
```

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 