### PR TITLE
[PPUL] Use runOnAllWorkspaces helper with concurrency 16

### DIFF
--- a/front/migrations/20251128_backfill_free_credits.ts
+++ b/front/migrations/20251128_backfill_free_credits.ts
@@ -3,7 +3,6 @@ import readline from "readline";
 import { Authenticator } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { CreditModel } from "@app/lib/resources/storage/models/credits";
-import type { WhereOptions } from "@app/lib/resources/storage/wrappers/workspace_models";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
@@ -41,10 +40,7 @@ async function confirmExecution(message: string): Promise<boolean> {
   });
 }
 
-function getIdempotencyKey(
-  workspaceId: number,
-  expirationDate: Date
-): string {
+function getIdempotencyKey(workspaceId: number, expirationDate: Date): string {
   return `backfill-free-${workspaceId}-${expirationDate.toISOString().split("T")[0]}`;
 }
 
@@ -163,7 +159,7 @@ async function removeFreeCredits(
     "Removing free credits"
   );
 
-  const whereClause: WhereOptions<CreditModel> = { type: "free" };
+  const whereClause: { type: "free"; expirationDate?: Date } = { type: "free" };
   if (!isAll) {
     whereClause.expirationDate = expirationDate;
   }


### PR DESCRIPTION
## Description

Follow-up to #18442. Refactors the free credits backfill script:

- Use `runOnAllWorkspaces` helper with concurrency 16
- Single pass for add (no pre-counting)
- Add `all` option for remove to delete all free credits at once

Usage:
```bash
# Add free credits
npx tsx migrations/20251128_backfill_free_credits.ts --action add --amountCents 500 --endDate 2024-12-15 --execute

# Remove free credits with specific expiration
npx tsx migrations/20251128_backfill_free_credits.ts --action remove --endDate 2024-11-29 --execute

# Remove ALL free credits
npx tsx migrations/20251128_backfill_free_credits.ts --action remove --endDate all --execute
```

## Risks

Blast radius: Credits management for programmatic usage
Risk: low (same functionality, confirmation prompt required)

## Deploy Plan

- No deployment needed, run migration manually when needed

## Test

- [x] Remove all free credits locally
- [x] Re-add free credits locally