### PR TITLE
Enable Next.js Standalone Output Mode for Production Deployments

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -131,19 +131,61 @@ runs:
           build_args+=("--build-arg NEXT_PUBLIC_DATADOG_SERVICE=$COMPONENT")
         fi
 
-        depot build \
-          --project $DEPOT_PROJECT_ID \
-          --platform linux/amd64 \
-          --provenance=false \
-          --cache-from type=gha,scope=${{ inputs.component }} \
-          --cache-to type=gha,mode=max,scope=${{ inputs.component }} \
-          -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
-          -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${{ inputs.component }}:${{ inputs.commit_sha }} \
-          --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
-          --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
-          ${build_args[@]} \
-          --push \
-          .
+        # Special handling for front component - build both front and workers targets
+        if [[ "$BASE_COMPONENT" == "front" ]]; then
+          echo "🏗️ Building front component with dual targets (front + workers)"
+
+          # Build front target
+          depot build \
+            --project $DEPOT_PROJECT_ID \
+            --platform linux/amd64 \
+            --provenance=false \
+            --target front \
+            --cache-from type=gha,scope=${{ inputs.component }}-deps \
+            --cache-from type=gha,scope=${{ inputs.component }}-front \
+            --cache-to type=gha,mode=max,scope=${{ inputs.component }}-deps \
+            --cache-to type=gha,mode=max,scope=${{ inputs.component }}-front \
+            -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
+            -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${{ inputs.component }}:${{ inputs.commit_sha }} \
+            --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
+            --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
+            ${build_args[@]} \
+            --push \
+            .
+
+          # Build workers target
+          depot build \
+            --project $DEPOT_PROJECT_ID \
+            --platform linux/amd64 \
+            --provenance=false \
+            --target workers \
+            --cache-from type=gha,scope=${{ inputs.component }}-deps \
+            --cache-from type=gha,scope=${{ inputs.component }}-workers \
+            --cache-to type=gha,mode=max,scope=${{ inputs.component }}-deps \
+            --cache-to type=gha,mode=max,scope=${{ inputs.component }}-workers \
+            -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
+            -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${{ inputs.component }}-workers:${{ inputs.commit_sha }} \
+            --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
+            --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
+            ${build_args[@]} \
+            --push \
+            .
+        else
+          # Standard single-target build for other components
+          depot build \
+            --project $DEPOT_PROJECT_ID \
+            --platform linux/amd64 \
+            --provenance=false \
+            --cache-from type=gha,scope=${{ inputs.component }} \
+            --cache-to type=gha,mode=max,scope=${{ inputs.component }} \
+            -f ./dockerfiles/${BASE_COMPONENT}.Dockerfile \
+            -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${{ inputs.component }}:${{ inputs.commit_sha }} \
+            --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
+            --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
+            ${build_args[@]} \
+            --push \
+            .
+        fi
 
     - name: Get current deployed version
       id: current_version

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -131,7 +131,7 @@ runs:
           build_args+=("--build-arg NEXT_PUBLIC_DATADOG_SERVICE=$COMPONENT")
         fi
 
-        # Special handling for front component - build both front and workers targets
+        # Special handling for front component, build both front and workers targets
         if [[ "$BASE_COMPONENT" == "front" ]]; then
           echo "🏗️ Building front component with dual targets (front + workers)"
 

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -94,10 +94,13 @@ WORKDIR /app
 COPY --from=deps /app/.next/standalone ./
 COPY --from=deps /app/.next/static ./.next/static
 COPY --from=deps /app/public ./public
+# Copy built SDK that front depends on
+COPY --from=deps /sdks ./sdks
 
 # Preload jemalloc for all processes:
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
+ARG COMMIT_HASH_LONG
 ENV DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/
 ENV DD_GIT_COMMIT_SHA=${COMMIT_HASH_LONG}
 
