### PR TITLE
fix(auth): redirect to relative URLs only

### DIFF
--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -293,7 +293,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
     }
 
     if (sanitizedReturnTo) {
-      res.redirect(sanitizedReturnTo as string);
+      res.redirect(sanitizedReturnTo);
       return;
     }
 

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -338,5 +338,5 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
     ? validatedReturnTo.sanitizedPath
     : "/";
 
-  res.redirect(sanitizedReturnTo as string);
+  res.redirect(sanitizedReturnTo);
 }

--- a/front/types/shared/utils/url_utils.ts
+++ b/front/types/shared/utils/url_utils.ts
@@ -55,7 +55,7 @@ export const validateRelativePath = (
   try {
     for (let i = 0; i < 5; i++) {
       const next = decodeURIComponent(decodedPath);
-      if (next === decodedPath) break;
+      if (next === decodedPath) {break;}
       decodedPath = next;
     }
   } catch {

--- a/front/types/shared/utils/url_utils.ts
+++ b/front/types/shared/utils/url_utils.ts
@@ -55,7 +55,9 @@ export const validateRelativePath = (
   try {
     for (let i = 0; i < 5; i++) {
       const next = decodeURIComponent(decodedPath);
-      if (next === decodedPath) {break;}
+      if (next === decodedPath) {
+        break;
+      }
       decodedPath = next;
     }
   } catch {

--- a/front/types/shared/utils/url_utils.ts
+++ b/front/types/shared/utils/url_utils.ts
@@ -26,3 +26,51 @@ export const validateUrl = (
 
   return { valid: true, standardized: url.href };
 };
+
+/**
+ * Validates and sanitizes a path to ensure it's a relative path.
+ * This prevents open redirect vulnerabilities by rejecting absolute URLs.
+ * @param path - The path string to validate (e.g., from returnTo parameter)
+ * @returns Object with valid flag and sanitized path (pathname + search only)
+ */
+export const validateRelativePath = (
+  path: string | string[] | undefined
+):
+  | {
+      valid: false;
+      sanitizedPath: null;
+    }
+  | {
+      valid: true;
+      sanitizedPath: string;
+    } => {
+  // Reject non-string or empty values
+  if (typeof path !== "string" || path.trim() === "") {
+    return { valid: false, sanitizedPath: null };
+  }
+
+  // Must start with / (relative path)
+  if (!path.startsWith("/")) {
+    return { valid: false, sanitizedPath: null };
+  }
+
+  // Reject protocol-relative URLs (//example.com)
+  if (path.startsWith("//")) {
+    return { valid: false, sanitizedPath: null };
+  }
+
+  // Try to parse as URL to extract only pathname and search
+  // This also validates the URL structure
+  try {
+    const url = new URL(path, "http://localhost");
+    // Ensure no host was somehow injected
+    if (url.hostname !== "localhost") {
+      return { valid: false, sanitizedPath: null };
+    }
+    // Return only the pathname and search params (no host, protocol, etc.)
+    return { valid: true, sanitizedPath: url.pathname + url.search };
+  } catch {
+    // If URL parsing fails, reject
+    return { valid: false, sanitizedPath: null };
+  }
+};


### PR DESCRIPTION
Closes: dust-tt/tasks#5235

## Description

- Relative path util
- WorkOS handlers returnTo URLs sanitization

## Tests

- http://localhost:3000/api/workos/login?returnTo=/w/cbWkwvee0F/conversation/KNOU2jaAq8
- http://localhost:3000/api/workos/logout?returnTo=https://evil.com
- http://localhost:3000/api/workos/login?returnTo=https://evil.com
- http://localhost:3000/api/workos/logout?returnTo=/home/security

## Risk

Breaks use cases relying on the bug.
