### PR TITLE
Fix: update correctly the send button state.

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -131,6 +131,7 @@ const InputBarContainer = ({
     UrlCandidate | NodeCandidate | null
   >(null);
   const [pastedCount, setPastedCount] = useState(0);
+  const [isEmpty, setIsEmpty] = useState(true);
 
   const [selectedNode, setSelectedNode] =
     useState<DataSourceViewContentNode | null>(null);
@@ -389,10 +390,27 @@ const InputBarContainer = ({
     },
   });
 
-  // Update the editor ref when the editor is created.
+  // Update the editor ref when the editor is created and listen for updates to the editor.
   useEffect(() => {
+    const handleUpdate = () => {
+      setIsEmpty(editorService.isEmpty());
+    };
+
+    if (editorRef.current) {
+      editorRef.current.off("update", handleUpdate);
+    }
+
+    if (editor) {
+      editor.on("update", handleUpdate);
+    }
     editorRef.current = editor;
-  }, [editor]);
+
+    return () => {
+      if (editor) {
+        editor.off("update", handleUpdate);
+      }
+    };
+  }, [editor, editorService]);
 
   // Disable the editor when disableTextInput is true.
   useEffect(() => {
@@ -650,7 +668,7 @@ const InputBarContainer = ({
                 icon={ArrowUpIcon}
                 variant="highlight"
                 disabled={
-                  editorService.isEmpty() ||
+                  isEmpty ||
                   disableSendButton ||
                   voiceTranscriberService.status !== "idle"
                 }


### PR DESCRIPTION
## Description

Somehow we made the editor stable and thus editing the text was no longer causing re-rendering of the input bar component.
This fixes it by listening to changes on the editor and updating the emptyness state.

## Tests

Local

## Risk

Medium as sensitive stuff but it is currently broken anyway in main.

## Deploy Plan

Deploy front