### PR TITLE
Catch personal auth error in Teams

### DIFF
--- a/connectors/src/api/webhooks/teams/adaptive_cards.ts
+++ b/connectors/src/api/webhooks/teams/adaptive_cards.ts
@@ -260,6 +260,57 @@ export function createThinkingAdaptiveCard(): Partial<Activity> {
   };
 }
 
+export function createPersonalAuthenticationAdaptiveCard({
+  conversationUrl,
+  workspaceId,
+}: {
+  conversationUrl: string | null;
+  workspaceId: string;
+}): Partial<Activity> {
+  return {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: {
+          type: "AdaptiveCard",
+          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+          version: "1.4",
+          body: [
+            {
+              type: "TextBlock",
+              text:
+                "The agent took an action that requires personal authentication. " +
+                (conversationUrl
+                  ? `Please go to [the conversation](${conversationUrl}) to authenticate.`
+                  : ""),
+              wrap: true,
+            },
+            {
+              type: "Container",
+              spacing: "Medium",
+              separator: true,
+              items: [
+                {
+                  type: "TextBlock",
+                  text: createFooterText({
+                    workspaceId,
+                    conversationUrl,
+                    isError: true,
+                  }),
+                  wrap: true,
+                  size: "Small",
+                  color: "Good",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
 /**
  * Creates an error adaptive card
  */


### PR DESCRIPTION
## Description

This PR improves error handling in the Teams bot when an MCP tool requires personal authentication. When a `tool_error` event is received with a personal auth requirement error, the bot now displays a dedicated adaptive card informing the user that the agent took an action requiring personal authentication and directing them to authenticate in the web conversation. This provides clearer feedback than the generic error handling that was previously used.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy connectors
