### PR TITLE
Fix front build to add admin folder

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -105,6 +105,8 @@ WORKDIR /app
 COPY --from=front-nextjs-build /app/.next/standalone ./
 COPY --from=front-nextjs-build /app/.next/static ./.next/static
 COPY --from=front-nextjs-build /app/public ./public
+# Copy admin directory (contains prestop.sh and other scripts)
+COPY --from=base-deps /app/admin ./admin
 # Copy built SDK from base dependencies (maintain absolute path for symlink resolution)
 COPY --from=base-deps /sdks /sdks
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/18368.

This PR update the `front.Dockerfile` to copy the admin folder in the front image. This is required as `preStop` needs to use a script from there. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
