### PR TITLE
Remove '(preview)' from Speech Generator and Sound studio tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1074,7 +1074,7 @@ The directive should be used to display a clickable version of the agent name in
     availability: "auto",
     allowMultipleInstances: false,
     isRestricted: undefined,
-    isPreview: true,
+    isPreview: false,
     tools_stakes: {
       text_to_speech: "low",
       text_to_dialogue: "low",
@@ -1158,7 +1158,7 @@ The directive should be used to display a clickable version of the agent name in
     availability: "manual",
     allowMultipleInstances: false,
     isRestricted: undefined,
-    isPreview: true,
+    isPreview: false,
     tools_stakes: {
       generate_music: "low",
       generate_sound_effects: "low",


### PR DESCRIPTION
## Description

Tiny PR to remove the Preview in title since it's in auto now?
Do you now why one of those appear both time on our workspace? 

<kbd>
<img width="379" height="169" alt="Screenshot 2025-11-27 at 10 18 13" src="https://github.com/user-attachments/assets/24d41b55-c35a-4bfa-af35-aa7d55465702" />
</kbd>

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 