### PR TITLE
Remove panic:true from user search log

### DIFF
--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -253,7 +253,6 @@ export class UserResource extends BaseResource<UserModel> {
 
       logger.error(
         {
-          panic: true,
           workspaceId: owner.sId,
           missingUserSIds: missingUserIds,
           owner: "spolu",


### PR DESCRIPTION
## Summary

Removed the `panic: true` flag from the logger.error call in the searchUsers method when revoked users are found in search results.

Fixes #18460

🤖 Generated with [Claude Code](https://claude.ai/code)