### PR TITLE
Split connectors_provider between back and front components

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceViewTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceViewTable.tsx
@@ -10,7 +10,7 @@ import {
   findSpaceFromNavigationHistory,
 } from "@app/components/data_source_view/context/utils";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import {
   getDataSourceNameFromView,
   isRemoteDatabase,
@@ -43,7 +43,7 @@ export function DataSourceViewTable({
       spaceDataSourceViews
         .filter((dsv) => {
           const connectorConfig = dsv.dataSource.connectorProvider
-            ? CONNECTOR_CONFIGURATIONS[dsv.dataSource.connectorProvider]
+            ? CONNECTOR_UI_CONFIGURATIONS[dsv.dataSource.connectorProvider]
             : null;
 
           if (connectorConfig?.isHiddenAsDataSource) {
@@ -63,7 +63,7 @@ export function DataSourceViewTable({
           const provider = dsv.dataSource.connectorProvider;
 
           const connectorProvider = provider
-            ? CONNECTOR_CONFIGURATIONS[provider]
+            ? CONNECTOR_UI_CONFIGURATIONS[provider]
             : null;
 
           const icon = provider

--- a/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
@@ -24,7 +24,7 @@ import {
   DATA_WAREHOUSE_SERVER_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import {
   CHANNEL_INTERNAL_MIME_TYPES,
   DATABASE_INTERNAL_MIME_TYPES,

--- a/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
@@ -25,13 +25,13 @@ import {
   TABLE_QUERY_V2_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
+import { getVisualForContentNodeType } from "@app/lib/content_nodes";
 import {
   CHANNEL_INTERNAL_MIME_TYPES,
   DATABASE_INTERNAL_MIME_TYPES,
   FILE_INTERNAL_MIME_TYPES,
-  getVisualForContentNodeType,
   SPREADSHEET_INTERNAL_MIME_TYPES,
-} from "@app/lib/content_nodes";
+} from "@app/lib/content_nodes_constants";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import type { DataSourceViewType } from "@app/types";
 import { asDisplayName, pluralize } from "@app/types";

--- a/front/components/assistant/WelcomeTourGuide.tsx
+++ b/front/components/assistant/WelcomeTourGuide.tsx
@@ -16,7 +16,7 @@ import { Button } from "@dust-tt/sparkle";
 import { useMemo, useRef } from "react";
 import { useState } from "react";
 
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { ConnectorProvider, UserType, WorkspaceType } from "@app/types";
 import { isBuilder } from "@app/types";
@@ -168,7 +168,7 @@ export function WelcomeTourGuide({
     !isBuilder(owner);
 
   const connections = useMemo(() => {
-    return Object.values(CONNECTOR_CONFIGURATIONS)
+    return Object.values(CONNECTOR_UI_CONFIGURATIONS)
       .filter((connector) =>
         CONNECTIONS_IN_TOUR_GUIDE.includes(connector.connectorProvider)
       )

--- a/front/components/assistant/WelcomeTourGuide.tsx
+++ b/front/components/assistant/WelcomeTourGuide.tsx
@@ -16,6 +16,7 @@ import { Button } from "@dust-tt/sparkle";
 import { useMemo, useRef } from "react";
 import { useState } from "react";
 
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { ConnectorProvider, UserType, WorkspaceType } from "@app/types";
@@ -168,13 +169,15 @@ export function WelcomeTourGuide({
     !isBuilder(owner);
 
   const connections = useMemo(() => {
-    return Object.values(CONNECTOR_UI_CONFIGURATIONS)
+    return Object.values(CONNECTOR_CONFIGURATIONS)
       .filter((connector) =>
         CONNECTIONS_IN_TOUR_GUIDE.includes(connector.connectorProvider)
       )
       .map((connector) => ({
         name: connector.name,
-        logo: connector.getLogoComponent(),
+        logo: CONNECTOR_UI_CONFIGURATIONS[
+          connector.connectorProvider
+        ].getLogoComponent(),
       }));
   }, []);
 

--- a/front/components/assistant/conversation/attachment/utils.test.tsx
+++ b/front/components/assistant/conversation/attachment/utils.test.tsx
@@ -14,6 +14,13 @@ vi.mock("@app/lib/connector_providers", () => ({
     google_drive: {},
     github: {},
   },
+}));
+
+vi.mock("@app/lib/connector_providers_ui", () => ({
+  CONNECTOR_UI_CONFIGURATIONS: {
+    google_drive: {},
+    github: {},
+  },
   getConnectorProviderLogoWithFallback: ({
     provider,
     isDark,

--- a/front/components/assistant/conversation/attachment/utils.tsx
+++ b/front/components/assistant/conversation/attachment/utils.tsx
@@ -27,10 +27,8 @@ import {
 import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import {
-  CONNECTOR_CONFIGURATIONS,
-  getConnectorProviderLogoWithFallback,
-} from "@app/lib/connector_providers";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import type {
   ConnectorProvider,
   ContentFragmentType,

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -17,7 +17,7 @@ import {
   isPastedFile,
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -20,7 +20,7 @@ import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { NodePathTooltip } from "@app/components/NodePathTooltip";
 import { useDebounce } from "@app/hooks/useDebounce";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -28,7 +28,7 @@ import type {
   TableDataSourceConfiguration,
 } from "@app/lib/api/assistant/configuration/types";
 import { getContentNodeInternalIdFromTableId } from "@app/lib/api/content_nodes";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import {
   canBeExpanded,

--- a/front/components/data_source/ConnectorOptionsPdfEnabled.tsx
+++ b/front/components/data_source/ConnectorOptionsPdfEnabled.tsx
@@ -1,7 +1,7 @@
 import { ContextItem, SliderToggle } from "@dust-tt/sparkle";
 import { GooglePdfLogo as GenericPdfLogo } from "@dust-tt/sparkle";
 
-import type { ConnectorOptionsProps } from "@app/lib/connector_providers";
+import type { ConnectorOptionsProps } from "@app/lib/connector_providers_ui";
 import {
   useConnectorConfig,
   useTogglePdfEnabled,

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -48,11 +48,12 @@ import { AdvancedNotionManagement } from "@app/components/spaces/AdvancedNotionM
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import {
-  CONNECTOR_CONFIGURATIONS,
+  CONNECTOR_UI_CONFIGURATIONS,
   getConnectorPermissionsConfigurableBlocked,
   isConnectorPermissionsEditable,
-} from "@app/lib/connector_providers";
+} from "@app/lib/connector_providers_ui";
 import {
   getDisplayNameForDataSource,
   isRemoteDatabase,
@@ -199,7 +200,7 @@ export async function updateConnectorConnectionId(
   if (error.type === "connector_oauth_target_mismatch") {
     return {
       success: false,
-      error: CONNECTOR_CONFIGURATIONS[provider].mismatchError,
+      error: CONNECTOR_UI_CONFIGURATIONS[provider].mismatchError,
     };
   }
   if (error.type === "connector_oauth_user_missing_rights") {
@@ -291,6 +292,8 @@ function UpdateConnectionOAuthModal({
 
   const connectorConfiguration =
     connectorProvider && CONNECTOR_CONFIGURATIONS[connectorProvider];
+  const connectorUIConfiguration =
+    connectorProvider && CONNECTOR_UI_CONFIGURATIONS[connectorProvider];
 
   const isDataSourceOwner = editedByUser?.userId === user.sId;
 
@@ -303,7 +306,7 @@ function UpdateConnectionOAuthModal({
         <div className="mt-4 flex flex-col">
           <div className="flex items-center gap-2">
             <Icon
-              visual={connectorConfiguration.getLogoComponent(isDark)}
+              visual={connectorUIConfiguration.getLogoComponent(isDark)}
               size="md"
             />
             <Page.SectionHeader
@@ -321,11 +324,11 @@ function UpdateConnectionOAuthModal({
                 Agents using them.
               </div>
 
-              {connectorConfiguration.guideLink && (
+              {connectorUIConfiguration.guideLink && (
                 <div className="copy-sm pl-4 text-info-800">
                   Read our{" "}
                   <a
-                    href={connectorConfiguration.guideLink}
+                    href={connectorUIConfiguration.guideLink}
                     className="text-highlight-600"
                     target="_blank"
                   >
@@ -373,11 +376,11 @@ function UpdateConnectionOAuthModal({
             >
               Editing permission rights with a different account will likely
               break the existing data structure in Dust and Agents using them.
-              {connectorConfiguration.guideLink && (
+              {connectorUIConfiguration.guideLink && (
                 <div>
                   Read our{" "}
                   <Hoverable
-                    href={connectorConfiguration.guideLink}
+                    href={connectorUIConfiguration.guideLink}
                     variant="primary"
                     target="_blank"
                   >
@@ -392,13 +395,13 @@ function UpdateConnectionOAuthModal({
             </ContentMessage>
           </div>
         )}
-        {connectorConfiguration.oauthExtraConfigComponent &&
+        {connectorUIConfiguration.oauthExtraConfigComponent &&
           // TODO(slackstorm) fabien: remove flag and rely on isLegacySlackApp
           !(
             isSlack &&
             !featureFlags.includes("self_created_slack_app_connector_rollout")
           ) && (
-            <connectorConfiguration.oauthExtraConfigComponent
+            <connectorUIConfiguration.oauthExtraConfigComponent
               extraConfig={extraConfig}
               setExtraConfig={setExtraConfig}
               setIsExtraConfigValid={setIsExtraConfigValid}
@@ -491,6 +494,8 @@ function DataSourceDeletionModal({
 
   const isDataSourceOwner = editedByUser?.userId === user.sId;
   const connectorConfiguration = CONNECTOR_CONFIGURATIONS[connectorProvider];
+  const connectorUIConfiguration =
+    CONNECTOR_UI_CONFIGURATIONS[connectorProvider];
 
   const handleDelete = async () => {
     setIsLoading(true);
@@ -525,7 +530,7 @@ function DataSourceDeletionModal({
         <div className="mt-4 flex flex-col">
           <div className="flex items-center gap-2">
             <Icon
-              visual={connectorConfiguration.getLogoComponent(isDark)}
+              visual={connectorUIConfiguration.getLogoComponent(isDark)}
               size="md"
             />
             <Page.SectionHeader
@@ -639,12 +644,12 @@ export function ConnectorPermissionsModal({
     CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider].isDeletable;
 
   const selectedPermission: ConnectorPermission = dataSource.connectorProvider
-    ? CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider].permissions
+    ? CONNECTOR_UI_CONFIGURATIONS[dataSource.connectorProvider].permissions
         .selected
     : "none";
 
   const unselectedPermission: ConnectorPermission = dataSource.connectorProvider
-    ? CONNECTOR_CONFIGURATIONS[dataSource.connectorProvider].permissions
+    ? CONNECTOR_UI_CONFIGURATIONS[dataSource.connectorProvider].permissions
         .unselected
     : "none";
 
@@ -829,8 +834,9 @@ export function ConnectorPermissionsModal({
   }, [connector.type, isOpen]);
 
   const connectorConfiguration = CONNECTOR_CONFIGURATIONS[connector.type];
+  const connectorUIConfiguration = CONNECTOR_UI_CONFIGURATIONS[connector.type];
 
-  const OptionsComponent = connectorConfiguration.optionsComponent;
+  const OptionsComponent = connectorUIConfiguration.optionsComponent;
 
   const permissionsConfigurable = getConnectorPermissionsConfigurableBlocked(
     connector.type
@@ -930,16 +936,16 @@ export function ConnectorPermissionsModal({
                       </div>
                     </>
                   )}
-                  {!connectorConfiguration.isResourceSelectionDisabled && (
+                  {!connectorUIConfiguration.isResourceSelectionDisabled && (
                     <>
                       <div className="flex items-center justify-between p-1">
                         <div className="heading-xl">
-                          {connectorConfiguration.selectLabel}
+                          {connectorUIConfiguration.selectLabel}
                         </div>
                       </div>
                       <ContentNodeTree
                         isTitleFilterEnabled={
-                          connectorConfiguration.isTitleFilterEnabled &&
+                          connectorUIConfiguration.isTitleFilterEnabled &&
                           canUpdatePermissions
                         }
                         isRoundedBackground={true}
@@ -952,8 +958,8 @@ export function ConnectorPermissionsModal({
                             ? setSelectedNodes
                             : undefined
                         }
-                        showExpand={connectorConfiguration?.isNested}
-                        emptyComponent={connectorConfiguration.emptyNodeLabel}
+                        showExpand={connectorUIConfiguration?.isNested}
+                        emptyComponent={connectorUIConfiguration.emptyNodeLabel}
                       />
                     </>
                   )}
@@ -967,7 +973,7 @@ export function ConnectorPermissionsModal({
                   )}
                 </div>
               </SheetContainer>
-              {!connectorConfiguration.isResourceSelectionDisabled && (
+              {!connectorUIConfiguration.isResourceSelectionDisabled && (
                 <SheetFooter
                   leftButtonProps={{
                     label: "Cancel",

--- a/front/components/data_source/CreateConnectionOAuthModal.tsx
+++ b/front/components/data_source/CreateConnectionOAuthModal.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
+import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 
 type CreateConnectionOAuthModalProps = {
   connectorProviderConfiguration: ConnectorProviderConfiguration;
@@ -32,6 +33,11 @@ export function CreateConnectionOAuthModal({
   const [isLoading, setIsLoading] = useState(false);
   const [extraConfig, setExtraConfig] = useState<Record<string, string>>({});
   const [isExtraConfigValid, setIsExtraConfigValid] = useState(true);
+
+  const connectorUIConfiguration =
+    CONNECTOR_UI_CONFIGURATIONS[
+      connectorProviderConfiguration.connectorProvider
+    ];
 
   useEffect(() => {
     if (isOpen) {
@@ -60,13 +66,13 @@ export function CreateConnectionOAuthModal({
             <Page.Vertical gap="lg" align="stretch">
               <Page.Header
                 title={`Connecting ${connectorProviderConfiguration.name}`}
-                icon={connectorProviderConfiguration.getLogoComponent(isDark)}
+                icon={connectorUIConfiguration.getLogoComponent(isDark)}
               />
               <Button
                 label="Read our guide"
                 size="xs"
                 variant="outline"
-                href={connectorProviderConfiguration.guideLink ?? ""}
+                href={connectorUIConfiguration.guideLink ?? ""}
                 target="_blank"
                 icon={BookOpenIcon}
               />
@@ -109,19 +115,19 @@ export function CreateConnectionOAuthModal({
                 </>
               )}
 
-              {connectorProviderConfiguration.limitations && (
+              {connectorUIConfiguration.limitations && (
                 <div className="flex flex-col gap-y-2">
                   <div className="copy-sm grow font-medium text-muted-foreground dark:text-muted-foreground-night">
                     Limitations
                   </div>
                   <div className="copy-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-                    {connectorProviderConfiguration.limitations}
+                    {connectorUIConfiguration.limitations}
                   </div>
                 </div>
               )}
 
-              {connectorProviderConfiguration.oauthExtraConfigComponent && (
-                <connectorProviderConfiguration.oauthExtraConfigComponent
+              {connectorUIConfiguration.oauthExtraConfigComponent && (
+                <connectorUIConfiguration.oauthExtraConfigComponent
                   extraConfig={extraConfig}
                   setExtraConfig={setExtraConfig}
                   setIsExtraConfigValid={setIsExtraConfigValid}

--- a/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
@@ -26,6 +26,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
+import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { useBigQueryLocations } from "@app/lib/swr/bigquery";
 import type { PostCredentialsBody } from "@app/pages/api/w/[wId]/credentials";
 import type {
@@ -151,6 +152,11 @@ export function CreateOrUpdateConnectionBigQueryModal({
     // Should never happen.
     return null;
   }
+
+  const connectorUIConfiguration =
+    CONNECTOR_UI_CONFIGURATIONS[
+      connectorProviderConfiguration.connectorProvider
+    ];
 
   function onSuccess(ds: DataSourceType) {
     setCredentials("");
@@ -307,7 +313,7 @@ export function CreateOrUpdateConnectionBigQueryModal({
           <SheetTitle className="flex items-center gap-2">
             <span className="[&>svg]:h-6 [&>svg]:w-6">
               <Icon
-                visual={connectorProviderConfiguration.getLogoComponent(isDark)}
+                visual={connectorUIConfiguration.getLogoComponent(isDark)}
               />
             </span>
             Connecting {connectorProviderConfiguration.name}
@@ -319,20 +325,20 @@ export function CreateOrUpdateConnectionBigQueryModal({
               <Button
                 label="Read our guide"
                 size="sm"
-                href={connectorProviderConfiguration.guideLink ?? ""}
+                href={connectorUIConfiguration.guideLink ?? ""}
                 variant="outline"
                 target="_blank"
                 rel="noopener noreferrer"
                 icon={BookOpenIcon}
               />
 
-              {connectorProviderConfiguration.limitations && (
+              {connectorUIConfiguration.limitations && (
                 <ContentMessage
                   variant="primary"
                   title="Limitations"
                   className="border-none"
                 >
-                  {connectorProviderConfiguration.limitations}
+                  {connectorUIConfiguration.limitations}
                 </ContentMessage>
               )}
             </div>

--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -22,6 +22,7 @@ import { useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
+import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import type {
   ConnectorProvider,
   ConnectorType,
@@ -72,6 +73,11 @@ export function CreateOrUpdateConnectionSnowflakeModal({
     // Should never happen.
     return null;
   }
+
+  const connectorUIConfiguration =
+    CONNECTOR_UI_CONFIGURATIONS[
+      connectorProviderConfiguration.connectorProvider
+    ];
 
   const areCredentialsValid = () => {
     const baseFieldsValid =
@@ -263,7 +269,7 @@ export function CreateOrUpdateConnectionSnowflakeModal({
           <SheetTitle className="flex items-center gap-2">
             <span className="[&>svg]:h-6 [&>svg]:w-6">
               <Icon
-                visual={connectorProviderConfiguration.getLogoComponent(isDark)}
+                visual={connectorUIConfiguration.getLogoComponent(isDark)}
               />
             </span>
             Connecting {connectorProviderConfiguration.name}
@@ -275,20 +281,20 @@ export function CreateOrUpdateConnectionSnowflakeModal({
               <Button
                 label="Read our guide"
                 size="sm"
-                href={connectorProviderConfiguration.guideLink ?? ""}
+                href={connectorUIConfiguration.guideLink ?? ""}
                 target="_blank"
                 rel="noopener noreferrer"
                 variant="outline"
                 icon={BookOpenIcon}
               />
 
-              {connectorProviderConfiguration.limitations && (
+              {connectorUIConfiguration.limitations && (
                 <div className="flex flex-col gap-y-2">
                   <div className="grow text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
                     Limitations
                   </div>
                   <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-                    {connectorProviderConfiguration.limitations}
+                    {connectorUIConfiguration.limitations}
                   </div>
                 </div>
               )}

--- a/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
+++ b/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
@@ -1,7 +1,7 @@
 import { classNames, Input, SliderToggle, TextArea } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
-import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers";
+import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers_ui";
 
 export function MicrosoftOAuthExtraConfig({
   extraConfig,

--- a/front/components/data_source/RequestDataSourceModal.tsx
+++ b/front/components/data_source/RequestDataSourceModal.tsx
@@ -19,7 +19,7 @@ import { useEffect, useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import { getDisplayNameForDataSource, isManaged } from "@app/lib/data_sources";
 import { sendRequestDataSourceEmail } from "@app/lib/email";
 import type { DataSourceType, LightWorkspaceType } from "@app/types";

--- a/front/components/data_source/SlackOAuthExtraConfig.tsx
+++ b/front/components/data_source/SlackOAuthExtraConfig.tsx
@@ -1,7 +1,7 @@
 import { Input } from "@dust-tt/sparkle";
 import { useEffect } from "react";
 
-import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers";
+import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers_ui";
 
 export function SlackOAuthExtraConfig({
   extraConfig,

--- a/front/components/data_source/ZendeskOAuthExtraConfig.tsx
+++ b/front/components/data_source/ZendeskOAuthExtraConfig.tsx
@@ -1,7 +1,7 @@
 import { Input } from "@dust-tt/sparkle";
 import { useEffect } from "react";
 
-import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers";
+import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers_ui";
 import { isValidZendeskSubdomain } from "@app/types";
 
 export function ZendeskOAuthExtraConfig({

--- a/front/components/data_source/salesforce/SalesforceOAuthExtractConfig.tsx
+++ b/front/components/data_source/salesforce/SalesforceOAuthExtractConfig.tsx
@@ -1,7 +1,7 @@
 import { Input } from "@dust-tt/sparkle";
 import { useEffect } from "react";
 
-import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers";
+import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers_ui";
 import { getPKCEConfig } from "@app/lib/utils/pkce";
 import { isValidClientIdOrSecret, isValidSalesforceDomain } from "@app/types";
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -24,7 +24,7 @@ import type {
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useDebounce } from "@app/hooks/useDebounce";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import {
   getViewTypeForURLNodeCandidateAccountingForNotion,

--- a/front/components/data_source_view/TagSearchInput.tsx
+++ b/front/components/data_source_view/TagSearchInput.tsx
@@ -7,7 +7,7 @@ import {
 } from "@dust-tt/sparkle";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import type { DataSourceTag } from "@app/types";
 
 export interface TagSearchProps {

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -7,6 +7,7 @@ import type {
   NodeSelectionState,
 } from "@app/components/data_source_view/context/types";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { CATEGORY_DETAILS, getSpaceIcon } from "@app/lib/spaces";
@@ -336,7 +337,7 @@ export function getVisualForTreeItem(
       // For data sources, we can use the connector provider logo or fall back to a generic icon
       if (item.dataSourceView.dataSource.connectorProvider) {
         const connectorProvider =
-          CONNECTOR_CONFIGURATIONS[
+          CONNECTOR_UI_CONFIGURATIONS[
             item.dataSourceView.dataSource.connectorProvider
           ];
 

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -6,7 +6,6 @@ import type {
   NavigationHistoryEntryType,
   NodeSelectionState,
 } from "@app/components/data_source_view/context/types";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -23,10 +23,13 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
   CONNECTOR_CONFIGURATIONS,
-  getConnectorProviderLogoWithFallback,
   isConnectionIdRequiredForProvider,
   isConnectorProviderAllowedForPlan,
 } from "@app/lib/connector_providers";
+import {
+  CONNECTOR_UI_CONFIGURATIONS,
+  getConnectorProviderLogoWithFallback,
+} from "@app/lib/connector_providers_ui";
 import { clientFetch } from "@app/lib/egress/client";
 import { useSystemSpace } from "@app/lib/swr/spaces";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -173,7 +176,7 @@ export const AddConnectionMenu = ({
 
   // Filter available integrations.
   const availableIntegrations = integrations.filter((i) => {
-    const hide = CONNECTOR_CONFIGURATIONS[i.connectorProvider].hide;
+    const hide = CONNECTOR_UI_CONFIGURATIONS[i.connectorProvider].hide;
     const rolloutFlag =
       CONNECTOR_CONFIGURATIONS[i.connectorProvider].rollingOutFlag;
     const hasFlag = rolloutFlag && featureFlags.includes(rolloutFlag);

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -26,7 +26,6 @@ import { RequestDataSourceModal } from "@app/components/data_source/RequestDataS
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
 import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getDisplayNameForDataSource, isManaged } from "@app/lib/data_sources";
 import { useKillSwitches } from "@app/lib/swr/kill";

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -27,6 +27,7 @@ import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManag
 import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
+import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getDisplayNameForDataSource, isManaged } from "@app/lib/data_sources";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import {
@@ -104,15 +105,15 @@ export function EditSpaceManagedDataSourcesViews({
   const filterSystemSpaceDataSourceViews = useMemo(
     () =>
       systemSpaceDataSourceViews.filter((dsv) => {
-        const connectorConfig = dsv.dataSource.connectorProvider
-          ? CONNECTOR_CONFIGURATIONS[dsv.dataSource.connectorProvider]
+        const connectorUIConfig = dsv.dataSource.connectorProvider
+          ? CONNECTOR_UI_CONFIGURATIONS[dsv.dataSource.connectorProvider]
           : null;
 
         return (
           isManaged(dsv.dataSource) &&
           (!dataSourceView ||
             dsv.dataSource.sId === dataSourceView.dataSource.sId) &&
-          !connectorConfig?.isHiddenAsDataSource
+          !connectorUIConfig?.isHiddenAsDataSource
         );
       }),
     [systemSpaceDataSourceViews, dataSourceView]

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -37,8 +37,8 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { ViewFolderAPIModal } from "@app/components/ViewFolderAPIModal";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import {
+  CONNECTOR_UI_CONFIGURATIONS,
   getConnectorProviderLogoWithFallback,
   isConnectorPermissionsEditable,
 } from "@app/lib/connector_providers_ui";
@@ -367,7 +367,7 @@ export const SpaceResourcesList = ({
     return spaceDataSourceViews
       .filter((dataSourceView) => {
         const connectorConfig = dataSourceView.dataSource.connectorProvider
-          ? CONNECTOR_CONFIGURATIONS[
+          ? CONNECTOR_UI_CONFIGURATIONS[
               dataSourceView.dataSource.connectorProvider
             ]
           : null;

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -37,11 +37,11 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { ViewFolderAPIModal } from "@app/components/ViewFolderAPIModal";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import {
-  CONNECTOR_CONFIGURATIONS,
   getConnectorProviderLogoWithFallback,
   isConnectorPermissionsEditable,
-} from "@app/lib/connector_providers";
+} from "@app/lib/connector_providers_ui";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import {
   useDeleteFolderOrWebsite,

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -28,7 +28,7 @@ import { useSpaceSidebarItemFocus } from "@app/hooks/useSpaceSidebarItemFocus";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import type { SpaceSectionGroupType } from "@app/lib/spaces";

--- a/front/esbuild.worker.ts
+++ b/front/esbuild.worker.ts
@@ -1,5 +1,5 @@
 import esbuild from "esbuild";
-import fs from 'fs';
+import fs from "fs";
 
 async function buildWorker() {
   try {
@@ -24,7 +24,7 @@ async function buildWorker() {
       `📦 Bundle size: ${(result.metafile.outputs["dist/start_worker.js"].bytes / 1024 / 1024).toFixed(2)} MB`
     );
 
-    fs.writeFileSync('dist/meta.json', JSON.stringify(result.metafile))
+    fs.writeFileSync("dist/meta.json", JSON.stringify(result.metafile));
 
     // Log any warnings
     if (result.warnings.length > 0) {

--- a/front/esbuild.worker.ts
+++ b/front/esbuild.worker.ts
@@ -1,4 +1,5 @@
 import esbuild from "esbuild";
+import fs from 'fs';
 
 async function buildWorker() {
   try {
@@ -22,6 +23,8 @@ async function buildWorker() {
     console.log(
       `📦 Bundle size: ${(result.metafile.outputs["dist/start_worker.js"].bytes / 1024 / 1024).toFixed(2)} MB`
     );
+
+    fs.writeFileSync('dist/meta.json', JSON.stringify(result.metafile))
 
     // Log any warnings
     if (result.warnings.length > 0) {

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
-import { SPREADSHEET_INTERNAL_MIME_TYPES } from "@app/lib/content_nodes";
+import { SPREADSHEET_INTERNAL_MIME_TYPES } from "@app/lib/content_nodes_constants";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type {
   ContentNodesViewType,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -18,7 +18,7 @@ import {
 } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes";
+import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes_constants";
 import { DustError } from "@app/lib/error";
 import { getDustDataSourcesBucket } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -1,134 +1,17 @@
-import {
-  BigQueryLogo,
-  ConfluenceLogo,
-  DiscordLogo,
-  DriveLogo,
-  FolderIcon,
-  GithubLogo,
-  GithubWhiteLogo,
-  GlobeAltIcon,
-  GongLogo,
-  IntercomLogo,
-  MicrosoftLogo,
-  NotionLogo,
-  SalesforceLogo,
-  SlackLogo,
-  SnowflakeLogo,
-  ZendeskLogo,
-  ZendeskWhiteLogo,
-} from "@dust-tt/sparkle";
-import type { ComponentType } from "react";
-
-import { BigQueryUseMetadataForDBMLView } from "@app/components/data_source/BigQueryUseMetadataForDBMLView";
-import { createConnectorOptionsPdfEnabled } from "@app/components/data_source/ConnectorOptionsPdfEnabled";
-import { GithubCodeEnableView } from "@app/components/data_source/GithubCodeEnableView";
-import { GongOptionComponent } from "@app/components/data_source/gong/GongOptionComponent";
-import { IntercomConfigView } from "@app/components/data_source/IntercomConfigView";
-import { MicrosoftOAuthExtraConfig } from "@app/components/data_source/MicrosoftOAuthExtraConfig";
-import { SalesforceOauthExtraConfig } from "@app/components/data_source/salesforce/SalesforceOAuthExtractConfig";
-import { SlackBotEnableView } from "@app/components/data_source/SlackBotEnableView";
-import { SlackOAuthExtraConfig } from "@app/components/data_source/SlackOAuthExtraConfig";
-import { ZendeskConfigView } from "@app/components/data_source/ZendeskConfigView";
-import { ZendeskOAuthExtraConfig } from "@app/components/data_source/ZendeskOAuthExtraConfig";
 import type {
-  ConnectorPermission,
   ConnectorProvider,
-  DataSourceType,
   PlanType,
   WhitelistableFeature,
-  WorkspaceType,
 } from "@app/types";
 import { assertNever } from "@app/types";
-
-export interface ConnectorOptionsProps {
-  owner: WorkspaceType;
-  readOnly: boolean;
-  isAdmin: boolean;
-  dataSource: DataSourceType;
-  plan: PlanType;
-}
-
-export interface ConnectorOauthExtraConfigProps {
-  extraConfig: Record<string, string>;
-  setExtraConfig: (
-    value:
-      | Record<string, string>
-      | ((prev: Record<string, string>) => Record<string, string>)
-  ) => void;
-  setIsExtraConfigValid: (valid: boolean) => void;
-}
-
-type ConnectorPermissionsConfigurable =
-  | {
-      isPermissionsConfigurableBlocked: true;
-      permissionsDisabledPlaceholder: string;
-    }
-  | {
-      isPermissionsConfigurableBlocked?: never;
-    };
 
 export type ConnectorProviderConfiguration = {
   name: string;
   connectorProvider: ConnectorProvider;
   status: "preview" | "built" | "rolling_out";
   rollingOutFlag?: WhitelistableFeature;
-  hide: boolean;
-  getLogoComponent: (
-    isDark?: boolean
-  ) => (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
-  optionsComponent?: ComponentType<ConnectorOptionsProps>;
-  description: string;
-  mismatchError: string;
-  limitations: string | null;
-  oauthExtraConfigComponent?: (
-    props: ConnectorOauthExtraConfigProps
-  ) => React.JSX.Element;
-  guideLink: string | null;
-  selectLabel?: string; // Show in the permissions modal, above the content node tree, note that a connector might not allow to select anything
   emptyNodeLabel?: string;
-  isNested: boolean;
-  isTitleFilterEnabled?: boolean;
-  isResourceSelectionDisabled?: boolean; // Whether the user cannot select distinct resources (everything is synced).
-  permissions: {
-    selected: ConnectorPermission;
-    unselected: ConnectorPermission;
-  };
   isDeletable: boolean;
-  isHiddenAsDataSource?: boolean;
-} & ConnectorPermissionsConfigurable;
-
-// TODO(slack 2025-06-19): Remove this function once the new app is published.
-export function getConnectorPermissionsConfigurableBlocked(
-  provider?: ConnectorProvider | null
-): { blocked: boolean; placeholder?: string } {
-  if (!provider) {
-    return { blocked: false };
-  }
-
-  const connectorConfig = CONNECTOR_CONFIGURATIONS[provider];
-  const isBlocked = connectorConfig.isPermissionsConfigurableBlocked;
-
-  if (!isBlocked) {
-    return { blocked: false };
-  }
-
-  return {
-    blocked: true,
-    placeholder: connectorConfig.permissionsDisabledPlaceholder,
-  };
-}
-
-export const isConnectorPermissionsEditable = (
-  provider?: ConnectorProvider | null
-): boolean => {
-  if (!provider) {
-    return false;
-  }
-
-  return (
-    CONNECTOR_CONFIGURATIONS[provider].permissions.selected !== "none" ||
-    CONNECTOR_CONFIGURATIONS[provider].permissions.unselected !== "none"
-  );
 };
 
 export const CONNECTOR_CONFIGURATIONS: Record<
@@ -139,68 +22,18 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     name: "Confluence",
     connectorProvider: "confluence",
     status: "built",
-    hide: false,
-    description:
-      "Grant tailored access to your organization's Confluence shared spaces.",
-    limitations:
-      "Dust indexes pages in selected global spaces without any view restrictions. If a page, or its parent pages, have view restrictions, it won't be indexed.",
-    mismatchError: `You cannot select another Confluence Domain.\nPlease contact us at support@dust.tt if you initially selected the wrong Domain.`,
-    guideLink: "https://docs.dust.tt/docs/confluence-connection",
-    selectLabel: "Select pages",
-    getLogoComponent: () => {
-      return ConfluenceLogo;
-    },
-    isNested: true,
-    permissions: {
-      selected: "read",
-      unselected: "none",
-    },
     isDeletable: false,
   },
   notion: {
     name: "Notion",
     connectorProvider: "notion",
     status: "built",
-    hide: false,
-    description:
-      "Authorize granular access to your company's Notion workspace, by top-level pages.",
-    limitations: "External files and content behind links are not indexed.",
-    mismatchError: `You cannot select another Notion Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.`,
-    guideLink: "https://docs.dust.tt/docs/notion-connection",
-    selectLabel: "Synchronized content",
-    getLogoComponent: () => {
-      return NotionLogo;
-    },
-    isNested: true,
-    permissions: {
-      selected: "none",
-      unselected: "none",
-    },
     isDeletable: false,
   },
   google_drive: {
     name: "Google Drive™",
     connectorProvider: "google_drive",
     status: "built",
-    hide: false,
-    description:
-      "Authorize granular access to your company's Google Drive, by drives and folders. Supported files include GDocs, GSlides, and .txt files. Email us for .pdf indexing.",
-    limitations:
-      "Files with empty text content or with more than 750KB of extracted text are ignored. By default, PDF files are not indexed. Email us at support@dust.tt to enable PDF indexing.",
-    mismatchError: `You cannot select another Google Drive Domain.\nPlease contact us at support@dust.tt if you initially selected a wrong shared Drive.`,
-    guideLink: "https://docs.dust.tt/docs/google-drive-connection",
-    selectLabel: "Select folders and files",
-    getLogoComponent: () => {
-      return DriveLogo;
-    },
-    optionsComponent: createConnectorOptionsPdfEnabled(
-      "When enabled, PDF documents from your Google Drive will be synced and processed by Dust."
-    ),
-    isNested: true,
-    permissions: {
-      selected: "read",
-      unselected: "none",
-    },
     isDeletable: false,
   },
   slack: {
@@ -208,254 +41,66 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     connectorProvider: "slack",
     status: "rolling_out",
     rollingOutFlag: "self_created_slack_app_connector_rollout",
-    hide: true,
-    description:
-      "Authorize granular access to your Slack workspace on a channel-by-channel basis.",
-    limitations: "External files and content behind links are not indexed.",
-    mismatchError: `You cannot select another Slack Team.\nPlease contact us at support@dust.tt if you initially selected the wrong Team.`,
-    guideLink: "https://docs.dust.tt/docs/slack-connection",
-    selectLabel: "Select channels",
-    getLogoComponent: () => {
-      return SlackLogo;
-    },
-    optionsComponent: SlackBotEnableView,
-    oauthExtraConfigComponent: SlackOAuthExtraConfig,
-    isNested: false,
-    isTitleFilterEnabled: true,
-    permissions: {
-      selected: "read_write",
-      unselected: "write",
-    },
     isDeletable: false,
   },
   slack_bot: {
     name: "Slack (Bot)",
     connectorProvider: "slack_bot",
     status: "built",
-    // Hidden from connections since used as bot integration only. Strings below are therefore all
-    // set to N/A
-    hide: true,
-    isPermissionsConfigurableBlocked: true,
-    permissionsDisabledPlaceholder: "N/A",
-    description: "N/A",
-    limitations: "N/A",
-    mismatchError: `You cannot select another Slack Team.\nPlease contact us at support@dust.tt if you initially selected the wrong Team.`,
-    guideLink: "https://docs.dust.tt/docs/slack-connection",
-    selectLabel: "N/A",
-    getLogoComponent: () => {
-      return SlackLogo;
-    },
-    isNested: false,
-    isTitleFilterEnabled: true,
-    permissions: {
-      selected: "read_write",
-      unselected: "write",
-    },
     isDeletable: false,
-    isHiddenAsDataSource: true,
   },
   discord_bot: {
     name: "Discord (Bot)",
     connectorProvider: "discord_bot",
     status: "rolling_out",
-    hide: true,
-    isPermissionsConfigurableBlocked: true,
-    permissionsDisabledPlaceholder: "N/A",
-    description: "N/A",
-    limitations: "N/A",
-    mismatchError: "N/A",
-    guideLink: "https://docs.dust.tt/docs/discord-bot",
-    selectLabel: "N/A",
-    getLogoComponent: () => {
-      return DiscordLogo;
-    },
-    isNested: false,
-    isTitleFilterEnabled: true,
-    permissions: {
-      selected: "read_write",
-      unselected: "write",
-    },
     isDeletable: false,
-    isHiddenAsDataSource: true,
   },
   github: {
     name: "GitHub",
     connectorProvider: "github",
     status: "built",
-    hide: false,
-    description:
-      "Authorize access to your company's GitHub on a repository-by-repository basis. Dust can access Issues, Discussions, and Pull Request threads. Code indexing can be controlled on-demand.",
-    limitations:
-      "Dust gathers data from issues, discussions, and pull-requests (top-level discussion, but not in-code comments). It synchronizes your code only if enabled. At this time, Dust cannot sync code repositories over 10GB. Please contact support@dust.tt if you need to sync larger repositories.",
-    mismatchError: `You cannot select another GitHub Organization.\nPlease contact us at support@dust.tt if you initially selected a wrong Organization or if you completely uninstalled the GitHub app.`,
-    guideLink: "https://docs.dust.tt/docs/github-connection",
-    selectLabel: "Authorized content",
-    getLogoComponent: (isDark?: boolean) => {
-      return isDark ? GithubWhiteLogo : GithubLogo;
-    },
-    optionsComponent: GithubCodeEnableView,
-    isNested: true,
-    permissions: {
-      selected: "none",
-      unselected: "none",
-    },
     isDeletable: false,
   },
   intercom: {
     name: "Intercom",
     connectorProvider: "intercom",
     status: "built",
-    hide: false,
-    description:
-      "Authorize granular access to your Intercom workspace. Access your Conversations at the Team level and Help Center Articles at the main Collection level.",
-    limitations:
-      "Dust will index only the conversations from the selected Teams that were initiated within the past 90 days and concluded (marked as closed). For the Help Center data, Dust will index every Article published within a selected Collection.",
-    mismatchError: `You cannot select another Intercom Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.`,
-    guideLink: "https://docs.dust.tt/docs/intercom-connection",
-    selectLabel: "Select pages",
-    getLogoComponent: () => {
-      return IntercomLogo;
-    },
-    optionsComponent: IntercomConfigView,
-    isNested: true,
-    permissions: {
-      selected: "read",
-      unselected: "none",
-    },
     isDeletable: false,
   },
   microsoft: {
     name: "Microsoft",
     connectorProvider: "microsoft",
     status: "built",
-    hide: false,
-    description:
-      "Authorize Dust to access a Microsoft account and index shared documents stored in SharePoint, OneDrive, and Office365.",
-    limitations:
-      "Dust will only index documents accessible to the account used when making the connection. Only organizational accounts are supported (Sharepoint). At the time, OneDrive cannot be synced.",
-    mismatchError: `You cannot select another Microsoft account.\nPlease contact us at support@dust.tt if you initially selected a wrong account.`,
-    guideLink: "https://docs.dust.tt/docs/microsoft-connection",
-    selectLabel: "Select folders and files",
-    emptyNodeLabel: "Select the folder to enable file synchronization.",
-    getLogoComponent: () => {
-      return MicrosoftLogo;
-    },
-    optionsComponent: createConnectorOptionsPdfEnabled(
-      "When enabled, PDF documents from your Microsoft OneDrive and SharePoint will be synced and processed by Dust."
-    ),
-    isNested: true,
-    isTitleFilterEnabled: true,
-    oauthExtraConfigComponent: MicrosoftOAuthExtraConfig,
-    permissions: {
-      selected: "read",
-      unselected: "none",
-    },
     isDeletable: false,
   },
   microsoft_bot: {
     name: "Microsoft Teams (Bot)",
     connectorProvider: "microsoft_bot",
     status: "built",
-    hide: true,
-    description:
-      "Enable your Microsoft Teams bot integration to interact with Dust directly from Teams.",
-    limitations: "Bot must be enabled in organization settings.",
-    mismatchError: `You cannot select another Microsoft tenant.\nPlease contact us at support@dust.tt if you initially selected a wrong tenant.`,
-    guideLink: "https://docs.dust.tt/docs/dust-in-teams",
-    selectLabel: "Bot configuration",
-    getLogoComponent: () => {
-      return MicrosoftLogo;
-    },
-    isNested: false,
-    oauthExtraConfigComponent: MicrosoftOAuthExtraConfig,
-    permissions: {
-      selected: "read_write",
-      unselected: "write",
-    },
     isDeletable: false,
-    isHiddenAsDataSource: true,
   },
   webcrawler: {
     name: "Web Crawler",
     connectorProvider: "webcrawler",
     status: "built",
-    hide: false,
-    description: "Crawl a website.",
-    limitations: null,
-    mismatchError: `You cannot change the URL. Please add a new Public URL instead.`,
-    guideLink: "https://docs.dust.tt/docs/website-connection",
-    getLogoComponent: () => {
-      return GlobeAltIcon;
-    },
-    isNested: true,
-    permissions: {
-      selected: "none",
-      unselected: "none",
-    },
     isDeletable: true,
   },
   snowflake: {
     name: "Snowflake",
     connectorProvider: "snowflake",
     status: "built",
-    hide: false,
-    description: "Query a Snowflake database.",
-    limitations: null,
-    mismatchError: `You cannot change the Snowflake account. Please add a new Snowflake connection instead.`,
-    getLogoComponent: () => {
-      return SnowflakeLogo;
-    },
-    isNested: true,
-    guideLink: "https://docs.dust.tt/docs/snowflake-connection",
-    selectLabel: "Select tables",
-    permissions: {
-      selected: "read",
-      unselected: "none",
-    },
     isDeletable: true,
   },
   zendesk: {
     name: "Zendesk",
     connectorProvider: "zendesk",
     status: "built",
-    hide: false,
-    description:
-      "Authorize access to Zendesk for indexing tickets from your support center and articles from your help center.",
-    limitations:
-      "Dust will index the content accessible to the authorized account only. Attachments are not indexed.",
-    mismatchError: `You cannot select another Zendesk Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.`,
-    guideLink: "https://docs.dust.tt/docs/zendesk-connection",
-    getLogoComponent: (isDark?: boolean) => {
-      return isDark ? ZendeskWhiteLogo : ZendeskLogo;
-    },
-    optionsComponent: ZendeskConfigView,
-    oauthExtraConfigComponent: ZendeskOAuthExtraConfig,
-    isNested: true,
-    permissions: {
-      selected: "read",
-      unselected: "none",
-    },
     isDeletable: false,
   },
   bigquery: {
     name: "BigQuery",
     connectorProvider: "bigquery",
     status: "built",
-    hide: false,
-    description: "Query a BigQuery database.",
-    limitations: null,
-    mismatchError: `You cannot change the BigQuery project. Please add a new BigQuery connection instead.`,
-    getLogoComponent: () => {
-      return BigQueryLogo;
-    },
-    optionsComponent: BigQueryUseMetadataForDBMLView,
-    isNested: true,
-    guideLink: "https://docs.dust.tt/docs/bigquery",
-    selectLabel: "Select tables",
-    permissions: {
-      selected: "read",
-      unselected: "none",
-    },
     isDeletable: true,
   },
   salesforce: {
@@ -463,44 +108,13 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     connectorProvider: "salesforce",
     status: "rolling_out",
     rollingOutFlag: "salesforce_synced_queries",
-    hide: true,
-    description:
-      "Authorize access to your Salesforce organization, in order to query your Salesforce data from Dust.",
-    limitations: null,
-    mismatchError: `You cannot change the Salesforce instance URL. Please add a new Salesforce connection instead.`,
-    getLogoComponent: () => {
-      return SalesforceLogo;
-    },
-    oauthExtraConfigComponent: SalesforceOauthExtraConfig,
-    isNested: true,
-    permissions: {
-      selected: "read",
-      unselected: "none",
-    },
     isDeletable: false,
-    guideLink: "https://docs.dust.tt/docs/salesforce",
   },
   gong: {
     name: "Gong",
     connectorProvider: "gong",
     status: "built",
-    isResourceSelectionDisabled: true,
-    optionsComponent: GongOptionComponent,
-    hide: false,
-    description: "Authorize access to Gong for indexing call transcripts.",
-    guideLink: "https://docs.dust.tt/docs/gong-connection",
-    getLogoComponent: () => {
-      return GongLogo;
-    },
-    isNested: true,
-    permissions: {
-      selected: "read",
-      unselected: "none",
-    },
     isDeletable: false,
-    limitations:
-      "Dust will index the content accessible to the authorized account only. All transcripts will be synchronized with Dust.",
-    mismatchError: `You cannot change the Gong account. Please add a new Gong connection instead.`,
   },
 };
 
@@ -524,21 +138,6 @@ export const REMOTE_DATABASE_CONNECTOR_PROVIDERS: ConnectorProvider[] = [
   "snowflake",
   "bigquery",
 ];
-
-export function getConnectorProviderLogoWithFallback({
-  provider,
-  fallback = FolderIcon,
-  isDark,
-}: {
-  provider: ConnectorProvider | null;
-  fallback?: ComponentType;
-  isDark?: boolean;
-}): ComponentType {
-  if (!provider) {
-    return fallback;
-  }
-  return CONNECTOR_CONFIGURATIONS[provider].getLogoComponent(isDark);
-}
 
 export const isValidConnectorSuffix = (suffix: string): boolean => {
   return /^[a-z0-9\-_]{1,16}$/.test(suffix);

--- a/front/lib/connector_providers_ui.ts
+++ b/front/lib/connector_providers_ui.ts
@@ -1,0 +1,448 @@
+import {
+  BigQueryLogo,
+  ConfluenceLogo,
+  DiscordLogo,
+  DriveLogo,
+  FolderIcon,
+  GithubLogo,
+  GithubWhiteLogo,
+  GlobeAltIcon,
+  GongLogo,
+  IntercomLogo,
+  MicrosoftLogo,
+  NotionLogo,
+  SalesforceLogo,
+  SlackLogo,
+  SnowflakeLogo,
+  ZendeskLogo,
+  ZendeskWhiteLogo,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+import { BigQueryUseMetadataForDBMLView } from "@app/components/data_source/BigQueryUseMetadataForDBMLView";
+import { createConnectorOptionsPdfEnabled } from "@app/components/data_source/ConnectorOptionsPdfEnabled";
+import { GithubCodeEnableView } from "@app/components/data_source/GithubCodeEnableView";
+import { GongOptionComponent } from "@app/components/data_source/gong/GongOptionComponent";
+import { IntercomConfigView } from "@app/components/data_source/IntercomConfigView";
+import { MicrosoftOAuthExtraConfig } from "@app/components/data_source/MicrosoftOAuthExtraConfig";
+import { SalesforceOauthExtraConfig } from "@app/components/data_source/salesforce/SalesforceOAuthExtractConfig";
+import { SlackBotEnableView } from "@app/components/data_source/SlackBotEnableView";
+import { ZendeskConfigView } from "@app/components/data_source/ZendeskConfigView";
+import { ZendeskOAuthExtraConfig } from "@app/components/data_source/ZendeskOAuthExtraConfig";
+import type {
+  ConnectorPermission,
+  ConnectorProvider,
+  DataSourceType,
+  PlanType,
+  WorkspaceType,
+} from "@app/types";
+import { SlackOAuthExtraConfig } from "@app/components/data_source/SlackOAuthExtraConfig";
+
+export interface ConnectorOptionsProps {
+  owner: WorkspaceType;
+  readOnly: boolean;
+  isAdmin: boolean;
+  dataSource: DataSourceType;
+  plan: PlanType;
+}
+
+export interface ConnectorOauthExtraConfigProps {
+  extraConfig: Record<string, string>;
+  setExtraConfig: (
+    value:
+      | Record<string, string>
+      | ((prev: Record<string, string>) => Record<string, string>)
+  ) => void;
+  setIsExtraConfigValid: (valid: boolean) => void;
+}
+
+type ConnectorPermissionsConfigurable =
+  | {
+      isPermissionsConfigurableBlocked: true;
+      permissionsDisabledPlaceholder: string;
+    }
+  | {
+      isPermissionsConfigurableBlocked?: never;
+    };
+
+export type ConnectorProviderUIDetails = {
+  hide: boolean;
+  getLogoComponent: (
+    isDark?: boolean
+  ) => (props: React.SVGProps<SVGSVGElement>) => React.JSX.Element;
+  optionsComponent?: ComponentType<ConnectorOptionsProps>;
+  description: string;
+  mismatchError: string;
+  limitations: string | null;
+  oauthExtraConfigComponent?: (
+    props: ConnectorOauthExtraConfigProps
+  ) => React.JSX.Element;
+  guideLink: string | null;
+  selectLabel?: string; // Show in the permissions modal, above the content node tree, note that a connector might not allow to select anything
+  emptyNodeLabel?: string;
+  isNested: boolean;
+  isTitleFilterEnabled?: boolean;
+  isResourceSelectionDisabled?: boolean; // Whether the user cannot select distinct resources (everything is synced).
+  permissions: {
+    selected: ConnectorPermission;
+    unselected: ConnectorPermission;
+  };
+  isHiddenAsDataSource?: boolean;
+} & ConnectorPermissionsConfigurable;
+
+// TODO(slack 2025-06-19): Remove this function once the new app is published.
+export function getConnectorPermissionsConfigurableBlocked(
+  provider?: ConnectorProvider | null
+): { blocked: boolean; placeholder?: string } {
+  if (!provider) {
+    return { blocked: false };
+  }
+
+  const connectorConfig = CONNECTOR_UI_CONFIGURATIONS[provider];
+  const isBlocked = connectorConfig.isPermissionsConfigurableBlocked;
+
+  if (!isBlocked) {
+    return { blocked: false };
+  }
+
+  return {
+    blocked: true,
+    placeholder: connectorConfig.permissionsDisabledPlaceholder,
+  };
+}
+
+export const isConnectorPermissionsEditable = (
+  provider?: ConnectorProvider | null
+): boolean => {
+  if (!provider) {
+    return false;
+  }
+
+  return (
+    CONNECTOR_UI_CONFIGURATIONS[provider].permissions.selected !== "none" ||
+    CONNECTOR_UI_CONFIGURATIONS[provider].permissions.unselected !== "none"
+  );
+};
+
+export const CONNECTOR_UI_CONFIGURATIONS: Record<
+  ConnectorProvider,
+  ConnectorProviderUIDetails
+> = {
+  confluence: {
+    hide: false,
+    description:
+      "Grant tailored access to your organization's Confluence shared spaces.",
+    limitations:
+      "Dust indexes pages in selected global spaces without any view restrictions. If a page, or its parent pages, have view restrictions, it won't be indexed.",
+    mismatchError: `You cannot select another Confluence Domain.\nPlease contact us at support@dust.tt if you initially selected the wrong Domain.`,
+    guideLink: "https://docs.dust.tt/docs/confluence-connection",
+    selectLabel: "Select pages",
+    getLogoComponent: () => {
+      return ConfluenceLogo;
+    },
+    isNested: true,
+    permissions: {
+      selected: "read",
+      unselected: "none",
+    },
+  },
+  notion: {
+    hide: false,
+    description:
+      "Authorize granular access to your company's Notion workspace, by top-level pages.",
+    limitations: "External files and content behind links are not indexed.",
+    mismatchError: `You cannot select another Notion Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.`,
+    guideLink: "https://docs.dust.tt/docs/notion-connection",
+    selectLabel: "Synchronized content",
+    getLogoComponent: () => {
+      return NotionLogo;
+    },
+    isNested: true,
+    permissions: {
+      selected: "none",
+      unselected: "none",
+    },
+  },
+  google_drive: {
+    hide: false,
+    description:
+      "Authorize granular access to your company's Google Drive, by drives and folders. Supported files include GDocs, GSlides, and .txt files. Email us for .pdf indexing.",
+    limitations:
+      "Files with empty text content or with more than 750KB of extracted text are ignored. By default, PDF files are not indexed. Email us at support@dust.tt to enable PDF indexing.",
+    mismatchError: `You cannot select another Google Drive Domain.\nPlease contact us at support@dust.tt if you initially selected a wrong shared Drive.`,
+    guideLink: "https://docs.dust.tt/docs/google-drive-connection",
+    selectLabel: "Select folders and files",
+    getLogoComponent: () => {
+      return DriveLogo;
+    },
+    optionsComponent: createConnectorOptionsPdfEnabled(
+      "When enabled, PDF documents from your Google Drive will be synced and processed by Dust."
+    ),
+    isNested: true,
+    permissions: {
+      selected: "read",
+      unselected: "none",
+    },
+  },
+  slack: {
+    // TODO(slack 2025-06-19): Hide the Slack connector until we publish the new app.
+    hide: true,
+    description:
+      "Authorize granular access to your Slack workspace on a channel-by-channel basis.",
+    limitations: "External files and content behind links are not indexed.",
+    mismatchError: `You cannot select another Slack Team.\nPlease contact us at support@dust.tt if you initially selected the wrong Team.`,
+    guideLink: "https://docs.dust.tt/docs/slack-connection",
+    selectLabel: "Select channels",
+    getLogoComponent: () => {
+      return SlackLogo;
+    },
+    optionsComponent: SlackBotEnableView,
+    oauthExtraConfigComponent: SlackOAuthExtraConfig,
+    isNested: false,
+    isTitleFilterEnabled: true,
+    permissions: {
+      selected: "read_write",
+      unselected: "write",
+    },
+  },
+  slack_bot: {
+    // Hidden from connections since used as bot integration only. Strings below are therefore all
+    // set to N/A
+    hide: true,
+    isPermissionsConfigurableBlocked: true,
+    permissionsDisabledPlaceholder: "N/A",
+    description: "N/A",
+    limitations: "N/A",
+    mismatchError: `You cannot select another Slack Team.\nPlease contact us at support@dust.tt if you initially selected the wrong Team.`,
+    guideLink: "https://docs.dust.tt/docs/slack-connection",
+    selectLabel: "N/A",
+    getLogoComponent: () => {
+      return SlackLogo;
+    },
+    isNested: false,
+    isTitleFilterEnabled: true,
+    permissions: {
+      selected: "read_write",
+      unselected: "write",
+    },
+    isHiddenAsDataSource: true,
+  },
+  discord_bot: {
+    hide: true,
+    isPermissionsConfigurableBlocked: true,
+    permissionsDisabledPlaceholder: "N/A",
+    description: "N/A",
+    limitations: "N/A",
+    mismatchError: "N/A",
+    guideLink: "https://docs.dust.tt/docs/discord-bot",
+    selectLabel: "N/A",
+    getLogoComponent: () => {
+      return DiscordLogo;
+    },
+    isNested: false,
+    isTitleFilterEnabled: true,
+    permissions: {
+      selected: "read_write",
+      unselected: "write",
+    },
+    isHiddenAsDataSource: true,
+  },
+  github: {
+    hide: false,
+    description:
+      "Authorize access to your company's GitHub on a repository-by-repository basis. Dust can access Issues, Discussions, and Pull Request threads. Code indexing can be controlled on-demand.",
+    limitations:
+      "Dust gathers data from issues, discussions, and pull-requests (top-level discussion, but not in-code comments). It synchronizes your code only if enabled. At this time, Dust cannot sync code repositories over 10GB. Please contact support@dust.tt if you need to sync larger repositories.",
+    mismatchError: `You cannot select another GitHub Organization.\nPlease contact us at support@dust.tt if you initially selected a wrong Organization or if you completely uninstalled the GitHub app.`,
+    guideLink: "https://docs.dust.tt/docs/github-connection",
+    selectLabel: "Authorized content",
+    getLogoComponent: (isDark?: boolean) => {
+      return isDark ? GithubWhiteLogo : GithubLogo;
+    },
+    optionsComponent: GithubCodeEnableView,
+    isNested: true,
+    permissions: {
+      selected: "none",
+      unselected: "none",
+    },
+  },
+  intercom: {
+    hide: false,
+    description:
+      "Authorize granular access to your Intercom workspace. Access your Conversations at the Team level and Help Center Articles at the main Collection level.",
+    limitations:
+      "Dust will index only the conversations from the selected Teams that were initiated within the past 90 days and concluded (marked as closed). For the Help Center data, Dust will index every Article published within a selected Collection.",
+    mismatchError: `You cannot select another Intercom Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.`,
+    guideLink: "https://docs.dust.tt/docs/intercom-connection",
+    selectLabel: "Select pages",
+    getLogoComponent: () => {
+      return IntercomLogo;
+    },
+    optionsComponent: IntercomConfigView,
+    isNested: true,
+    permissions: {
+      selected: "read",
+      unselected: "none",
+    },
+  },
+  microsoft: {
+    hide: false,
+    description:
+      "Authorize Dust to access a Microsoft account and index shared documents stored in SharePoint, OneDrive, and Office365.",
+    limitations:
+      "Dust will only index documents accessible to the account used when making the connection. Only organizational accounts are supported (Sharepoint). At the time, OneDrive cannot be synced.",
+    mismatchError: `You cannot select another Microsoft account.\nPlease contact us at support@dust.tt if you initially selected a wrong account.`,
+    guideLink: "https://docs.dust.tt/docs/microsoft-connection",
+    selectLabel: "Select folders and files",
+    emptyNodeLabel: "Select the folder to enable file synchronization.",
+    getLogoComponent: () => {
+      return MicrosoftLogo;
+    },
+    optionsComponent: createConnectorOptionsPdfEnabled(
+      "When enabled, PDF documents from your Microsoft OneDrive and SharePoint will be synced and processed by Dust."
+    ),
+    isNested: true,
+    isTitleFilterEnabled: true,
+    oauthExtraConfigComponent: MicrosoftOAuthExtraConfig,
+    permissions: {
+      selected: "read",
+      unselected: "none",
+    },
+  },
+  microsoft_bot: {
+    hide: true,
+    description:
+      "Enable your Microsoft Teams bot integration to interact with Dust directly from Teams.",
+    limitations: "Bot must be enabled in organization settings.",
+    mismatchError: `You cannot select another Microsoft tenant.\nPlease contact us at support@dust.tt if you initially selected a wrong tenant.`,
+    guideLink: "https://docs.dust.tt/docs/dust-in-teams",
+    selectLabel: "Bot configuration",
+    getLogoComponent: () => {
+      return MicrosoftLogo;
+    },
+    isNested: false,
+    oauthExtraConfigComponent: MicrosoftOAuthExtraConfig,
+    permissions: {
+      selected: "read_write",
+      unselected: "write",
+    },
+    isHiddenAsDataSource: true,
+  },
+  webcrawler: {
+    hide: false,
+    description: "Crawl a website.",
+    limitations: null,
+    mismatchError: `You cannot change the URL. Please add a new Public URL instead.`,
+    guideLink: "https://docs.dust.tt/docs/website-connection",
+    getLogoComponent: () => {
+      return GlobeAltIcon;
+    },
+    isNested: true,
+    permissions: {
+      selected: "none",
+      unselected: "none",
+    },
+  },
+  snowflake: {
+    hide: false,
+    description: "Query a Snowflake database.",
+    limitations: null,
+    mismatchError: `You cannot change the Snowflake account. Please add a new Snowflake connection instead.`,
+    getLogoComponent: () => {
+      return SnowflakeLogo;
+    },
+    isNested: true,
+    guideLink: "https://docs.dust.tt/docs/snowflake-connection",
+    selectLabel: "Select tables",
+    permissions: {
+      selected: "read",
+      unselected: "none",
+    },
+  },
+  zendesk: {
+    hide: false,
+    description:
+      "Authorize access to Zendesk for indexing tickets from your support center and articles from your help center.",
+    limitations:
+      "Dust will index the content accessible to the authorized account only. Attachments are not indexed.",
+    mismatchError: `You cannot select another Zendesk Workspace.\nPlease contact us at support@dust.tt if you initially selected a wrong Workspace.`,
+    guideLink: "https://docs.dust.tt/docs/zendesk-connection",
+    getLogoComponent: (isDark?: boolean) => {
+      return isDark ? ZendeskWhiteLogo : ZendeskLogo;
+    },
+    optionsComponent: ZendeskConfigView,
+    oauthExtraConfigComponent: ZendeskOAuthExtraConfig,
+    isNested: true,
+    permissions: {
+      selected: "read",
+      unselected: "none",
+    },
+  },
+  bigquery: {
+    hide: false,
+    description: "Query a BigQuery database.",
+    limitations: null,
+    mismatchError: `You cannot change the BigQuery project. Please add a new BigQuery connection instead.`,
+    getLogoComponent: () => {
+      return BigQueryLogo;
+    },
+    optionsComponent: BigQueryUseMetadataForDBMLView,
+    isNested: true,
+    guideLink: "https://docs.dust.tt/docs/bigquery",
+    selectLabel: "Select tables",
+    permissions: {
+      selected: "read",
+      unselected: "none",
+    },
+  },
+  salesforce: {
+    hide: true,
+    description:
+      "Authorize access to your Salesforce organization, in order to query your Salesforce data from Dust.",
+    limitations: null,
+    mismatchError: `You cannot change the Salesforce instance URL. Please add a new Salesforce connection instead.`,
+    getLogoComponent: () => {
+      return SalesforceLogo;
+    },
+    oauthExtraConfigComponent: SalesforceOauthExtraConfig,
+    isNested: true,
+    permissions: {
+      selected: "read",
+      unselected: "none",
+    },
+    guideLink: "https://docs.dust.tt/docs/salesforce",
+  },
+  gong: {
+    isResourceSelectionDisabled: true,
+    optionsComponent: GongOptionComponent,
+    hide: false,
+    description: "Authorize access to Gong for indexing call transcripts.",
+    guideLink: "https://docs.dust.tt/docs/gong-connection",
+    getLogoComponent: () => {
+      return GongLogo;
+    },
+    isNested: true,
+    permissions: {
+      selected: "read",
+      unselected: "none",
+    },
+    limitations:
+      "Dust will index the content accessible to the authorized account only. All transcripts will be synchronized with Dust.",
+    mismatchError: `You cannot change the Gong account. Please add a new Gong connection instead.`,
+  },
+};
+
+export function getConnectorProviderLogoWithFallback({
+  provider,
+  fallback = FolderIcon,
+  isDark,
+}: {
+  provider: ConnectorProvider | null;
+  fallback?: ComponentType;
+  isDark?: boolean;
+}): ComponentType {
+  if (!provider) {
+    return fallback;
+  }
+  return CONNECTOR_UI_CONFIGURATIONS[provider].getLogoComponent(isDark);
+}

--- a/front/lib/connector_providers_ui.ts
+++ b/front/lib/connector_providers_ui.ts
@@ -27,6 +27,7 @@ import { IntercomConfigView } from "@app/components/data_source/IntercomConfigVi
 import { MicrosoftOAuthExtraConfig } from "@app/components/data_source/MicrosoftOAuthExtraConfig";
 import { SalesforceOauthExtraConfig } from "@app/components/data_source/salesforce/SalesforceOAuthExtractConfig";
 import { SlackBotEnableView } from "@app/components/data_source/SlackBotEnableView";
+import { SlackOAuthExtraConfig } from "@app/components/data_source/SlackOAuthExtraConfig";
 import { ZendeskConfigView } from "@app/components/data_source/ZendeskConfigView";
 import { ZendeskOAuthExtraConfig } from "@app/components/data_source/ZendeskOAuthExtraConfig";
 import type {
@@ -36,7 +37,6 @@ import type {
   PlanType,
   WorkspaceType,
 } from "@app/types";
-import { SlackOAuthExtraConfig } from "@app/components/data_source/SlackOAuthExtraConfig";
 
 export interface ConnectorOptionsProps {
   owner: WorkspaceType;

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -1,6 +1,6 @@
 // Okay to use public API types as it's about internal types between connector and front that public API users do not care about.
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
-import { DATA_SOURCE_MIME_TYPE, INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 import {
   ChatBubbleLeftRightIcon,
   DocumentIcon,
@@ -23,33 +23,13 @@ import type {
 } from "@app/types";
 import { isConnectorProvider } from "@app/types";
 import { assertNever } from "@app/types";
-// Since titles will be synced in ES we don't support arbitrarily large titles.
-export const MAX_NODE_TITLE_LENGTH = 512;
 
-// Mime types that should be represented with a Channel icon.
-export const CHANNEL_INTERNAL_MIME_TYPES = [
-  INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
-  INTERNAL_MIME_TYPES.INTERCOM.TEAM,
-  INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
-  INTERNAL_MIME_TYPES.SLACK.CHANNEL,
-] as readonly string[];
-
-// Mime types that should be represented with a Database icon but are not of type "table".
-export const DATABASE_INTERNAL_MIME_TYPES = [
-  INTERNAL_MIME_TYPES.GITHUB.ISSUES,
-] as readonly string[];
-
-// Mime types that should be represented with a File icon but are not of type "document".
-export const FILE_INTERNAL_MIME_TYPES = [
-  INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
-] as readonly string[];
-
-// Mime types that should be represented with a Spreadsheet icon, despite being of type "folder".
-export const SPREADSHEET_INTERNAL_MIME_TYPES = [
-  INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
-  INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET,
-  INTERNAL_MIME_TYPES.FOLDER.SPREADSHEET,
-] as readonly string[];
+import {
+  CHANNEL_INTERNAL_MIME_TYPES,
+  DATABASE_INTERNAL_MIME_TYPES,
+  FILE_INTERNAL_MIME_TYPES,
+  SPREADSHEET_INTERNAL_MIME_TYPES,
+} from "./content_nodes_constants";
 
 export function getDocumentIcon(provider: string | null | undefined) {
   if (provider && isConnectorProvider(provider)) {

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -11,10 +11,11 @@ import {
   Square3Stack3DIcon,
 } from "@dust-tt/sparkle";
 
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import {
-  CONNECTOR_CONFIGURATIONS,
+  CONNECTOR_UI_CONFIGURATIONS,
   getConnectorProviderLogoWithFallback,
-} from "@app/lib/connector_providers";
+} from "@app/lib/connector_providers_ui";
 import type {
   ContentNode,
   ContentNodeType,
@@ -77,9 +78,11 @@ export function getVisualForDataSourceViewContentNode(
     node.mimeType &&
     node.mimeType === DATA_SOURCE_MIME_TYPE &&
     node.dataSourceView?.dataSource?.connectorProvider &&
-    CONNECTOR_CONFIGURATIONS[node.dataSourceView.dataSource.connectorProvider]
+    CONNECTOR_UI_CONFIGURATIONS[
+      node.dataSourceView.dataSource.connectorProvider
+    ]
   ) {
-    return CONNECTOR_CONFIGURATIONS[
+    return CONNECTOR_UI_CONFIGURATIONS[
       node.dataSourceView.dataSource.connectorProvider
     ].getLogoComponent();
   }

--- a/front/lib/content_nodes_constants.ts
+++ b/front/lib/content_nodes_constants.ts
@@ -1,0 +1,31 @@
+// Okay to use public API types as it's about internal types between connector and front that public API users do not care about.
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+
+// Since titles will be synced in ES we don't support arbitrarily large titles.
+export const MAX_NODE_TITLE_LENGTH = 512;
+
+// Mime types that should be represented with a Channel icon.
+export const CHANNEL_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
+  INTERNAL_MIME_TYPES.INTERCOM.TEAM,
+  INTERNAL_MIME_TYPES.INTERCOM.TEAMS_FOLDER,
+  INTERNAL_MIME_TYPES.SLACK.CHANNEL,
+] as readonly string[];
+
+// Mime types that should be represented with a Database icon but are not of type "table".
+export const DATABASE_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GITHUB.ISSUES,
+] as readonly string[];
+
+// Mime types that should be represented with a File icon but are not of type "document".
+export const FILE_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.WEBCRAWLER.FOLDER,
+] as readonly string[];
+
+// Mime types that should be represented with a Spreadsheet icon, despite being of type "folder".
+export const SPREADSHEET_INTERNAL_MIME_TYPES = [
+  INTERNAL_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET,
+  INTERNAL_MIME_TYPES.MICROSOFT.SPREADSHEET,
+  INTERNAL_MIME_TYPES.FOLDER.SPREADSHEET,
+] as readonly string[];

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -12,7 +12,7 @@ import apiConfig from "@app/lib/api/config";
 import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import { computeWorkspaceOverallSizeCached } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
-import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes";
+import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes_constants";
 import { runDocumentUpsertHooks } from "@app/lib/document_upsert_hooks/hooks";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
 import { DATASOURCE_QUOTA_PER_SEAT } from "@app/lib/plans/usage/types";

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -9,7 +9,7 @@ import type {
   WebhookCreateFormComponentProps,
   WebhookDetailsComponentProps,
 } from "@app/components/triggers/webhook_preset_components";
-import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers";
+import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers_ui";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { RemoteWebhookService } from "@app/types/triggers/remote_webhook_service";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";


### PR DESCRIPTION
## Description

Move UI related properties to dedicated file, keeps only server-side helpers in connector-providers . This should avoid importing UI components in workers.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy
