### PR TITLE
Re-enable inline latex support

### DIFF
--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -24,7 +24,7 @@ import {
   TableHeadBlock,
   TableHeaderBlock,
 } from "@sparkle/components/markdown/TableBlock";
-import { sanitizeContent } from "@sparkle/components/markdown/utils";
+import { preprocessDollarSigns, sanitizeContent } from "@sparkle/components/markdown/utils";
 import { cn } from "@sparkle/lib/utils";
 
 export const markdownHeaderClasses = {
@@ -70,7 +70,10 @@ export function Markdown({
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
 }) {
-  const processedContent = useMemo(() => sanitizeContent(content), [content]);
+  const processedContent = useMemo(() => {
+    const sanitized = sanitizeContent(content);
+    return preprocessDollarSigns(sanitized);
+  }, [content]);
 
   // Note on re-renderings. A lot of effort has been put into preventing rerendering across markdown
   // AST parsing rounds (happening at each token being streamed).
@@ -214,7 +217,7 @@ export function Markdown({
     () => [
       remarkDirective,
       remarkGfm,
-      [remarkMath, { singleDollarTextMath: false }],
+      [remarkMath, { singleDollarTextMath: true }],
       ...(additionalMarkdownPlugins || []),
       showUnsupportedDirective,
     ],

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -24,7 +24,10 @@ import {
   TableHeadBlock,
   TableHeaderBlock,
 } from "@sparkle/components/markdown/TableBlock";
-import { preprocessDollarSigns, sanitizeContent } from "@sparkle/components/markdown/utils";
+import {
+  preprocessDollarSigns,
+  sanitizeContent,
+} from "@sparkle/components/markdown/utils";
 import { cn } from "@sparkle/lib/utils";
 
 export const markdownHeaderClasses = {

--- a/sparkle/src/components/markdown/utils.ts
+++ b/sparkle/src/components/markdown/utils.ts
@@ -63,15 +63,15 @@ export function preprocessDollarSigns(content: string): string {
         // 2. Protect currency patterns
         // Matches: $100, $5.99, $1,000.50, $50k, $2.5M, $1 billion, etc.
         line = line.replace(
-          /\$(\d+(?:,\d{3})*(?:\.\d{1,2})?(?:\s*(?:USD|EUR|CAD|GBP|million|billion|thousand|[kKmMbB]))?)\b/g,
+          /(?<!\\)\$(\d+(?:,\d{3})*(?:\.\d{1,2})?(?:\s*(?:USD|EUR|CAD|GBP|million|billion|thousand|[kKmMbB]))?)\b/g,
           "\\$$$1"
         );
 
         // 3. Protect shell/code variables
         // Matches: $HOME, $PATH, $USER, ${variable}, ${foo.bar}
-        line = line.replace(/\$([A-Z_][A-Z0-9_]*)\b/g, "\\$$$1");
+        line = line.replace(/(?<!\\)\$([A-Z_][A-Z0-9_]*)\b/g, "\\$$$1");
 
-        line = line.replace(/\$\{([^}]+)\}/g, "\\${$1}");
+        line = line.replace(/(?<!\\)\$\{([^}]+)\}/g, "\\${$1}");
       }
       return line;
     })

--- a/sparkle/src/components/markdown/utils.ts
+++ b/sparkle/src/components/markdown/utils.ts
@@ -41,35 +41,41 @@ export function detectLanguage(children: React.ReactNode) {
 }
 
 /**
- * Preprocesses content to escape dollar signs that are likely NOT LaTeX math. This helps prevent
- * false positives when enabling single $ math rendering.
+ * Preprocesses content to escape dollar signs that are likely NOT inlione LaTeX math. This helps
+ * prevent false positives when enabling single $ math rendering.
  *
  * Patterns that are escaped:
+ * 1. Solo dollar signs: `$` (not part of a pair)
  * 1. Currency amounts: $100, $5.99, $1,000, $50k, $2.5M, $1 billion
  * 2. Shell/code variables: $HOME, $PATH, ${variable}
- * 3. Price ranges: "$50 to $100", "$5-$10"
  */
 export function preprocessDollarSigns(content: string): string {
   let processed = content;
 
-  // 1. Protect currency patterns
-  // Matches: $100, $5.99, $1,000.50, $50k, $2.5M, $1 billion, etc.
-  processed = processed.replace(
-    /\$(\d+(?:,\d{3})*(?:\.\d{1,2})?(?:\s*(?:USD|EUR|CAD|GBP|million|billion|thousand|[kKmMbB]))?)\b/g,
-    '\\$$$1'
-  );
+  processed = processed
+    .split("\n")
+    .map((line) => {
+      const unescapedDollarMatches = line.match(/(?<!\\)\$/g) ?? [];
+      // 1. Escape solo dollar signs per line: we ignore math spans crossing newlines.
+      if (unescapedDollarMatches.length === 1) {
+        return line.replace(/(?<!\\)\$/, "\\$");
+      } else if (unescapedDollarMatches.length > 1) {
+        // 2. Protect currency patterns
+        // Matches: $100, $5.99, $1,000.50, $50k, $2.5M, $1 billion, etc.
+        line = line.replace(
+          /\$(\d+(?:,\d{3})*(?:\.\d{1,2})?(?:\s*(?:USD|EUR|CAD|GBP|million|billion|thousand|[kKmMbB]))?)\b/g,
+          "\\$$$1"
+        );
 
-  // 2. Protect shell/code variables
-  // Matches: $HOME, $PATH, $USER, ${variable}, ${foo.bar}
-  processed = processed.replace(
-    /\$([A-Z_][A-Z0-9_]*)\b/g,
-    '\\$$$1'
-  );
+        // 3. Protect shell/code variables
+        // Matches: $HOME, $PATH, $USER, ${variable}, ${foo.bar}
+        line = line.replace(/\$([A-Z_][A-Z0-9_]*)\b/g, "\\$$$1");
 
-  processed = processed.replace(
-    /\$\{([^}]+)\}/g,
-    '\\${$1}'
-  );
+        line = line.replace(/\$\{([^}]+)\}/g, "\\${$1}");
+      }
+      return line;
+    })
+    .join("\n");
 
   return processed;
 }

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -128,9 +128,13 @@ Even **optimizers** are associative memories. Momentum with gradient descent is 
 
 The result is $a=2+t$
 
