### PR TITLE
Fixed url paste

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -436,7 +436,12 @@ const InputBarContainer = ({
   );
 
   useEffect(() => {
-    if (!nodeOrUrlCandidate || !onNodeSelect || isSearchLoading) {
+    if (
+      !nodeOrUrlCandidate ||
+      !onNodeSelect ||
+      isSearchLoading ||
+      isSpacesLoading
+    ) {
       return;
     }
 
@@ -487,6 +492,7 @@ const InputBarContainer = ({
     spacesMap,
     nodeOrUrlCandidate,
     sendNotification,
+    isSpacesLoading,
   ]);
 
   // When input bar animation is requested, it means the new button was clicked (removing focus from


### PR DESCRIPTION
## Description

We need to also check isSpaceLoading - space loading is disabled until a url is pasted, and search is diabled if spaces are not loaded. So full sequence when pasting the first time is 1/ loading spaces 2/ searching 3/ show result and reset url candidate. Right now we enter in the effect when spaces are loading (as search is not loading yet, wiaiting for spaces). Works the second time as spaces are already loaded.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

front
