### PR TITLE
UserSearch: indexation

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -19,6 +19,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger, { auditLog } from "@app/logger/logger";
+import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import type {
   LightWorkspaceType,
   MembershipOriginType,
@@ -546,6 +547,15 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       newRole: role,
     });
 
+    // Update user search index across all workspaces
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: user.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
+    }
+
     return new MembershipResource(MembershipModel, newMembership.get());
   }
 
@@ -628,6 +638,15 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           "Failed to deactivate WorkOS membership"
         );
       }
+    }
+
+    // Update user search index across all workspaces
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: user.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
     }
 
     return new Ok({
@@ -746,6 +765,16 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       },
       "Membership role updated"
     );
+
+    // Update user search index across all workspaces
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: user.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
+    }
+
     return new Ok({ previousRole, newRole });
   }
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -19,7 +19,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger, { auditLog } from "@app/logger/logger";
-import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
+// import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import type {
   LightWorkspaceType,
   MembershipOriginType,
@@ -548,13 +548,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
 
     // Update user search index across all workspaces
-    const workflowResult = await launchIndexUserSearchWorkflow({
-      userId: user.sId,
-    });
-    if (workflowResult.isErr()) {
-      // Throw if it fails to launch (unexpected).
-      throw workflowResult.error;
-    }
+    // const workflowResult = await launchIndexUserSearchWorkflow({
+    //   userId: user.sId,
+    // });
+    // if (workflowResult.isErr()) {
+    //   // Throw if it fails to launch (unexpected).
+    //   throw workflowResult.error;
+    // }
 
     return new MembershipResource(MembershipModel, newMembership.get());
   }
@@ -641,13 +641,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     }
 
     // Update user search index across all workspaces
-    const workflowResult = await launchIndexUserSearchWorkflow({
-      userId: user.sId,
-    });
-    if (workflowResult.isErr()) {
-      // Throw if it fails to launch (unexpected).
-      throw workflowResult.error;
-    }
+    // const workflowResult = await launchIndexUserSearchWorkflow({
+    //   userId: user.sId,
+    // });
+    // if (workflowResult.isErr()) {
+    //   // Throw if it fails to launch (unexpected).
+    //   throw workflowResult.error;
+    // }
 
     return new Ok({
       role: membership.role,
@@ -767,13 +767,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     );
 
     // Update user search index across all workspaces
-    const workflowResult = await launchIndexUserSearchWorkflow({
-      userId: user.sId,
-    });
-    if (workflowResult.isErr()) {
-      // Throw if it fails to launch (unexpected).
-      throw workflowResult.error;
-    }
+    // const workflowResult = await launchIndexUserSearchWorkflow({
+    //   userId: user.sId,
+    // });
+    // if (workflowResult.isErr()) {
+    //   // Throw if it fails to launch (unexpected).
+    //   throw workflowResult.error;
+    // }
 
     return new Ok({ previousRole, newRole });
   }

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -16,7 +16,7 @@ import {
   UserModel,
 } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
+// import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import type { LightWorkspaceType, ModelId, Result, UserType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 import type { UserSearchDocument } from "@app/types/user_search/user_search";
@@ -62,13 +62,13 @@ export class UserResource extends BaseResource<UserModel> {
     const userResource = new this(UserModel, user.get());
 
     // Update user search index across all workspaces.
-    const workflowResult = await launchIndexUserSearchWorkflow({
-      userId: userResource.sId,
-    });
-    if (workflowResult.isErr()) {
-      // Throw if it fails to launch (unexpected).
-      throw workflowResult.error;
-    }
+    // const workflowResult = await launchIndexUserSearchWorkflow({
+    //   userId: userResource.sId,
+    // });
+    // if (workflowResult.isErr()) {
+    //   // Throw if it fails to launch (unexpected).
+    //   throw workflowResult.error;
+    // }
 
     return userResource;
   }
@@ -272,13 +272,13 @@ export class UserResource extends BaseResource<UserModel> {
     });
 
     // Update user search index across all workspaces.
-    const workflowResult = await launchIndexUserSearchWorkflow({
-      userId: this.sId,
-    });
-    if (workflowResult.isErr()) {
-      // Throw if it fails to launch (unexpected).
-      throw workflowResult.error;
-    }
+    // const workflowResult = await launchIndexUserSearchWorkflow({
+    //   userId: this.sId,
+    // });
+    // if (workflowResult.isErr()) {
+    //   // Throw if it fails to launch (unexpected).
+    //   throw workflowResult.error;
+    // }
 
     return result;
   }
@@ -310,13 +310,13 @@ export class UserResource extends BaseResource<UserModel> {
     });
 
     // Update user search index across all workspaces.
