### PR TITLE
[Agent Loop] Temp: Add MCP heartbeat logs

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -291,6 +291,13 @@ export async function* tryCallMCPTool(
 
   const conversationId = agentLoopRunContext.conversation.sId;
   const messageId = agentLoopRunContext.agentMessage.sId;
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const toolLogContext = {
+    conversationId,
+    messageId,
+    toolName: toolConfiguration.originalName,
+    workspaceId,
+  };
 
   const connectionParamsRes = await getMCPClientConnectionParams(
     auth,
@@ -394,12 +401,14 @@ export async function* tryCallMCPTool(
     const getHeartbeatPromise = (): Promise<void> =>
       new Promise((resolve) => {
         setTimeout(() => {
+          logger.info(toolLogContext, "MCP tool heartbeat");
           heartbeat();
           resolve();
           // Reasonable delay to react to cancellation under 10s.
         }, 10_000);
       });
 
+    logger.info(toolLogContext, "Starting MCP tool notification loop");
     while (!toolDone) {
       const notificationOrDone = await Promise.race([
         notificationPromise,
@@ -430,7 +439,9 @@ export async function* tryCallMCPTool(
 
     let toolCallResult: Awaited<typeof toolPromise>;
     try {
+      logger.info(toolLogContext, "Awaiting MCP tool promise");
       toolCallResult = await toolPromise;
+      logger.info(toolLogContext, "MCP tool promise resolved");
     } catch (toolError) {
       if (abortSignal?.aborted) {
         return makeMCPToolExit({


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5055
- add info logs for MCP heartbeat emissions
- add info log when entering MCP notification loop
- add info logs before and after awaiting tool promise

## Risks
Blast radius: MCP tool execution logging and heartbeat loop
Risk: low

## Deploy Plan
- deploy front