### PR TITLE
Rework UX of tool seup flow

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.18",
-        "@dust-tt/sparkle": "^0.4.1",
+        "@dust-tt/sparkle": "^0.4.3",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1285,10 +1285,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.1.tgz",
-      "integrity": "sha512-+naYWInkcAOUFDmJ7fewDjZKmB1mRx8A/aF5SDBfmkCJV8ZNaont8pGlXwhkeZVlijpqahTdnWue+YMVnBChxw==",
-      "license": "ISC",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.3.tgz",
+      "integrity": "sha512-tyG0xeE8jrtZpU82y4QPkeptu8qgCbIFLd8rhkp9pAhdDpBimF1/6pGTJUotwNRMEvWQZ9rzP2lNFEsKwelllQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.18",
-    "@dust-tt/sparkle": "^0.4.1",
+    "@dust-tt/sparkle": "^0.4.3",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -224,7 +224,7 @@ export function ConnectMCPServerDialog({
           <DialogTitle>
             <div className="flex items-center gap-2">
               {getAvatarFromIcon(toolIcon, "sm")}
-              <span>Configure {toolName}</span>
+              <span>Connect {toolName}</span>
             </div>
           </DialogTitle>
         </DialogHeader>

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -126,24 +126,26 @@ export function MCPServerOAuthConnexion({
     authorization.supported_use_cases.includes("personal_actions");
   const supportsPlatformActions =
     authorization.supported_use_cases.includes("platform_actions");
+  const supportBoth = supportsPersonalActions && supportsPlatformActions;
 
   return (
     <div className="flex flex-col items-center gap-4">
       <>
         <div className="w-full space-y-4">
           <div className="heading-lg text-foreground dark:text-foreground-night">
-            How do you want to connect {toolName}?
+            {supportBoth ? "How do you want to connect?" : "Connection type"}
           </div>
           <CardGrid>
             <ConditionalTooltip
               showTooltip={!supportsPersonalActions}
-              label={`${toolName} does not support indiviual connection.`}
+              label={`${toolName} does not support individual connection.`}
             >
               <Card
                 variant={supportsPersonalActions ? "secondary" : "primary"}
                 selected={useCase === "personal_actions"}
                 disabled={!supportsPersonalActions}
                 className={cn(
+                  "h-full",
                   supportsPersonalActions
                     ? "cursor-pointer"
                     : "cursor-not-allowed"
@@ -175,7 +177,7 @@ export function MCPServerOAuthConnexion({
                       {OAUTH_USE_CASE_TO_LABEL["personal_actions"]}
                     </span>
                   </div>
-                  <span className="text-muted-foreground dark:text-muted-foreground-night">
+                  <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                     {OAUTH_USE_CASE_TO_DESCRIPTION["personal_actions"]}
                   </span>
                 </div>
@@ -190,6 +192,7 @@ export function MCPServerOAuthConnexion({
                 selected={useCase === "platform_actions"}
                 disabled={!supportsPlatformActions}
                 className={cn(
+                  "h-full",
                   supportsPlatformActions
                     ? "cursor-pointer"
                     : "cursor-not-allowed"
@@ -221,7 +224,7 @@ export function MCPServerOAuthConnexion({
                       {OAUTH_USE_CASE_TO_LABEL["platform_actions"]}
                     </span>
                   </div>
-                  <span className="text-muted-foreground dark:text-muted-foreground-night">
+                  <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                     {OAUTH_USE_CASE_TO_DESCRIPTION["platform_actions"]}
                   </span>
                 </div>
@@ -230,25 +233,8 @@ export function MCPServerOAuthConnexion({
           </CardGrid>
         </div>
 
-        <div className="w-full">
-          {useCase === "platform_actions" && (
-            <span>
-              Members will all use the credentials you provide to access{" "}
-              {toolName}.
-            </span>
-          )}
-          {useCase === "personal_actions" && (
-            <span>
-              Members will connect their own {toolName} account for this tool.
-            </span>
-          )}
-        </div>
-
         {inputs && (
-          <div className="w-full space-y-4 pt-6">
-            <div className="heading-lg text-foreground dark:text-foreground-night">
-              Required information to connect {toolName}
-            </div>
+          <div className="w-full space-y-4 pt-4">
             {inputs &&
               Object.entries(inputs).map(([key, inputData]) => {
                 if (inputData.value) {
@@ -292,7 +278,7 @@ export function MCPServerOAuthConnexion({
         )}
 
         {documentationUrl && (
-          <div className="w-full pt-6 text-muted-foreground dark:text-muted-foreground-night">
+          <div className="w-full pt-6 text-sm text-muted-foreground dark:text-muted-foreground-night">
             Questions ? Read{" "}
             <Hoverable
               href={documentationUrl}
@@ -319,7 +305,7 @@ function ConditionalTooltip({
   children: React.ReactElement;
 }) {
   if (showTooltip) {
-    return <Tooltip label={label} trigger={children} />;
+    return <Tooltip label={label} trigger={children} tooltipTriggerAsChild />;
   }
   return children;
 }

--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -1,17 +1,11 @@
-import {
-  Button,
-  Chip,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-  LoginIcon,
-  XMarkIcon,
-} from "@dust-tt/sparkle";
+import { Button, Chip, LoginIcon, XMarkIcon } from "@dust-tt/sparkle";
 import { useCallback, useMemo, useState } from "react";
 
 import { ConnectMCPServerDialog } from "@app/components/actions/mcp/ConnectMCPServerDialog";
-import { OAUTH_USE_CASE_TO_LABEL } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+import {
+  OAUTH_USE_CASE_TO_DESCRIPTION,
+  OAUTH_USE_CASE_TO_LABEL,
+} from "@app/components/actions/mcp/MCPServerOAuthConnexion";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   useDeleteMCPServerConnection,
@@ -124,56 +118,21 @@ export function MCPServerSettings({
       {connection && (
         <div className="space-y-2">
           <div className="heading-base">Credentials</div>
-
-          {mcpServerView.server.authorization &&
-            // Disabled for now, because switching to workspace credentials could be dangerous without knowing which account it was.
-            mcpServerView.server.authorization.supported_use_cases &&
-            mcpServerView.server.authorization.supported_use_cases.length <
-              0 && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    isSelect
-                    variant="outline"
-                    label={
-                      useCase
-                        ? OAUTH_USE_CASE_TO_LABEL[useCase]
-                        : "Select credentials type"
-                    }
-                    size="sm"
-                  />
-                </DropdownMenuTrigger>
-
-                <DropdownMenuContent>
-                  {mcpServerView.server.authorization.supported_use_cases.map(
-                    (selectableUseCase) => (
-                      <DropdownMenuCheckboxItem
-                        key={selectableUseCase}
-                        checked={selectableUseCase === useCase}
-                        onCheckedChange={() =>
-                          setSelectedUseCase(selectableUseCase)
-                        }
-                      >
-                        {OAUTH_USE_CASE_TO_LABEL[selectableUseCase]}
-                      </DropdownMenuCheckboxItem>
-                    )
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
           <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
             {useCase === "platform_actions" && (
               <>
-                <span className="font-semibold">Workspace credentials</span>:
-                These tools will use the account's credentials provided during
-                activation for all users.
+                <span className="font-semibold">
+                  {OAUTH_USE_CASE_TO_LABEL["platform_actions"]}
+                </span>
+                : {OAUTH_USE_CASE_TO_DESCRIPTION["platform_actions"]}
               </>
             )}
             {useCase === "personal_actions" && (
               <>
-                <span className="font-semibold">Personal credentials</span>:
-                Users will connect their own accounts the first time they
-                interact with these tools.
+                <span className="font-semibold">
+                  {OAUTH_USE_CASE_TO_LABEL["personal_actions"]}
+                </span>
+                : {OAUTH_USE_CASE_TO_DESCRIPTION["personal_actions"]}
               </>
             )}
           </div>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/sdk": "^0.67.1",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.1",
+        "@dust-tt/sparkle": "^0.4.3",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1259,10 +1259,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.1.tgz",
-      "integrity": "sha512-+naYWInkcAOUFDmJ7fewDjZKmB1mRx8A/aF5SDBfmkCJV8ZNaont8pGlXwhkeZVlijpqahTdnWue+YMVnBChxw==",
-      "license": "ISC",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.3.tgz",
+      "integrity": "sha512-tyG0xeE8jrtZpU82y4QPkeptu8qgCbIFLd8rhkp9pAhdDpBimF1/6pGTJUotwNRMEvWQZ9rzP2lNFEsKwelllQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -35,7 +35,7 @@
     "@anthropic-ai/sdk": "^0.67.1",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.1",
+    "@dust-tt/sparkle": "^0.4.3",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

Rework UX tool setup flow, after having it migrated to a Dialog: 

<kbd>
<img width="644" height="859" alt="Screenshot 2025-11-25 at 14 25 12" src="https://github.com/user-attachments/assets/b2fa546d-5630-4f54-82f0-7ad832610216" />
</kbd>

We now pick individual per default if both options are available. 

## Tests

Locally. 

## Risk

Break tool setup flow. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
Check if material needs to be updated on docs.dust.tt