### PR TITLE
Use conversion resource in validateAction and listBlockedActionsForConversation

### DIFF
--- a/front/.vscode/settings.json
+++ b/front/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.experimental.useTsgo": true
+}

--- a/front/.vscode/settings.json
+++ b/front/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "typescript.experimental.useTsgo": true
-}

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -13,9 +13,10 @@ import { DustError } from "@app/lib/error";
 import { Message } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
-import type { ConversationWithoutContentType, Result } from "@app/types";
+import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
 async function getUserMessageIdFromMessageId(
@@ -62,7 +63,7 @@ async function getUserMessageIdFromMessageId(
 
 export async function validateAction(
   auth: Authenticator,
-  conversation: ConversationWithoutContentType,
+  conversation: ConversationResource,
   {
     actionId,
     approvalState,
@@ -165,7 +166,7 @@ export async function validateAction(
   const blockedActions =
     await AgentMCPActionResource.listBlockedActionsForConversation(
       auth,
-      conversationId
+      conversation
     );
 
   // Harmless very rare race condition here where 2 validations get

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -30,7 +30,7 @@ import {
 import { AgentMessage, Message } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -361,7 +361,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       } else if (action.status === "blocked_child_action_input_required") {
         const conversationId = action.stepContext.resumeState?.conversationId;
 
-        // conversation was not created so we can return an empty list (= no blocked actions)
+        // conversation was not created so we can return early
         if (!conversationId || !isString(conversationId)) {
           return blockedActionsList;
         }

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -361,9 +361,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       } else if (action.status === "blocked_child_action_input_required") {
         const conversationId = action.stepContext.resumeState?.conversationId;
 
-        // conversation was not created so we can return early
+        // conversation was not created so we can skip it
         if (!conversationId || !isString(conversationId)) {
-          return blockedActionsList;
+          continue;
         }
 
         const childConversation = await ConversationResource.fetchById(
@@ -372,7 +372,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         );
 
         if (!childConversation) {
-          return blockedActionsList;
+          continue;
         }
 
         const childBlockedActionsList = isString(conversationId)

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -30,7 +30,7 @@ import {
 import { AgentMessage, Message } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
@@ -318,7 +318,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         "status" | "authorizationInfo"
       > = {
         messageId: agentMessage.message.sId,
-        conversationId,
+        conversationId: conversation.sId,
         actionId: this.modelIdToSId({
           id: action.id,
           workspaceId: owner.id,
@@ -338,7 +338,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           logger.warn(
             {
               actionId: action.id,
-              conversationId: conversation.id,
+              conversationId: conversation.sId,
               messageId: agentMessage.message.sId,
               workspaceId: owner.id,
             },

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
@@ -40,8 +41,23 @@ async function handler(
     });
   }
 
+  const conversation = await ConversationResource.fetchById(auth, cId);
+
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
   const blockedActions =
-    await AgentMCPActionResource.listBlockedActionsForConversation(auth, cId);
+    await AgentMCPActionResource.listBlockedActionsForConversation(
+      auth,
+      conversation
+    );
 
   res.status(200).json({ blockedActions });
 }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -127,7 +127,7 @@ async function handler(
 
   const { actionId, approved } = parseResult.data;
 
-  const result = await validateAction(auth, conversation.toJSON(), {
+  const result = await validateAction(auth, conversation, {
     actionId,
     approvalState: approved,
     messageId: mId,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
@@ -4,6 +4,7 @@ import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
@@ -39,8 +40,22 @@ async function handler(
     });
   }
 
+  const conversation = await ConversationResource.fetchById(auth, cId);
+
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
   const blockedActions =
-    await AgentMCPActionResource.listBlockedActionsForConversation(auth, cId);
+    await AgentMCPActionResource.listBlockedActionsForConversation(
+      auth,
+      conversation
+    );
 
   res.status(200).json({ blockedActions });
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -72,7 +72,7 @@ async function handler(
 
   const { actionId, approved } = parseResult.data;
 
-  const result = await validateAction(auth, conversation.toJSON(), {
+  const result = await validateAction(auth, conversation, {
     actionId,
     approvalState: approved,
     messageId: mId,


### PR DESCRIPTION
## Description
This PR is mini refactoring based on TIL feedback from flavien in https://github.com/dust-tt/dust/pull/18417 

both `validateAction` and `listBlockedActionsForConversation` takes conversationResource, and conversation check nows happens at api level and you don't have to fetch conversation twice 🎉


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
