### PR TITLE
[front] - feat(feedback): notification

### DIFF
--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -97,13 +97,17 @@ export async function upsertMessageFeedback(
   const { agentMessage, feedback, agentConfiguration, isGlobalAgent } =
     feedbackWithConversationContext.value;
 
+  const agentConfigurationId = isGlobalAgent
+    ? agentMessage.agentConfigurationId
+    : agentConfiguration.sId;
+
   if (feedback) {
     await feedback.updateFields({
       content,
       thumbDirection,
       isConversationShared,
     });
-    return new Ok(undefined);
+    return new Ok({ agentConfigurationId });
   }
 
   try {
@@ -111,9 +115,7 @@ export async function upsertMessageFeedback(
       workspaceId: auth.getNonNullableWorkspace().id,
       // If the agent is global, we use the agent configuration id from the agent message
       // Otherwise, we use the agent configuration id from the agent configuration
-      agentConfigurationId: isGlobalAgent
-        ? agentMessage.agentConfigurationId
-        : agentConfiguration.sId,
+      agentConfigurationId,
       agentConfigurationVersion: agentMessage.agentConfigurationVersion,
       agentMessageId: agentMessage.id,
       userId: user.id,
@@ -125,7 +127,7 @@ export async function upsertMessageFeedback(
   } catch (e) {
     return new Err(normalizeError(e));
   }
-  return new Ok(undefined);
+  return new Ok({ agentConfigurationId });
 }
 
 /**

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -107,11 +107,14 @@ export async function upsertMessageFeedback(
       thumbDirection,
       isConversationShared,
     });
-    return new Ok({ agentConfigurationId });
+    return new Ok({
+      agentConfigurationId,
+      feedbackId: feedback.sId,
+    });
   }
 
   try {
-    await AgentMessageFeedbackResource.makeNew({
+    const newFeedback = await AgentMessageFeedbackResource.makeNew({
       workspaceId: auth.getNonNullableWorkspace().id,
       // If the agent is global, we use the agent configuration id from the agent message
       // Otherwise, we use the agent configuration id from the agent configuration
@@ -124,10 +127,13 @@ export async function upsertMessageFeedback(
       isConversationShared: isConversationShared ?? false,
       dismissed: false,
     });
+    return new Ok({
+      agentConfigurationId,
+      feedbackId: newFeedback.sId,
+    });
   } catch (e) {
     return new Err(normalizeError(e));
   }
-  return new Ok({ agentConfigurationId });
 }
 
 /**

--- a/front/lib/notifications/email-templates/agent-message-feedback-digest.tsx
+++ b/front/lib/notifications/email-templates/agent-message-feedback-digest.tsx
@@ -1,0 +1,104 @@
+import { render } from "@react-email/render";
+import * as React from "react";
+import { z } from "zod";
+
+import { EmailLayout } from "@app/lib/notifications/email-templates/_layout";
+import { getConversationRoute } from "@app/lib/utils/router";
+
+export const AgentMessageFeedbackDigestEmailTemplatePropsSchema = z.object({
+  name: z.string(),
+  workspace: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+  feedbacks: z.array(
+    z.object({
+      agentName: z.string(),
+      conversationId: z.string(),
+      conversationTitle: z.string(),
+      userWhoGaveFeedbackFullName: z.string(),
+      thumbDirection: z.union([z.literal("up"), z.literal("down")]),
+      feedbackContent: z.string().optional(),
+    })
+  ),
+});
+
+type AgentMessageFeedbackDigestEmailTemplateProps = z.infer<
+  typeof AgentMessageFeedbackDigestEmailTemplatePropsSchema
+>;
+
+const AgentMessageFeedbackDigestEmailTemplate = ({
+  name,
+  workspace,
+  feedbacks,
+}: AgentMessageFeedbackDigestEmailTemplateProps) => {
+  const positiveCount = feedbacks.filter(
+    (f) => f.thumbDirection === "up"
+  ).length;
+  const negativeCount = feedbacks.filter(
+    (f) => f.thumbDirection === "down"
+  ).length;
+
+  return (
+    <EmailLayout workspace={workspace}>
+      <h3>Hi {name},</h3>
+      <p>
+        You received {feedbacks.length} feedback
+        {feedbacks.length > 1 ? "s" : ""} on your agents today:
+      </p>
+      <p style={{ marginBottom: "20px" }}>
+        👍 {positiveCount} positive • 👎 {negativeCount} negative
+      </p>
+      <ul style={{ listStyle: "none", padding: 0 }}>
+        {feedbacks.map((feedback, index) => (
+          <li
+            key={index}
+            style={{
+              marginBottom: "20px",
+              borderBottom: "1px solid #e0e0e0",
+              paddingBottom: "15px",
+            }}
+          >
+            <div>
+              <strong>
+                {feedback.thumbDirection === "up" ? "👍" : "👎"}{" "}
+                {feedback.agentName}
+              </strong>
+            </div>
+            <div style={{ color: "#666", fontSize: "14px", marginTop: "5px" }}>
+              by {feedback.userWhoGaveFeedbackFullName} in{" "}
+              <a
+                href={
+                  process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL +
+                  getConversationRoute(workspace.id, feedback.conversationId)
+                }
+                target="_blank"
+              >
+                {feedback.conversationTitle}
+              </a>
+            </div>
+            {feedback.feedbackContent && (
+              <div
+                style={{
+                  marginTop: "8px",
+                  padding: "10px",
+                  backgroundColor: "#f5f5f5",
+                  borderRadius: "4px",
+                  fontStyle: "italic",
+                }}
+              >
+                "{feedback.feedbackContent}"
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </EmailLayout>
+  );
+};
+
+export function renderEmail(
+  args: AgentMessageFeedbackDigestEmailTemplateProps
+) {
+  return render(<AgentMessageFeedbackDigestEmailTemplate {...args} />);
+}

--- a/front/lib/notifications/workflows/agent-message-feedback.ts
+++ b/front/lib/notifications/workflows/agent-message-feedback.ts
@@ -1,0 +1,410 @@
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
+import { getEditors } from "@app/lib/api/assistant/editors";
+import { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import type { NotificationAllowedTags } from "@app/lib/notifications";
+import { getNovuClient } from "@app/lib/notifications";
+import { renderEmail as renderDigestEmail } from "@app/lib/notifications/email-templates/agent-message-feedback-digest";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { getConversationRoute } from "@app/lib/utils/router";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, isDevelopment, Ok } from "@app/types";
+
+const AgentMessageFeedbackPayloadSchema = z.object({
+  workspaceId: z.string(),
+  conversationId: z.string(),
+  messageId: z.string(),
+  agentConfigurationId: z.string(),
+  userWhoGaveFeedbackId: z.string(),
+  thumbDirection: z.union([z.literal("up"), z.literal("down")]),
+  feedbackContent: z.string().optional(),
+});
+
+type AgentMessageFeedbackPayloadType = z.infer<
+  typeof AgentMessageFeedbackPayloadSchema
+>;
+
+const isAgentMessageFeedbackPayload = (
+  payload: unknown
+): payload is AgentMessageFeedbackPayloadType => {
+  return AgentMessageFeedbackPayloadSchema.safeParse(payload).success;
+};
+
+const AGENT_MESSAGE_FEEDBACK_TRIGGER_ID = "agent-message-feedback";
+
+const FeedbackDetailsSchema = z.object({
+  conversationTitle: z.string(),
+  userWhoGaveFeedbackFullName: z.string(),
+  agentName: z.string(),
+  workspaceName: z.string(),
+});
+
+type FeedbackDetailsType = z.infer<typeof FeedbackDetailsSchema>;
+
+const getFeedbackDetails = async ({
+  subscriberId,
+  payload,
+}: {
+  subscriberId?: string | null;
+  payload: AgentMessageFeedbackPayloadType;
+}): Promise<FeedbackDetailsType> => {
+  let conversationTitle: string = "A conversation";
+  let userWhoGaveFeedbackFullName: string = "Someone";
+  let agentName: string = "an agent";
+  let workspaceName: string = "A workspace";
+
+  if (subscriberId) {
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      subscriberId,
+      payload.workspaceId
+    );
+
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      payload.conversationId
+    );
+
+    if (conversation) {
+      workspaceName = auth.getNonNullableWorkspace().name;
+      conversationTitle = conversation.title ?? "Dust conversation";
+
+      const userWhoGaveFeedback = await UserResource.fetchById(
+        payload.userWhoGaveFeedbackId
+      );
+
+      if (userWhoGaveFeedback) {
+        userWhoGaveFeedbackFullName = userWhoGaveFeedback.fullName();
+      }
+
+      const agentConfiguration = await getAgentConfiguration(auth, {
+        agentId: payload.agentConfigurationId,
+        variant: "light",
+      });
+
+      if (agentConfiguration) {
+        agentName = `@${agentConfiguration.name}`;
+      }
+    }
+  }
+
+  return {
+    conversationTitle,
+    userWhoGaveFeedbackFullName,
+    agentName,
+    workspaceName,
+  };
+};
+
+const shouldSkipNotification = async ({
+  subscriberId,
+  payload,
+}: {
+  subscriberId?: string | null;
+  payload: AgentMessageFeedbackPayloadType;
+}): Promise<boolean> => {
+  if (!subscriberId) {
+    return true;
+  }
+
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    subscriberId,
+    payload.workspaceId
+  );
+
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    payload.conversationId
+  );
+
+  if (!conversation) {
+    return true;
+  }
+
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: payload.agentConfigurationId,
+    variant: "light",
+  });
+
+  return !agentConfiguration;
+};
+
+export const agentMessageFeedbackWorkflow = workflow(
+  AGENT_MESSAGE_FEEDBACK_TRIGGER_ID,
+  async ({ step, payload, subscriber }) => {
+    const details = await step.custom(
+      "get-feedback-details",
+      async () => {
+        return getFeedbackDetails({
+          subscriberId: subscriber.subscriberId,
+          payload,
+        });
+      },
+      {
+        outputSchema: FeedbackDetailsSchema,
+      }
+    );
+
+    await step.inApp(
+      "send-in-app",
+      async () => {
+        return {
+          subject: `New feedback on ${details.agentName}`,
+          body: `${details.userWhoGaveFeedbackFullName} left a ${payload.thumbDirection === "up" ? "positive" : "negative"} feedback on ${details.agentName}.`,
+          primaryAction: {
+            label: "View",
+            redirect: {
+              url: getConversationRoute(
+                payload.workspaceId,
+                payload.conversationId
+              ),
+            },
+          },
+          data: {
+            autoDelete: true,
+            conversationId: payload.conversationId,
+          },
+        };
+      },
+      {
+        skip: async () =>
+          shouldSkipNotification({
+            subscriberId: subscriber.subscriberId,
+            payload,
+          }),
+      }
+    );
+
+    const { events } = await step.digest(
+      "digest",
+      async () => {
+        const digestKey = `${subscriber.subscriberId}-workspace-${payload.workspaceId}-agent-feedbacks`;
+        return isDevelopment()
+          ? {
+              amount: 2,
+              unit: "minutes",
+              digestKey,
+            }
+          : {
+              amount: 1,
+              unit: "days",
+              digestKey,
+            };
+      },
+      {
+        skip: async () =>
+          shouldSkipNotification({
+            subscriberId: subscriber.subscriberId,
+            payload,
+          }),
+      }
+    );
+
+    await step.email(
+      "send-email",
+      async () => {
+        const feedbacks: Parameters<typeof renderDigestEmail>[0]["feedbacks"] =
+          [];
+
+        for (const event of events) {
+          if (!isAgentMessageFeedbackPayload(event.payload)) {
+            continue;
+          }
+
+          const shouldSkip = await shouldSkipNotification({
+            subscriberId: subscriber.subscriberId,
+            payload: event.payload,
+          });
+          if (shouldSkip) {
+            continue;
+          }
+
+          const eventDetails = await getFeedbackDetails({
+            subscriberId: subscriber.subscriberId,
+            payload: event.payload,
+          });
+
+          feedbacks.push({
+            agentName: eventDetails.agentName,
+            conversationId: event.payload.conversationId,
+            conversationTitle: eventDetails.conversationTitle,
+            userWhoGaveFeedbackFullName:
+              eventDetails.userWhoGaveFeedbackFullName,
+            thumbDirection: event.payload.thumbDirection,
+            feedbackContent: event.payload.feedbackContent,
+          });
+        }
+
+        const positiveCount = feedbacks.filter(
+          (f) => f.thumbDirection === "up"
+        ).length;
+        const negativeCount = feedbacks.filter(
+          (f) => f.thumbDirection === "down"
+        ).length;
+
+        const body = await renderDigestEmail({
+          name: subscriber.firstName ?? "You",
+          workspace: {
+            id: payload.workspaceId,
+            name: details.workspaceName,
+          },
+          feedbacks,
+        });
+
+        return {
+          subject: `[Dust] ${feedbacks.length} feedback${feedbacks.length > 1 ? "s" : ""} on your agents (👍 ${positiveCount} - 👎 ${negativeCount})`,
+          body,
+        };
+      },
+      {
+        skip: async () => {
+          const validEvents = events.filter((event) =>
+            isAgentMessageFeedbackPayload(event.payload)
+          );
+
+          if (validEvents.length === 0) {
+            return true;
+          }
+
+          const shouldSkip = await Promise.all(
+            validEvents.map(async (event) => {
+              if (!isAgentMessageFeedbackPayload(event.payload)) {
+                return true;
+              }
+              return shouldSkipNotification({
+                subscriberId: subscriber.subscriberId,
+                payload: event.payload,
+              });
+            })
+          );
+
+          // Skip email if all events should be skipped (meaning 0 valid feedbacks)
+          return shouldSkip.every(Boolean);
+        },
+      }
+    );
+  },
+  {
+    payloadSchema: AgentMessageFeedbackPayloadSchema,
+    tags: ["conversations"] as NotificationAllowedTags,
+  }
+);
+
+export const triggerAgentMessageFeedbackNotification = async (
+  auth: Authenticator,
+  {
+    conversationId,
+    messageId,
+    agentConfigurationId,
+    thumbDirection,
+    feedbackContent,
+  }: {
+    conversationId: string;
+    messageId: string;
+    agentConfigurationId: string;
+    thumbDirection: AgentMessageFeedbackDirection;
+    feedbackContent?: string;
+  }
+): Promise<Result<void, DustError<"internal_error">>> => {
+  const userWhoGaveFeedback = auth.user();
+
+  if (!userWhoGaveFeedback) {
+    return new Ok(undefined);
+  }
+
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+
+  if (!conversation) {
+    return new Err(new DustError("internal_error", "Conversation not found"));
+  }
+
+  if (conversation.depth > 0) {
+    logger.info(
+      { conversationDepth: conversation.depth },
+      "Skipping notification for sub-conversation"
+    );
+    return new Ok(undefined);
+  }
+
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
+
+  if (!agentConfiguration) {
+    return new Err(
+      new DustError("internal_error", "Agent configuration not found")
+    );
+  }
+
+  const editors = await getEditors(auth, agentConfiguration);
+
+  if (editors.length === 0) {
+    logger.info(
+      { agentConfigurationId },
+      "No editors found for agent, skipping notification"
+    );
+    return new Ok(undefined);
+  }
+
+  // In development, allow sending notifications to yourself for debugging
+  const editorsToNotify = isDevelopment()
+    ? editors
+    : editors.filter((editor) => editor.sId !== userWhoGaveFeedback.sId);
+
+  if (editorsToNotify.length === 0) {
+    return new Ok(undefined);
+  }
+
+  try {
+    const novuClient = await getNovuClient();
+
+    const payload: AgentMessageFeedbackPayloadType = {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      conversationId,
+      messageId,
+      agentConfigurationId,
+      userWhoGaveFeedbackId: userWhoGaveFeedback.sId,
+      thumbDirection,
+      ...(feedbackContent ? { feedbackContent } : {}),
+    };
+
+    const r = await novuClient.bulkTrigger(
+      editorsToNotify.map((editor) => ({
+        name: AGENT_MESSAGE_FEEDBACK_TRIGGER_ID,
+        to: {
+          subscriberId: editor.sId,
+          email: editor.email,
+          firstName: editor.firstName ?? undefined,
+          lastName: editor.lastName ?? undefined,
+        },
+        payload,
+      }))
+    );
+
+    if (r.status !== 200) {
+      return new Err({
+        name: "dust_error",
+        code: "internal_error",
+        message: `Failed to trigger agent message feedback notification: status=${r.status}`,
+      });
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (error) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_error",
+      message: "Failed to trigger agent message feedback notification",
+    });
+  }
+
+  return new Ok(undefined);
+};

--- a/front/lib/notifications/workflows/agent-message-feedback.ts
+++ b/front/lib/notifications/workflows/agent-message-feedback.ts
@@ -191,8 +191,7 @@ export const agentMessageFeedbackWorkflow = workflow(
               digestKey,
             }
           : {
-              amount: 1,
-              unit: "days",
+              cron: "0 9 * * *", // Every day at 9:00 AM UTC
               digestKey,
             };
       },

--- a/front/pages/api/novu/index.ts
+++ b/front/pages/api/novu/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "@novu/framework/next";
 
+import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/agent-message-feedback";
 import { conversationAddedAsParticipantWorkflow } from "@app/lib/notifications/workflows/conversation-added-as-participant";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";
 
@@ -12,5 +13,6 @@ export default serve({
   workflows: [
     conversationUnreadWorkflow,
     conversationAddedAsParticipantWorkflow,
+    agentMessageFeedbackWorkflow,
   ],
 });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
@@ -253,20 +253,22 @@ async function handler(
         });
       }
 
-      await launchAgentMessageFeedbackWorkflow(auth, {
-        message: {
+      await Promise.all([
+        launchAgentMessageFeedbackWorkflow(auth, {
+          message: {
+            conversationId: conversation.sId,
+            agentMessageId: messageId,
+          },
+        }),
+        triggerAgentMessageFeedbackNotification(auth, {
           conversationId: conversation.sId,
-          agentMessageId: messageId,
-        },
-      });
+          messageId,
+          agentConfigurationId: created.value.agentConfigurationId,
+          thumbDirection: bodyValidation.right.thumbDirection,
+          feedbackContent: bodyValidation.right.feedbackContent ?? undefined,
+        }),
+      ]);
 
-      await triggerAgentMessageFeedbackNotification(auth, {
-        conversationId: conversation.sId,
-        messageId,
-        agentConfigurationId: created.value.agentConfigurationId,
-        thumbDirection: bodyValidation.right.thumbDirection,
-        feedbackContent: bodyValidation.right.feedbackContent ?? undefined,
-      });
       res.status(200).json({ success: true });
       return;
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
@@ -269,7 +269,7 @@ async function handler(
           messageId,
           agentConfigurationId: created.value.agentConfigurationId,
           thumbDirection: bodyValidation.right.thumbDirection,
-          feedbackContent: bodyValidation.right.feedbackContent ?? undefined,
+          feedbackId: created.value.feedbackId,
         });
       }
       res.status(200).json({ success: true });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
@@ -4,7 +4,6 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import {
   deleteMessageFeedback,
@@ -12,6 +11,7 @@ import {
 } from "@app/lib/api/assistant/feedback";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { triggerAgentMessageFeedbackNotification } from "@app/lib/notifications/workflows/agent-message-feedback";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -20,8 +20,10 @@ import { launchAgentMessageFeedbackWorkflow } from "@app/temporal/analytics_queu
 import type { WithAPIErrorResponse } from "@app/types";
 import { getUserEmailFromHeaders } from "@app/types/user";
 
+const ThumbDirectionCodec = t.union([t.literal("up"), t.literal("down")]);
+
 export const MessageFeedbackRequestBodySchema = t.type({
-  thumbDirection: t.string,
+  thumbDirection: ThumbDirectionCodec,
   feedbackContent: t.union([t.string, t.undefined, t.null]),
   isConversationShared: t.union([t.boolean, t.undefined]),
 });
@@ -235,8 +237,7 @@ async function handler(
         messageId,
         conversation,
         user,
-        thumbDirection: bodyValidation.right
-          .thumbDirection as AgentMessageFeedbackDirection,
+        thumbDirection: bodyValidation.right.thumbDirection,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         content: bodyValidation.right.feedbackContent || "",
         isConversationShared: bodyValidation.right.isConversationShared,
@@ -259,6 +260,13 @@ async function handler(
         },
       });
 
+      await triggerAgentMessageFeedbackNotification(auth, {
+        conversationId: conversation.sId,
+        messageId,
+        agentConfigurationId: created.value.agentConfigurationId,
+        thumbDirection: bodyValidation.right.thumbDirection,
+        feedbackContent: bodyValidation.right.feedbackContent ?? undefined,
+      });
       res.status(200).json({ success: true });
       return;
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -122,7 +122,7 @@ async function handler(
           agentConfigurationId: created.value.agentConfigurationId,
           thumbDirection: bodyValidation.right
             .thumbDirection as AgentMessageFeedbackDirection,
-          feedbackContent: bodyValidation.right.feedbackContent ?? undefined,
+          feedbackId: created.value.feedbackId,
         });
       }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/api/assistant/feedback";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { triggerAgentMessageFeedbackNotification } from "@app/lib/notifications/workflows/agent-message-feedback";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import { launchAgentMessageFeedbackWorkflow } from "@app/temporal/analytics_queue/client";
@@ -108,6 +109,15 @@ async function handler(
           agentMessageId: messageId,
           conversationId: conversation.sId,
         },
+      });
+
+      const r = await triggerAgentMessageFeedbackNotification(auth, {
+        conversationId: conversation.sId,
+        messageId,
+        agentConfigurationId: created.value.agentConfigurationId,
+        thumbDirection: bodyValidation.right
+          .thumbDirection as AgentMessageFeedbackDirection,
+        feedbackContent: bodyValidation.right.feedbackContent ?? undefined,
       });
 
       res.status(200).json({ success: true });


### PR DESCRIPTION





## Description

Adds notification workflow for agent message feedback. When users give feedback (thumbs up/down) on agent responses, editors of the agent are now notified via in-app notifications and receive a daily email digest summarizing all feedback received. The workflow is triggered after feedback is submitted and skips notifications for sub-conversations and when users give feedback on their own agents. Behind the `notifications` feature flag.

## Risk

None. The feature is behind a feature flag and only affects workspaces where it's enabled.

## Tests

Manually tested with feature flag enabled. The workflow triggers in-app notifications immediately and emails are digested daily at 9:00 AM UTC (2 minutes in dev).

## Deploy Plan
Deploy front