### PR TITLE
feat(onboarding-chat): improve onboarding chat w/ multiple tool card + skip flow

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -738,14 +738,7 @@ function AgentMessageContent({
 
   const handleToolSetupComplete = React.useCallback(
     (toolId: string) => {
-      void postFollowUp(toolId, "completed");
-    },
-    [postFollowUp]
-  );
-
-  const handleToolSetupSkipped = React.useCallback(
-    (toolId: string) => {
-      void postFollowUp(toolId, "skipped");
+      void postFollowUp(toolId);
     },
     [postFollowUp]
   );
@@ -764,13 +757,7 @@ function AgentMessageContent({
       mention_user: getUserMentionPlugin(owner),
       dustimg: getImgPlugin(owner),
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),
-      toolSetup: getToolSetupPlugin(
-        owner,
-        conversationId,
-        isLastMessage,
-        handleToolSetupComplete,
-        handleToolSetupSkipped
-      ),
+      toolSetup: getToolSetupPlugin(owner, handleToolSetupComplete),
     }),
     [
       owner,
@@ -780,7 +767,6 @@ function AgentMessageContent({
       onQuickReplySend,
       isLastMessage,
       handleToolSetupComplete,
-      handleToolSetupSkipped,
     ]
   );
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -18,9 +18,9 @@ import {
 } from "@app/lib/swr/conversations";
 import { useIsOnboardingConversation } from "@app/lib/swr/user";
 import {
+  trackEvent,
   TRACKING_ACTIONS,
   TRACKING_AREAS,
-  trackEvent,
 } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 import type {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -16,7 +16,12 @@ import {
   useAddDeleteConversationTool,
   useConversationTools,
 } from "@app/lib/swr/conversations";
-import { trackEvent, TRACKING_AREAS } from "@app/lib/tracking";
+import { useIsOnboardingConversation } from "@app/lib/swr/user";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 import type {
   AgentMention,
@@ -115,6 +120,8 @@ export const InputBar = React.memo(function InputBar({
 
   const [isAnimating, setIsAnimating] = useState<boolean>(false);
   const { animate, setAnimate, selectedAgent } = useContext(InputBarContext);
+  const { isOnboardingConversation } =
+    useIsOnboardingConversation(conversationId);
   const animationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
@@ -221,6 +228,14 @@ export const InputBar = React.memo(function InputBar({
         message_length: markdown.length,
       },
     });
+
+    if (isOnboardingConversation) {
+      trackEvent({
+        area: TRACKING_AREAS.CONVERSATION,
+        object: "onboarding_conversation",
+        action: TRACKING_ACTIONS.SUBMIT,
+      });
+    }
 
     // When we are creating a new conversation, we will disable the input bar, show a loading
     // spinner and in case of error, re-enable the input bar

--- a/front/components/markdown/QuickReplyBlock.tsx
+++ b/front/components/markdown/QuickReplyBlock.tsx
@@ -2,6 +2,12 @@ import { Button } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 import { visit } from "unist-util-visit";
 
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
+
 interface QuickReplyBlockProps {
   label: string;
   message: string;
@@ -21,6 +27,12 @@ export function QuickReplyBlock({
     if (isSending || disabled) {
       return;
     }
+    trackEvent({
+      area: TRACKING_AREAS.CONVERSATION,
+      object: "onboarding_conversation",
+      action: TRACKING_ACTIONS.CLICK,
+      extra: { click_target: "quick_reply", label },
+    });
     setIsSending(true);
     try {
       await onSend(message);

--- a/front/components/markdown/QuickReplyBlock.tsx
+++ b/front/components/markdown/QuickReplyBlock.tsx
@@ -3,9 +3,9 @@ import React, { useState } from "react";
 import { visit } from "unist-util-visit";
 
 import {
+  trackEvent,
   TRACKING_ACTIONS,
   TRACKING_AREAS,
-  trackEvent,
 } from "@app/lib/tracking";
 
 interface QuickReplyBlockProps {

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -19,9 +19,9 @@ import {
 } from "@app/lib/swr/mcp_servers";
 import { useSpaces, useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import {
+  trackEvent,
   TRACKING_ACTIONS,
   TRACKING_AREAS,
-  trackEvent,
 } from "@app/lib/tracking";
 import type { WorkspaceType } from "@app/types";
 import { asDisplayToolName } from "@app/types";

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -18,6 +18,11 @@ import {
   useMCPServers,
 } from "@app/lib/swr/mcp_servers";
 import { useSpaces, useSpacesAsAdmin } from "@app/lib/swr/spaces";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
 import type { WorkspaceType } from "@app/types";
 import { asDisplayToolName } from "@app/types";
 
@@ -25,23 +30,17 @@ interface ToolSetupCardProps {
   toolName: string;
   toolId: InternalMCPServerNameType;
   owner: WorkspaceType;
-  conversationId?: string;
-  isLastMessage?: boolean;
   onSetupComplete?: (toolId: string) => void;
-  onSetupSkipped?: (toolId: string) => void;
 }
 
 export function ToolSetupCard({
   toolName,
   toolId,
   owner,
-  isLastMessage,
   onSetupComplete,
-  onSetupSkipped,
 }: ToolSetupCardProps) {
   const [isActivating, setIsActivating] = useState(false);
   const [isSetupSheetOpen, setIsSetupSheetOpen] = useState(false);
-  const [isSkipped, setIsSkipped] = useState(false);
   const isAdmin = owner.role === "admin";
 
   const { spaces: spacesAsUser } = useSpaces({
@@ -130,6 +129,12 @@ export function ToolSetupCard({
   };
 
   const handleAddToGlobalSpace = async () => {
+    trackEvent({
+      area: TRACKING_AREAS.CONVERSATION,
+      object: "onboarding_conversation",
+      action: TRACKING_ACTIONS.CLICK,
+      extra: { tool_id: toolId, click_target: "tool_setup_card" },
+    });
     setIsActivating(true);
     await addToSpace(matchingMCPServer, globalSpace);
     await mutateMCPServers();
@@ -138,6 +143,12 @@ export function ToolSetupCard({
   };
 
   const handleActivateClick = async () => {
+    trackEvent({
+      area: TRACKING_AREAS.CONVERSATION,
+      object: "onboarding_conversation",
+      action: TRACKING_ACTIONS.CLICK,
+      extra: { tool_id: toolId, click_target: "tool_setup_card" },
+    });
     setIsSetupSheetOpen(true);
   };
 
@@ -149,18 +160,8 @@ export function ToolSetupCard({
     onSetupComplete?.(toolId);
   };
 
-  const handleSkip = () => {
-    setIsSkipped(true);
-    onSetupSkipped?.(toolId);
-  };
-
-  const showSkipButton =
-    isAdmin && !isToolActivatedInGlobalSpace && !isActivating;
-
-  const isSkipDisabled = !isLastMessage || isSkipped;
-
   return (
-    <>
+    <div className="mb-2 mr-2 inline-block w-72 align-top">
       <ContentMessage
         title={`${asDisplayToolName(toolId) || toolName} Tool`}
         icon={getIcon(matchingMCPServer.icon)}
@@ -183,26 +184,15 @@ export function ToolSetupCard({
                 />
               )}
             </div>
-            <div className="flex gap-2">
-              {showSkipButton && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  label={isSkipped ? "Skipped" : "Skip"}
-                  onClick={handleSkip}
-                  disabled={isSkipDisabled}
-                />
-              )}
-              <Button
-                variant="highlight"
-                size="sm"
-                label={getButtonLabel()}
-                onClick={getButtonClickHandler()}
-                disabled={
-                  !isAdmin || isToolActivatedInGlobalSpace || isActivating
-                }
-              />
-            </div>
+            <Button
+              variant="highlight"
+              size="sm"
+              label={getButtonLabel()}
+              onClick={getButtonClickHandler()}
+              disabled={
+                !isAdmin || isToolActivatedInGlobalSpace || isActivating
+              }
+            />
           </div>
         </div>
       </ContentMessage>
@@ -217,6 +207,6 @@ export function ToolSetupCard({
           setIsOpen={setIsSetupSheetOpen}
         />
       )}
-    </>
+    </div>
   );
 }

--- a/front/components/markdown/tool/tool.tsx
+++ b/front/components/markdown/tool/tool.tsx
@@ -41,18 +41,12 @@ export function toolDirective() {
  * in ReactMarkdown to render the tool HTML elements.
  *
  * @param owner - The workspace context for tool interactions
- * @param conversationId - Optional conversation ID for triggering follow-up messages
- * @param isLastMessage - Whether this is the last message in the conversation
  * @param onSetupComplete - Optional callback when tool setup completes
- * @param onSetupSkipped - Optional callback when tool setup is skipped
  * @returns A React component for rendering tool cards
  */
 export function getToolSetupPlugin(
   owner: WorkspaceType,
-  conversationId?: string,
-  isLastMessage?: boolean,
-  onSetupComplete?: (toolId: string) => void,
-  onSetupSkipped?: (toolId: string) => void
+  onSetupComplete?: (toolId: string) => void
 ) {
   const ToolSetupPlugin = ({
     toolName,
@@ -69,10 +63,7 @@ export function getToolSetupPlugin(
         toolName={toolName}
         toolId={toolId}
         owner={owner}
-        conversationId={conversationId}
-        isLastMessage={isLastMessage}
         onSetupComplete={onSetupComplete}
-        onSetupSkipped={onSetupSkipped}
       />
     );
   };

--- a/front/lib/api/assistant/onboarding.ts
+++ b/front/lib/api/assistant/onboarding.ts
@@ -10,8 +10,26 @@ import type {
   UserMessageContext,
 } from "@app/types";
 import { Err, GLOBAL_AGENTS_SID, Ok } from "@app/types";
+import type { JobType } from "@app/types/job_type";
 
 import { createConversation, postUserMessage } from "./conversation";
+
+// Maps job types (from welcome form) to their primary recommended tool.
+const ROLE_TO_PRIMARY_TOOL: Partial<Record<JobType, { sId: string; name: string }>> = {
+  engineering: { sId: "github", name: "GitHub" },
+  sales: { sId: "hubspot", name: "HubSpot" },
+  customer_success: { sId: "hubspot", name: "HubSpot" },
+  customer_support: { sId: "hubspot", name: "HubSpot" },
+  product: { sId: "notion", name: "Notion" },
+  design: { sId: "notion", name: "Notion" },
+  marketing: { sId: "hubspot", name: "HubSpot" },
+  data: { sId: "github", name: "GitHub" },
+  operations: { sId: "notion", name: "Notion" },
+  finance: { sId: "notion", name: "Notion" },
+  people: { sId: "notion", name: "Notion" },
+  legal: { sId: "notion", name: "Notion" },
+  // "other" intentionally omitted - will fall back to email-only or Notion default
+};
 
 const TOOL_RECOMMENDATIONS_BY_ROLE = `
 Tool recommendations by role:
@@ -22,22 +40,28 @@ Tool recommendations by role:
 - Data: GitHub, Notion, Slack
 - Operations/Finance: Notion, Slack, HubSpot`;
 
+// Tool descriptions matching INTERNAL_MCP_SERVERS.serverInfo.description in constants.ts
 const AVAILABLE_TOOLS_LIST = `
 Available tools for personal connection (sId in parentheses):
-- Gmail (gmail), Outlook (outlook) - email
-- Google Calendar (google_calendar), Outlook Calendar (outlook_calendar) - calendar
-- Notion (notion) - knowledge base
-- GitHub (github), Jira (jira) - development
-- Slack (slack), Microsoft Teams (microsoft_teams) - messaging
-- Google Drive (google_drive), Microsoft Drive (microsoft_drive) - file storage
-- Microsoft Excel (microsoft_excel) - spreadsheets
-- HubSpot (hubspot) - CRM`;
+- Gmail (gmail) - Access messages and email drafts
+- Outlook (outlook) - Read emails, manage drafts and contacts
+- Google Calendar (google_calendar) - Access calendar schedules and appointments
+- Outlook Calendar (outlook_calendar) - Tools for managing Outlook calendars and events
+- Notion (notion) - Access workspace pages and databases
+- GitHub (github) - Manage issues and pull requests
+- Jira (jira) - Create, update and track project issues
+- Slack (slack) - Search and post messages
+- Microsoft Teams (microsoft_teams) - Search and post messages
+- Google Drive (google_drive) - Search and read files (Docs, Sheets, Presentations)
+- Microsoft Drive (microsoft_drive) - Tools for managing Microsoft files
+- Microsoft Excel (microsoft_excel) - Work with Excel files in SharePoint
+- HubSpot (hubspot) - Access CRM contacts, deals and customer activities`;
 
 function buildOnboardingPrompt(options: {
   emailProvider: EmailProviderType;
   userJobType: string | null;
 }): string {
-  // Build user context section if job type is available
+  // Build user context section if job type is available.
   const userContextSection = options.userJobType
     ? `
 ## User context
@@ -49,25 +73,50 @@ ${TOOL_RECOMMENDATIONS_BY_ROLE}
 `
     : "";
 
-  // Build the first message instructions based on email provider
-  let firstToolInstruction: string;
-  let toolSetupExample: string;
+  // Determine which tools to show in the first message.
+  const toolSetups: Array<{ sId: string; name: string }> = [];
 
+  // Add email tool if provider is detected.
   if (options.emailProvider === "google") {
-    firstToolInstruction = `The user signed up with a Google email. Mention this and recommend connecting Gmail as a first step to search and summarize emails.`;
-    toolSetupExample = `:toolSetup[Connect Gmail]{sId=gmail}`;
+    toolSetups.push({ sId: "gmail", name: "Gmail" });
   } else if (options.emailProvider === "microsoft") {
-    firstToolInstruction = `The user signed up with a Microsoft email. Mention this and recommend connecting Outlook as a first step to search and summarize emails.`;
-    toolSetupExample = `:toolSetup[Connect Outlook]{sId=outlook}`;
-  } else {
-    // Fallback for unknown email provider - suggest based on role or default to Notion
-    if (options.userJobType) {
-      firstToolInstruction = `Recommend connecting a tool that's most relevant for their role in ${options.userJobType}. Pick ONE tool from the recommendations above.`;
-      toolSetupExample = `:toolSetup[Connect Notion]{sId=notion}  (or another tool relevant to their role)`;
-    } else {
-      firstToolInstruction = `Recommend connecting Notion as a first step - it's useful for most teams to search and summarize documents.`;
-      toolSetupExample = `:toolSetup[Connect Notion]{sId=notion}`;
+    toolSetups.push({ sId: "outlook", name: "Outlook" });
+  }
+
+  // Add role-based tool if job type is available (avoid duplicates).
+  if (options.userJobType) {
+    const roleTool = ROLE_TO_PRIMARY_TOOL[options.userJobType as JobType];
+    if (roleTool && !toolSetups.some((t) => t.sId === roleTool.sId)) {
+      toolSetups.push(roleTool);
     }
+  }
+
+  // Fallback: if no tools determined, suggest Notion.
+  if (toolSetups.length === 0) {
+    toolSetups.push({ sId: "notion", name: "Notion" });
+  }
+
+  // Build the tool setup directives for the first message (on same line).
+  const toolSetupDirectives = toolSetups
+    .map((t) => `:toolSetup[Connect ${t.name}]{sId=${t.sId}}`)
+    .join(" ");
+
+  // Build first message instruction based on what we're recommending.
+  let firstToolInstruction: string;
+  if (
+    options.emailProvider === "google" ||
+    options.emailProvider === "microsoft"
+  ) {
+    const emailName = options.emailProvider === "google" ? "Gmail" : "Outlook";
+    if (toolSetups.length > 1) {
+      firstToolInstruction = `The user signed up with a ${options.emailProvider === "google" ? "Google" : "Microsoft"} email. Recommend connecting ${emailName} to search and summarize emails, and also recommend ${toolSetups[1].name} based on their role.`;
+    } else {
+      firstToolInstruction = `The user signed up with a ${options.emailProvider === "google" ? "Google" : "Microsoft"} email. Recommend connecting ${emailName} to search and summarize emails.`;
+    }
+  } else if (options.userJobType) {
+    firstToolInstruction = `Recommend connecting ${toolSetups[0].name} - it's relevant for their role in ${options.userJobType}.`;
+  } else {
+    firstToolInstruction = `Recommend connecting Notion as a first step - it's useful for most teams to search and summarize documents.`;
   }
 
   return `<dust_system>
@@ -75,28 +124,35 @@ You are onboarding a brand-new user to Dust. This prompt contains all the rules 
 ${userContextSection}
 ## CRITICAL RULE
 
-EVERY message MUST end with EITHER:
-- Quick reply buttons (:quickReply), OR
-- A tool setup directive (:toolSetup)
+EVERY message MUST end with at least one interactive element. You can use:
+- Tool setup cards (:toolSetup) - maximum 2 per message
+- Quick reply buttons (:quickReply) - 2-3 maximum per message
 
-NEVER both. NEVER neither.
+You CAN mix toolSetup and quickReply in the same message when appropriate.
 
 ## Directive reference
 
 ### Tool setup directive
-Shows a card to connect a tool. Use when offering to connect a specific tool.
+Shows a card to connect a tool. Use when offering to connect specific tools.
 
 :toolSetup[Button Label]{sId=toolId}
 
 Example: :toolSetup[Connect Gmail]{sId=gmail}
 
 Rules:
-- Only ONE toolSetup per message
-- Must be on its own line at the end of your message
-- Do NOT add quick replies in the same message
+- Maximum 2 toolSetup directives per message
+- **CRITICAL: When you have 2 toolSetup directives, they MUST be on the SAME line, separated by a space. NEVER put them on separate lines.**
+- Place toolSetup directives at the end of your message, before any quickReply
+
+CORRECT (2 cards on same line):
+:toolSetup[Connect Gmail]{sId=gmail} :toolSetup[Connect GitHub]{sId=github}
+
+WRONG (cards on separate lines - NEVER do this):
+:toolSetup[Connect Gmail]{sId=gmail}
+:toolSetup[Connect GitHub]{sId=github}
 
 ### Quick reply buttons
-Shows clickable buttons for the user to respond. Use for suggesting tasks or next steps.
+Shows clickable buttons for the user to respond. Use for suggesting tasks, next steps, or skip options.
 
 :quickReply[Label]{message="message to send"}
 
@@ -106,11 +162,12 @@ Rules:
 - All quick replies MUST be on a SINGLE line at the end (side by side)
 - 2-3 buttons maximum
 - Keep labels short and action-oriented
-- Do NOT add toolSetup in the same message
 
 ## Response style
 
 Keep responses short and direct. Minimize "thinking" or analysis - just respond naturally and concisely. Do NOT use step-by-step reasoning or lengthy explanations.
+
+**IMPORTANT: Always use the term "agent" (not "assistant") when referring to AI agents in Dust.**
 
 ## What is Dust
 
@@ -132,10 +189,11 @@ Structure:
   }
 3. Mention that Dust becomes more powerful when connected to their tools
 4. ${firstToolInstruction}
-5. End with the tool setup directive (NO quick replies)
+5. End with tool setup card(s) AND a skip quick reply
 
-Example ending:
-${toolSetupExample}
+You MUST end your first message EXACTLY like this:
+${toolSetupDirectives}
+:quickReply[Skip for now]{message="I'd like to skip connecting tools for now"}
 
 Keep it concise and welcoming. Use 1-3 emojis total. Do NOT ask about their goals yet.
 
@@ -143,43 +201,136 @@ Keep it concise and welcoming. Use 1-3 emojis total. Do NOT ask about their goal
 
 ## HANDLING SUBSEQUENT MESSAGES
 
-### After user completes any task
-When the user completes a task (searching emails, researching a topic, creating a chart, etc.):
-1. Provide the result
-2. End with quick replies to continue exploring
+### When user wants to skip initial tool setup
+The user chose to skip the initial recommendations. Show them ALL available tools to maximize the chance they find one they want:
+
+1. Acknowledge their choice briefly
+2. Present ALL available tools grouped by category:
+   - **Email & Calendar**: Gmail, Outlook, Google Calendar, Outlook Calendar
+   - **Knowledge & Docs**: Notion, Google Drive, Microsoft Drive
+   - **Development**: GitHub, Jira
+   - **Communication**: Slack, Microsoft Teams
+   - **CRM & Spreadsheets**: HubSpot, Microsoft Excel
+3. Offer 2 diverse toolSetup cards for popular tools (on same line)
+4. Include a "Skip all tools" quick reply
+
+Example ending:
+:toolSetup[Connect Notion]{sId=notion} :toolSetup[Connect Slack]{sId=slack}
+:quickReply[Skip all tools]{message="I don't want to connect any tools right now"}
+
+### When user skips ALL tools
+The user explicitly doesn't want to connect any tools:
+
+1. Acknowledge warmly - totally fine!
+2. Explain what Dust can do without tools: search the web, create charts and visualizations, answer questions
+3. Mention they can connect tools anytime from Settings
+4. End with quick replies for web research and chart creation
+
+Example ending:
+:quickReply[Research a topic]{message="Research the latest AI trends"} :quickReply[Create a chart]{message="Create a chart of global population"}
+
+### After user completes a tool setup
+When the user successfully connects a tool:
+1. Celebrate briefly (1 emoji)
+2. Briefly explain what they can now do with this tool
+3. Suggest 2-3 tasks they can try
+4. End with quick replies for those tasks
 
 Example:
-:quickReply[Connect more tools]{message="What other tools can I connect?"} :quickReply[Research a topic]{message="Research the latest AI trends"} :quickReply[Create a chart]{message="Create a chart of quarterly sales"}
+:quickReply[Summarize emails]{message="Summarize my emails from today"} :quickReply[Connect more tools]{message="What other tools can I connect?"}
 
 ### When user asks to connect more tools
 1. Briefly mention what the tool enables
-2. End with ONE toolSetup directive (most relevant for their role)
-3. NO quick replies
+2. Show 1-2 toolSetup directives on the same line (most relevant for their role)
+3. Include a skip quick reply
 
 Example:
-:toolSetup[Connect GitHub]{sId=github}
-
-### When user says they don't want to connect tools
-1. Acknowledge - that's totally fine
-2. Explain Dust can also research the web and create interactive visualizations
-3. End with quick replies for these capabilities
-
-Example:
-:quickReply[Research a topic]{message="Research the latest AI trends"} :quickReply[Create a chart]{message="Create a chart of global population"}
+:toolSetup[Connect GitHub]{sId=github} :toolSetup[Connect Notion]{sId=notion}
+:quickReply[Skip]{message="I don't need this tool"}
 </dust_system>`;
 }
 
-export function buildOnboardingFollowUpPrompt(toolId: string): string {
-  const isEmailTool = toolId === "gmail" || toolId === "outlook";
-
-  const taskSuggestions = isEmailTool
-    ? `Suggest 2-3 things they can try with their email:
+// Tool-specific task suggestions for the follow-up prompt after connecting a tool.
+const TOOL_TASK_SUGGESTIONS: Record<string, string> = {
+  gmail: `Suggest 2-3 things they can try with Gmail:
 - Summarize today's emails or recent threads
 - Search for emails by sender or topic
 
 Example quick replies:
-:quickReply[Summarize today's emails]{message="Summarize the emails I received today"} :quickReply[Search emails]{message="Find emails about project updates"}`
-    : `Suggest 2-3 things they can try with the connected tool. Only suggest tasks the tool can actually perform (reading/searching data).`;
+:quickReply[Summarize today's emails]{message="Summarize the emails I received today"} :quickReply[Search emails]{message="Find emails about project updates"}`,
+
+  outlook: `Suggest 2-3 things they can try with Outlook:
+- Summarize today's emails or recent threads
+- Search for emails by sender or topic
+
+Example quick replies:
+:quickReply[Summarize today's emails]{message="Summarize the emails I received today"} :quickReply[Search emails]{message="Find emails about project updates"}`,
+
+  github: `Suggest 2-3 things they can try with GitHub:
+- Search for issues or pull requests
+- Get a summary of recent activity in a repository
+- Find code or documentation
+
+Example quick replies:
+:quickReply[Find open PRs]{message="Show me open pull requests that need review"} :quickReply[Search issues]{message="Find issues related to bugs"}`,
+
+  notion: `Suggest 2-3 things they can try with Notion:
+- Search for documents or pages
+- Get a summary of recent updates
+- Find information across their workspace
+
+Example quick replies:
+:quickReply[Search docs]{message="Search for documentation about onboarding"} :quickReply[Recent updates]{message="What pages were updated recently?"}`,
+
+  slack: `Suggest 2-3 things they can try with Slack:
+- Search for messages or conversations
+- Get a summary of recent channel activity
+- Find discussions about a topic
+
+Example quick replies:
+:quickReply[Search messages]{message="Find messages about the product launch"} :quickReply[Channel summary]{message="Summarize what happened in #general today"}`,
+
+  hubspot: `Suggest 2-3 things they can try with HubSpot:
+- Search for contacts or companies
+- Get deal pipeline summaries
+- Find recent activity on accounts
+
+Example quick replies:
+:quickReply[Search contacts]{message="Find contacts from Acme Corp"} :quickReply[Deal summary]{message="Show me deals closing this month"}`,
+
+  jira: `Suggest 2-3 things they can try with Jira:
+- Search for tickets or issues
+- Get a sprint summary
+- Find work assigned to them
+
+Example quick replies:
+:quickReply[My tickets]{message="Show my open Jira tickets"} :quickReply[Sprint status]{message="What's the status of the current sprint?"}`,
+
+  google_drive: `Suggest 2-3 things they can try with Google Drive:
+- Search for documents or files
+- Find recently modified files
+- Get summaries of documents
+
+Example quick replies:
+:quickReply[Search files]{message="Find documents about Q4 planning"} :quickReply[Recent files]{message="Show files I edited recently"}`,
+
+  microsoft_drive: `Suggest 2-3 things they can try with OneDrive:
+- Search for documents or files
+- Find recently modified files
+- Get summaries of documents
+
+Example quick replies:
+:quickReply[Search files]{message="Find documents about Q4 planning"} :quickReply[Recent files]{message="Show files I edited recently"}`,
+};
+
+const DEFAULT_TASK_SUGGESTIONS = `Suggest 2-3 things they can try with the connected tool. Only suggest tasks the tool can actually perform (reading/searching data).
+
+Example quick replies:
+:quickReply[Try it out]{message="What can I do with this tool?"} :quickReply[Connect more tools]{message="What other tools can I connect?"}`;
+
+export function buildOnboardingFollowUpPrompt(toolId: string): string {
+  const taskSuggestions =
+    TOOL_TASK_SUGGESTIONS[toolId] ?? DEFAULT_TASK_SUGGESTIONS;
 
   return `<dust_system>
 The user just successfully connected a tool. Respond to this event.
@@ -189,39 +340,16 @@ The user just successfully connected a tool. Respond to this event.
 1. Celebrate briefly (1 emoji) - the tool is connected!
 2. Briefly explain what the tool enables
 3. ${taskSuggestions}
-4. End with quick replies for suggested tasks (NO toolSetup)
+4. End with quick replies for suggested tasks
 
 Keep it short and encouraging. Minimize "thinking" - just respond naturally. Do NOT repeat the welcome message.
 
 ## REMINDER: Rules for this conversation
 
 After ANY task is completed, always end with quick replies:
-:quickReply[Connect more tools]{message="What other tools can I connect?"} :quickReply[Research a topic]{message="Research the latest AI trends"} :quickReply[Create a chart]{message="Create a chart of quarterly sales"}
+:quickReply[Try something else]{message="What else can I try?"} :quickReply[Connect more tools]{message="What other tools can I connect?"}
 
-When user asks to connect tools, show ONE toolSetup only (no quick replies).
-Refer to the initial message for the full tool list and role-based recommendations.
-</dust_system>`;
-}
-
-export function buildOnboardingSkippedPrompt(): string {
-  return `<dust_system>
-The user chose to skip connecting the suggested tool. Respond to this event.
-
-## What to do NOW
-
-1. Acknowledge their choice warmly - it's totally fine to skip
-2. Mention they can connect tools anytime from Settings
-3. Offer two paths forward with quick replies (NO toolSetup)
-
-End with:
-:quickReply[See other tools]{message="What other tools can I connect?"} :quickReply[Explore without tools]{message="What can I do without connecting tools?"}
-
-Keep it short and friendly. Minimize "thinking" - just respond naturally. Use 1 emoji. Do NOT repeat the welcome message.
-
-## REMINDER: Rules for this conversation
-
-If user asks about other tools → show ONE toolSetup (no quick replies)
-If user wants to explore without tools → explain web research & charts, end with quick replies
+When user asks to connect tools, show toolSetup cards with a skip quick reply option.
 Refer to the initial message for the full tool list and role-based recommendations.
 </dust_system>`;
 }
@@ -291,7 +419,7 @@ export async function createOnboardingConversationIfNeeded(
   const userJobType = jobTypeMetadata?.value ?? null;
 
   const conversation = await createConversation(auth, {
-    title: null,
+    title: "Welcome to Dust",
     visibility: "unlisted",
     spaceId: null,
   });
@@ -306,6 +434,7 @@ export async function createOnboardingConversationIfNeeded(
     fullName: userJson.fullName,
     email: userJson.email,
     profilePictureUrl: userJson.image,
+    // UTC is used since this runs server-side and we don't have access to user's timezone.
     timezone: "UTC",
     origin: "onboarding_conversation",
   };

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -797,10 +797,7 @@ export function usePostOnboardingFollowUp({
   const sendNotification = useSendNotification();
 
   const postFollowUp = useCallback(
-    async (
-      toolId: string,
-      action: "completed" | "skipped"
-    ): Promise<boolean> => {
+    async (toolId: string): Promise<boolean> => {
       if (!conversationId) {
         return false;
       }
@@ -810,7 +807,7 @@ export function usePostOnboardingFollowUp({
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ toolId, action }),
+            body: JSON.stringify({ toolId }),
           }
         );
 
@@ -825,7 +822,6 @@ export function usePostOnboardingFollowUp({
           workspaceId,
           conversationId,
           toolId,
-          action,
         });
         sendNotification({
           type: "error",

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -80,6 +80,19 @@ export function useDeleteMetadata() {
   return { deleteMetadata };
 }
 
+export function useIsOnboardingConversation(conversationId: string | null) {
+  const { metadata, isMetadataLoading } = useUserMetadata(
+    "onboarding:conversation",
+    { disabled: !conversationId }
+  );
+
+  return {
+    isOnboardingConversation:
+      !!conversationId && !!metadata?.value && metadata.value === conversationId,
+    isLoading: isMetadataLoading,
+  };
+}
+
 export function usePatchUser() {
   const { mutateUser } = useUser();
   const sendNotification = useSendNotification();

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -4,10 +4,7 @@ import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/c
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
-import {
-  buildOnboardingFollowUpPrompt,
-  buildOnboardingSkippedPrompt,
-} from "@app/lib/api/assistant/onboarding";
+import { buildOnboardingFollowUpPrompt } from "@app/lib/api/assistant/onboarding";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -48,7 +45,7 @@ async function handler(
     });
   }
 
-  const { toolId, action } = req.body;
+  const { toolId } = req.body;
 
   if (!isString(toolId) || !isInternalMCPServerName(toolId)) {
     return apiError(req, res, {
@@ -56,17 +53,6 @@ async function handler(
       api_error: {
         type: "invalid_request_error",
         message: "Invalid request body, `toolId` (valid tool id) is required.",
-      },
-    });
-  }
-
-  if (!isString(action) || !["completed", "skipped"].includes(action)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "Invalid request body, `action` must be 'completed' or 'skipped'.",
       },
     });
   }
@@ -79,10 +65,7 @@ async function handler(
 
   const conversation = conversationRes.value;
 
-  const followUpPrompt =
-    action === "skipped"
-      ? buildOnboardingSkippedPrompt()
-      : buildOnboardingFollowUpPrompt(toolId);
+  const followUpPrompt = buildOnboardingFollowUpPrompt(toolId);
 
   const messageRes = await postUserMessage(auth, {
     conversation,


### PR DESCRIPTION

## Description

  Improves the onboarding conversation feature with several enhancements:

  ### New Features
  - **Multiple tool setup cards in first message**: Now shows both email provider tool (Gmail/Outlook) AND a role-based
  tool (e.g., GitHub for engineers, HubSpot for sales) when applicable
  - **Skip via quick reply**: Replaced per-card "Skip" buttons with a single "Skip for now" quick reply, allowing users to
  see all available tools before deciding
  - **Tool-specific follow-up suggestions**: Added tailored task suggestions for each tool (GitHub, Notion, Slack, HubSpot,
   Jira, Google Drive, etc.) instead of generic prompts

  ### Bug Fixes
  - **Fixed job type mismatch**: `ROLE_TO_PRIMARY_TOOL` keys now match the lowercase `JobType` values from the welcome form
   (was using capitalized labels like `"Engineering"` instead of `"engineering"`)
  - **Added missing job types**: Now supports all job types including `sales`, `customer_support`, `product`, `design`,
  `people`, `legal`, etc.

  ### Code Cleanup
  - Removed dead code: `buildOnboardingSkippedPrompt()` and the unused `action: "skipped"` path in the follow-up API
  - Simplified `usePostOnboardingFollowUp` hook (removed unused `action` parameter)
  - Removed `onSetupSkipped` prop from `ToolSetupCard` component
  - Set meaningful conversation title ("Welcome to Dust") instead of `null`

  ### Files Changed
  - `front/lib/api/assistant/onboarding.ts` - Main prompt logic and tool recommendations
  - `front/components/markdown/tool/ToolSetupCard.tsx` - Removed Skip button
  - `front/components/markdown/tool/tool.tsx` - Simplified plugin signature
  - `front/components/assistant/conversation/AgentMessage.tsx` - Removed skipped handler
  - `front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts` - Simplified API
  - `front/lib/swr/conversations.ts` - Simplified hook

  ## Tests

  Manual testing required with the feature flag enabled (`ONBOARDING_CONVERSATION_ENABLED = true`). Test scenarios:
  - New workspace with Google email → should see Gmail + role-based tool cards
  - New workspace with Microsoft email → should see Outlook + role-based tool cards
  - Various job types → verify correct role-based tool is recommended
  - Skip flow → verify all tools are shown with "Skip all tools" option
  - Tool setup completion → verify tool-specific suggestions appear

  ## Risk

  **Low risk** - Feature is behind a feature flag (`ONBOARDING_CONVERSATION_ENABLED = false` by default). Changes only  affect the onboarding conversation flow which is currently disabled.

  ## Deploy Plan

Deploy front (no immediate impact since feature flag is off)