### PR TITLE
Split first modjo sync activities

### DIFF
--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -48,9 +48,16 @@ import { CoreAPI } from "@app/types";
 
 class TranscriptNonRetryableError extends Error {}
 
+export interface RetrieveTranscriptsResult {
+  fileIds: string[];
+  nextCursor: number | null;
+  isFirstSync: boolean;
+}
+
 export async function retrieveNewTranscriptsActivity(
-  transcriptsConfigurationId: string
-): Promise<string[]> {
+  transcriptsConfigurationId: string,
+  modjoCursor: number | null = null
+): Promise<RetrieveTranscriptsResult> {
   const transcriptsConfiguration =
     await LabsTranscriptsConfigurationResource.fetchById(
       transcriptsConfigurationId
@@ -63,7 +70,7 @@ export async function retrieveNewTranscriptsActivity(
       },
       "[retrieveNewTranscripts] Transcript configuration not found. Skipping."
     );
-    return [];
+    return { fileIds: [], nextCursor: null, isFirstSync: false };
   }
 
   const localLogger = mainLogger.child({
@@ -103,10 +110,8 @@ export async function retrieveNewTranscriptsActivity(
     );
   }
 
-  const transcriptsIdsToProcess: string[] = [];
-
   switch (transcriptsConfiguration.provider) {
-    case "google_drive":
+    case "google_drive": {
       const googleTranscriptsRes = await retrieveGoogleTranscripts(
         auth,
         transcriptsConfiguration,
@@ -118,27 +123,39 @@ export async function retrieveNewTranscriptsActivity(
           `Error retrieving Google transcripts: ${googleTranscriptsRes.error.message}`
         );
       }
-      const googleTranscriptsIds = googleTranscriptsRes.value;
-      transcriptsIdsToProcess.push(...googleTranscriptsIds);
-      break;
+      return {
+        fileIds: googleTranscriptsRes.value,
+        nextCursor: null,
+        isFirstSync: false,
+      };
+    }
 
-    case "gong":
+    case "gong": {
       const gongTranscriptsIds = await retrieveGongTranscripts(
         auth,
         transcriptsConfiguration,
         localLogger
       );
-      transcriptsIdsToProcess.push(...gongTranscriptsIds);
-      break;
+      return {
+        fileIds: gongTranscriptsIds,
+        nextCursor: null,
+        isFirstSync: false,
+      };
+    }
 
-    case "modjo":
+    case "modjo": {
       try {
-        const modjoTranscriptsIds = await retrieveModjoTranscripts(
+        const modjoResult = await retrieveModjoTranscripts(
           auth,
           transcriptsConfiguration,
-          localLogger
+          localLogger,
+          modjoCursor
         );
-        transcriptsIdsToProcess.push(...modjoTranscriptsIds);
+        return {
+          fileIds: modjoResult.fileIds,
+          nextCursor: modjoResult.nextCursor,
+          isFirstSync: modjoResult.isFirstSync,
+        };
       } catch (error) {
         if (error instanceof ModjoAuthenticationError) {
           localLogger.error(
@@ -151,17 +168,15 @@ export async function retrieveNewTranscriptsActivity(
             await sendModjoDisconnectionEmail(user.email, workspace.name);
           }
 
-          return [];
+          return { fileIds: [], nextCursor: null, isFirstSync: false };
         }
         throw error;
       }
-      break;
+    }
 
     default:
       assertNever(transcriptsConfiguration.provider);
   }
-
-  return transcriptsIdsToProcess;
 }
 
 export async function processTranscriptActivity(

--- a/front/temporal/labs/transcripts/workflows.ts
+++ b/front/temporal/labs/transcripts/workflows.ts
@@ -22,11 +22,11 @@ const { retrieveNewTranscriptsActivity, processTranscriptActivity } =
 export async function retrieveNewTranscriptsWorkflow({
   workspaceId,
   transcriptsConfigurationId,
-  startIndex = 0,
+  modjoCursor = null,
 }: {
   workspaceId: string;
   transcriptsConfigurationId: string;
-  startIndex?: number;
+  modjoCursor?: number | null;
 }) {
   if (!transcriptsConfigurationId) {
     throw new Error(
@@ -34,28 +34,30 @@ export async function retrieveNewTranscriptsWorkflow({
     );
   }
 
-  const filesToProcess = await retrieveNewTranscriptsActivity(
-    transcriptsConfigurationId
-  );
-
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
-  for (let i = startIndex; i < filesToProcess.length; i++) {
+  const result = await retrieveNewTranscriptsActivity(
+    transcriptsConfigurationId,
+    modjoCursor
+  );
+
+  const filesToProcess = result.fileIds;
+  const nextCursor = result.nextCursor;
+
+  for (const fileId of filesToProcess) {
     const hasReachedWorkflowLimits =
       workflowInfo().historyLength > TEMPORAL_WORKFLOW_MAX_HISTORY_LENGTH ||
       workflowInfo().historySize >
         TEMPORAL_WORKFLOW_MAX_HISTORY_SIZE_MB * 1024 * 1024;
     if (hasReachedWorkflowLimits) {
-      // Continue from where we left off to avoid OOM when processing many files
       await continueAsNew<typeof retrieveNewTranscriptsWorkflow>({
         workspaceId,
         transcriptsConfigurationId,
-        startIndex: i,
+        modjoCursor,
       });
       return;
     }
 
-    const fileId = filesToProcess[i];
     const workflowId = makeProcessTranscriptWorkflowId({
       workspaceId,
       transcriptsConfigurationId,
@@ -71,6 +73,14 @@ export async function retrieveNewTranscriptsWorkflow({
         },
       ],
       memo,
+    });
+  }
+
+  if (nextCursor !== null) {
+    await continueAsNew<typeof retrieveNewTranscriptsWorkflow>({
+      workspaceId,
+      transcriptsConfigurationId,
+      modjoCursor: nextCursor,
     });
   }
 }


### PR DESCRIPTION






## Description

Modjo first syncs attempt to fetch all historical transcripts from epoch, which can result in very large result sets that cause Temporal workflow timeouts. This PR introduces pagination batching for first syncs by processing transcripts in batches of 50 pages (750 calls maximum per activity execution) and using a cursor to continue across multiple activity calls. The activity now returns a `RetrieveTranscriptsResult` object containing the file IDs, a cursor for the next batch (if applicable), and a flag indicating whether this is a first sync. The workflow uses `continueAsNew` to process the next batch when a cursor is returned, ensuring we can handle large historical syncs without hitting workflow limits.

## Risk

Low. The pagination logic only applies during first syncs. Regular incremental syncs continue to work as before with no cursor-based batching. We're using the same proven `continueAsNew` pattern already in place for workflow history limit management.

