### PR TITLE
Add analytics filters

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -48,11 +48,13 @@ export const INDEXED_COLORS = [
 export const MAX_TOOLS_DISPLAYED = 5;
 
 export const OTHER_LABEL = {
+  key: "others",
   label: "Others",
   color: "text-blue-300 dark:text-blue-300-night",
 };
 
 export const UNKNOWN_LABEL = {
+  key: "unknown",
   label: "Unknown",
   color: "text-gray-400 dark:text-gray-400-night",
 };

--- a/front/components/agent_builder/observability/shared/ChartLegend.tsx
+++ b/front/components/agent_builder/observability/shared/ChartLegend.tsx
@@ -32,6 +32,8 @@ export interface LegendItem {
   key: string;
   label: string;
   colorClassName: string;
+  onClick?: () => void;
+  isActive?: boolean;
 }
 
 interface ChartLegendProps {
@@ -42,7 +44,15 @@ export function ChartLegend({ items }: ChartLegendProps) {
   return (
     <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
       {items.map((item) => (
-        <div key={item.key} className="flex items-center gap-2">
+        <div
+          key={item.key}
+          className={`flex items-center gap-2 ${
+            item.onClick
+              ? "cursor-pointer transition-opacity hover:opacity-80"
+              : ""
+          } ${item.isActive === false ? "opacity-20" : ""}`}
+          onClick={item.onClick}
+        >
           <LegendDot
             className={item.colorClassName}
             rounded={item.key === "versionMarkers" ? "full" : "sm"}

--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -33,9 +33,9 @@ export function getSourceColor(source: UserMessageOrigin) {
  * "Other" and "Unknown" are special cases that have their own colors.
  */
 export function getIndexedColor(label: string, allLabels: string[]): string {
-  if (label === OTHER_LABEL.label) {
+  if (label === OTHER_LABEL.key) {
     return OTHER_LABEL.color;
-  } else if (label === UNKNOWN_LABEL.label) {
+  } else if (label === UNKNOWN_LABEL.key) {
     return UNKNOWN_LABEL.color;
   }
 

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -100,15 +100,15 @@ function GroupedTooltip(
     .map((p) => {
       const groupKey = p.name;
 
-      let label = "";
+      let label;
       if (groupKey === "others") {
         label = OTHER_LABEL.label;
       } else if (groupBy === "origin" && isUserMessageOrigin(groupKey)) {
         label = USER_MESSAGE_ORIGIN_LABELS[groupKey].label;
       } else {
-        label = availableGroupsArray.find(
-          (g) => g.groupKey === groupKey
-        )?.groupLabel;
+        label =
+          availableGroupsArray.find((g) => g.groupKey === groupKey)
+            ?.groupLabel ?? "";
       }
 
       const colorClassName = getColorClassName(

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -245,12 +245,6 @@ export function ProgrammaticCostChart({
   const availableGroupsArray = programmaticCostData?.availableGroups ?? [];
   const allGroupKeys = availableGroupsArray.map((g) => g.groupKey);
 
-  // Build map from groupKey to groupLabel from availableGroups.
-  const groupKeyToLabel = new Map<string, string>();
-  availableGroupsArray.forEach((group) => {
-    groupKeyToLabel.set(group.groupKey, group.groupLabel);
-  });
-
   // Extract visible group keys from filtered data.
   const visibleGroupKeys = new Set<string>();
   const points = programmaticCostData?.points ?? [];

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -90,7 +90,7 @@ function GroupedTooltip(
     return null;
   }
 
-  const rows: TooltipRow[] = payload
+  const rows = payload
     .filter(
       (p) =>
         p.dataKey !== "totalInitialCreditsCents" &&
@@ -100,7 +100,7 @@ function GroupedTooltip(
     .map((p) => {
       const groupKey = p.name;
 
-      let label;
+      let label = "";
       if (groupKey === "others") {
         label = OTHER_LABEL.label;
       } else if (groupBy === "origin" && isUserMessageOrigin(groupKey)) {

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -150,9 +150,12 @@ export function groupTopNAndAggregateOthers<
   topN: number = 5,
   valueKey: keyof T
 ): Array<{ groupKey: string; points: T[] }> {
-  // Keep top N groups
-  const topGroups = groups.slice(0, topN);
-  const otherGroups = groups.slice(topN);
+  if (groups.length <= topN) {
+    return groups;
+  }
+  // Keep top N-1 groups, last groups will be aggregated into "Others".
+  const topGroups = groups.slice(0, topN - 1);
+  const otherGroups = groups.slice(topN - 1);
 
   // If no groups beyond topN, return as-is
   if (otherGroups.length === 0) {

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -135,29 +135,31 @@ export function formatUTCDateFromMillis(ms: number): string {
 }
 
 /**
- * Groups data by keeping top N groups and aggregating the rest into "Others".
+ * Ensures at most N groups by keeping top N-1 groups and aggregating the rest into "Others".
+ * If there are N groups or less, returns them as is. Otherwise aggregates the last ones
+ * to make one single group.
  * The input must already be sorted by the desired criteria.
  *
  * @param groups - Array of groups with parsed points, already sorted by priority (e.g., by total cost)
- * @param topN - Number of top groups to keep individually (default: 5)
+ * @param max - Maximum number of groups to return (default: 5)
  * @param valueKey - Key of the numeric value to aggregate (e.g., "costCents")
- * @returns Array with top N groups + optional "others" group
+ * @returns Array with at most N groups (top N-1 + optional "others" group)
  */
-export function groupTopNAndAggregateOthers<
+export function ensureAtMostNGroups<
   T extends { timestamp: number; [key: string]: number },
 >(
   groups: Array<{ groupKey: string; points: T[] }>,
-  topN: number = 5,
+  max: number = 5,
   valueKey: keyof T
 ): Array<{ groupKey: string; points: T[] }> {
-  if (groups.length <= topN) {
+  if (groups.length <= max) {
     return groups;
   }
   // Keep top N-1 groups, last groups will be aggregated into "Others".
-  const topGroups = groups.slice(0, topN - 1);
-  const otherGroups = groups.slice(topN - 1);
+  const topGroups = groups.slice(0, max - 1);
+  const otherGroups = groups.slice(max - 1);
 
-  // If no groups beyond topN, return as-is
+  // If no groups beyond max, return as-is
   if (otherGroups.length === 0) {
     return topGroups;
   }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -3,7 +3,10 @@ import type { Fetcher } from "swr";
 
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetWorkspaceResponseBody } from "@app/pages/api/w/[wId]";
-import type { GetWorkspaceProgrammaticCostResponse } from "@app/pages/api/w/[wId]/analytics/programmatic-cost";
+import type {
+  GetWorkspaceProgrammaticCostResponse,
+  GroupByType,
+} from "@app/pages/api/w/[wId]/analytics/programmatic-cost";
 import type { GetWorkspaceFeatureFlagsResponseType } from "@app/pages/api/w/[wId]/feature-flags";
 import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
@@ -149,17 +152,17 @@ export function useFeatureFlags({
   };
 }
 
-export type GroupByType = "agent" | "origin" | "apiKey";
-
 export function useWorkspaceProgrammaticCost({
   workspaceId,
   groupBy,
   selectedMonth,
+  filter,
   disabled,
 }: {
   workspaceId: string;
   groupBy?: GroupByType;
   selectedMonth?: string;
+  filter?: Partial<Record<GroupByType, string[]>>;
   disabled?: boolean;
 }) {
   const fetcherFn: Fetcher<GetWorkspaceProgrammaticCostResponse> = fetcher;
@@ -171,7 +174,11 @@ export function useWorkspaceProgrammaticCost({
   if (groupBy) {
     queryParams.set("groupBy", groupBy);
   }
-  const key = `/api/w/${workspaceId}/analytics/programmatic-cost?${queryParams.toString()}`;
+  if (filter && Object.keys(filter).length > 0) {
+    queryParams.set("filter", JSON.stringify(filter));
+  }
+  const queryString = queryParams.toString();
+  const key = `/api/w/${workspaceId}/analytics/programmatic-cost${queryString ? `?${queryString}` : ""}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
@@ -11,7 +11,7 @@ import {
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   bucketsToArray,
-  groupTopNAndAggregateOthers,
+  ensureAtMostNGroups,
   searchAnalytics,
 } from "@app/lib/api/elasticsearch";
 import { getShouldTrackTokenUsageCostsESFilter } from "@app/lib/api/programmatic_usage_tracking";
@@ -345,8 +345,8 @@ async function handler(
           };
         });
 
-        // Group top 5 and aggregate others using extracted helper
-        const allGroupsToProcess = groupTopNAndAggregateOthers(
+        // Keep at most 5 groups
+        const allGroupsToProcess = ensureAtMostNGroups(
           groupsWithParsedPoints,
           5,
           "costCents"

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
@@ -20,9 +20,23 @@ import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { normalizeError } from "@app/types";
+
+const GROUP_BY_KEYS = ["agent", "origin", "apiKey"] as const;
+
+export type GroupByType = (typeof GROUP_BY_KEYS)[number];
+
+const GROUP_BY_KEY_TO_ES_FIELD: Record<GroupByType, string> = {
+  agent: "agent_id",
+  origin: "context_origin",
+  apiKey: "api_key_name",
+};
+
+const FilterSchema = z.record(z.enum(GROUP_BY_KEYS), z.string().array());
 
 const QuerySchema = z.object({
-  groupBy: z.enum(["agent", "origin", "apiKey"]).optional(),
+  groupBy: z.enum(GROUP_BY_KEYS).optional(),
+  filter: z.string().optional(),
   selectedMonth: z.string().optional(),
 });
 
@@ -30,7 +44,6 @@ export type WorkspaceProgrammaticCostPoint = {
   timestamp: number;
   groups: {
     groupKey: string;
-    groupLabel: string;
     costCents: number;
     programmaticCostCents?: number;
   }[];
@@ -39,8 +52,14 @@ export type WorkspaceProgrammaticCostPoint = {
   totalRemainingCreditsCents: number;
 };
 
+export type AvailableGroup = {
+  groupKey: string;
+  groupLabel: string;
+};
+
 export type GetWorkspaceProgrammaticCostResponse = {
   points: WorkspaceProgrammaticCostPoint[];
+  availableGroups: AvailableGroup[]; // All available groups (without filters applied)
 };
 
 // Reuse the MetricsBucket type from messages_metrics to ensure compatibility
@@ -117,6 +136,28 @@ function getDatesInRange(startOfMonth: Date, endDate: Date): number[] {
   return dates;
 }
 
+function getSelectedFilterClauses(
+  filterParams: Partial<Record<GroupByType, string[]>> | undefined,
+  excludeGroupBy?: GroupByType
+) {
+  const filterClauses: estypes.QueryDslQueryContainer[] = [];
+  if (filterParams) {
+    for (const filterKey of GROUP_BY_KEYS) {
+      if (filterKey !== excludeGroupBy) {
+        const filterValue = filterParams[filterKey];
+        if (filterValue) {
+          const filterValues = Array.isArray(filterValue)
+            ? filterValue
+            : [filterValue];
+          const esField = GROUP_BY_KEY_TO_ES_FIELD[filterKey];
+          filterClauses.push({ terms: { [esField]: filterValues } });
+        }
+      }
+    }
+  }
+  return filterClauses;
+}
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
@@ -137,7 +178,34 @@ async function handler(
         });
       }
 
-      const { groupBy, selectedMonth } = q.data;
+      const { groupBy, selectedMonth, filter: filterString } = q.data;
+
+      // Parse and validate the filter JSON
+      let filterParams: Partial<Record<GroupByType, string[]>> | undefined;
+      if (filterString) {
+        try {
+          const parsedFilter = JSON.parse(filterString);
+          const filterValidation = FilterSchema.safeParse(parsedFilter);
+          if (!filterValidation.success) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: `Invalid filter parameter: ${filterValidation.error.message}`,
+              },
+            });
+          }
+          filterParams = filterValidation.data;
+        } catch (error) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid filter JSON: ${normalizeError(error).message}`,
+            },
+          });
+        }
+      }
 
       const now = new Date();
       const startOfMonth = selectedMonth
@@ -150,18 +218,23 @@ async function handler(
       const timestamps = getDatesInRange(startOfMonth, endOfMonth);
 
       // Build query for the current month
+      const baseFilterClauses: estypes.QueryDslQueryContainer[] = [
+        getShouldTrackTokenUsageCostsESFilter(auth),
+        {
+          range: {
+            timestamp: {
+              gte: startOfMonth.toISOString(),
+              lt: endOfMonth.toISOString(),
+            },
+          },
+        },
+      ];
+
       const baseQuery = {
         bool: {
           filter: [
-            getShouldTrackTokenUsageCostsESFilter(auth),
-            {
-              range: {
-                timestamp: {
-                  gte: startOfMonth.toISOString(),
-                  lt: endOfMonth.toISOString(),
-                },
-              },
-            },
+            ...baseFilterClauses,
+            ...getSelectedFilterClauses(filterParams),
           ],
         },
       };
@@ -174,8 +247,11 @@ async function handler(
         credits,
         timestamps
       );
-      const groupLabels: Record<string, string> = {};
+
+      // Fetch all available groups (without filters) if groupBy is set
+      const availableGroups: AvailableGroup[] = [];
       const groupValues: Record<string, Map<number, number>> = {};
+
       if (!groupBy) {
         // Fetch usage metrics
         const usageMetricsResult = await fetchMessageMetrics(baseQuery, "day", [
@@ -192,25 +268,90 @@ async function handler(
           });
         }
 
-        groupLabels["total"] = "Cumulative Cost";
         groupValues["total"] = new Map<number, number>();
         usageMetricsResult.value.forEach((point) => {
           groupValues["total"]?.set(point.timestamp, point.costCents);
         });
+        availableGroups.push({
+          groupKey: "total",
+          groupLabel: "Cumulative Cost",
+        });
       } else {
-        let groupField: string;
-        // Grouped view (agent or origin)
-        switch (groupBy) {
-          case "agent":
-            groupField = "agent_id";
-            break;
-          case "origin":
-            groupField = "context_origin";
-            break;
-          case "apiKey":
-            groupField = "api_key_name";
-            break;
+        // Grouped view - use mapping to get ES field name
+        const groupField = GROUP_BY_KEY_TO_ES_FIELD[groupBy];
+        const availableGroupsResult = await searchAnalytics<never, GroupedAggs>(
+          {
+            bool: {
+              filter: [
+                ...baseFilterClauses,
+                ...getSelectedFilterClauses(filterParams, groupBy),
+              ],
+            },
+          },
+          {
+            aggregations: {
+              by_group: {
+                terms: {
+                  field: groupField,
+                  size: 100,
+                  missing: "unknown",
+                  order: { total_cost: "desc" },
+                },
+                aggs: {
+                  total_cost: {
+                    sum: { field: "tokens.cost_cents" },
+                  },
+                },
+              },
+            },
+            size: 0,
+          }
+        );
+
+        if (availableGroupsResult.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Failed to retrieve grouped programmatic cost: ${availableGroupsResult.error.message}`,
+            },
+          });
         }
+
+        const availableGroupBuckets = bucketsToArray(
+          availableGroupsResult.value.aggregations?.by_group?.buckets
+        );
+
+        // Fetch agent names if grouping by agent
+        const agentNamesForAvailable: Record<string, string> = {};
+        if (groupBy === "agent") {
+          const agentIds = availableGroupBuckets.map((b) => b.key);
+          const agents = await AgentConfiguration.findAll({
+            where: {
+              sId: agentIds,
+            },
+            attributes: ["sId", "name"],
+          });
+          agents.forEach((agent) => {
+            agentNamesForAvailable[agent.sId] = agent.name;
+          });
+        }
+
+        availableGroupBuckets.forEach((bucket) => {
+          let groupLabel = bucket.key;
+          if (bucket.key === "unknown") {
+            groupLabel = "Unknown";
+          } else if (
+            groupBy === "agent" &&
+            agentNamesForAvailable[bucket.key]
+          ) {
+            groupLabel = agentNamesForAvailable[bucket.key];
+          }
+          availableGroups.push({
+            groupKey: bucket.key,
+            groupLabel,
+          });
+        });
 
         // Use the extracted helper to build metric aggregates
         const metricAggregates = buildMetricAggregates(["costCents"]);
@@ -258,21 +399,6 @@ async function handler(
           result.value.aggregations?.by_group?.buckets
         );
 
-        // Fetch agent names if grouping by agent
-        const agentNames: Record<string, string> = {};
-        if (groupBy === "agent") {
-          const agentIds = groupBuckets.map((b) => b.key);
-          const agents = await AgentConfiguration.findAll({
-            where: {
-              sId: agentIds,
-            },
-            attributes: ["sId", "name"],
-          });
-          agents.forEach((agent) => {
-            agentNames[agent.sId] = agent.name;
-          });
-        }
-
         // ES already sorted by total cost, just parse and split into top 5 vs others
         const groupsWithParsedPoints = groupBuckets.map((groupBucket) => {
           // Parse each bucket once and store the results
@@ -293,16 +419,6 @@ async function handler(
 
         // Process all groups (top 5 + "Others") with single loop
         for (const { groupKey, points } of allGroupsToProcess) {
-          // Determine group name
-          if (groupKey === "others") {
-            groupLabels["others"] = "Others";
-          } else if (groupKey === "unknown") {
-            groupLabels["unknown"] = "Unknown";
-          } else if (groupBy === "agent") {
-            groupLabels[groupKey] = agentNames[groupKey] || groupKey;
-          } else {
-            groupLabels[groupKey] = groupKey;
-          }
           groupValues[groupKey] = new Map(
             points.map((point) => [point.timestamp, point.costCents])
           );
@@ -323,7 +439,6 @@ async function handler(
             programmaticCostCents[groupKey] = programmaticCost;
             return {
               groupKey,
-              groupLabel: groupLabels[groupKey],
               costCents: cost ?? 0,
               programmaticCostCents:
                 timestamp <= now.getTime() ? programmaticCost : undefined,
@@ -343,6 +458,7 @@ async function handler(
 
       return res.status(200).json({
         points,
+        availableGroups,
       });
     }
     default:


### PR DESCRIPTION
fixes: [#5127](https://github.com/dust-tt/tasks/issues/5127)

## Description

Allow to filter on api/agent/source by clicking on legend items . Can apply cross filter and breakdown by switching the group by option. Add a "Clear filter" button to remove all filters.
Endpoint is updated to take a third parameter, filter, which is a JSON serialztion of the filter to apply. It also returns a new "availableGroups" which is the unfiltered list of groups for the current grouping.
Cleaned chart and legend by using key instead of labels.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
