### PR TITLE
[front] Add back input bar disabling on blocked action

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -111,7 +111,7 @@ function PreviewContent({
         {!conversation && (
           <div className="mx-4 flex-shrink-0 py-4">
             <InputBar
-              disable={isSavingDraftAgent}
+              isSubmitting={isSavingDraftAgent}
               owner={owner}
               onSubmit={createConversation}
               stickyMentions={

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -190,10 +190,8 @@ export const AgentInputBar = ({
         conversationId={context.conversationId}
         disableAutoFocus={isMobile}
         actions={context.agentBuilderContext?.actionsToShow}
-        disable={
-          context.agentBuilderContext?.isSavingDraftAgent === true ||
-          hasBlockedActions
-        }
+        isSubmitting={context.agentBuilderContext?.isSavingDraftAgent === true}
+        disable={hasBlockedActions}
       />
     </div>
   );

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@virtuoso.dev/message-list";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import type {
@@ -35,6 +36,7 @@ export const AgentInputBar = ({
   context: VirtuosoMessageListContext;
 }) => {
   const generationContext = useContext(GenerationContext);
+  const { hasBlockedActions } = useBlockedActionsContext();
 
   if (!generationContext) {
     throw new Error(
@@ -188,7 +190,10 @@ export const AgentInputBar = ({
         conversationId={context.conversationId}
         disableAutoFocus={isMobile}
         actions={context.agentBuilderContext?.actionsToShow}
-        disable={context.agentBuilderContext?.isSavingDraftAgent}
+        disable={
+          context.agentBuilderContext?.isSavingDraftAgent === true ||
+          hasBlockedActions
+        }
       />
     </div>
   );

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -23,7 +23,7 @@ import { AgentMessageCompletionStatus } from "@app/components/assistant/conversa
 import { AgentMessageInteractiveContentGeneratedFiles } from "@app/components/assistant/conversation/AgentMessageGeneratedFiles";
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
-import { useActionValidationContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
@@ -136,7 +136,7 @@ export function AgentMessage({
   );
 
   const { showBlockedActionsDialog, enqueueBlockedAction } =
-    useActionValidationContext();
+    useBlockedActionsContext();
 
   const { mutateMessage } = useConversationMessage({
     conversationId,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -600,6 +600,7 @@ function AgentMessageContent({
     VirtuosoMessage,
     VirtuosoMessageListContext
   >();
+  const { mutateBlockedActions } = useBlockedActionsContext();
   const agentMessage = messageStreamState.message;
   const { sId, configuration: agentConfiguration } = agentMessage;
 
@@ -725,6 +726,7 @@ function AgentMessageContent({
   if (agentMessage.status === "failed") {
     const { error } = agentMessage;
     if (isPersonalAuthenticationRequiredErrorContent(error)) {
+      void mutateBlockedActions();
       return (
         <MCPServerPersonalAuthenticationRequired
           owner={owner}

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -275,8 +275,8 @@ export function BlockedActionsProvider({
     }
   }, [blockedActionsQueue.length, pendingValidations.length]);
 
-  const hasBlockedActions = pendingValidations.length > 0;
-  const totalBlockedActions = pendingValidations.length;
+  const hasBlockedActions = blockedActionsQueue.length > 0;
+  const totalBlockedActions = blockedActionsQueue.length;
 
   const pages = useMemo(() => {
     if (pendingValidations.length > 0) {

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -114,6 +114,7 @@ type BlockedActionsContextType = {
   }) => void;
   showBlockedActionsDialog: () => void;
   hasBlockedActions: boolean;
+  hasPendingValidations: boolean;
   totalBlockedActions: number;
 };
 
@@ -318,6 +319,7 @@ export function BlockedActionsProvider({
         showBlockedActionsDialog,
         enqueueBlockedAction,
         hasBlockedActions: blockedActionsQueue.length > 0,
+        hasPendingValidations: pendingValidations.length > 0,
         totalBlockedActions: blockedActionsQueue.length,
       }}
     >

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -107,7 +107,7 @@ function useBlockedActionsQueue({
   };
 }
 
-type ActionValidationContextType = {
+type BlockedActionsContextType = {
   enqueueBlockedAction: (params: {
     messageId: string;
     blockedAction: BlockedToolExecution;
@@ -117,15 +117,15 @@ type ActionValidationContextType = {
   totalBlockedActions: number;
 };
 
-const ActionValidationContext = createContext<
-  ActionValidationContextType | undefined
+const BlockedActionsContext = createContext<
+  BlockedActionsContextType | undefined
 >(undefined);
 
-export function useActionValidationContext() {
-  const context = useContext(ActionValidationContext);
+export function useBlockedActionsContext() {
+  const context = useContext(BlockedActionsContext);
   if (!context) {
     throw new Error(
-      "useActionValidationContext must be used within an ActionValidationContext"
+      "useActionValidationContext must be used within an BlockedActionsContext"
     );
   }
 
@@ -316,7 +316,7 @@ export function BlockedActionsProvider({
   }, [pages, currentValidationIndex, pendingValidations]);
 
   return (
-    <ActionValidationContext.Provider
+    <BlockedActionsContext.Provider
       value={{
         showBlockedActionsDialog,
         enqueueBlockedAction,
@@ -363,6 +363,6 @@ export function BlockedActionsProvider({
           />
         )}
       </MultiPageDialog>
-    </ActionValidationContext.Provider>
+    </BlockedActionsContext.Provider>
   );
 }

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -275,9 +275,6 @@ export function BlockedActionsProvider({
     }
   }, [blockedActionsQueue.length, pendingValidations.length]);
 
-  const hasBlockedActions = blockedActionsQueue.length > 0;
-  const totalBlockedActions = blockedActionsQueue.length;
-
   const pages = useMemo(() => {
     if (pendingValidations.length > 0) {
       return pendingValidations.map((item) => {
@@ -320,8 +317,8 @@ export function BlockedActionsProvider({
       value={{
         showBlockedActionsDialog,
         enqueueBlockedAction,
-        hasBlockedActions,
-        totalBlockedActions,
+        hasBlockedActions: blockedActionsQueue.length > 0,
+        totalBlockedActions: blockedActionsQueue.length,
       }}
     >
       {children}

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -116,6 +116,7 @@ type BlockedActionsContextType = {
   hasBlockedActions: boolean;
   hasPendingValidations: boolean;
   totalBlockedActions: number;
+  mutateBlockedActions: () => void;
 };
 
 const BlockedActionsContext = createContext<
@@ -147,7 +148,7 @@ export function BlockedActionsProvider({
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const conversationId = conversation?.sId || null;
 
-  const { blockedActions } = useBlockedActions({
+  const { blockedActions, mutate: mutateBlockedActions } = useBlockedActions({
     conversationId,
     workspaceId: owner.sId,
   });
@@ -318,6 +319,7 @@ export function BlockedActionsProvider({
       value={{
         showBlockedActionsDialog,
         enqueueBlockedAction,
+        mutateBlockedActions,
         hasBlockedActions: blockedActionsQueue.length > 0,
         hasPendingValidations: pendingValidations.length > 0,
         totalBlockedActions: blockedActionsQueue.length,

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -9,7 +9,7 @@ import { useCallback, useContext, useEffect, useState } from "react";
 
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { AgentBrowserContainer } from "@app/components/assistant/conversation/AgentBrowserContainer";
-import { useActionValidationContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
@@ -51,7 +51,7 @@ export function ConversationContainerVirtuoso({
   const { setSelectedAgent } = useContext(InputBarContext);
 
   const { hasBlockedActions, totalBlockedActions, showBlockedActionsDialog } =
-    useActionValidationContext();
+    useBlockedActionsContext();
 
   const router = useRouter();
 

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -170,7 +170,7 @@ export function ConversationContainerVirtuoso({
                 {totalBlockedActions} action
                 {pluralize(totalBlockedActions)}
               </span>{" "}
-              require{conjugate(totalBlockedActions)} manual approval
+              require{conjugate(totalBlockedActions)} a manual action
               <ContentMessageAction
                 label="Review actions"
                 variant="outline"

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -200,7 +200,7 @@ export function ConversationContainerVirtuoso({
               owner={owner}
               onSubmit={handleConversationCreation}
               conversationId={null}
-              disable={false}
+              disable={hasBlockedActions}
               disableAutoFocus={false}
             />
           </div>

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -50,8 +50,12 @@ export function ConversationContainerVirtuoso({
 
   const { setSelectedAgent } = useContext(InputBarContext);
 
-  const { hasBlockedActions, totalBlockedActions, showBlockedActionsDialog } =
-    useBlockedActionsContext();
+  const {
+    hasBlockedActions,
+    hasPendingValidations,
+    totalBlockedActions,
+    showBlockedActionsDialog,
+  } = useBlockedActionsContext();
 
   const router = useRouter();
 
@@ -171,12 +175,16 @@ export function ConversationContainerVirtuoso({
                 {pluralize(totalBlockedActions)}
               </span>{" "}
               require{conjugate(totalBlockedActions)} a manual action
-              <ContentMessageAction
-                label="Review actions"
-                variant="outline"
-                size="xs"
-                onClick={() => showBlockedActionsDialog()}
-              />
+              {/* If there are pending validations, we show a button allowing to open the dialog
+              from where they can be approved/denied */}
+              {hasPendingValidations && (
+                <ContentMessageAction
+                  label="Review actions"
+                  variant="outline"
+                  size="xs"
+                  onClick={() => showBlockedActionsDialog()}
+                />
+              )}
             </ContentMessageInline>
           )}
         </>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -46,6 +46,7 @@ interface InputBarProps {
   disableAutoFocus: boolean;
   isFloating?: boolean;
   isFloatingWithoutMargin?: boolean;
+  isSubmitting?: boolean;
   disable?: boolean;
 }
 
@@ -64,9 +65,10 @@ export const InputBar = React.memo(function InputBar({
   actions = DEFAULT_INPUT_BAR_ACTIONS,
   disableAutoFocus = false,
   isFloating = true,
+  isSubmitting = false,
   disable = false,
 }: InputBarProps) {
-  const [disableSendButton, setDisableSendButton] = useState(disable);
+  const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
 
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
@@ -224,7 +226,7 @@ export const InputBar = React.memo(function InputBar({
     // spinner and in case of error, re-enable the input bar
     if (!conversationId) {
       setLoading(true);
-      setDisableSendButton(true);
+      setIsLocalSubmitting(true);
 
       const r = await onSubmit(
         markdown,
@@ -245,7 +247,7 @@ export const InputBar = React.memo(function InputBar({
       );
 
       setLoading(false);
-      setDisableSendButton(false);
+      setIsLocalSubmitting(false);
       if (r.isOk()) {
         resetEditorText();
         fileUploaderService.resetUpload();
@@ -282,8 +284,8 @@ export const InputBar = React.memo(function InputBar({
   };
 
   useEffect(() => {
-    setDisableSendButton(disable);
-  }, [disable]);
+    setIsLocalSubmitting(isSubmitting);
+  }, [isSubmitting]);
 
   return (
     <div className="flex w-full flex-col">
@@ -331,10 +333,10 @@ export const InputBar = React.memo(function InputBar({
             onEnterKeyDown={handleSubmit}
             stickyMentions={stickyMentions}
             fileUploaderService={fileUploaderService}
-            disableSendButton={
-              disableSendButton || fileUploaderService.isProcessingFiles
+            isSubmitting={
+              isLocalSubmitting || fileUploaderService.isProcessingFiles
             }
-            disableTextInput={disable}
+            disableInput={disable}
             onNodeSelect={handleNodesAttachmentSelect}
             onNodeUnselect={handleNodesAttachmentRemove}
             selectedMCPServerViews={selectedMCPServerViews}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -65,8 +65,8 @@ export interface InputBarContainerProps {
   stickyMentions?: AgentMention[];
   actions: InputBarAction[];
   disableAutoFocus: boolean;
-  disableSendButton: boolean;
-  disableTextInput: boolean;
+  isSubmitting: boolean;
+  disableInput: boolean;
   fileUploaderService: FileUploaderService;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
@@ -86,8 +86,8 @@ const InputBarContainer = ({
   stickyMentions,
   actions,
   disableAutoFocus,
-  disableSendButton,
-  disableTextInput,
+  isSubmitting,
+  disableInput,
   fileUploaderService,
   onNodeSelect,
   onNodeUnselect,
@@ -383,6 +383,8 @@ const InputBarContainer = ({
     };
   }, [editor, editorService]);
 
+  const disableTextInput = isSubmitting || disableInput;
+
   // Disable the editor when disableTextInput is true.
   useEffect(() => {
     if (editor) {
@@ -633,14 +635,14 @@ const InputBarContainer = ({
               <Button
                 size={buttonSize}
                 isLoading={
-                  disableSendButton &&
+                  isSubmitting &&
                   voiceTranscriberService.status !== "transcribing"
                 }
                 icon={ArrowUpIcon}
                 variant="highlight"
                 disabled={
                   isEmpty ||
-                  disableSendButton ||
+                  disableTextInput ||
                   voiceTranscriberService.status !== "idle"
                 }
                 onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## Description

- Posting message should be prohibited when the conversation is blocked by actions that are pending validation or personal authentication.
- This behavior was lost in https://github.com/dust-tt/dust/pull/16388
- This PR adds back a fixed version of it.

## Tests

- Tested locally.

## Risk

- Medium to high as it affects the blocking state of the input bar, can be safely reverted.

## Deploy Plan

- Deploy front.
