### PR TITLE
POC universal attachment in tool (not to merge)

### DIFF
--- a/front/lib/actions/mcp_attachments.ts
+++ b/front/lib/actions/mcp_attachments.ts
@@ -1,0 +1,177 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
+import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
+import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import type { ContentNode } from "@app/types";
+
+// Extends ContentNode with server view info inline rather than grouping results by server.
+// This keeps each node self-contained: serverViewId is needed to fetch the file content
+// (ensures we use the same connection as search), serverName/serverIcon are for display.
+export type ToolContentNode = ContentNode & {
+  serverViewId: string;
+  serverName: string;
+  serverIcon: CustomResourceIconType | InternalAllowedIconType;
+};
+
+export type SearchForAttachResponseBody = {
+  nodes: ToolContentNode[];
+  resultsCount: number;
+};
+
+export type GetFileToAttachResponse = {
+  fileId: string;
+  fileName: string;
+  originalMimeType: string;
+  exportedMimeType: string;
+  contentBase64: string;
+  contentSize: number;
+};
+
+async function _callMCPTool({
+  auth,
+  serverId,
+  accessToken,
+  toolName,
+  toolArgs,
+}: {
+  auth: Authenticator;
+  serverId: string;
+  accessToken: string;
+  toolName: string;
+  toolArgs: Record<string, unknown>;
+}): Promise<CallToolResult> {
+  const mcpClient = new Client({
+    name: "dust-mcp-client",
+    version: "1.0.0",
+  });
+
+  try {
+    const [clientTransport, serverTransport] =
+      InMemoryWithAuthTransport.createLinkedPair();
+
+    await connectToInternalMCPServer(serverId, serverTransport, auth);
+    await mcpClient.connect(clientTransport);
+
+    clientTransport.setAuthInfo({
+      token: accessToken,
+      clientId: "dust",
+      scopes: [],
+      extra: {},
+    });
+
+    const toolResult = await mcpClient.callTool(
+      { name: toolName, arguments: toolArgs },
+      CallToolResultSchema,
+      { timeout: 30000 }
+    );
+
+    // Type cast needed due to MCP SDK using Zod passthrough in CallToolResultSchema.
+    return toolResult as CallToolResult;
+  } finally {
+    await mcpClient.close();
+  }
+}
+
+function _getTextContent(
+  toolResult: CallToolResult
+): { type: "text"; text: string } | undefined {
+  const content = (toolResult.content as CallToolResult["content"]) ?? [];
+  return content.find(
+    (c): c is { type: "text"; text: string } => c.type === "text"
+  );
+}
+
+export async function searchServerForAttachments({
+  auth,
+  serverId,
+  query,
+  pageSize,
+  accessToken,
+}: {
+  auth: Authenticator;
+  serverId: string;
+  query: string;
+  pageSize: number;
+  accessToken: string;
+}): Promise<ContentNode[]> {
+  try {
+    const toolResult = await _callMCPTool({
+      auth,
+      serverId,
+      accessToken,
+      toolName: "search_for_attach",
+      toolArgs: { query, pageSize },
+    });
+
+    if (toolResult.isError) {
+      logger.warn(
+        {
+          serverId,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "Tool execution failed for search_for_attach"
+      );
+      return [];
+    }
+
+    const textContent = _getTextContent(toolResult);
+    if (!textContent) {
+      return [];
+    }
+
+    const result: { nodes: ContentNode[] } = JSON.parse(textContent.text);
+    return result.nodes;
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        serverId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Error searching server for attachments"
+    );
+    return [];
+  }
+}
+
+export async function getFileToAttach({
+  auth,
+  serverId,
+  fileId,
+  accessToken,
+}: {
+  auth: Authenticator;
+  serverId: string;
+  fileId: string;
+  accessToken: string;
+}): Promise<GetFileToAttachResponse> {
+  const toolResult = await _callMCPTool({
+    auth,
+    serverId,
+    accessToken,
+    toolName: "get_file_to_attach",
+    toolArgs: { fileId },
+  });
+
+  const textContent = _getTextContent(toolResult);
+
+  if (toolResult.isError) {
+    throw new Error(
+      `Failed to get file: ${textContent?.text ?? "Unknown error"}`
+    );
+  }
+
+  if (!textContent) {
+    throw new Error("No result returned from tool.");
+  }
+
+  return JSON.parse(textContent.text);
+}

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -912,10 +912,13 @@ The directive should be used to display a clickable version of the agent name in
     allowMultipleInstances: true,
     isRestricted: undefined,
     isPreview: false,
