### PR TITLE
[Core + connectors + front] feat(slack): store credential ID reference in Slack connector for private integrations

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -97,6 +97,8 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
           configuration.restrictedSpaceAgentsEnabled ?? true,
         feedbackVisibleToAuthorOnly:
           configuration.feedbackVisibleToAuthorOnly ?? true,
+        privateIntegrationCredentialId:
+          configuration.privateIntegrationCredentialId,
       }
     );
 
@@ -604,6 +606,14 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         const enabled = configValue === "true";
         await slackConfig.model.update(
           { restrictedSpaceAgentsEnabled: enabled },
+          { where: { id: slackConfig.id } }
+        );
+        return new Ok(undefined);
+      }
+
+      case "privateIntegrationCredentialId": {
+        await slackConfig.model.update(
+          { privateIntegrationCredentialId: configValue },
           { where: { id: slackConfig.id } }
         );
         return new Ok(undefined);

--- a/connectors/src/resources/connector/slack.ts
+++ b/connectors/src/resources/connector/slack.ts
@@ -26,6 +26,7 @@ export class SlackConnectorStrategy
         ? [...blob.whitelistedDomains] // Ensure it's a readonly string[]
         : undefined,
       restrictedSpaceAgentsEnabled: blob.restrictedSpaceAgentsEnabled,
+      privateIntegrationCredentialId: blob.privateIntegrationCredentialId,
       connectorId,
       transaction,
     });

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -48,6 +48,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     whitelistedDomains,
     restrictedSpaceAgentsEnabled,
     feedbackVisibleToAuthorOnly,
+    privateIntegrationCredentialId,
     transaction,
   }: {
     slackTeamId: string;
@@ -56,6 +57,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     whitelistedDomains?: string[];
     restrictedSpaceAgentsEnabled?: boolean;
     feedbackVisibleToAuthorOnly?: boolean;
+    privateIntegrationCredentialId?: string | null;
     transaction: Transaction;
   }) {
     const otherSlackConfigurationWithBotEnabled =
@@ -76,6 +78,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
         restrictedSpaceAgentsEnabled: restrictedSpaceAgentsEnabled ?? true,
         whitelistedDomains,
         feedbackVisibleToAuthorOnly: feedbackVisibleToAuthorOnly ?? true,
+        privateIntegrationCredentialId,
       },
       { transaction }
     );

--- a/connectors/src/types/slack.ts
+++ b/connectors/src/types/slack.ts
@@ -25,6 +25,7 @@ export const SlackConfigurationTypeSchema = z.object({
   autoReadChannelPatterns: SlackAutoReadPatternsSchema,
   restrictedSpaceAgentsEnabled: z.boolean().optional(),
   feedbackVisibleToAuthorOnly: z.boolean().optional(),
+  privateIntegrationCredentialId: z.string().optional(),
 });
 
 export type SlackConfigurationType = z.infer<

--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -199,6 +199,7 @@ async fn connections_finalize(
                             "provider": c.provider(),
                             "status": c.status(),
                             "metadata": c.metadata(),
+                            "related_credential_id": c.related_credential_id(),
                         },
                     })),
                 }),

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -100,22 +100,22 @@ export async function handleUpdatePermissions(
 ) {
   const provider = connector.type;
 
-  const connectionIdRes = await setupConnection({
+  const connectionRes = await setupConnection({
     owner,
     provider,
     extraConfig,
   });
-  if (connectionIdRes.isErr()) {
+  if (connectionRes.isErr()) {
     sendNotification({
       type: "error",
       title: "Failed to update the permissions",
-      description: connectionIdRes.error.message,
+      description: connectionRes.error.message,
     });
     return;
   }
 
   const updateRes = await updateConnectorConnectionId(
-    connectionIdRes.value,
+    connectionRes.value.connectionId,
     provider,
     dataSource,
     owner
@@ -126,13 +126,40 @@ export async function handleUpdatePermissions(
       title: "Failed to update the connection",
       description: updateRes.error,
     });
-  } else {
-    sendNotification({
-      type: "success",
-      title: "Successfully updated connection",
-      description: "The connection was successfully updated.",
-    });
+    return;
   }
+
+  // Slack connectors will rely on customer credentials, we need to set a reference to it on the connector to be able to properly uninstall the app on connector deletion
+  if (connector.type === "slack" && connectionRes.value.relatedCredentialId) {
+    const credentialRes = await fetch(
+      `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/privateIntegrationCredentialId`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          configValue: connectionRes.value.relatedCredentialId,
+        }),
+      }
+    );
+
+    if (!credentialRes.ok) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update the connection",
+        description:
+          "The connection was updated but the credential could not be set.",
+      });
+      return;
+    }
+  }
+
+  sendNotification({
+    type: "success",
+    title: "Successfully updated connection",
+    description: "The connection was successfully updated.",
+  });
 }
 
 export async function updateConnectorConnectionId(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -64,6 +64,7 @@ export const PostDataSourceWithProviderRequestBodySchema = t.intersection([
   }),
   t.partial({
     connectionId: t.string, // Required for some providers
+    relatedCredentialId: t.string, // Required for private integrations
   }),
 ]);
 
