### PR TITLE
Use agenticMessageData for origin, keep old values in v1 for extension

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -18,7 +18,7 @@ import type {
 } from "@app/components/assistant/conversation/types";
 import {
   hasHumansInteracting,
-  isHiddenContextOrigin,
+  isHiddenMessage,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
 import { useCancelMessage, useConversation } from "@app/lib/swr/conversations";
@@ -63,7 +63,7 @@ export const AgentInputBar = ({
         isUserMessage(m) &&
         m.user?.id === context.user.id &&
         m.visibility !== "deleted" &&
-        !isHiddenContextOrigin(m)
+        !isHiddenMessage(m)
     );
 
   const agentMentions = useMemo(() => {

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -63,7 +63,7 @@ export const AgentInputBar = ({
         isUserMessage(m) &&
         m.user?.id === context.user.id &&
         m.visibility !== "deleted" &&
-        !isHiddenContextOrigin(m.context.origin)
+        !isHiddenContextOrigin(m)
     );
 
   const agentMentions = useMemo(() => {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -351,7 +351,11 @@ export function AgentMessage({
 
   const isAgentMessageHandingOver = methods.data
     .get()
-    .some((m) => isHandoverUserMessage(m) && m.context.originMessageId === sId);
+    .some(
+      (m) =>
+        isHandoverUserMessage(m) &&
+        m.agenticMessageData?.originMessageId === sId
+    );
 
   if (
     agentMessageToRender.status !== "created" &&

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -187,7 +187,7 @@ export const ConversationViewer = ({
       const raw = messages
         .flatMap((m) => m.messages)
         .filter((m) =>
-          isUserMessageType(m) ? !isHiddenContextOrigin(m.context.origin) : true
+          isUserMessageType(m) ? !isHiddenContextOrigin(m) : true
         );
 
       const messagesToRender = convertLightMessageTypeToVirtuosoMessages(raw);
@@ -216,7 +216,7 @@ export const ConversationViewer = ({
 
     if (olderMessagesFromBackend.length > 0) {
       const filtered = olderMessagesFromBackend.filter((m) =>
-        isUserMessageType(m) ? !isHiddenContextOrigin(m.context.origin) : true
+        isUserMessageType(m) ? !isHiddenContextOrigin(m) : true
       );
       ref.current.data.prepend(
         convertLightMessageTypeToVirtuosoMessages(filtered)
@@ -286,7 +286,7 @@ export const ConversationViewer = ({
         switch (event.type) {
           case "user_message_new":
             if (ref.current) {
-              if (isHiddenContextOrigin(event.message.context.origin)) {
+              if (isHiddenContextOrigin(event.message)) {
                 break;
               }
               const userMessage: VirtuosoMessage = {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -31,7 +31,7 @@ import {
   areSameRank,
   getMessageRank,
   hasHumansInteracting,
-  isHiddenContextOrigin,
+  isHiddenMessage,
   isMessageTemporayState,
   isUserMessage,
   makeInitialMessageStreamState,
@@ -186,9 +186,7 @@ export const ConversationViewer = ({
     if (!initialListData && messages.length > 0 && !isValidating) {
       const raw = messages
         .flatMap((m) => m.messages)
-        .filter((m) =>
-          isUserMessageType(m) ? !isHiddenContextOrigin(m) : true
-        );
+        .filter((m) => (isUserMessageType(m) ? !isHiddenMessage(m) : true));
 
       const messagesToRender = convertLightMessageTypeToVirtuosoMessages(raw);
 
@@ -216,7 +214,7 @@ export const ConversationViewer = ({
 
     if (olderMessagesFromBackend.length > 0) {
       const filtered = olderMessagesFromBackend.filter((m) =>
-        isUserMessageType(m) ? !isHiddenContextOrigin(m) : true
+        isUserMessageType(m) ? !isHiddenMessage(m) : true
       );
       ref.current.data.prepend(
         convertLightMessageTypeToVirtuosoMessages(filtered)
@@ -286,7 +284,7 @@ export const ConversationViewer = ({
         switch (event.type) {
           case "user_message_new":
             if (ref.current) {
-              if (isHiddenContextOrigin(event.message)) {
+              if (isHiddenMessage(event.message)) {
                 break;
               }
               const userMessage: VirtuosoMessage = {

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -88,7 +88,7 @@ export const isTriggeredOrigin = (origin?: UserMessageOrigin | null) => {
 
 // Central helper to control which user message origins should be hidden in the UI.
 // Extend this list as we introduce more bootstrap/system user messages.
-export const isHiddenContextOrigin = (message: UserMessageType): boolean => {
+export const isHiddenMessage = (message: UserMessageType): boolean => {
   return (
     message.context.origin === "onboarding_conversation" ||
     message?.agenticMessageData?.type === "agent_handover"

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -88,10 +88,11 @@ export const isTriggeredOrigin = (origin?: UserMessageOrigin | null) => {
 
 // Central helper to control which user message origins should be hidden in the UI.
 // Extend this list as we introduce more bootstrap/system user messages.
-export const isHiddenContextOrigin = (
-  origin?: UserMessageOrigin | null
-): boolean => {
-  return origin === "onboarding_conversation" || origin === "agent_handover";
+export const isHiddenContextOrigin = (message: UserMessageType): boolean => {
+  return (
+    message.context.origin === "onboarding_conversation" ||
+    message?.agenticMessageData?.type === "agent_handover"
+  );
 };
 
 export const isUserMessage = (

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -89,10 +89,7 @@ export const isTriggeredOrigin = (origin?: UserMessageOrigin | null) => {
 // Central helper to control which user message origins should be hidden in the UI.
 // Extend this list as we introduce more bootstrap/system user messages.
 export const isHiddenMessage = (message: UserMessageType): boolean => {
-  return (
-    message.context.origin === "onboarding_conversation" ||
-    message?.agenticMessageData?.type === "agent_handover"
-  );
+  return message.context.origin === "onboarding_conversation";
 };
 
 export const isUserMessage = (
@@ -105,7 +102,7 @@ export const isHandoverUserMessage = (
 ): msg is UserMessageType & { contentFragments: ContentFragmentType[] } =>
   "type" in msg &&
   msg.type === "user_message" &&
-  msg.context.origin === "agent_handover";
+  msg.agenticMessageData?.type === "agent_handover";
 
 export const isMessageTemporayState = (
   msg: VirtuosoMessage

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -756,13 +756,7 @@ export async function postUserMessage(
         user: user?.toJSON() ?? null,
         mentions,
         content,
-        context: {
-          ...context,
-          // TODO(2025-11-24 PPUL): Remove once extensions have been updated - return real user origin and no originMessageId
-          origin: agenticMessageData?.type ?? context.origin,
-          originMessageId:
-            agenticMessageData?.originMessageId ?? context.originMessageId,
-        },
+        context,
         agenticMessageData,
         rank: m.rank,
       };

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -206,12 +206,7 @@ async function batchRenderUserMessages(
         fullName: userMessage.userContextFullName,
         email: userMessage.userContextEmail,
         profilePictureUrl: userMessage.userContextProfilePictureUrl,
-        // TODO(2025-11-24 PPUL): Return real user origin even in case of run_agent, once extensions have been updated
-        origin: userMessage.agenticMessageType ?? userMessage.userContextOrigin,
-        // TODO(2025-11-24 PPUL): Remove once extensions have been updated
-        originMessageId:
-          userMessage.agenticOriginMessageId ??
-          userMessage.userContextOriginMessageId,
+        origin: userMessage.userContextOrigin,
         clientSideMCPServerIds: userMessage.clientSideMCPServerIds,
         lastTriggerRunAt:
           userMessage.userContextLastTriggerRunAt?.getTime() ?? null,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -9,8 +9,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { PatchConversationResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
-import { isUserMessageType, type WithAPIErrorResponse } from "@app/types";
-import logger from "@app/logger/logger";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isUserMessageType } from "@app/types";
 
 /**
  * @swagger


### PR DESCRIPTION
## Description

UserMessageType now returns consistent values from db in context, ensuring context.origin is the user origin, fixing the nested sub agents call . Fix the display in web app to rely on agenticMessageData.type .

/api/v1/../conversations endpoint is patched to continue returning run_agent/agent_handover in context.origin , to ekeep correct display in extension.


## Tests

locally :  

- checked display with web app
- checked display with old extension
- tested nested run-agent : context is correctly passed.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
