### PR TITLE
[front] Reduce concurrency on conversation deletion in workspace scrub

### DIFF
--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -185,7 +185,7 @@ export async function deleteAllConversations(auth: Authenticator) {
       }
     },
     {
-      concurrency: 12,
+      concurrency: 8,
     }
   );
 }


### PR DESCRIPTION
## Description

- We delete conversations at 3 locations: in. agent-level data retention policy (concurrency of 2), workspace-level data retention policy (concurrency of 2) and when scrubbing a workspace (concurrency of 12).
- We've observed that workspace scrub induce a high load on db resources.
- This PR reduces the concurrency to 8 (to be monitored).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
