### PR TITLE
Fix hidden bar in ScrollArea

### DIFF
--- a/sparkle/src/components/ScrollArea.tsx
+++ b/sparkle/src/components/ScrollArea.tsx
@@ -81,9 +81,13 @@ const ScrollArea = React.forwardRef<
         >
           {children}
         </ScrollAreaPrimitive.Viewport>
-        {!shouldHideDefaultScrollBar && (
-          <ScrollBar orientation={orientation} className={scrollBarClassName} />
-        )}
+        <ScrollBar
+          orientation={orientation}
+          className={cn(
+            scrollBarClassName,
+            shouldHideDefaultScrollBar && "s-hidden"
+          )}
+        />
         <ScrollAreaPrimitive.Corner />
       </ScrollAreaPrimitive.Root>
     );

--- a/sparkle/src/stories/ScrollArea.stories.tsx
+++ b/sparkle/src/stories/ScrollArea.stories.tsx
@@ -128,3 +128,42 @@ export const ScrollWithActiveState: Story = {
     );
   },
 };
+
+export const ScrollAreaHideScrollbar: Story = {
+  render: () => (
+    <div className="s-flex s-flex-row s-gap-6 s-bg-muted s-p-8">
+      <div className="s-h-[400px]">
+        <ScrollArea
+          className="s-h-full s-w-[200px] s-border-b s-border-t s-border-border s-bg-white"
+          hideScrollBar
+        >
+          <h4 className="s-mb-4 s-text-sm s-font-medium s-leading-none">
+            Mini ScrollBar
+          </h4>
+          {tags.map((tag) => (
+            <React.Fragment key={tag}>
+              <div className="s-text-sm">{tag}</div>
+              <Separator className="s-my-2" />
+            </React.Fragment>
+          ))}
+        </ScrollArea>
+      </div>
+      <div className="s-h-[400px]">
+        <ScrollArea
+          className="s-h-full s-w-[200px] s-border-b s-border-t s-border-border s-bg-white"
+          hideScrollBar
+        >
+          <h4 className="s-mb-4 s-text-sm s-font-medium s-leading-none">
+            Classic ScrollBar
+          </h4>
+          {tags.map((tag) => (
+            <React.Fragment key={tag}>
+              <div className="s-text-sm">{tag}</div>
+              <Separator className="s-my-2" />
+            </React.Fragment>
+          ))}
+        </ScrollArea>
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Description

This PR fixes a bug in the `ScrollArea` component where scrolling stopped working when the `hideScrollBar` attribute was enabled.

**Side Effects**:
This bug also caused issues with small scrollable components where the scrollbar was too wide, preventing touch scroll from working properly.

**The Solution**:
The scrollbar is now always rendered but hidden with the s-hidden class when needed. This keeps Radix UI's scroll mechanics intact while still hiding the scrollbar visually.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish Sparkle
