### PR TITLE
Add SQL Query Tagging for Cloud SQL Query Insights

### DIFF
--- a/front/instrumentation.ts
+++ b/front/instrumentation.ts
@@ -1,8 +1,17 @@
+import { registerOTel } from "@vercel/otel";
+
 export async function register() {
-  if (process.env.NEXT_RUNTIME === "nodejs") {
-    const { initializeLangfuseInstrumentation } = await import(
-      "@app/lib/api/instrumentation/init"
-    );
-    initializeLangfuseInstrumentation();
-  }
+  registerOTel({
+    serviceName: "dust-front",
+    // No exporter needed, we just want context.
+  });
+
+  // TODO(2025-11-25 flav) Add Langfuse back.
+  // if (process.env.NEXT_RUNTIME === "nodejs") {
+  //   // Initialize Langfuse first
+  //   const { initializeLangfuseInstrumentation } = await import(
+  //     "@app/lib/api/instrumentation/init"
+  //   );
+  //   initializeLangfuseInstrumentation();
+  // }
 }

--- a/front/lib/api/database.ts
+++ b/front/lib/api/database.ts
@@ -139,7 +139,6 @@ export class SequelizeWithComments extends Sequelize {
         )
         .join(",");
       sql = `${sql} /*${commentStr}*/`;
-      console.log(">> sql:" + sql);
     }
 
     return super.query(sql, options);

--- a/front/lib/api/database.ts
+++ b/front/lib/api/database.ts
@@ -1,6 +1,14 @@
 import { context as otelContext, trace } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
