### PR TITLE
Fix: issue with batchRenderMessage missing parent message for agent message.

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -499,7 +499,11 @@ export const ConversationViewer = ({
           // +1 per agent message mentioned
           rank += 1;
           placeholderAgentMessages.push(
-            createPlaceholderAgentMessage({ mention, rank })
+            createPlaceholderAgentMessage({
+              userMessage: placeholderUserMsg,
+              mention,
+              rank,
+            })
           );
         }
       }

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -146,9 +146,11 @@ export function createPlaceholderUserMessage({
 }
 
 export function createPlaceholderAgentMessage({
+  userMessage,
   mention,
   rank,
 }: {
+  userMessage: UserMessageType;
   mention: RichMention & { pictureUrl: string };
   rank: number;
 }): MessageTemporaryState {
@@ -161,7 +163,7 @@ export function createPlaceholderAgentMessage({
       version: 0,
       created: createdAt,
       completedTs: null,
-      parentMessageId: null,
+      parentMessageId: userMessage.sId,
       parentAgentMessageId: null,
       status: "created",
       content: null,

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -370,7 +370,7 @@ export const createAgentMessages = async (
     agentMessageRow: AgentMessage;
     messageRow: Message;
     configuration: LightAgentConfigurationType;
-    parentMessageId: string | null;
+    parentMessageId: string;
     parentAgentMessageId: string | null;
   }[] = [];
 

--- a/front/lib/api/assistant/messages.test.ts
+++ b/front/lib/api/assistant/messages.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessage,
+  Message,
+  UserMessage,
+} from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { AgentMessageType, LightAgentConfigurationType } from "@app/types";
+
+describe("batchRenderMessages", () => {
+  let auth: Authenticator;
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let agentConfig: LightAgentConfigurationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+
+    agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+  });
+
+  describe("with a single agentMessage", () => {
+    it("should automatically fetch the parent message if needed", async () => {
+      // Create a conversation with a user message and agent message
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [new Date()],
+      });
+
+      // Fetch the conversation resource
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      // Get all messages from the conversation
+      const allMessages = await Message.findAll({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: workspace.id,
+        },
+        include: [
+          {
+            model: UserMessage,
+            as: "userMessage",
+            required: false,
+          },
+          {
+            model: AgentMessage,
+            as: "agentMessage",
+            required: false,
+          },
+        ],
+        order: [["rank", "ASC"]],
+      });
+
+      // Find the agent message
+      const agentMessageModel = allMessages.find((m) => !!m.agentMessage);
+      expect(agentMessageModel).toBeDefined();
+      expect(agentMessageModel?.parentId).not.toBeNull();
+
+      // Find the parent user message
+      const parentUserMessage = allMessages.find(
+        (m) => m.id === agentMessageModel?.parentId
+      );
+      expect(parentUserMessage).toBeDefined();
+
+      // Now test: pass only the agent message (without the parent) to batchRenderMessages
+      // This simulates the scenario where you're rendering a subset of messages
+      const result = await batchRenderMessages(
+        auth,
+        conversationResource!,
+        [agentMessageModel!], // Only pass the agent message, not the parent
+        "full"
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const renderedMessages = result.value;
+        expect(renderedMessages.length).toBeGreaterThan(0);
+
+        // Find the rendered agent message
+        const renderedAgentMessage = renderedMessages.find(
+          (m) => m.type === "agent_message"
+        ) as AgentMessageType | undefined;
+        expect(renderedAgentMessage).toBeDefined();
+
+        if (renderedAgentMessage) {
+          // Verify that the parent message was fetched and included
+          expect(renderedAgentMessage.parentMessageId).toBe(
+            parentUserMessage!.sId
+          );
+          expect(renderedAgentMessage.id).toBe(agentMessageModel!.id);
+          expect(renderedAgentMessage.sId).toBe(agentMessageModel!.sId);
+        }
+      }
+    });
+
+    it("should work with parent message already included in messages array", async () => {
+      // Create a conversation with a user message and agent message
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [new Date()],
+      });
+
+      // Fetch the conversation resource
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      // Get all messages from the conversation
+      const allMessages = await Message.findAll({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: workspace.id,
+        },
+        include: [
+          {
+            model: UserMessage,
+            as: "userMessage",
+            required: false,
+          },
+          {
+            model: AgentMessage,
+            as: "agentMessage",
+            required: false,
+          },
+        ],
+        order: [["rank", "ASC"]],
+      });
+
+      // Find the agent message and its parent
+      const agentMessageModel = allMessages.find((m) => !!m.agentMessage);
+      const parentUserMessage = allMessages.find(
+        (m) => m.id === agentMessageModel?.parentId
+      );
+
+      expect(agentMessageModel).toBeDefined();
+      expect(parentUserMessage).toBeDefined();
+
+      // Test: pass both the parent and agent message
+      const result = await batchRenderMessages(
+        auth,
+        conversationResource!,
+        [parentUserMessage!, agentMessageModel!], // Include both messages
+        "full"
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const renderedMessages = result.value;
+        expect(renderedMessages.length).toBe(2);
+
+        const renderedAgentMessage = renderedMessages.find(
+          (m) => m.type === "agent_message"
+        ) as AgentMessageType | undefined;
+        expect(renderedAgentMessage).toBeDefined();
+
+        if (renderedAgentMessage) {
+          expect(renderedAgentMessage.parentMessageId).toBe(
+            parentUserMessage!.sId
+          );
+        }
+      }
+    });
+
+    it("should work with light view type", async () => {
+      // Create a conversation with a user message and agent message
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [new Date()],
+      });
+
+      // Fetch the conversation resource
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      // Get all messages from the conversation
+      const allMessages = await Message.findAll({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: workspace.id,
+        },
+        include: [
+          {
+            model: UserMessage,
+            as: "userMessage",
+            required: false,
+          },
+          {
+            model: AgentMessage,
+            as: "agentMessage",
+            required: false,
+          },
+        ],
+        order: [["rank", "ASC"]],
+      });
+
+      // Find the agent message
+      const agentMessageModel = allMessages.find((m) => !!m.agentMessage);
+      expect(agentMessageModel).toBeDefined();
+
+      // Test with light view type - only pass the agent message
+      const result = await batchRenderMessages(
+        auth,
+        conversationResource!,
+        [agentMessageModel!],
+        "light"
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const renderedMessages = result.value;
+        expect(renderedMessages.length).toBeGreaterThan(0);
+
+        const renderedAgentMessage = renderedMessages.find(
+          (m) => m.type === "agent_message"
+        );
+        expect(renderedAgentMessage).toBeDefined();
+      }
+    });
+  });
+});

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,3 +1,5 @@
+import assert from "assert";
+
 import {
   AgentMessageContentParser,
   getCoTDelimitersConfiguration,
@@ -418,9 +420,38 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         }
       })();
 
