### PR TITLE
[mentions] add abort actions endpoint 

### DIFF
--- a/front/.vscode/settings.json
+++ b/front/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.experimental.useTsgo": true
+}

--- a/front/.vscode/settings.json
+++ b/front/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "typescript.experimental.useTsgo": true
-}

--- a/front/lib/api/assistant/conversation/decline_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/decline_blocked_actions.ts
@@ -76,7 +76,7 @@ export async function declineBlockedActionsForConversations(
         isToolExecutionStatusBlocked(action.status)
       );
 
-      const results = await concurrentExecutor(
+      await concurrentExecutor(
         blockedActions,
         async (action) => {
           switch (action.status) {

--- a/front/lib/api/assistant/conversation/decline_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/decline_blocked_actions.ts
@@ -1,0 +1,187 @@
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
+import { fetchMessageInConversation } from "@app/lib/api/assistant/messages";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import type { ConversationType, Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+// This will update the status of an authentication required action to denied.
+// Since we don't launch a new agent loop after unlike action validation, we need to manually clear actionRequired status.
+export async function declineAuthenticationRequiredAction(
+  auth: Authenticator,
+  conversation: ConversationType,
+  {
+    actionId,
+    messageId,
+  }: {
+    actionId: string;
+    messageId: string;
+  }
+): Promise<Result<void, DustError>> {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.user();
+
+  const action = await AgentMCPActionResource.fetchById(auth, actionId);
+  if (!action) {
+    return new Err(
+      new DustError("action_not_found", `Action not found: ${actionId}`)
+    );
+  }
+
+  const agentStepContent = await AgentStepContentResource.fetchByModelId(
+    action.stepContentId
+  );
+
+  if (!agentStepContent) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        `Agent step content not found: ${action.stepContentId}`
+      )
+    );
+  }
+
+  if (action.status !== "blocked_authentication_required") {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        `Action is not blocked for authentication: ${action.status}`
+      )
+    );
+  }
+
+  const [updatedCount] = await action.updateStatus("denied");
+
+  if (updatedCount === 0) {
+    logger.info(
+      {
+        actionId,
+        messageId,
+        workspaceId: owner.sId,
+        userId: user?.sId,
+      },
+      "Action already declined"
+    );
+
+    return new Ok(undefined);
+  }
+
+  const messageResult = await fetchMessageInConversation(
+    auth,
+    conversation,
+    messageId
+  );
+  if (!messageResult) {
+    return new Err(
+      new DustError("internal_error", `Message not found: ${messageId}`)
+    );
+  }
+
+  if (!messageResult.agentMessage) {
+    logger.warn(
+      {
+        actionId,
+        messageId,
+        conversationId: conversation.sId,
+        workspaceId: owner.sId,
+        userId: user?.sId,
+      },
+      "Failed to find agent message to update status"
+    );
+    return new Ok(undefined);
+  }
+
+  await messageResult.agentMessage.update({
+    status: "failed",
+    updatedAt: new Date(),
+    errorCode: "mcp_server_personal_authentication_declined",
+    errorMessage: "Personal authentication was declined by the user",
+    ...messageResult.agentMessage.errorMetadata,
+  });
+
+  await ConversationResource.clearActionRequired(auth, conversation.sId);
+
+  return new Ok(undefined);
+}
+
+export type DeclineBlockedActionsForConversationsResult = {
+  failedActionCount: number;
+};
+
+export async function declineBlockedActionsForConversations(
+  auth: Authenticator,
+  conversationIds: string[]
+): Promise<Result<DeclineBlockedActionsForConversationsResult, Error>> {
+  let failedActionCount = 0;
+
+  for (const conversationId of conversationIds) {
+    const conversation = await getConversation(auth, conversationId);
+
+    // if it doesn't exist, we skip it
+    if (conversation.isErr()) {
+      continue;
+    }
+
+    const blockedActions =
+      await AgentMCPActionResource.listBlockedActionsForConversation(
+        auth,
+        conversation.value.sId
+      );
+
+    const authRequiredActions = blockedActions.filter(
+      (action) => action.status === "blocked_authentication_required"
+    );
+
+    const validationRequiredActions = blockedActions.filter(
+      (action) => action.status === "blocked_validation_required"
+    );
+
+    if (authRequiredActions.length > 0) {
+      for (const action of authRequiredActions) {
+        const result = await declineAuthenticationRequiredAction(
+          auth,
+          conversation.value,
+          {
+            actionId: action.actionId,
+            messageId: action.messageId,
+          }
+        );
+
+        if (result.isErr()) {
+          failedActionCount++;
+        }
+      }
+    }
+
+    if (validationRequiredActions.length > 0) {
+      for (const action of validationRequiredActions) {
+        const result = await validateAction(auth, conversation.value, {
+          actionId: action.actionId,
+          approvalState: "rejected",
+          messageId: action.messageId,
+        });
+
+        if (result.isErr()) {
+          failedActionCount++;
+        }
+      }
+    }
+  }
+
+  logger.info(
+    {
+      conversationIds,
+      failedActionCount,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      userId: auth.user()?.sId,
+    },
+    "Completed dismissing blocked actions"
+  );
+
+  return new Ok({ failedActionCount });
+}

