### PR TITLE
Improved user search

### DIFF
--- a/front/components/spaces/SearchMembersDropdown.tsx
+++ b/front/components/spaces/SearchMembersDropdown.tsx
@@ -93,7 +93,7 @@ export function SearchMembersDropdown({
             value={searchTerm}
             onChange={setSearchTerm}
             name="search"
-            placeholder="Search members (email)"
+            placeholder="Search members"
           />
         }
       >

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -218,10 +218,10 @@ export async function searchMembers(
     );
     total = users.length;
   } else {
-    const results = await UserResource.listUsersWithEmailPredicat(
+    const results = await UserResource.listUsersWithSearchPredicat(
       owner,
       {
-        email: options.searchTerm,
+        searchTerm: options.searchTerm,
       },
       paginationParams
     );

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -8,6 +8,7 @@ import type {
 import { fn, literal, Op, where } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
+import type { ResourceLogJSON } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import {

--- a/front/migrations/db/migration_418.sql
+++ b/front/migrations/db/migration_418.sql
@@ -1,0 +1,27 @@
+-- Migration created on Nov 25, 2024
+-- Add support for searching users by email, firstName, and lastName with unaccent
+
+-- Step 1: Enable required extensions if not already enabled
+CREATE EXTENSION IF NOT EXISTS unaccent;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Step 2: Create an IMMUTABLE wrapper function for unaccent
+-- This is required because unaccent() itself is not marked as IMMUTABLE
+-- and PostgreSQL requires IMMUTABLE functions for indexes
+CREATE OR REPLACE FUNCTION immutable_unaccent(text)
+  RETURNS text
+  LANGUAGE sql
+  IMMUTABLE PARALLEL SAFE STRICT
+AS $$
+  SELECT unaccent($1);
+$$;
+
+-- Step 3: Create GIN index for efficient search across email, firstName, and lastName
+-- This index will be used for case-insensitive, unaccented search
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_search_unaccent ON users USING gin (
+  (
+    immutable_unaccent(lower(coalesce(email, ''))) || ' ' ||
+    immutable_unaccent(lower(coalesce("firstName", ''))) || ' ' ||
+    immutable_unaccent(lower(coalesce("lastName", '')))
+  ) gin_trgm_ops
+);


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/5223
Fixes https://github.com/dust-tt/tasks/issues/5177

## Description

Introduce a GIN index on the concatenation of unaccented first, last, email on the User model and leverage that index to have a more flexible search.

The migration installs two required plugins `unaccent` and `pg_trgm`. It also defines a stable wrapper around `unaccent` that is not marked as stable (dictionaries of unaccentuation can move across versions).

This has the potential of messing with the index which I understand as results not being potentially properly returned. We never upgraded postgres so far so this is a very rare event. We would likely see failures on that query when we do so or missed hits which would be a bit impactful but easy to fix by rebuilding the index.

This is not great but I haven't found anything better when it comes to unaccented pg-based search.

cc @flvndvd in case you have some tokens on this ^

Note: @ElPicador this query can likely be optimized by merging the two membership/user queries into one. But I guess this is a starting point to convince ourselves whether we can rely on pg for this or want to go ES.

## Tests

Tested locally.

## Risk

Low latency on user search which is for now not critical (Space administration)

Graph to look at post deploy:

https://app.datadoghq.eu/logs?query=service%3Afront%20%40route%3A%22%2Fapi%2Fw%2F%5BwId%5D%2Fmembers%2Fsearch%22&agg_m=%40durationMs&agg_m_source=base&agg_t=avg&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=timeseries&from_ts=1764072517653&to_ts=1764086917653&live=true

## Deploy Plan

- run migration
- deploy `front`