### PR TITLE
Do not import assertNever in front from sparkle

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -4,7 +4,6 @@ import type {
   MessageDeltaUsage,
   MessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
-import { assertNever } from "@dust-tt/sparkle";
 import cloneDeep from "lodash/cloneDeep";
 
 import { validateContentBlockIndex } from "@app/lib/api/llm/clients/anthropic/utils/predicates";
@@ -22,6 +21,7 @@ import type {
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
+import { assertNever } from "@app/types";
 
 export async function* streamLLMEvents(
   messageStreamEvents: AsyncIterable<MessageStreamEvent>,

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -7,7 +7,8 @@ import {
   InformationCircleIcon,
   XCircleIcon,
 } from "@sparkle/icons/app";
-import { assertNever, cn } from "@sparkle/lib/utils";
+import { assertNever } from "@sparkle/lib/internal_utils";
+import { cn } from "@sparkle/lib/utils";
 
 import { Icon } from "./Icon";
 

--- a/sparkle/src/lib/internal_utils.ts
+++ b/sparkle/src/lib/internal_utils.ts
@@ -1,0 +1,5 @@
+// These utils should be internal to sparkle and not exposed to consumers of the library.
+
+export function assertNever(x: never): never {
+  throw new Error(`${x} is not of type never. This should never happen.`);
+}


### PR DESCRIPTION
## Description

- Update assertNever import in front
- Create non exported utils in sparkle

## Tests

local

## Risk

no

## Deploy Plan

front
sparkle
