### PR TITLE
Handle modjo disconnection + email on 401

### DIFF
--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -31,6 +31,26 @@ export async function sendGitHubDeletionEmail(email: string): Promise<void> {
   });
 }
 
+export async function sendModjoDisconnectionEmail(
+  email: string,
+  workspaceName: string
+): Promise<void> {
+  await sendEmailWithTemplate({
+    to: email,
+    from: config.getSupportEmailAddress(),
+    subject: "[Dust] Modjo connection disconnected - action required",
+    body: `<p>Your Modjo connection for the workspace "${workspaceName}" has been automatically disconnected.</p>
+    <p>This happened because your Modjo API key is no longer valid or your Modjo tenant has been deactivated.</p>
+    <p>To resume syncing your Modjo transcripts, please:</p>
+    <ol>
+      <li>Verify that your Modjo account is still active</li>
+      <li>Generate a new API key in Modjo if needed</li>
+      <li>Reconnect your Modjo account in Dust settings</li>
+    </ol>
+    <p>Please reply to this email if you have any questions.</p>`,
+  });
+}
+
 /** Emails for cancelling / reactivating subscription */
 
 export async function sendCancelSubscriptionEmail(

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -11,7 +11,10 @@ import { toFileContentFragment } from "@app/lib/api/assistant/conversation/conte
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import config from "@app/lib/api/config";
-import { sendEmailWithTemplate } from "@app/lib/api/email";
+import {
+  sendEmailWithTemplate,
+  sendModjoDisconnectionEmail,
+} from "@app/lib/api/email";
 import { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
@@ -29,6 +32,7 @@ import {
   retrieveGoogleTranscripts,
 } from "@app/temporal/labs/transcripts/utils/google";
 import {
+  ModjoAuthenticationError,
   retrieveModjoTranscriptContent,
   retrieveModjoTranscripts,
 } from "@app/temporal/labs/transcripts/utils/modjo";
@@ -128,12 +132,31 @@ export async function retrieveNewTranscriptsActivity(
       break;
 
     case "modjo":
-      const modjoTranscriptsIds = await retrieveModjoTranscripts(
-        auth,
-        transcriptsConfiguration,
-        localLogger
-      );
-      transcriptsIdsToProcess.push(...modjoTranscriptsIds);
+      try {
+        const modjoTranscriptsIds = await retrieveModjoTranscripts(
+          auth,
+          transcriptsConfiguration,
+          localLogger
+        );
+        transcriptsIdsToProcess.push(...modjoTranscriptsIds);
+      } catch (error) {
+        if (error instanceof ModjoAuthenticationError) {
+          localLogger.error(
+            { error: error.message },
+            "[retrieveNewTranscripts] Modjo authentication failed - disconnecting and notifying user"
+          );
+          await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
+
+          // Send email notification to the user
+          if (user) {
+            await sendModjoDisconnectionEmail(user.email, workspace.name);
+          }
+
+          // Return empty array - sync is stopped
+          return [];
+        }
+        throw error;
+      }
       break;
 
     default:

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -147,12 +147,10 @@ export async function retrieveNewTranscriptsActivity(
           );
           await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
 
-          // Send email notification to the user
           if (user) {
             await sendModjoDisconnectionEmail(user.email, workspace.name);
           }
 
-          // Return empty array - sync is stopped
           return [];
         }
         throw error;


### PR DESCRIPTION




## Description

When a Modjo API key becomes invalid or a Modjo tenant is deactivated, the API returns 401 errors. This PR adds proper handling for these authentication failures by introducing a custom `ModjoAuthenticationError` class that's thrown when 401 responses are received from the Modjo API. When this error is caught during transcript retrieval, the workflow is automatically stopped and the user receives an email notification with instructions on how to reconnect their Modjo account.

## Risk

None. This adds error handling for an existing failure scenario. The workflow stops gracefully instead of continuing to retry with invalid credentials.
