### PR TITLE
user-search: log explanation

### DIFF
--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -257,6 +257,9 @@ export class UserResource extends BaseResource<UserModel> {
           missingUserSIds: missingUserIds,
           owner: "spolu",
         },
+        // This log is expected has user search queries may happen before the index update completes
+        // (temporal workflow + ES indexing asyncrhonously). We keep it to ensure that volume stays
+        // flat. An increase would indicate a synchronization problem.
         "[user_search] Found revoked users in search results"
       );
     }

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -18,6 +18,7 @@ import {
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { searchUsers } from "@app/lib/user_search/search";
 import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import type { LightWorkspaceType, ModelId, Result, UserType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
@@ -251,14 +252,16 @@ export class UserResource extends BaseResource<UserModel> {
       const foundUserIds = new Set(users.map((u) => u.sId));
       const missingUserIds = userIds.filter((sId) => !foundUserIds.has(sId));
 
+      statsDClient.increment("user_search.revoked_users_in_results.count", 1);
+
       logger.error(
         {
           workspaceId: owner.sId,
           missingUserSIds: missingUserIds,
           owner: "spolu",
         },
-        // This log is expected has user search queries may happen before the index update completes
-        // (temporal workflow + ES indexing asyncrhonously). We keep it to ensure that volume stays
+        // This log is expected as user search queries may happen before the index update completes
+        // (temporal workflow + ES indexing asynchronously). We keep it to ensure that volume stays
         // flat. An increase would indicate a synchronization problem.
         "[user_search] Found revoked users in search results"
       );


### PR DESCRIPTION
## Description

Logs look good given ES / temporal expected delay. We want to make sure they don't grow. Leaving a comment for future us, I think it's good to keep it for now, obviously we don't want a panic. Sorry for that.

https://app.datadoghq.eu/logs?query=%22%5Buser_search%5D%20Found%20revoked%20users%20in%20search%20results%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1763971935751&to_ts=1764576735751&live=true

## Tests

N/A

## Risk

N/A

## Deploy Plan

- deploy `front`