### PR TITLE
Fix create_reply_draft Outlook tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
@@ -489,17 +489,18 @@ function createServer(
           }));
         }
 
-        const response = await fetchFromOutlook(endpoint, accessToken, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(replyMessage),
-        });
+        // Create the empty draft
+        const createDraftResponse = await fetchFromOutlook(
+          endpoint,
+          accessToken,
+          {
+            method: "POST",
+          }
+        );
 
-        if (!response.ok) {
-          const errorText = await getErrorText(response);
-          if (response.status === 404) {
+        if (!createDraftResponse.ok) {
+          const errorText = await getErrorText(createDraftResponse);
+          if (createDraftResponse.status === 404) {
             return new Err(
               new MCPError(`Message not found: ${messageId}`, {
                 tracked: false,
@@ -508,12 +509,55 @@ function createServer(
           }
           return new Err(
             new MCPError(
-              `Failed to create reply draft: ${response.status} ${response.statusText} - ${errorText}`
+              `Failed to create reply draft: ${createDraftResponse.status} ${createDraftResponse.statusText} - ${errorText}`
             )
           );
         }
 
-        const result = await response.json();
+        const createDraftResult = await createDraftResponse.json();
+
+        // Get the existing body content from the created draft (includes quoted original message)
+        const existingBody = createDraftResult.body?.content || "";
+
+        // Prepend the new body to the existing HTML content
+        // If contentType is HTML, we need to properly insert the new content
+        let combinedBody: string;
+        if (contentType === "html") {
+          // For HTML, add the new body as a paragraph before the existing content
+          combinedBody = `<div>${body}</div><br><br>${existingBody}`;
+        } else {
+          // For plain text, convert to HTML and combine
+          const escapedBody = body
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/\n/g, "<br>");
+          combinedBody = `<div>${escapedBody}</div><br><br>${existingBody}`;
+        }
+
+        const updateDraftResponse = await fetchFromOutlook(
+          `/me/messages/${createDraftResult.id}`,
+          accessToken,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              body: {
+                contentType: "html",
+                content: combinedBody,
+              },
+            }),
+          }
+        );
+
+        if (!updateDraftResponse.ok) {
+          const errorText = await getErrorText(updateDraftResponse);
+          return new Err(
+            new MCPError(`Failed to update the draft: ${errorText}`)
+          );
+        }
 
         return new Ok([
           { type: "text" as const, text: "Reply draft created successfully" },
@@ -521,10 +565,10 @@ function createServer(
             type: "text" as const,
             text: JSON.stringify(
               {
-                messageId: result.id,
-                conversationId: result.conversationId,
+                messageId: createDraftResult.id,
+                conversationId: createDraftResult.conversationId,
                 originalMessageId: messageId,
-                subject: result.subject,
+                subject: createDraftResult.subject,
               },
               null,
               2

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/index.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import sanitizeHtml from "sanitize-html";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
@@ -520,20 +521,8 @@ function createServer(
         const existingBody = createDraftResult.body?.content || "";
 
         // Prepend the new body to the existing HTML content
-        // If contentType is HTML, we need to properly insert the new content
-        let combinedBody: string;
-        if (contentType === "html") {
-          // For HTML, add the new body as a paragraph before the existing content
-          combinedBody = `<div>${body}</div><br><br>${existingBody}`;
-        } else {
-          // For plain text, convert to HTML and combine
-          const escapedBody = body
-            .replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/\n/g, "<br>");
-          combinedBody = `<div>${escapedBody}</div><br><br>${existingBody}`;
-        }
+        const sanitizedBody = sanitizeHtml(body);
+        const combinedBody = `<div>${sanitizedBody}</div><br><br>${existingBody}`;
 
         const updateDraftResponse = await fetchFromOutlook(
           `/me/messages/${createDraftResult.id}`,


### PR DESCRIPTION
## Description

The Outlook MCP `create_reply_draft` tool was not including email conversation history when creating reply drafts. The fix changes the implementation to first create an empty draft using the Microsoft Graph API createReply/createReplyAll endpoints (which automatically include the quoted original message), then updates the draft with the user's new reply content prepended to the existing body.

<img width="1276" height="774" alt="image" src="https://github.com/user-attachments/assets/89566083-f445-4a43-a9c8-16fc53c0c057" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