-import type { Options, QueryOptions, QueryOptionsWithType } from "sequelize";
+import type {
+  ColumnsDescription,
+  Model,
+  Options,
+  QueryOptions,
+  QueryOptionsWithModel,
+  QueryOptionsWithType,
+  QueryTypes,
+} from "sequelize";
 import { Sequelize } from "sequelize";
 
 /**
@@ -21,6 +29,65 @@ export class SequelizeWithComments extends Sequelize {
   /**
    * Overrides the query method to inject SQL comments with trace and route information
    */
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.UPDATE>
+  ): Promise<[undefined, number]>;
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.BULKUPDATE>
+  ): Promise<number>;
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.INSERT>
+  ): Promise<[number, number]>;
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.UPSERT>
+  ): Promise<number>;
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.DELETE>
+  ): Promise<void>;
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.BULKDELETE>
+  ): Promise<number>;
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.SHOWTABLES>
+  ): Promise<string[]>;
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.DESCRIBE>
+  ): Promise<ColumnsDescription>;
+  public query<M extends Model>(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithModel<M> & { plain: true }
+  ): Promise<M | null>;
+  public query<M extends Model>(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithModel<M>
+  ): Promise<M[]>;
+  public query<T extends object>(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.SELECT> & { plain: true }
+  ): Promise<T | null>;
+  public query<T extends object>(
+    sql: string | { query: string; values: unknown[] },
+    options: QueryOptionsWithType<QueryTypes.SELECT>
+  ): Promise<T[]>;
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options: (QueryOptions | QueryOptionsWithType<QueryTypes.RAW>) & {
+      plain: true;
+    }
+  ): Promise<{ [key: string]: unknown } | null>;
+  public query(
+    sql: string | { query: string; values: unknown[] },
+    options?: QueryOptions | QueryOptionsWithType<QueryTypes.RAW>
+  ): Promise<[unknown[], unknown]>;
+
   override async query(
     sql: string | { query: string; values: unknown[] },
     options?: QueryOptions | QueryOptionsWithType<any>

--- a/front/lib/api/database.ts
+++ b/front/lib/api/database.ts
@@ -1,0 +1,80 @@
+import { context as otelContext, trace } from "@opentelemetry/api";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import type { Options, QueryOptions, QueryOptionsWithType } from "sequelize";
+import { Sequelize } from "sequelize";
+
+/**
+ * Wrapper around Sequelize that adds sqlcommenter-style tags to queries.
+ *
+ * Context:
+ * - Sequelize doesn't officially support query interception:
+ *   https://github.com/sequelize/sequelize/issues/15416
+ * - Google's sqlcommenter uses similar internal patching:
+ *   https://github.com/google/sqlcommenter/blob/master/nodejs/sqlcommenter-nodejs/packages/sqlcommenter-sequelize/index.js
+ * - The official sqlcommenter package is unmaintained and incompatible with modern OpenTelemetry
+ */
+export class SequelizeWithComments extends Sequelize {
+  constructor(uri: string, options?: Options) {
+    super(uri, options);
+  }
+
+  /**
+   * Overrides the query method to inject SQL comments with trace and route information
+   */
+  override async query(
+    sql: string | { query: string; values: unknown[] },
+    options?: QueryOptions | QueryOptionsWithType<any>
+  ): Promise<any> {
+    // Only process string queries.
+    if (typeof sql !== "string") {
+      return super.query(sql, options);
+    }
+
+    // Skip if already has comments (avoid double-commenting).
+    if (sql.includes("/*")) {
+      return super.query(sql, options);
+    }
+
+    const comments: Record<string, string> = {};
+
+    // Get Next.js route from OpenTelemetry span.
+    const span = trace.getSpan(otelContext.active());
+    if (span && span.isRecording()) {
+      const readableSpan = span as unknown as ReadableSpan;
+      const attrs = readableSpan.attributes;
+
+      // Case 1: getServerSideProps/getStaticProps: has explicit `next.route`.
+      if (attrs?.["next.route"]) {
+        comments.route = attrs["next.route"] as string;
+      }
+      // Case 2: API routes: extract from next.span_name.
+      else if (attrs?.["next.span_name"]) {
+        const spanName = attrs["next.span_name"] as string;
+        // Extract route from: "executing api route (pages) /api/w/[wId]/feature-flags".
+        const match = spanName.match(/executing api route \(pages\) (.+)$/);
+        if (match) {
+          comments.route = match[1];
+        }
+      }
+    }
+
+    // Build comment string following sqlcommenter format
+    // https://google.github.io/sqlcommenter/spec/
+    const keys = Object.keys(comments)
+      .filter((key) => comments[key])
+      .sort();
+
+    if (keys.length > 0) {
+      const commentStr = keys
+        .map(
+          (key) =>
+            `${encodeURIComponent(key)}='${encodeURIComponent(comments[key])}'`
+        )
+        .join(",");
+      sql = `${sql} /*${commentStr}*/`;
+      console.log(">> sql:" + sql);
+    }
+
+    return super.query(sql, options);
+  }
+}

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
-//import { default as cls } from "cls-hooked";
-import { Sequelize } from "sequelize";
+import type { Sequelize } from "sequelize";
 
+import { SequelizeWithComments } from "@app/lib/api/database";
 import { dbConfig } from "@app/lib/resources/storage/config";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import { isDevelopment } from "@app/types";
@@ -36,7 +36,7 @@ types.setTypeParser(types.builtins.INT8, function (val: unknown) {
 export const statsDClient = getStatsDClient();
 const CONNECTION_ACQUISITION_THRESHOLD_MS = 100;
 
-export const frontSequelize = new Sequelize(
+export const frontSequelize = new SequelizeWithComments(
   dbConfig.getRequiredFrontDatabaseURI(),
   {
     pool: {
@@ -68,7 +68,7 @@ let frontReplicaDbInstance: Sequelize | null = null;
 
 export function getFrontReplicaDbConnection() {
   if (!frontReplicaDbInstance) {
-    frontReplicaDbInstance = new Sequelize(
+    frontReplicaDbInstance = new SequelizeWithComments(
       dbConfig.getRequiredFrontReplicaDatabaseURI() as string,
       {
         logging: false,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -48,6 +48,7 @@ const config = {
     // Prevents minification of the temporalio client workflow ids.
     serverMinification: false,
     esmExternals: false,
+    instrumentationHook: true,
   },
   async redirects() {
     return [

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -63,6 +63,7 @@
         "@types/json-schema": "^7.0.15",
         "@uiw/react-textarea-code-editor": "^3.0.2",
         "@valtown/sdk": "^2.0.0",
+        "@vercel/otel": "^2.1.0",
         "@virtuoso.dev/message-list": "^1.14.0",
         "@workos-inc/node": "^7.50.0",
         "adm-zip": "^0.5.16",
@@ -12493,6 +12494,24 @@
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@vercel/otel": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/otel/-/otel-2.1.0.tgz",
+      "integrity": "sha512-Zwu2Cu4t46DzBnY1DQSTxZ4MBLVfYsOjnlWuZuLRWnmVPX+SNrVHbs3ssiJ6uvY1J1JJswor4zSn8mHYxzYeBA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <2.0.0",
+        "@opentelemetry/api-logs": ">=0.200.0 <0.300.0",
+        "@opentelemetry/instrumentation": ">=0.200.0 <0.300.0",
+        "@opentelemetry/resources": ">=2.0.0 <3.0.0",
+        "@opentelemetry/sdk-logs": ">=0.200.0 <0.300.0",
+        "@opentelemetry/sdk-metrics": ">=2.0.0 <3.0.0",
+        "@opentelemetry/sdk-trace-base": ">=2.0.0 <3.0.0"
       }
     },
     "node_modules/@virtuoso.dev/gurx": {

--- a/front/package.json
+++ b/front/package.json
@@ -87,6 +87,7 @@
     "@types/json-schema": "^7.0.15",
     "@uiw/react-textarea-code-editor": "^3.0.2",
     "@valtown/sdk": "^2.0.0",
+    "@vercel/otel": "^2.1.0",
     "@virtuoso.dev/message-list": "^1.14.0",
     "@workos-inc/node": "^7.50.0",
     "adm-zip": "^0.5.16",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We  have more and more slow queries. We need to understand which API endpoints and pages are generating database queries to debug performance issues and identify slow queries by route. Cloud SQL Query Insights provides this capability through SQL comment-based tagging (sqlcommenter format), but the official `@google-cloud/sqlcommenter-sequelize` package is unmaintained and incompatible with our OpenTelemetry 2.x setup (dependency of Elasticsearch).

### Why Not Use sqlcommenter Package?

The official package has critical issues:
- **Dependency conflict**: Requires `@opentelemetry/core@^0.24.0` (4 years old) while our stack uses `@opentelemetry/core@2.2.0`
- **Unmaintained**: Last published 4 years ago, no updates planned
- **Migration stalled**: OpenTelemetry donation was archived without completion ([opentelemetry-sqlcommenter repo](https://github.com/open-telemetry/opentelemetry-sqlcommenter))

### Solution

Implemented a custom `SequelizeWithComments` wrapper that automatically adds route tags to SQL queries following the [sqlcommenter specification](https://google.github.io/sqlcommenter/spec/).

**Before:**
```sql
SELECT * FROM users WHERE workspace_id = 'abc123'
```

**After:**
```sql
SELECT * FROM users WHERE workspace_id = 'abc123' /*route='%2Fapi%2Fw%2F%5BwId%5D%2Fusers'*/
```

### How It Works

1. **OpenTelemetry Integration**: Next.js built-in OpenTelemetry instrumentation (via `@vercel/otel`) automatically captures route information in span attributes
2. **Query Interception**: Custom Sequelize wrapper overrides the `query()` method to inject SQL comments
3. **Route Extraction**: Handles both patterns:
   - **API routes**: Extracts from `next.span_name` (e.g., "executing api route (pages) /api/w/[wId]/users")
   - **getServerSideProps**: Uses explicit `next.route` attribute
4. Extensible, we can add more info tomorrow

### Implementation Details

**Technical Reference:**
- Sequelize has no official API for query transformation ([[Issue #15416](https://github.com/sequelize/sequelize/issues/15416)](https://github.com/sequelize/sequelize/issues/15416))
- Our approach mirrors sqlcommenter's strategy but uses the public `query()` method instead of internal prototypes

### Enabling in Cloud SQL

To make Cloud SQL Query Insights parse and index these tags, we need to do an infra PR to enable it. (see https://github.com/dust-tt/dust-infra/pull/519). 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested on front-edge:
```
>> sql:
        SELECT
        rank,
        "agentMessageId",
        version
      FROM (
        SELECT
          rank,
          "agentMessageId",
          version,
          ROW_NUMBER() OVER (
            PARTITION BY rank
            ORDER BY version DESC
          ) as rn
        FROM messages
        WHERE
          "workspaceId" = :workspaceId
          AND "conversationId" = :conversationId
          AND "agentMessageId" IS NOT NULL
      ) ranked_messages
      WHERE rn = 1
   /*route='%2Fapi%2Fw%2F%5BwId%5D%2Fassistant%2Fconversations%2F%5BcId%5D%2Factions%2Fblocked'*/
  ```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
