### PR TITLE
fix: copy/paste

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/cleanupPastedHTML.test.ts
+++ b/front/components/assistant/conversation/input_bar/editor/cleanupPastedHTML.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "vitest";
+
+import { cleanupPastedHTML } from "./cleanupPastedHTML";
+
+describe("cleanupPastedHTML", () => {
+  describe("allowed tags", () => {
+    test("preserves basic text formatting tags", () => {
+      const html = "<p>Hello <strong>world</strong> and <em>universe</em></p>";
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe(
+        "<p>Hello <strong>world</strong> and <em>universe</em></p>"
+      );
+    });
+
+    test("preserves links", () => {
+      const html = '<a href="https://example.com">Link</a>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toContain("<a");
+      expect(result).toContain("https://example.com");
+      expect(result).toContain("Link");
+    });
+  });
+
+  describe("forbidden tags removal", () => {
+    test("removes script tags but keeps content", () => {
+      const html = "<p>Before</p><script>alert('xss')</script><p>After</p>";
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<p>Before</p><p>After</p>");
+    });
+
+    test("removes style tags", () => {
+      const html = "<style>body { color: red; }</style><p>Text</p>";
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<p>Text</p>");
+    });
+
+    test("removes iframe tags", () => {
+      const html = '<iframe src="https://evil.com"></iframe><p>Safe</p>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<p>Safe</p>");
+    });
+
+    test("removes form elements", () => {
+      const html =
+        '<form><input type="text"><button>Submit</button></form><p>Text</p>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("Submit<p>Text</p>");
+    });
+
+    test("removes video and audio tags", () => {
+      const html =
+        '<video src="video.mp4"></video><audio src="audio.mp3"></audio><p>Content</p>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<p>Content</p>");
+    });
+
+    test("removes SVG tags", () => {
+      const html = '<svg><circle cx="50" cy="50" r="40"/></svg><p>Text</p>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<p>Text</p>");
+    });
+
+    test("removes object and embed tags", () => {
+      const html =
+        '<object data="file.pdf"></object><embed src="file.swf"><p>Safe</p>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<p>Safe</p>");
+    });
+
+    test("removes template tags", () => {
+      const html = "<template><p>Template content</p></template><p>Visible</p>";
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<p>Visible</p>");
+    });
+
+    test("removes link and meta tags", () => {
+      const html =
+        '<link rel="stylesheet" href="style.css"><meta charset="utf-8"><p>Content</p>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<p>Content</p>");
+    });
+  });
+
+  describe("forbidden attributes removal", () => {
+    test("removes style attributes", () => {
+      const html = '<p style="color: red; font-size: 20px;">Text</p>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<p>Text</p>");
+    });
+
+    test("removes class attributes", () => {
+      const html = '<div class="container main-content">Text</div>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<div>Text</div>");
+    });
+
+    test("removes id attributes", () => {
+      const html = '<span id="unique-id">Content</span>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe("<span>Content</span>");
+    });
+  });
+
+  describe("data attributes preservation", () => {
+    test("preserves data-* attributes", () => {
+      const html = '<div data-id="123" data-type="user">Content</div>';
+      const result = cleanupPastedHTML(html);
+      expect(result).toBe('<div data-id="123" data-type="user">Content</div>');
+    });
+  });
+
+  test("handles malformed HTML", () => {
+    const html = "<p>Unclosed paragraph<div>Mixed <span>nesting</div></span>";
+    const result = cleanupPastedHTML(html);
+    // DOMPurify should fix malformed HTML
+    expect(result).toBe(
+      "<p>Unclosed paragraph</p><div>Mixed <span>nesting</span></div>"
+    );
+  });
+
+  test("handles HTML from google docs", () => {
+    const html = `
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+</head>
+<body>
+<meta charset="utf-8">
+<h2 dir="ltr" style="line-height:1.38;margin-top:18pt;margin-bottom:6pt;"
+    id="docs-internal-guid-0a5ee12a-7fff-28b9-6d39-e8f41357f7f9"><span
+        style="font-size:16pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">&lt;h2&gt; hello you &lt;h2/&gt;</span>
+</h2><br/>
+<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span
+        style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Hello </span><span
+        style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">this is</span><span
+        style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;"> me and I&rsquo;m in </span><span
+        style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">italic</span>
+</p>
+<h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;"><span
+        style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">&lt;H2&gt; totot &lt;/H2&gt;</span>
+</h1><br/>
+<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span
+        style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Again bold </span><span
+        style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">and not bold</span>
+</p></body>
+</html>`;
+    const result = cleanupPastedHTML(html);
+    // DOMPurify should fix malformed HTML
+    expect(result).toBe(
+      `
+
+
+<h2 dir="ltr"><span>&lt;h2&gt; hello you &lt;h2/&gt;</span>
+</h2><br>
+<p dir="ltr"><span>Hello </span><span><strong>this is</strong></span><span> me and I’m in </span><span><em>italic</em></span>
+</p>
+<h1 dir="ltr"><span>&lt;H2&gt; totot &lt;/H2&gt;</span>
+</h1><br>
+<p dir="ltr"><span><strong>Again bold </strong></span><span>and not bold</span>
+</p>
+`
+    );
+  });
+
+  test("html from google doc in chrome", () => {
+    const html = `<meta charset='utf-8'><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-d522e2d0-7fff-389d-e6ca-8dcec5a664f4"><h2 dir="ltr" style="line-height:1.38;margin-top:18pt;margin-bottom:6pt;"><span style="font-size:16pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">&lt;h2&gt; hello you &lt;h2/&gt;</span></h2><br /><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Hello </span><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">this is</span><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;"> me and I&rsquo;m in </span><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:italic;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">italic</span></p><h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">&lt;H2&gt; totot &lt;/H2&gt;</span></h1><br /><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:700;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Again bold </span><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">and not bold</span></p></b><br class="Apple-interchange-newline">`;
+    const result = cleanupPastedHTML(html);
+    expect(result).toBe(
+      `<span><h2 dir="ltr"><span>&lt;h2&gt; hello you &lt;h2/&gt;</span></h2><br><p dir="ltr"><span>Hello </span><span><strong>this is</strong></span><span> me and I’m in </span><span><em>italic</em></span></p><h1 dir="ltr"><span>&lt;H2&gt; totot &lt;/H2&gt;</span></h1><br><p dir="ltr"><span><strong>Again bold </strong></span><span>and not bold</span></p></span>`
+    );
+  });
+});

