### PR TITLE
Simplify SQL query in listAllBeforeDate in data retention activity

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -185,17 +185,6 @@ describe("ConversationResource", () => {
       expect(oldConversationIds).toContain(convo3Id);
       expect(oldConversationIds).toContain(convo4Id);
     });
-
-    it("should return all old conversations no matter the batch size", async () => {
-      const oldConversations = await ConversationResource.listAllBeforeDate(
-        auth,
-        {
-          batchSize: 1,
-          cutoffDate: dateFromDaysAgo(1),
-        }
-      );
-      expect(oldConversations.length).toBe(4);
-    });
   });
 });
 


### PR DESCRIPTION
## Description

No need for a wild group by and having clause on the messages 
We can instead use the "updatedAt" of the conversation which is updated for each message insertion.

## Tests

Fix the actual tests in front/lib/resources/conversation_resource.test.ts

## Risk

UpdatedAt might be updated for other reason and might not reflect the actual last message date.
In that case we could introduce an additional "lastMessageDate" 

## Deploy Plan

deploy front
