### PR TITLE
Simplify createAgentMessage

### DIFF
--- a/front/lib/api/assistant/conversation/agent_loop.ts
+++ b/front/lib/api/assistant/conversation/agent_loop.ts
@@ -2,13 +2,11 @@ import assert from "assert";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMessage } from "@app/lib/models/agent/conversation";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type {
   AgentMessageType,
   ConversationWithoutContentType,
-  ModelId,
   UserMessageType,
 } from "@app/types";
 
@@ -18,28 +16,17 @@ const MAX_CONCURRENT_AGENT_EXECUTIONS_PER_USER_MESSAGE = 10;
 export const runAgentLoopWorkflow = async ({
   auth,
   agentMessages,
-  agentMessageRowById,
   conversation,
   userMessage,
 }: {
   auth: Authenticator;
   agentMessages: AgentMessageType[];
-  agentMessageRowById: Map<ModelId, AgentMessage>;
   conversation: ConversationWithoutContentType;
   userMessage: UserMessageType;
 }) => {
   await concurrentExecutor(
     agentMessages,
     async (agentMessage) => {
-      // TODO(DURABLE-AGENTS 2025-07-16): Consolidate around agentMessage.
-      const agentMessageRow = agentMessageRowById.get(
-        agentMessage.agentMessageId
-      );
-      assert(
-        agentMessageRow,
-        `Agent message row not found for agent message ${agentMessage.agentMessageId}`
-      );
-
       const agentConfiguration = await getAgentConfiguration(auth, {
         agentId: agentMessage.configuration.sId,
         variant: "full",

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -91,9 +91,9 @@ describe("createAgentMessages", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].m.configuration.sId).toBe(agentConfig1.sId);
-    expect(result[0].m.status).toBe("created");
-    expect(result[0].m.skipToolsValidation).toBe(false);
+    expect(result[0].configuration.sId).toBe(agentConfig1.sId);
+    expect(result[0].status).toBe("created");
+    expect(result[0].skipToolsValidation).toBe(false);
 
     // Verify database records were created
     const mentionInDb = await Mention.findOne({
@@ -104,9 +104,21 @@ describe("createAgentMessages", () => {
     });
     expect(mentionInDb).not.toBeNull();
 
-    const agentMessageInDb = await AgentMessage.findByPk(result[0].row.id);
+    const agentMessageInDb = await AgentMessage.findByPk(
+      result[0].agentMessageId
+    );
     expect(agentMessageInDb).not.toBeNull();
     expect(agentMessageInDb?.status).toBe("created");
+
+    const messageInDb = await Message.findByPk(result[0].id);
+    expect(messageInDb).not.toBeNull();
+    expect(messageInDb?.rank).toBe(1);
+    expect(messageInDb?.parentId).toBe(messageRow.id);
+    expect(messageInDb?.agentMessageId).toBe(result[0].agentMessageId);
+    expect(messageInDb?.workspaceId).toBe(workspace.id);
+    expect(messageInDb?.visibility).toBe("visible");
+    expect(messageInDb?.version).toBe(0);
+    expect(messageInDb?.createdAt).toBeDefined();
   });
 
   it("should create multiple agent messages for multiple mentions", async () => {
@@ -141,8 +153,8 @@ describe("createAgentMessages", () => {
     });
 
     expect(result).toHaveLength(2);
-    expect(result[0].m.configuration.sId).toBe(agentConfig1.sId);
-    expect(result[1].m.configuration.sId).toBe(agentConfig2.sId);
+    expect(result[0].configuration.sId).toBe(agentConfig1.sId);
+    expect(result[1].configuration.sId).toBe(agentConfig2.sId);
 
     // Verify both mentions were created
     const mentionsInDb = await Mention.findAll({
@@ -186,7 +198,7 @@ describe("createAgentMessages", () => {
 
     // Should only create one agent message for the valid configuration
     expect(result).toHaveLength(1);
-    expect(result[0].m.configuration.sId).toBe(agentConfig1.sId);
+    expect(result[0].configuration.sId).toBe(agentConfig1.sId);
   });
 
   it("should return empty array when no agent mentions are provided", async () => {
@@ -241,8 +253,7 @@ describe("createAgentMessages", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].m.skipToolsValidation).toBe(true);
-    expect(result[0].row.skipToolsValidation).toBe(true);
+    expect(result[0].skipToolsValidation).toBe(true);
   });
 
   it("should set parentAgentMessageId when context origin is agent_handover", async () => {
@@ -278,7 +289,7 @@ describe("createAgentMessages", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].m.parentAgentMessageId).toBe(originMessageId);
+    expect(result[0].parentAgentMessageId).toBe(originMessageId);
   });
 
   it("should set parentAgentMessageId to null when context origin is not agent_handover", async () => {
@@ -310,7 +321,7 @@ describe("createAgentMessages", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].m.parentAgentMessageId).toBeNull();
+    expect(result[0].parentAgentMessageId).toBeNull();
   });
 
   it("should increment message rank correctly for multiple agent messages", async () => {
@@ -347,8 +358,8 @@ describe("createAgentMessages", () => {
 
     expect(result).toHaveLength(2);
     // Note: The function increments nextMessageRank internally, so ranks should be 10 and 11
-    expect(result[0].m.rank).toBe(nextMessageRank);
-    expect(result[1].m.rank).toBe(nextMessageRank + 1);
+    expect(result[0].rank).toBe(nextMessageRank);
+    expect(result[1].rank).toBe(nextMessageRank + 1);
   });
 });
 

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -394,9 +394,8 @@ export const createAgentMessages = async ({
       parentMessageId,
       parentAgentMessageId,
       configuration,
-    }) => ({
-      row: agentMessageRow,
-      m: {
+    }) =>
+      ({
         id: messageRow.id,
         agentMessageId: agentMessageRow.id,
         created: agentMessageRow.createdAt.getTime(),
@@ -419,7 +418,6 @@ export const createAgentMessages = async ({
         contents: [],
         parsedContents: {},
         modelInteractionDurationMs: agentMessageRow.modelInteractionDurationMs,
-      } satisfies AgentMessageType,
-    })
+      }) satisfies AgentMessageType
   );
 };


### PR DESCRIPTION
## Description

Simplify create agent even further by directly returning the AgentMessageType without the db model instances (they were not really used).

## Tests

Local + green

## Risk

Low

## Deploy Plan

Deploy front