### PR TITLE
[connectors] refactor(Zendesk): uniformize client initialization

### DIFF
--- a/connectors/migrations/20250110_investigate_zendesk_hc.ts
+++ b/connectors/migrations/20250110_investigate_zendesk_hc.ts
@@ -22,10 +22,7 @@ makeScript({}, async ({ execute }, logger) => {
       connector.connectionId
     );
     const user = await fetchZendeskCurrentUser({ accessToken, subdomain });
-    const zendeskClient = await ZendeskClient.createClient(
-      accessToken,
-      connectorId
-    );
+    const zendeskClient = new ZendeskClient(accessToken, connectorId, null);
     const brandsOnDb = await ZendeskBrandResource.fetchByConnector(connector);
     for (const brandOnDb of brandsOnDb) {
       const { brandId } = brandOnDb;

--- a/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
+++ b/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
@@ -52,10 +52,7 @@ async function cleanupConnector(
   const { accessToken } = await getZendeskSubdomainAndAccessToken(
     connector.connectionId
   );
-  const zendeskClient = await ZendeskClient.createClient(
-    accessToken,
-    connector.id
-  );
+  const zendeskClient = new ZendeskClient(accessToken, connector.id, null);
   const brandSubdomains = new Map<number, string>();
   const ticketIdsSeen = new Set();
 

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -725,9 +725,10 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         const { accessToken, subdomain } =
           await getZendeskSubdomainAndAccessToken(connector.connectionId);
 
-        const zendeskClient = await ZendeskClient.createClient(
+        const zendeskClient = new ZendeskClient(
           accessToken,
-          connectorId
+          connectorId,
+          zendeskConfiguration.rateLimitTransactionsPerSecond
         );
 
         const convertedFields: { id: number; name: string }[] = [];

--- a/connectors/src/connectors/zendesk/lib/brand_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/brand_permissions.ts
@@ -1,7 +1,10 @@
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { ZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
-import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
+import {
+  ZendeskBrandResource,
+  ZendeskConfigurationResource,
+} from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 
 /**
@@ -17,6 +20,12 @@ export async function allowSyncZendeskBrand({
   connectionId: string;
   brandId: number;
 }): Promise<boolean> {
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
+
   const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
@@ -25,9 +34,11 @@ export async function allowSyncZendeskBrand({
   // fetching the brand from Zendesk
   const { subdomain, accessToken } =
     await getZendeskSubdomainAndAccessToken(connectionId);
-  const zendeskClient = await ZendeskClient.createClient(
+
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
   const fetchedBrand = await zendeskClient.fetchBrand({
     subdomain,

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -161,9 +161,11 @@ export const zendesk = async ({
   const { subdomain, accessToken } = await getZendeskSubdomainAndAccessToken(
     connector.connectionId
   );
-  const zendeskClient = await ZendeskClient.createClient(
+
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connector.id
+    connector.id,
+    configuration.rateLimitTransactionsPerSecond
   );
 
   // Run the command.

--- a/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/help_center_permissions.ts
@@ -7,7 +7,6 @@ import {
   ZendeskConfigurationResource,
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 /**
  * Marks a help center as permission "read".

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -6,7 +6,6 @@ import {
   ZendeskConfigurationResource,
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 /**
  * Marks the node "Tickets" of a Brand as permission "read".

--- a/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
+++ b/connectors/src/connectors/zendesk/lib/ticket_permissions.ts
@@ -1,8 +1,12 @@
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { ZendeskClient } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import logger from "@connectors/logger/logger";
-import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
+import {
+  ZendeskBrandResource,
+  ZendeskConfigurationResource,
+} from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 /**
  * Marks the node "Tickets" of a Brand as permission "read".
@@ -16,6 +20,12 @@ export async function allowSyncZendeskTickets({
   connectionId: string;
   brandId: number;
 }): Promise<boolean> {
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
+
   const brand = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
@@ -28,9 +38,11 @@ export async function allowSyncZendeskTickets({
   // fetching the brand from Zendesk
   const { subdomain, accessToken } =
     await getZendeskSubdomainAndAccessToken(connectionId);
-  const zendeskClient = await ZendeskClient.createClient(
+
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
   const fetchedBrand = await zendeskClient.fetchBrand({
     brandId,

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -43,10 +43,7 @@ import type { RateLimit } from "@connectors/lib/throttle";
 import { throttleWithRedis } from "@connectors/lib/throttle";
 import mainLogger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
-import {
-  ZendeskBrandResource,
-  ZendeskConfigurationResource,
-} from "@connectors/resources/zendesk_resources";
+import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 
 const RATE_LIMIT_MAX_RETRIES = 5;
@@ -66,29 +63,11 @@ const ZENDESK_URL_REGEX = /^https?:\/\/(.*)\.zendesk\.com([^?]*).*/;
 const ZENDESK_ENDPOINT_REGEX = /\/([a-zA-Z_]+)\/(\d+)/g;
 
 export class ZendeskClient {
-  private rateLimitTransactionsPerSecond: number | null = null;
-
-  private constructor(
+  constructor(
     private readonly accessToken: string,
-    private readonly connectorId: ModelId
+    private readonly connectorId: ModelId,
+    private readonly rateLimitTransactionsPerSecond: number | null
   ) {}
-
-  static async createClient(
-    accessToken: string,
-    connectorId: ModelId
-  ): Promise<ZendeskClient> {
-    const client = new ZendeskClient(accessToken, connectorId);
-
-    // Fetch configuration to get rate limit settings
-    const configuration =
-      await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
-    if (configuration) {
-      client.rateLimitTransactionsPerSecond =
-        configuration.rateLimitTransactionsPerSecond;
-    }
-
-    return client;
-  }
 
   private createRateLimitConfig(): RateLimit | null {
     if (this.rateLimitTransactionsPerSecond === null) {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -105,6 +105,12 @@ export async function syncZendeskBrandActivity({
     throw new Error("[Zendesk] Connector not found.");
   }
 
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
+
   const brandInDb = await ZendeskBrandResource.fetchByBrandId({
     connectorId,
     brandId,
@@ -118,9 +124,11 @@ export async function syncZendeskBrandActivity({
   const { subdomain, accessToken } = await getZendeskSubdomainAndAccessToken(
     connector.connectionId
   );
-  const zendeskClient = await ZendeskClient.createClient(
+
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
   const fetchedBrand = await zendeskClient.fetchBrand({
     subdomain,
@@ -273,13 +281,23 @@ export async function getZendeskHelpCenterReadAllowedBrandIdsActivity(
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
+
   const { subdomain, accessToken } = await getZendeskSubdomainAndAccessToken(
     connector.connectionId
   );
-  const zendeskClient = await ZendeskClient.createClient(
+
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
+
   for (const brandId of brandsWithHelpCenter) {
     const fetchedBrand = await zendeskClient.fetchBrand({
       subdomain,
@@ -343,6 +361,12 @@ export async function syncZendeskCategoryBatchActivity({
     throw new Error("[Zendesk] Connector not found.");
   }
 
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
+
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
@@ -354,9 +378,10 @@ export async function syncZendeskCategoryBatchActivity({
     brandId,
   });
 
-  const zendeskClient = await ZendeskClient.createClient(
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
 
   const brandSubdomain = await zendeskClient.getBrandSubdomain({
@@ -419,6 +444,13 @@ export async function syncZendeskCategoryActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
+
   const categoryInDb = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
     brandId,
@@ -444,9 +476,10 @@ export async function syncZendeskCategoryActivity({
     connector.connectionId
   );
 
-  const zendeskClient = await ZendeskClient.createClient(
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
 
   const brandSubdomain = await zendeskClient.getBrandSubdomain({
@@ -524,11 +557,13 @@ export async function syncZendeskArticleBatchActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+
   const configuration =
     await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
   if (!configuration) {
     throw new Error(`[Zendesk] Configuration not found.`);
   }
+
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {
     workspaceId: dataSourceConfig.workspaceId,
@@ -536,6 +571,7 @@ export async function syncZendeskArticleBatchActivity({
     provider: "zendesk",
     dataSourceId: dataSourceConfig.dataSourceId,
   };
+
   const category = await ZendeskCategoryResource.fetchByCategoryId({
     connectorId,
     brandId,
@@ -551,9 +587,10 @@ export async function syncZendeskArticleBatchActivity({
     connector.connectionId
   );
 
-  const zendeskClient = await ZendeskClient.createClient(
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
 
   const brandSubdomain = await zendeskClient.getBrandSubdomain({
@@ -632,11 +669,13 @@ export async function syncZendeskTicketBatchActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+
   const configuration =
     await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
   if (!configuration) {
     throw new Error(`[Zendesk] Configuration not found.`);
   }
+
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {
     workspaceId: dataSourceConfig.workspaceId,
@@ -649,9 +688,10 @@ export async function syncZendeskTicketBatchActivity({
     connector.connectionId
   );
 
-  const zendeskClient = await ZendeskClient.createClient(
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
 
   const brandSubdomain = await zendeskClient.getBrandSubdomain({

--- a/connectors/src/connectors/zendesk/temporal/gc_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/gc_activities.ts
@@ -134,6 +134,13 @@ export async function removeMissingArticleBatchActivity({
   if (!connector) {
     throw new Error("[Zendesk] Connector not found.");
   }
+
+  const configuration =
+    await ZendeskConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`[Zendesk] Configuration not found.`);
+  }
+
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {
     workspaceId: dataSourceConfig.workspaceId,
@@ -146,9 +153,11 @@ export async function removeMissingArticleBatchActivity({
   const { subdomain, accessToken } = await getZendeskSubdomainAndAccessToken(
     connector.connectionId
   );
-  const zendeskClient = await ZendeskClient.createClient(
+
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
   const brandSubdomain = await zendeskClient.getBrandSubdomain({
     brandId,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -106,9 +106,10 @@ export async function syncZendeskArticleUpdateBatchActivity({
     connector.connectionId
   );
 
-  const zendeskClient = await ZendeskClient.createClient(
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
 
   const brandSubdomain = await zendeskClient.getBrandSubdomain({
@@ -243,9 +244,10 @@ export async function syncZendeskTicketUpdateBatchActivity({
     connector.connectionId
   );
 
-  const zendeskClient = await ZendeskClient.createClient(
+  const zendeskClient = new ZendeskClient(
     accessToken,
-    connectorId
+    connectorId,
+    configuration.rateLimitTransactionsPerSecond
   );
 
   const brandSubdomain = await zendeskClient.getBrandSubdomain({


### PR DESCRIPTION
## Description

- This PR uniformizes the creation of a `ZendeskClient` by removing the `createClient` method, which used to fetch the configuration and read the rate limit configuration from it.
- The caller is now responsible for fetching the necessary data, in many cases this lead to refetching the configuration.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
