### PR TITLE
feat(ppul): display active filters in programmatic cost chart

### DIFF
--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -113,7 +113,7 @@ export function ChartContainer({
                 <div className="flex-1 overflow-hidden">
                   <ResponsiveContainer
                     width="100%"
-                    height={window.innerHeight - 200}
+                    height={window.innerHeight - 250}
                   >
                     {children}
                   </ResponsiveContainer>

--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -24,6 +24,7 @@ interface ChartContainerProps {
   emptyMessage?: string;
   children: ReactElement;
   additionalControls?: ReactNode;
+  bottomControls?: ReactNode;
   statusChip?: ReactNode;
   height?: number;
   description?: string;
@@ -38,6 +39,7 @@ export function ChartContainer({
   emptyMessage,
   children,
   additionalControls,
+  bottomControls,
   statusChip,
   height,
   description,
@@ -92,6 +94,7 @@ export function ChartContainer({
             <ResponsiveContainer width="100%" height={height}>
               {children}
             </ResponsiveContainer>
+            {bottomControls}
             {legendItems && <ChartLegend items={legendItems} />}
           </>
         )}
@@ -114,6 +117,7 @@ export function ChartContainer({
                   >
                     {children}
                   </ResponsiveContainer>
+                  {bottomControls}
                   {legendItems && <ChartLegend items={legendItems} />}
                 </div>
               </div>

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -347,29 +347,34 @@ export function ProgrammaticCostChart({
   }, [filter]);
 
   // Util function to get label for a filter key based on type
-  function getFilterLabel(type: GroupByType, key: string): string {
-    if (key === "others") {
-      return OTHER_LABEL.label;
-    }
-    if (type === "origin" && isUserMessageOrigin(key)) {
-      return USER_MESSAGE_ORIGIN_LABELS[key].label;
-    }
-    // Fallback to cached label if present, else original key
-    return labelCache[type]?.[key] ?? key;
-  }
+  const getFilterLabel = useCallback(
+    (type: GroupByType, key: string): string => {
+      if (key === "others") {
+        return OTHER_LABEL.label;
+      }
+      if (type === "origin" && isUserMessageOrigin(key)) {
+        return USER_MESSAGE_ORIGIN_LABELS[key].label;
+      }
+      // Fallback to cached label if present, else original key
+      return labelCache[type]?.[key] ?? key;
+    },
+    [labelCache]
+  );
 
   // Build active filter chips for all groupBy types
   const activeFilterChips = useMemo(() => {
     return GROUP_BY_TYPE_OPTIONS.flatMap(({ value: type }) => {
       const filterKeys = filter[type];
-      if (!filterKeys) return [];
+      if (!filterKeys) {
+        return [];
+      }
       return filterKeys.map((key) => ({
         groupByType: type,
         filterKey: key,
         label: getFilterLabel(type, key),
       }));
     });
-  }, [filter, labelCache]);
+  }, [filter, labelCache, getFilterLabel]);
 
   // Remove a specific filter
   const handleRemoveFilter = useCallback(
@@ -475,11 +480,12 @@ export function ProgrammaticCostChart({
             {activeFilterChips.map((chip) => (
               <Chip
                 key={`${chip.groupByType}:${chip.filterKey}`}
-                label={chip.label}
+                label={`${chip.groupByType}: ${chip.label}`}
                 size="xs"
                 onRemove={() =>
                   handleRemoveFilter(chip.groupByType, chip.filterKey)
                 }
+                className="capitalize"
               />
             ))}
           </div>

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -247,7 +247,10 @@ export function ProgrammaticCostChart({
   };
 
   // Getting list of all available groups.
-  const availableGroupsArray = programmaticCostData?.availableGroups ?? [];
+  const availableGroupsArray = useMemo(
+    () => programmaticCostData?.availableGroups ?? [],
+    [programmaticCostData]
+  );
   const allGroupKeys = availableGroupsArray.map((g) => g.groupKey);
 
   // Cache labels when availableGroupsArray changes
@@ -374,7 +377,7 @@ export function ProgrammaticCostChart({
         label: getFilterLabel(type, key),
       }));
     });
-  }, [filter, labelCache, getFilterLabel]);
+  }, [filter, getFilterLabel]);
 
   // Remove a specific filter
   const handleRemoveFilter = useCallback(

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
@@ -19,6 +19,8 @@ import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { randInt } from "three/src/math/MathUtils.js";
+import { cos } from "mathjs";
 
 const GROUP_BY_KEYS = ["agent", "origin", "apiKey"] as const;
 
@@ -477,9 +479,110 @@ async function handler(
         });
       }
 
+      // Generate dummy data for testing
+      const dummyGroupsByType: Record<GroupByType, AvailableGroup[]> = {
+        agent: [
+          { groupKey: "agent-1", groupLabel: "Sales Assistant" },
+          { groupKey: "agent-2", groupLabel: "Support Bot" },
+          { groupKey: "agent-3", groupLabel: "Code Helper" },
+        ],
+        origin: [
+          { groupKey: "slack", groupLabel: "Slack" },
+          { groupKey: "web", groupLabel: "Web" },
+          { groupKey: "api", groupLabel: "API" },
+        ],
+        apiKey: [
+          { groupKey: "api_key_1", groupLabel: "Production API" },
+          { groupKey: "api_key_2", groupLabel: "Staging API" },
+        ],
+      };
+
+      // Get groups for current groupBy mode
+      let dummyAvailableGroups: AvailableGroup[] = [];
+      let activeGroupKeys: string[] = [];
+
+      // Define fixed costs per group (these don't change with filtering)
+      const fixedGroupCosts: Record<GroupByType, Record<string, number>> = {
+        agent: {
+          "agent-1": 0.4,
+          "agent-2": 0.35,
+          "agent-3": 0.2,
+          others: 0.05,
+        },
+        origin: {
+          slack: 0.5,
+          web: 0.3,
+          api: 0.15,
+          others: 0.05,
+        },
+        apiKey: {
+          api_key_1: 0.6,
+          api_key_2: 0.35,
+          others: 0.05,
+        },
+      };
+
+      if (groupBy) {
+        dummyAvailableGroups = [...dummyGroupsByType[groupBy]];
+        // Add "others" group to available groups
+        dummyAvailableGroups.push({ groupKey: "others", groupLabel: "Others" });
+
+        // Apply filter for the current groupBy mode
+        const currentFilter = filterParams?.[groupBy];
+        if (currentFilter && currentFilter.length > 0) {
+          activeGroupKeys = currentFilter;
+        } else {
+          // By default, show all except "others"
+          activeGroupKeys = dummyGroupsByType[groupBy].map((g) => g.groupKey);
+        }
+      } else {
+        // Global mode - show total
+        dummyAvailableGroups = [
+          { groupKey: "total", groupLabel: "Cumulative Cost" },
+        ];
+        activeGroupKeys = ["total"];
+      }
+
+      const cumulatedCosts: Record<string, number> = {};
+      activeGroupKeys.forEach((key) => {
+        cumulatedCosts[key] = 0;
+      });
+
+      const dummyPoints: WorkspaceProgrammaticCostPoint[] = timestamps.map(
+        (timestamp, index) => {
+          const dayOfMonth = index + 1;
+          const baseCost = 10000 + cos(dayOfMonth + 1) * 10000; // Increasing cost over the month
+
+          const groups = activeGroupKeys.map((groupKey) => {
+            // Use fixed cost ratios - filtering changes which groups are shown, not the costs
+            const costRatio = groupBy
+              ? (fixedGroupCosts[groupBy][groupKey] ?? 0.1)
+              : 1;
+            const groupCost = Math.floor(baseCost * costRatio);
+            cumulatedCosts[groupKey] += groupCost;
+            return {
+              groupKey,
+              costCents: groupCost,
+              cumulatedCostCents:
+                timestamp <= now.getTime()
+                  ? cumulatedCosts[groupKey]
+                  : undefined,
+            };
+          });
+
+          return {
+            timestamp,
+            groups,
+            totalInitialCreditsCents: 100000, // $1000 in credits
+            totalConsumedCreditsCents: Math.floor(baseCost),
+            totalRemainingCreditsCents: 100000 - Math.floor(baseCost),
+          };
+        }
+      );
+
       return res.status(200).json({
-        points,
-        availableGroups,
+        points: dummyPoints,
+        availableGroups: dummyAvailableGroups,
       });
     }
     default:


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
<img width="1608" height="1040" alt="Capture d’écran 2025-11-27 à 11 23 27" src="https://github.com/user-attachments/assets/ab36c83f-297c-4a15-b8ba-deede9777699" />

This PR adds a list of Chip for the active filters at the bottom of the Programmatic Cost Chart.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand with dummy programmatic cost data. Will deploy on front-edge to make sure it works as we want.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low - behind ff

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.