### PR TITLE
UserSearch: query capabilities and first refactor on top

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -226,7 +226,7 @@ export async function searchMembers(
     });
 
     if (results.isErr()) {
-      logger.error("Error searching users: " + results.error.message);
+      logger.error({ err: results.error }, "Error searching users");
       return { members: [], total: 0 };
     }
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -218,15 +218,20 @@ export async function searchMembers(
     );
     total = users.length;
   } else {
-    const results = await UserResource.listUsersWithEmailPredicat(
+    const results = await UserResource.searchUsers({
       owner,
-      {
-        email: options.searchTerm,
-      },
-      paginationParams
-    );
-    users = results.users;
-    total = results.total;
+      searchTerm: options.searchTerm ?? "",
+      offset: paginationParams.offset,
+      limit: paginationParams.limit,
+    });
+
+    if (results.isErr()) {
+      logger.error("Error searching users: " + results.error.message);
+      return { members: [], total: 0 };
+    }
+
+    users = results.value.users;
+    total = results.value.total;
   }
 
   const usersWithWorkspace = await Promise.all(

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -253,14 +253,9 @@ export class UserResource extends BaseResource<UserModel> {
           panic: true,
           workspaceId: owner.sId,
           missingUserSIds: missingUserIds,
+          owner: "spolu",
         },
         "[user_search] Found revoked users in search results"
-      );
-
-      return new Err(
-        new Error(
-          `Found ${missingUserIds.length} revoked user(s) in search results for workspace ${owner.sId}`
-        )
       );
     }
 

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -16,14 +16,14 @@ import {
   UserModel,
 } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { searchUsers } from "@app/lib/user_search/search";
+import logger from "@app/logger/logger";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import type { LightWorkspaceType, ModelId, Result, UserType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 import type { UserSearchDocument } from "@app/types/user_search/user_search";
 
 export interface SearchMembersPaginationParams {
-  orderColumn: "name";
-  orderDirection: "asc" | "desc";
   offset: number;
   limit: number;
 }
@@ -195,6 +195,90 @@ export class UserResource extends BaseResource<UserModel> {
     return users.map((user) => new UserResource(UserModel, user.get()));
   }
 
+  static async searchUsers({
+    owner,
+    searchTerm,
+    offset,
+    limit,
+  }: {
+    owner: LightWorkspaceType;
+    searchTerm: string;
+    offset: number;
+    limit: number;
+  }): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
+    // Search users in Elasticsearch
+    const searchResult = await searchUsers({
+      owner,
+      searchTerm,
+      offset,
+      limit,
+    });
+    if (searchResult.isErr()) {
+      return searchResult;
+    }
+
+    const { users: userDocs, total } = searchResult.value;
+    const userIds = userDocs.map((doc) => doc.user_id);
+
+    if (userIds.length === 0) {
+      return new Ok({ users: [], total: 0 });
+    }
+
+    // Note that UserResource has stored sIds, not generated ones.
+    const users = await UserModel.findAll({
+      where: {
+        sId: { [Op.in]: userIds },
+      },
+      include: [
+        {
+          model: MembershipModel,
+          as: "memberships",
+          required: true, // INNER JOIN
+          where: {
+            workspaceId: owner.id,
+            startAt: { [Op.lte]: new Date() },
+            endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: new Date() }] },
+          },
+        },
+      ],
+    });
+
+    // Check if we found fewer users than expected (means some were revoked)
+    if (users.length < userIds.length) {
+      const foundUserIds = new Set(users.map((u) => u.sId));
+      const missingUserIds = userIds.filter((sId) => !foundUserIds.has(sId));
+
+      logger.error(
+        {
+          panic: true,
+          workspaceId: owner.sId,
+          missingUserSIds: missingUserIds,
+        },
+        "[user_search] Found revoked users in search results"
+      );
+
+      return new Err(
+        new Error(
+          `Found ${missingUserIds.length} revoked user(s) in search results for workspace ${owner.sId}`
+        )
+      );
+    }
+
+    // Create a map to maintain the order from Elasticsearch results
+    const userResourceMap = new Map<string, UserResource>();
+    users.forEach((u) => {
+      const userBlob = u.get();
+      userResourceMap.set(u.sId, new UserResource(UserModel, userBlob));
+    });
+
+    // Return users in the order from Elasticsearch results
+    const orderedUsers = userIds
+      .map((sId) => userResourceMap.get(sId))
+      .filter((user): user is UserResource => user !== undefined);
+
+    return new Ok({ users: orderedUsers, total });
+  }
+
   static async listUsersWithEmailPredicat(
     owner: LightWorkspaceType,
     options: {
@@ -241,9 +325,14 @@ export class UserResource extends BaseResource<UserModel> {
           },
         },
       ],
-      order: [[paginationParams.orderColumn, paginationParams.orderDirection]],
       limit: paginationParams.limit,
       offset: paginationParams.offset,
