### PR TITLE
[front] fix(poke): improve layout for poke trigger page

### DIFF
--- a/front/components/poke/triggers/view.tsx
+++ b/front/components/poke/triggers/view.tsx
@@ -64,16 +64,6 @@ export function ViewTriggerTable({
                 </PokeTableCell>
               </PokeTableRow>
               <PokeTableRow>
-                <PokeTableHead>Custom Prompt</PokeTableHead>
-                <PokeTableCell>{trigger.customPrompt ?? "None"}</PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableHead>Natural Language Description</PokeTableHead>
-                <PokeTableCell>
-                  {trigger.naturalLanguageDescription ?? "None"}
-                </PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
                 <PokeTableHead>Enabled</PokeTableHead>
                 <PokeTableCell>{trigger.enabled ? "Yes" : "No"}</PokeTableCell>
               </PokeTableRow>

--- a/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
@@ -82,6 +82,18 @@ export default function TriggerPage({
           {trigger.kind === "webhook" && (
             <PokeRecentWebhookRequests owner={owner} trigger={trigger} />
           )}
+          {trigger.customPrompt && (
+            <div className="border-material-200 my-4 flex min-h-24 flex-col rounded-lg border bg-muted-background dark:bg-muted-background-night">
+              <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4 dark:bg-primary-300-night">
+                <h2 className="text-md font-bold">Custom Prompt</h2>
+              </div>
+              <div className="flex flex-grow flex-col justify-center p-4">
+                <p className="whitespace-pre-wrap text-sm leading-relaxed">
+                  {trigger.customPrompt}
+                </p>
+              </div>
+            </div>
+          )}
           <ConversationDataTable owner={owner} trigger={trigger} />
         </div>
       </div>


### PR DESCRIPTION
## Description

- The layout is fairly broken for triggers with long custom prompts or natural language description.
- Example [here](https://dust.tt/poke/0ec9852c2f/assistants/8CBhMYJNp6/triggers/trg_nWqafL1MP4d).
- This PR moves these two fields from the overview table to the wider part on the right.

<img width="2003" height="530" alt="Screenshot 2025-11-24 at 2 35 15 PM" src="https://github.com/user-attachments/assets/8059a3ba-6b5e-4572-9fa0-1c7b3180e6cb" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
