### PR TITLE
feat(front): add markdown support for some extensions, with tests

### DIFF
--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -109,6 +109,7 @@ jobs:
         working-directory: front
         run: |
           explanations=$(cat << EOF
+          
           Relying on transitive dependencies is bad because:
           * Fragility: Your direct dependencies can remove or update their dependencies at any time, breaking your code without warning
           * No version control: You can't lock or manage versions of packages you don't explicitly declare

--- a/front/components/assistant/conversation/input_bar/editor/extensions/DataSourceLinkExtension.test.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/DataSourceLinkExtension.test.ts
@@ -1,0 +1,112 @@
+import type { Editor } from "@tiptap/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DataSourceLinkExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/DataSourceLinkExtension";
+import { EditorFactory } from "@app/components/assistant/conversation/input_bar/editor/extensions/tests/utils";
+
+describe("DataSourceLinkExtension", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = EditorFactory([DataSourceLinkExtension]);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("should handle data source link", () => {
+    editor.commands.setContent(
+      ":content_node_mention[Project Documentation]{url=https://example.com/docs}",
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const json = editor.getJSON();
+    expect(json.content).toEqual([
+      {
+        content: [
+          {
+            attrs: {
+              nodeId: null,
+              provider: null,
+              spaceId: null,
+              title: "Project Documentation",
+              url: "https://example.com/docs",
+            },
+            type: "dataSourceLink",
+          },
+        ],
+        type: "paragraph",
+      },
+    ]);
+
+    const result = editor.getMarkdown();
+    expect(result).toBe(":content_node_mention[Project Documentation]");
+  });
+
+  it("should handle data source link with space and other characters", () => {
+    editor.commands.setContent(
+      ":content_node_mention[My Document (v2.0) - Final.pdf]{url=https://example.com/docs/My%20Document%20(v2.0)%20-%20Final.pdf}",
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const json = editor.getJSON();
+    expect(json.content).toEqual([
+      {
+        content: [
+          {
+            attrs: {
+              nodeId: null,
+              provider: null,
+              spaceId: null,
+              title: "My Document (v2.0) - Final.pdf",
+              url: "https://example.com/docs/My%20Document%20(v2.0)%20-%20Final.pdf",
+            },
+            type: "dataSourceLink",
+          },
+        ],
+        type: "paragraph",
+      },
+    ]);
+
+    const result = editor.getMarkdown();
+    expect(result).toBe(
+      ":content_node_mention[My Document (v2.0) - Final.pdf]"
+    );
+  });
+
+  it("should handle data source link of google docs", () => {
+    editor.commands.setContent(
+      ":content_node_mention[Goodies Stock]{url=https://docs.google.com/spreadsheets/d/1fiWXOaCHIVybS1ZD9ODeVt2EvNPyESwRZe0bET47-h0/edit?gid=0#gid=0}",
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const json = editor.getJSON();
+    expect(json.content).toEqual([
+      {
+        content: [
+          {
+            attrs: {
+              nodeId: null,
+              provider: null,
+              spaceId: null,
+              title: "Goodies Stock",
+              url: "https://docs.google.com/spreadsheets/d/1fiWXOaCHIVybS1ZD9ODeVt2EvNPyESwRZe0bET47-h0/edit?gid=0#gid=0",
+            },
+            type: "dataSourceLink",
+          },
+        ],
+        type: "paragraph",
+      },
+    ]);
+
+    const result = editor.getMarkdown();
+    expect(result).toBe(":content_node_mention[Goodies Stock]");
+  });
+});

--- a/front/components/assistant/conversation/input_bar/editor/extensions/MentionExtension.test.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/MentionExtension.test.ts
@@ -1,0 +1,75 @@
+import type { Editor } from "@tiptap/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { MentionExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionExtension";
+import { EditorFactory } from "@app/components/assistant/conversation/input_bar/editor/extensions/tests/utils";
+
+describe("MentionExtension", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = EditorFactory([MentionExtension]);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("should handle agent mention", () => {
+    editor.commands.setContent(":mention[Code Assistant]{sId=agent-123}", {
+      contentType: "markdown",
+    });
+
+    const json = editor.getJSON();
+    expect(json.content).toEqual([
+      {
+        content: [
+          {
+            attrs: {
+              description: null,
+              id: "agent-123",
+              label: "Code Assistant",
+              mentionSuggestionChar: "@",
+              pictureUrl: null,
+              type: "agent",
+            },
+            type: "mention",
+          },
+        ],
+        type: "paragraph",
+      },
+    ]);
+
+    const result = editor.getMarkdown();
+    expect(result).toBe(":mention[Code Assistant]{sId=agent-123}");
+  });
+
+  it("should handle user mention", () => {
+    editor.commands.setContent(":mention_user[John Doe]{sId=user-456}", {
+      contentType: "markdown",
+    });
+
+    const json = editor.getJSON();
+    expect(json.content).toEqual([
+      {
+        content: [
+          {
+            attrs: {
+              description: null,
+              id: "user-456",
+              label: "John Doe",
+              mentionSuggestionChar: "@",
+              pictureUrl: null,
+              type: "user",
+            },
+            type: "mention",
+          },
+        ],
+        type: "paragraph",
+      },
+    ]);
+
+    const result = editor.getMarkdown();
+    expect(result).toBe(":mention_user[John Doe]{sId=user-456}");
+  });
+});

--- a/front/components/assistant/conversation/input_bar/editor/extensions/MentionExtension.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/MentionExtension.tsx
@@ -126,6 +126,17 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
     },
   },
 
