### PR TITLE
Call unpause and resume in all cases, remove check on paused status

### DIFF
--- a/connectors/src/api/unpause_connector.ts
+++ b/connectors/src/api/unpause_connector.ts
@@ -27,15 +27,6 @@ const _unpauseConnectorAPIHandler = async (
         status_code: 404,
       });
     }
-    if (!connector.isPaused()) {
-      logger.info(
-        {
-          connectorId: connector.id,
-        },
-        "No-Op: Connector is not paused"
-      );
-      return res.sendStatus(204);
-    }
 
     const unpauseRes = await getConnectorManager({
       connectorProvider: connector.type,


### PR DESCRIPTION
## Description

context: https://github.com/dust-tt/tasks/issues/5262

the cli and the ui in poke (and connectors api endpoint) were inconsistent, as the endpoint was checking the paused status before unpausing, whereas cli does not. In order to make things clearer stop/resume have been removed from poke, only "unpause" is available - it should be callable to resume even if the connectors was not explicitly paused.

"resume" has different implementations depending on the connectors - usually does nothing if workflows are already started/scheduled, but sometime restart them.

The impact on changing the api is that "unpauseAllManagedDataSources" will call resume on all connectors in all cases - but as it's only called on cli or when relocating, this should not be an issue.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy connectors
