### PR TITLE
[dev] Add workspace for vscode cursor

### DIFF
--- a/dust.code-workspace
+++ b/dust.code-workspace
@@ -1,0 +1,148 @@
+{
+  "folders": [
+    {
+      "name": "core",
+      "path": "core",
+      "settings": {
+        // Rust Analyzer settings
+        "rust-analyzer.checkOnSave.enable": true,
+        "rust-analyzer.checkOnSave.command": "clippy",
+        "rust-analyzer.cargo.buildScripts.enable": true,
+        "rust-analyzer.cargo.allFeatures": true,
+        "rust-analyzer.procMacro.enable": true,
+        "rust-analyzer.inlayHints.typeHints.enable": true,
+        "rust-analyzer.inlayHints.parameterHints.enable": true,
+        "rust-analyzer.inlayHints.chainingHints.enable": true,
+        "rust-analyzer.completion.autoimport.enable": true,
+        "rust-analyzer.imports.granularity.group": "module",
+        "rust-analyzer.imports.prefix": "crate",
+        // Exclude target directory from file watching
+        "files.watcherExclude": {
+          "**/target/**": true
+        }
+      }
+    },
+    {
+      "name": "sdks",
+      "path": "sdks/js",
+      "settings": {
+        "typescript.preferences.includePackageJsonAutoImports": "off",
+        "typescript.experimental.useTsgo": true,
+        "files.exclude": {
+          "**/node_modules": true,
+          "**/dist": true,
+        }
+      }
+    },
+    {
+      "name": "front",
+      "path": "front",
+      "settings": {
+        // Build tools (Next.js) will still resolve from node_modules during build
+        "typescript.preferences.useLabelDetailsInCompletion": true,
+        // Ensure this folder uses its own tsconfig.json for @app/* alias resolution
+        "typescript.preferences.includePackageJsonAutoImports": "off",
+        "typescript.experimental.useTsgo": true,
+        "files.exclude": {
+          "**/node_modules": true,
+          "**/dist": true,
+          "**/.next": true,
+          "**/workers-build": true,
+        }
+      }
+    },
+    {
+      "name": "connectors",
+      "path": "connectors",
+      "settings": {
+        // Ensure this folder uses its own tsconfig.json for @connectors/* alias resolution
+        "typescript.preferences.includePackageJsonAutoImports": "off",
+        "typescript.experimental.useTsgo": true,
+        "files.exclude": {
+          "**/node_modules": true,
+          "**/dist": true,
+        }
+      }
+    },
+    {
+      "name": "extension",
+      "path": "extension",
+      "settings": {
+        // Ensure this folder uses its own tsconfig.json for @app/* alias resolution
+        "typescript.preferences.includePackageJsonAutoImports": "off",
+        "typescript.experimental.useTsgo": true,
+        "files.exclude": {
+          "**/node_modules": true,
+          "**/dist": true,
+        }
+      }
+    }, 
+    {
+      "name": "firebase-functions",
+      "path": "firebase-functions",
+      "settings": {
+        "typescript.preferences.includePackageJsonAutoImports": "off",
+        "typescript.experimental.useTsgo": true,
+        "files.exclude": {
+          "**/node_modules": true,
+          "**/dist": true,
+        }
+      }
+    },
+    {
+      "name": "sparkle",
+      "path": "sparkle",
+      "settings": {
+        // Ensure this folder uses its own tsconfig.json for @sparkle/* alias resolution
+        "typescript.preferences.includePackageJsonAutoImports": "off",
+        "typescript.experimental.useTsgo": true,
+        "files.exclude": {
+          "**/node_modules": true,
+          "**/dist": true
+        }
+      }
+    },
+    {
+      "name": "viz",
+      "path": "viz",
+      "settings": {
+        // Ensure this folder uses its own tsconfig.json for @viz/* alias resolution
+        "typescript.preferences.includePackageJsonAutoImports": "off",
+        "typescript.experimental.useTsgo": true,
+        "files.exclude": {
+          "**/node_modules": true,
+          "**/.next": true,
+          "**/dist": true
+        }
+      }
+    }
+  ],
+  "settings": {
+    // TypeScript Native (tsgo) settings
+    // Enable TypeScript Native - requires "TypeScript (Native Preview)" extension
+    "typescript.experimental.useTsgo": true,
+
+    // TypeScript preferences (work with both tsserver and tsgo)
+    "typescript.preferences.useAliasesForRenames": true,
+    "typescript.preferences.includePackageJsonAutoImports": "off",
+    "typescript.disableAutomaticTypeAcquisition": true,
+
+    // File exclusions for better performance
+    "search.exclude": {
+      "**/node_modules": true,
+      "**/dist": true,
+      "**/build": true,
+      "**/out": true,
+      "**/target": true
+    },
+    "files.exclude": {
+      "**/node_modules": true,
+      "**/dist": true,
+      "**/build": true,
+      "**/out": true,
+      "**/target": true
+    },
+    "files.autoSave": "onFocusChange"
+  }
+}
+

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -34,5 +34,10 @@
     "**/*.mjs",
     "./.eslintrc.js"
   ],
-  "exclude": ["node_modules", "extension", ".next"]
+  "exclude": [
+    "node_modules",
+    ".next",
+    "workers-build",
+    "dist",
+  ]
 }

--- a/sparkle/tsconfig.json
+++ b/sparkle/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "rootDir": "src",
-    "baseUrl": "src",
+    "baseUrl": ".",
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
@@ -18,7 +18,7 @@
     "jsx": "react",
     "downlevelIteration": true,
     "paths": {
-      "@sparkle/*": ["./*"]
+      "@sparkle/*": ["./src/*"]
     },
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
## Description

Add shared workspace config for vscode/cursor. Open code-workspace file instead of the folder
This relies on `TypeScript (Native Preview)` plugin, which need to be installed.

Small fix in sparkle tsconfig.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

none
