### PR TITLE
[front] - chore(obs): breakdown other tools

### DIFF
--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -33,9 +33,9 @@ export function getSourceColor(source: UserMessageOrigin) {
  * "Other" and "Unknown" are special cases that have their own colors.
  */
 export function getIndexedColor(label: string, allLabels: string[]): string {
-  if (label === OTHER_LABEL.key) {
+  if (label === OTHER_LABEL.label) {
     return OTHER_LABEL.color;
-  } else if (label === UNKNOWN_LABEL.key) {
+  } else if (label === UNKNOWN_LABEL.label) {
     return UNKNOWN_LABEL.color;
   }
 


### PR DESCRIPTION
## Description

This PR enhances tool usage charts by providing a detailed breakdown of the "others" category. When hovering over the "others" segment in observability charts, users can now see which specific tools are grouped in that category, along with their individual counts and percentages.

## Tests

- [x] Locally
- [x] front-edge

## Risk

Low

## Deploy Plan

Deploy front