-    const workflowResult = await launchIndexUserSearchWorkflow({
-      userId: this.sId,
-    });
-    if (workflowResult.isErr()) {
-      // Throw if it fails to launch (unexpected).
-      throw workflowResult.error;
-    }
+    // const workflowResult = await launchIndexUserSearchWorkflow({
+    //   userId: this.sId,
+    // });
+    // if (workflowResult.isErr()) {
+    //   // Throw if it fails to launch (unexpected).
+    //   throw workflowResult.error;
+    // }
 
     return result;
   }

--- a/front/lib/user_search/index.ts
+++ b/front/lib/user_search/index.ts
@@ -38,65 +38,21 @@ export async function indexUserDocument(
 }
 
 /**
- * Update an existing user document with partial data.
- */
-export async function updateUserDocument(
-  workspaceId: string,
-  userId: string,
-  partialUpdate: Partial<UserSearchDocument>
-): Promise<Result<void, ElasticsearchError>> {
-  const documentId = makeUserDocumentId({ workspaceId, userId });
-
-  return withEs(async (client) => {
-    await client.update({
-      index: USER_SEARCH_ALIAS_NAME,
-      id: documentId,
-      body: {
-        doc: partialUpdate,
-      },
-    });
-  });
-}
-
-/**
  * Delete a user document from Elasticsearch.
  */
