### PR TITLE
[front] feat: PPUL - Send invoice for Ent Purchases

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -82,8 +82,8 @@ export function PluginForm({
               key,
               arg.async && asyncArgs?.[key] !== undefined
                 ? (asyncArgs[key] as AsyncEnumValues)
-                    .filter((v) => v.checked)
-                    .map((v) => v.value)
+                  .filter((v) => v.checked)
+                  .map((v) => v.value)
                 : arg.values.filter((v) => v.checked).map((v) => v.value),
             ];
           case "date":
@@ -163,7 +163,7 @@ export function PluginForm({
           }
           const fieldDescription =
             arg.asyncDescription &&
-            asyncArgs?.[`${key}_description`] !== undefined
+              asyncArgs?.[`${key}_description`] !== undefined
               ? String(asyncArgs[`${key}_description`])
               : arg.description;
 
@@ -236,6 +236,7 @@ export function PluginForm({
                       {fieldDescription}
                     </PokeFormDescription>
                   )}
+
                   <PokeFormMessage />
                 </PokeFormItem>
               )}

--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -236,7 +236,6 @@ export function PluginForm({
                       {fieldDescription}
                     </PokeFormDescription>
                   )}
-
                   <PokeFormMessage />
                 </PokeFormItem>
               )}

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -216,16 +216,11 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
     const existingConfig =
       await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-    const configData = {
-      freeCreditCents,
-      defaultDiscountPercent,
-    };
-
     if (existingConfig) {
-      const updateResult = await existingConfig.updateConfiguration(
-        auth,
-        configData
-      );
+      const updateResult = await existingConfig.updateConfiguration(auth, {
+        freeCreditCents,
+        defaultDiscountPercent,
+      });
       if (updateResult.isErr()) {
         return updateResult;
       }
@@ -233,7 +228,8 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       const createResult = await ProgrammaticUsageConfigurationResource.makeNew(
         auth,
         {
-          ...configData,
+          freeCreditCents,
+          defaultDiscountPercent,
           paygCapCents: null,
         }
       );

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -215,6 +215,10 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
     // Handle non-PAYG config fields first
     const existingConfig =
       await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+    // When PAYG is disabled, clear the cap (set to null)
+    // When enabled, convert dollars to cents
+    const paygCapCents =
+      paygEnabled && paygCapDollars ? Math.round(paygCapDollars * 100) : null;
 
     if (existingConfig) {
       const updateResult = await existingConfig.updateConfiguration(auth, {

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -215,10 +215,6 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
     // Handle non-PAYG config fields first
     const existingConfig =
       await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-    // When PAYG is disabled, clear the cap (set to null)
-    // When enabled, convert dollars to cents
-    const paygCapCents =
-      paygEnabled && paygCapDollars ? Math.round(paygCapDollars * 100) : null;
 
     if (existingConfig) {
       const updateResult = await existingConfig.updateConfiguration(auth, {

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -2,7 +2,7 @@ import type Stripe from "stripe";
 
 import type { Authenticator } from "@app/lib/auth";
 import {
-  ENTERPRISE_N30_PAYMENTS,
+  ENTERPRISE_N30_PAYMENTS_DAYS,
   finalizeInvoice,
   getCreditAmountFromInvoice,
   getCreditPurchaseCouponId,
@@ -136,7 +136,7 @@ export async function createEnterpriseCreditPurchase({
     amountCents,
     couponId,
     collectionMethod: "send_invoice",
-    daysUntilDue: ENTERPRISE_N30_PAYMENTS,
+    daysUntilDue: ENTERPRISE_N30_PAYMENTS_DAYS,
   });
 
   if (invoiceResult.isErr()) {

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -2,13 +2,14 @@ import type Stripe from "stripe";
 
 import type { Authenticator } from "@app/lib/auth";
 import {
-  attachCreditPurchaseToSubscription,
-  finalizeAndPayCreditPurchaseInvoice,
+  ENTERPRISE_N30_PAYMENTS,
+  finalizeInvoice,
   getCreditAmountFromInvoice,
   getCreditPurchaseCouponId,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
-  makeCreditPurchaseInvoice,
+  makeOneOffInvoice,
+  payInvoice,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import logger from "@app/logger/logger";
@@ -106,7 +107,9 @@ export async function createEnterpriseCreditPurchase({
   discountPercent?: number;
   startDate?: Date;
   expirationDate?: Date;
-}): Promise<Result<{ credit: CreditResource; invoiceItemId: string }, Error>> {
+}): Promise<
+  Result<{ credit: CreditResource; invoiceOrLineItemId: string }, Error>
+> {
   const workspace = auth.getNonNullableWorkspace();
 
   let couponId;
@@ -128,38 +131,50 @@ export async function createEnterpriseCreditPurchase({
     couponId = undefined;
   }
 
-  // Attach credit purchase to subscription
-  const attachResult = await attachCreditPurchaseToSubscription({
+  const invoiceResult = await makeOneOffInvoice({
     stripeSubscriptionId,
     amountCents,
     couponId,
+    collectionMethod: "send_invoice",
+    daysUntilDue: ENTERPRISE_N30_PAYMENTS,
   });
 
-  if (attachResult.isErr()) {
+  if (invoiceResult.isErr()) {
     logger.error(
       {
-        error: attachResult.error.error_message,
+        error: invoiceResult.error.error_message,
         workspaceId: workspace.sId,
         amountCents,
         discountPercent,
       },
-      "[Credit Purchase] Failed to attach credit purchase to subscription"
+      "[Credit Purchase] Failed to create enterprise credit purchase invoice"
     );
-    return new Err(new Error(attachResult.error.error_message));
+    return new Err(new Error(invoiceResult.error.error_message));
   }
 
-  const invoiceItemId = attachResult.value;
+  const invoice = invoiceResult.value;
 
-  // Create credit with full amount
   const credit = await CreditResource.makeNew(auth, {
     type: "committed",
     initialAmountCents: amountCents,
     consumedAmountCents: 0,
     discount: discountPercent,
-    invoiceOrLineItemId: invoiceItemId,
+    invoiceOrLineItemId: invoice.id,
   });
 
-  // Activate the credit immediately (optimistic activation for Enterprise)
+  const finalizeResult = await finalizeInvoice(invoice);
+  if (finalizeResult.isErr()) {
+    logger.error(
+      {
+        error: finalizeResult.error.error_message,
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+      },
+      "[Credit Purchase] Failed to finalize enterprise credit purchase invoice"
+    );
+    return new Err(new Error(finalizeResult.error.error_message));
+  }
+
   const startResult = await credit.start(startDate, expirationDate);
 
   if (startResult.isErr()) {
@@ -167,7 +182,7 @@ export async function createEnterpriseCreditPurchase({
       {
         error: startResult.error.message,
         workspaceId: workspace.sId,
-        invoiceItemId,
+        invoiceOrLineItemId: invoice.id,
       },
       "[Credit Purchase] Failed to start credit after creation"
     );
@@ -179,13 +194,13 @@ export async function createEnterpriseCreditPurchase({
       workspaceId: workspace.sId,
       amountCents,
       discountPercent,
-      invoiceItemId,
+      invoiceOrLineItemId: invoice.id,
       expirationDate: credit.expirationDate,
     },
-    "[Credit Purchase] Credit purchase attached to subscription and activated"
+    "[Credit Purchase] Enterprise credit purchase invoice created and credit activated"
   );
 
-  return new Ok({ credit, invoiceItemId });
+  return new Ok({ credit, invoiceOrLineItemId: invoice.id });
 }
 
 export async function createProCreditPurchase({
@@ -218,11 +233,11 @@ export async function createProCreditPurchase({
     couponId = couponResult.value;
   }
 
-  // Create and pay one-off invoice
-  const invoiceResult = await makeCreditPurchaseInvoice({
+  const invoiceResult = await makeOneOffInvoice({
     stripeSubscriptionId,
     amountCents,
     couponId,
+    collectionMethod: "charge_automatically",
   });
 
   if (invoiceResult.isErr()) {
@@ -239,7 +254,6 @@ export async function createProCreditPurchase({
 
   const invoice = invoiceResult.value;
 
-  // Create credit record (will be activated via webhook when paid)
   await CreditResource.makeNew(auth, {
     type: "committed",
     initialAmountCents: amountCents,
@@ -248,7 +262,7 @@ export async function createProCreditPurchase({
     invoiceOrLineItemId: invoice.id,
   });
 
-  const finalizeResult = await finalizeAndPayCreditPurchaseInvoice(invoice);
+  const finalizeResult = await finalizeInvoice(invoice);
   if (finalizeResult.isErr()) {
     logger.error(
       {
@@ -262,7 +276,21 @@ export async function createProCreditPurchase({
     return new Err(new Error(finalizeResult.error.error_message));
   }
 
-  const { paymentUrl } = finalizeResult.value;
+  const payResult = await payInvoice(finalizeResult.value);
+  if (payResult.isErr()) {
+    logger.error(
+      {
+        error: payResult.error.error_message,
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+        amountCents,
+      },
+      "[Credit Purchase] Failed to pay credit purchase invoice"
+    );
+    return new Err(new Error(payResult.error.error_message));
+  }
+
+  const { paymentUrl } = payResult.value;
 
   logger.info(
     {

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -87,7 +87,7 @@ async function getDefautPriceFromMetadata(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SUPPORTED_PAYMENT_METHODS = ["card", "sepa_debit"] as const;
 
-export const ENTERPRISE_N30_PAYMENTS = 30;
+export const ENTERPRISE_N30_PAYMENTS_DAYS = 30;
 
 type SupportedPaymentMethod = (typeof SUPPORTED_PAYMENT_METHODS)[number];
 

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -87,6 +87,8 @@ async function getDefautPriceFromMetadata(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SUPPORTED_PAYMENT_METHODS = ["card", "sepa_debit"] as const;
 
+export const ENTERPRISE_N30_PAYMENTS = 30;
+
 type SupportedPaymentMethod = (typeof SUPPORTED_PAYMENT_METHODS)[number];
 
 /**
@@ -686,70 +688,21 @@ export async function reportActiveSeats(
   );
 }
 
-/**
- * Attaches a credit purchase as an invoice item to a subscription.
- * The item will be included in the next regular subscription invoice.
- * Returns the invoice item ID for idempotency tracking.
- */
-export async function attachCreditPurchaseToSubscription({
+export async function makeOneOffInvoice({
   stripeSubscriptionId,
   amountCents,
   couponId,
+  collectionMethod,
+  daysUntilDue,
 }: {
   stripeSubscriptionId: string;
   amountCents: number;
   couponId?: string;
-}): Promise<Result<string, { error_message: string }>> {
-  const stripe = getStripeClient();
-
-  // Get the subscription to find the customer.
-  const subscription = await getStripeSubscription(stripeSubscriptionId);
-  if (!subscription) {
-    return new Err({
-      error_message: `Subscription ${stripeSubscriptionId} not found`,
-    });
-  }
-
-  const customerId = getCustomerId(subscription);
-
-  try {
-    // Create invoice item that will be charged in the next subscription invoice.
-    const invoiceItem = await stripe.invoiceItems.create(
-      makeCreditPurchaseLineItemPayload({
-        customerId,
-        amountCents,
-        subscription: stripeSubscriptionId,
-        couponId,
-      })
-    );
-
-    return new Ok(invoiceItem.id);
-  } catch (error) {
-    logger.error(
-      {
-        stripeSubscriptionId,
-        stripeError: true,
-      },
-      "[Credit Purchase] Failed to attach line item to Stripe subscription"
-    );
-    return new Err({
-      error_message: `Failed to attach credit purchase to subscription: ${normalizeError(error).message}`,
-    });
-  }
-}
-
-export async function makeCreditPurchaseInvoice({
-  stripeSubscriptionId,
-  amountCents,
-  couponId,
-}: {
-  stripeSubscriptionId: string;
-  amountCents: number;
-  couponId?: string;
+  collectionMethod: "charge_automatically" | "send_invoice";
+  daysUntilDue?: number;
 }): Promise<Result<Stripe.Invoice, { error_message: string }>> {
   const stripe = getStripeClient();
 
-  // Get the subscription to find the customer.
   const subscription = await getStripeSubscription(stripeSubscriptionId);
   if (!subscription) {
     return new Err({
@@ -761,13 +714,17 @@ export async function makeCreditPurchaseInvoice({
   const invoiceParams: Stripe.InvoiceCreateParams = {
     customer: customerId,
     subscription: stripeSubscriptionId,
-    collection_method: "charge_automatically",
+    collection_method: collectionMethod,
     metadata: {
       credit_purchase: "true",
       credit_amount_cents: amountCents.toString(),
     },
     auto_advance: true,
   };
+
+  if (collectionMethod === "send_invoice" && daysUntilDue) {
+    invoiceParams.days_until_due = daysUntilDue;
+  }
 
   try {
     const invoice = await stripe.invoices.create(invoiceParams);
@@ -791,38 +748,56 @@ export async function makeCreditPurchaseInvoice({
       "[Credit Purchase] Failed to create Stripe invoice"
     );
     return new Err({
-      error_message: `Failed to create invoice credit purchase: ${normalizeError(error).message}`,
+      error_message: `Failed to create invoice: ${normalizeError(error).message}`,
     });
   }
 }
 
-export async function finalizeAndPayCreditPurchaseInvoice(
+export async function finalizeInvoice(
+  invoice: Stripe.Invoice
+): Promise<Result<Stripe.Invoice, { error_message: string }>> {
+  const stripe = getStripeClient();
+
+  try {
+    const finalizedInvoice = await stripe.invoices.finalizeInvoice(invoice.id);
+    return new Ok(finalizedInvoice);
+  } catch (error) {
+    logger.error(
+      {
+        stripeInvoiceId: invoice.id,
+        stripeError: true,
+        error: normalizeError(error).message,
+      },
+      "[Stripe] Failed to finalize invoice"
+    );
+    return new Err({
+      error_message: `Failed to finalize invoice: ${normalizeError(error).message}`,
+    });
+  }
+}
+
+export async function payInvoice(
   invoice: Stripe.Invoice
 ): Promise<Result<{ paymentUrl: string | null }, { error_message: string }>> {
   const stripe = getStripeClient();
-  const finalizedInvoice = await stripe.invoices.finalizeInvoice(invoice.id);
 
-  // Attempt to pay the invoice.
   try {
-    const paidInvoice = await stripe.invoices.pay(finalizedInvoice.id);
+    const paidInvoice = await stripe.invoices.pay(invoice.id);
 
     if (paidInvoice.status === "paid") {
       return new Ok({ paymentUrl: null });
     }
   } catch (payError) {
-    // Payment failed or requires action (e.g., 3D Secure).
-    // We'll return the hosted invoice URL for the customer to complete payment.
     logger.info(
       {
         stripeInvoiceId: invoice.id,
         error: normalizeError(payError).message,
       },
-      "[Credit Purchase] Payment requires additional action or failed"
+      "[Stripe] Payment requires additional action or failed"
     );
   }
 
-  // Payment not completed - return hosted URL for customer to complete.
-  const invoiceWithUrl = await stripe.invoices.retrieve(finalizedInvoice.id);
+  const invoiceWithUrl = await stripe.invoices.retrieve(invoice.id);
   if (invoiceWithUrl.hosted_invoice_url) {
     return new Ok({ paymentUrl: invoiceWithUrl.hosted_invoice_url });
   }


### PR DESCRIPTION
## Description

Update the credit purchase flow for enterprise customers, sending them an one-off invoice with N30 payment terms instead of adding it to the next subscription invoice.

We will rename the column in the following PRs

## Tests

Tested manually

## Risk

Risk: Low 
Blast radius: Enterprise credit purchase 

## Deploy Plan

- [ ] Deploy front