### PR TITLE
Check files:write scope before using it

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -328,8 +328,15 @@ async function streamAgentAnswerToSlack(
           actions
         );
 
-        const files = actions.flatMap((action) => action.generatedFiles);
-        const filesUploaded = await getFilesFromDust(files, dustAPI);
+        const authResult = await slackClient.auth.test();
+        let filesUploaded: { file: Buffer; filename: string }[] = [];
+        if (
+          authResult.ok &&
+          authResult.response_metadata?.scopes?.includes("files:write")
+        ) {
+          const files = actions.flatMap((action) => action.generatedFiles);
+          filesUploaded = await getFilesFromDust(files, dustAPI);
+        }
 
         const slackContent = slackifyMarkdown(
           normalizeContentForSlack(formattedContent)

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -378,6 +378,12 @@ function buildFilteredListResponse<T, U = T>(
   ]);
 }
 
+export async function hasSlackScope(accessToken: string, scope: string): Promise<boolean> {
+  const slackClient = await getSlackClient(accessToken);
+  const authResult = await slackClient.auth.test();
+  return authResult.ok && !!authResult.response_metadata?.scopes?.includes(scope);
+}
+
 // Post message function.
 export async function executePostMessage(
   auth: Authenticator,
@@ -408,11 +414,7 @@ export async function executePostMessage(
   );
   message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
 
-  const authResult = await slackClient.auth.test();
-  if (
-    !authResult.ok ||
-    !authResult.response_metadata?.scopes?.includes("files:write")
-  ) {
+  if (!await hasSlackScope(accessToken, "files:write")) {
     fileId = undefined;
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -408,6 +408,14 @@ export async function executePostMessage(
   );
   message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
 
+  const authResult = await slackClient.auth.test();
+  if (
+    !authResult.ok ||
+    !authResult.response_metadata?.scopes?.includes("files:write")
+  ) {
+    fileId = undefined;
+  }
+
   // If a file is provided, upload it as attachment of the original message.
   if (fileId) {
     const file = await FileResource.fetchById(auth, fileId);

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -378,10 +378,15 @@ function buildFilteredListResponse<T, U = T>(
   ]);
 }
 
-export async function hasSlackScope(accessToken: string, scope: string): Promise<boolean> {
+export async function hasSlackScope(
+  accessToken: string,
+  scope: string
+): Promise<boolean> {
   const slackClient = await getSlackClient(accessToken);
   const authResult = await slackClient.auth.test();
-  return authResult.ok && !!authResult.response_metadata?.scopes?.includes(scope);
+  return (
+    authResult.ok && !!authResult.response_metadata?.scopes?.includes(scope)
+  );
 }
 
 // Post message function.
@@ -414,7 +419,7 @@ export async function executePostMessage(
   );
   message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
 
-  if (!await hasSlackScope(accessToken, "files:write")) {
+  if (!(await hasSlackScope(accessToken, "files:write"))) {
     fileId = undefined;
   }
 


### PR DESCRIPTION
## Description

Prevents file upload attempts when the files:write scope is not available on the Slack bot token. The code now checks the token's scopes via auth.test() before attempting to download files from Dust or upload them to Slack. If the scope is missing, files are silently skipped rather than causing upload failures.

Slack bots that don't have this new scope sometimes fail at answering messages. This PR prevents this issue.
See thread in [Slack](https://dust4ai.slack.com/archives/C05F84CFP0E/p1764085721272139)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front and connectors