### PR TITLE
[sparkle] add actions in conversation message

### DIFF
--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -1,7 +1,14 @@
 import { cva, VariantProps } from "class-variance-authority";
 import React from "react";
 
-import { Avatar, Button, CitationGrid } from "@sparkle/components";
+import { Avatar, Button, CitationGrid, IconButton } from "@sparkle/components";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@sparkle/components/Dropdown";
+import { MoreIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 
 export const ConversationContainer = React.forwardRef<
@@ -29,6 +36,7 @@ ConversationContainer.displayName = "ConversationContainer";
 interface ConversationMessageProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof messageVariants> {
+  actions?: ConversationMessageAction[];
   avatarBusy?: boolean;
   buttons?: React.ReactElement<typeof Button>[];
   children?: React.ReactNode;
@@ -44,6 +52,12 @@ interface ConversationMessageProps
 }
 
 export type ConversationMessageType = "user" | "agent";
+
+export interface ConversationMessageAction {
+  icon: React.ComponentType | React.ReactNode;
+  label: string;
+  onClick: () => void;
+}
 
 const messageVariants = cva("s-flex s-w-full s-flex-col s-rounded-2xl", {
   variants: {
@@ -90,6 +104,7 @@ export const ConversationMessage = React.forwardRef<
       renderName = (name) => <span>{name}</span>,
       infoChip,
       type,
+      actions,
       className,
       ...props
     },
@@ -107,6 +122,7 @@ export const ConversationMessage = React.forwardRef<
             isDisabled={isDisabled}
             renderName={renderName}
             infoChip={infoChip}
+            actions={actions}
           />
 
           <ConversationMessageContent citations={citations} type={type}>
@@ -159,6 +175,7 @@ ConversationMessageContent.displayName = "ConversationMessageContent";
 
 interface ConversationMessageHeaderProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  actions?: ConversationMessageAction[];
   avatarUrl?: string | React.ReactNode;
   isBusy?: boolean;
   isDisabled?: boolean;
@@ -183,6 +200,7 @@ export const ConversationMessageHeader = React.forwardRef<
       infoChip,
       completionStatus,
       renderName,
+      actions,
       className,
       ...props
     },
@@ -221,7 +239,31 @@ export const ConversationMessageHeader = React.forwardRef<
             </span>
             {infoChip && infoChip}
           </div>
-          {completionStatus ?? null}
+          <div className="s-flex s-items-center s-gap-2">
+            {completionStatus ?? null}
+            {actions && actions.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <IconButton
+                    icon={MoreIcon}
+                    size="xs"
+                    variant="highlight-secondary"
+                    aria-label="Message actions"
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  {actions.map((action, index) => (
+                    <DropdownMenuItem
+                      key={index}
+                      icon={action.icon}
+                      label={action.label}
+                      onClick={action.onClick}
+                    />
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
         </div>
       </div>
     );

--- a/sparkle/src/stories/ConversationMessage.stories.tsx
+++ b/sparkle/src/stories/ConversationMessage.stories.tsx
@@ -17,8 +17,10 @@ import {
   HandThumbUpIcon,
   Icon,
   Markdown,
+  PencilSquareIcon,
   SlackLogo,
   TableIcon,
+  TrashIcon,
 } from "../index_with_tw_base";
 
 const meta = {
@@ -282,3 +284,49 @@ Operates on a simple value exchange - provides unlimited affection in return for
 **Limitations:**
 Occasional system crashes when presented with empty food bowl. Single whisker may cause slight navigation errors when squeezing through spaces designed for two-whiskered models.
 `;
+
+export const ConversationWithActions = () => {
+  return (
+    <>
+      <div className="s-flex s-w-full s-justify-center s-gap-6">
+        <ConversationContainer>
+          <ConversationMessage
+            type="user"
+            name="Edouard"
+            pictureUrl="https://dust.tt/static/droidavatar/Droid_Lime_1.jpg"
+            timestamp="14:30"
+            actions={[
+              {
+                icon: PencilSquareIcon,
+                label: "Edit",
+                onClick: () => {
+                  console.log("Edit clicked");
+                },
+              },
+              {
+                icon: TrashIcon,
+                label: "Delete",
+                onClick: () => {
+                  console.log("Delete clicked");
+                },
+              },
+            ]}
+          >
+            This is a user message with edit and delete actions available in the
+            dropdown menu.
+          </ConversationMessage>
+
+          <ConversationMessage
+            type="agent"
+            name="@agent"
+            pictureUrl="https://dust.tt/static/droidavatar/Droid_Pink_3.jpg"
+            timestamp="14:31"
+          >
+            This is an agent message with edit and delete actions available in
+            the dropdown menu.
+          </ConversationMessage>
+        </ConversationContainer>
+      </div>
+    </>
+  );
+};

--- a/sparkle/src/stories/ConversationMessage.stories.tsx
+++ b/sparkle/src/stories/ConversationMessage.stories.tsx
@@ -287,46 +287,44 @@ Occasional system crashes when presented with empty food bowl. Single whisker ma
 
 export const ConversationWithActions = () => {
   return (
-    <>
-      <div className="s-flex s-w-full s-justify-center s-gap-6">
-        <ConversationContainer>
-          <ConversationMessage
-            type="user"
-            name="Edouard"
-            pictureUrl="https://dust.tt/static/droidavatar/Droid_Lime_1.jpg"
-            timestamp="14:30"
-            actions={[
-              {
-                icon: PencilSquareIcon,
-                label: "Edit",
-                onClick: () => {
-                  console.log("Edit clicked");
-                },
+    <div className="s-flex s-w-full s-justify-center s-gap-6">
+      <ConversationContainer>
+        <ConversationMessage
+          type="user"
+          name="Edouard"
+          pictureUrl="https://dust.tt/static/droidavatar/Droid_Lime_1.jpg"
+          timestamp="14:30"
+          actions={[
+            {
+              icon: PencilSquareIcon,
+              label: "Edit",
+              onClick: () => {
+                console.log("Edit clicked");
               },
-              {
-                icon: TrashIcon,
-                label: "Delete",
-                onClick: () => {
-                  console.log("Delete clicked");
-                },
+            },
+            {
+              icon: TrashIcon,
+              label: "Delete",
+              onClick: () => {
+                console.log("Delete clicked");
               },
-            ]}
-          >
-            This is a user message with edit and delete actions available in the
-            dropdown menu.
-          </ConversationMessage>
+            },
+          ]}
+        >
+          This is a user message with edit and delete actions available in the
+          dropdown menu.
+        </ConversationMessage>
 
-          <ConversationMessage
-            type="agent"
-            name="@agent"
-            pictureUrl="https://dust.tt/static/droidavatar/Droid_Pink_3.jpg"
-            timestamp="14:31"
-          >
-            This is an agent message with edit and delete actions available in
-            the dropdown menu.
-          </ConversationMessage>
-        </ConversationContainer>
-      </div>
-    </>
+        <ConversationMessage
+          type="agent"
+          name="@agent"
+          pictureUrl="https://dust.tt/static/droidavatar/Droid_Pink_3.jpg"
+          timestamp="14:31"
+        >
+          This is an agent message with edit and delete actions available in the
+          dropdown menu.
+        </ConversationMessage>
+      </ConversationContainer>
+    </div>
   );
 };


### PR DESCRIPTION
## Description
This PR is to add actions props in ConversationMessage, since you will be able to edit/delete user's message as a part of Mentions v2 initiative. 

<img width="1760" height="562" alt="CleanShot 2025-12-01 at 11 40 44@2x" src="https://github.com/user-attachments/assets/983b7d82-70c8-4ffb-a867-e71020d6cacb" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
