### PR TITLE
[front] Fix layout for triggers in poke

### DIFF
--- a/front/components/poke/conversation/table.tsx
+++ b/front/components/poke/conversation/table.tsx
@@ -1,25 +1,38 @@
 import { makeColumnsForConversations } from "@app/components/poke/conversation/columns";
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import type {
-  ConversationWithoutContentType,
-  LightWorkspaceType,
-} from "@app/types";
+import type { PokeConversationsFetchProps } from "@app/poke/swr/conversation";
+import { usePokeConversations } from "@app/poke/swr/conversation";
+import type { LightWorkspaceType } from "@app/types";
 
 interface ConversationDataTableProps {
   owner: LightWorkspaceType;
-  conversations: ConversationWithoutContentType[];
+  triggerId: string;
+  loadOnInit?: boolean;
 }
 
 export function ConversationDataTable({
   owner,
-  conversations,
+  triggerId,
+  loadOnInit,
 }: ConversationDataTableProps) {
-  const columns = makeColumnsForConversations(owner);
+  const useConversationsWithTrigger = (props: PokeConversationsFetchProps) =>
+    usePokeConversations({ ...props, triggerId });
 
   return (
-    <PokeDataTable<ConversationWithoutContentType, unknown>
-      columns={columns}
-      data={conversations}
-    />
+    <PokeDataTableConditionalFetch
+      header="Conversations"
+      owner={owner}
+      loadOnInit={loadOnInit}
+      showSensitiveDataWarning={true}
+      useSWRHook={useConversationsWithTrigger}
+    >
+      {(conversations) => (
+        <PokeDataTable
+          columns={makeColumnsForConversations(owner)}
+          data={conversations}
+        />
+      )}
+    </PokeDataTableConditionalFetch>
   );
 }

--- a/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
@@ -7,10 +7,8 @@ import PokeLayout from "@app/components/poke/PokeLayout";
 import { ViewTriggerTable } from "@app/components/poke/triggers/view";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type {
-  ConversationWithoutContentType,
   LightAgentConfigurationType,
   LightWorkspaceType,
   WorkspaceType,
@@ -21,7 +19,6 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   trigger: TriggerType;
   agent: LightAgentConfigurationType;
   owner: LightWorkspaceType;
-  conversations: ConversationWithoutContentType[];
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
@@ -49,17 +46,11 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const conversations = await ConversationResource.listConversationsForTrigger(
-    auth,
-    triggerId
-  );
-
   return {
     props: {
       trigger: trigger.toJSON(),
       agent: agentConfiguration,
       owner,
-      conversations,
     },
   };
 });
@@ -68,7 +59,6 @@ export default function TriggerPage({
   trigger,
   agent,
   owner,
-  conversations,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <>
@@ -88,7 +78,7 @@ export default function TriggerPage({
               workspace: owner,
             }}
           />
-          <ConversationDataTable owner={owner} conversations={conversations} />
+          <ConversationDataTable owner={owner} triggerId={trigger.sId} />
         </div>
       </div>
     </>
@@ -105,7 +95,6 @@ TriggerPage.getLayout = (
     owner: WorkspaceType;
     agent: LightAgentConfigurationType;
     trigger: TriggerType;
-    conversations: ConversationWithoutContentType[];
   }
 ) => {
   return (

--- a/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
@@ -71,23 +71,27 @@ export default function TriggerPage({
   conversations,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
-    <div className="flex flex-col gap-y-6">
-      <ViewTriggerTable trigger={trigger} agent={agent} owner={owner} />
-      <div className="border-t border-gray-200 pt-6">
-        <h2 className="mb-4 text-lg font-semibold">Plugins</h2>
-        <PluginList
-          pluginResourceTarget={{
-            resourceType: "triggers",
-            resourceId: trigger.sId,
-            workspace: owner,
-          }}
-        />
+    <>
+      <h3 className="text-xl font-bold">
+        Trigger {trigger.name} on agent {agent.name}{" "}
+        <a href={`/poke/${owner.sId}`} className="text-highlight-500">
+          {owner.name}
+        </a>
+      </h3>
+      <div className="flex flex-row gap-x-6">
+        <ViewTriggerTable trigger={trigger} agent={agent} owner={owner} />
+        <div className="mt-4 flex grow flex-col">
+          <PluginList
+            pluginResourceTarget={{
+              resourceType: "triggers",
+              resourceId: trigger.sId,
+              workspace: owner,
+            }}
+          />
+          <ConversationDataTable owner={owner} conversations={conversations} />
+        </div>
       </div>
-      <div className="border-t border-gray-200 pt-6">
-        <h2 className="mb-4 text-lg font-semibold">Conversations</h2>
-        <ConversationDataTable owner={owner} conversations={conversations} />
-      </div>
-    </div>
+    </>
   );
 }
 

--- a/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
@@ -89,7 +89,7 @@ export default function SpacePage({
       </h3>
       <div className="flex flex-row gap-x-6">
         <ViewSpaceViewTable space={space} />
-        <div className="flex grow flex-col">
+        <div className="mt-4 flex grow flex-col">
           {Object.entries(members).map(([groupName, groupMembers]) => (
             <MembersDataTable
               key={groupName}

--- a/front/poke/swr/conversation.ts
+++ b/front/poke/swr/conversation.ts
@@ -6,18 +6,26 @@ import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 
 export interface PokeConversationsFetchProps extends PokeConditionalFetchProps {
   agentId?: string;
+  triggerId?: string;
 }
 
 export function usePokeConversations({
   disabled,
   owner,
   agentId,
+  triggerId,
 }: PokeConversationsFetchProps) {
   const conversationsFetcher: Fetcher<PokeListConversations> = fetcher;
+
+  let url: string | null = null;
+  if (agentId) {
+    url = `/api/poke/workspaces/${owner.sId}/conversations?agentId=${agentId}`;
+  } else if (triggerId) {
+    url = `/api/poke/workspaces/${owner.sId}/conversations?triggerId=${triggerId}`;
+  }
+
   const { data, error, mutate } = useSWRWithDefaults(
-    agentId
-      ? `/api/poke/workspaces/${owner.sId}/conversations?agentId=${agentId}`
-      : null,
+    url,
     conversationsFetcher,
     { disabled }
   );


### PR DESCRIPTION
## Description

- This PR fixes the layout for the poke trigger page, aligning it with every other poke page.

Before
<img width="2500" height="928" alt="Screenshot 2025-11-24 at 10 06 15 AM" src="https://github.com/user-attachments/assets/4f68029e-75f1-43a3-91a1-6076361f5ae1" />

After
<img width="2500" height="478" alt="Screenshot 2025-11-24 at 10 05 42 AM" src="https://github.com/user-attachments/assets/ac774064-d573-4282-b70e-22c45f542f50" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
