### PR TITLE
[front] enh: Optimize get agent editors

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -203,8 +203,13 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     const groupAgent = groupAgents[0];
     const groupModel = await groupAgent.getGroup();
-    const group = new GroupResource(GroupModel, groupModel.get());
+    if (!groupModel) {
+      return new Err(
+        new DustError("group_not_found", "Editor group not found for agent.")
+      );
+    }
 
+    const group = new GroupResource(GroupModel, groupModel.get());
     if (group.kind !== "agent_editors") {
       // Should not happen based on creation logic, but good to check.
       // Might change when we allow other group kinds to be associated with agents.

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -205,6 +205,17 @@ export class GroupResource extends BaseResource<GroupModel> {
     const groupModel = await groupAgent.getGroup();
     const group = new GroupResource(GroupModel, groupModel.get());
 
+    if (group.kind !== "agent_editors") {
+      // Should not happen based on creation logic, but good to check.
+      // Might change when we allow other group kinds to be associated with agents.
+      return new Err(
+        new DustError(
+          "internal_error",
+          "Associated group is not an agent_editors group."
+        )
+      );
+    }
+
     return new Ok(group);
   }
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -174,6 +174,12 @@ export class GroupResource extends BaseResource<GroupModel> {
         agentConfigurationId: agent.id,
         workspaceId: owner.id,
       },
+      include: [
+        {
+          model: GroupModel,
+          as: "group",
+        },
+      ],
       attributes: ["groupId"],
     });
 
@@ -196,31 +202,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     const groupAgent = groupAgents[0];
+    const groupModel = await groupAgent.getGroup();
+    const group = new GroupResource(GroupModel, groupModel.get());
 
-    const group = await GroupResource.fetchById(
-      auth,
-      GroupResource.modelIdToSId({
-        id: groupAgent.groupId,
-        workspaceId: owner.id,
-      })
-    );
-
-    if (group.isErr()) {
-      return group;
-    }
-
-    if (group.value.kind !== "agent_editors") {
-      // Should not happen based on creation logic, but good to check.
-      // Might change when we allow other group kinds to be associated with agents.
-      return new Err(
-        new DustError(
-          "internal_error",
-          "Associated group is not an agent_editors group."
-        )
-      );
-    }
-
-    return group;
+    return new Ok(group);
   }
 
   /**
@@ -237,6 +222,12 @@ export class GroupResource extends BaseResource<GroupModel> {
         agentConfigurationId: agent.map((a) => a.id),
         workspaceId: owner.id,
       },
+      include: [
+        {
+          model: GroupModel,
+          as: "group",
+        },
+      ],
       attributes: ["groupId", "agentConfigurationId"],
     });
 
@@ -249,40 +240,30 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
-    const groups = await GroupResource.fetchByIds(
-      auth,
-      groupAgents.map((ga) =>
-        GroupResource.modelIdToSId({
-          id: ga.groupId,
-          workspaceId: owner.id,
-        })
-      )
-    );
-
-    if (groups.isErr()) {
-      return groups;
-    }
-
-    if (groups.value.some((g) => g.kind !== "agent_editors")) {
-      // Should not happen based on creation logic, but good to check.
-      // Might change when we allow other group kinds to be associated with agents.
-      return new Err(
-        new Error("Associated group is not an agent_editors group.")
-      );
-    }
-
-    const r = groupAgents.reduce<Record<string, GroupResource>>((acc, ga) => {
+    const r: Record<string, GroupResource> = {};
+    for (const ga of groupAgents) {
       if (ga.agentConfigurationId) {
         const agentConfiguration = agent.find(
           (a) => a.id === ga.agentConfigurationId
         );
-        const group = groups.value.find((g) => g.id === ga.groupId);
-        if (group && agentConfiguration) {
-          acc[agentConfiguration.sId] = group;
+        const group = await ga.getGroup();
+
+        if (group.kind !== "agent_editors") {
+          return new Err(
+            new DustError(
+              "group_not_found",
+              "Associated group is not an agent_editors group."
+            )
+          );
+        }
+        if (agentConfiguration) {
+          r[agentConfiguration.sId] = new GroupResource(
+            GroupModel,
+            group.get()
+          );
         }
       }
-      return acc;
-    }, {});
+    }
 
     return new Ok(r);
   }
@@ -871,6 +852,27 @@ export class GroupResource extends BaseResource<GroupModel> {
     const groups = [...(globalGroup ? [globalGroup] : []), ...userGroups];
 
     return groups.map((group) => new this(GroupModel, group.get()));
+  }
+
+  static async getActiveMembershipsForGroups(
+    auth: Authenticator,
+    groups: GroupResource[]
+  ): Promise<Record<ModelId, ModelId[]>> {
+    const owner = auth.getNonNullableWorkspace();
+    const res = await GroupMembershipModel.findAll({
+      where: {
+        workspaceId: owner.id,
+        groupId: groups.map((g) => g.id),
+        status: "active",
+        startAt: { [Op.lte]: new Date() },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+      },
+    });
+
+    return res.reduce<Record<ModelId, ModelId[]>>((acc, m) => {
+      acc[m.groupId] = [...(acc[m.groupId] || []), m.userId];
+      return acc;
+    }, {});
   }
 
   async isMember(user: UserResource): Promise<boolean> {


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/5261

getAgentEditors was individually fetching all groups and all members for all agents. Reduce the numbers of queries to get editors : 
- 1 join query to fetch editor groups of multiple agents, intead of n*2 ( `findEditorGroupsForAgents` )
- 1 query to fetch the memberships of multiple groups at the same time (`getActiveMembershipsForGroups`) (was done once per agent)
- 1 query to fetch all needed users (was done once per agent)

Also optimized query to fetch editor group for one agent `findEditorGroupForAgent` (one join instead of 2 queries)

## Tests

tested on front-edge. performance gain is not significant, but number of queries definitely lower

## Risk

low

## Deploy Plan

deploy front
