### PR TITLE
feat(poke): poke plugin to delete a folder

### DIFF
--- a/front/lib/api/poke/plugin_manager.ts
+++ b/front/lib/api/poke/plugin_manager.ts
@@ -21,8 +21,7 @@ class PluginManager {
         for (const rt of resourceTypes) {
           // Initialize and push in one statement.
           (this.pluginsByResourceType[rt] =
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            this.pluginsByResourceType[rt] || []).push(plugin);
+            this.pluginsByResourceType[rt] ?? []).push(plugin);
         }
 
         this.plugins.set(plugin.manifest.id, plugin);
@@ -41,8 +40,7 @@ class PluginManager {
   }
 
   getPluginsForResourceType(resourceType: SupportedResourceType): AllPlugins[] {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    return this.pluginsByResourceType[resourceType] || [];
+    return this.pluginsByResourceType[resourceType] ?? [];
   }
 
   getPluginById(pluginId: string): AllPlugins | undefined {

--- a/front/lib/api/poke/plugins/data_sources/delete_folder.ts
+++ b/front/lib/api/poke/plugins/data_sources/delete_folder.ts
@@ -1,0 +1,53 @@
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import logger from "@app/logger/logger";
+import { Err, Ok } from "@app/types";
+import { CoreAPI } from "@app/types/core/core_api";
+
+export const deleteFolderPlugin = createPlugin({
+  manifest: {
+    id: "delete-folder",
+    name: "Delete Folder",
+    warning: "This is a destructive action.",
+    description:
+      "Delete a specific folder from this data source by its folder ID. This will remove the folder and all its contents.",
+    resourceTypes: ["data_sources"],
+    args: {
+      folderId: {
+        type: "string",
+        label: "Folder ID",
+        description:
+          "The ID of the folder to delete (e.g., parent_id from documents)",
+      },
+    },
+  },
+  execute: async (auth, dataSource, args) => {
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    const { folderId } = args;
+    if (!folderId.trim()) {
+      return new Err(new Error("Folder ID is required"));
+    }
+
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+    const deleteRes = await coreAPI.deleteDataSourceFolder({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceId: dataSource.dustAPIDataSourceId,
+      folderId: folderId.trim(),
+    });
+
+    if (deleteRes.isErr()) {
+      return new Err(
+        new Error(`Failed to delete folder: ${deleteRes.error.message}`)
+      );
+    }
+
+    return new Ok({
+      display: "text",
+      value: `✅ Folder ${folderId} has been successfully deleted from data source ${dataSource.sId}`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -3,6 +3,7 @@ export * from "./check_slack_channel";
 export * from "./compute_statistics";
 export * from "./confluence_page_checker";
 export * from "./delete_data_source";
+export * from "./delete_folder";
 export * from "./garbage_collect_google_drive_document";
 export * from "./google_drive_sync_file";
 export * from "./intercom_set_sliding_window";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -173,14 +173,10 @@ async function handler(
         projectId: dataSource.dustAPIProjectId,
         dataSourceId: dataSource.dustAPIDataSourceId,
         folderId: fId,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        timestamp: timestamp || null,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        parentId: parentId || null,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        parents: parents || [fId],
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        title: title.trim() || "Untitled Folder",
+        timestamp: timestamp ?? null,
+        parentId: parentId ?? null,
+        parents: parents ?? [fId],
+        title: title.trim() ?? "Untitled Folder",
         mimeType: mime_type,
         sourceUrl: source_url ?? null,
         providerVisibility: provider_visibility,


### PR DESCRIPTION
## Description

Add a poke plugin to delete a folder. 

⚠️ I assumed the Core endpoint does it recursively and also deletes the files.

It's mostly to fix [this](https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=142421804&issue=dust-tt%7Ctasks%7C5358). I wasn't able to find errors in the gdrive garbage collector job, so I assumed it's on the customer side

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
