### PR TITLE
[connectors] refactor(zendesk): rename types to align with `front`

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -9,7 +9,7 @@ import {
   shouldSyncTicket,
   syncTicket,
 } from "@connectors/connectors/zendesk/lib/sync_ticket";
-import type { ZendeskFetchedTicket } from "@connectors/connectors/zendesk/lib/types";
+import type { ZendeskTicket } from "@connectors/connectors/zendesk/lib/types";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   fetchZendeskCurrentUser,
@@ -64,7 +64,7 @@ function getTagsArgs(args: ZendeskCommandType["args"]) {
 }
 
 async function checkTicketShouldBeSynced(
-  ticket: ZendeskFetchedTicket | null,
+  ticket: ZendeskTicket | null,
   configuration: ZendeskConfigurationResource,
   {
     brandId,

--- a/connectors/src/connectors/zendesk/lib/in_memory_cache.ts
+++ b/connectors/src/connectors/zendesk/lib/in_memory_cache.ts
@@ -1,10 +1,7 @@
-import type { ZendeskFetchedOrganization } from "@connectors/connectors/zendesk/lib/types";
+import type { ZendeskOrganization } from "@connectors/connectors/zendesk/lib/types";
 
 // Nested Map structure: brandSubdomain -> organizationId -> organization
-const organizationCache = new Map<
-  string,
-  Map<number, ZendeskFetchedOrganization>
->();
+const organizationCache = new Map<string, Map<number, ZendeskOrganization>>();
 
 export function getOrganizationFromCache({
   brandSubdomain,
@@ -12,13 +9,13 @@ export function getOrganizationFromCache({
 }: {
   brandSubdomain: string;
   organizationId: number;
-}): ZendeskFetchedOrganization | undefined {
+}): ZendeskOrganization | undefined {
   const brandCache = organizationCache.get(brandSubdomain);
   return brandCache?.get(organizationId);
 }
 
 export function setOrganizationInCache(
-  organization: ZendeskFetchedOrganization,
+  organization: ZendeskOrganization,
   {
     brandSubdomain,
     organizationId,
@@ -29,7 +26,7 @@ export function setOrganizationInCache(
 ): void {
   let brandCache = organizationCache.get(brandSubdomain);
   if (!brandCache) {
-    brandCache = new Map<number, ZendeskFetchedOrganization>();
+    brandCache = new Map<number, ZendeskOrganization>();
     organizationCache.set(brandSubdomain, brandCache);
   }
   brandCache.set(organizationId, organization);

--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -2,9 +2,9 @@ import TurndownService from "turndown";
 
 import { getArticleInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 import type {
-  ZendeskFetchedArticle,
-  ZendeskFetchedSection,
-  ZendeskFetchedUser,
+  ZendeskArticle,
+  ZendeskSection,
+  ZendeskUser,
 } from "@connectors/connectors/zendesk/lib/types";
 import {
   deleteDataSourceDocument,
@@ -27,13 +27,19 @@ const turndownService = new TurndownService();
 /**
  * Deletes an article from the db and the data sources.
  */
-export async function deleteArticle(
-  connectorId: ModelId,
-  brandId: number,
-  articleId: number,
-  dataSourceConfig: DataSourceConfig,
-  loggerArgs: Record<string, string | number | null>
-): Promise<void> {
+export async function deleteArticle({
+  connectorId,
+  brandId,
+  articleId,
+  dataSourceConfig,
+  loggerArgs,
+}: {
+  connectorId: ModelId;
+  brandId: number;
+  articleId: number;
+  dataSourceConfig: DataSourceConfig;
+  loggerArgs: Record<string, string | number | null>;
+}): Promise<void> {
   logger.info({ ...loggerArgs, articleId }, "[Zendesk] Deleting article.");
   await deleteDataSourceDocument(
     dataSourceConfig,
@@ -61,13 +67,13 @@ export async function syncArticle({
   dataSourceConfig,
   loggerArgs,
 }: {
-  article: ZendeskFetchedArticle;
+  article: ZendeskArticle;
   connector: ConnectorResource;
   configuration: ZendeskConfigurationResource;
   dataSourceConfig: DataSourceConfig;
-  section: ZendeskFetchedSection | null;
+  section: ZendeskSection | null;
   category: ZendeskCategoryResource;
-  user: ZendeskFetchedUser | null;
+  user: ZendeskUser | null;
   helpCenterIsAllowed: boolean;
   currentSyncDateMs: number;
   loggerArgs: Record<string, string | number | null>;

--- a/connectors/src/connectors/zendesk/lib/sync_category.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_category.ts
@@ -3,7 +3,7 @@ import {
   getCategoryInternalId,
   getHelpCenterInternalId,
 } from "@connectors/connectors/zendesk/lib/id_conversions";
-import type { ZendeskFetchedCategory } from "@connectors/connectors/zendesk/lib/types";
+import type { ZendeskCategory } from "@connectors/connectors/zendesk/lib/types";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   deleteDataSourceDocument,
@@ -80,7 +80,7 @@ export async function syncCategory({
 }: {
   connectorId: ModelId;
   brandId: number;
-  category: ZendeskFetchedCategory;
+  category: ZendeskCategory;
   isHelpCenterSelected: boolean;
   currentSyncDateMs: number;
   dataSourceConfig: DataSourceConfig;

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -3,9 +3,9 @@ import TurndownService from "turndown";
 import { filterCustomTags } from "@connectors/connectors/shared/tags";
 import { getTicketInternalId } from "@connectors/connectors/zendesk/lib/id_conversions";
 import type {
-  ZendeskFetchedTicket,
-  ZendeskFetchedTicketComment,
-  ZendeskFetchedUser,
+  ZendeskTicket,
+  ZendeskTicketComment,
+  ZendeskUser,
 } from "@connectors/connectors/zendesk/lib/types";
 import {
   deleteDataSourceDocument,
@@ -18,8 +18,7 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 import type { ZendeskConfigurationResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskTicketResource } from "@connectors/resources/zendesk_resources";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
-import { stripNullBytes } from "@connectors/types";
-import { INTERNAL_MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES, stripNullBytes } from "@connectors/types";
 
 const turndownService = new TurndownService();
 
@@ -28,7 +27,7 @@ function apiUrlToDocumentUrl(apiUrl: string): string {
 }
 
 export function shouldSyncTicket(
-  ticket: ZendeskFetchedTicket,
+  ticket: ZendeskTicket,
   configuration: ZendeskConfigurationResource,
   {
     brandId,
@@ -179,7 +178,7 @@ export async function syncTicket({
   comments,
   users,
 }: {
-  ticket: ZendeskFetchedTicket;
+  ticket: ZendeskTicket;
   connector: ConnectorResource;
   configuration: ZendeskConfigurationResource;
   dataSourceConfig: DataSourceConfig;
@@ -187,8 +186,8 @@ export async function syncTicket({
   currentSyncDateMs: number;
   loggerArgs: Record<string, string | number | null>;
   forceResync: boolean;
-  comments: ZendeskFetchedTicketComment[];
-  users: ZendeskFetchedUser[];
+  comments: ZendeskTicketComment[];
+  users: ZendeskUser[];
 }) {
   const connectorId = connector.id;
 

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -63,7 +63,6 @@ export const ZendeskTicketSchema = z
   .passthrough();
 
 export type ZendeskTicket = z.infer<typeof ZendeskTicketSchema>;
-export type ZendeskFetchedTicket = z.infer<typeof ZendeskTicketSchema>;
 
 export const ZendeskTicketResponseSchema = z.object({
   ticket: ZendeskTicketSchema,
@@ -171,7 +170,7 @@ export const ZendeskBrandSchema = z
   })
   .passthrough();
 
-export type ZendeskFetchedBrand = z.infer<typeof ZendeskBrandSchema>;
+export type ZendeskBrand = z.infer<typeof ZendeskBrandSchema>;
 
 export const ZendeskBrandResponseSchema = z.object({
   brand: ZendeskBrandSchema,
@@ -199,7 +198,7 @@ export const ZendeskArticleSchema = z
   })
   .passthrough();
 
-export type ZendeskFetchedArticle = z.infer<typeof ZendeskArticleSchema>;
+export type ZendeskArticle = z.infer<typeof ZendeskArticleSchema>;
 
 export const ZendeskArticleResponseSchema = z.object({
   article: ZendeskArticleSchema,
@@ -227,7 +226,7 @@ export const ZendeskCategorySchema = z
   })
   .passthrough();
 
-export type ZendeskFetchedCategory = z.infer<typeof ZendeskCategorySchema>;
+export type ZendeskCategory = z.infer<typeof ZendeskCategorySchema>;
 
 export const ZendeskCategoryResponseSchema = z.object({
   category: ZendeskCategorySchema,
@@ -251,7 +250,7 @@ export const ZendeskSectionSchema = z
   })
   .passthrough();
 
-export type ZendeskFetchedSection = z.infer<typeof ZendeskSectionSchema>;
+export type ZendeskSection = z.infer<typeof ZendeskSectionSchema>;
 
 export const ZendeskSectionResponseSchema = z.object({
   section: ZendeskSectionSchema,
@@ -275,7 +274,7 @@ export const ZendeskUserSchema = z
   })
   .passthrough();
 
-export type ZendeskFetchedUser = z.infer<typeof ZendeskUserSchema>;
+export type ZendeskUser = z.infer<typeof ZendeskUserSchema>;
 
 export const ZendeskUserResponseSchema = z.object({
   user: ZendeskUserSchema,
@@ -297,9 +296,7 @@ export const ZendeskOrganizationSchema = z
   })
   .passthrough();
 
-export type ZendeskFetchedOrganization = z.infer<
-  typeof ZendeskOrganizationSchema
->;
+export type ZendeskOrganization = z.infer<typeof ZendeskOrganizationSchema>;
 
 export const ZendeskOrganizationResponseSchema = z.object({
   organization: ZendeskOrganizationSchema,
@@ -321,9 +318,7 @@ export const ZendeskTicketFieldSchema = z
   })
   .passthrough();
 
-export type ZendeskFetchedTicketField = z.infer<
-  typeof ZendeskTicketFieldSchema
->;
+export type ZendeskTicketField = z.infer<typeof ZendeskTicketFieldSchema>;
 
 export const ZendeskTicketFieldResponseSchema = z.object({
   ticket_field: ZendeskTicketFieldSchema,
@@ -340,9 +335,7 @@ export const ZendeskTicketCommentSchema = z
   })
   .passthrough();
 
-export type ZendeskFetchedTicketComment = z.infer<
-  typeof ZendeskTicketCommentSchema
->;
+export type ZendeskTicketComment = z.infer<typeof ZendeskTicketCommentSchema>;
 
 export const ZendeskTicketCommentsResponseSchema = z.object({
   comments: z.array(ZendeskTicketCommentSchema),

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -10,15 +10,15 @@ import {
   setOrganizationInCache,
 } from "@connectors/connectors/zendesk/lib/in_memory_cache";
 import type {
-  ZendeskFetchedArticle,
-  ZendeskFetchedBrand,
-  ZendeskFetchedCategory,
-  ZendeskFetchedOrganization,
-  ZendeskFetchedSection,
-  ZendeskFetchedTicket,
-  ZendeskFetchedTicketComment,
-  ZendeskFetchedTicketField,
-  ZendeskFetchedUser,
+  ZendeskArticle,
+  ZendeskBrand,
+  ZendeskCategory,
+  ZendeskOrganization,
+  ZendeskSection,
+  ZendeskTicket,
+  ZendeskTicketComment,
+  ZendeskTicketField,
+  ZendeskUser,
 } from "@connectors/connectors/zendesk/lib/types";
 import {
   ZendeskArticleResponseSchema,
@@ -255,7 +255,7 @@ export class ZendeskClient {
   }: {
     subdomain: string;
     brandId: number;
-  }): Promise<ZendeskFetchedBrand | null> {
+  }): Promise<ZendeskBrand | null> {
     const url = `https://${subdomain}.zendesk.com/api/v2/brands/${brandId}`;
     try {
       const response = await this.fetchFromZendeskWithRetries(
@@ -277,7 +277,7 @@ export class ZendeskClient {
   }: {
     subdomain: string;
     fieldId: number;
-  }): Promise<ZendeskFetchedTicketField | null> {
+  }): Promise<ZendeskTicketField | null> {
     const url = `https://${subdomain}.zendesk.com/api/v2/ticket_fields/${fieldId}`;
     try {
       const response = await this.fetchFromZendeskWithRetries(
@@ -318,7 +318,7 @@ export class ZendeskClient {
   }: {
     brandSubdomain: string;
     ticketId: number;
-  }): Promise<ZendeskFetchedTicket | null> {
+  }): Promise<ZendeskTicket | null> {
     const url = `https://${brandSubdomain}.zendesk.com/api/v2/tickets/${ticketId}`;
     try {
       const response = await this.fetchFromZendeskWithRetries(
@@ -340,7 +340,7 @@ export class ZendeskClient {
   }: {
     brandSubdomain: string;
     ticketId: number;
-  }): Promise<ZendeskFetchedTicketComment[]> {
+  }): Promise<ZendeskTicketComment[]> {
     const comments = [];
     let url = `https://${brandSubdomain}.zendesk.com/api/v2/tickets/${ticketId}/comments?page[size]=${COMMENT_PAGE_SIZE}`;
     let hasMore = true;
@@ -371,8 +371,8 @@ export class ZendeskClient {
   }: {
     brandSubdomain: string;
     userIds: number[];
-  }): Promise<ZendeskFetchedUser[]> {
-    const users: ZendeskFetchedUser[] = [];
+  }): Promise<ZendeskUser[]> {
+    const users: ZendeskUser[] = [];
     for (const chunk of _.chunk(userIds, 100)) {
       const response = await this.fetchFromZendeskWithRetries(
         `https://${brandSubdomain}.zendesk.com/api/v2/users/show_many?ids=${chunk.join(",")}`,
@@ -389,12 +389,12 @@ export class ZendeskClient {
   }: {
     brandSubdomain: string;
     organizationIds: number[];
-  }): Promise<ZendeskFetchedOrganization[]> {
+  }): Promise<ZendeskOrganization[]> {
     if (organizationIds.length === 0) {
       return [];
     }
 
-    const results: ZendeskFetchedOrganization[] = [];
+    const results: ZendeskOrganization[] = [];
     const nonCachedOrganizationIds: number[] = [];
 
     for (const organizationId of organizationIds) {
@@ -447,7 +447,7 @@ export class ZendeskClient {
   }
 
   async getOrganizationTagMapForTickets(
-    tickets: ZendeskFetchedTicket[],
+    tickets: ZendeskTicket[],
     {
       brandSubdomain,
     }: {
@@ -475,7 +475,7 @@ export class ZendeskClient {
   }: {
     brandSubdomain: string;
     categoryId: number;
-  }): Promise<ZendeskFetchedCategory | null> {
+  }): Promise<ZendeskCategory | null> {
     const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories/${categoryId}`;
     try {
       const response = await this.fetchFromZendeskWithRetries(
@@ -494,7 +494,7 @@ export class ZendeskClient {
   async listCategoriesInBrand(
     params: { url: string } | { brandSubdomain: string; pageSize: number }
   ): Promise<{
-    categories: ZendeskFetchedCategory[];
+    categories: ZendeskCategory[];
     hasMore: boolean;
     nextLink: string | null;
   }> {
@@ -525,7 +525,7 @@ export class ZendeskClient {
       | { url: string }
       | { brandSubdomain: string; categoryId: number; pageSize: number }
   ): Promise<{
-    articles: ZendeskFetchedArticle[];
+    articles: ZendeskArticle[];
     hasMore: boolean;
     nextLink: string | null;
   }> {
@@ -557,7 +557,7 @@ export class ZendeskClient {
   }: {
     brandSubdomain: string;
     categoryId: number;
-  }): Promise<ZendeskFetchedSection[]> {
+  }): Promise<ZendeskSection[]> {
     const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories/${categoryId}/sections`;
     try {
       const response = await this.fetchFromZendeskWithRetries(
@@ -576,7 +576,7 @@ export class ZendeskClient {
   async listTickets(
     params: { url: string } | { brandSubdomain: string; startTime: number }
   ): Promise<{
-    tickets: ZendeskFetchedTicket[];
+    tickets: ZendeskTicket[];
     hasMore: boolean;
     nextLink: string | null;
   }> {
@@ -613,7 +613,7 @@ export class ZendeskClient {
     brandSubdomain: string;
     startTime: number;
   }): Promise<{
-    articles: ZendeskFetchedArticle[];
+    articles: ZendeskArticle[];
     hasMore: boolean;
     endTime: number;
   }> {
@@ -642,7 +642,7 @@ export class ZendeskClient {
   }: {
     brandSubdomain: string;
     sectionId: number;
-  }): Promise<ZendeskFetchedSection | null> {
+  }): Promise<ZendeskSection | null> {
     const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/sections/${sectionId}`;
     try {
       const response = await this.fetchFromZendeskWithRetries(
@@ -664,7 +664,7 @@ export class ZendeskClient {
   }: {
     brandSubdomain: string;
     userId: number;
-  }): Promise<ZendeskFetchedUser | null> {
+  }): Promise<ZendeskUser | null> {
     const url = `https://${brandSubdomain}.zendesk.com/api/v2/users/${userId}`;
     try {
       const response = await this.fetchFromZendeskWithRetries(
@@ -684,7 +684,7 @@ export class ZendeskClient {
     subdomain,
   }: {
     subdomain: string;
-  }): Promise<ZendeskFetchedBrand[]> {
+  }): Promise<ZendeskBrand[]> {
     const url = `https://${subdomain}.zendesk.com/api/v2/brands`;
     const response = await this.fetchFromZendeskWithRetries(
       url,
@@ -697,7 +697,7 @@ export class ZendeskClient {
     brandSubdomain,
   }: {
     brandSubdomain: string;
-  }): Promise<ZendeskFetchedCategory[]> {
+  }): Promise<ZendeskCategory[]> {
     const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/categories`;
     const response = await this.fetchFromZendeskWithRetries(
       url,
@@ -712,7 +712,7 @@ export class ZendeskClient {
   }: {
     brandSubdomain: string;
     articleId: number;
-  }): Promise<ZendeskFetchedArticle | null> {
+  }): Promise<ZendeskArticle | null> {
     try {
       const url = `https://${brandSubdomain}.zendesk.com/api/v2/help_center/articles/${articleId}`;
       const response = await this.fetchFromZendeskWithRetries(
@@ -775,7 +775,7 @@ function extractMetadataFromZendeskUrl(url: string): {
   };
 }
 
-export function isUserAdmin(user: ZendeskFetchedUser): boolean {
+export function isUserAdmin(user: ZendeskUser): boolean {
   return user.active && user.role === "admin";
 }
 
@@ -785,7 +785,7 @@ export async function fetchZendeskCurrentUser({
 }: {
   subdomain: string;
   accessToken: string;
-}): Promise<ZendeskFetchedUser> {
+}): Promise<ZendeskUser> {
   const url = `https://${subdomain}.zendesk.com/api/v2/users/me`;
   const response = await fetch(url, {
     method: "GET",

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -164,13 +164,13 @@ export async function removeMissingArticleBatchActivity({
         articleId,
       });
       if (!article) {
-        await deleteArticle(
+        await deleteArticle({
           connectorId,
           brandId,
           articleId,
           dataSourceConfig,
-          loggerArgs
-        );
+          loggerArgs,
+        });
       }
     },
     { concurrency: 10 }

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -7,7 +7,7 @@ import {
   shouldSyncTicket,
   syncTicket,
 } from "@connectors/connectors/zendesk/lib/sync_ticket";
-import type { ZendeskFetchedTicketComment } from "@connectors/connectors/zendesk/lib/types";
+import type { ZendeskTicketComment } from "@connectors/connectors/zendesk/lib/types";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { ZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
@@ -257,7 +257,7 @@ export async function syncZendeskTicketUpdateBatchActivity({
     url ? { url } : { brandSubdomain, startTime }
   );
 
-  const commentsPerTicket: Record<number, ZendeskFetchedTicketComment[]> = {};
+  const commentsPerTicket: Record<number, ZendeskTicketComment[]> = {};
   await concurrentExecutor(
     tickets,
     async (ticket) => {


### PR DESCRIPTION
## Description

- This PR renames the types used in the zendesk connector, which historically contained the "Fetched" keyword (`ZendeskFetchedXxx`) to align with `front`.
- No op in terms of runtime.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
