### PR TITLE
fix(gha): use env variables instead of script template expressions

### DIFF
--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -28,12 +28,16 @@ jobs:
               - '.github/workflows/build-and-test-core.yml'
 
       - name: Workflow Decision Summary
+        env:
+          CORE_CHANGES: ${{ steps.changes.outputs.core }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          echo "🔍 Workflow Decision: ${{ steps.changes.outputs.core == 'true' && 'RUNNING TESTS' || 'SKIPPING TESTS' }}"
-          if [ "${{ steps.changes.outputs.core }}" == "true" ]; then
-            echo "✅ Core changes detected vs ${{ github.event.repository.default_branch }} - running tests"
+          if [ "${CORE_CHANGES}" == "true" ]; then
+            echo "🔍 Workflow Decision: RUNNING TESTS"
+            echo "✅ Core changes detected vs ${DEFAULT_BRANCH} - running tests"
           else
-            echo "⏭️ No core changes vs ${{ github.event.repository.default_branch }} - skipping tests"
+            echo "🔍 Workflow Decision: SKIPPING TESTS"
+            echo "⏭️ No core changes vs ${DEFAULT_BRANCH} - skipping tests"
           fi
 
   test:


### PR DESCRIPTION
Minor fix as not actually exploitable.
Template expressions are evaluated before a script runs so scanners complain about script injection.