+    supportsAttachments: true,
     tools_stakes: {
       list_drives: "never_ask",
       search_files: "never_ask",
       get_file_content: "never_ask",
+      search_for_attach: "never_ask",
+      get_file_to_attach: "never_ask",
     },
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
@@ -1668,6 +1671,7 @@ The directive should be used to display a clickable version of the agent name in
     tools_retry_policies: Record<string, MCPToolRetryPolicyType> | undefined;
     timeoutMs: number | undefined;
     requiresBearerToken?: boolean;
+    supportsAttachments?: boolean;
     serverInfo: InternalMCPServerDefinitionType & { name: K };
   };
 };
@@ -1725,6 +1729,29 @@ export const allowsMultipleInstancesOfInternalMCPServerById = (
   }
   return !!INTERNAL_MCP_SERVERS[r.value.name].allowMultipleInstances;
 };
+
+export const supportsAttachmentsByInternalMCPServerName = (
+  name: InternalMCPServerNameType
+): boolean => {
+  return !!INTERNAL_MCP_SERVERS[name].supportsAttachments;
+};
+
+export const supportsAttachmentsByInternalMCPServerId = (
+  sId: string
+): boolean => {
+  const r = getInternalMCPServerNameAndWorkspaceId(sId);
+  if (r.isErr()) {
+    return false;
+  }
+  return supportsAttachmentsByInternalMCPServerName(r.value.name);
+};
+
+export const getInternalMCPServerNamesThatSupportAttachments =
+  (): InternalMCPServerNameType[] => {
+    return AVAILABLE_INTERNAL_MCP_SERVER_NAMES.filter((name) =>
+      supportsAttachmentsByInternalMCPServerName(name)
+    );
+  };
 
 export const getInternalMCPServerNameAndWorkspaceId = (
   sId: string

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -3,6 +3,10 @@ import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type {
+  SearchForAttachResponseBody,
+  ToolContentNode,
+} from "@app/lib/actions/mcp_attachments";
 import {
   getMcpServerViewDisplayName,
   mcpServerViewSortingFn,
@@ -1276,4 +1280,42 @@ export function useMCPServerViewsWithPersonalConnections({
           }),
     [connections, mcpServerViewsWithPersonalConnections]
   );
+}
+
+export type { ToolContentNode };
+
+export function useToolAttachmentSearch({
+  owner,
+  query,
+  pageSize = 25,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  query: string;
+  pageSize?: number;
+  disabled?: boolean;
+}) {
+  const searchFetcher: Fetcher<SearchForAttachResponseBody> = fetcher;
+
+  const url =
+    query && query.length >= 3 && !disabled
+      ? `/api/w/${owner.sId}/mcp/attachments/search?query=${encodeURIComponent(query)}&pageSize=${pageSize}`
+      : null;
+
+  const { data, error, isLoading, isValidating } = useSWRWithDefaults(
+    url,
+    searchFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
+
+  return {
+    searchResults: data?.nodes ?? emptyArray<ToolContentNode>(),
+    resultsCount: data?.resultsCount ?? 0,
+    isSearchLoading: isLoading,
+    isSearchValidating: isValidating,
+    isSearchError: error,
+  };
 }

--- a/front/pages/api/w/[wId]/mcp/attachments/search.ts
+++ b/front/pages/api/w/[wId]/mcp/attachments/search.ts
@@ -1,0 +1,123 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type {
+  SearchForAttachResponseBody,
+  ToolContentNode,
+} from "@app/lib/actions/mcp_attachments";
+import { searchServerForAttachments } from "@app/lib/actions/mcp_attachments";
+import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { supportsAttachmentsByInternalMCPServerId } from "@app/lib/actions/mcp_internal_actions/constants";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type { SearchForAttachResponseBody, ToolContentNode };
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<SearchForAttachResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { query, pageSize: pageSizeParam } = req.query;
+  if (typeof query !== "string" || query.length < 1) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Query parameter is required.",
+      },
+    });
+  }
+
+  const pageSize = pageSizeParam ? parseInt(pageSizeParam as string, 10) : 25;
+
+  try {
+    const spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
+    const serverViews = await MCPServerViewResource.listBySpaces(auth, spaces);
+    const attachmentServerViews = serverViews.filter((view) =>
+      supportsAttachmentsByInternalMCPServerId(view.mcpServerId)
+    );
+
+    if (attachmentServerViews.length === 0) {
+      return res.status(200).json({
+        nodes: [],
+        resultsCount: 0,
+      });
+    }
+
+    const results = await Promise.all(
+      attachmentServerViews.map(async (serverView) => {
+        const serverId = serverView.mcpServerId;
+        const connectionType: MCPServerConnectionConnectionType =
+          serverView.oAuthUseCase === "platform_actions"
+            ? "workspace"
+            : "personal";
+
+        const connectionResult = await getConnectionForMCPServer(auth, {
+          mcpServerId: serverId,
+          connectionType,
+        });
+
+        if (!connectionResult) {
+          return [];
+        }
+
+        const serverNodes = await searchServerForAttachments({
+          auth,
+          serverId,
+          query,
+          pageSize,
+          accessToken: connectionResult.access_token,
+        });
+
+        const serverJson = serverView.toJSON();
+        return serverNodes.map((node) => ({
+          ...node,
+          serverViewId: serverView.sId,
+          serverName: getMcpServerViewDisplayName(serverJson),
+          serverIcon: serverJson.server.icon,
+        }));
+      })
+    );
+
+    const allNodes = results.flat();
+
+    return res.status(200).json({
+      nodes: allNodes,
+      resultsCount: allNodes.length,
+    });
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Error in attachment search"
+    );
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to search for attachments: ${error instanceof Error ? error.message : "Unknown error"}`,
+      },
+    });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/mcp/views/[viewId]/attach.ts
+++ b/front/pages/api/w/[wId]/mcp/views/[viewId]/attach.ts
@@ -1,0 +1,108 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { GetFileToAttachResponse } from "@app/lib/actions/mcp_attachments";
+import { getFileToAttach } from "@app/lib/actions/mcp_attachments";
+import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
+import { supportsAttachmentsByInternalMCPServerId } from "@app/lib/actions/mcp_internal_actions/constants";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetFileToAttachResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { viewId, fileId } = req.query;
+  if (typeof viewId !== "string" || typeof fileId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "viewId and fileId are required.",
+      },
+    });
+  }
+
+  const serverView = await MCPServerViewResource.fetchById(auth, viewId);
+  if (!serverView) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "mcp_server_not_found",
+        message: "Server view not found.",
+      },
+    });
+  }
+  if (!supportsAttachmentsByInternalMCPServerId(serverView.mcpServerId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "This server does not support attachments.",
+      },
+    });
+  }
+
+  const serverId = serverView.mcpServerId;
+  const connectionType: MCPServerConnectionConnectionType =
+    serverView.oAuthUseCase === "platform_actions" ? "workspace" : "personal";
+  const connectionResult = await getConnectionForMCPServer(auth, {
+    mcpServerId: serverId,
+    connectionType,
+  });
+
+  if (!connectionResult) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "mcp_auth_error",
+        message: "Authentication required. Please connect your account first.",
+      },
+    });
+  }
+
+  try {
+    const result = await getFileToAttach({
+      auth,
+      serverId,
+      fileId,
+      accessToken: connectionResult.access_token,
+    });
+
+    return res.status(200).json(result);
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        serverId,
+        fileId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Error fetching file for attachment"
+    );
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch file: ${error instanceof Error ? error.message : "Unknown error"}`,
+      },
+    });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

First version of https://github.com/dust-tt/dust/pull/18527 that I decided to drop. 
But initially done in the mcp servers with new tools on MCP servers. 

One roughly implemented as is I dropped it because if feels too cracra: 
We don't want to call mcp tools that are supposed to be called in the agentic loop outside of it from a user action.
We don't want mcp tools that can't be called by agents

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Not to be merged