@@ -226,7 +227,7 @@ const handleDataSourceWithProvider = async ({
   req: NextApiRequest;
   res: NextApiResponse<WithAPIErrorResponse<PostSpaceDataSourceResponseBody>>;
 }) => {
-  const { provider, name, connectionId } = body;
+  const { provider, name, connectionId, relatedCredentialId } = body;
 
   // Checking that we have connectionId if we need id
   const isConnectionIdRequired = isConnectionIdRequiredForProvider(provider);
@@ -295,7 +296,17 @@ const handleDataSourceWithProvider = async ({
   let dataSourceDescription = getDefaultDataSourceDescription(provider, suffix);
 
   let { configuration } = body;
-  if (provider === "slack" || provider === "slack_bot") {
+  if (provider === "slack") {
+    configuration = {
+      botEnabled: false,
+      whitelistedDomains: undefined,
+      autoReadChannelPatterns: [],
+      restrictedSpaceAgentsEnabled: true,
+      privateIntegrationCredentialId: relatedCredentialId,
+    };
+  }
+
+  if (provider === "slack_bot") {
     configuration = {
       botEnabled: true,
       whitelistedDomains: undefined,

--- a/front/types/connectors/slack.ts
+++ b/front/types/connectors/slack.ts
@@ -23,6 +23,7 @@ export const SlackConfigurationTypeSchema = t.type({
   whitelistedDomains: t.union([t.array(t.string), t.undefined]),
   autoReadChannelPatterns: SlackAutoReadPatternsSchema,
   restrictedSpaceAgentsEnabled: t.union([t.boolean, t.undefined]),
+  privateIntegrationCredentialId: t.union([t.string, t.undefined]),
 });
 
 export type SlackConfigurationType = t.TypeOf<

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -276,6 +276,7 @@ export type OAuthConnectionType = {
   metadata: Record<string, string>;
   provider: OAuthProvider;
   status: "pending" | "finalized";
+  related_credential_id?: string | null;
 };
 
 export function isOAuthConnectionType(


### PR DESCRIPTION
## Description

This PR adds support for persisting credential IDs in Slack connector configurations when using private integrations (customer's own Slack app credentials).

**Context**: When customers connect Slack using their own private integration credentials rather than Dust's default Slack app, we need to track which credential was used. This is essential for proper cleanup - when the connector is deleted, we need to be able to uninstall the Slack app using the correct credentials.

**Changes**:
- Added `privateIntegrationCredentialId` field to `SlackConfiguration` model (connectors)
- Updated OAuth finalize endpoint to return `related_credential_id` in response (core)
- Modified connection setup flow to capture and pass through credential IDs (front)
- Updated connector creation/update logic to store credential reference for Slack connectors (front + connectors)
- Enhanced permission update modal to persist credential ID after OAuth flow (front)

This builds on top of #18475 which ensures credentials are always created for Slack connections.

[Part of Phase 2 - oauth flow updates
](https://www.notion.so/dust-tt/Design-Doc-Slack-Self-Created-App-2ab28599d9418093a52bd654837c69fa?source=copy_link#2b928599d9418076a414f7bc8ce6c567)
## Tests

Manual

## Risk

Low - Changes are additive, new optional field that doesn't affect existing connectors

## Deploy Plan

1. **Deploy core service** first (adds `related_credential_id` to OAuth response)
2. **Deploy connectors service** (adds field to model and handles updates)
3. **Deploy front service** last (consumes the new field and updates UI flows)