### PR TITLE
Fix agent suggestion display

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -135,7 +135,7 @@ export function UserMessage({
             />
           </NewConversationMessage>
         </div>
-        {message.mentions.length === 0 && isLastMessage && (
+        {showAgentSuggestions && (
           <AgentSuggestion
             conversationId={conversationId}
             owner={owner}


### PR DESCRIPTION
## Description

Refactors the condition for displaying agent suggestions in UserMessage.tsx by using the computed `showAgentSuggestions` variable instead of checking `message.mentions.length === 0 && isLastMessage inline`. The showAgentSuggestions variable already incorporates the complete logic including the check for human interactions, ensuring agent suggestions are not shown when multiple humans are interacting in the conversation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
