### PR TITLE
[LLM Router] Release Gemini 3 in the agent builder

### DIFF
--- a/front/lib/api/llm/clients/google/utils/errors.ts
+++ b/front/lib/api/llm/clients/google/utils/errors.ts
@@ -68,6 +68,15 @@ function categorizeGenAIError(
     };
   }
 
+  if (statusCode === 503) {
+    return {
+      type: "server_error",
+      message: `Server error from ${metadata.clientId}. The model is overloaded or unavailable. Please try again later.`,
+      isRetryable: true,
+      originalError,
+    };
+  }
+
   if (statusCode >= 500 && statusCode < 600) {
     return {
       type: "server_error",

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -83,5 +83,4 @@ export const GEMINI_3_PRO_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   useNativeLightReasoning: true,
-  featureFlag: "google_ai_studio_experimental_models_feature",
 };

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -67,7 +67,7 @@ export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
 export const GEMINI_3_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
   modelId: GEMINI_3_PRO_MODEL_ID,
-  displayName: "Gemini 3 Pro",
+  displayName: "Gemini 3 Pro (Preview)",
   contextSize: 1_000_000,
   recommendedTopK: 64,
   recommendedExhaustiveTopK: 64,


### PR DESCRIPTION
## Description

Remove gemini 3 feature flag from model to release it in the agent builder.

<img width="1677" height="986" alt="Screenshot 2025-11-25 at 17 32 02" src="https://github.com/user-attachments/assets/324ec748-1c2d-434f-84e1-871f169ace9a" />

**Out of scope**
- Set @gemini global agent to Gemini 3 pro

Things to have in mind:
🔴🔴🔴
- Gemini 3 has been very unstable, responding with 503 errors overloaded or unavailable service.
<img width="720" height="397" alt="image" src="https://github.com/user-attachments/assets/c7e3d61a-0f78-4c4f-885c-cbe086ef169f" />

🟢🟢🟢
- There is a high demand from customers

Plan is to release it only in the agent builder for customer in demand.

## Tests

local + Dust workspace for a few days

## Risk

Bad image for Dust if Gemini continues being unstable

## Deploy Plan

front
