### PR TITLE
Notion: avoid setting parents multiple times on the same nodes

### DIFF
--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -133,25 +133,38 @@ export async function updateAllParentsFields(
   createdOrMovedNotionPageIds: string[],
   createdOrMovedNotionDatabaseIds: string[],
   memoizationKey?: string,
-  onProgress?: () => Promise<void>
+  onProgress?: () => Promise<void>,
+  processingAllResources: boolean = false
 ): Promise<number> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error("Could not find connector");
   }
 
-  /* Computing all descendants, then updating, ensures the field is updated only
-    once per page, limiting the load on the Datasource */
-  const pageAndDatabaseIdsToUpdate = await getPagesAndDatabasesToUpdate(
-    createdOrMovedNotionPageIds,
-    createdOrMovedNotionDatabaseIds,
-    connectorId,
-    onProgress
-  );
+  let pageAndDatabaseIdsToUpdate: Set<string>;
+  if (processingAllResources) {
+    // If we're processing all items, we don't need to include descendants,
+    // as we're updating everybody anyway. This is an optimization to avoid processing
+    // the same resources multiple times.
+    pageAndDatabaseIdsToUpdate = new Set<string>([
+      ...createdOrMovedNotionPageIds,
+      ...createdOrMovedNotionDatabaseIds,
+    ]);
+  } else {
+    /* Computing all descendants, then updating, ensures the field is updated only
+      once per page, limiting the load on the Datasource */
+    pageAndDatabaseIdsToUpdate = await getPagesAndDatabasesToUpdate(
+      createdOrMovedNotionPageIds,
+      createdOrMovedNotionDatabaseIds,
+      connectorId,
+      onProgress
+    );
+  }
 
   logger.info(
     {
       connectorId,
+      processingAllResources,
       pageIdsToUpdateCount: pageAndDatabaseIdsToUpdate.size,
     },
     "notionUpdateAllParentsFields: Updating parents field for pages and databases"

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1466,7 +1466,8 @@ export async function updateParentsFields({
     notionPageIds,
     notionDatabaseIds,
     runTimestamp.toString(),
-    async () => heartbeat()
+    async () => heartbeat(),
+    parentsLastUpdatedAt == 0
   );
 
   localLogger.info({ nbUpdated, nextCursors }, "Updated parents fields.");


### PR DESCRIPTION
## Description

### Problem description

`updateAllParentsFields` starts with a clean list of numerical IDs to process (`createdOrMovedNotionPageIds`/`createdOrMovedNotionDatabaseIds`), but then `getPagesAndDatabasesToUpdate` adds all of the descendants to the list.

And then each of the resulting items gets upserted.

When this logic runs after a `parentsLastUpdatedAt` reset (or in the initial sync), we end up reprocessing the same nodes multiple time.

e.g. in one customer case, I saw 600k 'set parent' calls in core, while they only have a total of 97588 documents. It took 8 hours to complete just the Update Parents phase.

### Fix description

The fix is to special case the scenario where `parentsLastUpdatedAt` was reset (or it never ran). This happens for the initial sync, and when we reset it via some plugin. In that case, we just process the list that comes in, without adding the descendants.

Fixes https://github.com/dust-tt/tasks/issues/5199

## Tests

Manual.

## Risk

Small, but others familiar with the code need to validate that this is a correct optimization.

## Deploy Plan

Connectors.