### PR TITLE
[front] - chore(FeedbacksSection): use Timeline component

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.18",
-        "@dust-tt/sparkle": "^0.4.4",
+        "@dust-tt/sparkle": "^0.4.6",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1285,9 +1285,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.4.tgz",
-      "integrity": "sha512-gtanSYaB6q8v6qSvyCgWw48iGq5eOgF2TZM6YC7A4OhOaO3dK5Iwb+HA7+ksj92cf4US2I8mA4rSM1nt/SHfqg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.6.tgz",
+      "integrity": "sha512-92OeHrNKlVI/T1kVwGchbxcT8dV6nzFCWNo2U+FeMGa4pDD/frJfWyNGSCEMPwE8bVUorqAIpX4zb/gJcxzPVg==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.18",
-    "@dust-tt/sparkle": "^0.4.4",
+    "@dust-tt/sparkle": "^0.4.6",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/FeedbacksSection.tsx
+++ b/front/components/agent_builder/FeedbacksSection.tsx
@@ -37,20 +37,9 @@ import type {
 
 const FEEDBACKS_PAGE_SIZE = 50;
 
-type FeedbackFilter = "unseen" | "all";
-
-interface FeedbacksSectionProps {
-  owner: LightWorkspaceType;
-  agentConfigurationId: string;
-}
-
-function getAgentConfigurationVersionString(
-  config: LightAgentConfigurationType,
-  isLatestVersion: boolean
-): string {
-  if (isLatestVersion) {
-    return "Latest production version. All feedback is processed.";
-  }
+const getAgentConfigurationVersionString = (
+  config: LightAgentConfigurationType
+) => {
   if (!config.versionCreatedAt) {
     return `v${config.version}`;
   }
@@ -58,6 +47,13 @@ function getAgentConfigurationVersionString(
   return (
     "Version: " + formatTimestampToFriendlyDate(versionDate.getTime(), "long")
   );
+};
+
+type FeedbackFilter = "unseen" | "all";
+
+interface FeedbacksSectionProps {
+  owner: LightWorkspaceType;
+  agentConfigurationId: string;
 }
 
 export const FeedbacksSection = ({
@@ -159,8 +155,6 @@ export const FeedbacksSection = ({
       {} as Record<number, LightAgentConfigurationType>
     ) || {};
 
-  const latestVersion = agentConfigurationHistory[0].version;
-
   return (
     <TabContentChildSectionLayout
       title="Feedback"
@@ -196,29 +190,26 @@ export const FeedbacksSection = ({
           {versionsInOrder.map((version) => {
             const versionFeedbacks = feedbacksByVersion[version];
             const agentConfig = agentConfigByVersion[version];
-            const isLatestVersion = version === latestVersion;
-
-            const versionTitle = agentConfig
-              ? getAgentConfigurationVersionString(agentConfig, isLatestVersion)
-              : `v${version}`;
-
-            const feedbackCount = versionFeedbacks?.length || 0;
-            const meta =
-              feedbackCount === 1
-                ? "1 feedback item"
-                : `${feedbackCount} feedback items`;
-
-            const description = agentConfig?.versionAuthor
-              ? `Updated by ${agentConfig.versionAuthor}`
-              : undefined;
 
             return (
               <Timeline.Item
                 key={version}
-                variant={isLatestVersion ? "complete" : "upcoming"}
-                title={versionTitle}
-                meta={meta}
-                description={description}
+                variant="upcoming"
+                title={
+                  agentConfig
+                    ? getAgentConfigurationVersionString(agentConfig)
+                    : `v${version}`
+                }
+                meta={
+                  agentConfig?.versionCreatedAt
+                    ? timeAgoFrom(
+                        new Date(agentConfig.versionCreatedAt).getTime(),
+                        {
+                          useLongFormat: true,
+                        }
+                      ) + " ago"
+                    : undefined
+                }
               >
                 <div className="@container">
                   <div className="grid grid-cols-1 gap-4 @md:grid-cols-2">

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/sdk": "^0.67.1",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.6-rc-1",
+        "@dust-tt/sparkle": "^0.4.6",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1282,9 +1282,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.6-rc-1",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.6-rc-1.tgz",
-      "integrity": "sha512-PaFT3Op1vlLgFkAu6C/rkkJqALRZdJ2lfz5y13jDPZHOwpxUSRgSwei0RPslgCEfcvP8RKVgHMCQ9CE7rWVJsA==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.6.tgz",
+      "integrity": "sha512-92OeHrNKlVI/T1kVwGchbxcT8dV6nzFCWNo2U+FeMGa4pDD/frJfWyNGSCEMPwE8bVUorqAIpX4zb/gJcxzPVg==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,7 +11,7 @@
         "@anthropic-ai/sdk": "^0.67.1",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.5",
+        "@dust-tt/sparkle": "^0.4.6-rc-1",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1282,9 +1282,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.5.tgz",
-      "integrity": "sha512-k38FosTiLANCCsdCSEJHFydVYIhYNwGDpnqn0Z5zwtfo5poSoBLxCmsX0JiiqaUhLaKfO9ku51pe1p7LVYBKgA==",
+      "version": "0.4.6-rc-1",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.6-rc-1.tgz",
+      "integrity": "sha512-PaFT3Op1vlLgFkAu6C/rkkJqALRZdJ2lfz5y13jDPZHOwpxUSRgSwei0RPslgCEfcvP8RKVgHMCQ9CE7rWVJsA==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -35,7 +35,7 @@
     "@anthropic-ai/sdk": "^0.67.1",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.6-rc-1",
+    "@dust-tt/sparkle": "^0.4.6",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",

--- a/front/package.json
+++ b/front/package.json
@@ -35,7 +35,7 @@
     "@anthropic-ai/sdk": "^0.67.1",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.5",
+    "@dust-tt/sparkle": "^0.4.6-rc-1",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

This PR refactors the `FeedbacksSection` component to use the new `Timeline` component from Sparkle instead of the custom `AgentConfigurationVersionHeader` with `NavigationListLabel`. The Timeline component provides better visual structure and semantics for displaying feedback items grouped by agent version, with clear differentiation between the latest production version and previous versions.

<img width="917" height="688" alt="Screenshot 2025-11-26 at 19 58 58" src="https://github.com/user-attachments/assets/3607b36f-6483-4704-a166-1861a30b9d16" />

## Risk

Low - UI refactoring

## Tests

Locally

## Deploy Plan

- Publish sparkle
- Bump sparkle version in front
- Deploy front