### PR TITLE
Re-order layers to have the span working for core request logs

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -301,15 +301,16 @@ fn main() {
         .route("/tokenize/batch", post(tokenize::tokenize_batch))
         .route("/tokenize/batch/count", post(tokenize::tokenize_batch_count))
         .layer(OtelInResponseLayer::default())
-        // Start OpenTelemetry trace on incoming request.
-        .layer(OtelAxumLayer::default())
-        // Extensions
-        .layer(DefaultBodyLimit::disable())
+        // TraceLayer must come before OtelAxumLayer to ensure make_span is called
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(CoreRequestMakeSpan::new())
                 .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
         )
+        // Start OpenTelemetry trace on incoming request.
+        .layer(OtelAxumLayer::default())
+        // Extensions
+        .layer(DefaultBodyLimit::disable())
         .layer(from_fn(validate_api_key))
         .with_state(state.clone());
 


### PR DESCRIPTION
## Description

Moved ordering of layer so our http trace comes before otel's one. Goal is to get core api span to be associated with the log.

## Tests

Locally but i'm not 100% sure it will work.

## Risk

Low

## Deploy Plan

Deploy core