### PR TITLE
Mark as read on human messages and do not refresh the conversations list if we are already on the right page.

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -321,12 +321,19 @@ export const ConversationViewer = ({
                   }
                   return {
                     conversations: currentData.conversations.map((c) =>
-                      c.sId === conversationId ? { ...c, hasError: false } : c
+                      c.sId === conversationId
+                        ? { ...c, hasError: false, unread: false }
+                        : c
                     ),
                   };
                 },
                 { revalidate: false }
               );
+
+              // Mark as read if the message is not from the current user.
+              if (userMessage.user?.sId !== user.sId) {
+                void debouncedMarkAsRead(conversationId, false);
+              }
             }
             break;
           case "agent_message_new":
@@ -428,6 +435,7 @@ export const ConversationViewer = ({
       mutateConversationParticipants,
       mutateConversations,
       mutateMessages,
+      user.sId,
     ]
   );
 

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -65,7 +65,14 @@ export default function AppRootLayout({
             notification.result.tags?.includes("conversations") &&
             window !== undefined
           ) {
-            window.dispatchEvent(new ConversationsUpdatedEvent());
+            if (
+              window.location.pathname !==
+                notification.result.primaryAction?.redirect?.url ||
+              !window.document.hasFocus()
+            ) {
+              // If we are not already on the conversation page, dispatch the event to update the conversations list.
+              window.dispatchEvent(new ConversationsUpdatedEvent());
+            }
           }
 
           if (!allowBrowserNotification) {

--- a/front/lib/notifications/events.ts
+++ b/front/lib/notifications/events.ts
@@ -2,6 +2,6 @@ export const CONVERSATIONS_UPDATED_EVENT = "conversations-updated";
 
 export class ConversationsUpdatedEvent extends CustomEvent<void> {
   constructor() {
-    super("conversations-updated");
+    super(CONVERSATIONS_UPDATED_EVENT);
   }
 }


### PR DESCRIPTION
## Description

Mark as read on new human messages.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front