### PR TITLE
[Usage Tracking] Track programmatic usage for all origins

### DIFF
--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -1,5 +1,5 @@
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
-import { hasReachedPublicAPILimits } from "@app/lib/api/programmatic_usage_tracking";
+import { hasReachedProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage_tracking";
 import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { getWebhookRequestsBucket } from "@app/lib/file_storage";
@@ -325,7 +325,7 @@ async function checkTriggerRateLimits({
       workspaceRateLimitErrorMessage = globalRateLimitRes.error.message;
     }
   } else {
-    const publicAPILimit = await hasReachedPublicAPILimits(auth, true);
+    const publicAPILimit = await hasReachedProgrammaticUsageLimits(auth, true);
     if (publicAPILimit) {
       workspaceRateLimitErrorMessage =
         "Workspace has reached its public API limits for the current billing period.";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -12,7 +12,7 @@ import {
 } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { hasReachedPublicAPILimits } from "@app/lib/api/programmatic_usage_tracking";
+import { hasReachedProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage_tracking";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
@@ -102,7 +102,7 @@ async function handler(
         });
       }
 
-      const hasReachedLimits = await hasReachedPublicAPILimits(auth);
+      const hasReachedLimits = await hasReachedProgrammaticUsageLimits(auth);
       if (hasReachedLimits) {
         return apiError(req, res, {
           status_code: 429,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -20,7 +20,7 @@ import {
 } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { hasReachedPublicAPILimits } from "@app/lib/api/programmatic_usage_tracking";
+import { hasReachedProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage_tracking";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -141,7 +141,7 @@ async function handler(
         blocking,
       } = r.data;
 
-      const hasReachedLimits = await hasReachedPublicAPILimits(auth);
+      const hasReachedLimits = await hasReachedProgrammaticUsageLimits(auth);
       if (hasReachedLimits) {
         return apiError(req, res, {
           status_code: 429,

--- a/front/temporal/agent_loop/activities/usage_tracking.ts
+++ b/front/temporal/agent_loop/activities/usage_tracking.ts
@@ -1,4 +1,7 @@
-import { maybeTrackTokenUsageCost } from "@app/lib/api/programmatic_usage_tracking";
+import {
+  isProgrammaticUsage,
+  trackProgrammaticCost,
+} from "@app/lib/api/programmatic_usage_tracking";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import {
@@ -14,7 +17,7 @@ const AGENT_MESSAGE_STATUSES_TO_TRACK: AgentMessageStatus[] = [
   "cancelled",
 ];
 
-export async function trackUsageActivity(
+export async function trackProgrammaticUsageActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
@@ -63,10 +66,12 @@ export async function trackUsageActivity(
 
   if (
     AGENT_MESSAGE_STATUSES_TO_TRACK.includes(agentMessage.status) &&
-    agentMessage.runIds
+    agentMessage.runIds &&
+    isProgrammaticUsage(auth, {
+      userMessageOrigin: userMessage.userContextOrigin,
+    })
   ) {
-    // Track token usage cost for programmatic usage.
-    await maybeTrackTokenUsageCost(auth, {
+    await trackProgrammaticCost(auth, {
       dustRunIds: agentMessage.runIds,
       userMessageOrigin: userMessage.userContextOrigin ?? null,
     });

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -21,7 +21,7 @@ import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
-import { trackUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
+import { trackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 
@@ -48,7 +48,7 @@ export async function runAgentLoopWorker() {
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,
       runToolActivity,
-      trackUsageActivity,
+      trackUsageActivity: trackProgrammaticUsageActivity,
     },
     taskQueue: QUEUE_NAME,
     connection,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -110,7 +110,7 @@ const { notifyWorkflowError, finalizeCancellationActivity } = proxyActivities<
   },
 });
 
-const { trackProgrammaticUsageActivity } = proxyActivities<
+const { trackProgrammaticUsageActivity: trackUsageActivity } = proxyActivities<
   typeof usageTrackingActivities
 >({
   startToCloseTimeout: "2 minutes",
@@ -247,7 +247,7 @@ export async function agentLoopWorkflow({
       await CancellationScope.nonCancellable(async () => {
         await Promise.all([
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
-          trackProgrammaticUsageActivity(authType, agentLoopArgs),
+          trackUsageActivity(authType, agentLoopArgs),
           conversationUnreadNotificationActivity(authType, agentLoopArgs),
         ]);
       });
@@ -265,7 +265,7 @@ export async function agentLoopWorkflow({
         // Ensure analytics runs even when workflow is cancelled
         await Promise.all([
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
-          trackProgrammaticUsageActivity(authType, agentLoopArgs),
+          trackUsageActivity(authType, agentLoopArgs),
           finalizeCancellationActivity(authType, agentLoopArgs),
         ]);
         return;
@@ -273,7 +273,7 @@ export async function agentLoopWorkflow({
         // Ensure analytics runs even when workflow errors
         await Promise.all([
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
-          trackProgrammaticUsageActivity(authType, agentLoopArgs),
+          trackUsageActivity(authType, agentLoopArgs),
           notifyWorkflowError(authType, {
             conversationId: agentLoopArgs.conversationId,
             agentMessageId: agentLoopArgs.agentMessageId,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -110,7 +110,9 @@ const { notifyWorkflowError, finalizeCancellationActivity } = proxyActivities<
   },
 });
 
-const { trackUsageActivity } = proxyActivities<typeof usageTrackingActivities>({
+const { trackProgrammaticUsageActivity } = proxyActivities<
+  typeof usageTrackingActivities
+>({
   startToCloseTimeout: "2 minutes",
   retry: {
     maximumAttempts: 5,
@@ -245,7 +247,7 @@ export async function agentLoopWorkflow({
       await CancellationScope.nonCancellable(async () => {
         await Promise.all([
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
-          trackUsageActivity(authType, agentLoopArgs),
+          trackProgrammaticUsageActivity(authType, agentLoopArgs),
           conversationUnreadNotificationActivity(authType, agentLoopArgs),
         ]);
       });
@@ -263,7 +265,7 @@ export async function agentLoopWorkflow({
         // Ensure analytics runs even when workflow is cancelled
         await Promise.all([
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
-          trackUsageActivity(authType, agentLoopArgs),
+          trackProgrammaticUsageActivity(authType, agentLoopArgs),
           finalizeCancellationActivity(authType, agentLoopArgs),
         ]);
         return;
@@ -271,7 +273,7 @@ export async function agentLoopWorkflow({
         // Ensure analytics runs even when workflow errors
         await Promise.all([
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
-          trackUsageActivity(authType, agentLoopArgs),
+          trackProgrammaticUsageActivity(authType, agentLoopArgs),
           notifyWorkflowError(authType, {
             conversationId: agentLoopArgs.conversationId,
             agentMessageId: agentLoopArgs.agentMessageId,


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5295
- Track programmatic usage even when workspace limits are disabled by decoupling programmatic detection from limits.
- Rename usage tracking helpers and Temporal wiring to reflect programmatic cost tracking.
- Keep rate-limit enforcement confined to workspaces that opt into public API limits.

## Risks
Blast radius: Programmatic usage tracking, webhook triggers, assistant public API rate limits, agent loop usage accounting
Risk: standard

## Deploy Plan
- deploy front