### PR TITLE
feat(growth-zto): auto-duplicate admin OAuth connection for some perso tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -127,12 +127,6 @@ export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
   "http_client",
 ] as const;
 
-// Internal servers where the admin's OAuth connection should be automatically
-// duplicated as their personal connection during setup. This avoids requiring
-// the admin to re-authenticate when they first use the tool.
-export const INTERNAL_SERVERS_WITH_AUTO_CONNECTION_DUPLICATION: InternalMCPServerNameType[] =
-  ["gmail", "outlook"];
-
 // Whether the server is available by default in the global space.
 // Hidden servers are available by default in the global space but are not visible in the assistant builder.
 const MCP_SERVER_AVAILABILITY = [

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -127,6 +127,12 @@ export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
   "http_client",
 ] as const;
 
+// Internal servers where the admin's OAuth connection should be automatically
+// duplicated as their personal connection during setup. This avoids requiring
+// the admin to re-authenticate when they first use the tool.
+export const INTERNAL_SERVERS_WITH_AUTO_CONNECTION_DUPLICATION: InternalMCPServerNameType[] =
+  ["gmail", "outlook"];
+
 // Whether the server is available by default in the global space.
 // Hidden servers are available by default in the global space but are not visible in the assistant builder.
 const MCP_SERVER_AVAILABILITY = [

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -6,6 +6,7 @@ import { isCustomResourceIconType } from "@app/components/resources/resources_ic
 import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import {
   allowsMultipleInstancesOfInternalMCPServerByName,
+  INTERNAL_SERVERS_WITH_AUTO_CONNECTION_DUPLICATION,
   isInternalMCPServerName,
   isInternalMCPServerOfName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -332,6 +333,21 @@ async function handler(
             serverType: "internal",
             internalMCPServerId: newInternalMCPServer.id,
           });
+
+          // For certain personal-only servers (Gmail, Outlook), automatically duplicate
+          // the admin's workspace connection as their personal connection to avoid
+          // requiring them to re-authenticate when they first use the tool.
+          if (
+            body.useCase === "personal_actions" &&
+            INTERNAL_SERVERS_WITH_AUTO_CONNECTION_DUPLICATION.includes(name)
+          ) {
+            await MCPServerConnectionResource.makeNew(auth, {
+              connectionId: body.connectionId,
+              connectionType: "personal",
+              serverType: "internal",
+              internalMCPServerId: newInternalMCPServer.id,
+            });
+          }
         }
 
         if (body.includeGlobal) {


### PR DESCRIPTION
## Description

  When an admin sets up a "personal" tool, they go through OAuth to validate and configure the tool at
  the workspace level. However, when that same admin tries to use the tool for the first time, they were prompted to OAuth
  again because the system required a separate "personal" connection.

  This PR automatically duplicates the admin's workspace connection as their personal connection during setup. Both connections share the same OAuth `connectionId`, which is safe since:
  - No unique constraint exists on `connectionId` in the database
  - The OAuth service returns tokens for a given `connectionId` regardless of how many DB records reference it
  - Lookups filter by `connectionType` and `userId`, so both records work correctly

  **Changes:**
  - Modified the MCP server creation API to auto-create a personal connection when setting up these tools

  ## Tests

  Manual testing: Set up Gmail as personal tool, verify admin can use the tool immediately without a second OAuth
  prompt.

  ## Risk

  **Low risk.**
  - The change is additive (creates an extra connection record)
  - Safe to rollback: admins would simply be prompted to connect again on first use (previous behavior)
  - No database migrations required

  ## Deploy Plan

  Standard deploy. No special considerations needed.