### PR TITLE
[LLM Router] feat: fix claude light reasoning

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/index.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  CLAUDE_4_THINKING_BUDGET_TOKENS,
+  ANTHROPIC_THINKING_BUDGET_TOKENS_MAPPING,
   toThinkingConfig,
 } from "@app/lib/api/llm/clients/anthropic/utils";
 
 describe("toThinkingConfig", () => {
   it('returns undefined for "light" when native light reasoning is false', () => {
-    expect(toThinkingConfig("light", false)).toBeUndefined();
+    expect(toThinkingConfig("light", false)).toEqual({ type: "disabled" });
   });
 
   it('returns configured budget tokens for "medium"', () => {
     expect(toThinkingConfig("medium")).toEqual({
       type: "enabled",
-      budget_tokens: CLAUDE_4_THINKING_BUDGET_TOKENS.medium,
+      budget_tokens: ANTHROPIC_THINKING_BUDGET_TOKENS_MAPPING.medium,
     });
   });
 });

--- a/front/lib/api/llm/clients/anthropic/utils/index.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.ts
@@ -1,10 +1,16 @@
 import type { ThinkingConfigParam } from "@anthropic-ai/sdk/resources/messages.mjs";
 
 import type { ReasoningEffort } from "@app/types";
+import { assertNever } from "@app/types";
 
-export const CLAUDE_4_THINKING_BUDGET_TOKENS = {
-  // thinking.enabled.budget_tokens: Input should be greater than or equal to 1024
-  medium: 1024,
+// thinking.enabled.budget_tokens: Input should be greater than or equal to 1024
+const ANTHROPIC_MINIMUM_THINKING_BUDGET = 1024;
+
+export const ANTHROPIC_THINKING_BUDGET_TOKENS_MAPPING = {
+  // All Claude models have useNativeLightReasoning set to false,
+  // so light budget token should not be used.
+  light: ANTHROPIC_MINIMUM_THINKING_BUDGET,
+  medium: ANTHROPIC_MINIMUM_THINKING_BUDGET,
   high: 4096,
 };
 
@@ -12,23 +18,25 @@ export function toThinkingConfig(
   reasoningEffort: ReasoningEffort | null,
   useNativeLightReasoning?: boolean
 ): ThinkingConfigParam | undefined {
-  if (!reasoningEffort || reasoningEffort === "none") {
-    return undefined;
-  }
-  if (reasoningEffort !== "light") {
-    return {
-      type: "enabled",
-      budget_tokens: CLAUDE_4_THINKING_BUDGET_TOKENS[reasoningEffort],
-    };
+  // Use meta prompt chain of thoughts for performance
+  if (reasoningEffort === "light" && !useNativeLightReasoning) {
+    return { type: "disabled" };
   }
 
-  // For "light", we may not use thinking config but chain of thought from prompt.
-  if (useNativeLightReasoning) {
-    return {
-      type: "enabled",
-      budget_tokens: 1024, // Minimum budget.
-    };
+  switch (reasoningEffort) {
+    case null:
+      return undefined;
+    case "none":
+      return { type: "disabled" };
+    case "light":
+    case "medium":
+    case "high":
+      return {
+        type: "enabled",
+        budget_tokens:
+          ANTHROPIC_THINKING_BUDGET_TOKENS_MAPPING[reasoningEffort],
+      };
+    default:
+      assertNever(reasoningEffort);
   }
-
-  return undefined;
 }


### PR DESCRIPTION
## Description

We were sending `thinking: undefined` (default thinking config) rather than disable thinking for anthropic models with "none" reasoning effort.
A few claude agents have reasoningEffort: null in db, these will still rely on default thinking config.

## Tests

local

## Risk

low

## Deploy Plan

front
