### PR TITLE
UserSearch: incremental indexation

### DIFF
--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -19,7 +19,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger, { auditLog } from "@app/logger/logger";
-// import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
+import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import type {
   LightWorkspaceType,
   MembershipOriginType,
@@ -548,13 +548,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
 
     // Update user search index across all workspaces
-    // const workflowResult = await launchIndexUserSearchWorkflow({
-    //   userId: user.sId,
-    // });
-    // if (workflowResult.isErr()) {
-    //   // Throw if it fails to launch (unexpected).
-    //   throw workflowResult.error;
-    // }
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: user.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
+    }
 
     return new MembershipResource(MembershipModel, newMembership.get());
   }
@@ -641,13 +641,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     }
 
     // Update user search index across all workspaces
-    // const workflowResult = await launchIndexUserSearchWorkflow({
-    //   userId: user.sId,
-    // });
-    // if (workflowResult.isErr()) {
-    //   // Throw if it fails to launch (unexpected).
-    //   throw workflowResult.error;
-    // }
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: user.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
+    }
 
     return new Ok({
       role: membership.role,
@@ -767,13 +767,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     );
 
     // Update user search index across all workspaces
-    // const workflowResult = await launchIndexUserSearchWorkflow({
-    //   userId: user.sId,
-    // });
-    // if (workflowResult.isErr()) {
-    //   // Throw if it fails to launch (unexpected).
-    //   throw workflowResult.error;
-    // }
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: user.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
+    }
 
     return new Ok({ previousRole, newRole });
   }

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -16,7 +16,7 @@ import {
   UserModel,
 } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-// import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
+import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import type { LightWorkspaceType, ModelId, Result, UserType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 import type { UserSearchDocument } from "@app/types/user_search/user_search";
@@ -62,13 +62,13 @@ export class UserResource extends BaseResource<UserModel> {
     const userResource = new this(UserModel, user.get());
 
     // Update user search index across all workspaces.
-    // const workflowResult = await launchIndexUserSearchWorkflow({
-    //   userId: userResource.sId,
-    // });
-    // if (workflowResult.isErr()) {
-    //   // Throw if it fails to launch (unexpected).
-    //   throw workflowResult.error;
-    // }
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: userResource.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
+    }
 
     return userResource;
   }
@@ -272,13 +272,13 @@ export class UserResource extends BaseResource<UserModel> {
     });
 
     // Update user search index across all workspaces.
-    // const workflowResult = await launchIndexUserSearchWorkflow({
-    //   userId: this.sId,
-    // });
-    // if (workflowResult.isErr()) {
-    //   // Throw if it fails to launch (unexpected).
-    //   throw workflowResult.error;
-    // }
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: this.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
+    }
 
     return result;
   }
@@ -310,13 +310,13 @@ export class UserResource extends BaseResource<UserModel> {
     });
 
     // Update user search index across all workspaces.
-    // const workflowResult = await launchIndexUserSearchWorkflow({
-    //   userId: this.sId,
-    // });
-    // if (workflowResult.isErr()) {
-    //   // Throw if it fails to launch (unexpected).
-    //   throw workflowResult.error;
-    // }
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: this.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
+    }
 
     return result;
   }

--- a/front/pages/api/w/[wId]/members/[uId]/index.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 
 import handler from "./index";
 

--- a/front/pages/api/w/[wId]/members/[uId]/index.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 
 import handler from "./index";
 
