### PR TITLE
chore(authors): update .authors file to match slack email

### DIFF
--- a/.authors
+++ b/.authors
@@ -48,6 +48,6 @@ okal: okal@dust.tt
 fabiencelier: fabien@dust.tt
 Chrisjow: christophe@dust.tt
 id13: jd@dust.tt
-alexandre-pinon: alexandre.pinon@dust.tt
+alexandre-pinon: ap@dust.tt
 iliasbet: ilias@dust.tt
 margherita-ops: margherita@dust.tt


### PR DESCRIPTION
## Description

@zmarouf  updated my slack email and it broke the link github handle -> slack handle :
<img width="451" height="177" alt="image" src="https://github.com/user-attachments/assets/309272fd-fcba-4c27-b213-14407fb3326c" />


## Tests

None

## Risk

None

## Deploy Plan

None