### PR TITLE
feat(growth-zto): onboarding conversation tool setup follow-up

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -72,8 +72,11 @@ import {
   getUserMentionPlugin,
   userMentionDirective,
 } from "@app/lib/mentions/markdown/plugin";
-import { useCancelMessage } from "@app/lib/swr/conversations";
-import { useConversationMessage } from "@app/lib/swr/conversations";
+import {
+  useCancelMessage,
+  useConversationMessage,
+  usePostOnboardingFollowUp,
+} from "@app/lib/swr/conversations";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import type {
   ContentFragmentsType,
@@ -596,6 +599,11 @@ function AgentMessageContent({
   const agentMessage = messageStreamState.message;
   const { sId, configuration: agentConfiguration } = agentMessage;
 
+  const { postFollowUp } = usePostOnboardingFollowUp({
+    workspaceId: owner.sId,
+    conversationId,
+  });
+
   const retryHandlerWithResetState = useCallback(
     async (error: PersonalAuthenticationRequiredErrorContent) => {
       methods.data.map((m) =>
@@ -642,6 +650,13 @@ function AgentMessageContent({
     }
   }
 
+  const handleToolSetupComplete = React.useCallback(
+    (toolId: string) => {
+      void postFollowUp(toolId);
+    },
+    [postFollowUp]
+  );
+
   const additionalMarkdownComponents: Components = React.useMemo(
     () => ({
       visualization: getVisualizationPlugin(
@@ -655,8 +670,12 @@ function AgentMessageContent({
       mention: getAgentMentionPlugin(owner),
       mention_user: getUserMentionPlugin(owner),
       dustimg: getImgPlugin(owner),
-      toolSetup: getToolSetupPlugin(owner),
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
+      toolSetup: getToolSetupPlugin(
+        owner,
+        conversationId,
+        handleToolSetupComplete
+      ),
     }),
     [
       owner,
@@ -665,6 +684,7 @@ function AgentMessageContent({
       agentConfiguration.sId,
       onQuickReplySend,
       isLastMessage,
+      handleToolSetupComplete,
     ]
   );
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -681,6 +681,7 @@ function AgentMessageContent({
       toolSetup: getToolSetupPlugin(
         owner,
         conversationId,
+        isLastMessage,
         handleToolSetupComplete,
         handleToolSetupSkipped
       ),
@@ -688,6 +689,7 @@ function AgentMessageContent({
     [
       owner,
       conversationId,
+      isLastMessage,
       sId,
       agentConfiguration.sId,
       onQuickReplySend,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -652,7 +652,14 @@ function AgentMessageContent({
 
   const handleToolSetupComplete = React.useCallback(
     (toolId: string) => {
-      void postFollowUp(toolId);
+      void postFollowUp(toolId, "completed");
+    },
+    [postFollowUp]
+  );
+
+  const handleToolSetupSkipped = React.useCallback(
+    (toolId: string) => {
+      void postFollowUp(toolId, "skipped");
     },
     [postFollowUp]
   );
@@ -674,7 +681,8 @@ function AgentMessageContent({
       toolSetup: getToolSetupPlugin(
         owner,
         conversationId,
-        handleToolSetupComplete
+        handleToolSetupComplete,
+        handleToolSetupSkipped
       ),
     }),
     [
@@ -685,6 +693,7 @@ function AgentMessageContent({
       onQuickReplySend,
       isLastMessage,
       handleToolSetupComplete,
+      handleToolSetupSkipped,
     ]
   );
 

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -25,9 +25,16 @@ interface ToolSetupCardProps {
   toolName: string;
   toolId: InternalMCPServerNameType;
   owner: WorkspaceType;
+  conversationId?: string;
+  onSetupComplete?: (toolId: string) => void;
 }
 
-export function ToolSetupCard({ toolName, toolId, owner }: ToolSetupCardProps) {
+export function ToolSetupCard({
+  toolName,
+  toolId,
+  owner,
+  onSetupComplete,
+}: ToolSetupCardProps) {
   const [isActivating, setIsActivating] = useState(false);
   const [isSetupSheetOpen, setIsSetupSheetOpen] = useState(false);
   const isAdmin = owner.role === "admin";
@@ -122,6 +129,7 @@ export function ToolSetupCard({ toolName, toolId, owner }: ToolSetupCardProps) {
     await addToSpace(matchingMCPServer, globalSpace);
     await mutateMCPServers();
     setIsActivating(false);
+    onSetupComplete?.(toolId);
   };
 
   const handleActivateClick = async () => {
@@ -133,6 +141,7 @@ export function ToolSetupCard({ toolName, toolId, owner }: ToolSetupCardProps) {
     setIsActivating(true);
     await mutateMCPServers();
     setIsActivating(false);
+    onSetupComplete?.(toolId);
   };
 
   return (

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -27,6 +27,7 @@ interface ToolSetupCardProps {
   owner: WorkspaceType;
   conversationId?: string;
   onSetupComplete?: (toolId: string) => void;
+  onSetupSkipped?: (toolId: string) => void;
 }
 
 export function ToolSetupCard({
@@ -34,9 +35,11 @@ export function ToolSetupCard({
   toolId,
   owner,
   onSetupComplete,
+  onSetupSkipped,
 }: ToolSetupCardProps) {
   const [isActivating, setIsActivating] = useState(false);
   const [isSetupSheetOpen, setIsSetupSheetOpen] = useState(false);
+  const [isSkipped, setIsSkipped] = useState(false);
   const isAdmin = owner.role === "admin";
 
   const { spaces: spacesAsUser } = useSpaces({
@@ -144,6 +147,14 @@ export function ToolSetupCard({
     onSetupComplete?.(toolId);
   };
 
+  const handleSkip = () => {
+    setIsSkipped(true);
+    onSetupSkipped?.(toolId);
+  };
+
+  const showSkipButton =
+    isAdmin && !isToolActivatedInGlobalSpace && !isActivating && !isSkipped;
+
   return (
     <>
       <ContentMessage
@@ -166,13 +177,24 @@ export function ToolSetupCard({
                 target="_blank"
               />
             )}
+            {showSkipButton && (
+              <Button
+                variant="outline"
+                size="sm"
+                label="Skip"
+                onClick={handleSkip}
+              />
+            )}
             <Button
               variant="highlight"
               size="sm"
-              label={getButtonLabel()}
+              label={isSkipped ? "Skipped" : getButtonLabel()}
               onClick={getButtonClickHandler()}
               disabled={
-                !isAdmin || isToolActivatedInGlobalSpace || isActivating
+                !isAdmin ||
+                isToolActivatedInGlobalSpace ||
+                isActivating ||
+                isSkipped
               }
             />
           </div>

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -26,6 +26,7 @@ interface ToolSetupCardProps {
   toolId: InternalMCPServerNameType;
   owner: WorkspaceType;
   conversationId?: string;
+  isLastMessage?: boolean;
   onSetupComplete?: (toolId: string) => void;
   onSetupSkipped?: (toolId: string) => void;
 }
@@ -34,6 +35,7 @@ export function ToolSetupCard({
   toolName,
   toolId,
   owner,
+  isLastMessage,
   onSetupComplete,
   onSetupSkipped,
 }: ToolSetupCardProps) {
@@ -153,7 +155,9 @@ export function ToolSetupCard({
   };
 
   const showSkipButton =
-    isAdmin && !isToolActivatedInGlobalSpace && !isActivating && !isSkipped;
+    isAdmin && !isToolActivatedInGlobalSpace && !isActivating;
+
+  const isSkipDisabled = !isLastMessage || isSkipped;
 
   return (
     <>
@@ -167,36 +171,38 @@ export function ToolSetupCard({
           <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             {matchingMCPServer.description}
           </span>
-          <div className="flex justify-end gap-2">
-            {matchingMCPServer.documentationUrl && (
+          <div className="flex justify-between gap-2">
+            <div>
+              {matchingMCPServer.documentationUrl && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  label="About"
+                  href={matchingMCPServer.documentationUrl}
+                  target="_blank"
+                />
+              )}
+            </div>
+            <div className="flex gap-2">
+              {showSkipButton && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  label={isSkipped ? "Skipped" : "Skip"}
+                  onClick={handleSkip}
+                  disabled={isSkipDisabled}
+                />
+              )}
               <Button
-                variant="outline"
+                variant="highlight"
                 size="sm"
-                label="About"
-                href={matchingMCPServer.documentationUrl}
-                target="_blank"
+                label={getButtonLabel()}
+                onClick={getButtonClickHandler()}
+                disabled={
+                  !isAdmin || isToolActivatedInGlobalSpace || isActivating
+                }
               />
-            )}
-            {showSkipButton && (
-              <Button
-                variant="outline"
-                size="sm"
-                label="Skip"
-                onClick={handleSkip}
-              />
-            )}
-            <Button
-              variant="highlight"
-              size="sm"
-              label={isSkipped ? "Skipped" : getButtonLabel()}
-              onClick={getButtonClickHandler()}
-              disabled={
-                !isAdmin ||
-                isToolActivatedInGlobalSpace ||
-                isActivating ||
-                isSkipped
-              }
-            />
+            </div>
           </div>
         </div>
       </ContentMessage>

--- a/front/components/markdown/tool/tool.tsx
+++ b/front/components/markdown/tool/tool.tsx
@@ -40,9 +40,15 @@ export function toolDirective() {
  * in ReactMarkdown to render the tool HTML elements.
  *
  * @param owner - The workspace context for tool interactions
+ * @param conversationId - Optional conversation ID for triggering follow-up messages
+ * @param onSetupComplete - Optional callback when tool setup completes
  * @returns A React component for rendering tool cards
  */
-export function getToolSetupPlugin(owner: WorkspaceType) {
+export function getToolSetupPlugin(
+  owner: WorkspaceType,
+  conversationId?: string,
+  onSetupComplete?: (toolId: string) => void
+) {
   const ToolSetupPlugin = ({
     toolName,
     toolId,
@@ -53,7 +59,15 @@ export function getToolSetupPlugin(owner: WorkspaceType) {
     if (!toolId || !isInternalMCPServerName(toolId)) {
       return null;
     }
-    return <ToolSetupCard toolName={toolName} toolId={toolId} owner={owner} />;
+    return (
+      <ToolSetupCard
+        toolName={toolName}
+        toolId={toolId}
+        owner={owner}
+        conversationId={conversationId}
+        onSetupComplete={onSetupComplete}
+      />
+    );
   };
 
   return ToolSetupPlugin;

--- a/front/components/markdown/tool/tool.tsx
+++ b/front/components/markdown/tool/tool.tsx
@@ -41,6 +41,7 @@ export function toolDirective() {
  *
  * @param owner - The workspace context for tool interactions
  * @param conversationId - Optional conversation ID for triggering follow-up messages
+ * @param isLastMessage - Whether this is the last message in the conversation
  * @param onSetupComplete - Optional callback when tool setup completes
  * @param onSetupSkipped - Optional callback when tool setup is skipped
  * @returns A React component for rendering tool cards
@@ -48,6 +49,7 @@ export function toolDirective() {
 export function getToolSetupPlugin(
   owner: WorkspaceType,
   conversationId?: string,
+  isLastMessage?: boolean,
   onSetupComplete?: (toolId: string) => void,
   onSetupSkipped?: (toolId: string) => void
 ) {
@@ -67,6 +69,7 @@ export function getToolSetupPlugin(
         toolId={toolId}
         owner={owner}
         conversationId={conversationId}
+        isLastMessage={isLastMessage}
         onSetupComplete={onSetupComplete}
         onSetupSkipped={onSetupSkipped}
       />

--- a/front/components/markdown/tool/tool.tsx
+++ b/front/components/markdown/tool/tool.tsx
@@ -42,12 +42,14 @@ export function toolDirective() {
  * @param owner - The workspace context for tool interactions
  * @param conversationId - Optional conversation ID for triggering follow-up messages
  * @param onSetupComplete - Optional callback when tool setup completes
+ * @param onSetupSkipped - Optional callback when tool setup is skipped
  * @returns A React component for rendering tool cards
  */
 export function getToolSetupPlugin(
   owner: WorkspaceType,
   conversationId?: string,
-  onSetupComplete?: (toolId: string) => void
+  onSetupComplete?: (toolId: string) => void,
+  onSetupSkipped?: (toolId: string) => void
 ) {
   const ToolSetupPlugin = ({
     toolName,
@@ -66,6 +68,7 @@ export function getToolSetupPlugin(
         owner={owner}
         conversationId={conversationId}
         onSetupComplete={onSetupComplete}
+        onSetupSkipped={onSetupSkipped}
       />
     );
   };

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -360,7 +360,7 @@ Keep it brief and action-oriented.`,
 
   const suggestions =
     toolSuggestions[toolId] ||
-    `The user just connected a new tool. Briefly suggest 2-3 things they can now do with it. Keep it action-oriented.`;
+    `The user just connected the tool. Briefly suggest 2-3 things they can now do with it. Keep it action-oriented.`;
 
   return `<dust_system>
 You are continuing an onboarding conversation. The user just successfully connected a tool.
@@ -374,6 +374,24 @@ Keep your response short and encouraging. Use 1-2 emojis. Do NOT repeat the welc
 ${suggestions}
 
 End by asking if they'd like to try one of these, or if they have something specific they want to do.
+</dust_system>`;
+}
+
+export function buildOnboardingSkippedPrompt(): string {
+  return `<dust_system>
+The user chose to skip connecting the tool for now.
+
+## Response style
+
+Keep your response short and understanding. Use 1 emoji. Do NOT repeat the welcome message.
+
+## What to do
+
+1. Acknowledge their choice - it's totally fine to skip for now
+2. Briefly mention they can always connect tools later from Settings
+3. Ask what they'd like to explore or try with Dust instead (e.g., ask a question, learn about features, etc.)
+
+Keep it friendly and move the conversation forward.
 </dust_system>`;
 }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -344,6 +344,39 @@ ${providerSection}
 </dust_system>`;
 }
 
+export function buildOnboardingFollowUpPrompt(toolId: string): string {
+  const toolSuggestions: Record<string, string> = {
+    gmail: `The user just connected Gmail. Suggest 2-3 specific things they can now do:
+- Search for recent emails (e.g., "find emails from my manager this week")
+- Summarize email threads or their inbox
+- Draft replies to emails
+Keep it brief and action-oriented.`,
+    outlook: `The user just connected Outlook. Suggest 2-3 specific things they can now do:
+- Search for emails by sender, date, or topic
+- Summarize email threads or inbox highlights
+- Draft email replies
+Keep it brief and action-oriented.`,
+  };
+
+  const suggestions =
+    toolSuggestions[toolId] ||
+    `The user just connected a new tool. Briefly suggest 2-3 things they can now do with it. Keep it action-oriented.`;
+
+  return `<dust_system>
+You are continuing an onboarding conversation. The user just successfully connected a tool.
+
+## Response style
+
+Keep your response short and encouraging. Use 1-2 emojis. Do NOT repeat the welcome message.
+
+## What to do
+
+${suggestions}
+
+End by asking if they'd like to try one of these, or if they have something specific they want to do.
+</dust_system>`;
+}
+
 export async function createOnboardingConversationIfNeeded(
   auth: Authenticator,
   { force }: { force?: boolean } = { force: false }

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -794,7 +794,10 @@ export function usePostOnboardingFollowUp({
   const sendNotification = useSendNotification();
 
   const postFollowUp = useCallback(
-    async (toolId: string): Promise<boolean> => {
+    async (
+      toolId: string,
+      action: "completed" | "skipped"
+    ): Promise<boolean> => {
       if (!conversationId) {
         return false;
       }
@@ -804,7 +807,7 @@ export function usePostOnboardingFollowUp({
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ toolId }),
+            body: JSON.stringify({ toolId, action }),
           }
         );
 
@@ -819,6 +822,7 @@ export function usePostOnboardingFollowUp({
           workspaceId,
           conversationId,
           toolId,
+          action,
         });
         sendNotification({
           type: "error",

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -783,3 +783,52 @@ export const useJoinConversation = ({
 
   return joinConversation;
 };
+
+export function usePostOnboardingFollowUp({
+  workspaceId,
+  conversationId,
+}: {
+  workspaceId: string;
+  conversationId: string | null;
+}) {
+  const sendNotification = useSendNotification();
+
+  const postFollowUp = useCallback(
+    async (toolId: string): Promise<boolean> => {
+      if (!conversationId) {
+        return false;
+      }
+      try {
+        const response = await fetch(
+          `/api/w/${workspaceId}/assistant/conversations/${conversationId}/onboarding-followup`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ toolId }),
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to post onboarding follow-up");
+        }
+
+        return true;
+      } catch (error) {
+        datadogLogger.error("Error posting onboarding follow-up", {
+          error,
+          workspaceId,
+          conversationId,
+          toolId,
+        });
+        sendNotification({
+          type: "error",
+          title: "Failed to send follow-up message",
+        });
+        return false;
+      }
+    },
+    [workspaceId, conversationId, sendNotification]
+  );
+
+  return { postFollowUp };
+}

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -11,7 +11,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { AgentMessageType, WithAPIErrorResponse } from "@app/types";
-import { GLOBAL_AGENTS_SID } from "@app/types";
+import { GLOBAL_AGENTS_SID, isString } from "@app/types";
 
 export type PostOnboardingFollowupResponseBody = {
   agentMessages: AgentMessageType[];
@@ -25,8 +25,9 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const user = auth.getNonNullableUser();
+  const { cId: conversationId } = req.query;
 
-  if (typeof req.query.cId !== "string") {
+  if (!isString(conversationId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -35,8 +36,6 @@ async function handler(
       },
     });
   }
-
-  const conversationId = req.query.cId;
 
   if (req.method !== "POST") {
     return apiError(req, res, {
@@ -50,7 +49,7 @@ async function handler(
 
   const { toolId } = req.body;
 
-  if (typeof toolId !== "string" || !isInternalMCPServerName(toolId)) {
+  if (!isString(toolId) || !isInternalMCPServerName(toolId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -1,0 +1,101 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  buildOnboardingFollowUpPrompt,
+  postUserMessage,
+} from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { AgentMessageType, WithAPIErrorResponse } from "@app/types";
+import { GLOBAL_AGENTS_SID } from "@app/types";
+
+export type PostOnboardingFollowupResponseBody = {
+  agentMessages: AgentMessageType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PostOnboardingFollowupResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const user = auth.getNonNullableUser();
+
+  if (typeof req.query.cId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const { toolId } = req.body;
+
+  if (typeof toolId !== "string" || !isInternalMCPServerName(toolId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid request body, `toolId` (valid tool id) is required.",
+      },
+    });
+  }
+
+  const conversationRes = await getConversation(auth, conversationId);
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const conversation = conversationRes.value;
+
+  const followUpPrompt = buildOnboardingFollowUpPrompt(toolId);
+
+  const messageRes = await postUserMessage(auth, {
+    conversation,
+    content: followUpPrompt,
+    mentions: [
+      {
+        configurationId: GLOBAL_AGENTS_SID.DUST,
+      },
+    ],
+    context: {
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      username: user.username,
+      fullName: user.fullName(),
+      email: user.email,
+      profilePictureUrl: user.imageUrl,
+      origin: "onboarding_conversation",
+    },
+    skipToolsValidation: false,
+  });
+
+  if (messageRes.isErr()) {
+    return apiError(req, res, messageRes.error);
+  }
+
+  res.status(200).json({
+    agentMessages: messageRes.value.agentMessages,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

  When a user successfully connects a tool (Gmail, Outlook, etc.) during the onboarding conversation, the agent now
  automatically sends a follow-up message suggesting specific things they can do with the newly connected tool.

  Changes:
  - Added onSetupComplete callback to ToolSetupCard that fires after successful tool connection
  - Created new API endpoint /api/w/[wId]/assistant/conversations/[cId]/onboarding-followup to post follow-up messages
  - Added buildOnboardingFollowUpPrompt() with tool-specific suggestions for Gmail and Outlook
  - Added usePostOnboardingFollowUp hook to trigger the follow-up from the frontend

## Tests

Local

## Risk

Low (only for onboarding chat)

## Deploy Plan

Deploy front