### PR TITLE
POC Universal search (not to be merged as is)

### DIFF
--- a/front/lib/actions/mcp_internal_actions/search/search_google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/search/search_google_drive.ts
@@ -1,0 +1,170 @@
+import { google } from "googleapis";
+
+import type { ContentNodeType } from "@app/types";
+
+import type {
+  SearchableProvider,
+  ToolAttachment,
+  ToolSearchRawNode,
+} from "./types";
+
+const SUPPORTED_MIMETYPES = [
+  "application/vnd.google-apps.document",
+  "application/vnd.google-apps.presentation",
+  "application/vnd.google-apps.spreadsheet",
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/pdf",
+];
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB.
+
+function getClient(accessToken: string) {
+  const oauth2Client = new google.auth.OAuth2();
+  oauth2Client.setCredentials({ access_token: accessToken });
+  return google.drive({ version: "v3", auth: oauth2Client });
+}
+
+async function search({
+  accessToken,
+  query,
+  pageSize,
+}: {
+  accessToken: string;
+  query: string;
+  pageSize: number;
+}): Promise<ToolSearchRawNode[]> {
+  const drive = getClient(accessToken);
+
+  const searchQuery = `(name contains '${query.replace(/'/g, "\\'")}' or fullText contains '${query.replace(/'/g, "\\'")}') and trashed = false`;
+
+  const res = await drive.files.list({
+    q: searchQuery,
+    pageSize: Math.min(pageSize, 100),
+    fields: "files(id, name, mimeType)",
+    includeItemsFromAllDrives: true,
+    supportsAllDrives: true,
+    corpora: "allDrives",
+    orderBy: "modifiedTime desc",
+  });
+
+  return (res.data.files ?? []).map((file) => {
+    const mimeType = file.mimeType ?? "application/octet-stream";
+    let type: ContentNodeType = "document";
+    if (mimeType === "application/vnd.google-apps.folder") {
+      type = "folder";
+    } else if (
+      mimeType === "application/vnd.google-apps.spreadsheet" ||
+      mimeType === "text/csv"
+    ) {
+      type = "table";
+    }
+    return {
+      internalId: file.id ?? "",
+      mimeType,
+      title: file.name ?? "Untitled",
+      type,
+    };
+  });
+}
+
+async function getFile({
+  accessToken,
+  fileId,
+}: {
+  accessToken: string;
+  fileId: string;
+}): Promise<ToolAttachment> {
+  const drive = getClient(accessToken);
+
+  const fileMetadata = await drive.files.get({
+    fileId,
+    supportsAllDrives: true,
+    fields: "id, name, mimeType, size",
+  });
+  const file = fileMetadata.data;
+
+  if (!file.mimeType || !SUPPORTED_MIMETYPES.includes(file.mimeType)) {
+    throw new Error(
+      `Unsupported file type: ${file.mimeType}. Supported types: ${SUPPORTED_MIMETYPES.join(", ")}`
+    );
+  }
+
+  if (file.size && parseInt(file.size, 10) > MAX_FILE_SIZE) {
+    throw new Error(
+      `File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)} MB for attachments.`
+    );
+  }
+
+  let fileName = file.name ?? "untitled";
+  let content: Buffer;
+  let mimeType: string;
+
+  switch (file.mimeType) {
+    case "application/vnd.google-apps.document":
+    case "application/vnd.google-apps.presentation": {
+      const res = await drive.files.export(
+        { fileId, mimeType: "text/plain" },
+        { responseType: "text" }
+      );
+      content = Buffer.from(res.data as string, "utf-8");
+      mimeType = "text/plain";
+      if (!fileName.endsWith(".txt")) {
+        fileName = `${fileName}.txt`;
+      }
+      break;
+    }
+    case "application/vnd.google-apps.spreadsheet": {
+      const res = await drive.files.export(
+        { fileId, mimeType: "text/csv" },
+        { responseType: "text" }
+      );
+      content = Buffer.from(res.data as string, "utf-8");
+      mimeType = "text/csv";
+      if (!fileName.endsWith(".csv")) {
+        fileName = `${fileName}.csv`;
+      }
+      break;
+    }
+    case "application/pdf": {
+      const res = await drive.files.get(
+        { fileId, alt: "media" },
+        { responseType: "arraybuffer" }
+      );
+      content = Buffer.from(res.data as ArrayBuffer);
+      mimeType = "application/pdf";
+      break;
+    }
+    case "text/plain":
+    case "text/markdown":
+    case "text/csv": {
+      const res = await drive.files.get(
+        { fileId, alt: "media" },
+        { responseType: "text" }
+      );
+      content = Buffer.from(res.data as string, "utf-8");
+      mimeType = file.mimeType;
+      break;
+    }
+    default:
+      throw new Error(`Unsupported file type: ${file.mimeType}`);
+  }
+
+  if (content.length > MAX_FILE_SIZE) {
+    throw new Error(
+      `File size exceeds the maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)} MB for attachments.`
+    );
+  }
+
+  return {
+    fileName,
+    mimeType,
+    contentBase64: content.toString("base64"),
+  };
+}
+
+export const googleDriveProvider: SearchableProvider = {
+  search,
+  getFile,
+};

