### PR TITLE
[front] enh(poke): add filter natural language description to trigger page

### DIFF
--- a/front/components/poke/conversation/table.tsx
+++ b/front/components/poke/conversation/table.tsx
@@ -4,20 +4,21 @@ import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { PokeConversationsFetchProps } from "@app/poke/swr/conversation";
 import { usePokeConversations } from "@app/poke/swr/conversation";
 import type { LightWorkspaceType } from "@app/types";
+import type { TriggerType } from "@app/types/assistant/triggers";
 
 interface ConversationDataTableProps {
   owner: LightWorkspaceType;
-  triggerId: string;
+  trigger: TriggerType;
   loadOnInit?: boolean;
 }
 
 export function ConversationDataTable({
   owner,
-  triggerId,
+  trigger,
   loadOnInit,
 }: ConversationDataTableProps) {
   const useConversationsWithTrigger = (props: PokeConversationsFetchProps) =>
-    usePokeConversations({ ...props, triggerId });
+    usePokeConversations({ ...props, triggerId: trigger.sId });
 
   return (
     <PokeDataTableConditionalFetch

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -33,6 +33,16 @@ export function PokeRecentWebhookRequests({
         <h2 className="text-md font-bold">Webhook Request History</h2>
       </div>
       <div className="flex flex-grow flex-col justify-center p-4">
+        {trigger.naturalLanguageDescription && (
+          <div className="bg-secondary mb-4 rounded-md border border-border p-4 dark:border-border-night">
+            <p className="text-sm font-medium text-foreground dark:text-foreground-night">
+              Natural language description
+            </p>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground dark:text-muted-foreground-night">
+              {trigger.naturalLanguageDescription}
+            </p>
+          </div>
+        )}
         <CollapsibleComponent
           rootProps={{ defaultOpen, onOpenChange: setIsOpen }}
           triggerChildren={

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -13,15 +13,16 @@ import React, { useState } from "react";
 import { WebhookRequestStatusBadge } from "@app/components/agent_builder/triggers/WebhookRequestStatusBadge";
 import { usePokeWebhookRequests } from "@app/poke/swr/triggers";
 import type { LightWorkspaceType } from "@app/types";
+import type { TriggerType } from "@app/types/assistant/triggers";
 
 interface PokeRecentWebhookRequestsProps {
   owner: LightWorkspaceType;
-  triggerId: string;
+  trigger: TriggerType;
 }
 
 export function PokeRecentWebhookRequests({
   owner,
-  triggerId,
+  trigger,
 }: PokeRecentWebhookRequestsProps) {
   const defaultOpen = true;
   const [isOpen, setIsOpen] = useState(defaultOpen);
@@ -41,7 +42,7 @@ export function PokeRecentWebhookRequests({
             <PokeRecentWebhookRequestsContent
               isOpen={isOpen}
               owner={owner}
-              triggerId={triggerId}
+              triggerId={trigger.sId}
             />
           }
         />

--- a/front/components/poke/triggers/view.tsx
+++ b/front/components/poke/triggers/view.tsx
@@ -65,8 +65,13 @@ export function ViewTriggerTable({
               </PokeTableRow>
               <PokeTableRow>
                 <PokeTableHead>Custom Prompt</PokeTableHead>
-                {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-                <PokeTableCell>{trigger.customPrompt || "None"}</PokeTableCell>
+                <PokeTableCell>{trigger.customPrompt ?? "None"}</PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableHead>Natural Language Description</PokeTableHead>
+                <PokeTableCell>
+                  {trigger.naturalLanguageDescription ?? "None"}
+                </PokeTableCell>
               </PokeTableRow>
               <PokeTableRow>
                 <PokeTableHead>Enabled</PokeTableHead>

--- a/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
@@ -80,9 +80,9 @@ export default function TriggerPage({
             }}
           />
           {trigger.kind === "webhook" && (
-            <PokeRecentWebhookRequests owner={owner} triggerId={trigger.sId} />
+            <PokeRecentWebhookRequests owner={owner} trigger={trigger} />
           )}
-          <ConversationDataTable owner={owner} triggerId={trigger.sId} />
+          <ConversationDataTable owner={owner} trigger={trigger} />
         </div>
       </div>
     </>


### PR DESCRIPTION
## Description

- This PR adds the natural language description to the poke page for triggers, both in the overview left panel and in `Webhook Request History`.
- Useful to compare this to the payloads actually processed side by side.

<img width="2018" height="523" alt="Screenshot 2025-11-24 at 1 27 38 PM" src="https://github.com/user-attachments/assets/b330780a-d3b7-4249-9fbd-673e3092df0f" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
