### PR TITLE
[front] fix: Add ceiling to free credits you can get on first subscri…

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { createPlugin } from "@app/lib/api/poke/types";
 import {
   calculateFreeCreditAmount,
-  countElligibleUsersForFreeCredits,
+  countEligibleUsersForFreeCredits,
 } from "@app/lib/credits/free";
 import {
   startOrResumeEnterprisePAYG,
@@ -129,7 +129,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
 
   populateAsyncArgs: async (auth) => {
     const workspace = auth.getNonNullableWorkspace();
-    const userCount = await countElligibleUsersForFreeCredits(workspace, 0);
+    const userCount = await countEligibleUsersForFreeCredits(workspace);
     const automaticCreditsCents = calculateFreeCreditAmount(userCount);
     const automaticCreditsDollars = automaticCreditsCents / 100;
 

--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -29,12 +29,14 @@ const NOW_MS = NOW * 1000;
 
 function makeSubscription(
   currentPeriodStart: number,
-  startDate: number
+  startDate: number,
+  status: Stripe.Subscription.Status = "active"
 ): Stripe.Subscription {
   return {
     id: "sub_123",
     current_period_start: currentPeriodStart,
     start_date: startDate,
+    status,
   } as Stripe.Subscription;
 }
 
@@ -121,6 +123,15 @@ describe("isSubscriptionEligibleForFreeCredits", () => {
       makeSubscription(NOW, NOW)
     );
     expect(result).toBe(false);
+  });
+
+  it("returns true for trialing subscription even without paid invoices", async () => {
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+    const result = await isSubscriptionEligibleForFreeCredits(
+      makeSubscription(NOW, NOW, "trialing")
+    );
+    expect(result).toBe(true);
+    expect(getSubscriptionInvoices).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -1,8 +1,12 @@
 import type Stripe from "stripe";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { isSubscriptionEligibleForFreeCredits } from "@app/lib/credits/free";
+import {
+  countEligibleUsersForFreeCredits,
+  isSubscriptionEligibleForFreeCredits,
+} from "@app/lib/credits/free";
 import { getSubscriptionInvoices } from "@app/lib/plans/stripe";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 
 vi.mock("@app/lib/plans/stripe", async () => {
   const actual = await vi.importActual("@app/lib/plans/stripe");
@@ -11,6 +15,12 @@ vi.mock("@app/lib/plans/stripe", async () => {
     getSubscriptionInvoices: vi.fn(),
   };
 });
+
+vi.mock("@app/lib/resources/membership_resource", () => ({
+  MembershipResource: {
+    getMembersCountForWorkspace: vi.fn(),
+  },
+}));
 
 const MONTH_SECONDS = 30 * 24 * 60 * 60;
 const NOW = 1700000000; // Fixed timestamp for tests
@@ -104,6 +114,110 @@ describe("isSubscriptionEligibleForFreeCredits", () => {
         makeSubscription(NOW, oldStartDate)
       );
       expect(result).toBe(false);
+    });
+  });
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const USER_COUNT_CUTOFF_DAYS = 5;
+
+const mockWorkspace = {
+  id: 1,
+  sId: "ws_123",
+  name: "Test Workspace",
+} as Parameters<typeof countEligibleUsersForFreeCredits>[0];
+
+describe("countElligibleUsersForFreeCredits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("new customers (subscription started within cutoff period)", () => {
+    it("returns 1 for subscription started today", async () => {
+      const result = await countEligibleUsersForFreeCredits(
+        mockWorkspace,
+        NOW_MS
+      );
+      expect(result).toBe(1);
+      expect(
+        MembershipResource.getMembersCountForWorkspace
+      ).not.toHaveBeenCalled();
+    });
+
+    it("returns 1 for subscription started 4 days ago", async () => {
+      const subscriptionStartMs = NOW_MS - 4 * DAY_MS;
+      const result = await countEligibleUsersForFreeCredits(
+        mockWorkspace,
+        subscriptionStartMs
+      );
+      expect(result).toBe(1);
+      expect(
+        MembershipResource.getMembersCountForWorkspace
+      ).not.toHaveBeenCalled();
+    });
+
+    it("returns 1 for subscription started just under 5 days ago", async () => {
+      const subscriptionStartMs = NOW_MS - USER_COUNT_CUTOFF_DAYS * DAY_MS + 1;
+      const result = await countEligibleUsersForFreeCredits(
+        mockWorkspace,
+        subscriptionStartMs
+      );
+      expect(result).toBe(1);
+      expect(
+        MembershipResource.getMembersCountForWorkspace
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("existing customers (subscription started before cutoff period)", () => {
+    it("counts members for subscription started exactly 5 days ago", async () => {
+      vi.mocked(
+        MembershipResource.getMembersCountForWorkspace
+      ).mockResolvedValue(15);
+      const subscriptionStartMs = NOW_MS - USER_COUNT_CUTOFF_DAYS * DAY_MS;
+      const result = await countEligibleUsersForFreeCredits(
+        mockWorkspace,
+        subscriptionStartMs
+      );
+      expect(result).toBe(15);
+      expect(
+        MembershipResource.getMembersCountForWorkspace
+      ).toHaveBeenCalledWith({
+        workspace: expect.objectContaining({ sId: "ws_123" }),
+        activeOnly: true,
+        membershipSpan: {
+          fromDate: new Date(NOW_MS - USER_COUNT_CUTOFF_DAYS * DAY_MS),
+          toDate: new Date(NOW_MS - USER_COUNT_CUTOFF_DAYS * DAY_MS),
+        },
+      });
+    });
+
+    it("counts members for subscription started 30 days ago", async () => {
+      vi.mocked(
+        MembershipResource.getMembersCountForWorkspace
+      ).mockResolvedValue(42);
+      const subscriptionStartMs = NOW_MS - 30 * DAY_MS;
+      const result = await countEligibleUsersForFreeCredits(
+        mockWorkspace,
+        subscriptionStartMs
+      );
+      expect(result).toBe(42);
+      expect(
+        MembershipResource.getMembersCountForWorkspace
+      ).toHaveBeenCalledWith({
+        workspace: expect.objectContaining({ sId: "ws_123" }),
+        activeOnly: true,
+        membershipSpan: {
+          fromDate: new Date(NOW_MS - USER_COUNT_CUTOFF_DAYS * DAY_MS),
+          toDate: new Date(NOW_MS - USER_COUNT_CUTOFF_DAYS * DAY_MS),
+        },
+      });
     });
   });
 });

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -31,6 +31,15 @@ const USER_COUNT_CUTOFF = 5 * 24 * 60 * 60 * 1000;
 
 type CustomerStatus = "paying" | "trialing";
 
+/**
+ * Returns true if
+ * Customer's subscription is in trial
+ * OR if customer's subscription is less than one month old
+ * This is done so that customers who recently converted still get
+ * the trial 5$ credit on their new billing cycle
+ * (triggered when converted to from trial to active)
+ * This is required because of race conditions between Stripe's subscription.updated and invoice.paid
+ */
 function isTrialingOrNewCustomer(
   stripeSubscription: Stripe.Subscription
 ): boolean {

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -79,28 +79,18 @@ export async function countEligibleUsersForFreeCredits(
 /**
  * For enterprise: always eligible
  * For pro:
- *    if you are a new (incl. trial) or returning customer (subscription started 2 months ago), eligible
- *    else, if you are a "good payer" (last paid subscription invoice less than 2 months ago), eligible
+ *   if you are a "good payer" (last paid subscription invoice less than 2 months ago), eligible
  * Otherwise, not eligible
  */
 export async function isSubscriptionEligibleForFreeCredits(
   stripeSubscription: Stripe.Subscription
 ): Promise<boolean> {
-  const twoMonthsAgo = Date.now() - 2 * MONTHLY_BILLING_CYCLE_SECONDS * 1000;
-  const subscriptionStartMs = stripeSubscription.start_date * 1000;
-
-  // New customers (subscription started within last 2 months): always eligible
-  if (twoMonthsAgo <= subscriptionStartMs) {
-    return true;
-  }
-
-  // Existing customers: check if they have a recent paid invoice
   const paidInvoices = await getSubscriptionInvoices(stripeSubscription.id, {
     status: "paid",
     limit: 1,
   });
 
-  if (paidInvoices.length === 0) {
+  if (!paidInvoices || paidInvoices.length === 0) {
     return false;
   }
 


### PR DESCRIPTION
…ption trial

## Description

- Change the way we treat new subscription's free credit, especially the ones that are less than 5 days old
- Instead of taking the # of users, we will return a constant 1 user = 5$ of free credits

## Tests

Tested manually

## Risk

Risk: low
Blast radius: Small - All subscription renewal webhooks

## Deploy Plan

- [ ] Deploy front.