--- a/front/lib/actions/mcp_internal_actions/search/service.ts
+++ b/front/lib/actions/mcp_internal_actions/search/service.ts
@@ -1,0 +1,140 @@
+import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
+import { googleDriveProvider } from "@app/lib/actions/mcp_internal_actions/search/search_google_drive";
+import type {
+  SearchableProvider,
+  ToolAttachment,
+  ToolSearchNode,
+} from "@app/lib/actions/mcp_internal_actions/search/types";
+import type { Authenticator } from "@app/lib/auth";
+import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+
+const SEARCHABLE_MCP_SERVERS = {
+  google_drive: googleDriveProvider,
+} as const satisfies Partial<
+  Record<InternalMCPServerNameType, SearchableProvider>
+>;
+type SearchableMCPServerNameType = keyof typeof SEARCHABLE_MCP_SERVERS;
+
+function _isSearchableMCPServer(
+  serverName: InternalMCPServerNameType
+): serverName is SearchableMCPServerNameType {
+  return serverName in SEARCHABLE_MCP_SERVERS;
+}
+
+async function _getProviderAndAccessToken(
+  auth: Authenticator,
+  serverView: MCPServerViewResource
+): Promise<{ provider: SearchableProvider; accessToken: string } | null> {
+  const r = getInternalMCPServerNameAndWorkspaceId(serverView.mcpServerId);
+  if (r.isErr() || !_isSearchableMCPServer(r.value.name)) {
+    return null;
+  }
+
+  const connectionType: MCPServerConnectionConnectionType =
+    serverView.oAuthUseCase === "platform_actions" ? "workspace" : "personal";
+
+  const connectionResult = await getConnectionForMCPServer(auth, {
+    mcpServerId: serverView.mcpServerId,
+    connectionType,
+  });
+
+  if (!connectionResult) {
+    return null;
+  }
+
+  return {
+    provider: SEARCHABLE_MCP_SERVERS[r.value.name],
+    accessToken: connectionResult.access_token,
+  };
+}
+
+export async function searchToolNodes({
+  auth,
+  query,
+  pageSize,
+}: {
+  auth: Authenticator;
+  query: string;
+  pageSize: number;
+}): Promise<ToolSearchNode[]> {
+  const spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
+  const serverViews = await MCPServerViewResource.listBySpaces(auth, spaces);
+
+  const searchableServerViews = serverViews.filter((view) => {
+    const r = getInternalMCPServerNameAndWorkspaceId(view.mcpServerId);
+    return r.isOk() && _isSearchableMCPServer(r.value.name);
+  });
+
+  if (searchableServerViews.length === 0) {
+    return [];
+  }
+
+  const results = await Promise.all(
+    searchableServerViews.map(async (serverView) => {
+      const result = await _getProviderAndAccessToken(auth, serverView);
+      if (!result) {
+        return [];
+      }
+
+      try {
+        const nodes = await result.provider.search({
+          accessToken: result.accessToken,
+          query,
+          pageSize,
+        });
+        const serverJson = serverView.toJSON();
+        return nodes.map((node) => ({
+          ...node,
+          serverViewId: serverView.sId,
+          serverName: serverJson.server.name,
+          serverIcon: serverJson.server.icon,
+        }));
+      } catch (error) {
+        const r = getInternalMCPServerNameAndWorkspaceId(
+          serverView.mcpServerId
+        );
+        logger.error(
+          {
+            error,
+            serverName: r.isOk() ? r.value.name : "unknown",
+            workspaceId: auth.getNonNullableWorkspace().sId,
+          },
+          "Error searching for attachments"
+        );
+        return [];
+      }
+    })
+  );
+
+  return results.flat();
+}
+
+export async function getFileToAttach({
+  auth,
+  serverViewId,
+  fileId,
+}: {
+  auth: Authenticator;
+  serverViewId: string;
+  fileId: string;
+}): Promise<ToolAttachment> {
+  const serverView = await MCPServerViewResource.fetchById(auth, serverViewId);
+  if (!serverView) {
+    throw new Error("Server view not found.");
+  }
+
+  const result = await _getProviderAndAccessToken(auth, serverView);
+  if (!result) {
+    throw new Error("Could not authenticate to retrieve the file to attach.");
+  }
+
+  return result.provider.getFile({
+    accessToken: result.accessToken,
+    fileId,
+  });
+}

