### PR TITLE
Adding user roles in events tracking

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -166,6 +166,7 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
   }, [shouldTrack, user]);
 
   // Group users by workspace and set workspace properties (admin only)
+  const lastUserRole = useRef<string | null>(null);
   useEffect(() => {
     if (!posthog.__loaded || !workspaceId || !shouldTrack) {
       return;
@@ -186,7 +187,20 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
         lastPlanPropertiesString.current = planPropsString;
       }
     }
-  }, [workspaceId, planProperties, shouldTrack, isAdmin]);
+
+    // Track user role as a person property (updates when workspace changes).
+    const userRole = currentWorkspace?.role ?? null;
+    if (userRole && userRole !== lastUserRole.current) {
+      posthog.setPersonProperties({ user_role: userRole });
+      lastUserRole.current = userRole;
+    }
+  }, [
+    workspaceId,
+    planProperties,
+    shouldTrack,
+    isAdmin,
+    currentWorkspace?.role,
+  ]);
 
   // Track pageviews on route changes.
   useEffect(() => {


### PR DESCRIPTION





## Description

Adds user role tracking to PostHog by setting it as a person property. The user's role (`admin`, `builder`, `user`, or `none`) is now captured whenever the workspace changes, allowing better segmentation and analysis of user behavior by role in PostHog analytics. This follows recent PostHog tracking improvements and helps understand feature adoption patterns across different user types.

## Risk

Low. This only adds user role tracking without changing application behavior. The tracking is fire-and-forget and updates only when the role changes.
