### PR TITLE
[front] improve personal auth required display

### DIFF
--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -76,7 +76,7 @@ export function MCPServerPersonalAuthenticationRequired({
           : `${mcpServer && mcpServer.name ? getMcpServerDisplayName(mcpServer) : "Personal authentication required"}`
       }
       variant={isConnected ? "success" : "primary"}
-      className="flex w-fit min-w-80 flex-col gap-3"
+      className="flex w-80 flex-col gap-3"
       icon={icon}
     >
       <div className="font-sm whitespace-normal break-words text-foreground dark:text-foreground-night">

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -6,7 +6,9 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
+import type { MCPServerType } from "@app/lib/api/mcp";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import {
   useCreatePersonalConnection,
@@ -33,6 +35,7 @@ export function MCPServerPersonalAuthenticationRequired({
     owner,
     serverId: mcpServerId,
   });
+
   const { createPersonalConnection } = useCreatePersonalConnection(owner);
 
   const { submit: retry } = useSubmitFunction(async () => retryHandler());
@@ -40,47 +43,63 @@ export function MCPServerPersonalAuthenticationRequired({
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
 
+  const icon = mcpServer?.icon
+    ? getIcon(mcpServer.icon)
+    : InformationCircleIcon;
+
+  const onConnectClick = async (mcpServer: MCPServerType) => {
+    setIsConnecting(true);
+
+    const success = await createPersonalConnection({
+      mcpServerId: mcpServer.sId,
+      mcpServerDisplayName: getMcpServerDisplayName(mcpServer),
+      provider,
+      useCase: "personal_actions",
+      scope,
+    });
+
+    setIsConnecting(false);
+
+    if (!success) {
+      setIsConnected(false);
+    } else {
+      setIsConnected(true);
+      await retry();
+    }
+  };
+
   return (
     <ContentMessage
       title={
         isConnected
           ? "Connected successfully"
-          : "Personal authentication required"
+          : `${mcpServer && mcpServer.name ? getMcpServerDisplayName(mcpServer) : "Personal authentication required"}`
       }
-      variant={isConnected ? "success" : "info"}
-      className="flex flex-col gap-3"
-      icon={InformationCircleIcon}
+      variant={isConnected ? "success" : "primary"}
+      className="flex w-fit min-w-80 flex-col gap-3"
+      icon={icon}
     >
-      <div className="whitespace-normal break-words">
-        {isConnected
-          ? "You are now connected. Automatically retrying..."
-          : "The agent took an action that requires personal authentication."}
+      <div className="font-sm whitespace-normal break-words text-foreground dark:text-foreground-night">
+        {isConnected && "You are now connected. Automatically retrying..."}
+        {!isConnected && (
+          <>
+            {`Your agent is trying to use ${mcpServer && mcpServer.name ? getMcpServerDisplayName(mcpServer) : "a tool"}.`}
+            <br />
+            <span className="font-semibold">
+              Connect your account to continue.
+            </span>
+          </>
+        )}
       </div>
       {!isConnected && mcpServer && (
-        <div className="flex flex-col gap-2 pt-3 sm:flex-row">
+        <div className="mt-3 flex flex-col justify-end sm:flex-row">
           <Button
             label="Connect"
-            variant="outline"
+            variant="highlight"
             size="xs"
             icon={CloudArrowLeftRightIcon}
             disabled={isConnecting}
-            onClick={async () => {
-              setIsConnecting(true);
-              const success = await createPersonalConnection({
-                mcpServerId: mcpServer.sId,
-                mcpServerDisplayName: getMcpServerDisplayName(mcpServer),
-                provider,
-                useCase: "personal_actions",
-                scope,
-              });
-              setIsConnecting(false);
-              if (!success) {
-                setIsConnected(false);
-              } else {
-                setIsConnected(true);
-                await retry();
-              }
-            }}
+            onClick={() => void onConnectClick(mcpServer)}
           />
         </div>
       )}


### PR DESCRIPTION
## Description
This PR is to improve the personal authentication required message UI. We now show which tool requires the connection: 

|light|dark|
|---|---|
|<img width="724" height="432" alt="CleanShot 2025-11-28 at 17 10 55@2x" src="https://github.com/user-attachments/assets/0195efc1-766e-4e0c-a0f8-4737de55bd2c" />|<img width="708" height="430" alt="CleanShot 2025-11-28 at 17 12 48@2x" src="https://github.com/user-attachments/assets/c3bcec03-265b-4676-a36e-3544335886b5" />|

before:
<img width="1642" height="450" alt="CleanShot 2025-11-28 at 17 19 55@2x" src="https://github.com/user-attachments/assets/db4c861c-927e-4305-ae34-df128851ed18" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
