### PR TITLE
feat(internal): dust-quick global agt on gem3-light ff gated

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -37,6 +37,7 @@ import type {
 import {
   CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
+  GEMINI_3_PRO_MODEL_CONFIG,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   GLOBAL_AGENTS_SID,
@@ -606,6 +607,31 @@ export function _getDustEdgeGlobalAgent(
     agentId: GLOBAL_AGENTS_SID.DUST_EDGE,
     name: "dust-edge",
     preferredModelConfiguration: CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "light",
+  });
+}
+
+export function _getDustQuickGlobalAgent(
+  auth: Authenticator,
+  args: {
+    settings: GlobalAgentSettings | null;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
+    agentRouterMCPServerView: MCPServerViewResource | null;
+    webSearchBrowseMCPServerView: MCPServerViewResource | null;
+    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
+    toolsetsMCPServerView: MCPServerViewResource | null;
+    deepDiveMCPServerView: MCPServerViewResource | null;
+    interactiveContentMCPServerView: MCPServerViewResource | null;
+    dataWarehousesMCPServerView: MCPServerViewResource | null;
+    agentMemoryMCPServerView: MCPServerViewResource | null;
+    memories: AgentMemoryResource[];
+    availableToolsets: MCPServerViewResource[];
+  }
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_QUICK,
+    name: "dust-quick",
+    preferredModelConfiguration: GEMINI_3_PRO_MODEL_CONFIG,
     preferredReasoningEffort: "light",
   });
 }

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -264,6 +264,14 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
           "Same as dust but on another model to experiment internally.",
         pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
       };
+    case GLOBAL_AGENTS_SID.DUST_QUICK:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_QUICK,
+        name: "dust-quick",
+        description:
+          "Same as dust but running Gemini 3 with minimal reasoning for faster responses.",
+        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+      };
     case GLOBAL_AGENTS_SID.DUST:
       return {
         sId: GLOBAL_AGENTS_SID.DUST,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -18,6 +18,7 @@ import {
 import {
   _getDustEdgeGlobalAgent,
   _getDustGlobalAgent,
+  _getDustQuickGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import { _getNoopAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/noop";
 import { _getGeminiProGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/google";
@@ -363,6 +364,22 @@ function getGlobalAgent({
         availableToolsets,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_QUICK:
+      agentConfiguration = _getDustQuickGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        agentRouterMCPServerView,
+        webSearchBrowseMCPServerView,
+        dataSourcesFileSystemMCPServerView,
+        toolsetsMCPServerView,
+        deepDiveMCPServerView,
+        interactiveContentMCPServerView,
+        dataWarehousesMCPServerView,
+        agentMemoryMCPServerView,
+        memories,
+        availableToolsets,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
       agentConfiguration = _getDeepDiveGlobalAgent(auth, {
         settings,
@@ -583,6 +600,11 @@ export async function getGlobalAgents(
       (sId) => sId !== GLOBAL_AGENTS_SID.DUST_EDGE
     );
   }
+  if (!flags.includes("dust_quick_global_agent")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.DUST_QUICK
+    );
+  }
 
   let memories: AgentMemoryResource[] = [];
   if (
@@ -590,7 +612,8 @@ export async function getGlobalAgents(
     agentMemoryMCPServerView &&
     auth.user() &&
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE))
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK))
   ) {
     memories = await AgentMemoryResource.findByAgentConfigurationIdAndUser(
       auth,
@@ -605,7 +628,8 @@ export async function getGlobalAgents(
     variant === "full" &&
     toolsetsMCPServerView &&
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE))
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK))
   ) {
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
     availableToolsets = await MCPServerViewResource.listBySpace(

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -108,6 +108,7 @@ export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
   DUST_EDGE = "dust-edge",
+  DUST_QUICK = "dust-quick",
   DEEP_DIVE = "deep-dive",
   DUST_TASK = "dust-task",
   DUST_BROWSER_SUMMARY = "dust-browser-summary",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -13,6 +13,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Access to dust-edge global agent that we use internally to test other models on dust",
     stage: "dust_only",
   },
+  dust_quick_global_agent: {
+    description:
+      "Access to dust-quick global agent running Gemini 3 with minimal reasoning",
+    stage: "dust_only",
+  },
   notion_private_integration: {
     description: "Setup Notion private integration tokens",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -652,6 +652,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "deepseek_feature"
   | "deepseek_r1_global_agent_feature"
   | "dust_edge_global_agent"
+  | "dust_quick_global_agent"
   | "dev_mcp_actions"
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"


### PR DESCRIPTION
## Description

I want to benchmark various models on the `dust` global agent (running our existing benchmark set on prod data)

We have the mainline dust that runs on 4.5 sonnet, `edge` on 4.5 opus, and I'm adding `quick` on gemini 3.

early local tests (web only) shows low latency, comparable to gpt 5.1 @ minimal but much better instructions following.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