--- a/front/components/assistant/conversation/input_bar/editor/cleanupPastedHTML.ts
+++ b/front/components/assistant/conversation/input_bar/editor/cleanupPastedHTML.ts
@@ -74,6 +74,8 @@ const SANITIZE_CONFIG: Config = {
 };
 
 export function cleanupPastedHTML(html: string): string {
+  addHookOnce();
+
   try {
     // DOMPurify sanitizes without executing anything; returns a safe string.
     return DOMPurify.sanitize(html, SANITIZE_CONFIG);
@@ -83,4 +85,92 @@ export function cleanupPastedHTML(html: string): string {
     temp.textContent = html ?? "";
     return temp.innerHTML;
   }
+}
+
+let isHookAdded = false;
+
+// Add hook to convert inline styles to semantic tags
+function addHookOnce() {
+  if (isHookAdded) {
+    return;
+  }
+  isHookAdded = true;
+  DOMPurify.addHook("uponSanitizeElement", (node) => {
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+
+    // in fact it's an Element as per the check above
+    if (!(node instanceof Element)) {
+      return;
+    }
+
+    const element = node;
+    const style = element.getAttribute("style");
+    const tagName = element.tagName.toLowerCase();
+
+    // Convert <br class="Apple-interchange-newline"> to empty text node (Apple paste metadata)
+    // We replace it with a <span> but DOMPurify will handle the output formatting
+    if (
+      tagName === "br" &&
+      element.getAttribute("class") === "Apple-interchange-newline"
+    ) {
+      // Create a text node with zero-width content to preserve document structure
+      const textNode = document.createTextNode("");
+      element.replaceWith(textNode);
+      return;
+    }
+
+    if (style) {
+      const isNormal = /font-weight:\s*normal/i.test(style);
+      const isBold = /font-weight:\s*(?:700|bold)/i.test(style);
+      const isItalic = /font-style:\s*italic/i.test(style);
+
+      // If the tag is <b> or <strong> but has font-weight:normal, replace it with <span>
+      // For whatever reason, Google Docs, in Chrome *only*, adds a <b style="font-weight:normal"> tag around text
+      if (isNormal && (tagName === "b" || tagName === "strong")) {
+        const span = document.createElement("span");
+        // Copy all attributes except style
+        for (const attr of element.attributes) {
+          if (attr.name !== "style") {
+            span.setAttribute(attr.name, attr.value);
+          }
+        }
+        // Move all children
+        while (element.firstChild) {
+          span.appendChild(element.firstChild);
+        }
+        element.replaceWith(span);
+        return;
+      }
+
+      // Wrap text content in semantic tags
+      if (isBold || isItalic) {
+        const fragment = document.createDocumentFragment();
+        let wrapper: Node = fragment;
+
+        if (isBold) {
+          const strong = document.createElement("strong");
+          wrapper.appendChild(strong);
+          wrapper = strong;
+        }
+
+        if (isItalic) {
+          const em = document.createElement("em");
+          wrapper.appendChild(em);
+          wrapper = em;
+        }
+
+        // Move children into wrapper
+        while (node.firstChild) {
+          wrapper.appendChild(node.firstChild);
+        }
+
+        node.appendChild(fragment);
+      }
+
+      // Remove style attribute
+      element.removeAttribute("style");
+    }
+  });
 }


### PR DESCRIPTION
## Description

There was a nasty bug on copy/pasting from google docs => https://github.com/dust-tt/tasks/issues/5192#issuecomment-3563534356

This PR fixes it. I'm not so happy with the fix, as it adds quite some logic. I had basically 2 options:
* remove the current code that make sure pasted text uses _our_ styles
* do this fix

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
