### PR TITLE
[Credits] Fix null reference error in PAYG invoicing

### DIFF
--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -118,13 +118,11 @@ export async function invoiceEnterprisePAYGCredits({
   const workspace = auth.getNonNullableWorkspace();
 
   const paygEnabled = await isPAYGEnabled(auth);
-  if (!isEnterpriseSubscription(stripeSubscription)) {
-    logger.info(
-      { workspaceId: workspace.sId },
-      "[Credit PAYG] Not an enterprise subscription, skipping arrears invoicing"
-    );
-    return new Ok(undefined);
-  }
+
+  assert(
+    isEnterpriseSubscription(stripeSubscription) && paygEnabled,
+    "Unreachable: [Credit PAYG] Not an enterprise subscription or PAYG not enabled."
+  );
 
   const previousPeriodStartDate = new Date(previousPeriodStartSeconds * 1000);
   const previousPeriodEndDate = new Date(previousPeriodEndSeconds * 1000);
@@ -137,7 +135,7 @@ export async function invoiceEnterprisePAYGCredits({
   );
 
   assert(
-    paygCredit || !paygEnabled,
+    paygCredit,
     `[Credit PAYG] No PAYG credit found for period ${previousPeriodStartDate.toISOString()} - ${previousPeriodEndDate.toISOString()} in workspace ${workspace.sId}`
   );
 

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -19,6 +19,7 @@ import { grantFreeCreditsOnSubscriptionRenewal } from "@app/lib/credits/free";
 import {
   allocatePAYGCreditsOnCycleRenewal,
   invoiceEnterprisePAYGCredits,
+  isPAYGEnabled,
 } from "@app/lib/credits/payg";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import {
@@ -558,7 +559,10 @@ async function handler(
                 );
               }
 
-              if (isEnterpriseSubscription(stripeSubscription)) {
+              // TODO(PPUL): should we enforce that enterprise always has PAYG enabled?
+              const paygEnabled = await isPAYGEnabled(auth);
+
+              if (isEnterpriseSubscription(stripeSubscription) && paygEnabled) {
                 // Allocate PAYG credits for the new billing cycle
                 const currentPeriod = StripeBillingPeriodSchema.safeParse({
                   current_period_start: stripeSubscription.current_period_start,


### PR DESCRIPTION
## Description

Fixes error log: `Cannot read properties of null (reading 'consumedAmountCents')`.

The issue occurred when `invoiceEnterprisePAYGCredits` was called for enterprise subscriptions that don't have PAYG enabled. In this case, `paygCredit` is null and accessing `consumedAmountCents` throws.

The fix adds an `isPAYGEnabled` check in the Stripe webhook before calling `invoiceEnterprisePAYGCredits`, and converts the function's early return into an assert to make the precondition explicit.

## Risks

Blast radius: Enterprise PAYG billing
Risk: low

## Deploy Plan

- deploy front