### PR TITLE
Add tag filtering + display authors in blog posts

### DIFF
--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -174,6 +174,10 @@ function isContentfulEntry(
   );
 }
 
+function isNonNull<T>(value: T | null): value is T {
+  return value !== null;
+}
+
 function contentfulEntryToAuthor(
   entry: Entry<AuthorSkeleton> | undefined
 ): BlogAuthor | null {
@@ -213,10 +217,10 @@ function contentfulEntryToBlogPost(entry: Entry<BlogPageSkeleton>): BlogPost {
   const body = isContentfulDocument(fields.body) ? fields.body : EMPTY_DOCUMENT;
   const image = isContentfulAsset(fields.image) ? fields.image : undefined;
   const authors = Array.isArray(fields.authors)
-    ? (fields.authors
+    ? fields.authors
         .filter(isContentfulEntry)
         .map(contentfulEntryToAuthor)
-        .filter(Boolean) as BlogAuthor[])
+        .filter(isNonNull)
     : [];
 
   return {

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -1,5 +1,13 @@
 import type { Document } from "@contentful/rich-text-types";
-import type { Asset, EntrySkeletonType } from "contentful";
+import type { Asset, Entry, EntrySkeletonType } from "contentful";
+
+export interface AuthorFields {
+  name?: string;
+  image?: Asset;
+  email?: string;
+}
+
+export type AuthorSkeleton = EntrySkeletonType<AuthorFields, "author">;
 
 export interface BlogPageFields {
   title: string;
@@ -8,6 +16,7 @@ export interface BlogPageFields {
   tags?: string[];
   image?: Asset;
   publishedAt?: string;
+  authors?: Entry<AuthorSkeleton>[];
 }
 
 export type BlogPageSkeleton = EntrySkeletonType<BlogPageFields, "blogPage">;
@@ -19,6 +28,11 @@ export interface BlogImage {
   height: number;
 }
 
+export interface BlogAuthor {
+  name: string;
+  image: BlogImage | null;
+}
+
 export interface BlogPost {
   id: string;
   slug: string;
@@ -27,6 +41,7 @@ export interface BlogPost {
   body: Document;
   tags: string[];
   image: BlogImage | null;
+  authors: BlogAuthor[];
   createdAt: string;
   updatedAt: string;
 }

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -180,10 +180,49 @@ export default function BlogPost({
 
             <H1 mono>{post.title}</H1>
 
-            <div className="mt-4 text-muted-foreground">
-              {formatTimestampToFriendlyDate(
-                new Date(post.createdAt).getTime(),
-                "short"
+            <div className="mt-6 flex items-center gap-4">
+              {post.authors.length > 0 ? (
+                <>
+                  <div className="flex -space-x-2">
+                    {post.authors.map((author) =>
+                      author.image ? (
+                        <Image
+                          key={author.name}
+                          src={author.image.url}
+                          alt={author.name}
+                          width={40}
+                          height={40}
+                          className="rounded-full ring-2 ring-white"
+                        />
+                      ) : (
+                        <div
+                          key={author.name}
+                          className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 text-sm font-medium text-gray-600 ring-2 ring-white"
+                        >
+                          {author.name.charAt(0).toUpperCase()}
+                        </div>
+                      )
+                    )}
+                  </div>
+                  <div className="flex flex-col">
+                    <span className="font-medium text-foreground">
+                      {post.authors.map((a) => a.name).join(", ")}
+                    </span>
+                    <span className="text-sm text-muted-foreground">
+                      {formatTimestampToFriendlyDate(
+                        new Date(post.createdAt).getTime(),
+                        "short"
+                      )}
+                    </span>
+                  </div>
+                </>
+              ) : (
+                <span className="text-muted-foreground">
+                  {formatTimestampToFriendlyDate(
+                    new Date(post.createdAt).getTime(),
+                    "short"
+                  )}
+                </span>
               )}
             </div>
           </header>

--- a/front/pages/blog/index.tsx
+++ b/front/pages/blog/index.tsx
@@ -1,6 +1,9 @@
+import { ChevronDownIcon } from "@heroicons/react/20/solid";
 import type { GetServerSideProps } from "next";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import type { ReactElement } from "react";
+import { useMemo } from "react";
 
 import { BlogBlock } from "@app/components/home/ContentBlocks";
 import { Grid, P } from "@app/components/home/ContentComponents";
@@ -38,10 +41,27 @@ export const getServerSideProps: GetServerSideProps<
 };
 
 export default function BlogListing({ posts }: BlogListingPageProps) {
+  const router = useRouter();
+  const selectedTag =
+    typeof router.query.tag === "string" ? router.query.tag : null;
+
+  const allTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    posts.forEach((post) => post.tags.forEach((tag) => tagSet.add(tag)));
+    return Array.from(tagSet).sort();
+  }, [posts]);
+
+  const filteredPosts = useMemo(() => {
+    if (!selectedTag) {
+      return posts;
+    }
+    return posts.filter((post) => post.tags.includes(selectedTag));
+  }, [posts, selectedTag]);
+
   return (
     <>
       <Head>
-        <title>Blog | Dust</title>
+        <title>{selectedTag ? `${selectedTag} | ` : ""}Blog | Dust</title>
         <meta
           name="description"
           content="Insights, tutorials, and updates from the Dust team on AI agents, enterprise productivity, and building with AI."
@@ -57,14 +77,41 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
       </Head>
 
       <Grid>
+        {allTags.length > 0 && (
+          <div className="col-span-12 flex justify-end pt-8">
+            <div className="relative inline-block">
+              <select
+                value={selectedTag ?? ""}
+                onChange={(e) => {
+                  const tag = e.target.value;
+                  if (tag) {
+                    void router.push(`/blog?tag=${encodeURIComponent(tag)}`);
+                  } else {
+                    void router.push("/blog");
+                  }
+                }}
+                className="appearance-none rounded-full border border-gray-200 bg-white py-2 pl-4 pr-10 text-sm font-medium text-foreground transition-colors hover:border-gray-300 focus:border-highlight focus:outline-none focus:ring-1 focus:ring-highlight"
+              >
+                <option value="">All topics</option>
+                {allTags.map((tag) => (
+                  <option key={tag} value={tag}>
+                    {tag}
+                  </option>
+                ))}
+              </select>
+              <ChevronDownIcon className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            </div>
+          </div>
+        )}
+
         <div
           className={classNames(
-            "col-span-12 pt-8",
+            "col-span-12 pt-6",
             "grid gap-8 sm:grid-cols-2 lg:grid-cols-3"
           )}
         >
-          {posts.length > 0 ? (
-            posts.map((post) => (
+          {filteredPosts.length > 0 ? (
+            filteredPosts.map((post) => (
               <BlogBlock
                 key={post.id}
                 title={post.title}
@@ -109,7 +156,9 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
           ) : (
             <div className="col-span-full py-12 text-center">
               <P size="md" className="text-muted-foreground">
-                No blog posts available yet. Check back soon!
+                {selectedTag
+                  ? `No posts found with tag "${selectedTag}".`
+                  : "No blog posts available yet. Check back soon!"}
               </P>
             </div>
           )}


### PR DESCRIPTION


## Description

Adds author display and tag filtering functionality to blog pages. Authors are now fetched from Contentful with their name and profile image, and displayed prominently on blog post pages. The blog listing page includes a dropdown filter to view posts by tag, with dynamic URL updates via query parameters (`/blog?tag=tagname`).

<img width="886" height="269" alt="Screenshot 2025-12-01 at 12 00 38" src="https://github.com/user-attachments/assets/1f65b166-6812-44f4-a687-3ce22836e400" />


## Risk

Low. Changes are additive and only affect blog rendering. Tag filtering uses client-side router navigation with query parameters, and author display gracefully handles missing data.

