### PR TITLE
add option for conversation history in Zendesk tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
@@ -5,12 +5,14 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   ZendeskSearchResponse,
   ZendeskTicket,
+  ZendeskTicketComment,
   ZendeskTicketField,
   ZendeskTicketMetrics,
 } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
 import {
   isValidZendeskSubdomain,
   ZendeskSearchResponseSchema,
+  ZendeskTicketCommentsResponseSchema,
   ZendeskTicketFieldsResponseSchema,
   ZendeskTicketMetricsResponseSchema,
   ZendeskTicketResponseSchema,
@@ -230,5 +232,20 @@ class ZendeskClient {
     }
 
     return new Ok(result.value.ticket_fields.filter((f) => f.active));
+  }
+
+  async getTicketComments(
+    ticketId: number
+  ): Promise<Result<ZendeskTicketComment[], Error>> {
+    const result = await this.request(
+      `tickets/${ticketId}/comments`,
+      ZendeskTicketCommentsResponseSchema
+    );
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    return new Ok(result.value.comments);
   }
 }

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
@@ -8,6 +8,7 @@ import type {
   ZendeskTicketComment,
   ZendeskTicketField,
   ZendeskTicketMetrics,
+  ZendeskUser,
 } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
 import {
   isValidZendeskSubdomain,
@@ -16,6 +17,7 @@ import {
   ZendeskTicketFieldsResponseSchema,
   ZendeskTicketMetricsResponseSchema,
   ZendeskTicketResponseSchema,
+  ZendeskUsersResponseSchema,
 } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
@@ -247,5 +249,37 @@ class ZendeskClient {
     }
 
     return new Ok(result.value.comments);
+  }
+
+  async getUsersByIds(
+    userIds: number[]
+  ): Promise<Result<ZendeskUser[], Error>> {
+    if (userIds.length === 0) {
+      return new Ok([]);
+    }
+
+    // Zendesk API supports up to 100 user IDs per request
+    const chunks: number[][] = [];
+    for (let i = 0; i < userIds.length; i += 100) {
+      chunks.push(userIds.slice(i, i + 100));
+    }
+
+    const allUsers: ZendeskUser[] = [];
+
+    for (const chunk of chunks) {
+      const idsParam = chunk.join(",");
+      const result = await this.request(
+        `users/show_many?ids=${idsParam}`,
+        ZendeskUsersResponseSchema
+      );
+
+      if (result.isErr()) {
+        return new Err(result.error);
+      }
+
+      allUsers.push(...result.value.users);
+    }
+
+    return new Ok(allUsers);
   }
 }

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/rendering.ts
@@ -1,5 +1,6 @@
 import type {
   ZendeskTicket,
+  ZendeskTicketComment,
   ZendeskTicketField,
   ZendeskTicketMetrics,
 } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
@@ -174,6 +175,27 @@ export function renderTicketMetrics(metrics: ZendeskTicketMetrics): string {
     lines.push(
       `Initially Assigned At: ${new Date(metrics.initially_assigned_at).toISOString()}`
     );
+  }
+
+  return lines.join("\n");
+}
+
+export function renderConversation(comments: ZendeskTicketComment[]): string {
+  if (comments.length === 0) {
+    return "\n=== Conversation ===\nNo comments found.";
+  }
+
+  const lines = ["\n=== Conversation ==="];
+
+  const sortedComments = [...comments].sort(
+    (a, b) =>
+      new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+
+  for (const comment of sortedComments) {
+    const date = new Date(comment.created_at).toISOString();
+    const body = comment.plain_body || comment.body;
+    lines.push(`\n[${date}] Author ID: ${comment.author_id}\n${body}`);
   }
 
   return lines.join("\n");

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/rendering.ts
@@ -198,7 +198,7 @@ export function renderTicketComments(
 
   for (const comment of sortedComments) {
     const date = new Date(comment.created_at).toISOString();
-    const body = comment.plain_body || comment.body;
+    const body = comment.plain_body ?? comment.body;
     const author = users.find((user) => user.id === comment.author_id) ?? null;
     const authorLabel = author
       ? `${author.name} (${author.email ?? "Unknown email"})`


### PR DESCRIPTION
## Description

Add an option in get_ticket to retrieve the full convo.
Solves [#5240](https://github.com/dust-tt/tasks/issues/5240)

## Tests

locally

## Risk

low

## Deploy Plan

Front only