### PR TITLE
[PPUL] Add migration script to fix cents/USD conversion in Redis credits

### DIFF
--- a/front/migrations/20251202_fix_programmatic_credits_cents_conversion.ts
+++ b/front/migrations/20251202_fix_programmatic_credits_cents_conversion.ts
@@ -1,0 +1,127 @@
+import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
+import { runOnRedis } from "@app/lib/api/redis";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import type { LightWorkspaceType } from "@app/types";
+
+// Redis key name kept for backward compatibility with programmatic_usage_tracking.ts.
+const PROGRAMMATIC_USAGE_REMAINING_CREDITS_KEY = "public_api_remaining_credits";
+const REDIS_ORIGIN = "public_api_limits";
+
+function getRedisKey(workspace: LightWorkspaceType): string {
+  return `${PROGRAMMATIC_USAGE_REMAINING_CREDITS_KEY}:${workspace.id}`;
+}
+
+async function fixWorkspaceCredits(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const workspaceLogger = logger.child({ workspaceId: workspace.sId });
+
+  const publicApiLimits = getWorkspacePublicAPILimits(workspace);
+
+  if (!publicApiLimits || !publicApiLimits.enabled) {
+    workspaceLogger.info(
+      { enabled: publicApiLimits?.enabled },
+      "Skipping: publicApiLimits not enabled"
+    );
+    return;
+  }
+
+  const { monthlyLimit } = publicApiLimits;
+
+  // monthlyLimit is in USD (e.g., 100 = $100), but remainingAmount was incorrectly
+  // stored in cents before the fix. We need to add 100 * monthlyLimit to fix this.
+  const creditsToAdd = monthlyLimit * 100;
+
+  await runOnRedis({ origin: REDIS_ORIGIN }, async (redis) => {
+    const key = getRedisKey(workspace);
+    const currentCredits = await redis.get(key);
+
+    if (currentCredits === null) {
+      workspaceLogger.info(
+        "Skipping: no credits key in Redis (not initialized yet)"
+      );
+      return;
+    }
+
+    const currentCreditsValue = parseFloat(currentCredits);
+    const newCreditsValue = currentCreditsValue + creditsToAdd;
+
+    workspaceLogger.info(
+      {
+        monthlyLimit,
+        creditsToAdd,
+        currentCredits: currentCreditsValue,
+        newCredits: newCreditsValue,
+        execute,
+      },
+      execute
+        ? "Fixing credits by adding 100 * monthlyLimit"
+        : "Would fix credits by adding 100 * monthlyLimit (dry run)"
+    );
+
+    if (execute) {
+      // Preserve the TTL of the key.
+      await redis.set(key, newCreditsValue.toString(), { KEEPTTL: true });
+      workspaceLogger.info("Successfully updated credits");
+    }
+  });
+}
+
+makeScript(
+  {
+    wId: {
+      type: "string",
+      demandOption: false,
+      describe:
+        "Workspace sId to fix (optional, processes all workspaces with limits enabled if omitted)",
+    },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info(
+      { execute, workspaceId: wId ?? "all" },
+      "Starting programmatic credits fix migration"
+    );
+
+    if (wId) {
+      const workspace = await WorkspaceModel.findOne({ where: { sId: wId } });
+
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+
+      await fixWorkspaceCredits(
+        renderLightWorkspaceType({ workspace }),
+        execute,
+        logger
+      );
+    } else {
+      const workspaces = await WorkspaceModel.findAll({
+        where: {
+          "metadata.publicApiLimits.enabled": true,
+        },
+      });
+
+      logger.info({ count: workspaces.length }, "Found workspaces to process");
+
+      await concurrentExecutor(
+        workspaces,
+        async (workspace) => {
+          await fixWorkspaceCredits(
+            renderLightWorkspaceType({ workspace }),
+            execute,
+            logger
+          );
+        },
+        { concurrency: 8 }
+      );
+    }
+
+    logger.info("Programmatic credits fix migration completed");
+  }
+);


### PR DESCRIPTION
## Description

Following https://github.com/dust-tt/dust/pull/18526, this migration script fixes the incorrect remainingAmount values in Redis.

The bug was that `monthlyLimit` is stored in USD (e.g., 100 = $100) but `remainingAmount` was being treated as if it were in cents. This script adds `100 * monthlyLimit` to the current `remainingAmount` for all workspaces with public API limits enabled.

## Risks

Blast radius: programmatic usage tracking/billing for API users with limits enabled
Risk: low (read-only by default with --execute flag, can run dry-run first)

## Deploy Plan

- Run dry-run first: `npx tsx front/migrations/20251202_fix_programmatic_credits_cents_conversion.ts`
- Run with execute: `npx tsx front/migrations/20251202_fix_programmatic_credits_cents_conversion.ts --execute`