### PR TITLE
Implement Graceful Shutdown Handler for Next.js Pods

### DIFF
--- a/front/admin/prestop.sh
+++ b/front/admin/prestop.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-curl -X POST "http://localhost:3000/api/$PRESTOP_SECRET/prestop"
+curl -X POST "http://$(hostname -i):3000/api/$PRESTOP_SECRET/prestop"

--- a/front/lib/api/graceful_shutdown.ts
+++ b/front/lib/api/graceful_shutdown.ts
@@ -1,0 +1,43 @@
+import logger from "@app/logger/logger";
+
+let isShuttingDown = false;
+
+/**
+ * Sets up graceful shutdown handlers for SIGTERM and SIGINT signals.
+ *
+ * This prevents Next.js from immediately closing the HTTP server when receiving SIGTERM. Instead,
+ * we control the shutdown sequence ourselves.
+ *
+ * Important: This works in conjunction with the Kubernetes preStop hook.
+ * The preStop hook (which calls /api/prestop) handles:
+ * - Waiting 10s for load balancer propagation
+ * - Waiting for wake locks (in-flight operations) to clear
+ *
+ * Only after preStop completes does Kubernetes send SIGTERM to this handler.
+ * By that point, all operations are done, so we just exit immediately.
+ *
+ * Without this handler, the Next.js process would sit idle for the full
+ * terminationGracePeriodSeconds (130s) after the HTTP server closes, wasting resources.
+ *
+ * Requires: NEXT_MANUAL_SIG_HANDLE=true environment variable
+ */
+export function setupGracefulShutdown() {
+  if (process.env.NEXT_MANUAL_SIG_HANDLE !== "true") {
+    return;
+  }
+
+  const gracefulShutdown: NodeJS.SignalsListener = async (signal) => {
+    if (isShuttingDown) {
+      return;
+    }
+    isShuttingDown = true;
+
+    const childLogger = logger.child({ action: "gracefulShutdown" });
+    childLogger.info({ signal }, "Starting graceful shutdown");
+
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+  process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+}

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -1,7 +1,13 @@
 import Document, { Head, Html, Main, NextScript } from "next/document";
 import Script from "next/script";
 
-const { NODE_ENV, REACT_SCAN } = process.env;
+import { setupGracefulShutdown } from "@app/lib/api/graceful_shutdown";
+
+const { NEXT_MANUAL_SIG_HANDLE, NODE_ENV, REACT_SCAN } = process.env;
+
+if (NEXT_MANUAL_SIG_HANDLE) {
+  setupGracefulShutdown();
+}
 
 class MyDocument extends Document {
   render() {
@@ -119,12 +125,12 @@ class MyDocument extends Document {
                 function initPrivacyMask() {
                   const stored = localStorage.getItem('privacy-mask');
                   const isEnabled = stored === 'true';
-                  
+
                   if (isEnabled) {
                     document.body.classList.add('privacy-mask-enabled');
                   }
                 }
-                
+
                 // Run on DOM ready.
                 if (document.readyState === 'loading') {
                   document.addEventListener('DOMContentLoaded', initPrivacyMask);

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -44,6 +44,7 @@ async function handler(
   // Record pre-stop initiation.
   statsDClient.increment("prestop.requests");
 
+  // Wait 10s for load balancer propagation.
   await setTimeoutAsync(10000);
 
   const preStopStartTime = Date.now();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a custom SIGTERM/SIGINT handler to prevent pods from hanging for the full grace period after shutdown, reducing termination time from 130+ seconds to ~10-20 seconds in most cases.

## The Problem: Pods Hang After PreStop Completes

Investigating all the probes failures we observe on deployments revealed that during pod termination, pods sit idle for the full `terminationGracePeriodSeconds` (130s) even though all graceful shutdown work completes much earlier. As the process is idle, k8s keep running readiness check on the pod itself. NextJS server is closed so all probes actually fail.

### Current Pod Termination Lifecycle

When Kubernetes terminates a pod, the following sequence occurs:
```
T+0s:   Pod deletion triggered
        ├─ Pod marked as "Terminating" in Kubernetes API
        ├─ Endpoints controller begins removing pod from Service
        └─ PreStop hook starts executing
            ├─ Calls /api/prestop endpoint
            ├─ Waits 10s for load balancer propagation
            └─ Waits for wake locks (up to 120s timeout)

T+10-130s: PreStop hook completes
           └─ Kubernetes sends SIGTERM to container PID 1

T+10-130s: Next.js receives SIGTERM
           ├─ Next.js closes HTTP server immediately
           ├─ Health probes start failing ("connection refused")
           └─ Process stays alive but idle
               (Next.js doesn't call process.exit by default - see [doc](https://nextjs.org/docs/pages/guides/self-hosting))

T+130s: terminationGracePeriodSeconds expires
        └─ Kubernetes sends SIGKILL
            └─ Pod finally terminates
```

**The issue:** After the `preStop` hook completes all graceful shutdown work (waiting for load balancer propagation and wake locks), the Next.js process receives `SIGTERM`, closes its HTTP server, but then sits idle for the remaining grace period instead of exiting cleanly. We've observed pods spending 100+ seconds in this idle state.

## The Solution: Manual SIGTERM Handling

We implement a custom signal handler by:
Setting `NEXT_MANUAL_SIG_HANDLE=true`. This tells Next.js to not handle `SIGTERM` automatically, giving us control over the shutdown sequence.

The new signal handlers for `SIGTERM` (from Kubernetes) and `SIGINT` (for local development) that immediately call `process.exit(0)` when invoked.

### New Pod Termination Lifecycle (with this change):
```
T+0s:   Pod deletion triggered
        ├─ Pod marked as "Terminating"
        ├─ Endpoints removed (begins propagating)
        └─ PreStop hook executes
            ├─ Waits 10s for load balancer
            └─ Waits for wake locks to clear

T+10-130s: PreStop completes
           └─ SIGTERM sent to Next.js process

T+10-130s: Custom signal handler receives SIGTERM
           ├─ Logs shutdown initiation
           └─ Calls process.exit(0) immediately

T+10-130s: Process exits cleanly
           └─ Pod terminates immediately
```

Result: Pods now exit within 10-20 seconds (after `preStop` completes) instead of hanging for 130+ seconds. The HTTP server still closes (health probes still fail), but the process exits immediately afterward instead of waiting to be force-killed.

⚠️ When looking a wake lock it looks like the one around the block agent loop in the public API has been removed, will do a follow up PR to add it back.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
