### PR TITLE
[front] fix(poke): fix link to Temporal schedules/workflows

### DIFF
--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -68,9 +68,7 @@ export function ViewDataSourceTable({
   const isRunning = temporalRunningWorkflows.length > 0;
   const isScheduleBased =
     dataSource.connectorProvider === "gong" ||
-    dataSource.connectorProvider === "intercom"
-      ? "schedules"
-      : "workflows";
+    dataSource.connectorProvider === "intercom";
 
   return (
     <>


### PR DESCRIPTION
## Description

- This PR fixes the link to Temporal available on Poke data sources, which always points to schedules instead of workflows.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
