### PR TITLE
[front] Fix cents/USD conversion in programmatic usage tracking

### DIFF
--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -258,7 +258,7 @@ export async function trackProgrammaticCost(
   const runsCostUsd = runUsages
     .flat()
     .reduce((acc, usage) => acc + usage.costUsd, 0);
-  const runsCostCents = runsCostUsd > 0 ? Math.ceil(runsCostUsd * 100) : 0;
+  const runsCostCents = runsCostUsd > 0 ? Math.ceil(runsCostUsd) : 0;
 
   await decreaseProgrammaticCredits(
     auth.getNonNullableWorkspace(),


### PR DESCRIPTION
## Description

Fixes regression introduced in https://github.com/dust-tt/dust/pull/18124.

The `costUsd` field stores values in cents (despite the field name suggesting USD). PR #18124 introduced a `* 100` multiplication thinking it was converting USD to cents, but this resulted in values 100x too large being passed to `decreaseProgrammaticCredits`.

## Risks

Blast radius: programmatic usage tracking/billing for API users
Risk: low (one-line fix reverting incorrect conversion)

## Deploy Plan

- deploy front