### PR TITLE
UserSearch: debounce workflow start to avoid "workflow already started" errors.

### DIFF
--- a/front/temporal/es_indexation/client.ts
+++ b/front/temporal/es_indexation/client.ts
@@ -1,9 +1,8 @@
-import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
-
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/es_indexation/config";
 import { makeIndexUserSearchWorkflowId } from "@app/temporal/es_indexation/helpers";
+import { indexUserSearchSignal } from "@app/temporal/es_indexation/signals";
 import { indexUserSearchWorkflow } from "@app/temporal/es_indexation/workflows";
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
@@ -18,26 +17,26 @@ export async function launchIndexUserSearchWorkflow({
   const workflowId = makeIndexUserSearchWorkflowId({ userId });
 
   try {
-    await client.workflow.start(indexUserSearchWorkflow, {
+    await client.workflow.signalWithStart(indexUserSearchWorkflow, {
       args: [{ userId }],
       taskQueue: QUEUE_NAME,
       workflowId,
+      signal: indexUserSearchSignal,
+      signalArgs: undefined,
       memo: {
         userId,
       },
     });
     return new Ok(undefined);
   } catch (e) {
-    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
-      logger.error(
-        {
-          workflowId,
-          userId,
-          error: e,
-        },
-        "Failed starting index user workflow"
-      );
-    }
+    logger.error(
+      {
+        workflowId,
+        userId,
+        error: e,
+      },
+      "Failed starting index user workflow"
+    );
 
     return new Err(normalizeError(e));
   }

--- a/front/temporal/es_indexation/client.ts
+++ b/front/temporal/es_indexation/client.ts
@@ -2,10 +2,11 @@ import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/es_indexation/config";
 import { makeIndexUserSearchWorkflowId } from "@app/temporal/es_indexation/helpers";
-import { indexUserSearchSignal } from "@app/temporal/es_indexation/signals";
-import { indexUserSearchWorkflow } from "@app/temporal/es_indexation/workflows";
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
+
+import { indexUserSearchSignal } from "./signals";
+import { indexUserSearchWorkflow } from "./workflows";
 
 export async function launchIndexUserSearchWorkflow({
   userId,

--- a/front/temporal/es_indexation/signals.ts
+++ b/front/temporal/es_indexation/signals.ts
@@ -1,0 +1,5 @@
+import { defineSignal } from "@temporalio/workflow";
+
+export const indexUserSearchSignal = defineSignal<[void]>(
+  "index_user_search_signal"
+);

--- a/front/temporal/es_indexation/workflows.ts
+++ b/front/temporal/es_indexation/workflows.ts
@@ -1,9 +1,10 @@
 import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
 import type * as activities from "@app/temporal/es_indexation/activities";
-import { indexUserSearchSignal } from "@app/temporal/es_indexation/signals";
 
-const DEBOUNCE_DELAY_MS = 10_000;
+import { indexUserSearchSignal } from "./signals";
+
+const DEBOUNCE_DELAY_MS = 1_000;
 
 const { indexUserSearchActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
@@ -30,6 +31,6 @@ export async function indexUserSearchWorkflow({
     await indexUserSearchActivity({ userId });
   }
 
-  // /!\ Any signal received outside of the while loop will be lost, so don't make any async
-  // call here, which will allow the signal handler to be executed by the nodejs event loop. /!\
+  // /!\ Any signal received outside of the while loop will be lost, so don't make any async call
+  // here, which will allow the signal handler to be executed by the nodejs event loop.
 }


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1764668143838669
Fixes: https://github.com/dust-tt/tasks/issues/5367

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`