--- a/front/lib/actions/mcp_internal_actions/search/types.ts
+++ b/front/lib/actions/mcp_internal_actions/search/types.ts
@@ -1,0 +1,41 @@
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
+import type { ContentNodeType } from "@app/types";
+
+export type ToolSearchRawNode = {
+  internalId: string;
+  title: string;
+  mimeType: string;
+  type: ContentNodeType;
+};
+
+export type ToolSearchNode = ToolSearchRawNode & {
+  serverViewId: string;
+  serverName: string;
+  serverIcon: CustomResourceIconType | InternalAllowedIconType;
+};
+
+export type ToolSeachResults = {
+  nodes: ToolSearchNode[];
+  resultsCount: number;
+};
+
+export type ToolAttachment = {
+  fileName: string;
+  mimeType: string;
+  contentBase64: string;
+};
+
+export type SearchableProvider = {
+  search: (params: {
+    accessToken: string;
+    query: string;
+    pageSize: number;
+  }) => Promise<ToolSearchRawNode[]>;
+  getFile: (params: {
+    accessToken: string;
+    fileId: string;
+  }) => Promise<ToolAttachment>;
+};

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -20,7 +20,7 @@ const SUPPORTED_MIMETYPES = [
 ];
 
 const MAX_CONTENT_SIZE = 32000; // Max characters to return for file content
-const MAX_FILE_SIZE = 64 * 1024 * 1024; // 10 MB max original file size
+const MAX_FILE_SIZE = 64 * 1024 * 1024; // 64 MB max original file size
 
 function createServer(
   auth: Authenticator,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -12,6 +12,10 @@ import {
   mcpServersSortingFn,
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
+import type {
+  ToolSeachResults,
+  ToolSearchNode,
+} from "@app/lib/actions/mcp_internal_actions/search/types";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import type { MCPServerTypeWithViews } from "@app/lib/api/mcp";
 import type {
@@ -1276,4 +1280,39 @@ export function useMCPServerViewsWithPersonalConnections({
           }),
     [connections, mcpServerViewsWithPersonalConnections]
   );
+}
+
+export function useToolAttachmentSearch({
+  owner,
+  query,
+  pageSize = 25,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  query: string;
+  pageSize?: number;
+  disabled?: boolean;
+}) {
+  const searchFetcher: Fetcher<ToolSeachResults> = fetcher;
+  const url =
+    query && query.length >= 3 && !disabled
+      ? `/api/w/${owner.sId}/mcp/search?query=${encodeURIComponent(query)}&pageSize=${pageSize}`
+      : null;
+
+  const { data, error, isLoading, isValidating } = useSWRWithDefaults(
+    url,
+    searchFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
+
+  return {
+    searchResults: data?.nodes ?? emptyArray<ToolSearchNode>(),
+    resultsCount: data?.resultsCount ?? 0,
+    isSearchLoading: isLoading,
+    isSearchValidating: isValidating,
+    isSearchError: error,
+  };
 }

--- a/front/pages/api/w/[wId]/mcp/search.ts
+++ b/front/pages/api/w/[wId]/mcp/search.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { searchToolNodes } from "@app/lib/actions/mcp_internal_actions/search/service";
+import type { ToolSeachResults } from "@app/lib/actions/mcp_internal_actions/search/types";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<ToolSeachResults>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { query, pageSize: pageSizeParam } = req.query;
+  if (typeof query !== "string" || query.length < 1) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Query parameter is required.",
+      },
+    });
+  }
+
+  const pageSize = pageSizeParam ? parseInt(pageSizeParam as string, 10) : 25;
+
+  try {
+    const nodes = await searchToolNodes({ auth, query, pageSize });
+
+    return res.status(200).json({
+      nodes,
+      resultsCount: nodes.length,
+    });
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Error in attachment search"
+    );
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to search for attachments: ${error instanceof Error ? error.message : "Unknown error"}`,
+      },
+    });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/mcp/views/[viewId]/attach.ts
+++ b/front/pages/api/w/[wId]/mcp/views/[viewId]/attach.ts
@@ -1,0 +1,67 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getFileToAttach } from "@app/lib/actions/mcp_internal_actions/search/service";
+import type { ToolAttachment } from "@app/lib/actions/mcp_internal_actions/search/types";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { normalizeError } from "@app/types";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<ToolAttachment>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { viewId, fileId } = req.query;
+  if (typeof viewId !== "string" || typeof fileId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "viewId and fileId are required.",
+      },
+    });
+  }
+
+  try {
+    const result = await getFileToAttach({
+      auth,
+      serverViewId: viewId,
+      fileId,
+    });
+
+    return res.status(200).json(result);
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        viewId,
+        fileId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Error fetching file for attachment"
+    );
+
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: normalizeError(error).message,
+      },
+    });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

 POC to Add search and attach functionality for MCP servers (starting with Google Drive):

  - New `/api/w/[wId]/mcp/search` endpoint to search across searchable MCP servers
  - New `/api/w/[wId]/mcp/views/[viewId]/attach` endpoint to fetch file content for attachment
  - Provider-based architecture for searchable MCP servers (SearchableProvider interface)
  - Updated InputBarAttachmentsPicker to display and select files from MCP search results alongside knowledge search
  - Google Drive provider implementation so we have one tool to test the flow. 

## Tests

Locally I can search and attach from my Google Drive mcp tool. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

I won't merge as is, if we go with that I would at least: 
- first put under a FF. 
- exclude a server if a Connection exists for this provider. 
- fix the preview