### PR TITLE
[LLM Router] Yield retryable error if stream did not complete

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -257,7 +257,7 @@ export abstract class LLM {
           type: "stream_error",
           message: `LLM did not complete successfully for ${this.metadata.clientId}/${this.metadata.modelId}.`,
           isRetryable: true,
-          originalError: { lastEvent },
+          originalError: { lastEventType: lastEvent?.type },
         },
         this.metadata
       );


### PR DESCRIPTION
## Description

Some llm stream do not end with error or success event, leaving the conversation in a weird state. This PR checks for the last llm event of the stream, and yield a retryable error if it did not complete with a success or error already.

## Tests

local

## Risk

low

## Deploy Plan

front
