### PR TITLE
[front] Disable attachments and tools removal on input bar disabled

### DIFF
--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -17,8 +17,7 @@ import {
   isTextualContentType,
 } from "@app/components/assistant/conversation/attachment/utils";
 import type { LightWorkspaceType } from "@app/types";
-import { getFileFormat } from "@app/types";
-import { isSupportedImageContentType } from "@app/types";
+import { getFileFormat, isSupportedImageContentType } from "@app/types";
 
 interface AttachmentCitationProps {
   owner: LightWorkspaceType;
@@ -87,9 +86,7 @@ export function AttachmentCitation({
                 <CitationClose
                   onClick={(e) => {
                     e.stopPropagation();
-                    // eslint-disable-next-line no-unused-expressions
-                    attachmentCitation.onRemove &&
-                      attachmentCitation.onRemove();
+                    attachmentCitation.onRemove?.();
                   }}
                 />
               )

--- a/front/components/assistant/conversation/attachment/types.ts
+++ b/front/components/assistant/conversation/attachment/types.ts
@@ -12,7 +12,7 @@ export type FileAttachment = {
   title: string;
   contentType: SupportedFileContentType;
   isUploading: boolean;
-  onRemove: () => void;
+  onRemove?: () => void;
   description?: string;
   sourceUrl?: string;
 };
@@ -25,7 +25,7 @@ export type NodeAttachment = {
   spaceIcon: React.ComponentType;
   visual: React.ReactNode;
   path: string;
-  onRemove: () => void;
+  onRemove?: () => void;
   url: string | null;
 };
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -321,6 +321,7 @@ export const InputBar = React.memo(function InputBar({
               onRemove: handleNodesAttachmentRemove,
             }}
             conversationId={conversationId}
+            disable={disable}
           />
           <InputBarContainer
             actions={actions}

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -41,6 +41,7 @@ interface InputBarAttachmentsProps {
   files: FileAttachmentsProps;
   nodes?: NodeAttachmentsProps;
   conversationId: string | null;
+  disable?: boolean;
 }
 
 export function InputBarAttachments({
@@ -48,6 +49,7 @@ export function InputBarAttachments({
   files,
   nodes,
   conversationId,
+  disable = false,
 }: InputBarAttachmentsProps) {
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
@@ -87,11 +89,13 @@ export function InputBarAttachments({
           isUploading: blob.isUploading,
           description: uploadDate,
           fileId: blob.id,
-          onRemove: () => files.service.removeFile(blob.id),
+          onRemove: disable
+            ? undefined
+            : () => files.service.removeFile(blob.id),
         };
       }) ?? []
     );
-  }, [files?.service]);
+  }, [files?.service, disable]);
 
   // Convert content nodes to NodeAttachment objects
   const nodeAttachments: NodeAttachment[] = useMemo(() => {
@@ -125,11 +129,11 @@ export function InputBarAttachments({
           spaceIcon: spacesMap[node.dataSourceView.spaceId].icon,
           path: getLocationForDataSourceViewContentNode(node),
           visual,
-          onRemove: () => nodes.onRemove(node),
+          onRemove: disable ? undefined : () => nodes.onRemove(node),
         };
       }) ?? []
     );
-  }, [nodes, spacesMap]);
+  }, [nodes, spacesMap, disable]);
 
   const allAttachments: Attachment[] = [...fileAttachments, ...nodeAttachments];
 
@@ -138,20 +142,18 @@ export function InputBarAttachments({
   }
 
   return (
-    <>
-      <CitationGrid className="border-b border-separator px-3 pb-3 pt-3 dark:border-separator-night">
-        {allAttachments.map((attachment, index) => {
-          const attachmentCitation = attachmentToAttachmentCitation(attachment);
-          return (
-            <AttachmentCitation
-              key={index}
-              owner={owner}
-              attachmentCitation={attachmentCitation}
-              conversationId={conversationId}
-            />
-          );
-        })}
-      </CitationGrid>
-    </>
+    <CitationGrid className="border-b border-separator px-3 pb-3 pt-3 dark:border-separator-night">
+      {allAttachments.map((attachment, index) => {
+        const attachmentCitation = attachmentToAttachmentCitation(attachment);
+        return (
+          <AttachmentCitation
+            key={index}
+            owner={owner}
+            attachmentCitation={attachmentCitation}
+            conversationId={conversationId}
+          />
+        );
+      })}
+    </CitationGrid>
   );
 }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -539,22 +539,31 @@ const InputBarContainer = ({
           <div className="mb-1 flex flex-wrap items-center">
             {selectedMCPServerViews.map((msv) => (
               <React.Fragment key={msv.sId}>
+                {/* Two Chips: one for larger screens (desktop), one for smaller screens (mobile). */}
                 <Chip
                   size="xs"
                   label={getMcpServerViewDisplayName(msv)}
                   icon={getIcon(msv.server.icon)}
                   className="m-0.5 hidden bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:flex"
-                  onRemove={() => {
-                    onMCPServerViewDeselect(msv);
-                  }}
+                  onRemove={
+                    disableInput
+                      ? undefined
+                      : () => {
+                          onMCPServerViewDeselect(msv);
+                        }
+                  }
                 />
                 <Chip
                   size="xs"
                   icon={getIcon(msv.server.icon)}
                   className="m-0.5 flex bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:hidden"
-                  onRemove={() => {
-                    onMCPServerViewDeselect(msv);
-                  }}
+                  onRemove={
+                    disableInput
+                      ? undefined
+                      : () => {
+                          onMCPServerViewDeselect(msv);
+                        }
+                  }
                 />
               </React.Fragment>
             ))}


### PR DESCRIPTION
## Description

- This PR makes the attachments (files and nodes) and the list of JIT tools added non editable when the input bar is disabled.
- Will move the "1 action requires manual action" above the input bar in a follow up PR.

Before
<img width="1033" height="514" alt="Screenshot 2025-11-27 at 8 30 58 AM" src="https://github.com/user-attachments/assets/9226249b-4e15-44ee-b056-e86ee428fd19" />

After
<img width="1033" height="514" alt="Screenshot 2025-11-27 at 8 30 39 AM" src="https://github.com/user-attachments/assets/e2049446-fcc4-4c65-b779-799e05fd0ad7" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