+    });
+
+    users.sort((a, b) => {
+      const nameA = `${a.firstName} ${b.lastName}`.toLowerCase();
+      const nameB = `${b.firstName} + ${b.lastName}`.toLowerCase();
+      return nameA.localeCompare(nameB);
     });
 
     return {

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -330,7 +330,7 @@ export class UserResource extends BaseResource<UserModel> {
     });
 
     users.sort((a, b) => {
-      const nameA = `${a.firstName} ${b.lastName}`.toLowerCase();
+      const nameA = `${a.firstName} ${a.lastName}`.toLowerCase();
       const nameB = `${b.firstName} + ${b.lastName}`.toLowerCase();
       return nameA.localeCompare(nameB);
     });

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -331,7 +331,7 @@ export class UserResource extends BaseResource<UserModel> {
 
     users.sort((a, b) => {
       const nameA = `${a.firstName} ${a.lastName}`.toLowerCase();
-      const nameB = `${b.firstName} + ${b.lastName}`.toLowerCase();
+      const nameB = `${b.firstName} ${b.lastName}`.toLowerCase();
       return nameA.localeCompare(nameB);
     });
 

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -115,8 +115,6 @@ export function useSearchMembers({
 
   const searchParams = new URLSearchParams({
     searchTerm: debouncedSearchTerm,
-    orderColumn: "name",
-    orderDirection: "asc",
     offset: (pageIndex * pageSize).toString(),
     limit: pageSize.toString(),
   });

--- a/front/lib/user_search/search.ts
+++ b/front/lib/user_search/search.ts
@@ -1,0 +1,76 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { USER_SEARCH_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
+import type { LightWorkspaceType } from "@app/types";
+import type { Result } from "@app/types/shared/result";
+import type { UserSearchDocument } from "@app/types/user_search/user_search";
+
+export interface SearchUsersResult {
+  users: UserSearchDocument[];
+  total: number;
+}
+
+/**
+ * Search users by email and full name.
+ * - full_name: Uses prefix matching on any word (edge n-grams)
+ * - email: Uses token matching (uax_url_email tokenizer)
+ */
+export async function searchUsers({
+  owner,
+  searchTerm,
+  offset,
+  limit,
+}: {
+  owner: LightWorkspaceType;
+  searchTerm: string;
+  offset: number;
+  limit: number;
+}): Promise<Result<SearchUsersResult, ElasticsearchError>> {
+  return withEs(async (client) => {
+    // Build the query
+    const query: estypes.QueryDslQueryContainer = {
+      bool: {
+        filter: [{ term: { workspace_id: owner.sId } }],
+        should: [
+          // Prefix matching on full_name using edge n-grams
+          {
+            match_phrase_prefix: {
+              "full_name.edge": {
+                query: searchTerm,
+              },
+            },
+          },
+          // Token matching on email (works with email tokenizer)
+          {
+            match_phrase_prefix: {
+              email: {
+                query: searchTerm,
+              },
+            },
+          },
+        ],
+        minimum_should_match: 1,
+      },
+    };
+
+    const response = await client.search<UserSearchDocument>({
+      index: USER_SEARCH_ALIAS_NAME,
+      query,
+      size: limit,
+      from: offset,
+      sort: [{ _score: { order: "desc" } }],
+    });
+
+    const users = response.hits.hits.map((hit) => hit._source!);
+    const total =
+      typeof response.hits.total === "number"
+        ? response.hits.total
+        : (response.hits.total?.value ?? 0);
+
+    return {
+      users,
+      total,
+    };
+  });
+}

--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -46,7 +46,7 @@ vi.mock("@app/lib/user_search/search", () => ({
               const lowerSearchTerm = searchTerm.toLowerCase();
               const email = user.email?.toLowerCase() || "";
               const fullName =
-                `${user.firstName || ""} ${user.lastName || ""}`.toLowerCase();
+                `${user.firstName ?? ""} ${user.lastName ?? ""}`.toLowerCase();
               return (
                 email.includes(lowerSearchTerm) ||
                 fullName.includes(lowerSearchTerm)
@@ -61,7 +61,7 @@ vi.mock("@app/lib/user_search/search", () => ({
       const userDocs = paginatedUsers.map((user) => ({
         user_id: user.sId,
         email: user.email,
-        full_name: `${user.firstName || ""} ${user.lastName || ""}`.trim(),
+        full_name: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim(),
         updated_at: user.updatedAt,
       }));
 

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -25,11 +25,6 @@ const GroupKindWithoutSystemCodec = t.refinement(
 );
 
 const SearchMembersQueryCodec = t.type({
-  orderColumn: withFallback(t.literal("name"), "name"),
-  orderDirection: withFallback(
-    t.union([t.literal("asc"), t.literal("desc")]),
-    "desc"
-  ),
   offset: withFallback(NumberFromString, 0),
   limit: withFallback(
     t.refinement(


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/5177

- Adds query capability to the user_search index.
- Usese it for memebers/search (used by space group edition and invitation existence check)

ACTION(spolu): refactor query to using a DSL after @flvndvd has the runbook edited.
Next steps: replace https://github.com/dust-tt/dust/blob/main/front/lib/api/assistant/conversation/mention_suggestions.ts#L52

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- front