### PR TITLE
[front] fix(outlook): fix timezone conversions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -192,7 +192,6 @@ function createServer(
         }
 
         const formattedText = renderOutlookEventList(result.events, {
-          userTimezone,
           hasMore: result.nextLink !== undefined,
         });
 
@@ -246,7 +245,7 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
-        const formattedText = renderOutlookEvent(result, userTimezone);
+        const formattedText = renderOutlookEvent(result);
 
         return new Ok([{ type: "text" as const, text: formattedText }]);
       }
@@ -354,7 +353,7 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
-        const formattedText = renderOutlookEvent(result, userTimezone);
+        const formattedText = renderOutlookEvent(result);
 
         return new Ok([
           {
@@ -461,7 +460,7 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
-        const formattedText = renderOutlookEvent(result, userTimezone);
+        const formattedText = renderOutlookEvent(result);
 
         return new Ok([
           {

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -192,6 +192,7 @@ function createServer(
         }
 
         const formattedText = renderOutlookEventList(result.events, {
+          userTimezone,
           hasMore: result.nextLink !== undefined,
         });
 
@@ -245,7 +246,7 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
-        const formattedText = renderOutlookEvent(result);
+        const formattedText = renderOutlookEvent(result, userTimezone);
 
         return new Ok([{ type: "text" as const, text: formattedText }]);
       }
@@ -353,7 +354,7 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
-        const formattedText = renderOutlookEvent(result);
+        const formattedText = renderOutlookEvent(result, userTimezone);
 
         return new Ok([
           {
@@ -460,7 +461,7 @@ function createServer(
           return new Err(new MCPError(result.error));
         }
 
-        const formattedText = renderOutlookEvent(result);
+        const formattedText = renderOutlookEvent(result, userTimezone);
 
         return new Ok([
           {

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -36,10 +36,7 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&apos;/g, "'");
 }
 
-function enrichEventWithDayOfWeek(
-  event: OutlookEvent,
-  userTimezone?: string
-): EnrichedOutlookEvent {
+function enrichEventWithDayOfWeek(event: OutlookEvent): EnrichedOutlookEvent {
   const enrichedEvent: EnrichedOutlookEvent = {
     ...event,
     start: {
@@ -57,23 +54,20 @@ function enrichEventWithDayOfWeek(
   const startDate = new Date(event.start.dateTime);
   enrichedEvent.start.eventDayOfWeek = startDate.toLocaleDateString("en-US", {
     weekday: "long",
-    timeZone: userTimezone ?? event.start.timeZone ?? undefined,
+    timeZone: event.start.timeZone,
   });
 
   const endDate = new Date(event.end.dateTime);
   enrichedEvent.end.eventDayOfWeek = endDate.toLocaleDateString("en-US", {
     weekday: "long",
-    timeZone: userTimezone ?? event.end.timeZone ?? undefined,
+    timeZone: event.end.timeZone,
   });
 
   return enrichedEvent;
 }
 
-export function renderOutlookEvent(
-  event: OutlookEvent,
-  userTimezone?: string
-): string {
-  const enrichedEvent = enrichEventWithDayOfWeek(event, userTimezone);
+export function renderOutlookEvent(event: OutlookEvent): string {
+  const enrichedEvent = enrichEventWithDayOfWeek(event);
   const lines: string[] = [];
 
   lines.push(`# ${enrichedEvent.subject ?? "Untitled event"}`);
@@ -96,13 +90,13 @@ export function renderOutlookEvent(
       const timeStr = startDate.toLocaleTimeString("en-US", {
         hour: "numeric",
         minute: "2-digit",
-        timeZone: userTimezone ?? start.timeZone ?? undefined,
+        timeZone: start.timeZone,
       });
       const dateStr = startDate.toLocaleDateString("en-US", {
         month: "long",
         day: "numeric",
         year: "numeric",
-        timeZone: userTimezone ?? start.timeZone ?? undefined,
+        timeZone: start.timeZone,
       });
       lines.push(
         `Start: ${start.eventDayOfWeek}, ${dateStr} at ${timeStr}${start.timeZone ? ` (${start.timeZone})` : ""}`
@@ -116,13 +110,13 @@ export function renderOutlookEvent(
     const timeStr = endDate.toLocaleTimeString("en-US", {
       hour: "numeric",
       minute: "2-digit",
-      timeZone: userTimezone ?? end.timeZone ?? undefined,
+      timeZone: end.timeZone,
     });
     const dateStr = endDate.toLocaleDateString("en-US", {
       month: "long",
       day: "numeric",
       year: "numeric",
-      timeZone: userTimezone ?? end.timeZone ?? undefined,
+      timeZone: end.timeZone,
     });
     lines.push(
       `End: ${end.eventDayOfWeek}, ${dateStr} at ${timeStr}${end.timeZone ? ` (${end.timeZone})` : ""}`
@@ -191,10 +185,8 @@ export function renderOutlookEvent(
 export function renderOutlookEventList(
   events: OutlookEvent[],
   {
-    userTimezone,
     hasMore,
   }: {
-    userTimezone?: string;
     hasMore: boolean;
   }
 ): string {
@@ -210,7 +202,7 @@ export function renderOutlookEventList(
 
   for (const event of events) {
     lines.push("\n---");
-    lines.push(renderOutlookEvent(event, userTimezone));
+    lines.push(renderOutlookEvent(event));
   }
 
   return lines.join("\n");

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/rendering.ts
@@ -36,7 +36,10 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&apos;/g, "'");
 }
 
-function enrichEventWithDayOfWeek(event: OutlookEvent): EnrichedOutlookEvent {
+function enrichEventWithDayOfWeek(
+  event: OutlookEvent,
+  userTimezone?: string
+): EnrichedOutlookEvent {
   const enrichedEvent: EnrichedOutlookEvent = {
     ...event,
     start: {
@@ -54,20 +57,23 @@ function enrichEventWithDayOfWeek(event: OutlookEvent): EnrichedOutlookEvent {
   const startDate = new Date(event.start.dateTime);
   enrichedEvent.start.eventDayOfWeek = startDate.toLocaleDateString("en-US", {
     weekday: "long",
-    timeZone: event.start.timeZone,
+    timeZone: userTimezone ?? event.start.timeZone ?? undefined,
   });
 
   const endDate = new Date(event.end.dateTime);
   enrichedEvent.end.eventDayOfWeek = endDate.toLocaleDateString("en-US", {
     weekday: "long",
-    timeZone: event.end.timeZone,
+    timeZone: userTimezone ?? event.end.timeZone ?? undefined,
   });
 
   return enrichedEvent;
 }
 
-export function renderOutlookEvent(event: OutlookEvent): string {
-  const enrichedEvent = enrichEventWithDayOfWeek(event);
+export function renderOutlookEvent(
+  event: OutlookEvent,
+  userTimezone?: string
+): string {
+  const enrichedEvent = enrichEventWithDayOfWeek(event, userTimezone);
   const lines: string[] = [];
 
   lines.push(`# ${enrichedEvent.subject ?? "Untitled event"}`);
@@ -90,13 +96,13 @@ export function renderOutlookEvent(event: OutlookEvent): string {
       const timeStr = startDate.toLocaleTimeString("en-US", {
         hour: "numeric",
         minute: "2-digit",
-        timeZone: start.timeZone,
+        timeZone: userTimezone ?? start.timeZone ?? undefined,
       });
       const dateStr = startDate.toLocaleDateString("en-US", {
         month: "long",
         day: "numeric",
         year: "numeric",
-        timeZone: start.timeZone,
+        timeZone: userTimezone ?? start.timeZone ?? undefined,
       });
       lines.push(
         `Start: ${start.eventDayOfWeek}, ${dateStr} at ${timeStr}${start.timeZone ? ` (${start.timeZone})` : ""}`
@@ -110,13 +116,13 @@ export function renderOutlookEvent(event: OutlookEvent): string {
     const timeStr = endDate.toLocaleTimeString("en-US", {
       hour: "numeric",
       minute: "2-digit",
-      timeZone: end.timeZone,
+      timeZone: userTimezone ?? end.timeZone ?? undefined,
     });
     const dateStr = endDate.toLocaleDateString("en-US", {
       month: "long",
       day: "numeric",
       year: "numeric",
-      timeZone: end.timeZone,
+      timeZone: userTimezone ?? end.timeZone ?? undefined,
     });
     lines.push(
       `End: ${end.eventDayOfWeek}, ${dateStr} at ${timeStr}${end.timeZone ? ` (${end.timeZone})` : ""}`
@@ -185,8 +191,10 @@ export function renderOutlookEvent(event: OutlookEvent): string {
 export function renderOutlookEventList(
   events: OutlookEvent[],
   {
+    userTimezone,
     hasMore,
   }: {
+    userTimezone?: string;
     hasMore: boolean;
   }
 ): string {
@@ -202,7 +210,7 @@ export function renderOutlookEventList(
 
   for (const event of events) {
     lines.push("\n---");
-    lines.push(renderOutlookEvent(event));
+    lines.push(renderOutlookEvent(event, userTimezone));
   }
 
   return lines.join("\n");


### PR DESCRIPTION
## Description

This PR fixes how timezones are handled. Events are displayed in the user's timezone and their own timezone was not properly accounted for: events from the API come in a rich format (date without timezone, timezone).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