-### Some text with dollars
+### Some text with dollars signs:
 
 One want to import $USER_WORKSPACE but it will cost them $3.5 or $100 $1000
+
+-> The EF for this code is 0.49059 kgCO2e per $ (2018 USD).
+-> This code is 0.54895 kgCO2e per $ (2018 USD) more.
+-> This thing is $5-$10 range.
 
 ### This is a CSV:
 

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -112,9 +112,25 @@ footnote [^1]
 
 
 
-### Some lateX
+### Some LaTeX
 
 $$ \\sigma(z_i) = \\frac{e^{z_{i}}}{\\sum_{j=1}^K e^{z_{j}}} \\ \\ \\ for\\ i=1,2,\\dots,K $$
+
+### Some inline LaTeX
+
+**Example**: Linear attention is a 2-level optimization:
+- Inner level: Memory matrix $\\mathcal{M}_t = \\mathcal{M}_{t-1} + \\mathbf{v}_t \\mathbf{k}_t^\\top$ (updates every token)
+- Outer level: Projection matrices $W_k, W_v, W_q$ (updates during pre-training)
+
+Even **optimizers** are associative memories. Momentum with gradient descent is 2-level:
+- Momentum $\\mathbf{m}_t$ compresses past gradients
+- Weights $W_t$ are updated by momentum
+
+The result is $a=2+t$
+
+### Some text with dollars
+
+One want to import $USER_WORKSPACE but it will cost them $3.5 or $100 $1000
 
 ### This is a CSV:
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/5266

We disabled in the past inline Latex but models use it a lot. This PR attempts to re-enable it but with a pre-processing step of the markdown data that attempts to escape the dollar signs in simple common cases (use of $ as a currency or for ENV variables names, or spanning multiple lines).

<img width="557" height="456" alt="Screenshot 2025-12-03 at 14 03 14" src="https://github.com/user-attachments/assets/11bc51f8-9c1d-4756-ac4f-125bb71dbeab" />

## Tests

Updated stories

## Risk

Low: worst case scenario are some display issues

## Deploy Plan

- TBD post review (sparkle bump etc...)