### PR TITLE
[Credits] Add feature flag check to isPAYGEnabled

### DIFF
--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -99,6 +99,10 @@ export async function allocatePAYGCreditsOnCycleRenewal({
 }
 
 export async function isPAYGEnabled(auth: Authenticator): Promise<boolean> {
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  if (!featureFlags.includes("ppul")) {
+    return false;
+  }
   const config =
     await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
   return config !== null && config.paygCapCents !== null;


### PR DESCRIPTION
## Description

Context: [Slack thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1764581513351999)

Adds ppul feature flag check to isPAYGEnabled to prevent PAYG invoicing for enterprise workspaces that do not have the feature flag enabled. This resolves failing Stripe webhooks for customers without the flag.

## Risks

Blast radius: Enterprise PAYG billing
Risk: none

## Deploy Plan

- deploy front