@@ -333,6 +334,98 @@ describe("POST /api/w/[wId]/members/[uId]", () => {
       expect(res._getStatusCode()).toBe(404);
       const data = res._getJSONData();
       expect(data.error.type).toBe("workspace_user_not_found");
+    });
+  });
+
+  describe("user search indexation", () => {
+    it("should call launchIndexUserSearchWorkflow when role is updated", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      // Create a user with user role
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      // Clear any previous calls from user creation
+      const mockIndexWorkflow = vi.mocked(launchIndexUserSearchWorkflow);
+      mockIndexWorkflow.mockClear();
+
+      req.query.uId = targetUser.sId;
+      req.body = { role: "builder" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+
+      // Verify indexation was called with the correct userId
+      expect(mockIndexWorkflow).toHaveBeenCalledWith({
+        userId: targetUser.sId,
+      });
+      expect(mockIndexWorkflow).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call launchIndexUserSearchWorkflow when membership is revoked", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      // Create a user with user role
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      // Clear any previous calls from user creation
+      const mockIndexWorkflow = vi.mocked(launchIndexUserSearchWorkflow);
+      mockIndexWorkflow.mockClear();
+
+      req.query.uId = targetUser.sId;
+      req.body = { role: "revoked" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+
+      // Verify indexation was called with the correct userId
+      expect(mockIndexWorkflow).toHaveBeenCalledWith({
+        userId: targetUser.sId,
+      });
+      expect(mockIndexWorkflow).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call launchIndexUserSearchWorkflow when admin changes own role with multiple admins", async () => {
+      const { req, res, workspace, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+
+      // Create another admin so current user is not sole admin
+      const anotherAdmin = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, anotherAdmin, {
+        role: "admin",
+      });
+
+      // Clear any previous calls from user creation
+      const mockIndexWorkflow = vi.mocked(launchIndexUserSearchWorkflow);
+      mockIndexWorkflow.mockClear();
+
+      req.query.uId = user.sId;
+      req.body = { role: "user" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+
+      // Verify indexation was called with the correct userId
+      expect(mockIndexWorkflow).toHaveBeenCalledWith({
+        userId: user.sId,
+      });
+      expect(mockIndexWorkflow).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/front/runbooks/TEST.md
+++ b/front/runbooks/TEST.md
@@ -1,23 +1,48 @@
-Debugging Vitest tests in the front package
+# Testing Runbook
+
+## Running Tests
+
+### Run all tests (watch-mode)
+
+```bash
+NODE_ENV=test ./admin/test.sh
+```
+
+Agents should generally not attempt to run all tests as this command will initiate watch-mode, which
+is not suitable for CI environments.
+
+### Run a specific test file
+```bash
+FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI NODE_ENV=test npx vitest run --reporter verbose path/to/test.test.ts
+```
+
+Example:
+```bash
+FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI NODE_ENV=test npx vitest run --reporter verbose pages/api/w/\[wId\]/members/search.test.ts
+```
+
+Note: Use backslashes to escape special characters like brackets in file paths.
+
+## Debugging Vitest Tests
 
 This repository is configured so you can reliably hit breakpoints when running tests under a debugger, while keeping the default behavior optimized for isolation and performance in CI and regular runs.
 
-How it works
+### How it works
 
 - By default, Vitest runs with a pool of forked processes so each test file is isolated and can rely on CLS-based transaction isolation.
 - When a debugger is detected, Vitest automatically switches to a single-threaded worker pool so the Node inspector can attach to the worker running your tests and breakpoints will hit.
 
-Ways to enable debug mode
+### Ways to enable debug mode
 
 - Option A: Set an environment variable.
   - VITEST_DEBUG=1 pnpm --filter front test:watch
   - Or: VITEST_DEBUG=1 pnpm --filter front vitest --inspect-brk
 
-- Option B: Start Vitest with Node’s inspector flags.
+- Option B: Start Vitest with Node's inspector flags.
   - node --inspect-brk $(pnpm bin)/vitest --watch
   - Or configure your IDE to run Vitest with --inspect or --inspect-brk.
 
-Behavior summary
+### Behavior summary
 
 - Debug mode ON (via VITEST_DEBUG=1 or --inspect/--inspect-brk):
   - pool: "threads"
@@ -28,7 +53,7 @@ Behavior summary
   - pool: "forks"
   - Multiple forks for parallelism and isolation remain enabled, matching CI.
 
-Notes
+### Notes
 
 - CI behavior is unchanged; it continues using forks for isolation and performance.
 - No application runtime behavior is affected outside of test runs.

--- a/front/runbooks/TEST.md
+++ b/front/runbooks/TEST.md
@@ -2,23 +2,34 @@
 
 ## Running Tests
 
+### Run all tests
+
+```
+npm test
+```
+
+Typical run time 30s agents should favour running specific test files.
+
 ### Run all tests (watch-mode)
 
 ```bash
-NODE_ENV=test ./admin/test.sh
+./admin/test.sh
 ```
 
-Agents should generally not attempt to run all tests as this command will initiate watch-mode, which
-is not suitable for CI environments.
+Agents should generally not attempt to this command directly, as watch-mode is not suitable for CI environments.
 
 ### Run a specific test file
+
 ```bash
-FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI NODE_ENV=test npx vitest run --reporter verbose path/to/test.test.ts
+npm test path/to/test.test.ts
 ```
 
-Example:
+You can pass vitest CLI options after `npm test`.
+
+**Example:**
+
 ```bash
-FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI NODE_ENV=test npx vitest run --reporter verbose pages/api/w/\[wId\]/members/search.test.ts
+npm test --reporter verbose pages/api/w/\[wId\]/members/search.test.ts
 ```
 
 Note: Use backslashes to escape special characters like brackets in file paths.

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -8,50 +8,68 @@ import { afterEach, beforeEach, vi } from "vitest";
 
 import { frontSequelize } from "@app/lib/resources/storage";
 
+// Mock Redis - must be at module level
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisClient: vi.fn().mockResolvedValue({
+    get: vi.fn(),
+    set: vi.fn(),
+    ttl: vi.fn(),
+    zAdd: vi.fn(),
+    expire: vi.fn(),
+    zRange: vi.fn(),
+    hGetAll: vi.fn().mockResolvedValue([]),
+  }),
+  runOnRedis: vi
+    .fn()
+    .mockImplementation(
+      async (opts: unknown, fn: (client: any) => Promise<unknown>) => {
+        // Mock Redis client
+        const mockRedisClient = {
+          get: vi.fn(),
+          set: vi.fn(),
+          ttl: vi.fn(),
+          zAdd: vi.fn(),
+          expire: vi.fn(),
+          zRange: vi.fn(),
+          hGetAll: vi.fn().mockResolvedValue([]),
+        };
+
+        return fn(mockRedisClient);
+      }
+    ),
+}));
+
+// Mock Temporal - must be at module level
+vi.mock("@app/lib/temporal", () => ({
+  getTemporalClientForAgentNamespace: vi.fn().mockResolvedValue({
+    schedule: {
+      getHandle: vi.fn().mockReturnValue({
+        update: vi.fn(),
+      }),
+    },
+  }),
+  getTemporalClientForFrontNamespace: vi.fn().mockResolvedValue({
+    workflow: {
+      start: vi.fn().mockResolvedValue(undefined),
+    },
+  }),
+}));
+
+// Mock Temporal indexation workflow - must be at module level
+vi.mock("@app/temporal/es_indexation/client", async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    launchIndexUserSearchWorkflow: vi.fn(async () => {
+      const { Ok } = await import("@app/types");
+      return new Ok(undefined);
+    }),
+  };
+});
+
 beforeEach(async (c) => {
   vi.clearAllMocks();
 
-  // Mock Redis
-  vi.mock("@app/lib/api/redis", () => ({
-    getRedisClient: vi.fn().mockResolvedValue({
-      get: vi.fn(),
-      set: vi.fn(),
-      ttl: vi.fn(),
-      zAdd: vi.fn(),
-      expire: vi.fn(),
-      zRange: vi.fn(),
-      hGetAll: vi.fn().mockResolvedValue([]),
-    }),
-    runOnRedis: vi
-      .fn()
-      .mockImplementation(
-        async (opts: unknown, fn: (client: any) => Promise<unknown>) => {
-          // Mock Redis client
-          const mockRedisClient = {
-            get: vi.fn(),
-            set: vi.fn(),
-            ttl: vi.fn(),
-            zAdd: vi.fn(),
-            expire: vi.fn(),
-            zRange: vi.fn(),
-            hGetAll: vi.fn().mockResolvedValue([]),
-          };
-
-          return fn(mockRedisClient);
-        }
-      ),
-  }));
-
-  // Mock Temporal
-  vi.mock("@app/lib/temporal", () => ({
-    getTemporalClientForAgentNamespace: vi.fn().mockResolvedValue({
-      schedule: {
-        getHandle: vi.fn().mockReturnValue({
-          update: vi.fn(),
-        }),
-      },
-    }),
-  }));
   const namespace = cls.createNamespace("test-namespace");
 
   // We use CLS to create a namespace and a transaction to isolate each test.

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -57,7 +57,7 @@ vi.mock("@app/lib/temporal", () => ({
 
 // Mock Temporal indexation workflow - must be at module level
 vi.mock("@app/temporal/es_indexation/client", async (importOriginal) => {
-  const mod = await importOriginal();
+  const mod = (await importOriginal()) as Record<string, unknown>;
   return {
     ...mod,
     launchIndexUserSearchWorkflow: vi.fn(async () => {


### PR DESCRIPTION
## Description

Now that the index is created and the worker queue is setup, enable incremental indexation.

## Tests

Tested locally

## Risk

If the temporal client fails (should not even if queue not setup) it could disrupt user creation

## Deploy Plan

- deploy `front`