### PR TITLE
[front] enh(poke): add configured filter to poke trigger page

### DIFF
--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -7,9 +7,9 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import moment from "moment";
-import Link from "next/link";
 import React, { useState } from "react";
 
+import { TriggerFilterRenderer } from "@app/components/agent_builder/triggers/TriggerFilterRenderer";
 import { WebhookRequestStatusBadge } from "@app/components/agent_builder/triggers/WebhookRequestStatusBadge";
 import { usePokeWebhookRequests } from "@app/poke/swr/triggers";
 import type { LightWorkspaceType } from "@app/types";
@@ -41,6 +41,20 @@ export function PokeRecentWebhookRequests({
             <p className="mt-2 text-sm leading-relaxed text-muted-foreground dark:text-muted-foreground-night">
               {trigger.naturalLanguageDescription}
             </p>
+          </div>
+        )}
+        {trigger.kind === "webhook" && (
+          <div className="bg-secondary mb-4 rounded-md border border-border p-4 dark:border-border-night">
+            <p className="text-sm font-medium text-foreground dark:text-foreground-night">
+              Filter
+            </p>
+            {trigger.configuration.filter ? (
+              <TriggerFilterRenderer data={trigger.configuration.filter} />
+            ) : (
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground dark:text-muted-foreground-night">
+                No filter
+              </p>
+            )}
           </div>
         )}
         <CollapsibleComponent

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -114,18 +114,7 @@ function PokeRecentWebhookRequestsContent({
     <div className="space-y-2">
       {wasRateLimited && (
         <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          <p>
-            Some requests were rate limited.
-            <br />
-            Contact{" "}
-            <Link
-              href="mailto:support@dust.tt?subject=Increase%20Webhook%20Trigger%20Rate%20Limit"
-              className="underline"
-            >
-              support@dust.tt
-            </Link>{" "}
-            to increase the rate limit for this trigger.
-          </p>
+          Some requests were rate limited.
         </div>
       )}
       <div className="flex flex-col px-4">


### PR DESCRIPTION
## Description

- This PR adds the configured filter to the poke page for a trigger.

<img width="2103" height="476" alt="Screenshot 2025-11-24 at 2 21 56 PM" src="https://github.com/user-attachments/assets/33e43e4d-962d-4999-83bf-432e7b0a55bc" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
