### PR TITLE
Rename log property as 'message' is reserved

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -614,7 +614,7 @@ export async function getParsedDatabase(
     ) {
       if (e.code === "validation_error") {
         localLogger.info(
-          { message: e.message },
+          { errorMessage: e.message },
           "Got validation error trying to retrieve database (expected for linked databases)."
         );
       } else {


### PR DESCRIPTION
## Description

Can't use 'message' as a log property. TIL...

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Connectors