### PR TITLE
Try to reduce load on data retention query to get workspace to delete

### DIFF
--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -89,6 +89,10 @@ ConversationModel.init(
       {
         fields: ["workspaceId", "spaceId"],
       },
+      {
+        fields: ["workspaceId", "createdAt"],
+        name: "conversations_workspace_id_created_at_idx",
+      },
     ],
     sequelize: frontSequelize,
   }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -103,18 +103,22 @@ describe("ConversationResource", () => {
       const convo1 = await ConversationFactory.create(auth, {
         agentConfigurationId: agents[0].sId,
         messagesCreatedAt: [dateFromDaysAgo(10), dateFromDaysAgo(8)],
+        conversationCreatedAt: dateFromDaysAgo(10),
       });
       const convo2 = await ConversationFactory.create(auth, {
         agentConfigurationId: agents[1].sId,
         messagesCreatedAt: [dateFromDaysAgo(100), dateFromDaysAgo(1)],
+        conversationCreatedAt: dateFromDaysAgo(100),
       });
       const convo3 = await ConversationFactory.create(auth, {
         agentConfigurationId: agents[0].sId,
         messagesCreatedAt: [dateFromDaysAgo(100), dateFromDaysAgo(91)],
+        conversationCreatedAt: dateFromDaysAgo(100),
       });
       const convo4 = await ConversationFactory.create(auth, {
         agentConfigurationId: agents[1].sId,
         messagesCreatedAt: [dateFromDaysAgo(150), dateFromDaysAgo(110)],
+        conversationCreatedAt: dateFromDaysAgo(150),
       });
 
       convo1Id = convo1.sId;
@@ -136,6 +140,7 @@ describe("ConversationResource", () => {
       const anotherConvo = await ConversationFactory.create(anotherAuth, {
         agentConfigurationId: anotherAgents[0].sId,
         messagesCreatedAt: [dateFromDaysAgo(800)],
+        conversationCreatedAt: dateFromDaysAgo(800),
       });
       anotherConvoId = anotherConvo.sId;
     });
@@ -161,7 +166,7 @@ describe("ConversationResource", () => {
     it("should return only conversations with all messages before cutoff date: 90 days ago", async () => {
       const oldConversations = await ConversationResource.listAllBeforeDate(
         auth,
-        { cutoffDate: dateFromDaysAgo(90) }
+        dateFromDaysAgo(90)
       );
       expect(oldConversations.length).toBe(2);
       const oldConversationIds = oldConversations.map((c) => c.sId);
@@ -172,7 +177,7 @@ describe("ConversationResource", () => {
     it("should return only conversations with all messages before cutoff date: 200 days ago", async () => {
       const oldConversations = await ConversationResource.listAllBeforeDate(
         auth,
-        { cutoffDate: dateFromDaysAgo(200) }
+        dateFromDaysAgo(200)
       );
       expect(oldConversations.length).toBe(0);
     });
@@ -180,7 +185,7 @@ describe("ConversationResource", () => {
     it("should return only conversations with all messages before cutoff date: 5 days ago", async () => {
       const oldConversations = await ConversationResource.listAllBeforeDate(
         auth,
-        { cutoffDate: dateFromDaysAgo(5) }
+        dateFromDaysAgo(5)
       );
       expect(oldConversations.length).toBe(3);
       const oldConversationIds = oldConversations.map((c) => c.sId);
@@ -192,9 +197,9 @@ describe("ConversationResource", () => {
     it("should return all old conversations no matter the batch size", async () => {
       const oldConversations = await ConversationResource.listAllBeforeDate(
         auth,
+        dateFromDaysAgo(1),
         {
           batchSize: 1,
-          cutoffDate: dateFromDaysAgo(1),
         }
       );
       expect(oldConversations.length).toBe(4);

--- a/front/migrations/db/migration_479.sql
+++ b/front/migrations/db/migration_479.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jan 16, 2026
+CREATE INDEX CONCURRENTLY "conversations_workspace_id_created_at_idx"
+ON "conversations" ("workspaceId", "createdAt");

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -12,7 +12,7 @@ import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types";
 
 const WORKSPACE_CONVERSATIONS_BATCH_SIZE = 200;
-
+const HEARTBEAT_RATE = 100;
 /**
  * Get workspace ids with conversations retention policy.
  */
@@ -69,61 +69,63 @@ export async function purgeConversationsBatchActivity({
 
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    let conversations: ConversationResource[];
-    let nbConversationsDeleted = 0;
-
-    do {
-      conversations = await ConversationResource.listAllBeforeDate(auth, {
+    const conversations = await ConversationResource.listAllBeforeDate(
+      auth,
+      cutoffDate,
+      {
         batchSize: WORKSPACE_CONVERSATIONS_BATCH_SIZE,
-        cutoffDate,
         includeDeleted: true,
         includeTest: true,
-      });
+      }
+    );
 
-      logger.info(
-        {
-          workspaceId,
-          retentionDays,
-          cutoffDate,
-          nbConversations: conversations.length,
-        },
-        "Purging conversations for workspace."
-      );
+    logger.info(
+      {
+        workspaceId,
+        retentionDays,
+        cutoffDate,
+        nbConversations: conversations.length,
+      },
+      "Purging conversations for workspace."
+    );
+    heartbeat();
 
-      await concurrentExecutor(
-        conversations,
-        async (c) => {
-          const result = await destroyConversation(auth, {
-            conversationId: c.sId,
-          });
-          if (result.isErr()) {
-            if (result.error.type === "conversation_not_found") {
-              logger.warn(
-                {
-                  workspaceId,
-                  conversationId: c.sId,
-                  error: result.error,
-                },
-                "Attempting to delete a non-existing conversation."
-              );
-              return;
-            }
-            throw result.error;
+    let deletedCount = 0;
+    await concurrentExecutor(
+      conversations,
+      async (c) => {
+        const result = await destroyConversation(auth, {
+          conversationId: c.sId,
+        });
+        if (result.isErr()) {
+          if (result.error.type === "conversation_not_found") {
+            logger.warn(
+              {
+                workspaceId,
+                conversationId: c.sId,
+                error: result.error,
+              },
+              "Attempting to delete a non-existing conversation."
+            );
+            return;
           }
-        },
-        {
-          concurrency: 2,
+          throw result.error;
         }
-      );
-
-      nbConversationsDeleted += conversations.length;
-      heartbeat();
-    } while (conversations.length === WORKSPACE_CONVERSATIONS_BATCH_SIZE);
+        deletedCount++;
+        if (deletedCount % HEARTBEAT_RATE === 0) {
+          heartbeat();
+        }
+      },
+      {
+        concurrency: 2,
+      }
+    );
+    heartbeat();
 
     res.push({
       workspaceModelId: workspace.id,
       workspaceId: workspace.sId,
-      nbConversationsDeleted,
+      nbConversationsDeleted: conversations.length,
     });
   }
 


### PR DESCRIPTION
## Description

Try  to reduce the impact of these large group by queries by only running on the conversation created before the cutoff date (other can be safely ignored)

We want to avoid such large queries

```sql
SELECT
  "conversationId",
  MAX("createdAt") AS "lastMessageDate"
FROM
  "messages" AS "message"
WHERE
  "message"."workspaceId" = $1
GROUP BY
  "conversationId"
HAVING
  MAX("createdAt") < $2
ORDER BY
  MAX("createdAt") DESC
```

by now adding a where clause on the conversation started before the cutoff.


## Tests

There are existing test working

## Risk

I'll monitor the data rentention logs and activities to make sure it keep working as expected

## Deploy Plan

block front
merge
apply migration
deploy front
unlock front !!!
