### PR TITLE
Calculate default tool stake

### DIFF
--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -12,11 +12,11 @@ import {
 import { useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
-import type { MCPServerFormValues } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import type {MCPServerFormValues} from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import { getDefaultInternalToolStakeLevel  } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   CUSTOM_REMOTE_MCP_TOOL_STAKE_LEVELS,
-  FALLBACK_MCP_TOOL_STAKE_LEVEL,
   MCP_TOOL_STAKE_LEVELS,
 } from "@app/lib/actions/constants";
 import { isRemoteMCPServerType } from "@app/lib/actions/mcp_helper";
@@ -39,6 +39,7 @@ interface ToolItemProps {
     enabled: boolean;
     permission: MCPToolStakeLevelType;
   };
+  defaultPermission: MCPToolStakeLevelType;
 }
 
 function ToolItem({
@@ -46,6 +47,7 @@ function ToolItem({
   mayUpdate,
   availableStakeLevels,
   metadata,
+  defaultPermission,
 }: ToolItemProps) {
   const { control } = useFormContext<MCPServerFormValues>();
   const { field } = useController({
@@ -53,7 +55,7 @@ function ToolItem({
     name: `toolSettings.${tool.name}`,
     defaultValue: {
       enabled: metadata?.enabled ?? true,
-      permission: metadata?.permission ?? FALLBACK_MCP_TOOL_STAKE_LEVEL,
+      permission: metadata?.permission ?? defaultPermission,
     },
   });
 
@@ -190,6 +192,8 @@ export function ToolsList({
                   (m) => m.toolName === tool.name
                 );
 
+                const defaultPermission = getDefaultInternalToolStakeLevel(mcpServerView.server, tool.name);
+
                 return (
                   <ToolItem
                     key={index}
@@ -197,6 +201,7 @@ export function ToolsList({
                     mayUpdate={mayUpdate}
                     availableStakeLevels={availableStakeLevels}
                     metadata={metadata}
+                    defaultPermission={defaultPermission}
                   />
                 );
               }

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -12,8 +12,8 @@ import {
 import { useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
-import type {MCPServerFormValues} from "@app/components/actions/mcp/forms/mcpServerFormSchema";
-import { getDefaultInternalToolStakeLevel  } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import type { MCPServerFormValues } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import { getDefaultInternalToolStakeLevel } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   CUSTOM_REMOTE_MCP_TOOL_STAKE_LEVELS,
@@ -192,7 +192,10 @@ export function ToolsList({
                   (m) => m.toolName === tool.name
                 );
 
-                const defaultPermission = getDefaultInternalToolStakeLevel(mcpServerView.server, tool.name);
+                const defaultPermission = getDefaultInternalToolStakeLevel(
+                  mcpServerView.server,
+                  tool.name
+                );
 
                 return (
                   <ToolItem

--- a/front/components/actions/mcp/forms/mcpServerFormSchema.ts
+++ b/front/components/actions/mcp/forms/mcpServerFormSchema.ts
@@ -62,7 +62,7 @@ function getToolStake(
   return toolName in stakes ? stakes[toolName] : undefined;
 }
 
-function getDefaultInternalToolStakeLevel(
+export function getDefaultInternalToolStakeLevel(
   server: MCPServerViewType["server"],
   toolName: string
 ): MCPToolStakeLevelType {


### PR DESCRIPTION
## Description

Fixes tool permission defaults in the agent builder. Previously, when selecting tools in the agent builder, the permission would always default to `FALLBACK_MCP_TOOL_STAKE_LEVEL` ("high") instead of using the configured default from the MCP server definition. This was inconsistent with the tool settings page in admin which properly calculates defaults using getDefaultInternalToolStakeLevel(). The fix exports and uses this function in ToolsList.tsx to ensure the correct default permission is applied.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