--- a/front/lib/api/assistant/conversation/decline_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/decline_blocked_actions.ts
@@ -4,6 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -109,53 +110,65 @@ export async function declineBlockedActionsForConversations(
     conversationIds
   );
 
-  for (const conversation of conversations) {
-    const blockedActions =
-      await AgentMCPActionResource.listBlockedActionsForConversation(
-        auth,
-        conversation
-      );
-
-    const authRequiredActions = blockedActions.filter(
-      (action) => action.status === "blocked_authentication_required"
-    );
-
-    const validationRequiredActions = blockedActions.filter(
-      (action) => action.status === "blocked_validation_required"
-    );
-
-    if (authRequiredActions.length > 0) {
-      for (const action of authRequiredActions) {
-        const result = await declineAuthenticationRequiredAction(
+  await concurrentExecutor(
+    conversations,
+    async (conversation) => {
+      const blockedActions =
+        await AgentMCPActionResource.listBlockedActionsForConversation(
           auth,
-          conversation,
-          {
-            actionId: action.actionId,
-            messageId: action.messageId,
-          }
+          conversation
         );
 
-        if (result.isErr()) {
-          failedConversationIds.add(conversation.sId);
-        }
-      }
-    }
+      const authRequiredActions = blockedActions.filter(
+        (action) => action.status === "blocked_authentication_required"
+      );
 
-    if (validationRequiredActions.length > 0) {
-      for (const action of validationRequiredActions) {
-        const result = await validateAction(auth, conversation, {
-          actionId: action.actionId,
-          approvalState: "rejected",
-          messageId: action.messageId,
-          shouldRunAgentLoop: false,
-        });
+      const validationRequiredActions = blockedActions.filter(
+        (action) => action.status === "blocked_validation_required"
+      );
 
-        if (result.isErr()) {
-          failedConversationIds.add(conversation.sId);
-        }
+      if (authRequiredActions.length > 0) {
+        await concurrentExecutor(
+          authRequiredActions,
+          async (action) => {
+            const result = await declineAuthenticationRequiredAction(
+              auth,
+              conversation,
+              {
+                actionId: action.actionId,
+                messageId: action.messageId,
+              }
+            );
+
+            if (result.isErr()) {
+              failedConversationIds.add(conversation.sId);
+            }
+          },
+          { concurrency: 8 }
+        );
       }
-    }
-  }
+
+      if (validationRequiredActions.length > 0) {
+        await concurrentExecutor(
+          validationRequiredActions,
+          async (action) => {
+            const result = await validateAction(auth, conversation, {
+              actionId: action.actionId,
+              approvalState: "rejected",
+              messageId: action.messageId,
+              shouldRunAgentLoop: false,
+            });
+
+            if (result.isErr()) {
+              failedConversationIds.add(conversation.sId);
+            }
+          },
+          { concurrency: 8 }
+        );
+      }
+    },
+    { concurrency: 8 }
+  );
 
   return new Ok({ failedConversationIds: Array.from(failedConversationIds) });
 }

--- a/front/lib/api/assistant/conversation/decline_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/decline_blocked_actions.ts
@@ -8,8 +8,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
-// This will update the status of an authentication required action to denied.
-// Since we don't launch a new agent loop after unlike action validation, we need to manually clear actionRequired status.
 export async function declineAuthenticationRequiredAction(
   auth: Authenticator,
   conversation: ConversationResource,
@@ -74,9 +72,9 @@ export async function declineBlockedActionsForConversations(
           conversation
         );
 
-      const blockedActions = actions
-        .filter((action) => isToolExecutionStatusBlocked(action.status))
-        .flat();
+      const blockedActions = actions.filter((action) =>
+        isToolExecutionStatusBlocked(action.status)
+      );
 
       const results = await concurrentExecutor(
         blockedActions,
@@ -113,8 +111,6 @@ export async function declineBlockedActionsForConversations(
         },
         { concurrency: CLEAR_ACTION_CONCURRENCY }
       );
-
-      return results;
     },
     { concurrency: CLEAR_ACTION_CONCURRENCY }
   );

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -1,0 +1,56 @@
+import { fetchMessageInConversation } from "@app/lib/api/assistant/messages";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+export async function clearPersonalAuthenticationRequiredAction(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  {
+    actionId,
+    messageId,
+  }: {
+    actionId: string;
+    messageId: string;
+  }
+): Promise<Result<undefined, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.user();
+
+  const messageResult = await fetchMessageInConversation(
+    auth,
+    conversation.toJSON(),
+    messageId
+  );
+  if (!messageResult) {
+    return new Err(new Error(`Message not found: ${messageId}`));
+  }
+
+  if (!messageResult.agentMessage) {
+    logger.warn(
+      {
+        actionId,
+        messageId,
+        conversationId: conversation.sId,
+        workspaceId: owner.sId,
+        userId: user?.sId,
+      },
+      "Failed to find agent message to update status"
+    );
+    return new Ok(undefined);
+  }
+
+  await messageResult.agentMessage.update({
+    ...messageResult.agentMessage,
+    status: "failed",
+    updatedAt: new Date(),
+    errorCode: "mcp_server_personal_authentication_declined",
+    errorMessage: "Personal authentication was declined by the user",
+  });
+
+  await ConversationResource.clearActionRequired(auth, conversation.sId);
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -5,6 +5,8 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
+// This will update the status of an authentication required action to denied.
+// Since we don't launch a new agent loop unlike action validation, we need to manually clear actionRequired status.
 export async function clearPersonalAuthenticationRequiredAction(
   auth: Authenticator,
   conversation: ConversationResource,
@@ -43,9 +45,7 @@ export async function clearPersonalAuthenticationRequiredAction(
   }
 
   await messageResult.agentMessage.update({
-    ...messageResult.agentMessage,
     status: "failed",
-    updatedAt: new Date(),
     errorCode: "mcp_server_personal_authentication_declined",
     errorMessage: "Personal authentication was declined by the user",
   });

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -13,7 +13,7 @@ import { DustError } from "@app/lib/error";
 import { Message } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { Result } from "@app/types";
@@ -203,6 +203,9 @@ export async function validateAction(
       // started error.
       waitForCompletion: true,
     });
