### PR TITLE
[front] enh(poke): add webhook request history to poke

### DIFF
--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -1,0 +1,158 @@
+import {
+  CollapsibleComponent,
+  ContentMessageInline,
+  Label,
+  Markdown,
+  Separator,
+  Spinner,
+} from "@dust-tt/sparkle";
+import moment from "moment";
+import Link from "next/link";
+import React, { useState } from "react";
+
+import { WebhookRequestStatusBadge } from "@app/components/agent_builder/triggers/WebhookRequestStatusBadge";
+import { usePokeWebhookRequests } from "@app/poke/swr/triggers";
+import type { LightWorkspaceType } from "@app/types";
+
+interface PokeRecentWebhookRequestsProps {
+  owner: LightWorkspaceType;
+  triggerId: string;
+}
+
+export function PokeRecentWebhookRequests({
+  owner,
+  triggerId,
+}: PokeRecentWebhookRequestsProps) {
+  const defaultOpen = true;
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div className="border-material-200 my-4 flex min-h-24 flex-col rounded-lg border bg-muted-background dark:bg-muted-background-night">
+      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4 dark:bg-primary-300-night">
+        <h2 className="text-md font-bold">Webhook Request History</h2>
+      </div>
+      <div className="flex flex-grow flex-col justify-center p-4">
+        <CollapsibleComponent
+          rootProps={{ defaultOpen, onOpenChange: setIsOpen }}
+          triggerChildren={
+            <Label className="cursor-pointer">Recent requests (last 15)</Label>
+          }
+          contentChildren={
+            <PokeRecentWebhookRequestsContent
+              isOpen={isOpen}
+              owner={owner}
+              triggerId={triggerId}
+            />
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+interface PokeRecentWebhookRequestsContentProps {
+  isOpen: boolean;
+  owner: LightWorkspaceType;
+  triggerId: string;
+}
+
+function PokeRecentWebhookRequestsContent({
+  isOpen,
+  owner,
+  triggerId,
+}: PokeRecentWebhookRequestsContentProps) {
+  const { webhookRequests, isWebhookRequestsLoading, isWebhookRequestsError } =
+    usePokeWebhookRequests({
+      owner,
+      triggerId,
+      disabled: !isOpen,
+    });
+
+  if (isWebhookRequestsLoading || !isOpen) {
+    return (
+      <div className="flex items-center gap-2">
+        <Spinner size="sm" />
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Loading recent requests...
+        </span>
+      </div>
+    );
+  }
+
+  if (isWebhookRequestsError) {
+    return (
+      <ContentMessageInline variant="warning">
+        Unable to load recent webhook requests.
+      </ContentMessageInline>
+    );
+  }
+
+  if (webhookRequests.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        No webhook requests yet.
+      </p>
+    );
+  }
+
+  const wasRateLimited = webhookRequests.some(
+    (request) => request.status === "rate_limited"
+  );
+
+  return (
+    <div className="space-y-2">
+      {wasRateLimited && (
+        <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          <p>
+            Some requests were rate limited.
+            <br />
+            Contact{" "}
+            <Link
+              href="mailto:support@dust.tt?subject=Increase%20Webhook%20Trigger%20Rate%20Limit"
+              className="underline"
+            >
+              support@dust.tt
+            </Link>{" "}
+            to increase the rate limit for this trigger.
+          </p>
+        </div>
+      )}
+      <div className="flex flex-col px-4">
+        {webhookRequests.map((request, idx) => (
+          <div key={request.id}>
+            <CollapsibleComponent
+              rootProps={{ defaultOpen: false }}
+              triggerChildren={
+                <div className="my-2 flex w-full items-center justify-between gap-4">
+                  {moment(new Date(request.timestamp)).calendar(undefined, {
+                    sameDay: "[Today at] LTS",
+                    lastDay: "[Yesterday at] LTS",
+                    lastWeek: "[Last] dddd [at] LTS",
+                  })}
+                  <WebhookRequestStatusBadge status={request.status} />
+                </div>
+              }
+              contentChildren={
+                request.payload ? (
+                  <div className="rounded">
+                    <pre className="max-h-64 overflow-auto text-xs">
+                      <Markdown
+                        forcedTextSize="xs"
+                        content={`\`\`\`json\n${JSON.stringify(request.payload.body, null, 2)}\n\`\`\``}
+                      />
+                    </pre>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    No payload available.
+                  </p>
+                )
+              }
+            />
+            {idx < webhookRequests.length - 1 && <Separator />}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import type { WebhookRequestTriggerStatus } from "@app/lib/models/assistant/triggers/webhook_request_trigger";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { fetchRecentWebhookRequestTriggersWithPayload } from "@app/lib/triggers/webhook";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+export interface PokeGetWebhookRequestsResponseBody {
+  requests: {
+    id: number;
+    timestamp: number;
+    status: WebhookRequestTriggerStatus;
+    payload?: {
+      headers?: Record<string, string | string[]>;
+      body?: unknown;
+    };
+  }[];
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PokeGetWebhookRequestsResponseBody>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+
+  const { tId } = req.query;
+
+  if (!isString(tId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid trigger ID.",
+      },
+    });
+  }
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "trigger_not_found",
+        message: "Could not find trigger.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const trigger = await TriggerResource.fetchById(auth, tId);
+  if (!trigger) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "trigger_not_found",
+        message: "Trigger not found.",
+      },
+    });
+  }
+
+  const r = await fetchRecentWebhookRequestTriggersWithPayload(auth, {
+    trigger: trigger.toJSON(),
+  });
+
+  return res.status(200).json({ requests: r });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from "react";
 import { ConversationDataTable } from "@app/components/poke/conversation/table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import PokeLayout from "@app/components/poke/PokeLayout";
+import { PokeRecentWebhookRequests } from "@app/components/poke/triggers/RecentWebhookRequests";
 import { ViewTriggerTable } from "@app/components/poke/triggers/view";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
@@ -78,6 +79,9 @@ export default function TriggerPage({
               workspace: owner,
             }}
           />
+          {trigger.kind === "webhook" && (
+            <PokeRecentWebhookRequests owner={owner} triggerId={trigger.sId} />
+          )}
           <ConversationDataTable owner={owner} triggerId={trigger.sId} />
         </div>
       </div>

--- a/front/poke/swr/triggers.ts
+++ b/front/poke/swr/triggers.ts
@@ -2,7 +2,9 @@ import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListTriggers } from "@app/pages/api/poke/workspaces/[wId]/triggers";
+import type { PokeGetWebhookRequestsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { LightWorkspaceType } from "@app/types";
 
 export function usePokeTriggers({
   disabled,
@@ -20,5 +22,29 @@ export function usePokeTriggers({
     isLoading: !error && !data,
     isError: error,
     mutate,
+  };
+}
+
+export function usePokeWebhookRequests({
+  owner,
+  triggerId,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  triggerId: string;
+  disabled?: boolean;
+}) {
+  const requestsFetcher: Fetcher<PokeGetWebhookRequestsResponseBody> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/triggers/${triggerId}/webhook_requests`,
+    requestsFetcher,
+    { disabled }
+  );
+
+  return {
+    webhookRequests: data?.requests ?? [],
+    isWebhookRequestsLoading: !error && !data,
+    isWebhookRequestsError: error,
+    mutateWebhookRequests: mutate,
   };
 }


### PR DESCRIPTION
## Description

- This PR adds a section `Webhook Request History` to the poke trigger page to help debugging conversations not triggered/incorrectly triggered.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
