### PR TITLE
Add preview to contentful

### DIFF
--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -120,7 +120,7 @@ const renderOptions: Options = {
         {children}
       </blockquote>
     ),
-    [BLOCKS.HR]: () => <hr className="my-8 border-gray-200" />,
+    [BLOCKS.HR]: () => <hr className="mb-8 mt-8 border-gray-200" />,
     [BLOCKS.EMBEDDED_ASSET]: (node) => {
       const { file, title, description } = node.data.target.fields;
       if (!file) {

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -50,4 +50,5 @@ export interface BlogPostPageProps {
   post: BlogPost;
   relatedPosts: BlogPostSummary[];
   gtmTrackingId: string | null;
+  preview?: boolean;
 }

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -19,12 +19,18 @@ export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async (
   context
 ) => {
   const { slug } = context.params ?? {};
+  const { preview, secret } = context.query;
 
   if (!isString(slug)) {
     return { notFound: true };
   }
 
-  const postResult = await getBlogPostBySlug(slug);
+  // Enable preview mode if valid secret provided
+  const isPreview =
+    preview === "true" &&
+    secret === process.env.CONTENTFUL_PREVIEW_SECRET;
+
+  const postResult = await getBlogPostBySlug(slug, isPreview);
 
   if (postResult.isErr()) {
     logger.error(
@@ -40,7 +46,7 @@ export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async (
     return { notFound: true };
   }
 
-  const relatedPostsResult = await getRelatedPosts(slug, post.tags, 3);
+  const relatedPostsResult = await getRelatedPosts(slug, post.tags, 3, isPreview);
 
   if (relatedPostsResult.isErr()) {
     logger.error(
@@ -55,6 +61,7 @@ export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async (
       post,
       relatedPosts: relatedPostsResult.value,
       gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      preview: isPreview,
     },
   };
 };
@@ -66,14 +73,24 @@ const CONTENT_CLASSES = classNames(
 
 const WIDE_CLASSES = classNames("col-span-12", "lg:col-span-10 lg:col-start-2");
 
-export default function BlogPost({ post, relatedPosts }: BlogPostPageProps) {
+export default function BlogPost({
+  post,
+  relatedPosts,
+  preview,
+}: BlogPostPageProps) {
   const ogImageUrl = post.image?.url ?? "https://dust.tt/static/og_image.png";
   const canonicalUrl = `https://dust.tt/blog/${post.slug}`;
 
   return (
     <>
+      {preview && (
+        <div className="fixed left-0 right-0 top-0 z-50 bg-amber-100 px-4 py-2 text-center text-amber-800">
+          Preview Mode - This is a draft
+        </div>
+      )}
       <Head>
         <title>{post.title} | Dust Blog</title>
+        {preview && <meta name="robots" content="noindex, nofollow" />}
         {post.description && (
           <meta name="description" content={post.description} />
         )}

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -27,8 +27,7 @@ export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async (
 
   // Enable preview mode if valid secret provided
   const isPreview =
-    preview === "true" &&
-    secret === process.env.CONTENTFUL_PREVIEW_SECRET;
+    preview === "true" && secret === process.env.CONTENTFUL_PREVIEW_SECRET;
 
   const postResult = await getBlogPostBySlug(slug, isPreview);
 
@@ -46,7 +45,12 @@ export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async (
     return { notFound: true };
   }
 
-  const relatedPostsResult = await getRelatedPosts(slug, post.tags, 3, isPreview);
+  const relatedPostsResult = await getRelatedPosts(
+    slug,
+    post.tags,
+    3,
+    isPreview
+  );
 
   if (relatedPostsResult.isErr()) {
     logger.error(


### PR DESCRIPTION





## Description

Adds preview mode support for Contentful blog posts. Implements a `getPreviewClient()` function that connects to Contentful's Preview API using `CONTENTFUL_PREVIEW_TOKEN`. The preview mode is activated via query parameters (`?preview=true&secret=CONTENTFUL_PREVIEW_SECRET`) and displays draft blog posts before publication. When in preview mode, a banner is shown and robots meta tag prevents indexing.

## Risk

Low. Changes are additive and only affect blog post rendering when specific preview query parameters are provided. Production behavior remains unchanged.

## Deploy Plan

Set `CONTENTFUL_PREVIEW_TOKEN` and `CONTENTFUL_PREVIEW_SECRET` environment variables before deployment. (already done)
