### PR TITLE
[front] feat: Add buy PU credits poke plugin

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { fromZodError } from "zod-validation-error";
 
 import { createPlugin } from "@app/lib/api/poke/types";
-import { createEnterpriseCreditPurchase } from "@app/lib/credits/purchase";
+import { createEnterpriseCreditPurchase } from "@app/lib/credits/committed";
 import {
   getCustomerId,
   getStripeSubscription,

--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+
+import { createPlugin } from "@app/lib/api/poke/types";
+import { createEnterpriseCreditPurchase } from "@app/lib/credits/purchase";
+import {
+  getCustomerId,
+  getStripeAccountId,
+  getStripeSubscription,
+  isEnterpriseSubscription,
+} from "@app/lib/plans/stripe";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { Err, Ok } from "@app/types";
+
+const BuyCreditPurchaseArgsSchema = z.object({
+  amountDollars: z
+    .number()
+    .positive("Amount must be greater than $0")
+    .finite("Amount must be a valid number"),
+  discountPercent: z
+    .number()
+    .min(0, "Discount must be at least 0%")
+    .max(100, "Discount must be at most 100%")
+    .finite("Discount must be a valid number"),
+  confirm: z.boolean().refine((val) => val === true, {
+    message: "Please confirm the purchase by checking the confirmation box",
+  }),
+});
+
+export const buyProgrammaticUsageCreditsPlugin = createPlugin({
+  manifest: {
+    id: "buy-programmatic-usage-credits",
+    name: "Buy Programmatic Usage Credits",
+    description:
+      "Purchase programmatic usage credits for enterprise customers. The purchase will be added to the customer's subscription and paid on the next billing cycle.",
+    resourceTypes: ["workspaces"],
+    args: {
+      amountDollars: {
+        type: "number",
+        label: "Amount ($)",
+        description: "Amount in US dollars to purchase",
+      },
+      discountPercent: {
+        type: "number",
+        async: true,
+        label: "Discount (%)",
+        description: "Discount percentage to apply (0-100)",
+      },
+      confirm: {
+        type: "boolean",
+        label: "Confirm Purchase",
+        description:
+          "I understand that running this plugin will add a purchase in the customer's subscription, which will be paid on next billing cycle",
+      },
+    },
+  },
+  populateAsyncArgs: async (auth) => {
+    const config =
+      await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+    const defaultDiscount = config?.defaultDiscountPercent ?? 0;
+
+    return new Ok({
+      discountPercent: defaultDiscount,
+    });
+  },
+  execute: async (auth, _, args) => {
+    const validationResult = BuyCreditPurchaseArgsSchema.safeParse(args);
+    if (!validationResult.success) {
+      const validationError = fromZodError(validationResult.error);
+      return new Err(new Error(validationError.message));
+    }
+
+    const validatedArgs = validationResult.data;
+    const workspace = auth.getNonNullableWorkspace();
+    const subscription = auth.subscription();
+
+    if (!subscription?.stripeSubscriptionId) {
+      return new Err(
+        new Error(
+          `Workspace "${workspace.name}" does not have a Stripe subscription.`
+        )
+      );
+    }
+
+    const stripeSubscription = await getStripeSubscription(
+      subscription.stripeSubscriptionId
+    );
+    if (!stripeSubscription) {
+      return new Err(new Error("Failed to retrieve Stripe subscription."));
+    }
+
+    if (!isEnterpriseSubscription(stripeSubscription)) {
+      return new Err(
+        new Error("This plugin is only available for enterprise customers.")
+      );
+    }
+
+    const amountCents = Math.round(validatedArgs.amountDollars * 100);
+
+    const result = await createEnterpriseCreditPurchase({
+      auth,
+      stripeSubscriptionId: subscription.stripeSubscriptionId,
+      amountCents,
+      discountPercent:
+        validatedArgs.discountPercent > 0
+          ? validatedArgs.discountPercent
+          : undefined,
+    });
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    const customerId = getCustomerId(stripeSubscription);
+    const stripeAccountId = await getStripeAccountId();
+    const invoiceUrl = `https://dashboard.stripe.com/${stripeAccountId}/customers/${customerId}/upcoming_invoice/${subscription.stripeSubscriptionId}`;
+
+    const originalAmount = validatedArgs.amountDollars;
+    const discountAmount =
+      (originalAmount * validatedArgs.discountPercent) / 100;
+    const finalAmount = originalAmount - discountAmount;
+
+    return new Ok({
+      display: "textWithLink",
+      value: `Successfully added credit purchase of $${finalAmount.toFixed(2)} (original: $${originalAmount.toFixed(2)}, discount: ${validatedArgs.discountPercent}%) to the subscription. The charge will appear on the next billing cycle.`,
+      link: invoiceUrl,
+      linkText: "View Upcoming Invoice in Stripe",
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -1,5 +1,6 @@
 export * from "./add_user_to_workos_organization";
 export * from "./apply_group_roles";
+export * from "./buy_programmatic_usage_credits";
 export * from "./check_seat_count";
 export * from "./clean_outdated_directory_sync_groups";
 export * from "./compute_statistics";

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -53,12 +53,6 @@ export const getStripeClient = () => {
   });
 };
 
-export async function getStripeAccountId(): Promise<string> {
-  const stripe = getStripeClient();
-  const account = await stripe.accounts.retrieve();
-  return account.id;
-}
-
 async function getDefautPriceFromMetadata(
   productId: string,
   key: string


### PR DESCRIPTION
## Description

Introduce a poke plugin to buy programmatic usage credits on behalf of enterprise customers.
Credits are not paid immediately, instead they are added to the customer's upcoming subscription invoice.

Also introduce the ability to JIT create stripe coupons to accommodate for discounts granted to customers.

## Tests

Tested manually locally.

## Risk

Low

## Deploy Plan

- [ ] Deploy front