### PR TITLE
enh(query-tables): gracefully handle invalid table configs in get_schema

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
@@ -159,25 +159,42 @@ function createServer(
           dataSourceViews.map((dsv) => [dsv.sId, dsv])
         );
 
-        // Call Core API's /database_schema endpoint
-        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-        const schemaResult = await coreAPI.getDatabaseSchema({
-          tables: tableConfigurations.map((t) => {
-            const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
-            if (
-              !dataSourceView ||
-              !dataSourceView.dataSource.dustAPIDataSourceId
-            ) {
-              throw new Error(
-                `Missing data source ID for view ${t.dataSourceViewId}`
-              );
-            }
-            return {
+        // Build table list, filtering out invalid configurations
+        const validTables: Array<{
+          project_id: number;
+          data_source_id: string;
+          table_id: string;
+        }> = [];
+        const invalidTableIds: string[] = [];
+        for (const t of tableConfigurations) {
+          const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
+          if (
+            dataSourceView &&
+            dataSourceView.dataSource.dustAPIDataSourceId
+          ) {
+            validTables.push({
               project_id: parseInt(dataSourceView.dataSource.dustAPIProjectId),
               data_source_id: dataSourceView.dataSource.dustAPIDataSourceId,
               table_id: t.tableId,
-            };
-          }),
+            });
+          } else {
+            invalidTableIds.push(t.tableId);
+          }
+        }
+
+        if (validTables.length === 0) {
+          return new Ok([
+            {
+              type: "text",
+              text: "The agent does not have access to any valid tables. Some table configurations may be outdated. Please edit the agent's Query Tables tool to update the table selection.",
+            },
+          ]);
+        }
+
+        // Call Core API's /database_schema endpoint
+        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+        const schemaResult = await coreAPI.getDatabaseSchema({
+          tables: validTables,
         });
 
         if (schemaResult.isErr()) {
@@ -188,7 +205,18 @@ function createServer(
           );
         }
 
+        const warning =
+          invalidTableIds.length > 0
+            ? [
+                {
+                  type: "text" as const,
+                  text: `Warning: ${invalidTableIds.length} table(s) could not be loaded (${invalidTableIds.join(", ")}). Their configurations may be outdated.`,
+                },
+              ]
+            : [];
+
         return new Ok([
+          ...warning,
           {
             type: "resource",
             resource: {

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
@@ -168,10 +168,7 @@ function createServer(
         const invalidTableIds: string[] = [];
         for (const t of tableConfigurations) {
           const dataSourceView = dataSourceViewsMap.get(t.dataSourceViewId);
-          if (
-            dataSourceView &&
-            dataSourceView.dataSource.dustAPIDataSourceId
-          ) {
+          if (dataSourceView && dataSourceView.dataSource.dustAPIDataSourceId) {
             validTables.push({
               project_id: parseInt(dataSourceView.dataSource.dustAPIProjectId),
               data_source_id: dataSourceView.dataSource.dustAPIDataSourceId,
@@ -186,7 +183,7 @@ function createServer(
           return new Ok([
             {
               type: "text",
-              text: "The agent does not have access to any valid tables. Some table configurations may be outdated. Please edit the agent's Query Tables tool to update the table selection.",
+              text: "The agent does not have access to any valid tables. Some table configurations may be outdated.",
             },
           ]);
         }


### PR DESCRIPTION
## Description

When dsviews change or get deleted, some table configs can become invalid.
Table Query V2 `get_database_schema` tool currently doesn't handle that correctly and throws an exception.

This PR fixes the issue by returning a clear message to the agent.

## Tests

Local

## Risk

Low

## Deploy Plan

deploy front