### PR TITLE
Chrisjow/add toolbar shortcuts

### DIFF
--- a/front/components/assistant/conversation/input_bar/toolbar/ToolbarContent.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/ToolbarContent.tsx
@@ -22,18 +22,21 @@ export function ToolBarContent({ editor }: { editor: Editor }) {
         onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
         active={editor.isActive("heading")}
         tooltip="Heading"
+        shortcut="Mod+Alt+1"
       />
       <ToolbarIcon
         icon={BoldIcon}
         onClick={() => editor.chain().focus().toggleBold().run()}
         active={editor.isActive("bold")}
         tooltip="Bold"
+        shortcut="Mod+B"
       />
       <ToolbarIcon
         icon={ItalicIcon}
         onClick={() => editor.chain().focus().toggleItalic().run()}
         active={editor.isActive("italic")}
         tooltip="Italic"
+        shortcut="Mod+I"
       />
 
       <Separator orientation="vertical" className="my-1" />
@@ -45,12 +48,14 @@ export function ToolBarContent({ editor }: { editor: Editor }) {
         onClick={() => editor.chain().focus().toggleBulletList().run()}
         active={editor.isActive("bulletList")}
         tooltip="Bulleted list"
+        shortcut="Mod+Shift+8"
       />
       <ToolbarIcon
         icon={ListOrdered2Icon}
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
         active={editor.isActive("orderedList")}
         tooltip="Ordered list"
+        shortcut="Mod+Shift+7"
       />
       <ToolbarIcon
         icon={QuoteTextIcon}
@@ -64,6 +69,7 @@ export function ToolBarContent({ editor }: { editor: Editor }) {
         }}
         active={editor.isActive("blockquote")}
         tooltip="Blockquote"
+        shortcut="Mod+Shift+9"
       />
 
       <Separator orientation="vertical" className="my-1" />
@@ -72,6 +78,7 @@ export function ToolBarContent({ editor }: { editor: Editor }) {
         onClick={() => editor.chain().focus().toggleCode().run()}
         active={editor.isActive("code")}
         tooltip="Inline code"
+        shortcut="Mod+E"
       />
       <ToolbarIcon
         icon={CodeBlockIcon}
@@ -85,6 +92,7 @@ export function ToolBarContent({ editor }: { editor: Editor }) {
         }}
         active={editor.isActive("codeBlock")}
         tooltip="Code block"
+        shortcut="Mod+Alt+C"
       />
     </>
   );

--- a/front/components/assistant/conversation/input_bar/toolbar/ToolbarIcon.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/ToolbarIcon.tsx
@@ -1,12 +1,15 @@
 import { Button } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
