### PR TITLE
[Programmatic Usage] Fix: no user message origin counts as non-programmatic

### DIFF
--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -51,6 +51,8 @@ function getRedisKey(workspace: LightWorkspaceType): string {
   return `${PROGRAMMATIC_USAGE_REMAINING_CREDITS_KEY}:${workspace.id}`;
 }
 
+const USERS_HAVE_BEEN_WARNED = false;
+
 function shouldTrackTokenUsageCosts(
   auth: Authenticator,
   { userMessageOrigin }: { userMessageOrigin?: UserMessageOrigin | null } = {}
@@ -65,10 +67,21 @@ function shouldTrackTokenUsageCosts(
 
   // Track for API keys, listed programmatic origins or unspecified user message origins.
   // This must be in sync with the getShouldTrackTokenUsageCostsESFilter function.
+
+  if (!userMessageOrigin) {
+    logger.warn(
+      { workspaceId: workspace.sId },
+      "No user message origin provided, assuming programmatic usage for tracking"
+    );
+    return false;
+  }
+
   if (
     auth.authMethod() === "api_key" ||
-    !userMessageOrigin ||
-    USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic"
+    // TODO(PPUL): remove this after notifying users.
+    (USERS_HAVE_BEEN_WARNED &&
+      USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic") ||
+    userMessageOrigin === "triggered_programmatic"
   ) {
     return true;
   }

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -71,7 +71,7 @@ function shouldTrackTokenUsageCosts(
   if (!userMessageOrigin) {
     logger.warn(
       { workspaceId: workspace.sId },
-      "No user message origin provided, assuming programmatic usage for tracking"
+      "No user message origin provided, assuming non-programmatic usage for now"
     );
     return false;
   }


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5219
- Warn and skip tracking when user message origin is missing instead of assuming programmatic usage.
- Gate programmatic-origins tracking behind the USERS_HAVE_BEEN_WARNED flag and keep explicit support for triggered_programmatic.
- Keep API key traffic tracking unchanged while aligning ES filter logic.

Next steps:
- ungate when users are warned;
- make usermessageorigin mandatory on shouldTrack

## Risks
Blast radius: token usage accounting for public API and triggered workflow runs
Risk: low

## Deploy Plan
- deploy front