### PR TITLE
[sparkle] fix: Take string content only

### DIFF
--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -35,7 +35,7 @@ export function BlockquoteBlock({
 
   // Convert array content to string if necessary
   const contentAsString = Array.isArray(childrenContent)
-    ? childrenContent.join("")
+    ? childrenContent.filter((c) => typeof c === "string").join("")
     : childrenContent;
 
   // Only pass content if it exists


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/5307
## Description

children can contain react component , filter to copy only text in clipboard 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle
