### PR TITLE
[front] fix(triggers): fix webhook URL displayed in front end

### DIFF
--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -97,7 +97,7 @@ export function WebhookSourceDetailsInfo({
 
   const webhookUrl = useMemo(() => {
     return buildWebhookUrl({
-      apiBaseUrl: config.getDustAPIConfig().url,
+      apiBaseUrl: config.getClientFacingUrl(),
       workspaceId: owner.sId,
       webhookSource: webhookSourceView.webhookSource,
     });


### PR DESCRIPTION
## Description

- The URL displayed in `WebhookSourceDetailsInfo` incorrectly always starts with `dust.tt` instead of `eu.dust.tt` in EU.
- This is especially useful since meant to be copy pasted by users.

## Tests

- Tested locally

## Risk

- Low.

## Deploy Plan

- Deploy front.
