### PR TITLE
Firecrawl: handle webhook level error

### DIFF
--- a/connectors/src/api/webhooks/webhook_firecrawl.ts
+++ b/connectors/src/api/webhooks/webhook_firecrawl.ts
@@ -131,6 +131,19 @@ const _webhookFirecrawlAPIHandler = async (
     }
     case "batch_scrape.page":
     case "crawl.page": {
+      if (error) {
+        logger.error(
+          {
+            id,
+            metadata,
+            connectorId: connector.id,
+            error,
+          },
+          "Page reported error"
+        );
+        // Accept the webhook.
+        break;
+      }
       if (data && data.length > 0) {
         for (const page of data) {
           logger.info(
@@ -139,7 +152,7 @@ const _webhookFirecrawlAPIHandler = async (
               scrapeId: page.metadata.scrapeId,
               connectorId: connector.id,
             },
-            "[Firecrawl] Page crawled"
+            "Page crawled"
           );
           if (!page.metadata.scrapeId) {
             logger.error(
@@ -147,7 +160,7 @@ const _webhookFirecrawlAPIHandler = async (
                 id,
                 connectorId: connector.id,
               },
-              "[Firecrawl] Page crawled with no scrapeId"
+              "Page crawled with no scrapeId"
             );
             // Interrupt and refuse the webhook.
             return res.status(400).json({


### PR DESCRIPTION
## Description

We had some logs with for missing scrapeId. Fixing the Processed request log for Firecrawl it appeared that we had a 1-1 match with webhooks having their error field set.

https://app.datadoghq.eu/logs?query=%22%5BFirecrawl%5D%20Page%20crawled%20with%20no%20scrapeId%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764659326852&to_ts=1764662926852&live=true

https://app.datadoghq.eu/logs?query=%22%5BFirecrawl%5D%20Received%20webhook%22%20%40error%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764667007643&to_ts=1764670607643&live=true

Also remove `[Firecrawl]` prefix since it's injected above.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`