### PR TITLE
Send contentFragments with the user_message_new event.

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -290,20 +290,14 @@ export const ConversationViewer = ({
               if (isHiddenMessage(event.message)) {
                 break;
               }
-              const userMessage: VirtuosoMessage = {
-                ...event.message,
-                contentFragments: [],
-              };
+              const userMessage = event.message;
               const predicate = (m: VirtuosoMessage) =>
                 isUserMessage(m) && areSameRank(m, userMessage);
 
               const exists = ref.current.data.find(predicate);
 
               if (!exists) {
-                ref.current.data.append(
-                  [{ ...event.message, contentFragments: [] }],
-                  true
-                );
+                ref.current.data.append([userMessage], true);
                 // Using else if with the type guard just to please the type checker as we already know it's a user message from the predicate.
               } else if (isUserMessage(exists)) {
                 // We only update if the version is greater than the existing version.

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -39,7 +39,7 @@ import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type {
   BlockRunConfig,
-  ConversationType,
+  ConversationWithoutContentType,
   DatasetSchema,
   SpecificationBlockType,
   SupportedFileContentType,
@@ -181,7 +181,7 @@ async function prepareAppContext(
 async function processDustFileOutput(
   auth: Authenticator,
   sanitizedOutput: DustFileOutput,
-  conversation: ConversationType,
+  conversation: ConversationWithoutContentType,
   appName: string
 ): Promise<{ type: "resource"; resource: ToolGeneratedFileType }[]> {
   const content: { type: "resource"; resource: ToolGeneratedFileType }[] = [];

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -23,7 +23,7 @@ import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action
 import type {
   AgentConfigurationType,
   AgentMessageType,
-  ConversationType,
+  ConversationWithoutContentType,
   OAuthProvider,
 } from "@app/types";
 
@@ -97,7 +97,7 @@ export async function getExitOrPauseEvents({
   action: AgentMCPActionResource;
   agentConfiguration: AgentConfigurationType;
   agentMessage: AgentMessageType;
-  conversation: ConversationType;
+  conversation: ConversationWithoutContentType;
 }): Promise<
   (
     | MCPApproveExecutionEvent

--- a/front/lib/api/assistant/conversation/agent_loop.ts
+++ b/front/lib/api/assistant/conversation/agent_loop.ts
@@ -7,7 +7,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type {
   AgentMessageType,
-  ConversationType,
+  ConversationWithoutContentType,
   ModelId,
   UserMessageType,
 } from "@app/types";
@@ -25,7 +25,7 @@ export const runAgentLoopWorkflow = async ({
   auth: Authenticator;
   agentMessages: AgentMessageType[];
   agentMessageRowById: Map<ModelId, AgentMessage>;
-  conversation: ConversationType;
+  conversation: ConversationWithoutContentType;
   userMessage: UserMessageType;
 }) => {
   await concurrentExecutor(

--- a/front/lib/api/assistant/conversation/files.ts
+++ b/front/lib/api/assistant/conversation/files.ts
@@ -9,7 +9,6 @@ export function listGeneratedFiles(
 
   for (const versions of conversation.content) {
     const message = versions[versions.length - 1];
-
     if (isAgentMessageType(message)) {
       const generatedFiles = message.actions.flatMap(
         (action) => action.generatedFiles

--- a/front/lib/api/assistant/conversation/getRelatedContentFragments.test.ts
+++ b/front/lib/api/assistant/conversation/getRelatedContentFragments.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from "vitest";
+
+import { getRelatedContentFragments } from "@app/lib/api/assistant/conversation";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import type {
+  ContentFragmentType,
+  ConversationType,
+  UserMessageType,
+} from "@app/types";
+
+// Helper function to create a mock content fragment
+function createMockContentFragment(
+  rank: number,
+  title: string = "Test Fragment"
+): ContentFragmentType {
+  return {
+    type: "content_fragment",
+    id: 1,
+    sId: generateRandomModelSId(),
+    created: Date.now(),
+    visibility: "visible",
+    version: 0,
+    rank,
+    sourceUrl: null,
+    title,
+    contentType: "text/plain",
+    context: {
+      username: "testuser",
+      fullName: "Test User",
+      email: "test@example.com",
+      profilePictureUrl: null,
+    },
+    contentFragmentId: generateRandomModelSId(),
+    contentFragmentVersion: "latest",
+    expiredReason: null,
+    contentFragmentType: "file",
+    fileId: generateRandomModelSId(),
+    snippet: null,
+    generatedTables: [],
+    textUrl: "https://example.com/text",
+    textBytes: 100,
+  };
+}
+
+// Helper function to create a mock user message
+function createMockUserMessage(rank: number): UserMessageType {
+  return {
+    id: 1,
+    created: Date.now(),
+    type: "user_message",
+    sId: generateRandomModelSId(),
+    visibility: "visible",
+    version: 0,
+    rank,
+    user: null,
+    mentions: [],
+    content: "Test message",
+    context: {
+      username: "testuser",
+      timezone: "UTC",
+      fullName: null,
+      email: null,
+      profilePictureUrl: null,
+    },
+  };
+}
+
+// Helper function to create a mock agent message
+function createMockAgentMessage(rank: number) {
+  return {
+    type: "agent_message" as const,
+    sId: generateRandomModelSId(),
+    version: 0,
+    rank,
+    created: Date.now(),
+    completedTs: null,
+    parentMessageId: null,
+    parentAgentMessageId: null,
+    status: "succeeded" as const,
+    content: "Agent response",
+    chainOfThought: null,
+    error: null,
+    id: 1,
+    agentMessageId: 1,
+    actions: [],
+    configuration: {
+      sId: generateRandomModelSId(),
+      name: "Test Agent",
+    } as any,
+    skipToolsValidation: false,
+    contents: [],
+    parsedContents: {},
+    modelInteractionDurationMs: null,
+  };
+}
+
+// Helper function to create a mock conversation
+function createMockConversation(
+  content: (UserMessageType[] | ContentFragmentType[] | any[])[]
+): ConversationType {
+  return {
+    id: 1,
+    sId: generateRandomModelSId(),
+    created: Date.now(),
+    updated: Date.now(),
+    title: "Test Conversation",
+    depth: 0,
+    visibility: "unlisted",
+    unread: false,
+    actionRequired: false,
+    hasError: false,
+    requestedSpaceIds: [],
+    spaceId: null,
+    owner: {
+      id: 1,
+      sId: generateRandomModelSId(),
+      name: "Test Workspace",
+    } as any,
+    content,
+  };
+}
+
+describe("getRelatedContentFragments", () => {
+  it("should return empty array when conversation has no content", () => {
+    const conversation = createMockConversation([]);
+    const message = createMockUserMessage(0);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return empty array when there are no content fragments", () => {
+    const userMessage1 = createMockUserMessage(0);
+    const userMessage2 = createMockUserMessage(1);
+    const conversation = createMockConversation([
+      [userMessage1],
+      [userMessage2],
+    ]);
+    const message = createMockUserMessage(2);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return empty array when all content fragments have rank >= message rank", () => {
+    const message = createMockUserMessage(1);
+    const cf1 = createMockContentFragment(2, "Fragment 1");
+    const cf2 = createMockContentFragment(3, "Fragment 2");
+    const conversation = createMockConversation([[message], [cf1], [cf2]]);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return consecutive content fragments preceding the message", () => {
+    const cf1 = createMockContentFragment(0, "Fragment 1");
+    const cf2 = createMockContentFragment(1, "Fragment 2");
+    const cf3 = createMockContentFragment(2, "Fragment 3");
+    const conversation = createMockConversation([[cf1], [cf2], [cf3]]);
+    const message = createMockUserMessage(3);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].rank).toBe(2);
+    expect(result[1].rank).toBe(1);
+    expect(result[2].rank).toBe(0);
+    expect(result[0].title).toBe("Fragment 3");
+    expect(result[1].title).toBe("Fragment 2");
+    expect(result[2].title).toBe("Fragment 1");
+  });
+
+  it("should stop at the first gap in ranks", () => {
+    const cf1 = createMockContentFragment(0, "Fragment 1");
+    const cf2 = createMockContentFragment(1, "Fragment 2");
+    // Gap: rank 2 is missing
+    const cf3 = createMockContentFragment(3, "Fragment 3");
+    const conversation = createMockConversation([[cf1], [cf2], [cf3]]);
+    const message = createMockUserMessage(4);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    // Function starts from message rank (4), looks for rank 3 (cf3), finds it and adds it
+    // Then looks for rank 2, doesn't find it, stops
+    // So it should only return cf3, not cf2 and cf1 (because of the gap)
+    expect(result).toHaveLength(1);
+    expect(result[0].rank).toBe(3);
+    expect(result[0].title).toBe("Fragment 3");
+  });
+
+  it("should return only the latest version when multiple versions exist", () => {
+    const cf1v0 = createMockContentFragment(0, "Fragment 1 v0");
+    cf1v0.version = 0;
+    const cf1v1 = createMockContentFragment(0, "Fragment 1 v1");
+    cf1v1.version = 1;
+    const cf2 = createMockContentFragment(1, "Fragment 2");
+    const conversation = createMockConversation([
+      [cf1v0, cf1v1], // Multiple versions - last one should be used
+      [cf2],
+    ]);
+    const message = createMockUserMessage(2);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toHaveLength(2);
+    // Should use the latest version (v1) from the versions array
+    // Result is sorted by rank descending, so cf2 (rank 1) comes first
+    expect(result[0].rank).toBe(1);
+    expect(result[0].title).toBe("Fragment 2");
+    expect(result[1].rank).toBe(0);
+    expect(result[1].version).toBe(1);
+    expect(result[1].title).toBe("Fragment 1 v1");
+  });
+
+  it("should ignore user messages and agent messages", () => {
+    const userMessage = createMockUserMessage(0);
+    const agentMessage = createMockAgentMessage(1);
+    const cf1 = createMockContentFragment(2, "Fragment 1");
+    const cf2 = createMockContentFragment(3, "Fragment 2");
+    const conversation = createMockConversation([
+      [userMessage],
+      [agentMessage],
+      [cf1],
+      [cf2],
+    ]);
+    const message = createMockUserMessage(4);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].rank).toBe(3);
+    expect(result[1].rank).toBe(2);
+    expect(result[0].title).toBe("Fragment 2");
+    expect(result[1].title).toBe("Fragment 1");
+  });
+
+  it("should handle message with rank 0", () => {
+    const conversation = createMockConversation([]);
+    const message = createMockUserMessage(0);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should handle content fragments starting from rank 0", () => {
+    const cf1 = createMockContentFragment(0, "Fragment 1");
+    const cf2 = createMockContentFragment(1, "Fragment 2");
+    const conversation = createMockConversation([[cf1], [cf2]]);
+    const message = createMockUserMessage(2);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].rank).toBe(1);
+    expect(result[1].rank).toBe(0);
+  });
+
+  it("should return empty array when there is a gap immediately before the message", () => {
+    const cf1 = createMockContentFragment(0, "Fragment 1");
+    // Gap: rank 1 is missing, message is at rank 2
+    const conversation = createMockConversation([[cf1]]);
+    const message = createMockUserMessage(2);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should handle mixed content types correctly", () => {
+    const userMessage1 = createMockUserMessage(0);
+    const cf1 = createMockContentFragment(1, "Fragment 1");
+    const agentMessage = createMockAgentMessage(2);
+    const cf2 = createMockContentFragment(3, "Fragment 2");
+    const cf3 = createMockContentFragment(4, "Fragment 3");
+    const conversation = createMockConversation([
+      [userMessage1],
+      [cf1],
+      [agentMessage],
+      [cf2],
+      [cf3],
+    ]);
+    const message = createMockUserMessage(5);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    // Should only return consecutive fragments: cf3 (rank 4) and cf2 (rank 3)
+    // Should stop before cf1 (rank 1) because of the gap at rank 2
+    expect(result).toHaveLength(2);
+    expect(result[0].rank).toBe(4);
+    expect(result[1].rank).toBe(3);
+    expect(result[0].title).toBe("Fragment 3");
+    expect(result[1].title).toBe("Fragment 2");
+  });
+
+  it("should return fragments in descending rank order", () => {
+    const cf1 = createMockContentFragment(0, "Fragment 1");
+    const cf2 = createMockContentFragment(1, "Fragment 2");
+    const cf3 = createMockContentFragment(2, "Fragment 3");
+    const conversation = createMockConversation([[cf1], [cf2], [cf3]]);
+    const message = createMockUserMessage(3);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toHaveLength(3);
+    // Should be in descending order (highest rank first)
+    expect(result[0].rank).toBe(2);
+    expect(result[1].rank).toBe(1);
+    expect(result[2].rank).toBe(0);
+  });
+
+  it("should handle a single consecutive content fragment", () => {
+    const cf1 = createMockContentFragment(2, "Fragment 1");
+    const conversation = createMockConversation([[cf1]]);
+    const message = createMockUserMessage(3);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].rank).toBe(2);
+    expect(result[0].title).toBe("Fragment 1");
+  });
+
+  it("should handle non-consecutive fragments with gaps", () => {
+    const cf1 = createMockContentFragment(0, "Fragment 1");
+    // Gap: rank 1 missing
+    const cf2 = createMockContentFragment(2, "Fragment 2");
+    // Gap: rank 3 missing
+    const cf3 = createMockContentFragment(4, "Fragment 3");
+    const conversation = createMockConversation([[cf1], [cf2], [cf3]]);
+    const message = createMockUserMessage(5);
+
+    const result = getRelatedContentFragments(conversation, message);
+
+    // Should only return cf3 (rank 4) since there's a gap before it
+    expect(result).toHaveLength(1);
+    expect(result[0].rank).toBe(4);
+    expect(result[0].title).toBe("Fragment 3");
+  });
+});

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -17,7 +17,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type {
   AgentMention,
-  ConversationType,
+  ConversationWithoutContentType,
   LightAgentConfigurationType,
   MentionType,
   WorkspaceType,
@@ -26,7 +26,7 @@ import type {
 describe("createAgentMessages", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;
-  let conversation: ConversationType;
+  let conversation: ConversationWithoutContentType;
   let agentConfig1: LightAgentConfigurationType;
   let agentConfig2: LightAgentConfigurationType;
 
@@ -346,7 +346,7 @@ describe("createAgentMessages", () => {
 describe("createUserMentions", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;
-  let conversation: ConversationType;
+  let conversation: ConversationWithoutContentType;
 
   beforeEach(async () => {
     // Create workspace, user, spaces, and groups using the helper

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -11,10 +11,9 @@ import {
 import { triggerConversationAddedAsParticipantNotification } from "@app/lib/notifications/workflows/conversation-added-as-participant";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-import type { MentionType } from "@app/types";
+import type { ConversationWithoutContentType, MentionType } from "@app/types";
 import type {
   AgentMessageType,
-  ConversationType,
   LightAgentConfigurationType,
   UserMessageType,
   WorkspaceType,
@@ -31,7 +30,7 @@ export const createUserMentions = async (
   }: {
     mentions: MentionType[];
     message: Message;
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     transaction?: Transaction;
   }
 ) => {
@@ -88,7 +87,7 @@ export const createAgentMessages = async ({
   owner: WorkspaceType;
   skipToolsValidation: boolean;
   nextMessageRank: number;
-  conversation: ConversationType;
+  conversation: ConversationWithoutContentType;
   userMessage: UserMessageType;
   transaction?: Transaction;
 }) => {

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -4,7 +4,6 @@ import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import type {
-  ConversationType,
   ConversationWithoutContentType,
   Result,
   UserType,
@@ -46,7 +45,7 @@ export type AgentMessageFeedbackWithMetadataType = AgentMessageFeedbackType &
 
 export async function getConversationFeedbacksForUser(
   auth: Authenticator,
-  conversation: ConversationType | ConversationWithoutContentType
+  conversation: ConversationWithoutContentType
 ) {
   const feedbacksRes =
     await AgentMessageFeedbackResource.getConversationFeedbacksForUser(
@@ -76,7 +75,7 @@ export async function upsertMessageFeedback(
     isConversationShared,
   }: {
     messageId: string;
-    conversation: ConversationType | ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType;
     user: UserType;
     thumbDirection: AgentMessageFeedbackDirection;
     content?: string;
@@ -141,7 +140,7 @@ export async function deleteMessageFeedback(
     user,
   }: {
     messageId: string;
-    conversation: ConversationType | ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType;
     user: UserType;
   }
 ) {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -34,7 +34,10 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { AgentConfigurationType, ConversationType } from "@app/types";
+import type {
+  AgentConfigurationType,
+  ConversationWithoutContentType,
+} from "@app/types";
 import { CoreAPI } from "@app/types";
 
 export async function getJITServers(
@@ -45,7 +48,7 @@ export async function getJITServers(
     attachments,
   }: {
     agentConfiguration: AgentConfigurationType;
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     attachments: ConversationAttachmentType[];
   }
 ): Promise<MCPServerConfigurationType[]> {
@@ -421,7 +424,7 @@ export async function getJITServers(
  */
 async function getConversationDataSourceViews(
   auth: Authenticator,
-  conversation: ConversationType,
+  conversation: ConversationWithoutContentType,
   attachments: ConversationAttachmentType[]
 ): Promise<Map<string, DataSourceViewResource>> {
   const conversationIdToDataSourceViewMap = new Map<

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -24,7 +24,6 @@ export function listAttachments(
   const attachments: ConversationAttachmentType[] = [];
   for (const versions of conversation.content) {
     const m = versions[versions.length - 1];
-
     if (isContentFragmentType(m)) {
       // We don't list images.
       if (isSupportedImageContentType(m.contentType)) {

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -6,7 +6,6 @@ import {
 import type {
   ConversationError,
   ConversationMessageReactions,
-  ConversationType,
   ConversationWithoutContentType,
   MessageReactionType,
   Result,
@@ -19,7 +18,7 @@ import { Ok } from "@app/types";
  */
 export async function getMessageReactions(
   auth: Authenticator,
-  conversation: ConversationType | ConversationWithoutContentType
+  conversation: ConversationWithoutContentType
 ): Promise<Result<ConversationMessageReactions, ConversationError>> {
   const owner = auth.workspace();
   if (!owner) {
@@ -94,7 +93,7 @@ export async function createMessageReaction(
     reaction,
   }: {
     messageId: string;
-    conversation: ConversationType | ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType;
     user: UserType | null;
     context: {
       username: string;
@@ -142,7 +141,7 @@ export async function deleteMessageReaction(
     reaction,
   }: {
     messageId: string;
-    conversation: ConversationType | ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType;
     user: UserType | null;
     context: {
       username: string;

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -12,9 +12,9 @@ import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type {
   AgentMessageNewEvent,
   AgentMessageType,
-  ConversationType,
+  ConversationWithoutContentType,
   UserMessageNewEvent,
-  UserMessageType,
+  UserMessageTypeWithContentFragments,
 } from "@app/types";
 import { assertNever } from "@app/types";
 
@@ -143,8 +143,8 @@ export async function publishConversationRelatedEvent(
 }
 
 export async function publishMessageEventsOnMessagePostOrEdit(
-  conversation: ConversationType,
-  userMessage: UserMessageType,
+  conversation: ConversationWithoutContentType,
+  userMessage: UserMessageTypeWithContentFragments,
   agentMessages: AgentMessageType[]
 ) {
   const userMessageEvent: UserMessageNewEvent = {
@@ -181,7 +181,7 @@ export async function publishMessageEventsOnMessagePostOrEdit(
 }
 
 export async function publishAgentMessageEventOnMessageRetry(
-  conversation: ConversationType,
+  conversation: ConversationWithoutContentType,
   agentMessage: AgentMessageType
 ) {
   const agentMessageEvent: AgentMessageNewEvent = {

--- a/front/lib/notifications/workflows/conversation-added-as-participant.ts
+++ b/front/lib/notifications/workflows/conversation-added-as-participant.ts
@@ -9,7 +9,7 @@ import { renderEmail } from "@app/lib/notifications/email-templates/default";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { ConversationType, Result } from "@app/types";
+import type { ConversationWithoutContentType, Result } from "@app/types";
 import { Err } from "@app/types";
 import { Ok } from "@app/types";
 
@@ -187,7 +187,7 @@ export const triggerConversationAddedAsParticipantNotification = async (
     conversation,
     addedUserId,
   }: {
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     addedUserId: string;
   }
 ): Promise<Result<void, DustError<"internal_error">>> => {

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -26,7 +26,6 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   AgentConfigurationType,
   AgentMessageType,
-  ConversationType,
   ConversationWithoutContentType,
   LightAgentConfigurationType,
   MessageType,
@@ -359,7 +358,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
 
   static async getConversationFeedbacksForUser(
     auth: Authenticator,
-    conversation: ConversationType | ConversationWithoutContentType
+    conversation: ConversationWithoutContentType
   ) {
     const user = auth.getNonNullableUser();
 
@@ -420,7 +419,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   }: {
     auth: Authenticator;
     messageId: string;
-    conversation: ConversationType | ConversationWithoutContentType;
+    conversation: ConversationWithoutContentType;
     user: UserType;
   }): Promise<
     Result<

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -30,7 +30,7 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type {
-  ConversationType,
+  ConversationWithoutContentType,
   LightAgentConfigurationType,
   LightWorkspaceType,
 } from "@app/types";
@@ -1827,7 +1827,7 @@ describe("Space Handling", () => {
 
   describe("getMessageById", () => {
     let auth: Authenticator;
-    let conversation: ConversationType;
+    let conversation: ConversationWithoutContentType;
     let agents: LightAgentConfigurationType[];
     let conversationIds: string[];
 
@@ -2077,7 +2077,7 @@ describe("Space Handling", () => {
 
   describe("fetchMessagesForPage", () => {
     let auth: Authenticator;
-    let conversation: ConversationType;
+    let conversation: ConversationWithoutContentType;
     let agents: LightAgentConfigurationType[];
 
     beforeEach(async () => {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -38,7 +38,6 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   ConversationMCPServerViewType,
-  ConversationType,
   ConversationWithoutContentType,
   LightAgentConfigurationType,
   ModelId,
@@ -526,6 +525,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       requestedGroupIds: [],
       requestedSpaceIds: conversation.getRequestedSpaceIdsFromModel(),
       spaceId: conversation.space?.sId ?? null,
+      depth: conversation.depth,
     });
   }
 
@@ -648,6 +648,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           requestedGroupIds: [],
           requestedSpaceIds: c.getRequestedSpaceIdsFromModel(),
           spaceId: c.space?.sId ?? null,
+          depth: c.depth,
         };
       })
     );
@@ -801,7 +802,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       action,
       user,
     }: {
-      conversation: ConversationWithoutContentType | ConversationType;
+      conversation: ConversationWithoutContentType;
       action: ParticipantActionType;
       user: UserType | null;
     }
@@ -1506,6 +1507,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       sId: this.sId,
       title: this.title,
       unread: participation.unread,
+      depth: this.depth,
     };
   }
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -104,9 +104,7 @@ async function handler(
         conversationId,
         limit: paginationRes.value.limit,
         lastRank: paginationRes.value.lastValue,
-        viewType: useNewResponseFormat
-          ? ("light" as const)
-          : ("legacy-light" as const),
+        viewType: useNewResponseFormat ? "light" : "legacy-light",
       });
 
       if (messagesRes.isErr()) {

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -13,8 +13,8 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import type {
-  ConversationType,
   ConversationVisibility,
+  ConversationWithoutContentType,
   ModelId,
   SupportedContentFragmentType,
   UserMessageOrigin,
@@ -40,7 +40,7 @@ export class ConversationFactory {
       visibility?: ConversationVisibility;
       t?: Transaction;
     }
-  ): Promise<ConversationType> {
+  ): Promise<ConversationWithoutContentType> {
     const user = auth.getNonNullableUser();
     const workspace = auth.getNonNullableWorkspace();
 
@@ -102,7 +102,7 @@ export class ConversationFactory {
   }: {
     auth: Authenticator;
     workspace: WorkspaceType;
-    conversation: ConversationType;
+    conversation: ConversationWithoutContentType;
     content: string;
     origin?: UserMessageOrigin;
     agenticMessageType?: "run_agent" | "agent_handover";

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -258,6 +258,7 @@ export type ConversationWithoutContentType = {
   sId: string;
   title: string | null;
   spaceId: string | null;
+  depth: number;
 
   // Ideally, this property should be moved to the ConversationType.
   requestedSpaceIds: string[];
@@ -270,7 +271,6 @@ export type ConversationWithoutContentType = {
 export type ConversationType = ConversationWithoutContentType & {
   owner: WorkspaceType;
   visibility: ConversationVisibility;
-  depth: number;
   content: (UserMessageType[] | AgentMessageType[] | ContentFragmentType[])[];
 };
 
@@ -337,7 +337,7 @@ export type UserMessageNewEvent = {
   type: "user_message_new";
   created: number;
   messageId: string;
-  message: UserMessageType;
+  message: UserMessageTypeWithContentFragments;
 };
 
 // Event sent when the user message is created.


### PR DESCRIPTION
## Description

- Send the related content fragments in the user_message_new event so that attachments are visible without reloading.
- Fixed a lot of typing with `ConversationType` => `ConversationWithoutContentType` (moved `depth` to the `ConversationWithoutContentType`)

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front