### PR TITLE
Reduce batch size of syncRemoteMCPServersWorkflow to 50

### DIFF
--- a/front/temporal/remote_tools/workflows.ts
+++ b/front/temporal/remote_tools/workflows.ts
@@ -2,6 +2,8 @@ import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@app/temporal/remote_tools/activities";
 
+const BATCH_SIZE = 50;
+
 const { syncRemoteMCPServers, getBatchRemoteMCPServers } = proxyActivities<
   typeof activities
 >({
@@ -11,13 +13,13 @@ const { syncRemoteMCPServers, getBatchRemoteMCPServers } = proxyActivities<
 export async function syncRemoteMCPServersWorkflow() {
   let ids = await getBatchRemoteMCPServers({
     firstId: 0,
-    limit: 100,
+    limit: BATCH_SIZE,
   });
   do {
     await syncRemoteMCPServers(ids);
     ids = await getBatchRemoteMCPServers({
       firstId: ids[ids.length - 1] + 1,
-      limit: 100,
+      limit: BATCH_SIZE,
     });
   } while (ids.length > 0);
 }


### PR DESCRIPTION
## Description

Activity is currenctly failing with 
```
{
  "message": "activity StartToClose timeout",
  "source": "Server",
  "timeoutFailureInfo": {
    "timeoutType": "TIMEOUT_TYPE_START_TO_CLOSE"
  }
}
```
The timeout is 10 minutes
Let's try to reduce the number of server to process to 50 per batch

I'm not 100% sure it is the root cause of the issue because other batches of 100 take ~4m to run so it might be some specific server ids causing the issue.

but previous run failed on 3 different batches, so reducing to 50 seems a good idea anyway:

<img width="2936" height="850" alt="image" src="https://github.com/user-attachments/assets/59aa3f9b-8c19-457b-94f1-b1a343ea07db" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
