### PR TITLE
[front] enh(poke): Allow to disable invitation button

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -24,6 +24,7 @@ export * from "./send_onboarding_conversation";
 export * from "./set_public_api_limits";
 export * from "./sync_missing_transcripts_date_range";
 export * from "./toggle_auto_create_space";
+export * from "./toggle_disable_manual_invitations";
 export * from "./toggle_feature_flag";
 export * from "./upgrade_downgrade";
 export * from "./upgrade_to_business_plan";

--- a/front/lib/api/poke/plugins/workspaces/toggle_disable_manual_invitations.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_disable_manual_invitations.ts
@@ -1,0 +1,44 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { updateWorkspaceMetadata } from "@app/lib/api/workspace";
+import { Err, Ok } from "@app/types";
+
+export const toggleDisableManualInvitationsPlugin = createPlugin({
+  manifest: {
+    id: "toggle-disable-manual-invitations",
+    name: "Toggle Disable Manual Invitations",
+    description:
+      "Enable/disable manual user invitations. " +
+      "When enabled, the 'Invite members' button will be hidden. Existing invitations will not be affected, and emmbers can still be invited with poke plugin.",
+    resourceTypes: ["workspaces"],
+    args: {
+      disabled: {
+        type: "boolean",
+        label: "Disable Manual Invitations",
+        description:
+          "When checked, manual invitations via the 'Invite members' button will be disabled",
+      },
+    },
+  },
+  execute: async (auth, workspace, args) => {
+    if (!workspace) {
+      return new Err(new Error("Cannot find workspace."));
+    }
+
+    const { disabled } = args;
+
+    const result = await updateWorkspaceMetadata(workspace, {
+      disableManualInvitations: disabled,
+    });
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    return new Ok({
+      display: "text",
+      value: disabled
+        ? `Manual invitations are now DISABLED for workspace "${workspace.name}". The 'Invite members' button will be hidden.`
+        : `Manual invitations are now ENABLED for workspace "${workspace.name}". The 'Invite members' button will be visible.`,
+    });
+  },
+});

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -403,6 +403,7 @@ export interface WorkspaceMetadata {
   allowContentCreationFileSharing?: boolean;
   allowVoiceTranscription?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;
+  disableManualInvitations?: boolean;
 }
 
 export async function updateWorkspaceMetadata(

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -95,6 +95,8 @@ export default function WorkspaceAdmin({
   const hasVerifiedDomains = workspaceVerifiedDomains.length > 0;
   const isProvisioningEnabled =
     plan.limits.users.isSCIMAllowed && hasVerifiedDomains;
+  const isManualInvitationsEnabled =
+    owner.metadata?.disableManualInvitations !== true;
 
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
@@ -146,18 +148,21 @@ export default function WorkspaceAdmin({
                 name="search"
                 onChange={setSearchTerm}
               />
-              <InviteEmailButtonWithModal
-                owner={owner}
-                prefillText=""
-                perSeatPricing={perSeatPricing}
-                onInviteClick={onInviteClick}
-              />
+              {isManualInvitationsEnabled && (
+                <InviteEmailButtonWithModal
+                  owner={owner}
+                  prefillText=""
+                  perSeatPricing={perSeatPricing}
+                  onInviteClick={onInviteClick}
+                />
+              )}
             </div>
             <WorkspaceMembersGroupsList
               currentUser={user}
               owner={owner}
               searchTerm={searchTerm}
               isProvisioningEnabled={isProvisioningEnabled}
+              isManualInvitationsEnabled={isManualInvitationsEnabled}
             />
           </WorkspaceSection>
           {inviteBlockedPopupReason && (
@@ -180,6 +185,7 @@ const DEFAULT_PAGE_SIZE = 25;
 interface WorkspaceMembersGroupsListProps {
   currentUser: UserType | null;
   isProvisioningEnabled: boolean;
+  isManualInvitationsEnabled: boolean;
   owner: WorkspaceType;
   searchTerm: string;
 }
@@ -187,6 +193,7 @@ interface WorkspaceMembersGroupsListProps {
 function WorkspaceMembersGroupsList({
   currentUser,
   isProvisioningEnabled,
+  isManualInvitationsEnabled,
   owner,
   searchTerm,
 }: WorkspaceMembersGroupsListProps) {
@@ -195,7 +202,9 @@ function WorkspaceMembersGroupsList({
       <Tabs defaultValue="members">
         <TabsList className="mb-4">
           <TabsTrigger value="members" label="Members" />
-          <TabsTrigger value="invitations" label="Invitations" />
+          {isManualInvitationsEnabled && (
+            <TabsTrigger value="invitations" label="Invitations" />
+          )}
         </TabsList>
         <TabsContent value="members">
           <WorkspaceMembersList
@@ -205,9 +214,11 @@ function WorkspaceMembersGroupsList({
             isProvisioningEnabled={isProvisioningEnabled}
           />
         </TabsContent>
-        <TabsContent value="invitations">
-          <InvitationsList owner={owner} searchText={searchTerm} />
-        </TabsContent>
+        {isManualInvitationsEnabled && (
+          <TabsContent value="invitations">
+            <InvitationsList owner={owner} searchText={searchTerm} />
+          </TabsContent>
+        )}
       </Tabs>
     </div>
   );


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/6744

## Description

Add a flag in workspace metadata to disable manual invitations. Only affects the admin UI.

## Tests

Locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front 
