### PR TITLE
Temporary bump max connections in Sequelize front's pool

### DIFF
--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -41,7 +41,8 @@ export const frontSequelize = new SequelizeWithComments(
   {
     pool: {
       // Default is 5.
-      max: 16,
+      // TODO(2025-11-29 flav) Revisit all Sequelize pool settings.
+      max: 25,
     },
     logging: isDevelopment() && DB_LOGGING_ENABLED ? sequelizeLogger : false,
     hooks: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1764403178546319)

This PR increases the max connections in the Sequelize pool used for front. This can be safely done as we now hit the MCP (Managed Connection Pool) endpoint. This is a temporary measure, a follow up PR will tweak all Sequelize pool settings.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
