### PR TITLE
[front] - fix(MCP): agent mcp server configuration creation

### DIFF
--- a/front/lib/api/assistant/configuration/actions.ts
+++ b/front/lib/api/assistant/configuration/actions.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import type { Transaction } from "sequelize";
 
+import { DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/actions/constants";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { UnsavedMCPServerConfigurationType } from "@app/lib/actions/types/agent";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
@@ -21,10 +22,12 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
-import type { LightAgentConfigurationType, Result } from "@app/types";
-import type { ReasoningModelConfigurationType } from "@app/types";
-import { removeNulls } from "@app/types";
-import { Err, Ok } from "@app/types";
+import type {
+  LightAgentConfigurationType,
+  ReasoningModelConfigurationType,
+  Result,
+} from "@app/types";
+import { Err, Ok, removeNulls } from "@app/types";
 
 /**
  * Called by Agent Builder to create an action configuration.
@@ -61,7 +64,13 @@ export async function createAgentActionConfiguration(
         additionalConfiguration: action.additionalConfiguration,
         timeFrame: action.timeFrame,
         jsonSchema: action.jsonSchema,
-        name: serverName !== action.name ? action.name : null,
+        // specific case in which the server_name has an extra "&" compare
+        // to the action name
+        name:
+          serverName !== action.name &&
+          serverName !== DEFAULT_WEBSEARCH_ACTION_NAME
+            ? action.name
+            : null,
         singleToolDescriptionOverride:
           serverDescription !== action.description ? action.description : null,
         appId: action.dustAppConfiguration?.appId ?? null,

--- a/front/migrations/db/migration_411.sql
+++ b/front/migrations/db/migration_411.sql
@@ -1,0 +1,3 @@
+UPDATE agent_mcp_server_configurations
+SET name = null
+where name = 'web_search__browse';


### PR DESCRIPTION
## Description

Fixes an edge case in MCP server configuration action naming during agent action creation. The websearch action server has an ampersand (&) character in its internal server name (web_search_&_browse), which was causing incorrect naming logic. The fix adds an explicit check to exclude the default websearch action name from the custom naming logic, ensuring that configurations with this specific server name are handled correctly.

## Tests

Locally

## Risk

Moderate - DB update

## Deploy Plan

- Deploy front
- Apply migration in EU & US
