### PR TITLE
feat(growth-zto): start tour as a markdown directive

### DIFF
--- a/front/components/assistant/WelcomeTourGuideProvider.tsx
+++ b/front/components/assistant/WelcomeTourGuideProvider.tsx
@@ -1,9 +1,19 @@
-import { createContext, useContext, useMemo, useRef } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 type WelcomeTourGuideContextType = {
   startConversationRef: React.RefObject<HTMLDivElement>;
   spaceMenuButtonRef: React.RefObject<HTMLDivElement>;
   createAgentButtonRef: React.RefObject<HTMLDivElement>;
+  showTourGuide: boolean;
+  startTour: () => void;
+  endTour: () => void;
 };
 
 const WelcomeTourGuideContext =
@@ -17,14 +27,33 @@ export function WelcomeTourGuideProvider({
   const startConversationRef = useRef<HTMLDivElement>(null);
   const spaceMenuButtonRef = useRef<HTMLDivElement>(null);
   const createAgentButtonRef = useRef<HTMLDivElement>(null);
+  const [showTourGuide, setShowTourGuide] = useState(false);
+
+  const startTour = useCallback(() => {
+    setShowTourGuide(true);
+  }, []);
+
+  const endTour = useCallback(() => {
+    setShowTourGuide(false);
+  }, []);
 
   const value = useMemo(() => {
     return {
       startConversationRef,
       spaceMenuButtonRef,
       createAgentButtonRef,
+      showTourGuide,
+      startTour,
+      endTour,
     };
-  }, [startConversationRef, spaceMenuButtonRef, createAgentButtonRef]);
+  }, [
+    startConversationRef,
+    spaceMenuButtonRef,
+    createAgentButtonRef,
+    showTourGuide,
+    startTour,
+    endTour,
+  ]);
 
   return (
     <WelcomeTourGuideContext.Provider value={value}>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -50,6 +50,10 @@ import {
 import { getImgPlugin, imgDirective } from "@app/components/markdown/Image";
 import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import {
+  getStartTourPlugin,
+  startTourDirective,
+} from "@app/components/markdown/StartTourBlock";
+import {
   getToolSetupPlugin,
   toolDirective,
 } from "@app/components/markdown/tool/tool";
@@ -611,6 +615,7 @@ function AgentMessageContent({
       mention_user: getUserMentionPlugin(owner),
       dustimg: getImgPlugin(owner),
       toolSetup: getToolSetupPlugin(owner),
+      startTour: getStartTourPlugin(),
     }),
     [owner, conversationId, sId, agentConfiguration.sId]
   );
@@ -623,6 +628,7 @@ function AgentMessageContent({
       visualizationDirective,
       imgDirective,
       toolDirective,
+      startTourDirective,
     ],
     []
   );

--- a/front/components/markdown/StartTourBlock.tsx
+++ b/front/components/markdown/StartTourBlock.tsx
@@ -1,0 +1,56 @@
+/**
+ * Markdown directive plugin for starting the welcome tour guide.
+ *
+ * This module provides a remark-directive plugin for parsing and rendering
+ * start tour directives in markdown content, enabling the :startTour[label] syntax.
+ *
+ * When the onboarding agent wants to offer the user a button to start the tour,
+ * it can include :startTour[Take a quick tour] in its message.
+ */
+
+import { Button } from "@dust-tt/sparkle";
+import { visit } from "unist-util-visit";
+
+import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
+
+/**
+ * Remark directive plugin for parsing startTour directives.
+ *
+ * Transforms `:startTour[label]` into a custom HTML element
+ * that can be rendered by the StartTourButton component.
+ */
+export function startTourDirective() {
+  return (tree: any) => {
+    visit(tree, ["textDirective"], (node) => {
+      if (node.name === "startTour") {
+        const data = node.data || (node.data = {});
+        data.hName = "startTour";
+        data.hProperties = {
+          label: node.children[0]?.value || "Take the tour",
+        };
+      }
+    });
+  };
+}
+
+/**
+ * React component for rendering the start tour button in markdown.
+ */
+function StartTourButton({ label }: { label: string }) {
+  const { startTour } = useWelcomeTourGuide();
+
+  return (
+    <span className="inline-block">
+      <Button variant="highlight" label={label} size="sm" onClick={startTour} />
+    </span>
+  );
+}
+
+/**
+ * Creates a React component plugin for rendering the start tour button in markdown.
+ *
+ * @returns A React component for rendering the start tour button
+ */
+export function getStartTourPlugin() {
+  return StartTourButton;
+}


### PR DESCRIPTION
## Description

  **Bug fix:** When `ONBOARDING_CONVERSATION_ENABLED` is `true`, only the first member of a workspace gets an onboarding conversation created. Other users who complete the welcome form were left with nothing - no tour guide, no onboarding  conversation. Now, if a user reaches the conversation page with `?welcome=true` and no conversation was created for them, they'll see the welcome tour guide as a fallback.

  **New feature:** Added a `:startTour[label]` markdown directive that renders a button to trigger the welcome tour guide.
  This allows the onboarding agent (in the onboarding conversation) to offer users a way to take the tour, e.g.:

> Would you like a quick tour? :startTour[Take the tour]

  ### Changes
  - `ConversationLayout.tsx`: Removed dependency on `ONBOARDING_CONVERSATION_ENABLED` flag for showing tour guide
  - `WelcomeTourGuideProvider.tsx`: Added `showTourGuide` state with `startTour()`/`endTour()` functions
  - `StartTourBlock.tsx`: New directive and component for `:startTour[label]`
  - `AgentMessage.tsx`: Registered the new directive

  ## Tests

  Manual testing:
  - Verified tour guide shows when `?welcome=true` is set regardless of `ONBOARDING_CONVERSATION_ENABLED`
  - Verified `:startTour[label]` renders a button that opens the tour guide

  ## Risk

  Low risk. The changes are additive and the tour guide fallback is a safe default for users who don't get an onboarding
  conversation.

  ## Deploy Plan

  Standard deployment, no special steps required.