### PR TITLE
Add support for structured output in Gemini 3

### DIFF
--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@app/lib/api/llm/clients/google/utils/conversation_to_google";
 import { streamLLMEvents } from "@app/lib/api/llm/clients/google/utils/google_to_events";
 import {
+  toResponseSchemaParam,
   toThinkingConfig,
   toToolConfigParam,
 } from "@app/lib/api/llm/clients/google/utils/to_thinking";
@@ -55,7 +56,6 @@ export class GoogleLLM extends LLM {
       const contents = await Promise.all(
         conversation.messages.map((message) => toContent(message, this.modelId))
       );
-
       const generateContentResponses =
         await this.client.models.generateContentStream({
           model: this.modelId,
@@ -72,6 +72,11 @@ export class GoogleLLM extends LLM {
               useNativeLightReasoning: this.modelConfig.useNativeLightReasoning,
             }),
             toolConfig: toToolConfigParam(specifications, forceToolCall),
+            // Structured response format
+            responseMimeType: this.responseFormat
+              ? "application/json"
+              : undefined,
+            responseSchema: toResponseSchemaParam(this.responseFormat),
           },
         });
 

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -61,6 +61,7 @@ export async function getLLM(
       modelId,
       temperature,
       reasoningEffort,
+      responseFormat,
       bypassFeatureFlag,
       context,
     });

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -289,6 +289,11 @@ export const TEST_STRUCTURED_OUTPUT_CONVERSATIONS: (Omit<
   },
 ];
 
+export type ConversationId =
+  | (typeof TEST_CONVERSATIONS)[number]["id"]
+  | (typeof TEST_VISION_CONVERSATIONS)[number]["id"]
+  | (typeof TEST_STRUCTURED_OUTPUT_CONVERSATIONS)[number]["id"];
+
 export const runConversation = async (
   conversation: TestConversation,
   config: TestConfig

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -132,9 +132,9 @@ function checkJsonResponse(key: TestStructuredOutputKey): ResponseChecker {
   };
 }
 
