### PR TITLE
Customers Stories page

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -278,6 +278,11 @@ const config = {
   getProfilerSecret: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("DEBUG_PROFILER_SECRET");
   },
+  getContentfulPreviewSecret: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "CONTENTFUL_PREVIEW_SECRET"
+    );
+  },
   // Untrusted egress proxy.
   getUntrustedEgressProxyHost: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -364,8 +364,12 @@ function contentfulEntryToCustomerStory(
   // Check assets directly
   const body = isDocument(fields.body) ? fields.body : EMPTY_DOCUMENT;
   const heroImage = isAsset(fields.heroImage) ? fields.heroImage : undefined;
-  const companyLogo = isAsset(fields.companyLogo) ? fields.companyLogo : undefined;
-  const contactPhoto = isAsset(fields.contactPhoto) ? fields.contactPhoto : undefined;
+  const companyLogo = isAsset(fields.companyLogo)
+    ? fields.companyLogo
+    : undefined;
+  const contactPhoto = isAsset(fields.contactPhoto)
+    ? fields.contactPhoto
+    : undefined;
   const gallery = Array.isArray(fields.gallery)
     ? fields.gallery.filter(isAsset)
     : [];

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -349,6 +349,9 @@ function contentfulEntryToCustomerStory(
     ? metaDescriptionField
     : generateDescription(body);
 
+  const featuredField = fields.featured;
+  const featured = typeof featuredField === "boolean" ? featuredField : false;
+
   return {
     id: sys.id,
     slug,
@@ -380,7 +383,7 @@ function contentfulEntryToCustomerStory(
       title
     ),
     gallery,
-    featured: fields.featured === true,
+    featured,
     tags,
     createdAt: publishedAt,
     updatedAt: sys.updatedAt,

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -67,11 +67,23 @@ const renderOptions: Options = {
     ),
     [MARKS.ITALIC]: (text: ReactNode) => <em>{text}</em>,
     [MARKS.UNDERLINE]: (text: ReactNode) => <u>{text}</u>,
-    [MARKS.CODE]: (text: ReactNode) => (
-      <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-sm">
-        {text}
-      </code>
-    ),
+    [MARKS.CODE]: (text: ReactNode) => {
+      // Check if code contains newlines - render as block
+      const textContent = typeof text === "string" ? text : "";
+      if (textContent.includes("\n")) {
+        return (
+          <pre className="my-4 overflow-x-auto rounded-lg bg-gray-100 p-4">
+            <code className="font-mono text-sm">{text}</code>
+          </pre>
+        );
+      }
+      // Inline code
+      return (
+        <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-sm">
+          {text}
+        </code>
+      );
+    },
   },
   renderNode: {
     [BLOCKS.HEADING_1]: (_node, children) => (
@@ -135,20 +147,12 @@ const renderOptions: Options = {
         <figure className="my-8">
           <Image
             src={`https:${url}`}
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            alt={title || description || "Blog image"}
+            alt={title ?? description ?? "Blog image"}
             width={width}
             height={height}
             className="rounded-lg"
             loading="lazy"
           />
-          {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-          {(title || description) && (
-            <figcaption className="mt-2 text-center text-sm text-muted-foreground">
-              {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-              {description || title}
-            </figcaption>
-          )}
         </figure>
       );
     },

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -11,6 +11,7 @@ import Image from "next/image";
 import type { ReactNode } from "react";
 
 import { A, H2, H3, H4, H5 } from "@app/components/home/ContentComponents";
+import { isString } from "@app/types";
 
 function getYouTubeVideoId(text: string): string | null {
   const patterns = [
@@ -69,7 +70,7 @@ const renderOptions: Options = {
     [MARKS.UNDERLINE]: (text: ReactNode) => <u>{text}</u>,
     [MARKS.CODE]: (text: ReactNode) => {
       // Check if code contains newlines - render as block
-      const textContent = typeof text === "string" ? text : "";
+      const textContent = isString(text) ? text : "";
       if (textContent.includes("\n")) {
         return (
           <pre className="my-4 overflow-x-auto rounded-lg bg-gray-100 p-4">

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -52,3 +52,112 @@ export interface BlogPostPageProps {
   gtmTrackingId: string | null;
   preview?: boolean;
 }
+
+// Customer Story types
+
+export interface CustomerStoryFields {
+  // Required
+  title: string;
+  slug: string;
+  companyName: string;
+  body: Document;
+  industry: string;
+  department: string[];
+
+  // Customer info (optional)
+  companyLogo?: Asset;
+  companyLogoWhite?: Asset;
+  companyWebsite?: string;
+
+  // Contact person (optional)
+  contactName?: string;
+  contactTitle?: string;
+  contactPhoto?: Asset;
+
+  // Metrics (optional)
+  headlineMetric?: string;
+  secondaryMetrics?: string[];
+
+  // Filtering (optional)
+  companySize?: string;
+
+  // Media (optional)
+  heroImage?: Asset;
+  thumbnailImage?: Asset;
+  gallery?: Asset[];
+
+  // Publishing
+  publishedAt?: string;
+  featured?: boolean;
+  tags?: string[];
+
+  // SEO
+  metaDescription?: string;
+}
+
+export type CustomerStorySkeleton = EntrySkeletonType<
+  CustomerStoryFields,
+  "customerStory"
+>;
+
+export interface CustomerStory {
+  id: string;
+  slug: string;
+  title: string;
+  companyName: string;
+  companyLogo: BlogImage | null;
+  companyLogoWhite: BlogImage | null;
+  companyWebsite: string | null;
+  contactName: string | null;
+  contactTitle: string | null;
+  contactPhoto: BlogImage | null;
+  headlineMetric: string | null;
+  secondaryMetrics: string[];
+  industry: string;
+  department: string[];
+  companySize: string | null;
+  description: string | null;
+  body: Document;
+  heroImage: BlogImage | null;
+  thumbnailImage: BlogImage | null;
+  gallery: BlogImage[];
+  featured: boolean;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomerStorySummary {
+  id: string;
+  slug: string;
+  title: string;
+  companyName: string;
+  companyLogo: BlogImage | null;
+  headlineMetric: string | null;
+  description: string | null;
+  thumbnailImage: BlogImage | null;
+  industry: string;
+  department: string[];
+  companySize: string | null;
+  featured: boolean;
+  createdAt: string;
+}
+
+export interface CustomerStoryFilters {
+  industry?: string[];
+  department?: string[];
+  companySize?: string[];
+  featured?: boolean;
+}
+
+export interface CustomerStoryListingPageProps {
+  stories: CustomerStorySummary[];
+  gtmTrackingId: string | null;
+}
+
+export interface CustomerStoryPageProps {
+  story: CustomerStory;
+  relatedStories: CustomerStorySummary[];
+  gtmTrackingId: string | null;
+  preview?: boolean;
+}

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -66,7 +66,6 @@ export interface CustomerStoryFields {
 
   // Customer info (optional)
   companyLogo?: Asset;
-  companyLogoWhite?: Asset;
   companyWebsite?: string;
 
   // Contact person (optional)
@@ -76,20 +75,17 @@ export interface CustomerStoryFields {
 
   // Metrics (optional)
   headlineMetric?: string;
-  secondaryMetrics?: string[];
 
   // Filtering (optional)
   companySize?: string;
 
   // Media (optional)
   heroImage?: Asset;
-  thumbnailImage?: Asset;
   gallery?: Asset[];
 
   // Publishing
   publishedAt?: string;
   featured?: boolean;
-  tags?: string[];
 
   // SEO
   metaDescription?: string;
@@ -106,23 +102,19 @@ export interface CustomerStory {
   title: string;
   companyName: string;
   companyLogo: BlogImage | null;
-  companyLogoWhite: BlogImage | null;
   companyWebsite: string | null;
   contactName: string | null;
   contactTitle: string | null;
   contactPhoto: BlogImage | null;
   headlineMetric: string | null;
-  secondaryMetrics: string[];
   industry: string;
   department: string[];
   companySize: string | null;
   description: string | null;
   body: Document;
   heroImage: BlogImage | null;
-  thumbnailImage: BlogImage | null;
   gallery: BlogImage[];
   featured: boolean;
-  tags: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -135,7 +127,7 @@ export interface CustomerStorySummary {
   companyLogo: BlogImage | null;
   headlineMetric: string | null;
   description: string | null;
-  thumbnailImage: BlogImage | null;
+  heroImage: BlogImage | null;
   industry: string;
   department: string[];
   companySize: string | null;
@@ -150,8 +142,15 @@ export interface CustomerStoryFilters {
   featured?: boolean;
 }
 
+export interface CustomerStoryFilterOptions {
+  industries: string[];
+  departments: string[];
+  companySizes: string[];
+}
+
 export interface CustomerStoryListingPageProps {
   stories: CustomerStorySummary[];
+  filterOptions: CustomerStoryFilterOptions;
   gtmTrackingId: string | null;
 }
 

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -19,15 +19,17 @@ export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async (
   context
 ) => {
   const { slug } = context.params ?? {};
-  const { preview, secret } = context.query;
 
   if (!isString(slug)) {
     return { notFound: true };
   }
 
-  // Enable preview mode if valid secret provided
+  const searchParams = new URLSearchParams(context.resolvedUrl.split("?")[1]);
+  const preview = searchParams.get("preview");
+  const secret = searchParams.get("secret");
+  const previewSecret = process.env.CONTENTFUL_PREVIEW_SECRET;
   const isPreview =
-    preview === "true" && secret === process.env.CONTENTFUL_PREVIEW_SECRET;
+    preview === "true" && !!previewSecret && secret === previewSecret;
 
   const postResult = await getBlogPostBySlug(slug, isPreview);
 

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -8,6 +8,7 @@ import { BlogBlock } from "@app/components/home/ContentBlocks";
 import { Grid, H1, H2 } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
+import config from "@app/lib/api/config";
 import { getBlogPostBySlug, getRelatedPosts } from "@app/lib/contentful/client";
 import { renderRichTextFromContentful } from "@app/lib/contentful/richTextRenderer";
 import type { BlogPostPageProps } from "@app/lib/contentful/types";
@@ -27,7 +28,7 @@ export const getServerSideProps: GetServerSideProps<BlogPostPageProps> = async (
   const searchParams = new URLSearchParams(context.resolvedUrl.split("?")[1]);
   const preview = searchParams.get("preview");
   const secret = searchParams.get("secret");
-  const previewSecret = process.env.CONTENTFUL_PREVIEW_SECRET;
+  const previewSecret = config.getContentfulPreviewSecret();
   const isPreview =
     preview === "true" && !!previewSecret && secret === previewSecret;
 

--- a/front/pages/blog/index.tsx
+++ b/front/pages/blog/index.tsx
@@ -13,8 +13,8 @@ import logger from "@app/logger/logger";
 
 export const getServerSideProps: GetServerSideProps<
   BlogListingPageProps
-> = async () => {
-  const postsResult = await getAllBlogPosts();
+> = async (context) => {
+  const postsResult = await getAllBlogPosts(context.resolvedUrl);
 
   if (postsResult.isErr()) {
     logger.error(

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -28,7 +28,6 @@ export const getServerSideProps: GetServerSideProps<
     return { notFound: true };
   }
 
-  // Enable preview mode if valid secret provided
   const previewSecret = config.getContentfulPreviewSecret();
   const isPreview = preview === "true" && secret === previewSecret;
 
@@ -45,10 +44,6 @@ export const getServerSideProps: GetServerSideProps<
   const story = storyResult.value;
 
   if (!story) {
-    logger.info(
-      { slug, isPreview },
-      `Customer story "${slug}" not found (preview: ${isPreview})`
-    );
     return { notFound: true };
   }
 
@@ -256,12 +251,9 @@ export default function CustomerStoryPage({
             )}
           </div>
 
-          {/* Sidebar */}
           <aside className={classNames(SIDEBAR_CLASSES, "mt-12 lg:mt-12")}>
             <div className="sticky top-24 space-y-6">
-              {/* Company card */}
               <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-                {/* Company logo header */}
                 <div className="flex items-center justify-center border-b border-gray-100 bg-white px-6 py-8">
                   {story.companyLogo ? (
                     <Image
@@ -278,7 +270,6 @@ export default function CustomerStoryPage({
                   )}
                 </div>
 
-                {/* Company details */}
                 <div className="p-6">
                   <dl className="space-y-4">
                     <div className="flex items-start justify-between">
@@ -326,7 +317,6 @@ export default function CustomerStoryPage({
                 </div>
               </div>
 
-              {/* Contact person */}
               {(story.contactName !== null || story.contactTitle !== null) && (
                 <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
                   <div className="flex items-center gap-4">
@@ -366,7 +356,6 @@ export default function CustomerStoryPage({
         </Grid>
       </article>
 
-      {/* Related stories */}
       {relatedStories.length > 0 && (
         <section className="mt-20">
           <Grid>
@@ -389,7 +378,6 @@ export default function CustomerStoryPage({
                     "hover:bg-primary-100"
                   )}
                 >
-                  {/* Hero image */}
                   <div className="relative flex aspect-[16/9] w-full items-center justify-center overflow-hidden bg-gray-100">
                     {relatedStory.heroImage ? (
                       <Image

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -29,7 +29,11 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   const previewSecret = config.getContentfulPreviewSecret();
-  const isPreview = preview === "true" && secret === previewSecret;
+  const isPreview =
+    preview === "true" &&
+    isString(secret) &&
+    isString(previewSecret) &&
+    secret === previewSecret;
 
   const storyResult = await getCustomerStoryBySlug(slug, isPreview);
 

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -22,18 +22,17 @@ export const getServerSideProps: GetServerSideProps<
   CustomerStoryPageProps
 > = async (context) => {
   const { slug } = context.params ?? {};
-  const { preview, secret } = context.query;
 
   if (!isString(slug)) {
     return { notFound: true };
   }
 
+  const searchParams = new URLSearchParams(context.resolvedUrl.split("?")[1]);
+  const preview = searchParams.get("preview");
+  const secret = searchParams.get("secret");
   const previewSecret = config.getContentfulPreviewSecret();
   const isPreview =
-    preview === "true" &&
-    isString(secret) &&
-    isString(previewSecret) &&
-    secret === previewSecret;
+    preview === "true" && !!previewSecret && secret === previewSecret;
 
   const storyResult = await getCustomerStoryBySlug(slug, isPreview);
 

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -1,0 +1,476 @@
+import type { GetServerSideProps } from "next";
+import Head from "next/head";
+import Image from "next/image";
+import Link from "next/link";
+import type { ReactElement } from "react";
+
+import { Grid, H1, H2, H5 } from "@app/components/home/ContentComponents";
+import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
+import LandingLayout from "@app/components/home/LandingLayout";
+import {
+  getCustomerStoryBySlug,
+  getRelatedCustomerStories,
+} from "@app/lib/contentful/client";
+import { renderRichTextFromContentful } from "@app/lib/contentful/richTextRenderer";
+import type { CustomerStoryPageProps } from "@app/lib/contentful/types";
+import { classNames } from "@app/lib/utils";
+import logger from "@app/logger/logger";
+import { isString } from "@app/types";
+
+export const getServerSideProps: GetServerSideProps<
+  CustomerStoryPageProps
+> = async (context) => {
+  const { slug } = context.params ?? {};
+  const { preview, secret } = context.query;
+
+  if (!isString(slug)) {
+    return { notFound: true };
+  }
+
+  // Enable preview mode if valid secret provided
+  const isPreview =
+    preview === "true" && secret === process.env.CONTENTFUL_PREVIEW_SECRET;
+
+  if (preview === "true" && !isPreview) {
+    const envSecret = process.env.CONTENTFUL_PREVIEW_SECRET;
+    logger.warn(
+      {
+        slug,
+        providedSecretLength: typeof secret === "string" ? secret.length : 0,
+        envSecretLength: envSecret?.length ?? 0,
+        envSecretSet: !!envSecret,
+        match: secret === envSecret,
+      },
+      `Preview requested but secret validation failed for "${slug}"`
+    );
+  }
+
+  const storyResult = await getCustomerStoryBySlug(slug, isPreview);
+
+  if (storyResult.isErr()) {
+    logger.error(
+      { slug, error: storyResult.error, isPreview },
+      `Error fetching customer story "${slug}"`
+    );
+    return { notFound: true };
+  }
+
+  const story = storyResult.value;
+
+  if (!story) {
+    logger.info(
+      { slug, isPreview },
+      `Customer story "${slug}" not found (preview: ${isPreview})`
+    );
+    return { notFound: true };
+  }
+
+  const relatedStoriesResult = await getRelatedCustomerStories(
+    slug,
+    story.industry,
+    story.department,
+    3,
+    isPreview
+  );
+
+  if (relatedStoriesResult.isErr()) {
+    logger.error(
+      { slug, error: relatedStoriesResult.error },
+      `Error fetching related stories for "${slug}"`
+    );
+  }
+
+  return {
+    props: {
+      story,
+      relatedStories: relatedStoriesResult.isOk()
+        ? relatedStoriesResult.value
+        : [],
+      gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      preview: isPreview,
+    },
+  };
+};
+
+const CONTENT_CLASSES = classNames("col-span-12", "lg:col-span-8");
+
+const SIDEBAR_CLASSES = classNames(
+  "col-span-12",
+  "lg:col-span-4 lg:col-start-9"
+);
+
+const WIDE_CLASSES = classNames("col-span-12");
+
+export default function CustomerStoryPage({
+  story,
+  relatedStories,
+  preview,
+}: CustomerStoryPageProps) {
+  const ogImageUrl =
+    story.heroImage?.url ??
+    story.companyLogo?.url ??
+    "https://dust.tt/static/og_image.png";
+  const canonicalUrl = `https://dust.tt/customers/${story.slug}`;
+
+  return (
+    <>
+      {preview && (
+        <div className="fixed left-0 right-0 top-0 z-50 bg-amber-100 px-4 py-2 text-center text-amber-800">
+          Preview Mode - This is a draft
+        </div>
+      )}
+      <Head>
+        <title>
+          {story.companyName}: {story.title} | Dust Customer Story
+        </title>
+        {preview && <meta name="robots" content="noindex, nofollow" />}
+        {story.description && (
+          <meta name="description" content={story.description} />
+        )}
+        <link rel="canonical" href={canonicalUrl} />
+
+        <meta
+          property="og:title"
+          content={`${story.companyName}: ${story.title}`}
+        />
+        {story.description && (
+          <meta property="og:description" content={story.description} />
+        )}
+        <meta property="og:type" content="article" />
+        <meta property="og:image" content={ogImageUrl} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:site_name" content="Dust" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content={`${story.companyName}: ${story.title}`}
+        />
+        {story.description && (
+          <meta name="twitter:description" content={story.description} />
+        )}
+        <meta name="twitter:image" content={ogImageUrl} />
+
+        <meta property="article:published_time" content={story.createdAt} />
+        <meta property="article:modified_time" content={story.updatedAt} />
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "Article",
+              headline: `${story.companyName}: ${story.title}`,
+              ...(story.description && { description: story.description }),
+              image: ogImageUrl,
+              url: canonicalUrl,
+              datePublished: story.createdAt,
+              dateModified: story.updatedAt,
+              author: {
+                "@type": "Organization",
+                name: "Dust",
+              },
+              publisher: {
+                "@type": "Organization",
+                name: "Dust",
+                logo: {
+                  "@type": "ImageObject",
+                  url: "https://dust.tt/static/og_image.png",
+                },
+              },
+              about: {
+                "@type": "Organization",
+                name: story.companyName,
+                ...(story.companyWebsite && { url: story.companyWebsite }),
+              },
+              mainEntityOfPage: {
+                "@type": "WebPage",
+                "@id": canonicalUrl,
+              },
+            }),
+          }}
+        />
+      </Head>
+
+      <article>
+        <Grid>
+          {/* Header */}
+          <header className={classNames(WIDE_CLASSES, "pt-16")}>
+            <Link
+              href="/customers"
+              className="mb-8 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <span>&larr;</span> All Customer Stories
+            </Link>
+
+            {/* Tags */}
+            <div className="mb-4 flex flex-wrap gap-2">
+              <span className="rounded-full bg-highlight/10 px-3 py-1 text-sm font-medium text-highlight">
+                {story.industry}
+              </span>
+              {story.department.map((dept) => (
+                <span
+                  key={dept}
+                  className="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600"
+                >
+                  {dept}
+                </span>
+              ))}
+            </div>
+
+            <H1 mono>{story.title}</H1>
+
+            {/* Headline metric */}
+            {story.headlineMetric && (
+              <div className="mt-6">
+                <span className="inline-block rounded-lg bg-emerald-50 px-4 py-2 text-xl font-bold text-emerald-600">
+                  {story.headlineMetric}
+                </span>
+              </div>
+            )}
+          </header>
+
+          {/* Hero image */}
+          {story.heroImage && (
+            <div className={classNames(WIDE_CLASSES, "mt-8")}>
+              <Image
+                src={story.heroImage.url}
+                alt={story.heroImage.alt}
+                width={story.heroImage.width}
+                height={story.heroImage.height}
+                className="rounded-2xl"
+                priority
+              />
+            </div>
+          )}
+
+          {/* Main content and sidebar */}
+          <div className={classNames(CONTENT_CLASSES, "mt-12")}>
+            {/* Secondary metrics */}
+            {story.secondaryMetrics.length > 0 && (
+              <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {story.secondaryMetrics.map((metric, index) => (
+                  <div
+                    key={index}
+                    className="rounded-lg bg-muted-background p-4 text-center"
+                  >
+                    <span className="text-lg font-semibold text-foreground">
+                      {metric}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Rich text body */}
+            {renderRichTextFromContentful(story.body)}
+
+            {/* Gallery */}
+            {story.gallery.length > 0 && (
+              <div className="mt-12">
+                <H2 className="mb-6">Gallery</H2>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {story.gallery.map((image, index) => (
+                    <Image
+                      key={index}
+                      src={image.url}
+                      alt={image.alt}
+                      width={image.width}
+                      height={image.height}
+                      className="rounded-lg"
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Sidebar */}
+          <aside className={classNames(SIDEBAR_CLASSES, "mt-12 lg:mt-12")}>
+            <div className="sticky top-24 space-y-6">
+              {/* Company card */}
+              <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+                {/* Company logo header */}
+                <div className="flex items-center justify-center border-b border-gray-100 bg-white px-6 py-8">
+                  {story.companyLogo ? (
+                    <Image
+                      src={story.companyLogo.url}
+                      alt={story.companyLogo.alt}
+                      width={200}
+                      height={100}
+                      className="h-16 w-auto object-contain"
+                    />
+                  ) : (
+                    <span className="text-xl font-bold text-foreground">
+                      {story.companyName}
+                    </span>
+                  )}
+                </div>
+
+                {/* Company details */}
+                <div className="p-6">
+                  <dl className="space-y-4">
+                    <div className="flex items-start justify-between">
+                      <dt className="text-sm text-muted-foreground">
+                        Industry
+                      </dt>
+                      <dd className="text-right text-sm font-medium text-foreground">
+                        {story.industry}
+                      </dd>
+                    </div>
+                    {story.companySize && (
+                      <div className="flex items-start justify-between">
+                        <dt className="text-sm text-muted-foreground">
+                          Company Size
+                        </dt>
+                        <dd className="text-right text-sm font-medium text-foreground">
+                          {story.companySize}
+                        </dd>
+                      </div>
+                    )}
+                    {story.department.length > 0 && (
+                      <div className="flex items-start justify-between">
+                        <dt className="text-sm text-muted-foreground">
+                          Departments
+                        </dt>
+                        <dd className="text-right text-sm font-medium text-foreground">
+                          {story.department.join(", ")}
+                        </dd>
+                      </div>
+                    )}
+                    {story.companyWebsite && (
+                      <div className="pt-2">
+                        <a
+                          href={story.companyWebsite}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-gray-50"
+                        >
+                          Visit website
+                          <span className="text-muted-foreground">&rarr;</span>
+                        </a>
+                      </div>
+                    )}
+                  </dl>
+                </div>
+              </div>
+
+              {/* Contact person */}
+              {(story.contactName !== null || story.contactTitle !== null) && (
+                <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <div className="flex items-center gap-4">
+                    {story.contactPhoto ? (
+                      <Image
+                        src={story.contactPhoto.url}
+                        alt={story.contactPhoto.alt}
+                        width={56}
+                        height={56}
+                        className="h-14 w-14 rounded-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-highlight/10">
+                        <span className="text-lg font-semibold text-highlight">
+                          {story.contactName?.charAt(0) || "?"}
+                        </span>
+                      </div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      {story.contactName && (
+                        <p className="font-semibold text-foreground">
+                          {story.contactName}
+                        </p>
+                      )}
+                      {story.contactTitle && (
+                        <p className="truncate text-sm text-muted-foreground">
+                          {story.contactTitle}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </aside>
+        </Grid>
+      </article>
+
+      {/* Related stories */}
+      {relatedStories.length > 0 && (
+        <section className="mt-20">
+          <Grid>
+            <div className={WIDE_CLASSES}>
+              <H2 className="mb-8">More Customer Stories</H2>
+            </div>
+            <div
+              className={classNames(
+                WIDE_CLASSES,
+                "grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
+              )}
+            >
+              {relatedStories.map((relatedStory) => (
+                <Link
+                  key={relatedStory.id}
+                  href={`/customers/${relatedStory.slug}`}
+                  className={classNames(
+                    "flex h-full flex-col overflow-hidden rounded-xl bg-muted-background",
+                    "group transition duration-300 ease-out",
+                    "hover:bg-primary-100"
+                  )}
+                >
+                  {/* Thumbnail */}
+                  <div className="relative flex aspect-[16/9] w-full items-center justify-center overflow-hidden bg-gray-100">
+                    {relatedStory.thumbnailImage ? (
+                      <Image
+                        src={relatedStory.thumbnailImage.url}
+                        alt={relatedStory.thumbnailImage.alt}
+                        fill
+                        className="object-cover brightness-100 transition duration-300 ease-out group-hover:brightness-110"
+                      />
+                    ) : relatedStory.companyLogo ? (
+                      <div className="flex h-full w-full items-center justify-center bg-white p-8">
+                        <Image
+                          src={relatedStory.companyLogo.url}
+                          alt={relatedStory.companyLogo.alt}
+                          width={120}
+                          height={60}
+                          className="max-h-12 w-auto object-contain"
+                        />
+                      </div>
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center bg-primary-100">
+                        <span className="text-2xl font-bold text-primary-400">
+                          {relatedStory.companyName.charAt(0)}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex flex-1 flex-col p-6">
+                    <span className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      {relatedStory.companyName}
+                    </span>
+                    <H5 className="line-clamp-2 text-foreground" mono>
+                      {relatedStory.title}
+                    </H5>
+                    {relatedStory.headlineMetric && (
+                      <span className="mt-2 inline-block self-start rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-600">
+                        {relatedStory.headlineMetric}
+                      </span>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </Grid>
+        </section>
+      )}
+    </>
+  );
+}
+
+CustomerStoryPage.getLayout = (
+  page: ReactElement,
+  pageProps: LandingLayoutProps
+) => {
+  return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
+};

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -7,6 +7,7 @@ import type { ReactElement } from "react";
 import { Grid, H1, H2, H5 } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
+import config from "@app/lib/api/config";
 import {
   getCustomerStoryBySlug,
   getRelatedCustomerStories,
@@ -28,22 +29,8 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   // Enable preview mode if valid secret provided
-  const isPreview =
-    preview === "true" && secret === process.env.CONTENTFUL_PREVIEW_SECRET;
-
-  if (preview === "true" && !isPreview) {
-    const envSecret = process.env.CONTENTFUL_PREVIEW_SECRET;
-    logger.warn(
-      {
-        slug,
-        providedSecretLength: typeof secret === "string" ? secret.length : 0,
-        envSecretLength: envSecret?.length ?? 0,
-        envSecretSet: !!envSecret,
-        match: secret === envSecret,
-      },
-      `Preview requested but secret validation failed for "${slug}"`
-    );
-  }
+  const previewSecret = config.getContentfulPreviewSecret();
+  const isPreview = preview === "true" && secret === previewSecret;
 
   const storyResult = await getCustomerStoryBySlug(slug, isPreview);
 
@@ -246,22 +233,6 @@ export default function CustomerStoryPage({
 
           {/* Main content and sidebar */}
           <div className={classNames(CONTENT_CLASSES, "mt-12")}>
-            {/* Secondary metrics */}
-            {story.secondaryMetrics.length > 0 && (
-              <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {story.secondaryMetrics.map((metric, index) => (
-                  <div
-                    key={index}
-                    className="rounded-lg bg-muted-background p-4 text-center"
-                  >
-                    <span className="text-lg font-semibold text-foreground">
-                      {metric}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            )}
-
             {/* Rich text body */}
             {renderRichTextFromContentful(story.body)}
 
@@ -418,12 +389,12 @@ export default function CustomerStoryPage({
                     "hover:bg-primary-100"
                   )}
                 >
-                  {/* Thumbnail */}
+                  {/* Hero image */}
                   <div className="relative flex aspect-[16/9] w-full items-center justify-center overflow-hidden bg-gray-100">
-                    {relatedStory.thumbnailImage ? (
+                    {relatedStory.heroImage ? (
                       <Image
-                        src={relatedStory.thumbnailImage.url}
-                        alt={relatedStory.thumbnailImage.alt}
+                        src={relatedStory.heroImage.url}
+                        alt={relatedStory.heroImage.alt}
                         fill
                         className="object-cover brightness-100 transition duration-300 ease-out group-hover:brightness-110"
                       />

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -359,7 +359,7 @@ export default function CustomerStoryPage({
               {(story.contactName !== null || story.contactTitle !== null) && (
                 <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
                   <div className="flex items-center gap-4">
-                    {story.contactPhoto ? (
+                    {story.contactPhoto && (
                       <Image
                         src={story.contactPhoto.url}
                         alt={story.contactPhoto.alt}
@@ -367,10 +367,11 @@ export default function CustomerStoryPage({
                         height={56}
                         className="h-14 w-14 rounded-full object-cover"
                       />
-                    ) : (
+                    )}
+                    {!story.contactPhoto && story.contactName && (
                       <div className="flex h-14 w-14 items-center justify-center rounded-full bg-highlight/10">
                         <span className="text-lg font-semibold text-highlight">
-                          {story.contactName?.charAt(0) || "?"}
+                          {story.contactName.charAt(0)}
                         </span>
                       </div>
                     )}

--- a/front/pages/customers/index.tsx
+++ b/front/pages/customers/index.tsx
@@ -46,8 +46,8 @@ function extractFilterOptions(
 
 export const getServerSideProps: GetServerSideProps<
   CustomerStoryListingPageProps
-> = async () => {
-  const storiesResult = await getAllCustomerStories();
+> = async (context) => {
+  const storiesResult = await getAllCustomerStories(context.resolvedUrl);
 
   if (storiesResult.isErr()) {
     logger.error(

--- a/front/pages/customers/index.tsx
+++ b/front/pages/customers/index.tsx
@@ -1,0 +1,405 @@
+import type { GetServerSideProps } from "next";
+import Head from "next/head";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import type { ReactElement } from "react";
+import { useCallback, useMemo } from "react";
+
+import { Grid, H1, H5, P } from "@app/components/home/ContentComponents";
+import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
+import LandingLayout from "@app/components/home/LandingLayout";
+import { getAllCustomerStories } from "@app/lib/contentful/client";
+import type { CustomerStoryListingPageProps } from "@app/lib/contentful/types";
+import { classNames } from "@app/lib/utils";
+import logger from "@app/logger/logger";
+
+// Filter options
+const INDUSTRIES = [
+  "B2B SaaS",
+  "Financial Services",
+  "Insurance",
+  "Healthcare",
+  "Retail & E-commerce",
+  "Marketplace",
+  "Consulting",
+  "Technology",
+  "Travel",
+  "Real Estate",
+  "Other",
+] as const;
+
+const DEPARTMENTS = [
+  "Sales",
+  "Marketing",
+  "Customer Support",
+  "Engineering",
+  "Product",
+  "HR & People",
+  "Legal",
+  "Finance",
+  "IT",
+  "Operations",
+  "Data",
+  "Knowledge Management",
+  "Executive",
+] as const;
+
+const COMPANY_SIZES = [
+  "1-50",
+  "51-200",
+  "201-1000",
+  "1001-5000",
+  "5000+",
+] as const;
+
+export const getServerSideProps: GetServerSideProps<
+  CustomerStoryListingPageProps
+> = async () => {
+  const storiesResult = await getAllCustomerStories();
+
+  if (storiesResult.isErr()) {
+    logger.error(
+      { error: storiesResult.error },
+      "Error fetching customer stories from Contentful"
+    );
+    return {
+      props: {
+        stories: [],
+        gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      },
+    };
+  }
+
+  return {
+    props: {
+      stories: storiesResult.value,
+      gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+    },
+  };
+};
+
+interface FilterCheckboxProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function FilterCheckbox({ label, checked, onChange }: FilterCheckboxProps) {
+  return (
+    <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-4 w-4 rounded border-gray-300 text-highlight focus:ring-highlight"
+      />
+      {label}
+    </label>
+  );
+}
+
+interface FilterSectionProps {
+  title: string;
+  options: readonly string[];
+  selected: string[];
+  onChange: (selected: string[]) => void;
+}
+
+function FilterSection({
+  title,
+  options,
+  selected,
+  onChange,
+}: FilterSectionProps) {
+  const handleToggle = useCallback(
+    (option: string, checked: boolean) => {
+      if (checked) {
+        onChange([...selected, option]);
+      } else {
+        onChange(selected.filter((s) => s !== option));
+      }
+    },
+    [selected, onChange]
+  );
+
+  return (
+    <div className="mb-6">
+      <h3 className="mb-3 text-sm font-semibold text-foreground">{title}</h3>
+      <div className="flex flex-col gap-2">
+        {options.map((option) => (
+          <FilterCheckbox
+            key={option}
+            label={option}
+            checked={selected.includes(option)}
+            onChange={(checked) => handleToggle(option, checked)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function CustomerStoriesListing({
+  stories,
+}: CustomerStoryListingPageProps) {
+  const router = useRouter();
+
+  // Parse filters from URL query params
+  const selectedIndustries = useMemo(() => {
+    const param = router.query.industry;
+    if (!param) {
+      return [];
+    }
+    return Array.isArray(param) ? param : [param];
+  }, [router.query.industry]);
+
+  const selectedDepartments = useMemo(() => {
+    const param = router.query.department;
+    if (!param) {
+      return [];
+    }
+    return Array.isArray(param) ? param : [param];
+  }, [router.query.department]);
+
+  const selectedCompanySizes = useMemo(() => {
+    const param = router.query.size;
+    if (!param) {
+      return [];
+    }
+    return Array.isArray(param) ? param : [param];
+  }, [router.query.size]);
+
+  // Update URL with new filters
+  const updateFilters = useCallback(
+    (key: string, values: string[]) => {
+      const newQuery = { ...router.query };
+      if (values.length > 0) {
+        newQuery[key] = values;
+      } else {
+        delete newQuery[key];
+      }
+      void router.push({ pathname: router.pathname, query: newQuery }, undefined, {
+        shallow: true,
+      });
+    },
+    [router]
+  );
+
+  // Filter stories based on selected filters
+  const filteredStories = useMemo(() => {
+    return stories.filter((story) => {
+      if (
+        selectedIndustries.length > 0 &&
+        !selectedIndustries.includes(story.industry)
+      ) {
+        return false;
+      }
+      if (
+        selectedDepartments.length > 0 &&
+        !story.department.some((d) => selectedDepartments.includes(d))
+      ) {
+        return false;
+      }
+      if (
+        selectedCompanySizes.length > 0 &&
+        story.companySize &&
+        !selectedCompanySizes.includes(story.companySize)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [stories, selectedIndustries, selectedDepartments, selectedCompanySizes]);
+
+  const hasActiveFilters =
+    selectedIndustries.length > 0 ||
+    selectedDepartments.length > 0 ||
+    selectedCompanySizes.length > 0;
+
+  const clearAllFilters = useCallback(() => {
+    void router.push({ pathname: router.pathname }, undefined, { shallow: true });
+  }, [router]);
+
+  return (
+    <>
+      <Head>
+        <title>Customer Stories | Dust</title>
+        <meta
+          name="description"
+          content="Discover how leading companies use Dust to transform their workflows with AI agents. Read customer success stories from Sales, Marketing, Customer Support, and more."
+        />
+        <meta property="og:title" content="Customer Stories | Dust" />
+        <meta
+          property="og:description"
+          content="Discover how leading companies use Dust to transform their workflows with AI agents."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://dust.tt/customers" />
+        <meta property="og:image" content="/static/og_image.png" />
+      </Head>
+
+      <Grid>
+        <div className="col-span-12 pt-12">
+          <H1 mono>Customer Stories</H1>
+          <P size="lg" className="mt-4 text-muted-foreground">
+            See how teams across industries are transforming their work with
+            Dust
+          </P>
+        </div>
+
+        {/* Main content area */}
+        <div className="col-span-12 mt-8 flex flex-col gap-8 lg:flex-row">
+          {/* Filters sidebar */}
+          <aside className="w-full shrink-0 lg:w-64">
+            <div className="sticky top-24 rounded-xl bg-muted-background p-6">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="font-semibold text-foreground">Filters</h2>
+                {hasActiveFilters && (
+                  <button
+                    onClick={clearAllFilters}
+                    className="text-sm text-highlight hover:underline"
+                  >
+                    Clear all
+                  </button>
+                )}
+              </div>
+
+              <FilterSection
+                title="Industry"
+                options={INDUSTRIES}
+                selected={selectedIndustries}
+                onChange={(values) => updateFilters("industry", values)}
+              />
+
+              <FilterSection
+                title="Department"
+                options={DEPARTMENTS}
+                selected={selectedDepartments}
+                onChange={(values) => updateFilters("department", values)}
+              />
+
+              <FilterSection
+                title="Company Size"
+                options={COMPANY_SIZES}
+                selected={selectedCompanySizes}
+                onChange={(values) => updateFilters("size", values)}
+              />
+            </div>
+          </aside>
+
+          {/* Stories grid */}
+          <div className="flex-1">
+            {filteredStories.length > 0 ? (
+              <>
+                <p className="mb-6 text-sm text-muted-foreground">
+                  {filteredStories.length}{" "}
+                  {filteredStories.length === 1 ? "story" : "stories"}
+                  {hasActiveFilters && " matching your filters"}
+                </p>
+                <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                  {filteredStories.map((story) => (
+                    <Link
+                      key={story.id}
+                      href={`/customers/${story.slug}`}
+                      className={classNames(
+                        "flex h-full flex-col overflow-hidden rounded-xl bg-muted-background",
+                        "group transition duration-300 ease-out",
+                        "hover:bg-primary-100"
+                      )}
+                    >
+                      {/* Thumbnail or logo area */}
+                      <div className="relative flex aspect-[16/9] w-full items-center justify-center overflow-hidden bg-gray-100">
+                        {story.thumbnailImage ? (
+                          <Image
+                            src={story.thumbnailImage.url}
+                            alt={story.thumbnailImage.alt}
+                            fill
+                            className="object-cover brightness-100 transition duration-300 ease-out group-hover:brightness-110"
+                          />
+                        ) : story.companyLogo ? (
+                          <div className="flex h-full w-full items-center justify-center bg-white p-8">
+                            <Image
+                              src={story.companyLogo.url}
+                              alt={story.companyLogo.alt}
+                              width={160}
+                              height={80}
+                              className="max-h-16 w-auto object-contain"
+                            />
+                          </div>
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center bg-primary-100">
+                            <span className="text-2xl font-bold text-primary-400">
+                              {story.companyName.charAt(0)}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="flex flex-1 flex-col p-6">
+                        {/* Company name and headline metric */}
+                        <div className="mb-2 flex items-start justify-between gap-2">
+                          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            {story.companyName}
+                          </span>
+                          {story.headlineMetric && (
+                            <span className="shrink-0 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-600">
+                              {story.headlineMetric}
+                            </span>
+                          )}
+                        </div>
+
+                        {/* Title */}
+                        <H5 className="line-clamp-3 text-foreground" mono>
+                          {story.title}
+                        </H5>
+
+                        {/* Tags */}
+                        <div className="mt-auto flex flex-wrap gap-1 pt-4">
+                          <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                            {story.industry}
+                          </span>
+                          {story.department.slice(0, 2).map((dept) => (
+                            <span
+                              key={dept}
+                              className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600"
+                            >
+                              {dept}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <div className="py-12 text-center">
+                <P size="md" className="text-muted-foreground">
+                  {hasActiveFilters
+                    ? "No stories match your filters. Try adjusting your selection."
+                    : "No customer stories available yet. Check back soon!"}
+                </P>
+                {hasActiveFilters && (
+                  <button
+                    onClick={clearAllFilters}
+                    className="mt-4 text-highlight hover:underline"
+                  >
+                    Clear all filters
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </Grid>
+    </>
+  );
+}
+
+CustomerStoriesListing.getLayout = (
+  page: ReactElement,
+  pageProps: LandingLayoutProps
+) => {
+  return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
+};

--- a/front/pages/customers/index.tsx
+++ b/front/pages/customers/index.tsx
@@ -179,9 +179,13 @@ export default function CustomerStoriesListing({
       } else {
         delete newQuery[key];
       }
-      void router.push({ pathname: router.pathname, query: newQuery }, undefined, {
-        shallow: true,
-      });
+      void router.push(
+        { pathname: router.pathname, query: newQuery },
+        undefined,
+        {
+          shallow: true,
+        }
+      );
     },
     [router]
   );
@@ -218,7 +222,9 @@ export default function CustomerStoriesListing({
     selectedCompanySizes.length > 0;
 
   const clearAllFilters = useCallback(() => {
-    void router.push({ pathname: router.pathname }, undefined, { shallow: true });
+    void router.push({ pathname: router.pathname }, undefined, {
+      shallow: true,
+    });
   }, [router]);
 
   return (
@@ -292,11 +298,6 @@ export default function CustomerStoriesListing({
           <div className="flex-1">
             {filteredStories.length > 0 ? (
               <>
-                <p className="mb-6 text-sm text-muted-foreground">
-                  {filteredStories.length}{" "}
-                  {filteredStories.length === 1 ? "story" : "stories"}
-                  {hasActiveFilters && " matching your filters"}
-                </p>
                 <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
                   {filteredStories.map((story) => (
                     <Link


### PR DESCRIPTION




## Description

Adds a new Customer Stories section to the website with dedicated pages for showcasing customer case studies. This follows the same Contentful integration pattern as the blog migration (PR #18411).

The implementation includes:
- New `/customers` listing page with filterable customer stories by industry, department, and company size
- Individual `/customers/[slug]` pages for each customer story with rich text content, company details, metrics, contact information, and gallery support
- Preview mode support (similar to PR #18477) for drafting stories before publication
- Related stories functionality based on industry and department
- Full SEO metadata and structured data
<img width="1239" height="915" alt="Screenshot 2025-12-01 at 16 08 37" src="https://github.com/user-attachments/assets/4604ba57-1d65-4cc5-ad76-41d929e7cca7" />

<img width="1774" height="949" alt="Screenshot 2025-12-01 at 16 09 07" src="https://github.com/user-attachments/assets/c85c6626-0c15-44b7-ac70-7ccd14e9bd05" />


## Risk

Low. Changes are additive and only affect the public-facing customer stories section. No impact on authenticated users or core product functionality.