@@ -116,10 +119,13 @@ WORKDIR /app
 COPY --from=deps /app/dist ./dist
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/package.json ./package.json
+# Copy built SDK that workers depend on
+COPY --from=deps /sdks ./sdks
 
 # Preload jemalloc for all processes:
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
+ARG COMMIT_HASH_LONG
 ENV DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/
 ENV DD_GIT_COMMIT_SHA=${COMMIT_HASH_LONG}
 

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -77,6 +77,13 @@ RUN BUILD_WITH_SOURCE_MAPS=${DATADOG_API_KEY:+true} \
         --service=$NEXT_PUBLIC_DATADOG_SERVICE && \
         find .next -type f -name "*.map" -print -delete; \
     fi
+
+# Next.js standalone build doesn't automatically copy public and static assets
+# Copy public folder
+RUN cp -r public .next/standalone/
+# Copy static assets
+RUN cp -r .next/static .next/standalone/.next/
+
 RUN npm run sitemap
 
 # Preload jemalloc for all processes:

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -119,8 +119,8 @@ WORKDIR /app
 COPY --from=deps /app/dist ./dist
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/package.json ./package.json
-# Copy built SDK that workers depend on
-COPY --from=deps /sdks ./sdks
+# Copy built SDK that workers depend on (symlink points to ../../../sdks/js)
+COPY --from=deps /sdks/js ./sdks/js
 
 # Preload jemalloc for all processes:
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -1,3 +1,11 @@
+/**
+ * Force dd-trace inclusion in Next.js standalone mode.
+ * Side-effect import ensures dd-trace/init is available at runtime.
+ * Safe: this file is server-only (API routes, getServerSideProps).
+ * See: https://github.com/DataDog/dd-trace-js/issues/4003
+ */
+import "dd-trace";
+
 import tracer from "dd-trace";
 import type {
   GetServerSidePropsContext,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -53,6 +53,8 @@ const config = {
     serverMinification: false,
     esmExternals: false,
     instrumentationHook: true,
+    // Ensure dd-trace is included in standalone build for NODE_OPTIONS preload
+    serverComponentsExternalPackages: ["dd-trace"],
   },
   async redirects() {
     return [

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -36,6 +36,8 @@ const withBundleAnalyzer = bundleAnalyzer({
 });
 
 const config = {
+  // Standalone output for optimized Docker builds. It doesn't include static asset.
+  output: "standalone",
   transpilePackages: ["@uiw/react-textarea-code-editor"],
   // As of Next 14.2.3 swc minification creates a bug in the generated client side files.
   swcMinify: false,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -53,12 +53,17 @@ const config = {
     serverMinification: false,
     esmExternals: false,
     instrumentationHook: true,
-    // Ensure dd-trace and other dependencies are included in standalone build
+    // Ensure dd-trace and other dependencies are included in standalone build.
     outputFileTracingIncludes: {
       "/**": [
         "./node_modules/dd-trace/**/*",
-        "./node_modules/@datadog/**/*", 
-        "./node_modules/@reduxjs/toolkit/**/*"
+        "./node_modules/@datadog/**/*",
+        // Include entire Redux ecosystem to avoid issues with partial inclusion.
+        "./node_modules/redux/**/*",
+        "./node_modules/@reduxjs/**/*",
+        "./node_modules/immer/**/*",
+        "./node_modules/reselect/**/*",
+        "./node_modules/redux-thunk/**/*",
       ],
     },
   },

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -54,7 +54,9 @@ const config = {
     esmExternals: false,
     instrumentationHook: true,
     // Ensure dd-trace is included in standalone build for NODE_OPTIONS preload
-    serverComponentsExternalPackages: ["dd-trace"],
+    outputFileTracingIncludes: {
+      "/**": ["./node_modules/dd-trace/**/*", "./node_modules/@datadog/**/*"],
+    },
   },
   async redirects() {
     return [

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -36,7 +36,9 @@ const withBundleAnalyzer = bundleAnalyzer({
 });
 
 const config = {
-  // Standalone output for optimized Docker builds. It doesn't include static asset.
+  // Standalone output creates self-contained server with minimal dependencies for Docker. It
+  // creates standalone folder that copies only the necessary files for a production deployment
+  // including select files in node_modules.
   output: "standalone",
   transpilePackages: ["@uiw/react-textarea-code-editor"],
   // As of Next 14.2.3 swc minification creates a bug in the generated client side files.

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -53,9 +53,13 @@ const config = {
     serverMinification: false,
     esmExternals: false,
     instrumentationHook: true,
-    // Ensure dd-trace is included in standalone build for NODE_OPTIONS preload
+    // Ensure dd-trace and other dependencies are included in standalone build
     outputFileTracingIncludes: {
-      "/**": ["./node_modules/dd-trace/**/*", "./node_modules/@datadog/**/*"],
+      "/**": [
+        "./node_modules/dd-trace/**/*",
+        "./node_modules/@datadog/**/*", 
+        "./node_modules/@reduxjs/toolkit/**/*"
+      ],
     },
   },
   async redirects() {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We've been experiencing probe failures on every deployment for a while now. Zooming in, front pods take significant time to start. A good chunk goes to pulling the 2GB image, then starting Next.js. It was about time to start doing something about it.

This PR enables Next.js standalone mode for the front deployment, reducing the Next.js Docker image size by 67% (1.8GB → 600MB) and improving deployment speed, autoscaling response time.

## What and Why

Standalone mode ([doc](https://nextjs.org/docs/pages/api-reference/config/next-config-js/output#automatically-copying-traced-files)) uses `@vercel/nft` to trace dependencies and copy only what's needed into `.next/standalone/node_modules`, rather than shipping the entire dependency tree. This means faster image pulls, faster deployments, and lower memory usage.
The trade-off is that the file tracer can miss dependencies with dynamic imports, native modules, or ESM/CJS patterns that can't be statically analyzed (I'll add a linter rule in a follow up PR for newly added modules).

## Architectural Change: One Image → Two Images

Previously, we built a single Docker image (`front.Dockerfile`) used by both the Next.js deployment (front) and Temporal worker deployments (front-workers, front-agent-loop, ...) with different commands. This worked because both needed full `node_modules`.

With standalone mode, this approach breaks. Next.js standalone strips `node_modules` to the minimum, but our Temporal workers use esbuild with `packages: 'external'`, meaning they bundle the worker code but expect full `node_modules at runtime`. We can't have both in one image.

**Solution:** We now build two separate images through docker multi-stage build:
- `--target=front`: Next.js with standalone mode (600MB)
- `--target=front-workers` Temporal workers with full `node_modules` (~1.8GB) (will optimized later)

Both images share the same multi-stage build pattern and build from the same source code, but produce different outputs optimized for their respective workloads. An infrastructure PR will follow to update Helm charts and deployment configurations to use the two separate images.

This is a one-time architectural change that sets us up for better per-service optimization going forward.

## Road bumps

### Missing Dependencies in Standalone
Testing revealed that critical packages were being excluded from standalone builds:
- `dd-trace`: Loaded via `NODE_OPTIONS="-r dd-trace/init"`, but its dynamic requires and native modules (`@datadog/pprof`) weren't being traced
- Redux ecosystem: ESM/CJS dual exports confused the tracer, causing MODULE_NOT_FOUND errors for redux.mjs at runtime

These failures only surface when running the standalone build or in production, not during regular development. We will add an eslint rules for every new node modules added so that engineers first test on `front-edge`.

## Tests

Extensively tested on `front-edge` (see example build [here](https://dust4ai.slack.com/archives/C05DS517CUR/p1764180472144899)).

## Risk

Blast radius is very high, rollback will require to rollback the infra PR as well. 

## Deploy Plan

To deploy this, we need to first build the two images, then manually change apply the updated charts with the newly created images.