### PR TITLE
Remove tsx from production workers, use esbuild for bundling

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -47,6 +47,9 @@ COPY /front .
 # Build temporal workers
 RUN FRONT_DATABASE_URI="sqlite:foo.sqlite" npm run build:temporal-bundles
 
+# Build workers with esbuild
+RUN npm run build:workers
+
 # Remove test files
 RUN find . -name "*.test.ts" -delete
 RUN find . -name "*.test.tsx" -delete

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -45,7 +45,7 @@ RUN npm ci
 COPY /front .
 
 # Build temporal workers
-RUN FRONT_DATABASE_URI="sqlite:foo.sqlite" npm run build:workers
+RUN FRONT_DATABASE_URI="sqlite:foo.sqlite" npm run build:temporal-bundles
 
 # Remove test files
 RUN find . -name "*.test.ts" -delete

--- a/front/esbuild.worker.js
+++ b/front/esbuild.worker.js
@@ -1,0 +1,37 @@
+const esbuild = require("esbuild");
+const path = require("path");
+
+async function buildWorker() {
+  try {
+    console.log("Building worker with esbuild...");
+
+    const result = await esbuild.build({
+      entryPoints: ["start_worker.ts"],
+      bundle: true,
+      platform: "node",
+      target: "node20",
+      outfile: "dist/start_worker.js",
+      alias: {
+        "@app": ".",
+      },
+      packages: "external",
+      logLevel: "info",
+      metafile: true,
+    });
+
+    console.log("✅ Worker built successfully!");
+    console.log(
+      `📦 Bundle size: ${(result.metafile.outputs["dist/start_worker.js"].bytes / 1024 / 1024).toFixed(2)} MB`
+    );
+
+    // Log any warnings
+    if (result.warnings.length > 0) {
+      console.log(`⚠️  ${result.warnings.length} warning(s) during build`);
+    }
+  } catch (error) {
+    console.error("❌ Build failed:", error);
+    process.exit(1);
+  }
+}
+
+buildWorker();

