### PR TITLE
Add deterministic processing for calendar availability

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import assert from "assert";
 import { randomUUID } from "crypto";
 import { google } from "googleapis";
+import { DateTime, Interval } from "luxon";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
@@ -640,22 +641,63 @@ function createServer(
 
   server.tool(
     "check_availability",
-    "Check the calendar availability of a specific person for a given time slot.",
+    "Compute combined availability across multiple participants within a date range.",
     {
-      email: z
-        .string()
-        .describe("The email address of the person to check availability for"),
-      startTime: z
-        .string()
-        .describe("The start time in ISO format (e.g., 2024-03-20T10:00:00Z)"),
-      endTime: z
-        .string()
-        .describe("The end time in ISO format (e.g., 2024-03-20T11:00:00Z)"),
-      timeZone: z
-        .string()
-        .optional()
+      participants: z
+        .array(
+          z.object({
+            email: z
+              .string()
+              .describe(
+                "Email address of the participant whose calendar should be checked."
+              ),
+            timezone: z
+              .string()
+              .describe(
+                "IANA timezone identifier for this participant (e.g., 'America/New_York')."
+              ),
+            dailyTimeWindowStart: z
+              .string()
+              .regex(
+                /^([01]?[0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9])?$/,
+                "Time must be in HH:mm or HH:mm:ss format (24-hour)"
+              )
+              .optional()
+              .describe(
+                "Optional start of the participant's working window (local time, HH:mm or HH:mm:ss)."
+              ),
+            dailyTimeWindowEnd: z
+              .string()
+              .regex(
+                /^([01]?[0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9])?$/,
+                "Time must be in HH:mm or HH:mm:ss format (24-hour)"
+              )
+              .optional()
+              .describe(
+                "Optional end of the participant's working window (local time, HH:mm or HH:mm:ss)."
+              ),
+          })
+        )
+        .min(1, "Provide at least one participant.")
+        .max(10, "A maximum of 10 participants is supported.")
         .describe(
-          "Time zone used in the response. Optional. The default is UTC."
+          "Participants to include in the availability check. Specify their timezone and optional daily working window."
+        ),
+      startTimeRange: z
+        .string()
+        .describe(
+          "ISO 8601 timestamp for the beginning of the range to analyze (UTC)."
+        ),
+      endTimeRange: z
+        .string()
+        .describe(
+          "ISO 8601 timestamp for the end of the range to analyze (UTC)."
+        ),
+      excludeWeekends: z
+        .boolean()
+        .default(false)
+        .describe(
+          "If true, Saturdays and Sundays (in each participant's timezone) are ignored when computing availability."
         ),
     },
     withToolLogging(
@@ -664,7 +706,10 @@ function createServer(
         toolNameForMonitoring: GOOGLE_CALENDAR_TOOL_NAME,
         agentLoopContext,
       },
-      async ({ email, startTime, endTime, timeZone }, { authInfo }) => {
+      async (
+        { participants, startTimeRange, endTimeRange, excludeWeekends = false },
+        { authInfo }
+      ) => {
         const calendar = await getCalendarClient(authInfo);
         assert(
           calendar,
@@ -672,50 +717,101 @@ function createServer(
         );
 
         try {
-          const res = await calendar.freebusy.query({
-            requestBody: {
-              timeMin: startTime,
-              timeMax: endTime,
-              timeZone,
-              items: [{ id: email }],
-            },
-          });
+          const rangeStart = DateTime.fromISO(startTimeRange, { zone: "utc" });
+          const rangeEnd = DateTime.fromISO(endTimeRange, { zone: "utc" });
 
-          const calendarData = res.data.calendars?.[email];
-          for (const error of calendarData?.errors ?? []) {
-            if (error.reason === "notFound") {
-              return new Err(
-                new MCPError(
-                  `Calendar not found for email: ${email}. The calendar may not exist or you may not have access to it.`
-                )
-              );
-            }
+          if (!rangeStart.isValid || !rangeEnd.isValid) {
             return new Err(
               new MCPError(
-                `Error checking calendar availability for ${email}: ${error.reason}`
+                "Invalid startTimeRange or endTimeRange. Provide ISO 8601 timestamps."
               )
             );
           }
 
-          const busySlots = calendarData?.busy ?? [];
-          const available = busySlots.length === 0;
-          return new Ok([
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  available,
-                  busySlots: busySlots.map((slot) => ({
-                    start: slot.start ?? "",
+          if (rangeEnd.toMillis() <= rangeStart.toMillis()) {
+            return new Err(
+              new MCPError("endTimeRange must be later than startTimeRange.")
+            );
+          }
 
-                    end: slot.end ?? "",
-                  })),
-                },
-                null,
-                2
-              ),
+          const rangeInterval = Interval.fromDateTimes(rangeStart, rangeEnd);
+
+          const rangeStartDate = rangeInterval.start;
+          const rangeEndDate = rangeInterval.end;
+          if (!rangeStartDate || !rangeEndDate) {
+            return new Err(new MCPError("Invalid time range provided."));
+          }
+
+          const res = await calendar.freebusy.query({
+            requestBody: {
+              timeMin: rangeStartDate.toISO(),
+              timeMax: rangeEndDate.toISO(),
+              items: participants.map((p) => ({ id: p.email })),
             },
-          ]);
+          });
+
+          // Aggregate all busy intervals from API response
+          const allBusyIntervals: Interval[] = [];
+          for (const participant of participants) {
+            const calendarData = res.data.calendars?.[participant.email];
+            for (const error of calendarData?.errors ?? []) {
+              if (error.reason === "notFound") {
+                return new Err(
+                  new MCPError(
+                    `Calendar not found for email: ${participant.email}. The calendar may not exist or you may not have access to it.`
+                  )
+                );
+              }
+              return new Err(
+                new MCPError(
+                  `Error checking calendar availability for ${participant.email}: ${error.reason}`
+                )
+              );
+            }
+
+            const busyIntervals =
+              calendarData?.busy
+                ?.map((slot) => {
+                  const start = slot.start ?? rangeStartDate.toISO();
+                  const end = slot.end ?? rangeEndDate.toISO();
+                  const interval = Interval.fromDateTimes(
+                    DateTime.fromISO(start, { zone: "utc" }),
+                    DateTime.fromISO(end, { zone: "utc" })
+                  );
+                  return interval.isValid && !interval.isEmpty()
+                    ? interval
+                    : null;
+                })
+                .filter((interval): interval is Interval =>
+                  Boolean(interval)
+                ) ?? [];
+            allBusyIntervals.push(...busyIntervals);
+          }
+
+          // Add unavailable intervals (time outside each participant's windows)
+          for (const participant of participants) {
+            const unavailableIntervals = buildUnavailableIntervals(
+              rangeInterval,
+              participant,
+              excludeWeekends
+            );
+            allBusyIntervals.push(...unavailableIntervals);
+          }
+
+          const combinedBusyIntervals = mergeIntervals(allBusyIntervals);
+          const availabilitySlots = computeAvailability(
+            rangeInterval,
+            combinedBusyIntervals
+          );
+
+          const formattedText = formatAvailabilitySummary({
+            participants,
+            range: rangeInterval,
+            availabilitySlots,
+            excludeWeekends,
+          });
+
+          return new Ok([{ type: "text" as const, text: formattedText }]);
         } catch (err) {
           return new Err(
             new MCPError(
@@ -832,20 +928,42 @@ function isGoogleCalendarEvent(event: any): event is GoogleCalendarEvent {
   return event && typeof event === "object";
 }
 
+function formatDayOfWeek(date: Date, timezone?: string): string {
+  return date.toLocaleDateString("en-US", {
+    weekday: "long",
+    timeZone: timezone,
+  });
+}
+
+function formatDate(date: Date, timezone?: string): string {
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: timezone,
+  });
+}
+
+function formatTime(date: Date, timezone?: string): string {
+  return date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: timezone,
+  });
+}
+
 function enrichEventWithDayOfWeek(
   event: GoogleCalendarEvent,
   userTimezone: string | null
 ): EnrichedGoogleCalendarEvent {
   const enrichedEvent: EnrichedGoogleCalendarEvent = { ...event };
+  const timezone = userTimezone ?? undefined;
 
   if (event.start?.dateTime) {
     const startDate = new Date(event.start.dateTime);
     enrichedEvent.start = {
       ...event.start,
-      eventDayOfWeek: startDate.toLocaleDateString("en-US", {
-        weekday: "long",
-        timeZone: userTimezone ?? undefined,
-      }),
+      eventDayOfWeek: formatDayOfWeek(startDate, timezone),
       isAllDay: false,
     };
   } else if (event.start?.date) {
@@ -853,9 +971,7 @@ function enrichEventWithDayOfWeek(
     const startDate = new Date(event.start.date);
     enrichedEvent.start = {
       ...event.start,
-      eventDayOfWeek: startDate.toLocaleDateString("en-US", {
-        weekday: "long",
-      }),
+      eventDayOfWeek: formatDayOfWeek(startDate),
       isAllDay: true,
     };
   }
@@ -864,10 +980,7 @@ function enrichEventWithDayOfWeek(
     const endDate = new Date(event.end.dateTime);
     enrichedEvent.end = {
       ...event.end,
-      eventDayOfWeek: endDate.toLocaleDateString("en-US", {
-        weekday: "long",
-        timeZone: userTimezone ?? undefined,
-      }),
+      eventDayOfWeek: formatDayOfWeek(endDate, timezone),
       isAllDay: false,
     };
   } else if (event.end?.date) {
@@ -875,9 +988,7 @@ function enrichEventWithDayOfWeek(
     const endDate = new Date(event.end.date);
     enrichedEvent.end = {
       ...event.end,
-      eventDayOfWeek: endDate.toLocaleDateString("en-US", {
-        weekday: "long",
-      }),
+      eventDayOfWeek: formatDayOfWeek(endDate),
       isAllDay: true,
     };
   }
@@ -900,17 +1011,9 @@ function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
       } else {
         if (start.dateTime) {
           const startDate = new Date(start.dateTime);
-          const timeStr = startDate.toLocaleTimeString("en-US", {
-            hour: "numeric",
-            minute: "2-digit",
-            timeZone: start.timeZone ?? undefined,
-          });
-          const dateStr = startDate.toLocaleDateString("en-US", {
-            month: "long",
-            day: "numeric",
-            year: "numeric",
-            timeZone: start.timeZone ?? undefined,
-          });
+          const timezone = start.timeZone ?? undefined;
+          const timeStr = formatTime(startDate, timezone);
+          const dateStr = formatDate(startDate, timezone);
           lines.push(
             `Start: ${start.eventDayOfWeek}, ${dateStr} at ${timeStr}${start.timeZone ? ` (${start.timeZone})` : ""}`
           );
@@ -931,17 +1034,9 @@ function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
       } else {
         if (end.dateTime) {
           const endDate = new Date(end.dateTime);
-          const timeStr = endDate.toLocaleTimeString("en-US", {
-            hour: "numeric",
-            minute: "2-digit",
-            timeZone: end.timeZone ?? undefined,
-          });
-          const dateStr = endDate.toLocaleDateString("en-US", {
-            month: "long",
-            day: "numeric",
-            year: "numeric",
-            timeZone: end.timeZone ?? undefined,
-          });
+          const timezone = end.timeZone ?? undefined;
+          const timeStr = formatTime(endDate, timezone);
+          const dateStr = formatDate(endDate, timezone);
           lines.push(
             `End: ${end.eventDayOfWeek}, ${dateStr} at ${timeStr}${end.timeZone ? ` (${end.timeZone})` : ""}`
           );
@@ -1010,6 +1105,287 @@ function formatEventsListAsText(
   });
 
   return lines.join("\n");
+}
+
+interface AvailabilityParticipant {
+  email: string;
+  timezone: string;
+  dailyTimeWindowStart?: string;
+  dailyTimeWindowEnd?: string;
+}
+
+function buildUnavailableIntervals(
+  range: Interval,
+  participant: AvailabilityParticipant,
+  excludeWeekends: boolean
+): Interval[] {
+  const rangeStartDate = range.start;
+  const rangeEndDate = range.end;
+  if (!rangeStartDate || !rangeEndDate) {
+    return [];
+  }
+
+  // If no daily windows or weekend exclusion, participant is available for entire range
+  if (
+    !participant.dailyTimeWindowStart &&
+    !participant.dailyTimeWindowEnd &&
+    !excludeWeekends
+  ) {
+    return [];
+  }
+
+  const unavailable: Interval[] = [];
+  const startInZone = rangeStartDate.setZone(participant.timezone);
+  const endInZone = rangeEndDate.setZone(participant.timezone);
+
+  let cursor = startInZone.startOf("day");
+
+  while (cursor < endInZone) {
+    const dayStart = cursor;
+    const dayEnd = cursor.plus({ days: 1 });
+
+    // Skip weekends if excludeWeekends is true
+    if (excludeWeekends && (dayStart.weekday === 6 || dayStart.weekday === 7)) {
+      // Mark entire weekend day as unavailable
+      const unavailableStart = DateTime.max(dayStart, startInZone);
+      const unavailableEnd = DateTime.min(dayEnd, endInZone);
+      if (unavailableStart < unavailableEnd) {
+        unavailable.push(
+          Interval.fromDateTimes(
+            unavailableStart.toUTC(),
+            unavailableEnd.toUTC()
+          )
+        );
+      }
+      cursor = dayEnd;
+      continue;
+    }
+
+    // If no daily windows, participant is available all day
+    if (!participant.dailyTimeWindowStart && !participant.dailyTimeWindowEnd) {
+      cursor = dayEnd;
+      continue;
+    }
+
+    const windowStart = participant.dailyTimeWindowStart
+      ? applyTimeToDateTime(dayStart, participant.dailyTimeWindowStart)
+      : dayStart;
+    const windowEnd = participant.dailyTimeWindowEnd
+      ? applyTimeToDateTime(dayStart, participant.dailyTimeWindowEnd)
+      : dayEnd;
+
+    // Add interval before window start
+    if (participant.dailyTimeWindowStart) {
+      const beforeStart = DateTime.max(dayStart, startInZone);
+      const beforeEnd = DateTime.min(windowStart, endInZone);
+      if (beforeStart < beforeEnd) {
+        unavailable.push(
+          Interval.fromDateTimes(beforeStart.toUTC(), beforeEnd.toUTC())
+        );
+      }
+    }
+
+    // Add interval after window end
+    if (participant.dailyTimeWindowEnd) {
+      const afterStart = DateTime.max(windowEnd, startInZone);
+      const afterEnd = DateTime.min(dayEnd, endInZone);
+      if (afterStart < afterEnd) {
+        unavailable.push(
+          Interval.fromDateTimes(afterStart.toUTC(), afterEnd.toUTC())
+        );
+      }
+    }
+
+    cursor = dayEnd;
+  }
+
+  return unavailable;
+}
+
+function applyTimeToDateTime(base: DateTime, timeStr: string): DateTime {
+  const [hourStr, minuteStr = "0", secondStr = "0"] = timeStr.split(":");
+  return base.set({
+    hour: Number(hourStr),
+    minute: Number(minuteStr),
+    second: Number(secondStr),
+    millisecond: 0,
+  });
+}
+
+function isValidInterval(interval: Interval | null): interval is Interval {
+  if (!interval) {
+    return false;
+  }
+  return (
+    interval.isValid &&
+    !interval.isEmpty() &&
+    interval.start !== null &&
+    interval.end !== null
+  );
+}
+
+function mergeIntervals(intervals: Interval[]): Interval[] {
+  const sorted = intervals
+    .filter(isValidInterval)
+    .sort((a, b) => a.start!.toMillis() - b.start!.toMillis());
+
+  if (sorted.length === 0) {
+    return [];
+  }
+
+  const merged: Interval[] = [];
+  for (const interval of sorted) {
+    if (merged.length === 0) {
+      merged.push(interval);
+      continue;
+    }
+
+    const prev = merged[merged.length - 1];
+    if (prev.end! >= interval.start!) {
+      merged[merged.length - 1] = Interval.fromDateTimes(
+        prev.start!,
+        DateTime.max(prev.end!, interval.end!)
+      );
+    } else {
+      merged.push(interval);
+    }
+  }
+
+  return merged;
+}
+
+function computeAvailability(
+  range: Interval,
+  busyIntervals: Interval[]
+): Interval[] {
+  if (!isValidInterval(range)) {
+    return [];
+  }
+
+  if (busyIntervals.length === 0) {
+    return [range];
+  }
+
+  const availability: Interval[] = [];
+  const rangeStart = range.start;
+  const rangeEnd = range.end;
+  if (!rangeStart || !rangeEnd) {
+    return [];
+  }
+  let cursor: DateTime = rangeStart;
+
+  for (const busy of busyIntervals) {
+    const busyStart = busy.start;
+    const busyEnd = busy.end;
+    if (!busyStart || !busyEnd) {
+      continue;
+    }
+
+    // Clamp to range boundaries
+    const clampedStart = DateTime.max(busyStart, rangeStart);
+    const clampedEnd = DateTime.min(busyEnd, rangeEnd);
+
+    if (clampedStart >= clampedEnd) {
+      continue;
+    }
+
+    if (cursor < clampedStart) {
+      availability.push(Interval.fromDateTimes(cursor, clampedStart));
+    }
+    cursor = DateTime.max(cursor, clampedEnd);
+  }
+
+  if (cursor < rangeEnd) {
+    availability.push(Interval.fromDateTimes(cursor, rangeEnd));
+  }
+
+  return mergeIntervals(availability);
+}
+
+function formatAvailabilitySummary({
+  participants,
+  range,
+  availabilitySlots,
+  excludeWeekends,
+}: {
+  participants: AvailabilityParticipant[];
+  range: Interval;
+  availabilitySlots: Interval[];
+  excludeWeekends: boolean;
+}): string {
+  const lines: string[] = [];
+  const referenceTimezone = participants[0]?.timezone ?? "UTC";
+  const rangeStartDate = range.start;
+  const rangeEndDate = range.end;
+
+  if (rangeStartDate && rangeEndDate) {
+    lines.push(
+      `Combined availability between ${formatDateTime(
+        rangeStartDate,
+        referenceTimezone
+      )} and ${formatDateTime(rangeEndDate, referenceTimezone)}`
+    );
+  } else {
+    lines.push("Combined availability for requested range:");
+  }
+  lines.push("");
+  lines.push("Participants:");
+  participants.forEach((participant) => {
+    const windowDescription =
+      (participant.dailyTimeWindowStart ?? participant.dailyTimeWindowEnd)
+        ? `, window: ${participant.dailyTimeWindowStart ?? "00:00"} - ${
+            participant.dailyTimeWindowEnd ?? "24:00"
+          }`
+        : "";
+    lines.push(
+      `- ${participant.email} (${participant.timezone}${windowDescription})`
+    );
+  });
+
+  lines.push("");
+  if (excludeWeekends) {
+    lines.push("Weekends excluded from consideration.");
+    lines.push("");
+  }
+
+  if (availabilitySlots.length === 0) {
+    lines.push("No shared availability found for the requested range.");
+    return lines.join("\n");
+  }
+
+  lines.push("Shared availability (all participants free):");
+  const maxSlotsToDisplay = 10;
+  availabilitySlots.slice(0, maxSlotsToDisplay).forEach((slot, index) => {
+    lines.push(
+      `  ${index + 1}. ${formatIntervalForDisplay(slot, referenceTimezone)}`
+    );
+  });
+
+  if (availabilitySlots.length > maxSlotsToDisplay) {
+    lines.push(
+      `  ...and ${availabilitySlots.length - maxSlotsToDisplay} more slot${
+        availabilitySlots.length - maxSlotsToDisplay === 1 ? "" : "s"
+      }.`
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function formatIntervalForDisplay(
+  interval: Interval,
+  timezone: string
+): string {
+  if (!interval.start || !interval.end) {
+    return "Unknown interval";
+  }
+  const start = formatDateTime(interval.start, timezone);
+  const end = formatDateTime(interval.end, timezone);
+  return `${start} → ${end}`;
+}
+
+function formatDateTime(date: DateTime, timezone: string): string {
+  return date.setZone(timezone).toFormat("EEE, MMM d yyyy 'at' HH:mm ZZZZ");
 }
 
 export default createServer;


### PR DESCRIPTION
## Description

* Got consistent impact that the LLM was doing a poor job of determining scheduling availability. Adding logic to do some deterministic processing for availability based on the available hours for each participant.

## Tests

```
Combined availability between Sun, Nov 23 2025 at 19:00 EST and Fri, Nov 28 2025 at 19:00 EST
Participants:
[frank@dust.tt](mailto:frank@dust.tt) (America/New_York, window: 09:00 - 17:00)
[leandre@dust.tt](mailto:leandre@dust.tt) (Europe/Paris, window: 09:00 - 17:00)
[stephen@dust.tt](mailto:stephen@dust.tt) (America/New_York, window: 09:00 - 17:00)
Weekends excluded from consideration.
Shared availability (all participants free):
Mon, Nov 24 2025 at 10:15 EST → Mon, Nov 24 2025 at 10:30 EST
```

## Risk

* Low

## Deploy Plan

* Deploy front