### PR TITLE
[core] Add logging in code path for retrieving a document's text

### DIFF
--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -86,11 +86,33 @@ impl FileStorageDocument {
         );
         let bucket = FileStorageDocument::get_bucket().await?;
 
-        let bytes = Object::download(&bucket, &file_path).await?;
-
-        match String::from_utf8(bytes) {
-            Ok(content) => Ok(serde_json::from_str(&content)?),
-            Err(err) => Err(anyhow!("Failed to retrieve stored document: {}", err)),
+        let now = utils::now();
+        match Object::download(&bucket, &file_path).await {
+            Ok(bytes) => {
+                info!(
+                    data_source_internal_id = data_source.internal_id(),
+                    document_id_hash = document_id_hash,
+                    duration = utils::now() - now,
+                    size_bytes = bytes.len(),
+                    blob_url = format!("gs://{}/{}", bucket, file_path),
+                    "Downloaded document blob"
+                );
+                match String::from_utf8(bytes) {
+                    Ok(content) => Ok(serde_json::from_str(&content)?),
+                    Err(e) => Err(anyhow!("Failed to retrieve stored document: {}", e)),
+                }
+            }
+            Err(e) => {
+                info!(
+                    data_source_internal_id = data_source.internal_id(),
+                    document_id_hash = document_id_hash,
+                    duration = utils::now() - now,
+                    error = %e,
+                    blob_url = format!("gs://{}/{}", bucket, file_path),
+                    "Failed to download document blob"
+                );
+                Err(e)?
+            }
         }
     }
 

--- a/core/src/data_sources/file_storage_document.rs
+++ b/core/src/data_sources/file_storage_document.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use cloud_storage::{ErrorList, GoogleErrorResponse, Object};
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use tracing::{error, info};
 
 use crate::utils;
 
@@ -103,7 +103,7 @@ impl FileStorageDocument {
                 }
             }
             Err(e) => {
-                info!(
+                error!(
                     data_source_internal_id = data_source.internal_id(),
                     document_id_hash = document_id_hash,
                     duration = utils::now() - now,


### PR DESCRIPTION
## Description

-  This PR adds some logs in the code path triggered by the `cat` tool, when retrieving the textual content.
- We have observed cases like [this one](https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40toolName%3Acat%20%28%22Unexpected%20network%20error%20from%20CoreAPI%3A%20TypeError%3A%20fetch%20failed%22%20OR%20%22Tool%20execution%20success%22%29&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZrImTF-AryEvAAAABhBWnJJbVRMdUFBRF9FbWVYOWVrejJRRTcAAAAkZjE5YWM4OWUtMjlmYy00YmY4LTgyMTAtMDhkZjA5NmYzZGExAAUjNA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764301279000&to_ts=1764302479000&live=false) where the `searchNodes` succeeds but the `getDataSourceDocumentText` fails with a `fetch failed` on core `other side closed`.
- This PR adds logs to track the different main steps (retrieving the document from gcs, applying the offset, the grep).
- Next step depend on what we see in the logs. Potentially we can add some retries or fetch a compressed version from gcs (`Accept-Encoding: gzip`).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy core.