+import { useKeyboardShortcutLabel } from "@app/hooks/useKeyboardShortcutLabel";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
+
 interface ToolbarIconProps {
   icon: ComponentType<{ className?: string }>;
   onClick: () => void;
   active?: boolean;
   tooltip: string;
+  shortcut?: string;
 }
 
 export function ToolbarIcon({
@@ -14,12 +17,22 @@ export function ToolbarIcon({
   onClick,
   active,
   tooltip,
+  shortcut,
 }: ToolbarIconProps) {
   const isMobile = useIsMobile();
+  const shortcutLabel = useKeyboardShortcutLabel(shortcut);
   const buttonSize = isMobile ? "xs" : "mini";
+
+  let tooltipText = tooltip;
+  if (isMobile) {
+    tooltipText = ""; // No tooltips on mobile
+  } else if (shortcutLabel) {
+    tooltipText = `${tooltip} (${shortcutLabel})`;
+  }
+
   return (
     <Button
-      tooltip={tooltip}
+      tooltip={tooltipText}
       icon={icon}
       onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault(); // Prevents editor from losing focus

--- a/front/components/assistant/conversation/input_bar/toolbar/ToolbarLink.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/ToolbarLink.tsx
@@ -47,26 +47,17 @@ export function ToolbarLink({ editor }: ToolbarLinkProps) {
 
   // Listen for keyboard shortcut event from the editor
   useEffect(() => {
-    const handleOpenDialog = (e: CustomEvent) => {
-      // Only handle if not already handled.
+    const handleOpenDialog = (e: Event) => {
+      // Prevent other toolbar instances from handling the same event.
       // This is necessary because there are two toolbar components (one for mobile and one for desktop)
-      if (e.detail.handled) {
-        return;
-      }
-      e.detail.handled = true; // Mark as handled
+      e.stopImmediatePropagation();
 
       openLinkDialog(editorRef.current);
     };
 
-    window.addEventListener(
-      "dust:openLinkDialog",
-      handleOpenDialog as EventListener
-    );
+    window.addEventListener("dust:openLinkDialog", handleOpenDialog);
     return () => {
-      window.removeEventListener(
-        "dust:openLinkDialog",
-        handleOpenDialog as EventListener
-      );
+      window.removeEventListener("dust:openLinkDialog", handleOpenDialog);
     };
   }, []);
 
@@ -141,6 +132,7 @@ export function ToolbarLink({ editor }: ToolbarLinkProps) {
             label="Link"
             placeholder="Link"
             value={linkUrl}
+            autoFocus
             onChange={(e) => setLinkUrl(e.target.value)}
           />
         </DialogContainer>

--- a/front/components/assistant/conversation/input_bar/toolbar/ToolbarLink.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/ToolbarLink.tsx
@@ -2,99 +2,73 @@ import {
   Dialog,
   DialogContainer,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
   Input,
   LinkMIcon,
 } from "@dust-tt/sparkle";
-import type { EditorState } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import { calculateLinkTextAndPosition } from "@app/components/assistant/conversation/input_bar/toolbar/helpers";
 import { ToolbarIcon } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarIcon";
 
 interface ToolbarLinkProps {
   editor: Editor;
 }
 
-const getLinkPosition = (
-  state: EditorState,
-  from: number,
-  to: number,
-  href: string
-): { linkStart: number; linkEnd: number } => {
-  const linkMarkType = state.schema.marks.link;
-
-  // Start with the current cursor position
-  let linkStart = from;
-  let linkEnd = to || from;
-
-  // Look backwards for the start of the link
-  for (let pos = linkStart; pos >= 0; pos--) {
-    const $testPos = state.doc.resolve(pos);
-    const marks = $testPos.marks();
-    const hasMatchingLink = marks.some(
-      (mark) => mark.type === linkMarkType && mark.attrs.href === href
-    );
-    if (hasMatchingLink) {
-      linkStart = pos - 1;
-    } else {
-      break;
-    }
-  }
-
-  // Look forwards for the end of the link
-  for (let pos = linkEnd; pos <= state.doc.content.size; pos++) {
-    const $testPos = state.doc.resolve(pos);
-    const marks = $testPos.marks();
-    const hasMatchingLink = marks.some(
-      (mark) => mark.type === linkMarkType && mark.attrs.href === href
-    );
-    if (hasMatchingLink) {
-      linkEnd = pos;
-    } else {
-      break;
-    }
-  }
-
-  return { linkStart, linkEnd };
-};
-
 export function ToolbarLink({ editor }: ToolbarLinkProps) {
   const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
   const [linkText, setLinkText] = useState("");
   const [linkUrl, setLinkUrl] = useState("");
   const [linkPos, setLinkPos] = useState({ from: 0, to: 0 });
+  const editorRef = useRef(editor);
 
-  const handleLinkDialogOpen = () => {
-    const { state } = editor;
-    const { from, to } = state.selection;
-    // Check if we're inside a link
-    const linkMark = editor.getAttributes("link");
+  // Keep editor ref up to date
+  useEffect(() => {
+    editorRef.current = editor;
+  }, [editor]);
 
-    if (linkMark.href) {
-      // We're inside or on a link, need to find the full link range
-      const { linkStart, linkEnd } = getLinkPosition(
-        state,
-        from,
-        to,
-        linkMark.href
-      );
-
-      const fullLinkText = state.doc.textBetween(linkStart, linkEnd);
-      setLinkUrl(linkMark.href);
-      setLinkText(fullLinkText);
-      setLinkPos({ from: linkStart, to: linkEnd });
-    } else {
-      // No link, just use selected text
-      const selectedText = state.doc.textBetween(from, to);
-      setLinkUrl("");
-      setLinkText(selectedText);
-      setLinkPos({ from, to });
-    }
+  const openLinkDialog = (editorInstance: Editor) => {
+    const { linkUrl, linkText, linkPos } = calculateLinkTextAndPosition({
+      editor: editorInstance,
+    });
+    setLinkUrl(linkUrl);
+    setLinkText(linkText);
+    setLinkPos(linkPos);
     setIsLinkDialogOpen(true);
   };
+
+  const handleLinkDialogOpen = () => {
+    openLinkDialog(editor);
+  };
+
+  // Listen for keyboard shortcut event from the editor
+  useEffect(() => {
+    const handleOpenDialog = (e: CustomEvent) => {
+      // Only handle if not already handled.
+      // This is necessary because there are two toolbar components (one for mobile and one for desktop)
+      if (e.detail.handled) {
+        return;
+      }
+      e.detail.handled = true; // Mark as handled
+
+      openLinkDialog(editorRef.current);
+    };
+
+    window.addEventListener(
+      "dust:openLinkDialog",
+      handleOpenDialog as EventListener
+    );
+    return () => {
+      window.removeEventListener(
+        "dust:openLinkDialog",
+        handleOpenDialog as EventListener
+      );
+    };
+  }, []);
 
   const handleLinkSubmit = () => {
     let finalText = linkText;
@@ -123,6 +97,7 @@ export function ToolbarLink({ editor }: ToolbarLinkProps) {
         { updateSelection: true }
       )
       .insertContent(linkUrl ? " " : "")
+      .focus()
       .run();
 
     setLinkText("");
@@ -130,17 +105,28 @@ export function ToolbarLink({ editor }: ToolbarLinkProps) {
     setIsLinkDialogOpen(false);
   };
 
+  const onClose = (open: boolean) => {
+    if (!open) {
+      editor.chain().focus().run();
+    }
+    setIsLinkDialogOpen(open);
+  };
+
   return (
-    <Dialog open={isLinkDialogOpen} onOpenChange={setIsLinkDialogOpen}>
+    <Dialog open={isLinkDialogOpen} onOpenChange={onClose}>
       <ToolbarIcon
         icon={LinkMIcon}
         onClick={handleLinkDialogOpen}
         active={editor.isActive("link")}
         tooltip="Link"
+        shortcut="Mod+K"
       />
       <DialogContent onClick={(e) => e.stopPropagation()}>
         <DialogHeader>
           <DialogTitle>Insert Link</DialogTitle>
+          <DialogDescription>
+            Add a link to your message with custom text.
+          </DialogDescription>
         </DialogHeader>
         <DialogContainer>
           <Input
@@ -162,7 +148,7 @@ export function ToolbarLink({ editor }: ToolbarLinkProps) {
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
-            onClick: () => setIsLinkDialogOpen(false),
+            onClick: () => onClose(false),
           }}
           rightButtonProps={{
             label: "Save",

--- a/front/components/assistant/conversation/input_bar/toolbar/helpers.ts
+++ b/front/components/assistant/conversation/input_bar/toolbar/helpers.ts
@@ -1,0 +1,81 @@
+import type { EditorState } from "@tiptap/pm/state";
+import type { Editor } from "@tiptap/react";
+
+const getLinkPosition = (
+  state: EditorState,
+  from: number,
+  to: number,
+  href: string
+): { linkStart: number; linkEnd: number } => {
+  const linkMarkType = state.schema.marks.link;
+
+  // Start with the current cursor position
+  let linkStart = from;
+  let linkEnd = to || from;
+
+  // Look backwards for the start of the link
+  for (let pos = linkStart; pos >= 0; pos--) {
+    const $testPos = state.doc.resolve(pos);
+    const marks = $testPos.marks();
+    const hasMatchingLink = marks.some(
+      (mark) => mark.type === linkMarkType && mark.attrs.href === href
+    );
+    if (hasMatchingLink) {
+      linkStart = pos - 1;
+    } else {
+      break;
+    }
+  }
+
+  // Look forwards for the end of the link
+  for (let pos = linkEnd; pos <= state.doc.content.size; pos++) {
+    const $testPos = state.doc.resolve(pos);
+    const marks = $testPos.marks();
+    const hasMatchingLink = marks.some(
+      (mark) => mark.type === linkMarkType && mark.attrs.href === href
+    );
+    if (hasMatchingLink) {
+      linkEnd = pos;
+    } else {
+      break;
+    }
+  }
+
+  return { linkStart, linkEnd };
+};
+
+export const calculateLinkTextAndPosition = ({
+  editor,
+}: {
+  editor: Editor;
+}) => {
+  const { state } = editor;
+  const { from, to } = state.selection;
+  // Check if we're inside a link
+  const linkMark = editor.getAttributes("link");
+
+  if (linkMark.href) {
+    // We're inside or on a link, need to find the full link range
+    const { linkStart, linkEnd } = getLinkPosition(
+      state,
+      from,
+      to,
+      linkMark.href
+    );
+
+    const fullLinkText = state.doc.textBetween(linkStart, linkEnd);
+    return {
+      linkUrl: linkMark.href,
+      linkText: fullLinkText,
+      linkPos: { from: linkStart, to: linkEnd },
+    };
+  } else {
+    // No link, just use selected text
+    const selectedText = state.doc.textBetween(from, to);
+    return {
+      linkUrl: "",
+      linkText: selectedText,
+      linkPos: { from, to },
+    };
+  }
+};

--- a/front/components/editor/extensions/agent_builder/HeadingExtension.ts
+++ b/front/components/editor/extensions/agent_builder/HeadingExtension.ts
@@ -4,7 +4,12 @@ import { Heading } from "@tiptap/extension-heading";
 import type { Node } from "@tiptap/pm/model";
 
 export const HeadingExtension = Heading.extend({
-  levels: [1, 2, 3, 4, 5, 6],
+  addOptions() {
+    return {
+      levels: [1, 2, 3, 4, 5, 6],
+      HTMLAttributes: {},
+    };
+  },
   renderHTML({
     node,
     HTMLAttributes,

--- a/front/components/editor/input_bar/BlockquoteExtension.ts
+++ b/front/components/editor/input_bar/BlockquoteExtension.ts
@@ -1,0 +1,13 @@
+import Blockquote from "@tiptap/extension-blockquote";
+
+/**
+ * Custom Blockquote extension that overrides the default keyboard shortcut
+ * to use Mod+Shift+9 instead of Mod+Shift+B
+ */
+export const BlockquoteExtension = Blockquote.extend({
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Shift-9": () => this.editor.commands.toggleBlockquote(),
+    };
+  },
+});

--- a/front/components/editor/input_bar/LinkExtension.ts
+++ b/front/components/editor/input_bar/LinkExtension.ts
@@ -1,0 +1,28 @@
+import Link from "@tiptap/extension-link";
+
+export const LinkExtension = Link.extend({
+  renderHTML({ HTMLAttributes }: { HTMLAttributes: { href: string } }) {
+    const href = HTMLAttributes.href || "";
+    return [
+      "span",
+      {
+        ...HTMLAttributes,
+        title: href, // Add title attribute to show URL as tooltip
+      },
+      0,
+    ];
+  },
+  addKeyboardShortcuts() {
+    return {
+      ...this.parent?.(),
+      "Mod-k": () => {
+        // This event is caught by the ToolbarLink component to open the link dialog
+        const event = new CustomEvent("dust:openLinkDialog", {
+          detail: { editor: this.editor },
+        });
+        window.dispatchEvent(event);
+        return true;
+      },
+    };
+  },
+});

--- a/front/components/editor/input_bar/LinkExtension.ts
+++ b/front/components/editor/input_bar/LinkExtension.ts
@@ -18,7 +18,7 @@ export const LinkExtension = Link.extend({
       "Mod-k": () => {
         // This event is caught by the ToolbarLink component to open the link dialog
         const event = new CustomEvent("dust:openLinkDialog", {
-          detail: { editor: this.editor },
+          detail: { handled: false },
         });
         window.dispatchEvent(event);
         return true;

--- a/front/components/editor/input_bar/LinkExtension.ts
+++ b/front/components/editor/input_bar/LinkExtension.ts
@@ -17,9 +17,7 @@ export const LinkExtension = Link.extend({
       ...this.parent?.(),
       "Mod-k": () => {
         // This event is caught by the ToolbarLink component to open the link dialog
-        const event = new CustomEvent("dust:openLinkDialog", {
-          detail: { handled: false },
-        });
+        const event = new CustomEvent("dust:openLinkDialog");
         window.dispatchEvent(event);
         return true;
       },

--- a/front/components/editor/input_bar/LinkExtension.ts
+++ b/front/components/editor/input_bar/LinkExtension.ts
@@ -1,8 +1,8 @@
 import Link from "@tiptap/extension-link";
 
 export const LinkExtension = Link.extend({
-  renderHTML({ HTMLAttributes }: { HTMLAttributes: { href: string } }) {
-    const href = HTMLAttributes.href || "";
+  renderHTML({ HTMLAttributes }) {
+    const href = HTMLAttributes.href ?? "";
     return [
       "span",
       {

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -1,5 +1,4 @@
 import { markdownStyles } from "@dust-tt/sparkle";
-import Link from "@tiptap/extension-link";
 import { Placeholder } from "@tiptap/extensions";
 import { Markdown } from "@tiptap/markdown";
 import type { Editor } from "@tiptap/react";
@@ -17,7 +16,9 @@ import { PastedAttachmentExtension } from "@app/components/editor/extensions/inp
 import { URLDetectionExtension } from "@app/components/editor/extensions/input_bar/URLDetectionExtension";
 import { URLStorageExtension } from "@app/components/editor/extensions/input_bar/URLStorageExtension";
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
+import { BlockquoteExtension } from "@app/components/editor/input_bar/BlockquoteExtension";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
+import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import {
   createMentionSuggestion,
   mentionPluginKey,
@@ -191,17 +192,14 @@ export const buildEditorExtensions = ({
     StarterKit.configure({
       hardBreak: false, // Disable the built-in Shift+Enter. We handle it ourselves in the keymap extension
       strike: false,
+      link: false, // Disable built-in Link extension, using custom LinkExtension instead
       heading: {
         levels: [1],
       },
       bold: false, // Disable default bold, we use a custom one
       italic: false, // Disable default italic, we use a custom one
+      blockquote: false, // Disable default blockquote, we use a custom one
       // Markdown styles configuration.
-      blockquote: {
-        HTMLAttributes: {
-          class: markdownStyles.blockquote(),
-        },
-      },
       code: {
         HTMLAttributes: {
           class: markdownStyles.code(),
@@ -235,21 +233,14 @@ export const buildEditorExtensions = ({
     }),
     CustomBold,
     CustomItalic,
+    BlockquoteExtension.configure({
+      HTMLAttributes: {
+        class: markdownStyles.blockquote(),
+      },
+    }),
     Markdown,
     DataSourceLinkExtension,
-    Link.extend({
-      renderHTML({ HTMLAttributes }: { HTMLAttributes: { href: string } }) {
-        const href = HTMLAttributes.href || "";
-        return [
-          "span",
-          {
-            ...HTMLAttributes,
-            title: href, // Add title attribute to show URL as tooltip
-          },
-          0,
-        ];
-      },
-    }).configure({
+    LinkExtension.configure({
       HTMLAttributes: {
         class: "text-blue-600 hover:underline hover:text-blue-800",
       },

--- a/front/hooks/useKeyboardShortcutLabel.ts
+++ b/front/hooks/useKeyboardShortcutLabel.ts
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+
+/**
+ * Detects if the user is on a Mac platform
+ */
+function useIsMac(): boolean {
+  return useMemo(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+  }, []);
+}
+
+/**
+ * Formats a keyboard shortcut for display based on the user's platform.
+ *
+ * @param shortcut - The shortcut definition. Use "Mod" for Cmd (Mac) / Ctrl (Windows/Linux)
+ * @example
+ * formatKeyboardShortcut("Mod+B") // Returns "⌘B" on Mac, "Ctrl+B" on Windows/Linux
+ * formatKeyboardShortcut("Mod+Shift+H") // Returns "⌘⇧H" on Mac, "Ctrl+Shift+H" on Windows/Linux
+ */
+export function useKeyboardShortcutLabel(shortcut: string | undefined): string {
+  const isMac = useIsMac();
+
+  return useMemo(() => {
+    if (!shortcut) {
+      return "";
+    }
+
+    let formatted = shortcut;
+
+    if (isMac) {
+      // Mac symbols
+      formatted = formatted
+        .replace(/Mod/g, "⌘")
+        .replace(/Cmd/g, "⌘")
+        .replace(/Ctrl/g, "⌃")
+        .replace(/Shift/g, "⇧")
+        .replace(/Alt/g, "⌥")
+        .replace(/\+/g, "");
+    } else {
+      // Windows/Linux labels
+      formatted = formatted.replace(/Mod/g, "Ctrl");
+    }
+
+    return formatted;
+  }, [shortcut, isMac]);
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -58,6 +58,7 @@
         "@temporalio/workflow": "^1.12.1",
         "@textea/json-viewer": "^3.1.1",
         "@tiptap/core": "^3.11.0",
+        "@tiptap/extension-blockquote": "^3.11.1",
         "@tiptap/extension-bold": "^3.11.0",
         "@tiptap/extension-heading": "^3.11.0",
         "@tiptap/extension-italic": "^3.11.0",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10556,29 +10556,30 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.11.0.tgz",
-      "integrity": "sha512-kmS7ZVpHm1EMnW1Wmft9H5ZLM7E0G0NGBx+aGEHGDcNxZBXD2ZUa76CuWjIhOGpwsPbELp684ZdpF2JWoNi4Dg==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.11.1.tgz",
+      "integrity": "sha512-q7uzYrCq40JOIi6lceWe2HuA8tSr97iPwP/xtJd0bZjyL1rWhUyqxMb7y+aq4RcELrx/aNRa2JIvLtRRdy02Dg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.11.0"
+        "@tiptap/pm": "^3.11.1"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.11.0.tgz",
-      "integrity": "sha512-0H8WVW6Vn4GJ7sQ6wfyDgUU+DqM8fp62g8N0fFPiEhoYtpIYUmCqGhpKnqYR0tet6ofFa648XmA6n2VX7sugzw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.11.1.tgz",
+      "integrity": "sha512-c3DN5c/9kl8w1wCcylH9XqW0OyCegqE3EL4rDlVYkyBD0GwCnUS30pN+jdxCUq/tl94lkkRk7XMyEUwzQmG+5g==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.11.0"
+        "@tiptap/core": "^3.11.1"
       }
     },
     "node_modules/@tiptap/extension-bold": {
@@ -10941,10 +10942,11 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.11.0.tgz",
-      "integrity": "sha512-plCQDLCZIOc92cizB8NNhBRN0szvYR3cx9i5IXo6v9Xsgcun8KHNcJkesc2AyeqdIs0BtOJZaqQ9adHThz8UDw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.11.1.tgz",
+      "integrity": "sha512-8RIUhlEoCFGsbdNb+EUdQctG1Wnd7rl4wlMLS6giO7UcZT5dVfg625eMZVrl0/kA7JBJdKLIuqNmzzQ0MxsJEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",

--- a/front/package.json
+++ b/front/package.json
@@ -84,6 +84,7 @@
     "@temporalio/workflow": "^1.12.1",
     "@textea/json-viewer": "^3.1.1",
     "@tiptap/core": "^3.11.0",
+    "@tiptap/extension-blockquote": "^3.11.1",
     "@tiptap/extension-bold": "^3.11.0",
     "@tiptap/extension-heading": "^3.11.0",
     "@tiptap/extension-italic": "^3.11.0",


### PR DESCRIPTION
## Description

- Adds keyboard shortcuts to all toolbar formatting options and displays them in tooltips. 
- Implements custom shortcuts for link insertion (Mod+K) and blockquote (Mod+Shift+9). 
- The shortcuts are displayed with platform-appropriate symbols (⌘ on Mac, Ctrl on Windows/Linux).
- Hide the tooltips on mobile.

For links:
- Make the shortcut open the dialog
- Re-focus on the editor when the dialog is closed

<img width="336" height="213" alt="image" src="https://github.com/user-attachments/assets/1343decb-3c4c-42f1-8301-5648ebe73c4e" />


### Not included in this PR 
There are some display bugs in the message content (italic, bold, quote block). They already existed before this PR.
A task has been created: https://github.com/dust-tt/tasks/issues/5365

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