-export async function deleteUserDocument(
-  workspaceId: string,
-  userId: string
-): Promise<Result<void, ElasticsearchError>> {
+export async function deleteUserDocument({
+  workspaceId,
+  userId,
+}: {
+  workspaceId: string;
+  userId: string;
+}): Promise<Result<void, ElasticsearchError>> {
   const documentId = makeUserDocumentId({ workspaceId, userId });
 
   return withEs(async (client) => {
     await client.delete({
       index: USER_SEARCH_ALIAS_NAME,
       id: documentId,
-    });
-  });
-}
-
-/**
- * Bulk index user documents for batch operations.
- */
-export async function bulkIndexUserDocuments(
-  documents: UserSearchDocument[]
-): Promise<Result<void, ElasticsearchError>> {
-  return withEs(async (client) => {
-    const body = documents.flatMap((doc) => {
-      const documentId = makeUserDocumentId({
-        workspaceId: doc.workspace_id,
-        userId: doc.user_id,
-      });
-
-      return [
-        { index: { _index: USER_SEARCH_ALIAS_NAME, _id: documentId } },
-        doc,
-      ];
-    });
-
-    await client.bulk({
-      body,
-      refresh: false, // Don't force refresh for performance
     });
   });
 }

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -69,6 +69,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/upsert_queue");
     case "upsert_table_queue":
       return path.join(baseDir, "temporal/upsert_tables");
+    case "es_indexation_queue":
+      return path.join(baseDir, "temporal/es_indexation");
     case "workos_events_queue":
       return path.join(baseDir, "temporal/workos_events_queue");
     default:

--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -1,0 +1,74 @@
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { deleteUserDocument, indexUserDocument } from "@app/lib/user_search";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
+
+export async function indexUserSearchActivity({
+  userId,
+}: {
+  userId: string;
+}): Promise<void> {
+  const user = await UserResource.fetchById(userId);
+  if (!user) {
+    throw new Error(`User not found: ${userId}`);
+  }
+
+  // Get all memberships for this user
+  const { memberships } = await MembershipResource.getLatestMemberships({
+    users: [user],
+  });
+
+  // Process each membership
+  for (const membership of memberships) {
+    const workspace = await WorkspaceResource.fetchByModelId(
+      membership.workspaceId
+    );
+    if (!workspace) {
+      logger.warn(
+        { membershipId: membership.id, workspaceId: membership.workspaceId },
+        `[user_search] Failed to retrieve workspace (likely scrubbed)`
+      );
+      continue;
+    }
+
+    if (membership.isRevoked()) {
+      // If we didn't find the workspace (scrubbed) or membership is revoked, remove user from index
+      const deleteResult = await deleteUserDocument({
+        workspaceId: workspace.sId,
+        userId: user.sId,
+      });
+      if (deleteResult.isErr()) {
+        // Log but don't fail - user might not be in index
+        logger.warn(
+          {
+            userId: user.sId,
+            workspaceId: workspace.sId,
+            error: deleteResult.error,
+          },
+          `[user_search] Failed to de-index user for workspace`
+        );
+      }
+    } else {
+      // Membership is active, index user in this workspace
+      const document = user.toUserSearchDocument(
+        renderLightWorkspaceType({ workspace, role: membership.role })
+      );
+      const indexResult = await indexUserDocument(document);
+      if (indexResult.isErr()) {
+        logger.error(
+          {
+            userId: user.sId,
+            workspaceId: workspace.sId,
+            error: indexResult.error,
+          },
+          `[user_search] Failed to index user for workspace`
+        );
+        throw new Error(
+          `Failed to index user ${user.sId} in workspace ${workspace.sId}: ${indexResult.error.message}`
+        );
+      }
+    }
+  }
+}

--- a/front/temporal/es_indexation/client.ts
+++ b/front/temporal/es_indexation/client.ts
@@ -1,0 +1,44 @@
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/es_indexation/config";
+import { makeIndexUserSearchWorkflowId } from "@app/temporal/es_indexation/helpers";
+import { indexUserSearchWorkflow } from "@app/temporal/es_indexation/workflows";
+import type { Result } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
+
+export async function launchIndexUserSearchWorkflow({
+  userId,
+}: {
+  userId: string;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  const workflowId = makeIndexUserSearchWorkflowId({ userId });
+
+  try {
+    await client.workflow.start(indexUserSearchWorkflow, {
+      args: [{ userId }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: {
+        userId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
+      logger.error(
+        {
+          workflowId,
+          userId,
+          error: e,
+        },
+        "Failed starting index user workflow"
+      );
+    }
+
+    return new Err(normalizeError(e));
+  }
+}

--- a/front/temporal/es_indexation/config.ts
+++ b/front/temporal/es_indexation/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `es-indexation-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/es_indexation/helpers.ts
+++ b/front/temporal/es_indexation/helpers.ts
@@ -1,0 +1,7 @@
+export function makeIndexUserSearchWorkflowId({
+  userId,
+}: {
+  userId: string;
+}): string {
+  return `es-indexation-user-search-${userId}`;
+}

--- a/front/temporal/es_indexation/worker.ts
+++ b/front/temporal/es_indexation/worker.ts
@@ -1,0 +1,39 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/es_indexation/activities";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runESIndexationQueueWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "es_indexation_queue",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 16,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/es_indexation/workflows.ts
+++ b/front/temporal/es_indexation/workflows.ts
@@ -1,0 +1,15 @@
+import { proxyActivities } from "@temporalio/workflow";
+
+import type * as activities from "@app/temporal/es_indexation/activities";
+
+const { indexUserSearchActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
+export async function indexUserSearchWorkflow({
+  userId,
+}: {
+  userId: string;
+}): Promise<void> {
+  await indexUserSearchActivity({ userId });
+}

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -62,7 +62,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   update_workspace_usage: runUpdateWorkspaceUsageWorker,
   upsert_queue: runUpsertQueueWorker,
   upsert_table_queue: runUpsertTableQueueWorker,
-  es_indexation_search_queue: runESIndexationQueueWorker,
+  es_indexation_queue: runESIndexationQueueWorker,
   workos_events_queue: runWorkOSEventsWorker,
 };
 

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -2,6 +2,7 @@ import { runPokeWorker } from "@app/poke/temporal/worker";
 import { runAgentLoopWorker } from "@app/temporal/agent_loop/worker";
 import { runAnalyticsWorker } from "@app/temporal/analytics_queue/worker";
 import { runDataRetentionWorker } from "@app/temporal/data_retention/worker";
+import { runESIndexationQueueWorker } from "@app/temporal/es_indexation/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runLabsTranscriptsWorker } from "@app/temporal/labs/transcripts/worker";
 import { runMentionsCountWorker } from "@app/temporal/mentions_count_queue/worker";
@@ -27,6 +28,7 @@ export type WorkerName =
   | "analytics_queue"
   | "data_retention"
   | "document_tracker"
+  | "es_indexation_queue"
   | "hard_delete"
   | "labs"
   | "mentions_count"
@@ -60,6 +62,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   update_workspace_usage: runUpdateWorkspaceUsageWorker,
   upsert_queue: runUpsertQueueWorker,
   upsert_table_queue: runUpsertTableQueueWorker,
+  es_indexation_search_queue: runESIndexationQueueWorker,
   workos_events_queue: runWorkOSEventsWorker,
 };
 


### PR DESCRIPTION
## Description

***Temporal Workflow Architecture***

- Workflow are on a shared `es_indexation` queue (to be shared with future ES indexation work)
- Workflow takes only userId (not workspace-specific)
- Activity fetches all user memberships and:
  - For active memberships: indexes the user in that workspace's search
  - For revoked memberships: removes the user from that workspace's search index

***Triggers Added***

Added but commented for now to avoid queue things pending worker setup in dust-infra.

`UserResource` (triggers on user data changes):
- `makeNew()` - When user is created
- `updateName()` - When first/last name is updated
- `updateInfo()` - When email or name is updated

MembershipResource (triggers on membership changes):
- `createMembership()` - When a new membership is created
- `revokeMembership()` - When a membership is revoked
- `updateMembershipRole()` - When a membership role changes

All triggers throw if the workflow fails to launch (not fire-and-forget), ensuring the workflow gets started whenever a change is made to any of these resources. 

## Tests

Tested locally

## Risk

Medium. Can impact user creation if interaction with the temporal client fails, otherwise low since this is just incremental write-only and not used yet.

## Deploy Plan

- deploy `front`
- work in `dust-infra` to add launch the new `es_indexation` worker
- uncomment triggers