### PR TITLE
[front] fix(Zendesk): add back missing types

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/types.ts
@@ -304,9 +304,15 @@ export const ZendeskTicketFieldSchema = z
   })
   .passthrough();
 
-export const ZendeskTicketFieldResponseSchema = z.object({
-  ticket_field: ZendeskTicketFieldSchema,
+export type ZendeskTicketField = z.infer<typeof ZendeskTicketFieldSchema>;
+
+export const ZendeskTicketFieldsResponseSchema = z.object({
+  ticket_fields: z.array(ZendeskTicketFieldSchema),
 });
+
+export type ZendeskTicketFieldsResponse = z.infer<
+  typeof ZendeskTicketFieldsResponseSchema
+>;
 
 // Ticket comment schemas
 export const ZendeskTicketCommentSchema = z


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/dust/pull/18246 removed types actually being used (uncaught by the CI that only ran on connectors).
- This PR adds them back.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
