### PR TITLE
[front] chore: untrack `plan_message_limit_exceeded` errors in `run_agent`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -70,7 +70,9 @@ export async function getOrCreateConversation(
       // Do not track invalid request errors, since they are user-side and should
       // not trigger an alert on our end. For user-side errors, surface the
       // underlying message to the model.
-      const isUserSide = convRes.error.type === "invalid_request_error";
+      const isUserSide =
+        convRes.error.type === "invalid_request_error" ||
+        convRes.error.type === "plan_message_limit_exceeded";
       const message = isUserSide
         ? convRes.error.message
         : "Failed to get conversation";


### PR DESCRIPTION
## Description

- This PR untracks `plan_message_limit_exceeded` errors in the `run_agent` tool.
- These errors do not need to be plugged in our alerting.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
