### PR TITLE
Do not remove expired content fragment but handle them correctly

### DIFF
--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -91,17 +91,25 @@ export function conversationAttachmentId(
 export function getAttachmentFromContentFragment(
   cf: ContentFragmentType
 ): ConversationAttachmentType | null {
-  if (isContentNodeContentFragment(cf)) {
-    return getAttachmentFromContentNodeContentFragment(cf);
+  // Expired content fragments cannot be converted to attachments
+  if (cf.expiredReason) {
+    return null;
   }
-  if (isFileContentFragment(cf)) {
-    return getAttachmentFromFileContentFragment(cf);
+
+  // After this check, we know expiredReason is null
+  const nonExpiredCf = cf as ContentFragmentType & { expiredReason: null };
+
+  if (isContentNodeContentFragment(nonExpiredCf)) {
+    return getAttachmentFromContentNodeContentFragment(nonExpiredCf);
   }
-  assertNever(cf);
+  if (isFileContentFragment(nonExpiredCf)) {
+    return getAttachmentFromFileContentFragment(nonExpiredCf);
+  }
+  assertNever(nonExpiredCf);
 }
 
 export function getAttachmentFromContentNodeContentFragment(
-  cf: ContentNodeContentFragmentType
+  cf: ContentNodeContentFragmentType & { expiredReason: null }
 ): ContentNodeAttachmentType {
   const isQueryable =
     isQueryableContentType(cf.contentType) || cf.nodeType === "table";

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -22,6 +22,7 @@ import {
   assertNever,
   DATA_SOURCE_NODE_ID,
   isContentNodeContentFragment,
+  isExpiredContentFragment,
   isFileContentFragment,
 } from "@app/types";
 
@@ -92,20 +93,17 @@ export function getAttachmentFromContentFragment(
   cf: ContentFragmentType
 ): ConversationAttachmentType | null {
   // Expired content fragments cannot be converted to attachments
-  if (cf.expiredReason) {
+  if (isExpiredContentFragment(cf)) {
     return null;
   }
 
-  // After this check, we know expiredReason is null
-  const nonExpiredCf = cf as ContentFragmentType & { expiredReason: null };
-
-  if (isContentNodeContentFragment(nonExpiredCf)) {
-    return getAttachmentFromContentNodeContentFragment(nonExpiredCf);
+  if (isContentNodeContentFragment(cf)) {
+    return getAttachmentFromContentNodeContentFragment(cf);
   }
-  if (isFileContentFragment(nonExpiredCf)) {
-    return getAttachmentFromFileContentFragment(nonExpiredCf);
+  if (isFileContentFragment(cf)) {
+    return getAttachmentFromFileContentFragment(cf);
   }
-  assertNever(nonExpiredCf);
+  assertNever(cf);
 }
 
 export function getAttachmentFromContentNodeContentFragment(

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -508,10 +508,6 @@ async function batchRenderContentFragment(
   return Promise.all(
     messagesWithContentFragment.map(async (message: Message) => {
       const contentFragment = ContentFragmentResource.fromMessage(message);
-      if (contentFragment.expiredReason) {
-        // ignore expired content fragments
-        return null;
-      }
       const render = await contentFragment.renderFromMessage({
         auth,
         conversationId,
@@ -520,7 +516,7 @@ async function batchRenderContentFragment(
 
       return render;
     })
-  ).then((results) => removeNulls(results));
+  );
 }
 
 /**

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -313,6 +313,33 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       expiredReason: this.expiredReason,
     };
 
+    if (this.expiredReason) {
+      if (contentFragmentType === "file") {
+        return {
+          ...baseContentFragment,
+          contentFragmentType: "file",
+          expiredReason: this.expiredReason,
+          fileId: null,
+          snippet: null,
+          generatedTables: [],
+          textUrl: null,
+          textBytes: null,
+        };
+      } else if (contentFragmentType === "content_node") {
+        return {
+          ...baseContentFragment,
+          contentFragmentType: "content_node",
+          expiredReason: this.expiredReason,
+          nodeId: null,
+          nodeDataSourceViewId: null,
+          nodeType: null,
+          contentNodeData: null,
+        };
+      } else {
+        assertNever(contentFragmentType);
+      }
+    }
+
     if (contentFragmentType === "file") {
       const location = fileAttachmentLocation({
         workspaceId: owner.sId,
@@ -338,6 +365,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       return {
         ...baseContentFragment,
         contentFragmentType: "file",
+        expiredReason: null,
         fileId: fileStringId,
         snippet,
         generatedTables,
@@ -400,6 +428,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       return {
         ...baseContentFragment,
         contentFragmentType: "content_node",
+        expiredReason: null,
         nodeId,
         nodeDataSourceViewId,
         nodeType,

--- a/front/pages/poke/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversation/[cId]/index.tsx
@@ -298,7 +298,7 @@ const ContentFragmentView = ({ message }: ContentFragmentViewProps) => {
         </a>
       )}{" "}
       <a
-        href={isFileContentFragment(message) ? message.textUrl : ""}
+        href={isFileContentFragment(message) ? (message.textUrl ?? "") : ""}
         target="_blank"
         className="text-highlight-500"
       >

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -56,20 +56,43 @@ export type BaseContentFragmentType = {
 
 export type ContentNodeContentFragmentType = BaseContentFragmentType & {
   contentFragmentType: "content_node";
-  nodeId: string;
-  nodeDataSourceViewId: string;
-  nodeType: ContentNodeType;
-  contentNodeData: ContentFragmentNodeData;
-};
+} & (
+    | {
+        expiredReason: null;
+        nodeId: string;
+        nodeDataSourceViewId: string;
+        nodeType: ContentNodeType;
+        contentNodeData: ContentFragmentNodeData;
+      }
+    | {
+        expiredReason: ContentFragmentExpiredReason;
+        nodeId: null;
+        nodeDataSourceViewId: null;
+        nodeType: null;
+        contentNodeData: null;
+      }
+  );
 
 export type FileContentFragmentType = BaseContentFragmentType & {
   contentFragmentType: "file";
-  fileId: string | null;
-  snippet: string | null;
-  generatedTables: string[];
-  textUrl: string;
-  textBytes: number | null;
-};
+} & (
+    | {
+        expiredReason: null;
+        fileId: string | null;
+        snippet: string | null;
+        generatedTables: string[];
+        textUrl: string;
+        textBytes: number | null;
+      }
+    | {
+        expiredReason: ContentFragmentExpiredReason;
+        fileId: null;
+        snippet: null;
+        generatedTables: [];
+        textUrl: null;
+        textBytes: null;
+      }
+  );
 
 export type ContentFragmentType =
   | FileContentFragmentType
@@ -102,4 +125,21 @@ export function isContentNodeContentFragment(
   arg: ContentFragmentType
 ): arg is ContentNodeContentFragmentType {
   return arg.contentFragmentType === "content_node";
+}
+
+// Type guard to check if content fragment is expired
+export function isExpiredContentFragment(
+  arg: ContentFragmentType
+): arg is ContentFragmentType & {
+  expiredReason: ContentFragmentExpiredReason;
+} {
+  return arg.expiredReason !== null;
+}
+
+// Type guard to filter out expired content fragments
+// Use this in API responses where complete data is required
+export function isNonExpiredContentFragment(
+  arg: ContentFragmentType
+): arg is ContentFragmentType & { expiredReason: null } {
+  return arg.expiredReason === null;
 }

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -127,19 +127,10 @@ export function isContentNodeContentFragment(
   return arg.contentFragmentType === "content_node";
 }
 
-// Type guard to check if content fragment is expired
 export function isExpiredContentFragment(
   arg: ContentFragmentType
 ): arg is ContentFragmentType & {
   expiredReason: ContentFragmentExpiredReason;
 } {
   return arg.expiredReason !== null;
-}
-
-// Type guard to filter out expired content fragments
-// Use this in API responses where complete data is required
-export function isNonExpiredContentFragment(
-  arg: ContentFragmentType
-): arg is ContentFragmentType & { expiredReason: null } {
-  return arg.expiredReason === null;
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -880,6 +880,8 @@ const ContentFragmentNodeData = z.object({
   spaceName: z.string(),
 });
 
+const ContentFragmentExpiredReasonSchema = z.literal("data_source_deleted");
+
 const BaseContentFragmentSchema = z.object({
   type: z.literal("content_fragment"),
   id: ModelIdSchema,
@@ -898,22 +900,45 @@ const BaseContentFragmentSchema = z.object({
   ]),
 });
 
-const FileContentFragmentSchema = BaseContentFragmentSchema.extend({
-  contentFragmentType: z.literal("file"),
-  fileId: z.string().nullable(),
-  snippet: z.string().nullable(),
-  generatedTables: z.array(z.string()),
-  textUrl: z.string(),
-  textBytes: z.number().nullable(),
-});
+const FileContentFragmentSchema = z.union([
+  BaseContentFragmentSchema.extend({
+    contentFragmentType: z.literal("file"),
+    expiredReason: z.null(),
+    fileId: z.string().nullable(),
+    snippet: z.string().nullable(),
+    generatedTables: z.array(z.string()),
+    textUrl: z.string(),
+    textBytes: z.number().nullable(),
+  }),
+  BaseContentFragmentSchema.extend({
+    contentFragmentType: z.literal("file"),
+    expiredReason: ContentFragmentExpiredReasonSchema,
+    fileId: z.null(),
+    snippet: z.null(),
+    generatedTables: z.array(z.never()),
+    textUrl: z.null(),
+    textBytes: z.null(),
+  }),
+]);
 
-const ContentNodeContentFragmentSchema = BaseContentFragmentSchema.extend({
-  contentFragmentType: z.literal("content_node"),
-  nodeId: z.string(),
-  nodeDataSourceViewId: z.string(),
-  nodeType: ContentNodeTypeSchema,
-  contentNodeData: ContentFragmentNodeData,
-});
+const ContentNodeContentFragmentSchema = z.union([
+  BaseContentFragmentSchema.extend({
+    contentFragmentType: z.literal("content_node"),
+    expiredReason: z.null(),
+    nodeId: z.string(),
+    nodeDataSourceViewId: z.string(),
+    nodeType: ContentNodeTypeSchema,
+    contentNodeData: ContentFragmentNodeData,
+  }),
+  BaseContentFragmentSchema.extend({
+    contentFragmentType: z.literal("content_node"),
+    expiredReason: ContentFragmentExpiredReasonSchema,
+    nodeId: z.null(),
+    nodeDataSourceViewId: z.null(),
+    nodeType: z.null(),
+    contentNodeData: z.null(),
+  }),
+]);
 
 const ContentFragmentSchema = z.union([
   FileContentFragmentSchema,


### PR DESCRIPTION
## Description

Follow up of https://github.com/dust-tt/dust/pull/18128 and https://github.com/dust-tt/dust/pull/18197
Removing the content fragment from the messages was not ok I there is now missing messages.
Instead we should return expired content fragments

The UI should already handle correctly the expired CF in 

https://github.com/dust-tt/dust/blob/e3127f69142b665d9ece3c61e392600bd815cf6e/front/components/assistant/conversation/attachment/utils.tsx#L118-L139 


## Tests

no

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