+  } else {
+    // if we don't run the agent loop, we need to clear the action required status manually.
+    await ConversationResource.clearActionRequired(auth, conversationId);
   }
 
   logger.info(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -30,7 +30,7 @@ import {
 import { AgentMessage, Message } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -30,7 +30,7 @@ import {
 import { AgentMessage, Message } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -614,6 +614,10 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   async updateStatus(
     status: ToolExecutionStatus
   ): Promise<[affectedCount: number]> {
+    if (status === this.status) {
+      return [0];
+    }
+
     return this.update({
       status,
     });

--- a/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
@@ -39,7 +39,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${parseResult.error.message}. Provide conversationIds in the request body.`,
+        message: `Invalid request body: ${parseResult.error.message}. You need to have at least one conversation ID and at most 50 conversation IDs.`,
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
@@ -9,7 +9,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 export type DeclineBlockedActionsResponse = {
   success: true;
-  totalFailed: number;
+  totalFailedActions: number;
 };
 
 export const DismissAllActionsQuerySchema = z.object({
@@ -81,7 +81,7 @@ async function handler(
 
   return res.status(200).json({
     success: true,
-    totalFailed: result.value.failedActionCount,
+    totalFailedActions: result.value.failedActionCount,
   });
 }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
@@ -1,0 +1,88 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { declineBlockedActionsForConversations } from "@app/lib/api/assistant/conversation/decline_blocked_actions";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type DeclineBlockedActionsResponse = {
+  success: true;
+  totalFailed: number;
+};
+
+export const DismissAllActionsQuerySchema = z.object({
+  conversationIds: z.array(z.string()).min(1),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<DeclineBlockedActionsResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  if (
+    req.query.conversationIds &&
+    typeof req.query.conversationIds === "string"
+  ) {
+    req.query.conversationIds = [req.query.conversationIds];
+  }
+
+  const parseResult = DismissAllActionsQuerySchema.safeParse(req.query);
+  if (!parseResult.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid query parameters: ${parseResult.error.message}. Provide conversationIds as query parameters.`,
+      },
+    });
+  }
+
+  const { conversationIds } = parseResult.data;
+
+  if (conversationIds.length === 0) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "At least one conversation ID is required",
+      },
+    });
+  }
+
+  const result = await declineBlockedActionsForConversations(
+    auth,
+    conversationIds
+  );
+
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          result.error instanceof Error
+            ? result.error.message
+            : "Failed to decline blocked actions",
+      },
+    });
+  }
+
+  return res.status(200).json({
+    success: true,
+    totalFailed: result.value.failedActionCount,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
@@ -6,13 +6,13 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { normalizeError } from "@app/types";
 
 export type DeclineBlockedActionsResponse = {
-  success: true;
-  totalFailedActions: number;
+  failedConversationIds: string[];
 };
 
-export const DismissAllActionsQuerySchema = z.object({
+export const DismissAllActionsBodySchema = z.object({
   conversationIds: z.array(z.string()).min(1),
 });
 
@@ -31,35 +31,18 @@ async function handler(
     });
   }
 
-  if (
-    req.query.conversationIds &&
-    typeof req.query.conversationIds === "string"
-  ) {
-    req.query.conversationIds = [req.query.conversationIds];
-  }
-
-  const parseResult = DismissAllActionsQuerySchema.safeParse(req.query);
+  const parseResult = DismissAllActionsBodySchema.safeParse(req.body);
   if (!parseResult.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid query parameters: ${parseResult.error.message}. Provide conversationIds as query parameters.`,
+        message: `Invalid request body: ${parseResult.error.message}. Provide conversationIds in the request body.`,
       },
     });
   }
 
   const { conversationIds } = parseResult.data;
-
-  if (conversationIds.length === 0) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "At least one conversation ID is required",
-      },
-    });
-  }
 
   const result = await declineBlockedActionsForConversations(
     auth,
@@ -71,17 +54,13 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message:
-          result.error instanceof Error
-            ? result.error.message
-            : "Failed to decline blocked actions",
+        message: normalizeError(result.error).message,
       },
     });
   }
 
   return res.status(200).json({
-    success: true,
-    totalFailedActions: result.value.failedActionCount,
+    failedConversationIds: result.value.failedConversationIds,
   });
 }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
@@ -13,8 +13,9 @@ export type DeclineBlockedActionsResponse = {
   failedConversationIds: string[];
 };
 
+// TODO (2025-12-03 yuka): we limit the number of conversations to 50 and ideally we should move this to temporal.
 export const DismissAllActionsBodySchema = z.object({
-  conversationIds: z.array(z.string()).min(1),
+  conversationIds: z.array(z.string()).min(1).max(50),
 });
 
 async function handler(

--- a/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/decline-blocked-actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { declineBlockedActionsForConversations } from "@app/lib/api/assistant/conversation/decline_blocked_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { normalizeError } from "@app/types";
@@ -50,6 +51,13 @@ async function handler(
   );
 
   if (result.isErr()) {
+    logger.error(
+      {
+        error: result.error,
+      },
+      "Failed to decline blocked actions for conversations"
+    );
+
     return apiError(req, res, {
       status_code: 400,
       api_error: {


### PR DESCRIPTION
## Description
This PR is to add an endpoint to dismiss all the pending actions from given conversation ids for making your inbox 0. 

There are two type of actions that can block a conversation and we need to handle them differently. 

If it's `blocked_authentication_required`:
We will decline the action and update the agent message error code (we need to show a different error message in frontend). This won't launch a new agent loop so we manually need to update the actionRequired status. Minor problem is if you are in this conversation when you dismiss all the pending action, it won't get updated automatically and you need to reload the page, but given that your inbox will be clear I think it's okay. 

If it's `blocked_validation_required`:
We will deny actions, and that will start a new agent flow so you will get a new agent message (= new unread conversation in your inbox). Not ideal but not much we can do so we will leave as it is. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
