### PR TITLE
Try fix sliceConversationForAgentMessage and stuck temporal workflows

### DIFF
--- a/front/temporal/agent_loop/lib/loop_utils.ts
+++ b/front/temporal/agent_loop/lib/loop_utils.ts
@@ -57,6 +57,7 @@ export function sliceConversationForAgentMessage(
     (versions, index) =>
       index === agentMessageIndex ||
       // Only check the first version - all versions have the same parentMessageId
+      versions.length === 0 ||
       !isAgentMessageType(versions[0]) ||
       versions[0].parentMessageId !== slicedAgentMessage.parentMessageId
   );


### PR DESCRIPTION
## Description

I don't know. why versions can sometimes be emptuy, but it fails the call to isAgentMessageType below.

There are stuck workflows due to this

```
TypeError: Cannot read properties of undefined (reading 'type')
    at isAgentMessageType (/app/dist/start_worker.js:2965:14)
    at /app/dist/start_worker.js:100184:6
    at Array.filter (<anonymous>)
    at sliceConversationForAgentMessage (/app/dist/start_worker.js:100182:47)
    at runModelActivity (/app/dist/start_worker.js:100855:82)
    at runModelAndCreateActionsActivity2 (/app/dist/start_worker.js:101420:29)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ActivityInboundLogInterceptor.execute (/app/dist/start_worker.js:196:14)
    at async Activity.execute (/app/node_modules/@temporalio/worker/lib/activity.js:95:20)
    at async /app/node_modules/@temporalio/worker/lib/activity.js:130:32
```

## Tests

no

## Risk

low

## Deploy Plan

deploy front
