### PR TITLE
refactor: move agent creativity in types

### DIFF
--- a/front/components/agent_builder/instructions/utils.ts
+++ b/front/components/agent_builder/instructions/utils.ts
@@ -1,14 +1,12 @@
-import type { AgentCreativityLevel } from "@app/components/agent_builder/types";
-import {
-  AGENT_CREATIVITY_LEVEL_DISPLAY_NAMES,
-  AGENT_CREATIVITY_LEVEL_TEMPERATURES,
-} from "@app/components/agent_builder/types";
+import { AGENT_CREATIVITY_LEVEL_DISPLAY_NAMES } from "@app/components/agent_builder/types";
 import type {
+  AgentCreativityLevel,
   ModelConfigurationType,
   ModelIdType,
   ModelProviderIdType,
 } from "@app/types";
 import {
+  AGENT_CREATIVITY_LEVEL_TEMPERATURES,
   CLAUDE_4_5_SONNET_20250929_MODEL_ID,
   GEMINI_2_5_PRO_MODEL_ID,
   GPT_5_MODEL_ID,

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -2,7 +2,6 @@ import uniqueId from "lodash/uniqueId";
 
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
-import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/components/agent_builder/types";
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type {
   LightAgentConfigurationType,
@@ -10,6 +9,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import {
+  AGENT_CREATIVITY_LEVEL_TEMPERATURES,
   CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
   getLargeWhitelistedModel,
   isProviderWhitelisted,

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -26,29 +26,12 @@ type AgentBuilderFormData = z.infer<typeof agentBuilderFormSchema>;
 
 export type AgentBuilderAction = AgentBuilderFormData["actions"][number];
 
-export const AGENT_CREATIVITY_LEVELS = [
-  "deterministic",
-  "factual",
-  "balanced",
-  "creative",
-] as const;
-export type AgentCreativityLevel = (typeof AGENT_CREATIVITY_LEVELS)[number];
-
 export const AGENT_CREATIVITY_LEVEL_DISPLAY_NAMES = {
   deterministic: "Deterministic",
   factual: "Factual",
   balanced: "Balanced",
   creative: "Creative",
 } as const;
-export const AGENT_CREATIVITY_LEVEL_TEMPERATURES: Record<
-  AgentCreativityLevel,
-  number
-> = {
-  deterministic: 0.0,
-  factual: 0.2,
-  balanced: 0.7,
-  creative: 1.0,
-};
 
 export const BUILDER_FLOWS = [
   "workspace_assistants",

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -1,7 +1,6 @@
 import { startObservation } from "@langfuse/tracing";
 import { randomUUID } from "crypto";
 
-import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/components/agent_builder/types";
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
   createLLMTraceId,
@@ -25,6 +24,7 @@ import type {
   ReasoningEffort,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
+import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types";
 
 export abstract class LLM {
   protected modelId: ModelIdType;

--- a/front/types/assistant/creativity.ts
+++ b/front/types/assistant/creativity.ts
@@ -1,0 +1,18 @@
+export const AGENT_CREATIVITY_LEVEL_TEMPERATURES: Record<
+  AgentCreativityLevel,
+  number
+> = {
+  deterministic: 0.0,
+  factual: 0.2,
+  balanced: 0.7,
+  creative: 1.0,
+};
+
+export const AGENT_CREATIVITY_LEVELS = [
+  "deterministic",
+  "factual",
+  "balanced",
+  "creative",
+] as const;
+
+export type AgentCreativityLevel = (typeof AGENT_CREATIVITY_LEVELS)[number];

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -10,6 +10,7 @@ export * from "./assistant/assistant";
 export * from "./assistant/avatar";
 export * from "./assistant/builder";
 export * from "./assistant/conversation";
+export * from "./assistant/creativity";
 export * from "./assistant/generation";
 export * from "./assistant/mentions";
 export * from "./assistant/models/anthropic";


### PR DESCRIPTION
## Description

- Move creativity types in types folder in order to not import from components in front

## Tests

local

## Risk

no

## Deploy Plan

front
