### PR TITLE
Rename DUST_REGION to REGION

### DIFF
--- a/connectors/src/connectors/shared/config.ts
+++ b/connectors/src/connectors/shared/config.ts
@@ -14,6 +14,6 @@ export const connectorsConfig = {
     return EnvironmentConfig.getEnvVariable("GCP_WEBHOOK_ROUTER_CONFIG_BUCKET");
   },
   getCurrentRegion: (): RegionType => {
-    return EnvironmentConfig.getEnvVariable("DUST_REGION") as RegionType;
+    return EnvironmentConfig.getEnvVariable("REGION") as RegionType;
   },
 };

--- a/core/admin/elasticsearch_run_command_from_file.sh
+++ b/core/admin/elasticsearch_run_command_from_file.sh
@@ -21,7 +21,7 @@ if ! echo "$ES_BODY" | jq . >/dev/null 2>&1; then
     exit 1
 fi
 
-read -p "Run command from file ${1} in region ${DUST_REGION}? [y/N] " response
+read -p "Run command from file ${1} in region ${REGION}? [y/N] " response
 if [[ ! $response =~ ^[Yy]$ ]]; then
     echo "Operation cancelled"
     exit 0

--- a/core/bin/elasticsearch/create_index.rs
+++ b/core/bin/elasticsearch/create_index.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let region = match std::env::var("NODE_ENV").unwrap_or_default().as_str() {
         "development" => "local".to_string(),
-        _ => std::env::var("DUST_REGION").expect("DUST_REGION must be set"),
+        _ => std::env::var("REGION").expect("REGION must be set"),
     };
 
     // create ES client

--- a/front/lib/api/regions/config.ts
+++ b/front/lib/api/regions/config.ts
@@ -14,7 +14,7 @@ export function isRegionType(region: string): region is RegionType {
 
 export const config = {
   getCurrentRegion: (): RegionType => {
-    return EnvironmentConfig.getEnvVariable("DUST_REGION") as RegionType;
+    return EnvironmentConfig.getEnvVariable("REGION") as RegionType;
   },
   getLookupApiSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("REGION_RESOLVER_SECRET");
@@ -40,7 +40,7 @@ export const config = {
   },
   getDustRegionSyncEnabled: (): boolean => {
     return (
-      EnvironmentConfig.getEnvVariable("DUST_REGION") !== "us-central1" ||
+      EnvironmentConfig.getEnvVariable("REGION") !== "us-central1" ||
       isDevelopment()
     );
   },

--- a/front/runbooks/ELASTICSEARCH.md
+++ b/front/runbooks/ELASTICSEARCH.md
@@ -12,7 +12,7 @@ This runbook provides step-by-step instructions for creating a new Elasticsearch
 ELASTICSEARCH_URL=https://your-elasticsearch-instance.com:9200
 ELASTICSEARCH_USERNAME=your-username
 ELASTICSEARCH_PASSWORD=your-password
-DUST_REGION=local  # or us-central1, europe-west1
+REGION=local  # or us-central1, europe-west1
 ```
 
 These are configured in `lib/api/config.ts:316-326`.

--- a/front/scripts/create_elasticsearch_index.ts
+++ b/front/scripts/create_elasticsearch_index.ts
@@ -55,7 +55,7 @@ makeScript(
     const region =
       EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") === "development"
         ? "local"
-        : EnvironmentConfig.getEnvVariable("DUST_REGION");
+        : EnvironmentConfig.getEnvVariable("REGION");
 
     logger.info("Configuration:");
     logger.info(`  Index name: ${indexFullname}`);

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -17,7 +17,7 @@ const {
   DUST_MANAGED_XAI_API_KEY = "",
   DUST_MANAGED_FIRECRAWL_API_KEY = "",
   DUST_MANAGED_ELEVENLABS_API_KEY = "",
-  DUST_REGION = "",
+  REGION = "",
 } = process.env;
 
 export const credentialsFromProviders = (
@@ -95,7 +95,7 @@ export const dustManagedCredentials = (): CredentialsType => {
     OPENAI_API_KEY: DUST_MANAGED_OPENAI_API_KEY,
     OPENAI_BASE_URL: DUST_MANAGED_OPENAI_BASE_URL,
     // In Core this will determine the openai endpoint we use (EU vs US).
-    OPENAI_USE_EU_ENDPOINT: DUST_REGION === "europe-west1" ? "true" : "false",
+    OPENAI_USE_EU_ENDPOINT: REGION === "europe-west1" ? "true" : "false",
     TEXTSYNTH_API_KEY: DUST_MANAGED_TEXTSYNTH_API_KEY,
     GOOGLE_AI_STUDIO_API_KEY: DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY,
     SERP_API_KEY: DUST_MANAGED_SERP_API_KEY,

--- a/prodbox/init.sh
+++ b/prodbox/init.sh
@@ -21,7 +21,7 @@ git remote set-url origin git@github.com:dust-tt/dust.git
 
 git pull origin main
 
-echo "export PS1='\[\e[0;31m\]prodbox(${DUST_REGION})\[\e[0m\]:\w\$ '" >> /root/.bashrc
+echo "export PS1='\[\e[0;31m\]prodbox(${REGION})\[\e[0m\]:\w\$ '" >> /root/.bashrc
 
 # This is the script used to start the container, so it needs to stay alive, otherwise the
 # kube pod (container) dies.


### PR DESCRIPTION
## Description

We're renaming the env var DUST_REGION to just REGION, as the DUST prefix is not meaningful. We'll also get a new CELL env var.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front, Connectors, Core