### PR TITLE
chore(connectors): add privateIntegrationCredentialId to slack_configurations table

### DIFF
--- a/connectors/migrations/db/migration_108.sql
+++ b/connectors/migrations/db/migration_108.sql
@@ -1,0 +1,2 @@
+-- Migration created on Nov 27, 2025
+ALTER TABLE "public"."slack_configurations" ADD COLUMN "privateIntegrationCredentialId" VARCHAR(255);

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -19,6 +19,7 @@ export class SlackConfigurationModel extends ConnectorBaseModel<SlackConfigurati
   declare whitelistedDomains?: readonly string[];
   declare autoReadChannelPatterns: SlackAutoReadPattern[];
   declare feedbackVisibleToAuthorOnly: boolean;
+  declare privateIntegrationCredentialId?: string | null;
 }
 
 SlackConfigurationModel.init(
@@ -60,6 +61,10 @@ SlackConfigurationModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: true,
+    },
+    privateIntegrationCredentialId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {


### PR DESCRIPTION

## Description


- Adds privateIntegrationCredentialId nullable column to slack_configurations (same as we have today for notion_connector_states)

Needed for task : https://github.com/dust-tt/tasks/issues/5272

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Merge PR
- Execute migration on prodbox in both regions
- Deploy connectors