### PR TITLE
[front,extension] Bump sparkle version

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.18",
-        "@dust-tt/sparkle": "^0.4.3",
+        "@dust-tt/sparkle": "^0.4.4",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1285,9 +1285,10 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.3.tgz",
-      "integrity": "sha512-tyG0xeE8jrtZpU82y4QPkeptu8qgCbIFLd8rhkp9pAhdDpBimF1/6pGTJUotwNRMEvWQZ9rzP2lNFEsKwelllQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.4.tgz",
+      "integrity": "sha512-gtanSYaB6q8v6qSvyCgWw48iGq5eOgF2TZM6YC7A4OhOaO3dK5Iwb+HA7+ksj92cf4US2I8mA4rSM1nt/SHfqg==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.18",
-    "@dust-tt/sparkle": "^0.4.3",
+    "@dust-tt/sparkle": "^0.4.4",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/sdk": "^0.67.1",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.3",
+        "@dust-tt/sparkle": "^0.4.4",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1261,9 +1261,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.3.tgz",
-      "integrity": "sha512-tyG0xeE8jrtZpU82y4QPkeptu8qgCbIFLd8rhkp9pAhdDpBimF1/6pGTJUotwNRMEvWQZ9rzP2lNFEsKwelllQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.4.tgz",
+      "integrity": "sha512-gtanSYaB6q8v6qSvyCgWw48iGq5eOgF2TZM6YC7A4OhOaO3dK5Iwb+HA7+ksj92cf4US2I8mA4rSM1nt/SHfqg==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -35,7 +35,7 @@
     "@anthropic-ai/sdk": "^0.67.1",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.3",
+    "@dust-tt/sparkle": "^0.4.4",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

- This PR bumps the version of sparkle to take the changes in https://github.com/dust-tt/dust/pull/18241
- The sparkle change wraps long lines in the raw mode of the json viewer to avoid situations where the component overflows heavily like [here](https://dust.tt/poke/0ec9852c2f/assistants/8CBhMYJNp6/triggers/trg_wFfpJVATnTN).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
