### PR TITLE
Content fragments are no longer accounted for in the messages count.

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -582,7 +582,6 @@ export async function fetchConversationMessages(
 
   const { hasMore, messages } = await conversation.fetchMessagesForPage(
     auth,
-
     paginationParams
   );
 


### PR DESCRIPTION
## Description

Change the behavior of `fetchMessagesForPage` to ignore content fragments in the messages count.
In addition to pave the way to merge content fragments in user message directly in the backend, this also fixes this issue:

Consider: cf, cf, user, agent

with limit of 2 (last first)
Before:  page 1 is agent, user, page 2 is cf, cf
After: page 1 is agent, user, cf, cf, no page 2

with limit of 3 (last first)
Before:  page 1 is agent, user, cf page 2 is cf
After: page 1 is agent, user, cf, cf, no page 2

## Tests

Added a bunch.

## Risk

Medium: it touches the message fetch so becareful, but also, 90% of conversations have < 2.5 messages and the limit is 50...

## Deploy Plan

Deploy front