### PR TITLE
feat(oauth): always create credentials for Slack connections and add client_id to metadata

### DIFF
--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -100,3 +100,5 @@ jobs:
           OAUTH_DATABASE_URI: "postgres://test:test@localhost:5433/oauth"
           REDIS_URI: "redis://localhost:5434"
           OAUTH_ENCRYPTION_KEY: ${{ secrets.TEST_OAUTH_ENCRYPTION_KEY }}
+          OAUTH_SLACK_CLIENT_ID: "test_slack_client_id"
+          OAUTH_SLACK_CLIENT_SECRET: "test_slack_client_secret"

--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -3,6 +3,7 @@ use crate::{
     oauth::{
         connection::{self, Connection, ConnectionProvider, MigratedCredentials},
         credential::{Credential, CredentialMetadata, CredentialProvider},
+        providers::slack::SlackConnectionProvider,
         store,
     },
     utils::{error_response, APIResponse},
@@ -76,6 +77,26 @@ async fn connections_create(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "credential_creation_failed",
                     "Failed to create credential",
+                    Some(e),
+                );
+            }
+        }
+    } else if payload.provider == ConnectionProvider::Slack {
+        // Temporary until all customers have migrated to the new system credential creation flow
+        // Auto-create system credential for Slack connection use-case if needed
+        match SlackConnectionProvider::create_system_credential_if_needed(
+            state.store.clone(),
+            &payload.metadata,
+        )
+        .await
+        {
+            Ok(Some(credential)) => Some(credential.credential_id().to_string()),
+            Ok(None) => None,
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "credential_creation_failed",
+                    "Failed to create system credential for Slack",
                     Some(e),
                 );
             }

--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -7,8 +7,9 @@ use crate::oauth::{
         ProviderError,
         RefreshResult, // PROVIDER_TIMEOUT_SECONDS,
     },
-    credential::{Credential, CredentialProvider},
+    credential::{Credential, CredentialMetadata, CredentialProvider},
     providers::utils::execute_request,
+    store::OAuthStore,
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -98,6 +99,53 @@ impl SlackConnectionProvider {
 
         Ok((client_id.to_string(), client_secret.to_string()))
     }
+
+    /// Creates a system credential for Slack connection use-case using env variables
+    /// Returns None if this is not a Slack connection use-case
+    pub async fn create_system_credential_if_needed(
+        store: Box<dyn OAuthStore + Sync + Send>,
+        metadata: &serde_json::Value,
+    ) -> Result<Option<Credential>> {
+        // Check if this is a connection use-case
+        if metadata.get("use_case").and_then(|v| v.as_str()) != Some("connection") {
+            return Ok(None);
+        }
+
+        let workspace_id = metadata
+            .get("workspace_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing workspace_id in metadata"))?;
+
+        let user_id = metadata
+            .get("user_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing user_id in metadata"))?;
+
+        let client_id = OAUTH_SLACK_CLIENT_ID.clone();
+        let client_secret = OAUTH_SLACK_CLIENT_SECRET.clone();
+
+        let credential_metadata = CredentialMetadata {
+            user_id: user_id.to_string(),
+            workspace_id: workspace_id.to_string(),
+        };
+
+        let mut credential_content = serde_json::Map::new();
+        credential_content.insert("client_id".to_string(), serde_json::json!(client_id));
+        credential_content.insert(
+            "client_secret".to_string(),
+            serde_json::json!(client_secret),
+        );
+
+        let credential = Credential::create(
+            store,
+            CredentialProvider::Slack,
+            credential_metadata,
+            credential_content,
+        )
+        .await?;
+
+        Ok(Some(credential))
+    }
 }
 
 #[async_trait]
@@ -122,6 +170,23 @@ impl Provider for SlackConnectionProvider {
                 _ => Err(anyhow!("Slack use_case format invalid"))?,
             },
             None => Err(anyhow!("Slack use_case missing"))?,
+        };
+
+        // Extract client_id early for metadata
+        let client_id = match app_type {
+            SlackUseCase::Connection => match &related_credentials {
+                Some(credentials) => {
+                    let content = credentials.unseal_encrypted_content()?;
+                    content
+                        .get("client_id")
+                        .and_then(|v| v.as_str())
+                        .ok_or_else(|| anyhow!("Missing client_id in Slack credential"))?
+                        .to_string()
+                }
+                None => OAUTH_SLACK_CLIENT_ID.clone(),
+            },
+            SlackUseCase::PlatformActions | SlackUseCase::Bot => OAUTH_SLACK_BOT_CLIENT_ID.clone(),
+            SlackUseCase::PersonalActions => OAUTH_SLACK_TOOLS_CLIENT_ID.clone(),
         };
 
         let req = self
@@ -192,6 +257,10 @@ impl Provider for SlackConnectionProvider {
                 (
                     "team_name".to_string(),
                     serde_json::Value::String(team_name.to_string()),
+                ),
+                (
+                    "client_id".to_string(),
+                    serde_json::Value::String(client_id.to_string()),
                 ),
             ])),
             raw_json,

--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -106,7 +106,6 @@ impl SlackConnectionProvider {
         store: Box<dyn OAuthStore + Sync + Send>,
         metadata: &serde_json::Value,
     ) -> Result<Option<Credential>> {
-        // Check if this is a connection use-case
         if metadata.get("use_case").and_then(|v| v.as_str()) != Some("connection") {
             return Ok(None);
         }


### PR DESCRIPTION
## Description

Adds automatic system credential creation for Slack OAuth connections. When creating a Slack connection with `use_case: "connection"` without custom credentials, the system auto-creates credentials from environment variables. Also adds `client_id` to Slack connection metadata.

[Part of phase 2 of the design doc](https://www.notion.so/dust-tt/Design-Doc-Slack-Self-Created-App-2ab28599d9418093a52bd654837c69fa?source=copy_link#2b928599d94180c28fdfe27f344e64b8)


## Tests

Added 3 integration tests covering:
- Auto-creation for connection use-case
- No auto-creation for bot use-case  
- Custom credentials take precedence

Tested locally with system credentials connection

## Risk

Low - Only affects Slack connections with `use_case: "connection"` and no custom credentials. Other flows unchanged. Safe to rollback.

## Deploy Plan

Oauth