### PR TITLE
[connectors] fix(Zendesk): update type for satisfaction rating

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -286,7 +286,7 @@ export async function syncTicket({
         }
         const author =
           users.find((user) => user.id === comment.author_id) ?? null;
-        return `[${comment?.created_at}] ${author ? `${author.name} (${author.email})` : "Unknown User"}:\n${commentContent}`;
+        return `[${comment?.created_at}] ${author ? `${author.name} (${author.email ?? "Unknown email"})` : "Unknown User"}:\n${commentContent}`;
       })
       .join("\n")}`.trim();
 

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -53,8 +53,8 @@ export const ZendeskTicketSchema = z
     has_incidents: z.boolean(),
     satisfaction_rating: z
       .object({
-        comment: z.string().optional(),
-        id: z.number().optional(),
+        comment: z.string().optional().nullable(),
+        id: z.number().optional().nullable(),
         score: z.string(),
       })
       .optional(),

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -336,7 +336,7 @@ export const ZendeskTicketCommentSchema = z
     body: z.string(),
     author_id: z.number(),
     created_at: z.string(),
-    plain_body: z.string(),
+    plain_body: z.string().optional(),
   })
   .passthrough();
 

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -267,7 +267,7 @@ export const ZendeskUserSchema = z
     id: z.number(),
     url: z.string(),
     name: z.string(),
-    email: z.string(),
+    email: z.string().nullable(),
     created_at: z.string(),
     updated_at: z.string(),
     active: z.boolean(),


### PR DESCRIPTION
## Description

- This PR updates the zod schema used to validate content coming from the Zendesk API.
- Error logs [here](https://app.datadoghq.eu/logs?query=%22%5BZendesk%5D%20Invalid%20API%20response%20format%22&additional_filters=%5B%5D&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=193898&storage=hot&stream_sort=desc&viz=stream&from_ts=1764055216667&to_ts=1764058816667&live=true), flltered logs [here](https://app.datadoghq.eu/logs?query=%22%5BZendesk%5D%20Invalid%20API%20response%20format%22%20-%40error%3A%2Asatisfaction_rating%2A%20-%40error%3A%2Aplain_body%2A%20-%40error%3A%2Aemail%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=193898&storage=hot&stream_sort=desc&viz=stream&from_ts=1764055216667&to_ts=1764058816667&live=true).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
