### PR TITLE
[front] feat: PPUL - Bill PAYG Credits on subscription cycle renew

### DIFF
--- a/front/components/workspace/CreditsList.tsx
+++ b/front/components/workspace/CreditsList.tsx
@@ -12,7 +12,7 @@ import { getPriceAsString } from "@app/lib/client/subscription";
 import type { CreditDisplayData, CreditType } from "@app/types/credits";
 
 type RowData = {
-  id: number;
+  sId: string;
   type: CreditType;
   initialAmount: string;
   consumedAmount: string;
@@ -75,7 +75,7 @@ function isExpired(credit: CreditDisplayData): boolean {
 
 function getTableRows(credits: CreditDisplayData[]): RowData[] {
   return credits.map((credit) => ({
-    id: credit.id,
+    sId: credit.sId,
     type: credit.type,
     initialAmount: getPriceAsString({
       currency: "usd",

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import assert from "assert";
 import type Stripe from "stripe";
 

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import assert from "assert";
 import type Stripe from "stripe";
 

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -114,5 +114,7 @@ export async function invoiceEnterprisePAYGCreditsArrears({
     return new Err(new Error("Failed to create Credits PAYG invoice"));
   }
 
+  await paygCredit.markAsPaid(invoiceResult.value.id);
+
   return new Ok(undefined);
 }

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -18,7 +18,7 @@ export async function isPAYGEnabled(auth: Authenticator): Promise<boolean> {
   return config !== null && config.paygCapCents !== null;
 }
 
-export async function invoiceEnterprisePAYGCreditsArrears({
+export async function invoiceEnterprisePAYGCredits({
   auth,
   stripeSubscription,
   previousPeriodStartSeconds,

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -1,0 +1,118 @@
+import assert from "assert";
+import type Stripe from "stripe";
+
+import type { Authenticator } from "@app/lib/auth";
+import {
+  isEnterpriseSubscription,
+  makeCreditsPAYGInvoice,
+} from "@app/lib/plans/stripe";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+export async function isPAYGEnabled(auth: Authenticator): Promise<boolean> {
+  const config =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+  return config !== null && config.paygCapCents !== null;
+}
+
+export async function invoiceEnterprisePAYGCreditsArrears({
+  auth,
+  stripeSubscription,
+  previousPeriodStartSeconds,
+  previousPeriodEndSeconds,
+}: {
+  auth: Authenticator;
+  stripeSubscription: Stripe.Subscription;
+  previousPeriodStartSeconds: number;
+  previousPeriodEndSeconds: number;
+}): Promise<Result<undefined, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const paygEnabled = await isPAYGEnabled(auth);
+  if (!isEnterpriseSubscription(stripeSubscription)) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "[Credit PAYG] Not an enterprise subscription, skipping arrears invoicing"
+    );
+    return new Ok(undefined);
+  }
+
+  const previousPeriodStartDate = new Date(previousPeriodStartSeconds * 1000);
+  const previousPeriodEndDate = new Date(previousPeriodEndSeconds * 1000);
+
+  const paygCredit = await CreditResource.fetchByTypeAndDates(
+    auth,
+    "payg",
+    previousPeriodStartDate,
+    previousPeriodEndDate
+  );
+
+  assert(
+    paygCredit || !paygEnabled,
+    `[Credit PAYG] No PAYG credit found for period ${previousPeriodStartDate.toISOString()} - ${previousPeriodEndDate.toISOString()} in workspace ${workspace.sId}`
+  );
+
+  if (paygCredit.consumedAmountCents === 0) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        creditId: paygCredit.id,
+      },
+      "[Credit PAYG] No consumption in this period, skipping invoice"
+    );
+    return new Ok(undefined);
+  }
+
+  const idempotencyKey = `credits-payg-arrears-${paygCredit.sId}`;
+  const config =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const discountPercent = config?.defaultDiscountPercent ?? 0;
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      creditId: paygCredit.id,
+      consumedAmountCents: paygCredit.consumedAmountCents,
+      discountPercent,
+      periodStart: previousPeriodStartDate.toISOString(),
+      periodEnd: previousPeriodEndDate.toISOString(),
+    },
+    "[Credit PAYG] Creating arrears invoice"
+  );
+
+  const invoiceResult = await makeCreditsPAYGInvoice({
+    stripeSubscription,
+    amountCents: paygCredit.consumedAmountCents,
+    periodStartSeconds: previousPeriodStartSeconds,
+    periodEndSeconds: previousPeriodEndSeconds,
+    idempotencyKey,
+  });
+
+  if (invoiceResult.isErr()) {
+    if (invoiceResult.error.error_type === "idempotency") {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          idempotencyKey,
+        },
+        "[Credit PAYG] Invoice already created (idempotency), skipping"
+      );
+      return new Err(new Error("Invoice already created (idempotency)"));
+    }
+
+    logger.error(
+      {
+        panic: true,
+        workspaceId: workspace.sId,
+        error: invoiceResult.error.error_message,
+      },
+      "[Credit PAYG] Failed to create invoice"
+    );
+    return new Err(new Error("Failed to create Credits PAYG invoice"));
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -11,6 +11,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { CreditModel } from "@app/lib/resources/storage/models/credits";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok, removeNulls } from "@app/types";
@@ -29,6 +30,10 @@ export class CreditResource extends BaseResource<CreditModel> {
 
   constructor(_model: ModelStatic<CreditModel>, blob: Attributes<CreditModel>) {
     super(CreditModel, blob);
+  }
+
+  get sId(): string {
+    return makeSId("credit", { id: this.id, workspaceId: this.workspaceId });
   }
 
   // Create a new credit line for a workspace.
@@ -150,6 +155,22 @@ export class CreditResource extends BaseResource<CreditModel> {
     const [row] = await this.baseFetch(auth, {
       where: {
         invoiceOrLineItemId,
+      },
+    });
+    return row ?? null;
+  }
+
+  static async fetchByTypeAndDates(
+    auth: Authenticator,
+    type: (typeof CREDIT_TYPES)[number],
+    startDate: Date,
+    expirationDate: Date
+  ) {
+    const [row] = await this.baseFetch(auth, {
+      where: {
+        type,
+        startDate,
+        expirationDate,
       },
     });
     return row ?? null;

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -13,10 +13,10 @@ import { CreditModel } from "@app/lib/resources/storage/models/credits";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok, removeNulls } from "@app/types";
 import type { CreditDisplayData } from "@app/types/credits";
-import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import {
   CREDIT_EXPIRATION_DAYS,
   CREDIT_TYPES,

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -39,6 +39,7 @@ const RESOURCES_PREFIX = {
   agent_message_feedback: "amf",
   onboarding_task: "obt",
   programmatic_usage_configuration: "puc",
+  credit: "crd",
 
   // Resource relative to triggers.
   trigger: "trg",

--- a/front/pages/api/poke/workspaces/[wId]/credits/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/credits/index.ts
@@ -60,7 +60,7 @@ async function handler(
       const credits = await CreditResource.listAll(auth);
 
       return res.status(200).json({
-        credits: credits.map((credit) => credit.toJSON()),
+        credits: credits.map((credit) => credit.toPokeJSON()),
       });
 
     default:

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -374,6 +374,25 @@ async function handler(
                 "[Stripe Webhook] Error processing credit purchase"
               );
             }
+          } else if (invoice.billing_reason === "subscription_cycle") {
+            const freeCreditsResult =
+              await grantFreeCreditsOnSubscriptionRenewal({
+                auth,
+                invoice,
+                stripeSubscription,
+              });
+
+            if (freeCreditsResult.isErr()) {
+              logger.error(
+                {
+                  error: freeCreditsResult.error,
+                  invoiceId: invoice.id,
+                  stripeSubscriptionId: invoice.subscription,
+                  workspaceId: subscription.workspace.sId,
+                },
+                "[Stripe Webhook] Error granting free credits on renewal"
+              );
+            }
           } else if (!isCreditPurchaseInvoice(invoice)) {
             await subscription.update({ paymentFailingSince: null });
           }

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -374,25 +374,6 @@ async function handler(
                 "[Stripe Webhook] Error processing credit purchase"
               );
             }
-          } else if (invoice.billing_reason === "subscription_cycle") {
-            const freeCreditsResult =
-              await grantFreeCreditsOnSubscriptionRenewal({
-                auth,
-                invoice,
-                stripeSubscription,
-              });
-
-            if (freeCreditsResult.isErr()) {
-              logger.error(
-                {
-                  error: freeCreditsResult.error,
-                  invoiceId: invoice.id,
-                  stripeSubscriptionId: invoice.subscription,
-                  workspaceId: subscription.workspace.sId,
-                },
-                "[Stripe Webhook] Error granting free credits on renewal"
-              );
-            }
           } else if (!isCreditPurchaseInvoice(invoice)) {
             await subscription.update({ paymentFailingSince: null });
           }

--- a/front/pages/api/w/[wId]/credits/index.ts
+++ b/front/pages/api/w/[wId]/credits/index.ts
@@ -50,18 +50,7 @@ async function handler(
       // Transform credits to display format with computed consumed amount.
       const creditsData: CreditDisplayData[] = credits
         .filter((credit) => !!credit.startDate)
-        .map((credit) => ({
-          id: credit.id,
-          type: credit.type,
-          initialAmount: credit.initialAmountCents,
-          remainingAmount:
-            credit.initialAmountCents - credit.consumedAmountCents,
-          consumedAmount: credit.consumedAmountCents,
-          startDate: credit.startDate ? credit.startDate.getTime() : null,
-          expirationDate: credit.expirationDate
-            ? credit.expirationDate.getTime()
-            : null,
-        }));
+        .map((credit) => credit.toJSON());
 
       return res.status(200).json({
         credits: creditsData,

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -10,7 +10,7 @@ export function isCreditType(value: unknown): value is CreditType {
 export const CREDIT_EXPIRATION_DAYS = 365;
 
 export type CreditDisplayData = {
-  id: number;
+  sId: string;
   type: CreditType;
   initialAmount: number;
   remainingAmount: number;


### PR DESCRIPTION
## Description

- Upon subscription cycle renew, trigger a routine that looks for the PAYG credit record of the corresponding period (and panics if not found) and creates a one-off invoice sent to the customer (through stripe) for payment.
- In a subsequent PR, we will create the PAYG credit records for the next period from the same webhook event.

## Tests

- [ ] Tested manually

## Risk

Low, for now this is dead code unless we insert manually PAYG credits

## Deploy Plan

- [ ] Create price in test / production Stripe