### PR TITLE
[front] enh(poke): add provider to poke triggers data table

### DIFF
--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -3,13 +3,14 @@ import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { TriggerWithProviderType } from "@app/pages/api/poke/workspaces/[wId]/triggers";
 import type {
   LightAgentConfigurationType,
   LightWorkspaceType,
 } from "@app/types";
 import type { TriggerType } from "@app/types/assistant/triggers";
 
-type TriggerDisplayType = TriggerType & {
+type TriggerDisplayType = TriggerWithProviderType & {
   agentName?: string;
 };
 
@@ -91,13 +92,36 @@ export function makeColumnsForTriggers(
       },
       accessorFn: (row) => {
         const agent = agentConfigMap.get(row.agentConfigurationId);
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        return agent?.name || row.agentConfigurationId;
+        return agent?.name ?? row.agentConfigurationId;
       },
     },
     {
       accessorKey: "kind",
       header: "Kind",
+    },
+    {
+      accessorKey: "provider",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Provider</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      cell: ({ row }) => {
+        const trigger = row.original;
+        if (trigger.kind === "webhook") {
+          return trigger.provider ?? "N/A";
+        }
+        return "-";
+      },
     },
     {
       accessorKey: "configuration",

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -118,7 +118,7 @@ export function makeColumnsForTriggers(
       cell: ({ row }) => {
         const trigger = row.original;
         if (trigger.kind === "webhook") {
-          return trigger.provider ?? "N/A";
+          return trigger.provider ?? "Custom";
         }
         return "-";
       },

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -122,6 +122,12 @@ export function makeColumnsForTriggers(
         }
         return "-";
       },
+      filterFn: (row, columnId, filterValue) => {
+        if (!filterValue || filterValue.length === 0) {
+          return true;
+        }
+        return filterValue.includes(row.getValue(columnId));
+      },
     },
     {
       accessorKey: "configuration",

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -122,11 +122,8 @@ export function makeColumnsForTriggers(
         }
         return "-";
       },
-      filterFn: (row, columnId, filterValue) => {
-        if (!filterValue || filterValue.length === 0) {
-          return true;
-        }
-        return filterValue.includes(row.getValue(columnId));
+      filterFn: (row, id, value) => {
+        return value.includes(row.getValue(id));
       },
     },
     {

--- a/front/components/poke/triggers/table.tsx
+++ b/front/components/poke/triggers/table.tsx
@@ -4,6 +4,8 @@ import { makeColumnsForTriggers } from "@app/components/poke/triggers/columns";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
 import { usePokeTriggers } from "@app/poke/swr/triggers";
 import type { LightWorkspaceType } from "@app/types";
+import { asDisplayName } from "@app/types";
+import { WEBHOOK_PROVIDERS } from "@app/types/triggers/webhooks";
 
 interface TriggerDataTableProps {
   owner: LightWorkspaceType;
@@ -44,7 +46,28 @@ export function TriggerDataTable({
             )
           : triggers;
 
-        return <PokeDataTable columns={columns} data={filteredTriggers} />;
+        // Create facet options for provider filter
+        const providerFacets = [
+          {
+            columnId: "provider",
+            title: "Provider",
+            options: [
+              ...WEBHOOK_PROVIDERS.map((provider) => ({
+                label: asDisplayName(provider),
+                value: provider,
+              })),
+              { label: "Custom", value: "Custom" },
+            ],
+          },
+        ];
+
+        return (
+          <PokeDataTable
+            columns={columns}
+            data={filteredTriggers}
+            facets={providerFacets}
+          />
+        );
       }}
     </PokeDataTableConditionalFetch>
   );


### PR DESCRIPTION
## Description

- This PR adds a "Provider" column to the Triggers data table in poke.
- Comes with filtering capabilities.

<img width="1584" height="525" alt="Screenshot 2025-11-21 at 6 01 23 PM" src="https://github.com/user-attachments/assets/e4dd1eba-18b6-4946-9646-5de1c7ad06d4" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