-export const TEST_CONVERSATIONS: TestConversation[] = [
+export const TEST_CONVERSATIONS = [
   {
-    id: "simple-math",
+    id: "simple-math" as const,
     name: "Simple Math",
     systemPrompt: SYSTEM_PROMPT,
     conversationActions: [
@@ -144,7 +144,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     configs: TEST_CONFIGS,
   },
   {
-    id: "yes-no-question",
+    id: "yes-no-question" as const,
     name: "Yes/No Question",
     systemPrompt: SYSTEM_PROMPT,
     conversationActions: [
@@ -153,7 +153,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     expectedInResponses: [containsTextChecker(["yes"])],
   },
   {
-    id: "multi-step-conversation",
+    id: "multi-step-conversation" as const,
     name: "2 steps conversation",
     systemPrompt: SYSTEM_PROMPT,
     conversationActions: [
@@ -163,7 +163,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     expectedInResponses: [null, containsTextChecker(["Stan"])],
   },
   {
-    id: "tool-usage",
+    id: "tool-usage" as const,
     name: "Tool usage required",
     systemPrompt: SYSTEM_PROMPT,
     conversationActions: [
@@ -192,7 +192,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     ],
   },
   {
-    id: "tool-call-without-params",
+    id: "tool-call-without-params" as const,
     name: "Tool call without params",
     systemPrompt: SYSTEM_PROMPT,
     conversationActions: [
@@ -216,7 +216,7 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     ],
   },
   {
-    id: "force-tool-usage",
+    id: "force-tool-usage" as const,
     name: "Force tool usage",
     systemPrompt: SYSTEM_PROMPT,
     conversationActions: [userMessage("What is the current date?")],
@@ -234,11 +234,11 @@ export const TEST_CONVERSATIONS: TestConversation[] = [
     ],
     forceToolCall: "GetCurrentDate",
   },
-];
+] satisfies TestConversation[];
 
-export const TEST_VISION_CONVERSATIONS: TestConversation[] = [
+export const TEST_VISION_CONVERSATIONS = [
   {
-    id: "image-description",
+    id: "image-description" as const,
     name: "Image description",
     systemPrompt: SYSTEM_PROMPT,
     conversationActions: [
@@ -249,14 +249,14 @@ export const TEST_VISION_CONVERSATIONS: TestConversation[] = [
     ],
     expectedInResponses: [containsTextChecker(["cat"])],
   },
-];
+] satisfies TestConversation[];
 
 export const TEST_STRUCTURED_OUTPUT_CONVERSATIONS: (Omit<
   TestConversation,
   "id"
 > & { id: TestStructuredOutputKey })[] = [
   {
-    id: "user-profile",
+    id: "user-profile" as const,
     name: "Structured output - user profile",
     systemPrompt: SYSTEM_PROMPT,
     conversationActions: [
@@ -272,7 +272,7 @@ export const TEST_STRUCTURED_OUTPUT_CONVERSATIONS: (Omit<
     ],
   },
   {
-    id: "data-extraction",
+    id: "data-extraction" as const,
     name: "Structured output - data extraction",
     systemPrompt: SYSTEM_PROMPT,
     conversationActions: [
@@ -287,12 +287,22 @@ export const TEST_STRUCTURED_OUTPUT_CONVERSATIONS: (Omit<
       },
     ],
   },
-];
+] satisfies TestConversation[];
 
 export type ConversationId =
   | (typeof TEST_CONVERSATIONS)[number]["id"]
   | (typeof TEST_VISION_CONVERSATIONS)[number]["id"]
   | (typeof TEST_STRUCTURED_OUTPUT_CONVERSATIONS)[number]["id"];
+
+export const ALL_CONVERSATION_IDS: ConversationId[] = [
+  ...TEST_CONVERSATIONS,
+  ...TEST_VISION_CONVERSATIONS,
+  ...TEST_STRUCTURED_OUTPUT_CONVERSATIONS,
+].map((c) => c.id);
+
+export function isConversationId(id: string): id is ConversationId {
+  return ALL_CONVERSATION_IDS.some((existingId) => existingId === id);
+}
 
 export const runConversation = async (
   conversation: TestConversation,

--- a/front/lib/api/llm/tests/vite.config.js
+++ b/front/lib/api/llm/tests/vite.config.js
@@ -29,6 +29,10 @@ export default defineConfig(() => {
           process.env.DUST_MANAGED_FIREWORKS_API_KEY ?? "",
         DUST_MANAGED_XAI_API_KEY: process.env.DUST_MANAGED_XAI_API_KEY ?? "",
         OPENAI_BASE_URL: "https://api.openai.com/v1",
+        // When not empty, filter the conversations to run (comma-separated list of conversation IDs)
+        FILTER_CONVERSATION_IDS: process.env.FILTER_CONVERSATION_IDS ?? "",
+        // When set to "true", run all model tests regardless of their `runTest` flag
+        RUN_ALL_MODEL_TESTS: process.env.RUN_ALL_MODEL_TESTS ?? "false",
       },
     },
   });

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -21,6 +21,7 @@ export const GEMINI_2_5_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
   isLatest: true,
   generationTokensCount: 64_000,
   supportsVision: true,
+  supportsResponseFormat: false, // response format not compatible with tool use
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
@@ -41,6 +42,7 @@ export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   isLatest: true,
   generationTokensCount: 64_000,
   supportsVision: true,
+  supportsResponseFormat: false, // response format not compatible with tool use
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
@@ -61,6 +63,7 @@ export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   isLatest: false,
   generationTokensCount: 64_000,
   supportsVision: true,
+  supportsResponseFormat: false, // response format not compatible with tool use
   minimumReasoningEffort: "light",
   maximumReasoningEffort: "high",
   defaultReasoningEffort: "light",
@@ -81,6 +84,7 @@ export const GEMINI_3_PRO_MODEL_CONFIG: ModelConfigurationType = {
   isLatest: true,
   generationTokensCount: 64_000,
   supportsVision: true,
+  supportsResponseFormat: true,
   minimumReasoningEffort: "light",
   maximumReasoningEffort: "high",
   defaultReasoningEffort: "light",


### PR DESCRIPTION
## Description

It's easy to add and test with the new LLM router 🥳 
Other Gemini have the support for response Format but it's not compatible with tools use so I don't think it is usable in Dust. 

## Tests

### Unit tests

```
# RUN_LLM_TEST=true npx vitest --config lib/api/llm/tests/vite.config.js lib/api/llm/tests/llm.test.ts --run

 RUN  v3.0.8 /Users/fabiencelier/spaces/dust/front

 ✓ lib/api/llm/tests/llm.test.ts (2 tests) 10137ms
   ✓ 'google_ai_studio' / 'gemini-3-pro-preview' > should handle: 'Structured output - user profile' > temperature: undefined, reasoningEffort: undefined, testStructuredOutputKey: 'user-profile' 10136ms
   ✓ 'google_ai_studio' / 'gemini-3-pro-preview' > should handle: 'Structured output - data extraction' > temperature: undefined, reasoningEffort: undefined, testStructuredOutputKey: 'data-extraction' 7351ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  18:08:11
   Duration  13.20s (transform 673ms, setup 768ms, collect 1.61s, tests 10.14s, environment 308ms, prepare 38ms)
```

### Manual tests

<img width="1630" height="1114" alt="image" src="https://github.com/user-attachments/assets/72bac783-7e84-4f37-b8c3-069d4c924277" />

<img width="2484" height="1460" alt="image" src="https://github.com/user-attachments/assets/65688f18-ed43-472c-82f0-059de00d1122" />

https://github.com/user-attachments/assets/6d0b54cf-b718-4514-b1b7-cf46a3f93fa8


## Risk

low

## Deploy Plan

deploy front
