### PR TITLE
[front] Move blocked action warning above `InputBar`

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -2,6 +2,9 @@ import {
   ArrowDownDashIcon,
   ArrowPathIcon,
   Button,
+  ContentMessageAction,
+  ContentMessageInline,
+  InformationCircleIcon,
   StopIcon,
 } from "@dust-tt/sparkle";
 import {
@@ -26,6 +29,7 @@ import { useCancelMessage, useConversation } from "@app/lib/swr/conversations";
 import { emptyArray } from "@app/lib/swr/swr";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { AgentMention } from "@app/types";
+import { conjugate, pluralize } from "@app/types";
 import { isAgentMention } from "@app/types";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
@@ -36,7 +40,12 @@ export const AgentInputBar = ({
   context: VirtuosoMessageListContext;
 }) => {
   const generationContext = useContext(GenerationContext);
-  const { hasBlockedActions } = useBlockedActionsContext();
+  const {
+    hasBlockedActions,
+    hasPendingValidations,
+    totalBlockedActions,
+    showBlockedActionsDialog,
+  } = useBlockedActionsContext();
 
   if (!generationContext) {
     throw new Error(
@@ -182,6 +191,29 @@ export const AgentInputBar = ({
           />
         )}
       </div>
+      {hasBlockedActions && (
+        <ContentMessageInline
+          icon={InformationCircleIcon}
+          variant="primary"
+          className="max-h-dvh mb-5 flex w-full sm:w-full sm:max-w-3xl"
+        >
+          <span className="font-bold">
+            {totalBlockedActions} action
+            {pluralize(totalBlockedActions)}
+          </span>{" "}
+          require{conjugate(totalBlockedActions)} a manual action
+          {/* If there are pending validations, we show a button allowing to open the dialog
+              from where they can be approved/denied */}
+          {hasPendingValidations && (
+            <ContentMessageAction
+              label="Review actions"
+              variant="outline"
+              size="xs"
+              onClick={() => showBlockedActionsDialog()}
+            />
+          )}
+        </ContentMessageInline>
+      )}
       <InputBar
         owner={context.owner}
         onSubmit={context.handleSubmit}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -4,7 +4,6 @@ import { useCallback, useContext, useEffect, useState } from "react";
 
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { AgentBrowserContainer } from "@app/components/assistant/conversation/AgentBrowserContainer";
-import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
@@ -44,8 +43,6 @@ export function ConversationContainerVirtuoso({
   const [planLimitReached, setPlanLimitReached] = useState(false);
 
   const { setSelectedAgent } = useContext(InputBarContext);
-
-  const { hasBlockedActions } = useBlockedActionsContext();
 
   const router = useRouter();
 
@@ -173,7 +170,6 @@ export function ConversationContainerVirtuoso({
               owner={owner}
               onSubmit={handleConversationCreation}
               conversationId={null}
-              disable={hasBlockedActions}
               disableAutoFocus={false}
             />
           </div>

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -1,9 +1,4 @@
-import {
-  ContentMessageAction,
-  ContentMessageInline,
-  InformationCircleIcon,
-  Page,
-} from "@dust-tt/sparkle";
+import { Page } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useState } from "react";
 
@@ -31,7 +26,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
-import { conjugate, Err, Ok, pluralize, toMentionType } from "@app/types";
+import { Err, Ok, toMentionType } from "@app/types";
 
 interface ConversationContainerProps {
   owner: WorkspaceType;
@@ -50,12 +45,7 @@ export function ConversationContainerVirtuoso({
 
   const { setSelectedAgent } = useContext(InputBarContext);
 
-  const {
-    hasBlockedActions,
-    hasPendingValidations,
-    totalBlockedActions,
-    showBlockedActionsDialog,
-  } = useBlockedActionsContext();
+  const { hasBlockedActions } = useBlockedActionsContext();
 
   const router = useRouter();
 
@@ -157,37 +147,12 @@ export function ConversationContainerVirtuoso({
       title="Attach files to the conversation"
     >
       {activeConversationId ? (
-        <>
-          <ConversationViewer
-            owner={owner}
-            user={user}
-            conversationId={activeConversationId}
-            setPlanLimitReached={setPlanLimitReached}
-          />
-          {hasBlockedActions && (
-            <ContentMessageInline
-              icon={InformationCircleIcon}
-              variant="primary"
-              className="max-h-dvh mb-5 flex w-full sm:w-full sm:max-w-3xl"
-            >
-              <span className="font-bold">
-                {totalBlockedActions} action
-                {pluralize(totalBlockedActions)}
-              </span>{" "}
-              require{conjugate(totalBlockedActions)} a manual action
-              {/* If there are pending validations, we show a button allowing to open the dialog
-              from where they can be approved/denied */}
-              {hasPendingValidations && (
-                <ContentMessageAction
-                  label="Review actions"
-                  variant="outline"
-                  size="xs"
-                  onClick={() => showBlockedActionsDialog()}
-                />
-              )}
-            </ContentMessageInline>
-          )}
-        </>
+        <ConversationViewer
+          owner={owner}
+          user={user}
+          conversationId={activeConversationId}
+          setPlanLimitReached={setPlanLimitReached}
+        />
       ) : (
         <>
           <div


### PR DESCRIPTION
## Description

- In the initial design and implementation the "1 action requires manual action" was above the `InputBar`.
- This PR moves the warning block above the input bar.

Before
<img width="1033" height="514" alt="Screenshot 2025-11-27 at 8 43 39 AM" src="https://github.com/user-attachments/assets/c46dc7ba-4769-4e87-8ed0-7dd0b4abfbef" />

After
<img width="1033" height="514" alt="Screenshot 2025-11-27 at 8 41 46 AM" src="https://github.com/user-attachments/assets/8f59f484-07c8-4b91-af19-ecc27b23db92" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
