### PR TITLE
Poké: new plugin Intercom set conversation sliding window

### DIFF
--- a/connectors/src/api/admin.ts
+++ b/connectors/src/api/admin.ts
@@ -89,6 +89,14 @@ const whitelistedCommands = [
     majorCommand: "google_drive",
     command: "upsert-file",
   },
+  {
+    majorCommand: "intercom",
+    command: "get-conversations-sliding-window",
+  },
+  {
+    majorCommand: "intercom",
+    command: "set-conversations-sliding-window",
+  },
 ];
 
 const _adminAPIHandler = async (

--- a/connectors/src/connectors/intercom/lib/cli.ts
+++ b/connectors/src/connectors/intercom/lib/cli.ts
@@ -26,6 +26,7 @@ import type {
   IntercomFetchArticlesResponseType,
   IntercomFetchConversationResponseType,
   IntercomForceResyncArticlesResponseType,
+  IntercomGetConversationsSlidingWindowResponseType,
   IntercomSearchConversationsResponseType,
 } from "@connectors/types";
 
@@ -36,6 +37,7 @@ type IntercomResponse =
   | IntercomCheckMissingConversationsResponseType
   | IntercomForceResyncArticlesResponseType
   | IntercomFetchArticlesResponseType
+  | IntercomGetConversationsSlidingWindowResponseType
   | IntercomSearchConversationsResponseType;
 
 export const intercom = async ({
@@ -291,6 +293,23 @@ export const intercom = async ({
           last_closed_at: conv.statistics?.last_close_at || null,
         })),
         totalCount,
+      };
+    }
+
+    case "get-conversations-sliding-window": {
+      if (!connector) {
+        throw new Error(`Connector ${connectorId} not found`);
+      }
+      const w = await IntercomWorkspaceModel.findOne({
+        where: {
+          connectorId: connector.id,
+        },
+      });
+      if (!w) {
+        throw new Error(`No workspace found for connector ${connector.id}`);
+      }
+      return {
+        conversationsSlidingWindow: w.conversationsSlidingWindow,
       };
     }
 

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -281,6 +281,7 @@ export const IntercomCommandSchema = t.type({
     t.literal("check-missing-conversations"),
     t.literal("check-teams"),
     t.literal("set-conversations-sliding-window"),
+    t.literal("get-conversations-sliding-window"),
     t.literal("search-conversations"),
   ]),
   args: t.type({
@@ -357,6 +358,13 @@ export const IntercomForceResyncArticlesResponseSchema = t.type({
 });
 export type IntercomForceResyncArticlesResponseType = t.TypeOf<
   typeof IntercomForceResyncArticlesResponseSchema
+>;
+
+export const IntercomGetConversationsSlidingWindowResponseSchema = t.type({
+  conversationsSlidingWindow: t.number,
+});
+export type IntercomGetConversationsSlidingWindowResponseType = t.TypeOf<
+  typeof IntercomGetConversationsSlidingWindowResponseSchema
 >;
 
 export const IntercomSearchConversationsResponseSchema = t.type({
@@ -854,6 +862,7 @@ export const AdminResponseSchema = t.union([
   IntercomFetchArticlesResponseSchema,
   IntercomFetchConversationResponseSchema,
   IntercomForceResyncArticlesResponseSchema,
+  IntercomGetConversationsSlidingWindowResponseSchema,
   IntercomSearchConversationsResponseSchema,
   NotionApiRequestResponseSchema,
   NotionCheckUrlResponseSchema,

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -5,6 +5,7 @@ export * from "./confluence_page_checker";
 export * from "./delete_data_source";
 export * from "./garbage_collect_google_drive_document";
 export * from "./google_drive_sync_file";
+export * from "./intercom_set_sliding_window";
 export * from "./mark_connector_as_error";
 export * from "./notion_unstuck_syncing_nodes";
 export * from "./notion_update_orphaned_resources_parents";

--- a/front/lib/api/poke/plugins/data_sources/intercom_set_sliding_window.ts
+++ b/front/lib/api/poke/plugins/data_sources/intercom_set_sliding_window.ts
@@ -1,0 +1,118 @@
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import logger from "@app/logger/logger";
+import type {
+  IntercomCommandType,
+  IntercomGetConversationsSlidingWindowResponseType,
+} from "@app/types";
+import { ConnectorsAPI, Err, Ok } from "@app/types";
+
+export const intercomSetSlidingWindowPlugin = createPlugin({
+  manifest: {
+    id: "intercom-set-conversations-sliding-window",
+    name: "Set Conversations Sliding Window",
+    description:
+      "Set the time window (in days) for syncing conversations from Intercom. Default is 180 days.",
+    resourceTypes: ["data_sources"],
+    args: {
+      conversationsSlidingWindow: {
+        type: "number",
+        async: true,
+        label: "Sliding Window (days)",
+        description:
+          "Number of days to look back for conversations. Must be 0 or greater.",
+      },
+    },
+  },
+  isApplicableTo: (auth, resource) => {
+    if (!resource) {
+      return false;
+    }
+
+    return resource.connectorProvider === "intercom";
+  },
+  populateAsyncArgs: async (auth, resource) => {
+    if (!resource || !resource.connectorId) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    const command: IntercomCommandType = {
+      majorCommand: "intercom",
+      command: "get-conversations-sliding-window",
+      args: {
+        connectorId: Number(resource.connectorId),
+        force: undefined,
+        conversationId: undefined,
+        day: undefined,
+        helpCenterId: undefined,
+        conversationsSlidingWindow: undefined,
+      },
+    };
+
+    const result = await connectorsAPI.admin(command);
+
+    if (result.isErr()) {
+      return new Err(
+        new Error(`Failed to get current sliding window: ${result.error}`)
+      );
+    }
+
+    const response =
+      result.value as IntercomGetConversationsSlidingWindowResponseType;
+
+    return new Ok({
+      conversationsSlidingWindow: response.conversationsSlidingWindow,
+    });
+  },
+  execute: async (auth, resource, args) => {
+    const { conversationsSlidingWindow } = args;
+
+    if (!resource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    if (!resource.connectorId) {
+      return new Err(new Error("No connector on datasource."));
+    }
+
+    if (conversationsSlidingWindow < 0) {
+      return new Err(
+        new Error("Sliding window must be 0 or a positive number.")
+      );
+    }
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    const command: IntercomCommandType = {
+      majorCommand: "intercom",
+      command: "set-conversations-sliding-window",
+      args: {
+        connectorId: Number(resource.connectorId),
+        conversationsSlidingWindow,
+        force: undefined,
+        conversationId: undefined,
+        day: undefined,
+        helpCenterId: undefined,
+      },
+    };
+
+    const result = await connectorsAPI.admin(command);
+
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Successfully set conversations sliding window to ${conversationsSlidingWindow} days.`,
+    });
+  },
+});

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -280,6 +280,7 @@ export const IntercomCommandSchema = t.type({
     t.literal("fetch-articles"),
     t.literal("check-missing-conversations"),
     t.literal("check-teams"),
+    t.literal("get-conversations-sliding-window"),
     t.literal("set-conversations-sliding-window"),
   ]),
   args: t.type({
@@ -349,6 +350,13 @@ export const IntercomForceResyncArticlesResponseSchema = t.type({
 });
 export type IntercomForceResyncArticlesResponseType = t.TypeOf<
   typeof IntercomForceResyncArticlesResponseSchema
+>;
+
+export const IntercomGetConversationsSlidingWindowResponseSchema = t.type({
+  conversationsSlidingWindow: t.number,
+});
+export type IntercomGetConversationsSlidingWindowResponseType = t.TypeOf<
+  typeof IntercomGetConversationsSlidingWindowResponseSchema
 >;
 /**
  * </ Intercom>
@@ -827,6 +835,7 @@ export const AdminResponseSchema = t.union([
   IntercomFetchArticlesResponseSchema,
   IntercomFetchConversationResponseSchema,
   IntercomForceResyncArticlesResponseSchema,
+  IntercomGetConversationsSlidingWindowResponseSchema,
   NotionApiRequestResponseSchema,
   NotionCheckUrlResponseSchema,
   NotionDeleteUrlResponseSchema,


### PR DESCRIPTION
## Description

New poké plugin to be able to read/update the conversation sliding window on Intercom connectors.

<img width="706" height="360" alt="Screenshot 2025-11-24 at 22 47 11" src="https://github.com/user-attachments/assets/a84e9c1d-81db-4a31-9e23-4401000bfb5b" />


## Tests

Locally. 

## Risk

Poké only. 

## Deploy Plan

Deploy connectors. 
Deploy front. 