--- a/front/esbuild.worker.ts
+++ b/front/esbuild.worker.ts
@@ -1,5 +1,4 @@
-const esbuild = require("esbuild");
-const path = require("path");
+import esbuild from "esbuild";
 
 async function buildWorker() {
   try {
@@ -34,4 +33,7 @@ async function buildWorker() {
   }
 }
 
-buildWorker();
+buildWorker().catch((error) => {
+  console.error("❌ Unhandled error:", error);
+  process.exit(1);
+});

--- a/front/lib/triggers/temporal/common/worker.ts
+++ b/front/lib/triggers/temporal/common/worker.ts
@@ -18,7 +18,7 @@ export async function runAgentTriggerWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "agent_schedule",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/lib/triggers/temporal/webhook/worker.ts
+++ b/front/lib/triggers/temporal/webhook/worker.ts
@@ -18,7 +18,7 @@ export async function runAgentTriggerWebhookWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "agent_trigger_webhook",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,7 @@
     "dev-datadog": "NODE_OPTIONS='-r dd-trace/init' DD_TAGS=service:front-edge DD_TAGS=env:dev-ben DD_GIT_COMMIT_SHA=`git rev-parse HEAD` DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/ npm run dev",
     "build": "next build",
     "build:temporal-bundles": "tsx scripts/temporal-build/build-temporal-bundles.ts",
-    "build:workers": "esbuild start_worker.ts --bundle --platform=node --target=node20 --outfile=dist/start_worker.js --alias:@app=. --packages=external",
+    "build:workers": "node esbuild.worker.js",
     "start": "next start --keepAliveTimeout 5000",
     "start:worker": "tsx ./start_worker.ts",
     "dev:worker": "./admin/dev_worker.sh",

--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,7 @@
     "dev-datadog": "NODE_OPTIONS='-r dd-trace/init' DD_TAGS=service:front-edge DD_TAGS=env:dev-ben DD_GIT_COMMIT_SHA=`git rev-parse HEAD` DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/ npm run dev",
     "build": "next build",
     "build:temporal-bundles": "tsx scripts/temporal-build/build-temporal-bundles.ts",
-    "build:workers": "node esbuild.worker.js",
+    "build:workers": "tsx esbuild.worker.ts",
     "start": "next start --keepAliveTimeout 5000",
     "start:worker": "tsx ./start_worker.ts",
     "dev:worker": "./admin/dev_worker.sh",

--- a/front/package.json
+++ b/front/package.json
@@ -7,6 +7,7 @@
     "dev-datadog": "NODE_OPTIONS='-r dd-trace/init' DD_TAGS=service:front-edge DD_TAGS=env:dev-ben DD_GIT_COMMIT_SHA=`git rev-parse HEAD` DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/ npm run dev",
     "build": "next build",
     "build:temporal-bundles": "tsx scripts/temporal-build/build-temporal-bundles.ts",
+    "build:workers": "esbuild start_worker.ts --bundle --platform=node --target=node20 --outfile=dist/start_worker.js --alias:@app=. --packages=external",
     "start": "next start --keepAliveTimeout 5000",
     "start:worker": "tsx ./start_worker.ts",
     "dev:worker": "./admin/dev_worker.sh",

--- a/front/package.json
+++ b/front/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "dev-datadog": "NODE_OPTIONS='-r dd-trace/init' DD_TAGS=service:front-edge DD_TAGS=env:dev-ben DD_GIT_COMMIT_SHA=`git rev-parse HEAD` DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/ npm run dev",
     "build": "next build",
-    "build:workers": "tsx scripts/temporal-build/build-temporal-bundles.ts",
+    "build:temporal-bundles": "tsx scripts/temporal-build/build-temporal-bundles.ts",
     "start": "next start --keepAliveTimeout 5000",
     "start:worker": "tsx ./start_worker.ts",
     "dev:worker": "./admin/dev_worker.sh",

--- a/front/poke/temporal/worker.ts
+++ b/front/poke/temporal/worker.ts
@@ -15,7 +15,7 @@ export async function runPokeWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "poke",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: "poke-queue",

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -33,7 +33,7 @@ export async function runAgentLoopWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "agent_loop",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities: {
       conversationUnreadNotificationActivity,

--- a/front/temporal/analytics_queue/worker.ts
+++ b/front/temporal/analytics_queue/worker.ts
@@ -18,7 +18,7 @@ export async function runAnalyticsWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "analytics_queue",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/bundle_helper.ts
+++ b/front/temporal/bundle_helper.ts
@@ -15,10 +15,10 @@ import type { WorkerName } from "./worker_registry";
  */
 export function getWorkflowConfig({
   workerName,
-  workflowsPath,
+  getWorkflowsPath,
 }: {
   workerName: WorkerName;
-  workflowsPath: string;
+  getWorkflowsPath: () => string;
 }) {
   if (process.env.NODE_ENV === "production") {
     const bundlePath = path.join(
@@ -40,10 +40,10 @@ export function getWorkflowConfig({
       );
 
       // Fallback to runtime bundling if bundle read fails.
-      return { workflowsPath };
+      return { workflowsPath: getWorkflowsPath() };
     }
   }
 
   // Development: use runtime bundling
-  return { workflowsPath };
+  return { workflowsPath: getWorkflowsPath() };
 }

--- a/front/temporal/data_retention/worker.ts
+++ b/front/temporal/data_retention/worker.ts
@@ -18,7 +18,7 @@ export async function runDataRetentionWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "data_retention",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/hard_delete/worker.ts
+++ b/front/temporal/hard_delete/worker.ts
@@ -18,7 +18,7 @@ export async function runHardDeleteWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "hard_delete",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/labs/transcripts/worker.ts
+++ b/front/temporal/labs/transcripts/worker.ts
@@ -14,7 +14,7 @@ export async function runLabsTranscriptsWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "labs",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: TRANSCRIPTS_QUEUE_NAME,

--- a/front/temporal/mentions_count_queue/worker.ts
+++ b/front/temporal/mentions_count_queue/worker.ts
@@ -17,7 +17,7 @@ export async function runMentionsCountWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "mentions_count",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/production_checks/worker.ts
+++ b/front/temporal/production_checks/worker.ts
@@ -17,7 +17,7 @@ export async function runProductionChecksWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "production_checks",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/relocation/worker.ts
+++ b/front/temporal/relocation/worker.ts
@@ -23,7 +23,7 @@ export async function runRelocationWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "relocation",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities: {
       ...connectorsDestinationActivities,

--- a/front/temporal/remote_tools/worker.ts
+++ b/front/temporal/remote_tools/worker.ts
@@ -17,7 +17,7 @@ export async function runRemoteToolsSyncWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "remote_tools_sync",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/scrub_workspace/worker.ts
+++ b/front/temporal/scrub_workspace/worker.ts
@@ -17,7 +17,7 @@ export async function runScrubWorkspaceQueueWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "scrub_workspace_queue",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     maxConcurrentActivityTaskExecutions: 2,

--- a/front/temporal/tracker/worker.ts
+++ b/front/temporal/tracker/worker.ts
@@ -20,7 +20,7 @@ export async function runTrackerWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "document_tracker",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: RUN_QUEUE_NAME,
@@ -48,7 +48,7 @@ export async function runTrackerNotificationWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "tracker_notification",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: TRACKER_NOTIFICATION_QUEUE_NAME,

--- a/front/temporal/upsert_queue/worker.ts
+++ b/front/temporal/upsert_queue/worker.ts
@@ -15,7 +15,7 @@ export async function runUpsertQueueWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "upsert_queue",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/upsert_tables/worker.ts
+++ b/front/temporal/upsert_tables/worker.ts
@@ -16,7 +16,7 @@ export async function runUpsertTableQueueWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "upsert_table_queue",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/usage_queue/worker.ts
+++ b/front/temporal/usage_queue/worker.ts
@@ -14,7 +14,7 @@ export async function runUpdateWorkspaceUsageWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "update_workspace_usage",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,

--- a/front/temporal/workos_events_queue/worker.ts
+++ b/front/temporal/workos_events_queue/worker.ts
@@ -17,7 +17,7 @@ export async function runWorkOSEventsWorker() {
   const worker = await Worker.create({
     ...getWorkflowConfig({
       workerName: "workos_events_queue",
-      workflowsPath: require.resolve("./workflows"),
+      getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities,
     taskQueue: QUEUE_NAME,


### PR DESCRIPTION
## Problem

Production workers are currently running TypeScript at runtime via `tsx`, which caused significant memory overhead:
- 478 MB JS heap consumed by development artifacts (SourceMaps, Module metadata)
- 12,000 Module objects cached in memory from runtime transpilation
- 1.6M Arrays for source map line/column mappings
- Slower startup times due to JIT compilation

This was identified through heap snapshots showing minimal actual application memory (~17 MB) versus massive dev tooling overhead on front-workers pods in the us-central1 region.

## Solution

Pre-compile TypeScript during Docker build using `esbuild`, following the same pattern we use for Temporal workflow bundles.

**Before:**
```
node --require tsx/cjs ./start_worker.ts --workers agent_loop
```

**After:**
```
node dist/start_worker.js --workers agent_loop
```

### Prerequisites

Bundling Temporal workers in the CI step, done in https://github.com/dust-tt/dust/pull/18170.

### Build Configuration
- Added `esbuild.worker.ts`
- Updated Dockerfile to compile workers during image creation
- Workers now run pre-compiled JavaScript (`dist/start_worker.js`)
- Removed tsx from production runtime
- Development preserves tsx via start:worker

An infra PR will follow to update the helm chart.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
