### PR TITLE
Handle mentions from agents themselves.

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -36,6 +36,7 @@ import type { NextRouter } from "next/router";
 import { useRouter } from "next/router";
 import {
   forwardRef,
+  memo,
   useCallback,
   useContext,
   useEffect,
@@ -685,90 +686,92 @@ function getConversationDotStatus(
   return "idle";
 }
 
-const ConversationListItem = ({
-  conversation,
-  isMultiSelect,
-  selectedConversations,
-  toggleConversationSelection,
-  router,
-  owner,
-}: {
-  conversation: ConversationWithoutContentType;
-  isMultiSelect: boolean;
-  selectedConversations: ConversationWithoutContentType[];
-  toggleConversationSelection: (c: ConversationWithoutContentType) => void;
-  router: NextRouter;
-  owner: WorkspaceType;
-}) => {
-  const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
-  const {
-    isMenuOpen,
-    menuTriggerPosition,
-    handleRightClick,
-    handleMenuOpenChange,
-  } = useConversationMenu();
+const ConversationListItem = memo(
+  ({
+    conversation,
+    isMultiSelect,
+    selectedConversations,
+    toggleConversationSelection,
+    router,
+    owner,
+  }: {
+    conversation: ConversationWithoutContentType;
+    isMultiSelect: boolean;
+    selectedConversations: ConversationWithoutContentType[];
+    toggleConversationSelection: (c: ConversationWithoutContentType) => void;
+    router: NextRouter;
+    owner: WorkspaceType;
+  }) => {
+    const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
+    const {
+      isMenuOpen,
+      menuTriggerPosition,
+      handleRightClick,
+      handleMenuOpenChange,
+    } = useConversationMenu();
 
-  const conversationLabel =
-    conversation.title ??
-    (moment(conversation.created).isSame(moment(), "day")
-      ? "New Conversation"
-      : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
+    const conversationLabel =
+      conversation.title ??
+      (moment(conversation.created).isSame(moment(), "day")
+        ? "New Conversation"
+        : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
 
-  return (
-    <>
-      {isMultiSelect ? (
-        <div className="flex items-center px-2 py-2">
-          <Checkbox
-            id={`conversation-${conversation.sId}`}
-            className="bg-background dark:bg-background-night"
-            checked={selectedConversations.includes(conversation)}
-            onCheckedChange={() => toggleConversationSelection(conversation)}
-          />
-          <Label
-            htmlFor={`conversation-${conversation.sId}`}
-            className="copy-sm ml-2 text-muted-foreground dark:text-muted-foreground-night"
-          >
-            {conversationLabel}
-          </Label>
-        </div>
-      ) : (
-        <NavigationListItem
-          selected={router.query.cId === conversation.sId}
-          status={getConversationDotStatus(conversation)}
-          label={conversationLabel}
-          moreMenu={
-            <ConversationMenu
-              activeConversationId={conversation.sId}
-              conversation={conversation}
-              owner={owner}
-              trigger={<NavigationListItemAction />}
-              isConversationDisplayed={router.query.cId === conversation.sId}
-              isOpen={isMenuOpen}
-              onOpenChange={handleMenuOpenChange}
-              triggerPosition={menuTriggerPosition}
+    return (
+      <>
+        {isMultiSelect ? (
+          <div className="flex items-center px-2 py-2">
+            <Checkbox
+              id={`conversation-${conversation.sId}`}
+              className="bg-background dark:bg-background-night"
+              checked={selectedConversations.includes(conversation)}
+              onCheckedChange={() => toggleConversationSelection(conversation)}
             />
-          }
-          onContextMenu={handleRightClick}
-          onClick={async () => {
-            // Side bar is the floating sidebar that appears when the screen is small.
-            if (sidebarOpen) {
-              setSidebarOpen(false);
-              // Wait a bit before moving to the new conversation to avoid the sidebar from flickering.
-              await new Promise((resolve) => setTimeout(resolve, 600));
+            <Label
+              htmlFor={`conversation-${conversation.sId}`}
+              className="copy-sm ml-2 text-muted-foreground dark:text-muted-foreground-night"
+            >
+              {conversationLabel}
+            </Label>
+          </div>
+        ) : (
+          <NavigationListItem
+            selected={router.query.cId === conversation.sId}
+            status={getConversationDotStatus(conversation)}
+            label={conversationLabel}
+            moreMenu={
+              <ConversationMenu
+                activeConversationId={conversation.sId}
+                conversation={conversation}
+                owner={owner}
+                trigger={<NavigationListItemAction />}
+                isConversationDisplayed={router.query.cId === conversation.sId}
+                isOpen={isMenuOpen}
+                onOpenChange={handleMenuOpenChange}
+                triggerPosition={menuTriggerPosition}
+              />
             }
-            await router.push(
-              getConversationRoute(owner.sId, conversation.sId),
-              undefined,
-              {
-                shallow: true,
+            onContextMenu={handleRightClick}
+            onClick={async () => {
+              // Side bar is the floating sidebar that appears when the screen is small.
+              if (sidebarOpen) {
+                setSidebarOpen(false);
+                // Wait a bit before moving to the new conversation to avoid the sidebar from flickering.
+                await new Promise((resolve) => setTimeout(resolve, 600));
               }
-            );
-          }}
-        />
-      )}
-    </>
-  );
-};
+              await router.push(
+                getConversationRoute(owner.sId, conversation.sId),
+                undefined,
+                {
+                  shallow: true,
+                }
+              );
+            }}
+          />
+        )}
+      </>
+    );
+  }
+);
 
 interface NavigationListWithInboxProps {
   conversations: ConversationWithoutContentType[];

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -8,7 +8,6 @@ import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types"
 import type { DustError } from "@app/lib/error";
 import type {
   ContentFragmentsType,
-  ContentFragmentType,
   LightAgentConfigurationType,
   LightAgentMessageType,
   LightAgentMessageWithActionsType,
@@ -93,15 +92,11 @@ export const isHiddenMessage = (message: UserMessageType): boolean => {
 
 export const isUserMessage = (
   msg: VirtuosoMessage
-): msg is UserMessageType & { contentFragments: ContentFragmentType[] } =>
+): msg is UserMessageTypeWithContentFragments =>
   "type" in msg && msg.type === "user_message" && "contentFragments" in msg;
 
-export const isHandoverUserMessage = (
-  msg: VirtuosoMessage
-): msg is UserMessageType & { contentFragments: ContentFragmentType[] } =>
-  "type" in msg &&
-  msg.type === "user_message" &&
-  msg.agenticMessageData?.type === "agent_handover";
+export const isHandoverUserMessage = (msg: VirtuosoMessage): boolean =>
+  isUserMessage(msg) && msg.agenticMessageData?.type === "agent_handover";
 
 export const isMessageTemporayState = (
   msg: VirtuosoMessage

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -35,6 +35,10 @@ export const DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME =
 export const DEFAULT_CONVERSATION_SEARCH_ACTION_NAME =
   "search_conversation_files";
 
+export const SEARCH_AVAILABLE_USERS_OR_AGENTS_TOOL_NAME =
+  "search_available_users_or_agents";
+export const GET_MENTION_MARKDOWN_TOOL_NAME = "get_mention_markdown";
+
 export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
   "__dust_conversation_history";
 

--- a/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
@@ -1,21 +1,30 @@
+import { DustAPI } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { compile } from "mathjs";
 import { z } from "zod";
 
+import {
+  GET_MENTION_MARKDOWN_TOOL_NAME,
+  SEARCH_AVAILABLE_USERS_OR_AGENTS_TOOL_NAME,
+} from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { Err, normalizeError, Ok } from "@app/types";
+import { getFeatureFlags, prodAPICredentialsForOwner } from "@app/lib/auth";
+import { serializeMention } from "@app/lib/mentions/format";
+import logger from "@app/logger/logger";
+import { Err, getHeaderFromUserEmail, normalizeError, Ok } from "@app/types";
 
 const RANDOM_INTEGER_DEFAULT_MAX = 1_000_000;
 const MAX_WAIT_DURATION_MS = 3 * 60 * 1_000;
 
-function createServer(
+async function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer {
+): Promise<McpServer> {
   const server = makeInternalMCPServer("common_utilities");
 
   server.tool(
@@ -189,6 +198,108 @@ function createServer(
       }
     )
   );
+
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  if (featureFlags.includes("mentions_v2")) {
+    // Add tools for searching users or agents to mention in a message.
+    server.tool(
+      SEARCH_AVAILABLE_USERS_OR_AGENTS_TOOL_NAME,
+      "Search for users or agents that are available to the conversation.",
+      {
+        filter: z
+          .array(z.enum(["agents", "users"]))
+          .describe("A list of types to filter by.")
+          .default(["agents", "users"]),
+        searchTerm: z
+          .string()
+          .describe(
+            "A single search term to find users or agents. Returns all the users and agents that contain the search term in their name or description. Use an empty string to return all items of a type."
+          ),
+      },
+      withToolLogging(
+        auth,
+        {
+          toolNameForMonitoring: SEARCH_AVAILABLE_USERS_OR_AGENTS_TOOL_NAME,
+          agentLoopContext,
+        },
+        async ({ filter, searchTerm }) => {
+          const user = auth.user();
+          const prodCredentials = await prodAPICredentialsForOwner(
+            auth.getNonNullableWorkspace()
+          );
+          const api = new DustAPI(
+            config.getDustAPIConfig(),
+            {
+              ...prodCredentials,
+              extraHeaders: {
+                // We use a system API key to override the user here (not groups and role) so that the
+                // sub-agent can access the same spaces as the user but also as the sub-agent may rely
+                // on personal actions that have to be operated in the name of the user initiating the
+                // interaction.
+                ...getHeaderFromUserEmail(user?.email),
+              },
+            },
+            logger
+          );
+
+          const r = await api.getMentionsSuggestions({
+            query: searchTerm,
+            select: filter,
+            conversationId: agentLoopContext?.runContext?.conversation?.sId,
+          });
+
+          if (r.isErr()) {
+            return new Err(
+              new MCPError(
+                `Error getting mentions suggestions: ${r.error.message}`,
+                {
+                  cause: r.error,
+                }
+              )
+            );
+          }
+
+          const suggestions = r.value;
+
+          return new Ok([
+            {
+              type: "text",
+              text: JSON.stringify(suggestions),
+            },
+          ]);
+        }
+      )
+    );
+
+    server.tool(
+      GET_MENTION_MARKDOWN_TOOL_NAME,
+      "Get the markdown directive to use to mention a user or agent in a message.",
+      {
+        mention: z
+          .object({
+            id: z.string(),
+            type: z.enum(["agent", "user"]),
+            label: z.string(),
+          })
+          .describe("A mention to get the markdown directive for."),
+      },
+      withToolLogging(
+        auth,
+        {
+          toolNameForMonitoring: GET_MENTION_MARKDOWN_TOOL_NAME,
+          agentLoopContext,
+        },
+        async ({ mention }) => {
+          return new Ok([
+            {
+              type: "text",
+              text: serializeMention(mention),
+            },
+          ]);
+        }
+      )
+    );
+  }
 
   return server;
 }

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -35,6 +35,7 @@ import type { CoreDataSourceSearchCriteria } from "@app/lib/api/assistant/proces
 import { processDataSources } from "@app/lib/api/assistant/process_data_sources";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   AgentConfigurationType,
@@ -397,6 +398,8 @@ async function getPromptForProcessDustApp({
   const userMessage: UserMessageType =
     lastUserMessageTuple[0] as UserMessageType;
 
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+
   return constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -405,6 +408,7 @@ async function getPromptForProcessDustApp({
     model: getSupportedModelConfig(agentConfiguration.model),
     hasAvailableActions: false,
     agentsList: null,
+    featureFlags,
   });
 }
 

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -135,9 +135,16 @@ export async function getOrCreateConversation(
   const parentMessage = mainConversation.content
     .flat()
     .find((m) => m.sId === originMessage.parentMessageId);
-  if (parentMessage && isUserMessageType(parentMessage)) {
-    parentOrigin = parentMessage.context.origin ?? null;
+
+  if (!parentMessage) {
+    return new Err(new MCPError("Parent message not found."));
   }
+
+  if (!isUserMessageType(parentMessage)) {
+    return new Err(new MCPError("Parent message is not a user message."));
+  }
+
+  parentOrigin = parentMessage.context.origin ?? null;
 
   if (parentOrigin === "run_agent" || parentOrigin === "agent_handover") {
     logger.error(

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -1228,19 +1228,12 @@ describe("createUserMessage", () => {
 
     // Create an origin message first with rank 0
     const originMessage = await withTransaction(async (transaction) => {
-      const userJson = user.toJSON();
-      const originUserMessage = await UserMessage.create(
+      const originAgentMessage = await AgentMessage.create(
         {
-          content: "Origin message",
-          userId: user.id,
           workspaceId: workspace.id,
-          userContextUsername: userJson.username,
-          userContextTimezone: "UTC",
-          userContextFullName: userJson.fullName,
-          userContextEmail: userJson.email,
-          userContextProfilePictureUrl: userJson.image,
-          userContextOrigin: "web",
-          clientSideMCPServerIds: [],
+          skipToolsValidation: false,
+          agentConfigurationId: "not-a-real-agent",
+          agentConfigurationVersion: 0,
         },
         { transaction }
       );
@@ -1250,7 +1243,7 @@ describe("createUserMessage", () => {
           sId: generateRandomModelSId(),
           rank: 0,
           conversationId: conversation.id,
-          userMessageId: originUserMessage.id,
+          agentMessageId: originAgentMessage.id,
           workspaceId: workspace.id,
         },
         { transaction }
@@ -1487,18 +1480,12 @@ describe("createUserMessage", () => {
 
     // Create origin message
     const originMessage = await withTransaction(async (transaction) => {
-      const originUserMessage = await UserMessage.create(
+      const originAgentMessage = await AgentMessage.create(
         {
-          content: "Origin message",
-          userId: user.id,
           workspaceId: workspace.id,
-          userContextUsername: userJson.username,
-          userContextTimezone: "UTC",
-          userContextFullName: userJson.fullName,
-          userContextEmail: userJson.email,
-          userContextProfilePictureUrl: userJson.image,
-          userContextOrigin: "web",
-          clientSideMCPServerIds: [],
+          skipToolsValidation: false,
+          agentConfigurationId: "not-a-real-agent",
+          agentConfigurationVersion: 0,
         },
         { transaction }
       );
@@ -1508,7 +1495,7 @@ describe("createUserMessage", () => {
           sId: generateRandomModelSId(),
           rank: 0,
           conversationId: conversation.id,
-          userMessageId: originUserMessage.id,
+          agentMessageId: originAgentMessage.id,
           workspaceId: workspace.id,
         },
         { transaction }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -4,6 +4,8 @@ import {
   DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME,
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
   DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
+  GET_MENTION_MARKDOWN_TOOL_NAME,
+  SEARCH_AVAILABLE_USERS_OR_AGENTS_TOOL_NAME,
 } from "@app/lib/actions/constants";
 import type { ServerToolsAndInstructions } from "@app/lib/actions/mcp_actions";
 import {
@@ -20,6 +22,7 @@ import type {
   LightAgentConfigurationType,
   ModelConfigurationType,
   UserMessageType,
+  WhitelistableFeature,
 } from "@app/types";
 import { CHAIN_OF_THOUGHT_META_PROMPT } from "@app/types/assistant/chain_of_thought_meta_prompt";
 
@@ -43,6 +46,7 @@ export function constructPromptMultiActions(
     agentsList,
     conversationId,
     serverToolsAndInstructions,
+    featureFlags,
   }: {
     userMessage: UserMessageType;
     agentConfiguration: AgentConfigurationType;
@@ -53,6 +57,7 @@ export function constructPromptMultiActions(
     agentsList: LightAgentConfigurationType[] | null;
     conversationId?: string;
     serverToolsAndInstructions?: ServerToolsAndInstructions[];
+    featureFlags: WhitelistableFeature[];
   }
 ) {
   const d = moment(new Date()).tz(userMessage.context.timezone);
@@ -190,6 +195,18 @@ export function constructPromptMultiActions(
     'When rendering markdown images, always use the file id of the image, which can be extracted from the corresponding `<attachment id="{FILE_ID}" type... title...>` tag in the conversation history.' +
     'Also always use the file title which can similarly be extracted from the same `<attachment id... type... title="{TITLE}">` tag in the conversation history.' +
     "\nEvery image markdown should follow this pattern ![{TITLE}]({FILE_ID}).\n";
+
+  if (featureFlags.includes("mentions_v2")) {
+    guidelinesSection +=
+      `\n## MENTIONNING AGENTS AND USERS\n` +
+      "You have the abillity to mention users and agents in a message using the markdown directive." +
+      '\nUsers can also refer to mention as "ping".' +
+      `\nUse the \`${SEARCH_AVAILABLE_USERS_OR_AGENTS_TOOL_NAME}\` tool to search for users and agents that are available to the conversation.` +
+      `\nUse the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tool to get the markdown directive to use to mention a user or agent in a message.` +
+      "\nImportant:" +
+      "\n - In conversation with more than one user talking, always answer to users by prefixing your message with their markdown mention directive in order to address them directly, avoid confusion and ensure users are happy." +
+      "\n - Use the markdown directive only when you want to ping the user or agent, if you just want to refer to them, use their name only.";
+  }
 
   // INSTRUCTIONS section
   let instructions = "# INSTRUCTIONS\n\n";

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -445,39 +445,34 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
             {
               model: UserMessage,
               as: "userMessage",
-              required: false,
+              required: true,
             },
           ],
         });
       }
 
-      assert(parentMessage !== null, "Parent message must be found.");
+      assert(!!parentMessage, "Parent message must be found.");
+      const userMessage = parentMessage.userMessage;
+      assert(!!userMessage, "Parent message must be a userMessage.");
 
       let parentAgentMessage: Message | null = null;
 
       // TODO(2025-11-24 PPUL): Remove this block once data has been backfilled
       if (
-        parentMessage &&
-        parentMessage?.userMessage &&
-        parentMessage.userMessage.userContextOrigin === "agent_handover" &&
-        parentMessage.userMessage.userContextOriginMessageId
+        userMessage.userContextOrigin === "agent_handover" &&
+        userMessage.userContextOriginMessageId
       ) {
         parentAgentMessage =
-          messagesBySId.get(
-            parentMessage.userMessage.userContextOriginMessageId
-          ) ?? null;
+          messagesBySId.get(userMessage.userContextOriginMessageId) ?? null;
       }
       // END TODO
 
       if (
-        parentMessage &&
-        parentMessage?.userMessage &&
-        parentMessage.userMessage.agenticMessageType === "agent_handover" &&
-        parentMessage.userMessage.agenticOriginMessageId
+        userMessage.agenticMessageType === "agent_handover" &&
+        userMessage.agenticOriginMessageId
       ) {
         parentAgentMessage =
-          messagesBySId.get(parentMessage.userMessage.agenticOriginMessageId) ??
-          null;
+          messagesBySId.get(userMessage.agenticOriginMessageId) ?? null;
       }
 
       const m = {

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -38,7 +38,9 @@ export const USER_MENTION_REGEX_BEGINNING = new RegExp(
  *  * user: `:mention_user[name]{sId=xxx}`
  */
 export function serializeMention(
-  mention: RichMention | { name: string; sId: string }
+  mention:
+    | { name: string; sId: string }
+    | { id: string; type: "agent" | "user"; label: string }
 ): string {
   if ("name" in mention && "sId" in mention) {
     // Legacy format support

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -5,6 +5,7 @@ import { deleteConversation } from "@app/components/assistant/conversation/lib";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { getVisualizationRetryMessage } from "@app/lib/client/visualization";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
   fetcher,
@@ -286,7 +287,7 @@ export function useCancelMessage({
         return;
       }
       try {
-        await fetch(
+        await clientFetch(
           `/api/w/${owner.sId}/assistant/conversations/${conversationId}/cancel`,
           {
             method: "POST",
@@ -325,7 +326,7 @@ export function useAddDeleteConversationTool({
       }
 
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/conversations/${conversationId}/tools`,
           {
             method: "POST",
@@ -366,7 +367,7 @@ export function useAddDeleteConversationTool({
       }
 
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/conversations/${conversationId}/tools`,
           {
             method: "POST",
@@ -419,7 +420,7 @@ export function useVisualizationRevert({
       agentConfigurationId: string;
     }): Promise<boolean> => {
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages`,
           {
             method: "POST",
@@ -479,7 +480,7 @@ export function useVisualizationRetry({
       }
 
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages`,
           {
             method: "POST",
@@ -612,7 +613,7 @@ export function useConversationMarkAsRead({
      */
     async (conversationId: string, mutateList: boolean): Promise<void> => {
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/conversations/${conversationId}`,
           {
             method: "PATCH",
@@ -629,13 +630,16 @@ export function useConversationMarkAsRead({
           throw new Error("Failed to mark conversation as read");
         }
         if (mutateList) {
-          void mutateConversations((prevState) => ({
-            ...prevState,
-            conversations:
-              prevState?.conversations.map((c) =>
-                c.sId === conversationId ? { ...c, unread: false } : c
-              ) ?? [],
-          }));
+          void mutateConversations(
+            (prevState) => ({
+              ...prevState,
+              conversations:
+                prevState?.conversations.map((c) =>
+                  c.sId === conversationId ? { ...c, unread: false } : c
+                ) ?? [],
+            }),
+            { revalidate: false }
+          );
         }
       } catch (error) {
         console.error("Error marking conversation as read:", error);
@@ -734,7 +738,7 @@ export const useJoinConversation = ({
       return false;
     }
     try {
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/w/${ownerId}/assistant/conversations/${conversationId}/participants`,
         {
           method: "POST",
@@ -802,7 +806,7 @@ export function usePostOnboardingFollowUp({
         return false;
       }
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/conversations/${conversationId}/onboarding-followup`,
           {
             method: "POST",

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -12,7 +12,7 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getSupportedModelConfig } from "@app/lib/assistant";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { tokenCountForTexts } from "@app/lib/tokenization";
@@ -228,6 +228,10 @@ async function handler(
           })
         : null;
 
+      const featureFlags = await getFeatureFlags(
+        auth.getNonNullableWorkspace()
+      );
+
       const prompt = constructPromptMultiActions(auth, {
         userMessage,
         agentConfiguration,
@@ -238,6 +242,7 @@ async function handler(
         agentsList,
         conversationId: conversation.sId,
         serverToolsAndInstructions,
+        featureFlags,
       });
 
       // Build tool specifications to estimate tokens for tool definitions (names + schemas only).

--- a/front/pages/api/v1/viz/files/fileId.test.ts
+++ b/front/pages/api/v1/viz/files/fileId.test.ts
@@ -6,8 +6,10 @@ import { Readable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -552,53 +554,40 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
   describe("conversation hierarchy access tests", () => {
     it("should allow access to files from sub-conversations created by agent handover", async () => {
       const {
-        req: parentReq,
-        res: parentRes,
-        workspace,
+        req: childReq,
+        res: childRes,
         key,
+        workspace,
       } = await createPublicApiMockRequest({
         systemKey: true,
         method: "POST",
       });
 
-      // Create parent conversation A using API.
-      const parentBody: PublicPostConversationsRequestBody = {
-        title: "Parent Conversation",
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "not_a_real_agent_configuration_id",
+        messagesCreatedAt: [],
         visibility: "unlisted",
-        depth: 0,
-        message: {
-          content: `${serializeMention({
-            name: "noop",
-            sId: "noop",
-          })} Hello from parent`,
-          mentions: [{ configurationId: "noop" }],
-          context: {
-            timezone: "UTC",
-            username: "test-user",
-            fullName: "Test User",
-            email: "test@example.com",
-            profilePictureUrl: null,
-            origin: "web",
-          },
-        },
-      };
+      });
 
-      parentReq.body = parentBody;
-      parentReq.query.wId = workspace.sId;
-
-      await publicConversationsHandler(parentReq, parentRes);
-
-      expect(parentRes._getStatusCode()).toBe(200);
-      const parentData = parentRes._getJSONData();
-      const parentConversation = parentData.conversation;
-      const parentMessageId = parentData.message.sId;
-
-      const { req: childReq, res: childRes } = await createPublicApiMockRequest(
+      await ConversationFactory.createUserMessageWithRank({
+        auth,
+        workspace,
+        conversationId: conversation.id,
+        content: "Hello from parent",
+        rank: 0,
+      });
+      const agentMessage = await ConversationFactory.createAgentMessageWithRank(
         {
-          systemKey: true,
-          method: "POST",
+          workspace,
+          conversationId: conversation.id,
+          rank: 1,
+          agentConfigurationId: "not_a_real_agent_configuration_id",
         }
       );
+
+      const parentMessageId = agentMessage.sId;
 
       // Use a new request to avoid state carry-over. But reuse same workspace and key.
       childReq.headers = {
@@ -635,7 +624,6 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       childReq.body = body;
 
       await publicConversationsHandler(childReq, childRes);
-
       expect(childRes._getStatusCode()).toBe(200);
       const childData = childRes._getJSONData();
       const childConversation = childData.conversation;
@@ -647,7 +635,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         fileSize: 1000,
         status: "ready",
         useCase: "conversation",
-        useCaseMetadata: { conversationId: parentConversation.sId },
+        useCaseMetadata: { conversationId: conversation.sId },
       });
 
       // Create target file in sub-conversation B.

--- a/front/temporal/agent_loop/activities/mentions.ts
+++ b/front/temporal/agent_loop/activities/mentions.ts
@@ -1,0 +1,118 @@
+import { handleAgentMessage } from "@app/lib/api/assistant/conversation";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import { isAgentMessageType } from "@app/types";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+/**
+ * Handle mentions in the agent message content.
+ */
+export async function handleMentionsActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  // Contruct back an authenticator from the auth type.
+  const auth = await Authenticator.fromJSON(authType);
+  if (!auth) {
+    logger.error(
+      { authType },
+      "Failed to construct authenticator from auth type"
+    );
+    return;
+  }
+
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  if (!featureFlags.includes("mentions_v2")) {
+    return;
+  }
+
+  const conversationResource = await ConversationResource.fetchById(
+    auth,
+    agentLoopArgs.conversationId
+  );
+  if (!conversationResource) {
+    logger.warn(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+      },
+      "Conversation not found while handling mentions"
+    );
+    return;
+  }
+
+  const messageRes = await conversationResource.getMessageById(
+    auth,
+    agentLoopArgs.agentMessageId
+  );
+
+  if (messageRes.isErr()) {
+    logger.error(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+        error: messageRes.error,
+      },
+      "Failed to fetch agent message while handling mentions"
+    );
+    return;
+  }
+
+  const renderMessageRes = await batchRenderMessages(
+    auth,
+    conversationResource,
+    [messageRes.value],
+    "full"
+  );
+
+  if (renderMessageRes.isErr()) {
+    logger.error(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+        error: renderMessageRes.error,
+      },
+      "Failed to batch render agent messages while handling mentions"
+    );
+    return;
+  }
+  if (renderMessageRes.value.length !== 1) {
+    logger.error(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+      },
+      "Unexpected number of messages post render processing while handling mentions"
+    );
+    return;
+  }
+
+  const agentMessage = renderMessageRes.value[0];
+  if (!isAgentMessageType(agentMessage)) {
+    logger.error(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+      },
+      "Message is not an agent message while handling mentions"
+    );
+    return;
+  }
+
+  if (!agentMessage.content) {
+    return;
+  }
+
+  if (agentMessage.status !== "succeeded") {
+    return;
+  }
+
+  const conversation = conversationResource.toJSON();
+  await handleAgentMessage(auth, {
+    conversation,
+    agentMessage,
+  });
+}

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -31,6 +31,7 @@ import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -239,6 +240,8 @@ export async function runModelActivity(
       })
     : null;
 
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+
   const prompt = constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -249,6 +252,7 @@ export async function runModelActivity(
     agentsList,
     conversationId: conversation.sId,
     serverToolsAndInstructions: mcpActions,
+    featureFlags,
   });
 
   const specifications: AgentActionSpecification[] = [];

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -17,6 +17,7 @@ import {
   logAgentLoopPhaseStartActivity,
   logAgentLoopStepCompletionActivity,
 } from "@app/temporal/agent_loop/activities/instrumentation";
+import { handleMentionsActivity } from "@app/temporal/agent_loop/activities/mentions";
 import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
@@ -40,6 +41,7 @@ export async function runAgentLoopWorker() {
       conversationUnreadNotificationActivity,
       ensureConversationTitleActivity,
       finalizeCancellationActivity,
+      handleMentionsActivity,
       launchAgentMessageAnalyticsActivity,
       logAgentLoopPhaseCompletionActivity,
       logAgentLoopPhaseStartActivity,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -17,6 +17,7 @@ import type * as analyticsActivities from "@app/temporal/agent_loop/activities/a
 import type * as commonActivities from "@app/temporal/agent_loop/activities/common";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import type * as instrumentationActivities from "@app/temporal/agent_loop/activities/instrumentation";
+import type * as mentionsActivities from "@app/temporal/agent_loop/activities/mentions";
 import type * as notificationActivities from "@app/temporal/agent_loop/activities/notification";
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
@@ -88,6 +89,10 @@ const { conversationUnreadNotificationActivity } = proxyActivities<
   retry: {
     maximumAttempts: 1,
   },
+});
+
+const { handleMentionsActivity } = proxyActivities<typeof mentionsActivities>({
+  startToCloseTimeout: "3 minutes",
 });
 
 const { ensureConversationTitleActivity } = proxyActivities<
@@ -249,6 +254,7 @@ export async function agentLoopWorkflow({
           launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
           trackProgrammaticUsageActivity(authType, agentLoopArgs),
           conversationUnreadNotificationActivity(authType, agentLoopArgs),
+          handleMentionsActivity(authType, agentLoopArgs),
         ]);
       });
     });

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -41,7 +41,7 @@ export class ConversationFactory {
       t?: Transaction;
     }
   ): Promise<ConversationWithoutContentType> {
-    const user = auth.getNonNullableUser();
+    const user = auth.user();
     const workspace = auth.getNonNullableWorkspace();
 
     const conversation = await createConversation(auth, {
@@ -181,7 +181,7 @@ export class ConversationFactory {
     origin?: UserMessageOrigin;
   }): Promise<Message> {
     const userMessageRow = await UserMessage.create({
-      userId: auth.getNonNullableUser().id,
+      userId: auth.user()?.id,
       workspaceId: workspace.id,
       content,
       userContextUsername: "testuser",
@@ -312,7 +312,7 @@ const createUserMessage = async ({
   rank,
   t,
 }: {
-  user: UserResource;
+  user: UserResource | null;
   workspace: WorkspaceType;
   conversationModelId: ModelId;
   createdAt: Date;
@@ -332,7 +332,7 @@ const createUserMessage = async ({
           {
             createdAt,
             updatedAt: createdAt,
-            userId: user.id,
+            userId: user?.id,
             workspaceId: workspace.id,
             content: "Test user Message.",
             userContextUsername: "soupinou",

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -25,6 +25,8 @@ export type AgentLoopArgs = {
   agentMessageVersion: number;
   conversationId: string;
   conversationTitle: string | null;
+
+  // Note that the original user message may not be the same as the parent message as agent might mention other agents.
   userMessageId: string;
   userMessageVersion: number;
   userMessageOrigin?: UserMessageOrigin | null;


### PR DESCRIPTION
## Description

Give agents the ability to mention users and agents, via:
- Some generic prompt
- 2 tools (search agents / users and get mention markdown)

Implementation is done in a new activity at the end of the agentic loop that will parse the agent's answer for mentions:
- if it's an agent mention, follow the same approach as the run_agent "handoff" mode by inserting a fake user message
- if it's a user mention, upsert participation.

## Tests

Local

## Risk

Low, behind a FF.

## Deploy Plan

Deploy front