### PR TITLE
Update conversation viewer to send content fragment attached to user message directly.

### DIFF
--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -18,6 +18,7 @@ import type {
   RichMention,
   UserMessageOrigin,
   UserMessageType,
+  UserMessageTypeWithContentFragments,
   UserType,
 } from "@app/types";
 import { isLightAgentMessageWithActionsType } from "@app/types";
@@ -58,9 +59,7 @@ export type AgentMessageStateWithControlEvent =
 
 export type VirtuosoMessage =
   | MessageTemporaryState
-  | (UserMessageType & {
-      contentFragments: ContentFragmentType[];
-    });
+  | UserMessageTypeWithContentFragments;
 
 export type VirtuosoMessageListContext = {
   owner: LightWorkspaceType;

--- a/front/lib/client/conversation/event_handlers.ts
+++ b/front/lib/client/conversation/event_handlers.ts
@@ -1,48 +1,6 @@
-import cloneDeep from "lodash/cloneDeep";
-
-import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { FetchConversationParticipantsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/participants";
-import type {
-  AgentMessageNewEvent,
-  AgentMessageType,
-  FetchConversationMessagesResponse,
-  UserMessageNewEvent,
-  UserMessageType,
-} from "@app/types";
+import type { AgentMessageNewEvent, UserMessageNewEvent } from "@app/types";
 import { isAgentMessageType, isUserMessageType } from "@app/types";
-
-/**
- * If no message pages exist, create a single page with the optimistic message.
- * If message pages exist, add the optimistic message to the first page, since
- * the message pages array is not yet reversed.
- */
-export function updateMessagePagesWithOptimisticData(
-  currentMessagePages: FetchConversationMessagesResponse[] | undefined,
-  messageOrPlaceholder: AgentMessageType | UserMessageType
-): FetchConversationMessagesResponse[] {
-  const m = isAgentMessageType(messageOrPlaceholder)
-    ? {
-        ...getLightAgentMessageFromAgentMessage(messageOrPlaceholder),
-        rank: messageOrPlaceholder.rank,
-      }
-    : messageOrPlaceholder;
-
-  if (!currentMessagePages || currentMessagePages.length === 0) {
-    return [
-      {
-        messages: [m],
-        hasMore: false,
-        lastValue: null,
-      },
-    ];
-  }
-
-  // We need to deep clone here, since SWR relies on the reference.
-  const updatedMessages = cloneDeep(currentMessagePages);
-  updatedMessages.at(0)?.messages.push(m);
-
-  return updatedMessages;
-}
 
 // Function to update the participants with the new message from the event.
 export function getUpdatedParticipantsFromEvent(

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -120,7 +120,7 @@ const getConversationDetails = async ({
           auth,
           conversation,
           [messageRes.value],
-          "legacy-light"
+          "light"
         );
 
         if (rendered.isOk() && rendered.value.length === 1) {

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -18,6 +18,7 @@ import type {
   PatchConversationsRequestBody,
 } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
 import type { GetConversationFilesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
+import type { FetchConversationMessagesResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";
 import type { FetchConversationMessageResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]";
 import type { FetchConversationParticipantsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/participants";
 import type {
@@ -27,7 +28,6 @@ import type {
 import type {
   ConversationError,
   ConversationWithoutContentType,
-  FetchConversationMessagesResponse,
   LightWorkspaceType,
 } from "@app/types";
 
@@ -146,10 +146,10 @@ export function useConversationMessages({
         }
 
         if (previousPageData === null) {
-          return `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages?orderDirection=desc&orderColumn=rank&limit=${limit}`;
+          return `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages?newResponseFormat=1&orderDirection=desc&orderColumn=rank&limit=${limit}`;
         }
 
-        return `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages?lastValue=${previousPageData.lastValue}&orderDirection=desc&orderColumn=rank&limit=${limit}`;
+        return `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages?newResponseFormat=1&lastValue=${previousPageData.lastValue}&orderDirection=desc&orderColumn=rank&limit=${limit}`;
       },
       messagesFetcher,
       {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -16,7 +16,8 @@ import { apiError } from "@app/logger/withlogging";
 import type {
   AgentMessageType,
   ContentFragmentType,
-  FetchConversationMessagesResponse,
+  LegacyLightMessageType,
+  LightMessageType,
   UserMessageType,
   WithAPIErrorResponse,
 } from "@app/types";
@@ -33,11 +34,26 @@ export type PostMessagesResponseBody = {
   agentMessages: AgentMessageType[];
 };
 
+// TODO remove after monday 2025-12-01 (once everyone has likely reloaded their browser)
+interface LegacyFetchConversationMessagesResponse {
+  hasMore: boolean;
+  lastValue: number | null;
+  messages: LegacyLightMessageType[];
+}
+
+export interface FetchConversationMessagesResponse {
+  hasMore: boolean;
+  lastValue: number | null;
+  messages: LightMessageType[];
+}
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<
-      PostMessagesResponseBody | FetchConversationMessagesResponse
+      | PostMessagesResponseBody
+      | LegacyFetchConversationMessagesResponse
+      | FetchConversationMessagesResponse
     >
   >,
   auth: Authenticator
@@ -81,11 +97,16 @@ async function handler(
         );
       }
 
+      const useNewResponseFormat = req.query.newResponseFormat === "1";
+
       // Note that we don't use the order column and order direction here because we enforce sorting by rank in descending order.
       const messagesRes = await fetchConversationMessages(auth, {
         conversationId,
         limit: paginationRes.value.limit,
         lastRank: paginationRes.value.lastValue,
+        viewType: useNewResponseFormat
+          ? ("light" as const)
+          : ("legacy-light" as const),
       });
 
       if (messagesRes.isErr()) {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -43,6 +43,11 @@ export type LegacyLightMessageType =
   | UserMessageType
   | ContentFragmentType;
 
+// This is the new format where content fragments are attached to the user messages.
+export type LightMessageType =
+  | LightAgentMessageType
+  | UserMessageTypeWithContentFragments;
+
 /**
  * User messages
  */
@@ -123,10 +128,20 @@ export type UserMessageType = {
   agenticMessageData?: AgenticMessageData;
 };
 
+export type UserMessageTypeWithContentFragments = UserMessageType & {
+  contentFragments: ContentFragmentType[];
+};
+
 export function isUserMessageType(
-  arg: MessageType | LegacyLightMessageType
+  arg: MessageType | LegacyLightMessageType | LightMessageType
 ): arg is UserMessageType {
   return arg.type === "user_message";
+}
+
+export function isUserMessageTypeWithContentFragments(
+  arg: MessageType | LightMessageType
+): arg is UserMessageTypeWithContentFragments {
+  return arg.type === "user_message" && "contentFragments" in arg;
 }
 
 /**
@@ -312,12 +327,6 @@ export type SubmitMessageError = {
   title: string;
   message: string;
 };
-
-export interface FetchConversationMessagesResponse {
-  hasMore: boolean;
-  lastValue: number | null;
-  messages: LegacyLightMessageType[];
-}
 
 /**
  * Conversation events.


### PR DESCRIPTION
## Description

Use the new reponse format where content fragments are bundled with the user messages in the backend.
I kept backward compatibility until everybody has reloaded their page.

## Tests

Local

## Risk

Medium

## Deploy Plan

Deploy front