### PR TITLE
Revert commit + check has access to convo

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -591,9 +591,9 @@ export async function postUserMessage(
           auth,
           conversation.sId
         );
-        if (conversationRes.isOk() && conversationRes.value) {
+        if (conversationRes) {
           await triggerConversationUnreadNotifications(auth, {
-            conversation: conversationRes.value,
+            conversation: conversationRes,
             messageId: m.sId,
           });
         }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -142,16 +142,11 @@ export async function updateConversationTitle(
     title: string;
   }
 ): Promise<Result<undefined, ConversationError>> {
-  const conversationRes = await ConversationResource.fetchById(
+  const conversation = await ConversationResource.fetchById(
     auth,
     conversationId
   );
 
-  if (conversationRes.isErr()) {
-    return conversationRes;
-  }
-
-  const conversation = conversationRes.value;
   if (!conversation) {
     return new Err(new ConversationError("conversation_not_found"));
   }
@@ -174,7 +169,7 @@ export async function deleteOrLeaveConversation(
     conversationId: string;
   }
 ): Promise<Result<{ success: true }, Error>> {
-  const conversationRes = await ConversationResource.fetchById(
+  const conversation = await ConversationResource.fetchById(
     auth,
     conversationId,
     {
@@ -182,11 +177,6 @@ export async function deleteOrLeaveConversation(
     }
   );
 
-  if (conversationRes.isErr()) {
-    return conversationRes;
-  }
-
-  const conversation = conversationRes.value;
   if (!conversation) {
     return new Err(new ConversationError("conversation_not_found"));
   }

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -205,13 +205,13 @@ export async function destroyConversation(
 
   await destroyConversationDataSource(auth, { conversation });
 
-  const cRes = await ConversationResource.fetchById(auth, conversation.sId, {
+  const c = await ConversationResource.fetchById(auth, conversation.sId, {
     includeDeleted: true,
     includeTest: true,
     dangerouslySkipPermissionFiltering: true,
   });
-  if (cRes.isOk() && cRes.value) {
-    await cRes.value.delete(auth);
+  if (c) {
+    await c.delete(auth);
   }
 
   return new Ok(undefined);

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -27,17 +27,12 @@ export async function getConversation(
 ): Promise<Result<ConversationType, ConversationError>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const conversationRes = await ConversationResource.fetchById(
+  const conversation = await ConversationResource.fetchById(
     auth,
     conversationId,
     { includeDeleted }
   );
 
-  if (conversationRes.isErr()) {
-    return conversationRes;
-  }
-
-  const conversation = conversationRes.value;
   if (!conversation) {
     return new Err(new ConversationError("conversation_not_found"));
   }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -680,16 +680,11 @@ export async function fetchConversationMessages(
     return new Err(new Error("Unexpected `auth` without `workspace`."));
   }
 
-  const conversationRes = await ConversationResource.fetchById(
+  const conversation = await ConversationResource.fetchById(
     auth,
     conversationId
   );
 
-  if (conversationRes.isErr()) {
-    return conversationRes;
-  }
-
-  const conversation = conversationRes.value;
   if (!conversation) {
     return new Err(new ConversationError("conversation_not_found"));
   }

--- a/front/lib/api/viz/files.ts
+++ b/front/lib/api/viz/files.ts
@@ -144,30 +144,25 @@ export async function canAccessFileInConversation(
   // We only need to verify if the conversation exists, but internalBuilderForWorkspace only has
   // global group access and can't see agents from other groups that this conversation might
   // reference.
-  const requestedConversationRes = await ConversationResource.fetchById(
+  const requestedConversation = await ConversationResource.fetchById(
     auth,
     requestedConversationId,
     {
       dangerouslySkipPermissionFiltering: true,
     }
   );
-  if (requestedConversationRes.isErr()) {
-    return requestedConversationRes;
-  }
-  const requestedConversation = requestedConversationRes.value;
   if (!requestedConversation) {
     return new Err(new Error("Requested conversation not found"));
   }
 
   // Check if file belongs to a conversation created through a sub agent run.
-  const fileConversationRes = await ConversationResource.fetchById(
+  const fileConversation = await ConversationResource.fetchById(
     auth,
     useCaseMetadata.conversationId
   );
-  if (fileConversationRes.isErr() || !fileConversationRes.value) {
+  if (!fileConversation) {
     return new Err(new Error("File conversation not found"));
   }
-  const fileConversation = fileConversationRes.value;
 
   // Traverse up the conversation hierarchy of the file's conversation.
   const fileBelongsToSubConversation = await isAncestorConversation(

--- a/front/lib/notifications/workflows/conversation-added-as-participant.ts
+++ b/front/lib/notifications/workflows/conversation-added-as-participant.ts
@@ -94,7 +94,7 @@ const shouldSkipConversation = async ({
       payload.conversationId
     );
 
-    if (conversation) {
+    if (!conversation) {
       return true;
     }
   }

--- a/front/lib/notifications/workflows/conversation-added-as-participant.ts
+++ b/front/lib/notifications/workflows/conversation-added-as-participant.ts
@@ -51,24 +51,21 @@ const getConversationDetails = async ({
       payload.workspaceId
     );
 
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       payload.conversationId
     );
 
-    if (conversationRes.isOk()) {
-      const conversation = conversationRes.value;
-      if (conversation) {
-        workspaceName = auth.getNonNullableWorkspace().name;
-        subject = conversation.title ?? "Dust conversation";
+    if (conversation) {
+      workspaceName = auth.getNonNullableWorkspace().name;
+      subject = conversation.title ?? "Dust conversation";
 
-        const userThatAddedYou = await UserResource.fetchById(
-          payload.userThatAddedYouId
-        );
+      const userThatAddedYou = await UserResource.fetchById(
+        payload.userThatAddedYouId
+      );
 
-        if (userThatAddedYou) {
-          userThatAddedYouFullname = userThatAddedYou.fullName();
-        }
+      if (userThatAddedYou) {
+        userThatAddedYouFullname = userThatAddedYou.fullName();
       }
     }
   }
@@ -92,12 +89,12 @@ const shouldSkipConversation = async ({
       payload.workspaceId
     );
 
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       payload.conversationId
     );
 
-    if (conversationRes.isErr() || !conversationRes.value) {
+    if (conversation) {
       return true;
     }
   }

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -96,52 +96,49 @@ const getConversationDetails = async ({
       payload.workspaceId
     );
 
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       payload.conversationId
     );
 
-    if (conversationRes.isOk()) {
-      const conversation = conversationRes.value;
-      if (conversation) {
-        workspaceName = auth.getNonNullableWorkspace().name;
-        subject = conversation.title ?? "Dust conversation";
-        isFromTrigger = !!conversation.triggerSId;
+    if (conversation) {
+      workspaceName = auth.getNonNullableWorkspace().name;
+      subject = conversation.title ?? "Dust conversation";
+      isFromTrigger = !!conversation.triggerSId;
 
-        // Retrieve the message that triggered the notification
-        const messageRes = await conversation.getMessageById(
+      // Retrieve the message that triggered the notification
+      const messageRes = await conversation.getMessageById(
+        auth,
+        payload.messageId
+      );
+
+      if (messageRes.isOk()) {
+        const rendered = await batchRenderMessages(
           auth,
-          payload.messageId
+          conversation,
+          [messageRes.value],
+          "light"
         );
 
-        if (messageRes.isOk()) {
-          const rendered = await batchRenderMessages(
-            auth,
-            conversation,
-            [messageRes.value],
-            "light"
-          );
-
-          if (rendered.isOk() && rendered.value.length === 1) {
-            const lightMessage = rendered.value[0];
-            if (isContentFragmentType(lightMessage)) {
-              // Do nothing. Content fragments are not displayed in the notification.
-            } else if (isUserMessageType(lightMessage)) {
-              author = lightMessage.user?.fullName ?? "Someone else";
-              avatarUrl = lightMessage.user?.image ?? undefined;
-              previewText = lightMessage.content;
-            } else {
-              author = lightMessage.configuration.name
-                ? `@${lightMessage.configuration.name}`
-                : "An agent";
-              avatarUrl = lightMessage.configuration.pictureUrl ?? undefined;
-              previewText = lightMessage.content ?? "No content";
-            }
-            previewText =
-              previewText.length > 1024
-                ? previewText.slice(0, 1024) + "..."
-                : previewText;
+        if (rendered.isOk() && rendered.value.length === 1) {
+          const lightMessage = rendered.value[0];
+          if (isContentFragmentType(lightMessage)) {
+            // Do nothing. Content fragments are not displayed in the notification.
+          } else if (isUserMessageType(lightMessage)) {
+            author = lightMessage.user?.fullName ?? "Someone else";
+            avatarUrl = lightMessage.user?.image ?? undefined;
+            previewText = lightMessage.content;
+          } else {
+            author = lightMessage.configuration.name
+              ? `@${lightMessage.configuration.name}`
+              : "An agent";
+            avatarUrl = lightMessage.configuration.pictureUrl ?? undefined;
+            previewText = lightMessage.content ?? "No content";
           }
+          previewText =
+            previewText.length > 1024
+              ? previewText.slice(0, 1024) + "..."
+              : previewText;
         }
       }
     }
@@ -171,16 +168,15 @@ const shouldSkipConversation = async ({
       payload.workspaceId
     );
 
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       payload.conversationId
     );
 
-    if (conversationRes.isErr() || !conversationRes.value) {
+    if (!conversation) {
       return true;
     }
 
-    const conversation = conversationRes.value;
     if (triggerShouldSkip && conversation.triggerSId) {
       return true;
     }

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -201,14 +201,13 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   ): Promise<BlockedToolExecution[]> {
     const owner = auth.getNonNullableWorkspace();
 
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       conversationId
     );
-    if (conversationRes.isErr() || !conversationRes.value) {
+    if (!conversation) {
       return [];
     }
-    const conversation = conversationRes.value;
 
     const latestAgentMessages =
       await conversation.getLatestAgentMessageIdByRank(auth);

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -12,7 +12,6 @@ import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy
 import { Authenticator } from "@app/lib/auth";
 import { Message } from "@app/lib/models/assistant/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import {
   createResourcePermissionsFromSpacesWithMap,
@@ -921,16 +920,12 @@ describe("ConversationResource", () => {
       const { ConversationParticipantModel } = await import(
         "@app/lib/models/assistant/conversation"
       );
-      const conversationRes = await ConversationResource.fetchById(
-        adminAuth,
-        conversationIds[0]
-      );
-      assert(conversationRes.isOk(), "Failed to fetch conversation");
-      assert(conversationRes.value, "Conversation not found");
-
       const participation = await ConversationParticipantModel.findOne({
         where: {
-          conversationId: conversationRes.value.id,
+          conversationId: (await ConversationResource.fetchById(
+            adminAuth,
+            conversationIds[0]
+          ))!.id,
           userId: userAuth.getNonNullableUser().id,
           workspaceId: userAuth.getNonNullableWorkspace().id,
         },
@@ -1064,12 +1059,10 @@ describe("ConversationResource", () => {
 
     it("should retrieve a user message with the userMessage include", async () => {
       // Get the conversation resource to access getMessageById
-      const conversationRes = await ConversationResource.fetchById(
+      const conversationResource = await ConversationResource.fetchById(
         auth,
         conversation.sId
       );
-      assert(conversationRes.isOk(), "Failed to fetch conversation");
-      const conversationResource = conversationRes.value;
       assert(conversationResource, "Conversation resource not found");
 
       // Get all messages to find a user message
@@ -1105,12 +1098,10 @@ describe("ConversationResource", () => {
 
     it("should retrieve an agent message with the agentMessage include", async () => {
       // Get the conversation resource to access getMessageById
-      const conversationRes = await ConversationResource.fetchById(
+      const conversationResource = await ConversationResource.fetchById(
         auth,
         conversation.sId
       );
-      assert(conversationRes.isOk(), "Failed to fetch conversation");
-      const conversationResource = conversationRes.value;
       assert(conversationResource, "Conversation resource not found");
 
       // Get all messages to find an agent message
@@ -1148,12 +1139,10 @@ describe("ConversationResource", () => {
     });
 
     it("should return error when message not found", async () => {
-      const conversationRes = await ConversationResource.fetchById(
+      const conversationResource = await ConversationResource.fetchById(
         auth,
         conversation.sId
       );
-      assert(conversationRes.isOk(), "Failed to fetch conversation");
-      const conversationResource = conversationRes.value;
       assert(conversationResource, "Conversation resource not found");
 
       // Try to fetch a non-existent message
@@ -1176,25 +1165,19 @@ describe("ConversationResource", () => {
       });
       conversationIds.push(otherConversation.sId);
 
-      const conversationRes = await ConversationResource.fetchById(
+      const conversationResource = await ConversationResource.fetchById(
         auth,
         conversation.sId
       );
-      assert(conversationRes.isOk(), "Failed to fetch conversation");
-      const conversationResource = conversationRes.value;
       assert(conversationResource, "Conversation resource not found");
 
       // Get a message from the other conversation
-      const otherConversationRes = await ConversationResource.fetchById(
-        auth,
-        otherConversation.sId
-      );
-      assert(otherConversationRes.isOk(), "Failed to fetch other conversation");
-      assert(otherConversationRes.value, "Other conversation not found");
-
       const otherMessages = await Message.findAll({
         where: {
-          conversationId: otherConversationRes.value.id,
+          conversationId: (await ConversationResource.fetchById(
+            auth,
+            otherConversation.sId
+          ))!.id,
           workspaceId: auth.getNonNullableWorkspace().id,
         },
       });
@@ -1214,12 +1197,10 @@ describe("ConversationResource", () => {
     });
 
     it("should verify includes are not optional (both UserMessage and AgentMessage)", async () => {
-      const conversationRes = await ConversationResource.fetchById(
+      const conversationResource = await ConversationResource.fetchById(
         auth,
         conversation.sId
       );
-      assert(conversationRes.isOk(), "Failed to fetch conversation");
-      const conversationResource = conversationRes.value;
       assert(conversationResource, "Conversation resource not found");
 
       // Get all messages
@@ -1261,12 +1242,10 @@ describe("ConversationResource", () => {
     });
 
     it("should return a valid Message object with all expected fields", async () => {
-      const conversationRes = await ConversationResource.fetchById(
+      const conversationResource = await ConversationResource.fetchById(
         auth,
         conversation.sId
       );
-      assert(conversationRes.isOk(), "Failed to fetch conversation");
-      const conversationResource = conversationRes.value;
       assert(conversationResource, "Conversation resource not found");
 
       // Get the first message

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1135,6 +1135,10 @@ describe("ConversationResource", () => {
     it("should return 'conversation_not_found' when conversation belongs to different workspace", async () => {
       // Create a conversation in a different workspace
       const anotherWorkspace = await WorkspaceFactory.basic();
+
+      // Create the required default groups for the workspace
+      await GroupResource.makeDefaultsForWorkspace(anotherWorkspace);
+
       const anotherUser = await UserFactory.basic();
       await MembershipFactory.associate(anotherWorkspace, anotherUser, {
         role: "admin",

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -214,16 +214,20 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       auth,
       conversation.requestedSpaceIds
     );
-    const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
-    if (
-      !auth.canRead(
-        createResourcePermissionsFromSpacesWithMap(
-          spaceIdToGroupsMap,
-          conversation.requestedSpaceIds.map((id) => Number(id))
+    try {
+      const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
+      if (
+        !auth.canRead(
+          createResourcePermissionsFromSpacesWithMap(
+            spaceIdToGroupsMap,
+            conversation.requestedSpaceIds.map((id) => Number(id))
+          )
         )
-      )
-    ) {
-      return "conversation_access_restricted";
+      ) {
+        return "conversation_access_restricted";
+      }
+    } catch (error) {
+      return "conversation_not_found";
     }
     return "allowed";
   }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -192,7 +192,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return res.length > 0 ? res[0] : null;
   }
 
-  static async canAccess(auth: Authenticator, sId: string): Promise<'allowed' | 'conversation_not_found' | 'conversation_access_restricted'> {
+  static async canAccess(
+    auth: Authenticator,
+    sId: string
+  ): Promise<
+    "allowed" | "conversation_not_found" | "conversation_access_restricted"
+  > {
     const workspace = auth.getNonNullableWorkspace();
     const { where } = this.getOptions();
     const conversation = await this.model.findOne({
@@ -203,14 +208,24 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       },
     });
     if (!conversation) {
-      return 'conversation_not_found';
+      return "conversation_not_found";
     }
-    const spaces = await SpaceResource.fetchByModelIds(auth, conversation.requestedSpaceIds);
+    const spaces = await SpaceResource.fetchByModelIds(
+      auth,
+      conversation.requestedSpaceIds
+    );
     const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
-    if (!auth.canRead(createResourcePermissionsFromSpacesWithMap(spaceIdToGroupsMap, conversation.requestedSpaceIds.map((id) => Number(id))))) {
-      return 'conversation_access_restricted';
+    if (
+      !auth.canRead(
+        createResourcePermissionsFromSpacesWithMap(
+          spaceIdToGroupsMap,
+          conversation.requestedSpaceIds.map((id) => Number(id))
+        )
+      )
+    ) {
+      return "conversation_access_restricted";
     }
-    return 'allowed';
+    return "allowed";
   }
 
   static async listAll(

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -97,12 +97,10 @@ describe("FileResource", () => {
       assert(token, "Share token should be defined");
 
       // Soft-delete the conversation.
-      const conversationRes = await ConversationResource.fetchById(
+      const conversationResource = await ConversationResource.fetchById(
         auth,
         conversation.sId
       );
-      assert(conversationRes.isOk(), "Failed to fetch conversation");
-      const conversationResource = conversationRes.value;
       assert(conversationResource, "Conversation resource should be defined");
       await conversationResource.updateVisibilityToDeleted();
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -177,12 +177,12 @@ export class FileResource extends BaseResource<FileModel> {
       // conversation exists, but internalBuilderForWorkspace only has global group
       // access and can't see agents from other groups that this conversation might reference.
       // Skip permission filtering since share token provides its own authorization.
-      const conversationRes = await ConversationResource.fetchById(
+      const conversation = await ConversationResource.fetchById(
         auth,
         conversationId,
         { dangerouslySkipPermissionFiltering: true }
       );
-      if (conversationRes.isErr() || !conversationRes.value) {
+      if (!conversation) {
         return null;
       }
     }

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -129,13 +129,12 @@ async function handler(
   let isParticipant = false;
 
   if (user && conversationId) {
-    const conversationRes = await ConversationResource.fetchById(
+    const conversationResource = await ConversationResource.fetchById(
       auth,
       conversationId
     );
 
-    if (conversationRes.isOk() && conversationRes.value && user) {
-      const conversationResource = conversationRes.value;
+    if (user && conversationResource) {
       isParticipant =
         await conversationResource.isConversationParticipant(user);
     }

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -78,11 +78,11 @@ async function handler(
     file.useCaseMetadata?.conversationId
   ) {
     // For conversation files, check if the user has access to the conversation
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       file.useCaseMetadata.conversationId
     );
-    if (conversationRes.isErr() || !conversationRes.value) {
+    if (!conversation) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {

--- a/front/pages/api/v1/w/[wId]/files/fileId.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/fileId.test.ts
@@ -7,10 +7,7 @@ import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_
 
 vi.mock("@app/lib/resources/file_resource", () => ({
   FileResource: {
-    fetchById: vi.fn().mockResolvedValue({
-      isErr: () => false,
-      value: { id: "test-file-id" },
-    }),
+    fetchById: vi.fn(),
   },
 }));
 
@@ -53,10 +50,7 @@ vi.mock("@app/lib/api/data_sources", () => ({
 
 vi.mock("@app/lib/resources/conversation_resource", () => ({
   ConversationResource: {
-    fetchById: vi.fn().mockResolvedValue({
-      isErr: () => false,
-      value: { id: "test-conversation-id" },
-    }),
+    fetchById: vi.fn().mockResolvedValue({ id: "test-conversation-id" }),
   },
 }));
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -62,12 +62,15 @@ async function handler(
   switch (req.method) {
     case "GET": {
       const canAccess = await ConversationResource.canAccess(auth, cId);
-      if (canAccess !== 'allowed') {
+      if (canAccess !== "allowed") {
         return apiError(req, res, {
-          status_code: canAccess === 'conversation_not_found' ? 404 : 403,
+          status_code: canAccess === "conversation_not_found" ? 404 : 403,
           api_error: {
             type: canAccess,
-            message: canAccess === 'conversation_not_found' ? "Conversation not found." : "You don't have access to this conversation.",
+            message:
+              canAccess === "conversation_not_found"
+                ? "Conversation not found."
+                : "You don't have access to this conversation.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -61,10 +61,18 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const conversationRes =
-        await ConversationResource.fetchConversationWithoutContent(auth, cId, {
-          alertIfNoAccessible: true,
+      const canAccess = await ConversationResource.canAccess(auth, cId);
+      if (canAccess !== 'allowed') {
+        return apiError(req, res, {
+          status_code: canAccess === 'conversation_not_found' ? 404 : 403,
+          api_error: {
+            type: canAccess,
+            message: canAccess === 'conversation_not_found' ? "Conversation not found." : "You don't have access to this conversation.",
+          },
         });
+      }
+      const conversationRes =
+        await ConversationResource.fetchConversationWithoutContent(auth, cId);
 
       if (conversationRes.isErr()) {
         return apiErrorForConversation(req, res, conversationRes.error);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -42,9 +42,9 @@ async function handler(
     });
   }
 
-  const conversationRes = await ConversationResource.fetchById(auth, cId);
+  const conversation = await ConversationResource.fetchById(auth, cId);
 
-  if (conversationRes.isErr() || !conversationRes.value) {
+  if (!conversation) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -53,8 +53,6 @@ async function handler(
       },
     });
   }
-
-  const conversation = conversationRes.value;
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
@@ -44,10 +44,7 @@ vi.mock("@app/lib/api/data_sources", () => ({
 
 vi.mock("@app/lib/resources/conversation_resource", () => ({
   ConversationResource: {
-    fetchById: vi.fn().mockResolvedValue({
-      isErr: () => false,
-      value: { id: "test-conversation-id" },
-    }),
+    fetchById: vi.fn().mockResolvedValue({ id: "test-conversation-id" }),
   },
 }));
 

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -122,11 +122,11 @@ async function handler(
     isConversationFileUseCase(file.useCase) &&
     file.useCaseMetadata?.conversationId
   ) {
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       file.useCaseMetadata.conversationId
     );
-    if (conversationRes.isErr() || !conversationRes.value) {
+    if (!conversation) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {

--- a/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
@@ -64,12 +64,12 @@ async function handler(
 
   // Check permissions based on useCase and useCaseMetadata.
   if (isConversationFileUseCase(useCase) && useCaseMetadata?.conversationId) {
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       useCaseMetadata.conversationId
     );
 
-    if (conversationRes.isErr() || !conversationRes.value) {
+    if (!conversation) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -55,11 +55,11 @@ async function handler(
     file.useCaseMetadata?.conversationId
   ) {
     // For conversation files, check if the user has access to the conversation.
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       file.useCaseMetadata.conversationId
     );
-    if (conversationRes.isErr() || !conversationRes.value) {
+    if (!conversation) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {

--- a/front/scripts/debug_conversation_accessibility.ts
+++ b/front/scripts/debug_conversation_accessibility.ts
@@ -41,15 +41,13 @@ makeScript(
 
     // Step 1: Check if conversation exists (bypass permissions)
     logger.info("STEP 1: Checking if conversation exists...");
-    const conversationWithoutPermCheckRes =
-      await ConversationResource.fetchById(auth, conversationId, {
-        dangerouslySkipPermissionFiltering: true,
-      });
+    const conversationWithoutPermCheck = await ConversationResource.fetchById(
+      auth,
+      conversationId,
+      { dangerouslySkipPermissionFiltering: true }
+    );
 
-    if (
-      conversationWithoutPermCheckRes.isErr() ||
-      !conversationWithoutPermCheckRes.value
-    ) {
+    if (!conversationWithoutPermCheck) {
       logger.error(
         "✗ Conversation not found in this workspace (or doesn't exist)"
       );
@@ -62,8 +60,6 @@ makeScript(
       return;
     }
 
-    const conversationWithoutPermCheck = conversationWithoutPermCheckRes.value;
-
     logger.info("✓ Conversation exists", {
       conversationId: conversationWithoutPermCheck.sId,
       visibility: conversationWithoutPermCheck.visibility,
@@ -75,13 +71,12 @@ makeScript(
 
     // Step 2: Check if user has access (with permission filtering)
     logger.info("STEP 2: Checking user access (with permission filtering)...");
-    const conversationRes = await ConversationResource.fetchById(
+    const conversation = await ConversationResource.fetchById(
       auth,
       conversationId
     );
 
-    if (conversationRes.isOk() && conversationRes.value) {
-      const conversation = conversationRes.value;
+    if (conversation) {
       logger.info("✓ USER HAS ACCESS TO CONVERSATION", {
         conversationExists: true,
         userHasAccess: true,

--- a/front/temporal/agent_loop/activities/notification.ts
+++ b/front/temporal/agent_loop/activities/notification.ts
@@ -69,7 +69,7 @@ export async function conversationUnreadNotificationActivity(
     conversation,
     messageId: agentLoopArgs.agentMessageId,
   });
-  
+
   if (r.isErr()) {
     logger.error(
       { error: r.error },

--- a/front/temporal/agent_loop/activities/notification.ts
+++ b/front/temporal/agent_loop/activities/notification.ts
@@ -52,12 +52,12 @@ export async function conversationUnreadNotificationActivity(
   );
 
   // Get conversation participants
-  const conversationRes = await ConversationResource.fetchById(
+  const conversation = await ConversationResource.fetchById(
     auth,
     agentLoopArgs.conversationId
   );
 
-  if (conversationRes.isErr() || !conversationRes.value) {
+  if (!conversation) {
     logger.warn(
       { conversationId: agentLoopArgs.conversationId },
       "Conversation not found after delay"
@@ -65,13 +65,11 @@ export async function conversationUnreadNotificationActivity(
     return;
   }
 
-  const conversation = conversationRes.value;
-
   const r = await triggerConversationUnreadNotifications(auth, {
     conversation,
     messageId: agentLoopArgs.agentMessageId,
   });
-
+  
   if (r.isErr()) {
     logger.error(
       { error: r.error },


### PR DESCRIPTION
## Description

This PR reverts the change that made ConversationResource.fetchById return a `Result<ConversationResource | null, ConversationError>` back to the original pattern of returning `ConversationResource | null`.

A new canAccess method has been added that explicitly checks permissions and returns `'allowed' | 'conversation_not_found' | 'conversation_access_restricted'`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Medium.
Double-check conversation-unread.ts since there were some conflicts.

## Deploy Plan

Deploy front
