### PR TITLE
[PPUL] Add logic for credit consumption

### DIFF
--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -9,6 +9,7 @@ type PricingEntry = {
   cache_read_input_tokens?: number;
 };
 
+export const DUST_MARKUP_PERCENT = 30;
 // Pricing (in USD) per million of tokens for current models.
 // This record must contain all BaseModelIdType values.
 const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {

--- a/front/lib/api/programmatic_usage_tracking.test.ts
+++ b/front/lib/api/programmatic_usage_tracking.test.ts
@@ -149,7 +149,10 @@ describe("decreaseProgrammaticCreditsV2", () => {
     workspace = await WorkspaceFactory.basic();
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "admin" });
-    auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
   });
 
   async function createCredit(

--- a/front/lib/api/programmatic_usage_tracking.test.ts
+++ b/front/lib/api/programmatic_usage_tracking.test.ts
@@ -194,7 +194,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, 300);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
 
       const refreshed = await refreshCredit(credit);
       expect(refreshed.consumedAmountCents).toBe(300);
@@ -207,14 +207,14 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, 1000);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 1000 });
 
       const refreshed = await refreshCredit(credit);
       expect(refreshed.consumedAmountCents).toBe(500);
     });
 
     it("should not throw when no credits are available", async () => {
-      await decreaseProgrammaticCreditsV2(auth, 1000);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 1000 });
       // Should complete without error
     });
 
@@ -225,7 +225,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, 0);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 0 });
 
       const refreshed = await refreshCredit(credit);
       expect(refreshed.consumedAmountCents).toBe(0);
@@ -245,7 +245,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, 300);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
 
       const refreshedFree = await refreshCredit(freeCredit);
       const refreshedPayg = await refreshCredit(paygCredit);
@@ -266,7 +266,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, 300);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
 
       const refreshedCommitted = await refreshCredit(committedCredit);
       const refreshedPayg = await refreshCredit(paygCredit);
@@ -296,7 +296,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
       // 1. freeCredit (200)
       // 2. committedCredit (200)
       // 3. paygCredit (100)
-      await decreaseProgrammaticCreditsV2(auth, 500);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 500 });
 
       const refreshedFree = await refreshCredit(freeCredit);
       const refreshedCommitted = await refreshCredit(committedCredit);
@@ -321,7 +321,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + TWO_MONTHS)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, 300);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
 
       const refreshedEarlier = await refreshCredit(earlierCredit);
       const refreshedLater = await refreshCredit(laterCredit);
@@ -342,7 +342,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + TWO_MONTHS)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, 500);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 500 });
 
       const refreshedEarlier = await refreshCredit(earlierCredit);
       const refreshedLater = await refreshCredit(laterCredit);
@@ -366,7 +366,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + 6 * ONE_MONTH)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, 300);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
 
       const refreshedPayg = await refreshCredit(paygCredit);
       const refreshedFree = await refreshCredit(freeCredit);
@@ -409,7 +409,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
       // 2. freeLater (100)
       // 3. committedEarlier (100)
       // 4. paygEarlier (50)
-      await decreaseProgrammaticCreditsV2(auth, 350);
+      await decreaseProgrammaticCreditsV2(auth, { amountCents: 350 });
 
       const refreshedFreeEarlier = await refreshCredit(freeEarlier);
       const refreshedFreeLater = await refreshCredit(freeLater);