-      const parentMessage = message.parentId
+      assert(message.parentId !== null, "Agent message must have a parentId.");
+
+      let parentMessage = message.parentId
         ? (messagesById.get(message.parentId) ?? null)
         : null;
+
+      if (!parentMessage) {
+        logger.info(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            conversationSId: message.sId,
+            agentMessageId: agentMessage.id,
+          },
+          "Couldn't find parent message for agent message in the messages map, can happen if you are only rendering a subset of the messages. Falling back to fetch the message from the database."
+        );
+        parentMessage = await Message.findOne({
+          where: {
+            id: message.parentId,
+            workspaceId: auth.getNonNullableWorkspace().id,
+            conversationId: message.conversationId,
+          },
+          include: [
+            {
+              model: UserMessage,
+              as: "userMessage",
+              required: false,
+            },
+          ],
+        });
+      }
+
+      assert(parentMessage !== null, "Parent message must be found.");
 
       let parentAgentMessage: Message | null = null;
 
@@ -459,7 +490,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         visibility: message.visibility,
         version: message.version,
         rank: message.rank,
-        parentMessageId: parentMessage?.sId ?? null,
+        parentMessageId: parentMessage.sId,
         parentAgentMessageId: parentAgentMessage?.sId ?? null,
         status: agentMessage.status,
         actions,

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -176,7 +176,7 @@ async function handler(
         rank: 0,
         created: Date.now(),
         completedTs: null,
-        parentMessageId: null,
+        parentMessageId: userMessage.sId,
         parentAgentMessageId: null,
         status: "created",
         content: null,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -175,7 +175,7 @@ export type BaseAgentMessageType = {
   rank: number;
   created: number;
   completedTs: number | null;
-  parentMessageId: string | null;
+  parentMessageId: string;
   parentAgentMessageId: string | null; // If handover, this is the agent message that summoned this agent.
   status: AgentMessageStatus;
   content: string | null;


### PR DESCRIPTION
## Description

Enforce the contract that agent message must have a parent message.
In case we only pass a subset of messages to batchRenderMessage, we'll automatically fetch the parent message.

## Tests

Added

## Risk

Low, worst case, 1 extra query, not part of the hot path.

## Deploy Plan

Deploy front