+  renderMarkdown: (node) => {
+    const mentionType = node.attrs?.type ?? "agent";
+    const id = node.attrs?.id ?? "";
+    const label = node.attrs?.label ?? "";
+
+    if (mentionType === "user") {
+      return `:mention_user[${label}]{sId=${id}}`;
+    }
+    return `:mention[${label}]{sId=${id}}`;
+  },
+
   // Parse Markdown token to Tiptap JSON
   parseMarkdown: (token) => {
     return {

--- a/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.test.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.test.ts
@@ -1,0 +1,77 @@
+import type { Editor } from "@tiptap/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { PastedAttachmentExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension";
+import { EditorFactory } from "@app/components/assistant/conversation/input_bar/editor/extensions/tests/utils";
+
+describe("PastedAttachmentExtension", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = EditorFactory([PastedAttachmentExtension]);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("should handle pasted content", () => {
+    editor.commands.setContent(
+      ":pasted_content[Document.pdf]{pastedId=file-123}",
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const json = editor.getJSON();
+    expect(json.content).toEqual([
+      {
+        content: [
+          {
+            attrs: {
+              fileId: "file-123",
+              textContent: null,
+              title: "Document.pdf",
+            },
+            type: "pastedAttachment",
+          },
+        ],
+        type: "paragraph",
+      },
+    ]);
+
+    const result = editor.getMarkdown();
+    expect(result).toBe(":pasted_content[Document.pdf]{pastedId=file-123}");
+  });
+
+  it("should handle pasted content with space and other characters", () => {
+    editor.commands.setContent(
+      ":pasted_content[My File (2024).pdf]{pastedId=file-456}",
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const json = editor.getJSON();
+    expect(json.content).toEqual([
+      {
+        content: [
+          {
+            attrs: {
+              fileId: "file-456",
+              textContent: null,
+              title: "My File (2024).pdf",
+            },
+            type: "pastedAttachment",
+          },
+        ],
+        type: "paragraph",
+      },
+    ]);
+
+    const result = editor.getMarkdown();
+    expect(result).toBe(
+      ":pasted_content[My File (2024).pdf]{pastedId=file-456}"
+    );
+  });
+});

--- a/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.ts
@@ -7,6 +7,10 @@ export interface PastedAttachmentOptions {
   onInlineText?: (fileId: string, textContent: string) => void;
 }
 
+// Regex to match :pasted_content[title]{pastedId=fileId}
+const PASTED_ATTACHMENT_REGEX_BEGINNING =
+  /^:pasted_content\[([^\]]+)]\{pastedId=([^}]+)}/;
+
 export const PastedAttachmentExtension = Node.create<PastedAttachmentOptions>({
   name: "pastedAttachment",
   group: "inline",
@@ -40,5 +44,44 @@ export const PastedAttachmentExtension = Node.create<PastedAttachmentOptions>({
 
   addNodeView() {
     return ReactNodeViewRenderer(PastedAttachmentComponent);
+  },
+
+  // Define a custom Markdown tokenizer to recognize :pasted_content: syntax
+  markdownTokenizer: {
+    name: "pastedAttachment",
+    level: "inline", // inline element
+    // Fast hint for the lexer to find candidate positions
+    start: (src) => src.indexOf(":pasted_content"),
+    tokenize: (src) => {
+      const match = PASTED_ATTACHMENT_REGEX_BEGINNING.exec(src);
+      if (!match) {
+        return undefined;
+      }
+
+      return {
+        type: "pastedAttachment", // token type (must match name)
+        raw: match[0], // full matched string
+        attrs: {
+          title: match[1],
+          fileId: match[2],
+        },
+      };
+    },
+  },
+
+  parseMarkdown: (token) => {
+    return {
+      type: "pastedAttachment",
+      attrs: {
+        title: token.attrs.title,
+        fileId: token.attrs.fileId,
+      },
+    };
+  },
+
+  renderMarkdown: (node) => {
+    const title = node.attrs?.title ?? "";
+    const fileId = node.attrs?.fileId ?? "";
+    return `:pasted_content[${title}]{pastedId=${fileId}}`;
   },
 });

--- a/front/components/assistant/conversation/input_bar/editor/extensions/tests/utils.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/tests/utils.ts
@@ -1,0 +1,10 @@
+import type { Extensions } from "@tiptap/core";
+import { Markdown } from "@tiptap/markdown";
+import { Editor } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+
+export const EditorFactory = (extensions: Extensions) => {
+  return new Editor({
+    extensions: [StarterKit, ...extensions, Markdown],
+  });
+};


### PR DESCRIPTION
## Description

This is the first PR to have tiptap render messages. It'll be split in two main parts: User messages, agent messages.

The plan:
1. Add markdown support for user inputs
1. Render user messages with tiptap
1. Add markdown support for agent inputs (there are more)
1. Render agent messages with tiptap
1. Remove old markdown support

This PR is 1)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
