### PR TITLE
[front] fix: Remove stripe race condition during credit purchase for pro

### DIFF
--- a/front/lib/credits/purchase.ts
+++ b/front/lib/credits/purchase.ts
@@ -3,10 +3,11 @@ import type Stripe from "stripe";
 import type { Authenticator } from "@app/lib/auth";
 import {
   attachCreditPurchaseToSubscription,
+  finalizeCreditPurchaseInvoice,
   getCreditAmountFromInvoice,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
-  makeAndMaybePayCreditPurchaseInvoice,
+  makeCreditPurchaseInvoice,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import logger from "@app/logger/logger";
@@ -170,7 +171,7 @@ export async function createProCreditPurchase({
   const workspace = auth.getNonNullableWorkspace();
 
   // Create and pay one-off invoice
-  const invoiceResult = await makeAndMaybePayCreditPurchaseInvoice({
+  const invoiceResult = await makeCreditPurchaseInvoice({
     stripeSubscriptionId,
     amountCents,
   });
@@ -197,6 +198,8 @@ export async function createProCreditPurchase({
     discount: null,
     invoiceOrLineItemId: invoice.id,
   });
+
+  await finalizeCreditPurchaseInvoice(invoice);
 
   logger.info(
     {

--- a/front/lib/credits/purchase.ts
+++ b/front/lib/credits/purchase.ts
@@ -199,7 +199,19 @@ export async function createProCreditPurchase({
     invoiceOrLineItemId: invoice.id,
   });
 
-  await finalizeCreditPurchaseInvoice(invoice);
+  const finalizeResult = await finalizeCreditPurchaseInvoice(invoice);
+  if (finalizeResult.isErr()) {
+    logger.error(
+      {
+        error: finalizeResult.error.error_message,
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+        amountCents,
+      },
+      "[Credit Purchase] Failed to finalize credit purchase invoice"
+    );
+    return new Err(new Error(finalizeResult.error.error_message));
+  }
 
   logger.info(
     {

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -650,11 +650,7 @@ export async function attachCreditPurchaseToSubscription({
   }
 }
 
-/**
- * Creates and pays a one-off invoice for credit purchase.
- * The invoice is created, finalized, and immediately paid.
- */
-export async function makeAndMaybePayCreditPurchaseInvoice({
+export async function makeCreditPurchaseInvoice({
   stripeSubscriptionId,
   amountCents,
 }: {
@@ -680,7 +676,7 @@ export async function makeAndMaybePayCreditPurchaseInvoice({
       credit_purchase: "true",
       credit_amount_cents: amountCents.toString(),
     },
-    auto_advance: false,
+    auto_advance: true,
   };
 
   try {
@@ -694,23 +690,7 @@ export async function makeAndMaybePayCreditPurchaseInvoice({
       })
     );
 
-    const finalizedInvoice = await stripe.invoices.finalizeInvoice(invoice.id);
-    // Why this double try-catch ?
-    // The customer's invoice payment MAY fail, but we are OK with it,
-    // we still want to create the credit purchase on our side,
-    // and IF the payment succeeds, we will activate it via stripe `invoice.paid` webhook.
-    try {
-      // Try to pay the invoice immediately.
-      await stripe.invoices.pay(finalizedInvoice.id);
-    } catch (error) {
-      logger.info(
-        {
-          invoiceStripeId: finalizedInvoice.id,
-        },
-        "[Credit Purchase] Invoice payment failed."
-      );
-    }
-    return new Ok(finalizedInvoice);
+    return new Ok(invoice);
   } catch (error) {
     logger.error(
       {
@@ -721,6 +701,27 @@ export async function makeAndMaybePayCreditPurchaseInvoice({
     );
     return new Err({
       error_message: `Failed to create invoice credit purchase: ${normalizeError(error).message}`,
+    });
+  }
+}
+
+export async function finalizeCreditPurchaseInvoice(
+  invoice: Stripe.Invoice
+): Promise<Result<undefined, { error_message: string }>> {
+  const stripe = getStripeClient();
+  try {
+    await stripe.invoices.finalizeInvoice(invoice.id);
+    return new Ok(undefined);
+  } catch (error) {
+    logger.error(
+      {
+        stripeInvoiceId: invoice.id,
+        stripeError: true,
+      },
+      "[Credit Purchase] Failed to create Stripe invoice"
+    );
+    return new Err({
+      error_message: `Failed to finalize invoice credit purchase: ${normalizeError(error).message}`,
     });
   }
 }


### PR DESCRIPTION
## Description

Current flow:
1. Create, finalize and pay an invoice
2. Create a Credit in db

between 1 and 2, we can receive a stripe webhook in another thread / pod for `invoice.paid` that we count on to start the credit, but will end-up skipping it if step 2. is not done yet.

New flow:

1. Create invoice, in draft
2. Create a credit in db
3. finalize invoice with stripe auto_advance (will pay automatically and smart retry)

## Tests

Tested manually

## Risk

Low

## Deploy Plan

- [ ] Deploy front