### PR TITLE
[front] Add invoice info to credits usage page

### DIFF
--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -347,7 +347,10 @@ export default function CreditsUsagePage({
         {/* History Section */}
         <Page.Vertical>
           <Page.H variant="h5">History</Page.H>
-          <Page.P>Credit history for programmatic API usage</Page.P>
+          <Page.P>
+            Credit history for programmatic API usage. Credits invoices are sent
+            by email at time of purchase.
+          </Page.P>
 
           <CreditsList credits={credits} isLoading={isCreditsLoading} />
         </Page.Vertical>


### PR DESCRIPTION
## Description
Adds a note to the credits usage page clarifying that credits invoices are sent by email at time of purchase.

## Risks
Blast radius: credits usage page display
Risk: none

## Deploy Plan
- deploy front