### PR TITLE
[front] Disable alerting on `get_database_schema`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
@@ -118,7 +118,6 @@ function createServer(
       {
         toolNameForMonitoring: GET_DATABASE_SCHEMA_TOOL_NAME,
         agentLoopContext,
-        enableAlerting: true,
       },
       async ({ tables }) => {
         // Fetch table configurations


### PR DESCRIPTION
## Description

- This PR disables the alerting on the `get_database_schema` tool following this [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1764089582822299).
- The alerting we currently have is unattended and doesn't bring value.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