--- a/front/lib/api/programmatic_usage_tracking.test.ts
+++ b/front/lib/api/programmatic_usage_tracking.test.ts
@@ -1,0 +1,416 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  compareCreditsForConsumption,
+  decreaseProgrammaticCreditsV2,
+} from "@app/lib/api/programmatic_usage_tracking";
+import { Authenticator } from "@app/lib/auth";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types";
+
+describe("compareCreditsForConsumption", () => {
+  const NOW = new Date();
+  const ONE_DAY = 24 * 60 * 60 * 1000;
+
+  function makeMockCredit(
+    type: "free" | "payg" | "committed",
+    expirationDate: Date
+  ): CreditResource {
+    return { type, expirationDate } as CreditResource;
+  }
+
+  describe("type ordering", () => {
+    it("should prioritize free credits over payg", () => {
+      const free = makeMockCredit("free", NOW);
+      const payg = makeMockCredit("payg", NOW);
+
+      expect(compareCreditsForConsumption(free, payg)).toBeLessThan(0);
+      expect(compareCreditsForConsumption(payg, free)).toBeGreaterThan(0);
+    });
+
+    it("should prioritize free credits over committed", () => {
+      const free = makeMockCredit("free", NOW);
+      const committed = makeMockCredit("committed", NOW);
+
+      expect(compareCreditsForConsumption(free, committed)).toBeLessThan(0);
+      expect(compareCreditsForConsumption(committed, free)).toBeGreaterThan(0);
+    });
+
+    it("should prioritize payg over committed", () => {
+      const payg = makeMockCredit("payg", NOW);
+      const committed = makeMockCredit("committed", NOW);
+
+      expect(compareCreditsForConsumption(payg, committed)).toBeLessThan(0);
+      expect(compareCreditsForConsumption(committed, payg)).toBeGreaterThan(0);
+    });
+  });
+
+  describe("expiration date ordering within same type", () => {
+    it("should prioritize earlier expiration dates for free credits", () => {
+      const earlier = makeMockCredit("free", NOW);
+      const later = makeMockCredit("free", new Date(NOW.getTime() + ONE_DAY));
+
+      expect(compareCreditsForConsumption(earlier, later)).toBeLessThan(0);
+      expect(compareCreditsForConsumption(later, earlier)).toBeGreaterThan(0);
+    });
+
+    it("should prioritize earlier expiration dates for payg credits", () => {
+      const earlier = makeMockCredit("payg", NOW);
+      const later = makeMockCredit("payg", new Date(NOW.getTime() + ONE_DAY));
+
+      expect(compareCreditsForConsumption(earlier, later)).toBeLessThan(0);
+      expect(compareCreditsForConsumption(later, earlier)).toBeGreaterThan(0);
+    });
+
+    it("should prioritize earlier expiration dates for committed credits", () => {
+      const earlier = makeMockCredit("committed", NOW);
+      const later = makeMockCredit(
+        "committed",
+        new Date(NOW.getTime() + ONE_DAY)
+      );
+
+      expect(compareCreditsForConsumption(earlier, later)).toBeLessThan(0);
+      expect(compareCreditsForConsumption(later, earlier)).toBeGreaterThan(0);
+    });
+
+    it("should return 0 for credits with same type and expiration date", () => {
+      const credit1 = makeMockCredit("free", NOW);
+      const credit2 = makeMockCredit("free", NOW);
+
+      expect(compareCreditsForConsumption(credit1, credit2)).toBe(0);
+    });
+  });
+
+  describe("type takes precedence over expiration date", () => {
+    it("should prioritize free over payg even with later expiration", () => {
+      const free = makeMockCredit(
+        "free",
+        new Date(NOW.getTime() + 30 * ONE_DAY)
+      );
+      const payg = makeMockCredit("payg", NOW);
+
+      expect(compareCreditsForConsumption(free, payg)).toBeLessThan(0);
+    });
+
+    it("should prioritize payg over committed even with later expiration", () => {
+      const payg = makeMockCredit(
+        "payg",
+        new Date(NOW.getTime() + 30 * ONE_DAY)
+      );
+      const committed = makeMockCredit("committed", NOW);
+
+      expect(compareCreditsForConsumption(payg, committed)).toBeLessThan(0);
+    });
+  });
+
+  describe("sorting an array of credits", () => {
+    it("should sort credits correctly: free first, then payg, then committed, by expiration", () => {
+      const credits = [
+        makeMockCredit("committed", new Date(NOW.getTime() + ONE_DAY)),
+        makeMockCredit("payg", new Date(NOW.getTime() + 2 * ONE_DAY)),
+        makeMockCredit("free", new Date(NOW.getTime() + 3 * ONE_DAY)),
+        makeMockCredit("committed", NOW),
+        makeMockCredit("payg", NOW),
+        makeMockCredit("free", NOW),
+      ];
+
+      const sorted = [...credits].sort(compareCreditsForConsumption);
+
+      // Free credits first (by expiration)
+      expect(sorted[0].type).toBe("free");
+      expect(sorted[0].expirationDate).toEqual(NOW);
+      expect(sorted[1].type).toBe("free");
+
+      // Then payg (by expiration)
+      expect(sorted[2].type).toBe("payg");
+      expect(sorted[2].expirationDate).toEqual(NOW);
+      expect(sorted[3].type).toBe("payg");
+
+      // Then committed (by expiration)
+      expect(sorted[4].type).toBe("committed");
+      expect(sorted[4].expirationDate).toEqual(NOW);
+      expect(sorted[5].type).toBe("committed");
+    });
+  });
+});
+
+describe("decreaseProgrammaticCreditsV2", () => {
+  const ONE_YEAR = 365 * 24 * 60 * 60 * 1000;
+  const ONE_MONTH = 30 * 24 * 60 * 60 * 1000;
+  const TWO_MONTHS = 60 * 24 * 60 * 60 * 1000;
+
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+  });
+
+  async function createCredit(
+    type: "free" | "payg" | "committed",
+    initialAmountCents: number,
+    expirationDate: Date
+  ): Promise<CreditResource> {
+    const credit = await CreditResource.makeNew(auth, {
+      type,
+      initialAmountCents,
+      consumedAmountCents: 0,
+    });
+    await credit.start(new Date(), expirationDate);
+    return credit;
+  }
+
+  async function refreshCredit(
+    credit: CreditResource
+  ): Promise<CreditResource> {
+    const refreshed = await CreditResource.fetchById(
+      auth,
+      credit.id.toString()
+    );
+    if (!refreshed) {
+      throw new Error("Credit not found");
+    }
+    return refreshed;
+  }
+
+  describe("basic consumption", () => {
+    it("should consume from a single credit", async () => {
+      const credit = await createCredit(
+        "free",
+        1000,
+        new Date(Date.now() + ONE_YEAR)
+      );
+
+      await decreaseProgrammaticCreditsV2(auth, 300);
+
+      const refreshed = await refreshCredit(credit);
+      expect(refreshed.consumedAmountCents).toBe(300);
+    });
+
+    it("should fully consume a credit and stop", async () => {
+      const credit = await createCredit(
+        "free",
+        500,
+        new Date(Date.now() + ONE_YEAR)
+      );
+
+      await decreaseProgrammaticCreditsV2(auth, 1000);
+
+      const refreshed = await refreshCredit(credit);
+      expect(refreshed.consumedAmountCents).toBe(500);
+    });
+
+    it("should not throw when no credits are available", async () => {
+      await decreaseProgrammaticCreditsV2(auth, 1000);
+      // Should complete without error
+    });
+
+    it("should do nothing when amount is zero", async () => {
+      const credit = await createCredit(
+        "free",
+        1000,
+        new Date(Date.now() + ONE_YEAR)
+      );
+
+      await decreaseProgrammaticCreditsV2(auth, 0);
+
+      const refreshed = await refreshCredit(credit);
+      expect(refreshed.consumedAmountCents).toBe(0);
+    });
+  });
+
+  describe("consumption order by type", () => {
+    it("should consume free credits before payg", async () => {
+      const freeCredit = await createCredit(
+        "free",
+        500,
+        new Date(Date.now() + ONE_YEAR)
+      );
+      const paygCredit = await createCredit(
+        "payg",
+        500,
+        new Date(Date.now() + ONE_YEAR)
+      );
+
+      await decreaseProgrammaticCreditsV2(auth, 300);
+
+      const refreshedFree = await refreshCredit(freeCredit);
+      const refreshedPayg = await refreshCredit(paygCredit);
+
+      expect(refreshedFree.consumedAmountCents).toBe(300);
+      expect(refreshedPayg.consumedAmountCents).toBe(0);
+    });
+
+    it("should consume payg credits before committed", async () => {
+      const paygCredit = await createCredit(
+        "payg",
+        500,
+        new Date(Date.now() + ONE_YEAR)
+      );
+      const committedCredit = await createCredit(
+        "committed",
+        500,
+        new Date(Date.now() + ONE_YEAR)
+      );
+
+      await decreaseProgrammaticCreditsV2(auth, 300);
+
+      const refreshedPayg = await refreshCredit(paygCredit);
+      const refreshedCommitted = await refreshCredit(committedCredit);
+
+      expect(refreshedPayg.consumedAmountCents).toBe(300);
+      expect(refreshedCommitted.consumedAmountCents).toBe(0);
+    });
+
+    it("should consume in order: free -> payg -> committed", async () => {
+      const freeCredit = await createCredit(
+        "free",
+        200,
+        new Date(Date.now() + ONE_YEAR)
+      );
+      const paygCredit = await createCredit(
+        "payg",
+        200,
+        new Date(Date.now() + ONE_YEAR)
+      );
+      const committedCredit = await createCredit(
+        "committed",
+        200,
+        new Date(Date.now() + ONE_YEAR)
+      );
+
+      await decreaseProgrammaticCreditsV2(auth, 500);
+
+      const refreshedFree = await refreshCredit(freeCredit);
+      const refreshedPayg = await refreshCredit(paygCredit);
+      const refreshedCommitted = await refreshCredit(committedCredit);
+
+      expect(refreshedFree.consumedAmountCents).toBe(200);
+      expect(refreshedPayg.consumedAmountCents).toBe(200);
+      expect(refreshedCommitted.consumedAmountCents).toBe(100);
+    });
+  });
+
+  describe("consumption order by expiration date", () => {
+    it("should consume earlier-expiring credits first within same type", async () => {
+      const earlierCredit = await createCredit(
+        "free",
+        500,
+        new Date(Date.now() + ONE_MONTH)
+      );
+      const laterCredit = await createCredit(
+        "free",
+        500,
+        new Date(Date.now() + TWO_MONTHS)
+      );
+
+      await decreaseProgrammaticCreditsV2(auth, 300);
+
+      const refreshedEarlier = await refreshCredit(earlierCredit);
+      const refreshedLater = await refreshCredit(laterCredit);
+
+      expect(refreshedEarlier.consumedAmountCents).toBe(300);
+      expect(refreshedLater.consumedAmountCents).toBe(0);
+    });
+
+    it("should spill over to later-expiring credits when earlier ones are exhausted", async () => {
+      const earlierCredit = await createCredit(
+        "free",
+        200,
+        new Date(Date.now() + ONE_MONTH)
+      );
+      const laterCredit = await createCredit(
+        "free",
+        500,
+        new Date(Date.now() + TWO_MONTHS)
+      );
+
+      await decreaseProgrammaticCreditsV2(auth, 500);
+
+      const refreshedEarlier = await refreshCredit(earlierCredit);
+      const refreshedLater = await refreshCredit(laterCredit);
+
+      expect(refreshedEarlier.consumedAmountCents).toBe(200);
+      expect(refreshedLater.consumedAmountCents).toBe(300);
+    });
+  });
+
+  describe("mixed type and expiration scenarios", () => {
+    it("should prioritize type over expiration date", async () => {
+      // Payg expires sooner than free
+      const paygCredit = await createCredit(
+        "payg",
+        500,
+        new Date(Date.now() + ONE_MONTH)
+      );
+      const freeCredit = await createCredit(
+        "free",
+        500,
+        new Date(Date.now() + 6 * ONE_MONTH)
+      );
+
+      await decreaseProgrammaticCreditsV2(auth, 300);
+
+      const refreshedPayg = await refreshCredit(paygCredit);
+      const refreshedFree = await refreshCredit(freeCredit);
+
+      // Free should be consumed first despite later expiration
+      expect(refreshedFree.consumedAmountCents).toBe(300);
+      expect(refreshedPayg.consumedAmountCents).toBe(0);
+    });
+
+    it("should handle complex scenario with multiple credits of each type", async () => {
+      // Create credits in non-sorted order
+      const paygLater = await createCredit(
+        "payg",
+        100,
+        new Date(Date.now() + TWO_MONTHS)
+      );
+      const freeEarlier = await createCredit(
+        "free",
+        100,
+        new Date(Date.now() + ONE_MONTH)
+      );
+      const committedEarlier = await createCredit(
+        "committed",
+        100,
+        new Date(Date.now() + ONE_MONTH)
+      );
+      const freeLater = await createCredit(
+        "free",
+        100,
+        new Date(Date.now() + TWO_MONTHS)
+      );
+      const paygEarlier = await createCredit(
+        "payg",
+        100,
+        new Date(Date.now() + ONE_MONTH)
+      );
+
+      // Consume 350 cents - should go through:
+      // 1. freeEarlier (100)
+      // 2. freeLater (100)
+      // 3. paygEarlier (100)
+      // 4. paygLater (50)
+      await decreaseProgrammaticCreditsV2(auth, 350);
+
+      const refreshedFreeEarlier = await refreshCredit(freeEarlier);
+      const refreshedFreeLater = await refreshCredit(freeLater);
+      const refreshedPaygEarlier = await refreshCredit(paygEarlier);
+      const refreshedPaygLater = await refreshCredit(paygLater);
+      const refreshedCommittedEarlier = await refreshCredit(committedEarlier);
+
+      expect(refreshedFreeEarlier.consumedAmountCents).toBe(100);
+      expect(refreshedFreeLater.consumedAmountCents).toBe(100);
+      expect(refreshedPaygEarlier.consumedAmountCents).toBe(100);
+      expect(refreshedPaygLater.consumedAmountCents).toBe(50);
+      expect(refreshedCommittedEarlier.consumedAmountCents).toBe(0);
+    });
+  });
+});

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -316,14 +316,14 @@ export async function trackProgrammaticCost(
   const runsCostUsd = runUsages
     .flat()
     .reduce((acc, usage) => acc + usage.costUsd, 0);
-  const runsCostUsdFloored = runsCostUsd > 0 ? Math.ceil(runsCostUsd) : 0;
+  const runsCostUsdRounded = runsCostUsd > 0 ? Math.ceil(runsCostUsd) : 0;
 
   await decreaseProgrammaticCredits(
     auth.getNonNullableWorkspace(),
-    runsCostUsdFloored
+    runsCostUsdRounded
   );
   // Percentage not divided by 100 because of the cents->dollars conversion at the same time.
-  const costWithMarkupCents = runsCostUsdFloored * (100 + DUST_MARKUP_PERCENT);
+  const costWithMarkupCents = runsCostUsdRounded * (100 + DUST_MARKUP_PERCENT);
   await decreaseProgrammaticCreditsV2(auth, {
     amountCents: costWithMarkupCents,
   });

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -322,10 +322,8 @@ export async function trackProgrammaticCost(
     auth.getNonNullableWorkspace(),
     runsCostUsdFloored
   );
-  const costWithMarkupCents = Math.ceil(
-    // Explicit dollar conversion and percentage.
-    runsCostUsdFloored * (1 + DUST_MARKUP_PERCENT / 100) * 100
-  );
+  // Percentage not divided by 100 because of the cents->dollars conversion at the same time.
+  const costWithMarkupCents = runsCostUsdFloored * (100 + DUST_MARKUP_PERCENT);
   await decreaseProgrammaticCreditsV2(auth, {
     amountCents: costWithMarkupCents,
   });

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -1,10 +1,14 @@
+import assert from "node:assert";
+
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 import type { RedisClientType } from "redis";
 
+import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { runOnRedis } from "@app/lib/api/redis";
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -13,9 +17,6 @@ import type {
   PublicAPILimitsType,
   UserMessageOrigin,
 } from "@app/types";
-import { CreditResource } from "@app/lib/resources/credit_resource";
-import assert from "node:assert";
-import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
 
 export const USAGE_ORIGINS_CLASSIFICATION: Record<
   UserMessageOrigin,

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -234,6 +234,12 @@ export async function decreaseProgrammaticCreditsV2(
         {
           amount: amountToConsume,
           workspaceId: auth.getNonNullableWorkspace().sId,
+          // For eng on-call: this error should be investigated since it likely
+          // reveals an underlying issue in our billing / credit logic. The only
+          // legitimate case this error could happen would be a race condition
+          // in which two messages consume the same credit at exactly the same
+          // time--in which case it's a no-op, but at time of writing this is
+          // considered very unlikely, so to be confirmed first before skipping.
           panic: true,
           error: result.error,
         },

--- a/front/lib/resources/.#credit_resource.ts
+++ b/front/lib/resources/.#credit_resource.ts
@@ -1,1 +1,0 @@
-filou@Philippes-MacBook-Pro.local.10353:1764104946

--- a/front/lib/resources/.#credit_resource.ts
+++ b/front/lib/resources/.#credit_resource.ts
@@ -1,0 +1,1 @@
+filou@Philippes-MacBook-Pro.local.10353:1764104946

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -203,7 +203,7 @@ export class CreditResource extends BaseResource<CreditModel> {
         id: this.id,
         workspaceId: this.workspaceId,
         // Already-depleted credit should not be consumed.
-        consumedAmountCents: { [Op.lte]: Sequelize.col("initialAmountCents") },
+        consumedAmountCents: { [Op.lt]: Sequelize.col("initialAmountCents") },
         // Credit must be started (startDate not null and <= now)
         startDate: { [Op.ne]: null, [Op.lte]: now },
         // Credit must not be expired

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -115,7 +115,10 @@ export class CreditResource extends BaseResource<CreditModel> {
     return this.baseFetch(auth);
   }
 
-  static async listActive(auth: Authenticator, fromDate: Date = new Date()) {
+  static async listActive(
+    auth: Authenticator,
+    minExpirationDate: Date = new Date()
+  ) {
     const now = new Date();
     return this.baseFetch(auth, {
       where: {
@@ -131,7 +134,7 @@ export class CreditResource extends BaseResource<CreditModel> {
         // Credit must not be expired
         [Op.or]: [
           { expirationDate: null },
-          { expirationDate: { [Op.gt]: fromDate } },
+          { expirationDate: { [Op.gt]: minExpirationDate } },
         ],
       },
     });

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -202,7 +202,7 @@ export class CreditResource extends BaseResource<CreditModel> {
       where: {
         id: this.id,
         workspaceId: this.workspaceId,
-        // Credit must not be over-consumed (atomic check to avoid race conditions)
+        // Already-depleted credit should not be consumed.
         consumedAmountCents: { [Op.lte]: Sequelize.col("initialAmountCents") },
         // Credit must be started (startDate not null and <= now)
         startDate: { [Op.ne]: null, [Op.lte]: now },

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import type {
   Attributes,
   CreationAttributes,
@@ -118,7 +117,6 @@ export class CreditResource extends BaseResource<CreditModel> {
 
   static async listActive(auth: Authenticator, fromDate: Date = new Date()) {
     const now = new Date();
-    assert(this.model.sequelize, "Unexpected sequelize undefined");
     return this.baseFetch(auth, {
       where: {
         // Credit must have remaining balance (consumed < initial)


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5296

- Add `decreaseProgrammaticCreditsV2` function to consume credits from CreditResource
- Credits are consumed in priority order: free → committed → payg, then by expiration date (earliest first)
- Export `DUST_MARKUP_PERCENT` constant and apply markup with `Math.ceil()` rounding
- Add error handling for `credit.consume()` failures with panic logging
- Allow over-consumption in CreditResource (tokens are consumed before credits are decremented)
- Fix Sequelize `increment()` return value check for PostgreSQL (check `affectedRows.length` instead of unreliable `affectedCount`)
- Add comprehensive tests for credit consumption logic

## Risks

Blast radius: Programmatic usage credit tracking (new v2 path runs alongside existing v1)
Risk: low

## Deploy Plan
- run migration script from incoming pr to add free credits to all
- deploy front