### PR TITLE
Fix display of plan in pricing table when workspace whitelisted for Business

### DIFF
--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -346,7 +346,7 @@ export function BusinessPriceTable({
         onClose={() => setIsFairUseModalOpened(false)}
       />
       <PriceTable
-        title="Business"
+        title="Enterprise (Seat-based)"
         price={price}
         color="blue"
         priceLabel="/ month / user, excl. tax."
@@ -426,6 +426,7 @@ function EnterprisePriceTable({
 }
 
 interface PricePlanProps {
+  owner?: WorkspaceType;
   plan?: PlanType;
   onClickProPlan?: () => void;
   isProcessing?: boolean;
@@ -434,6 +435,7 @@ interface PricePlanProps {
 }
 
 export function PricePlans({
+  owner,
   flexCSS = "mx-4 flex flex-row w-full md:-mx-12 md:gap-4 lg:gap-6 xl:mx-0 xl:gap-8 2xl:gap-10",
   plan,
   onClickProPlan,
@@ -461,6 +463,7 @@ export function PricePlans({
           <div className="mt-8">
             <TabsContent value="pro">
               <ProPriceTable
+                owner={owner}
                 display={display}
                 size="xs"
                 plan={plan}
@@ -478,6 +481,7 @@ export function PricePlans({
       {/* Cards view for larger screens (hidden below lg) */}
       <div className={classNames(flexCSS, "hidden lg:flex")}>
         <ProPriceTable
+          owner={owner}
           size="sm"
           plan={plan}
           isProcessing={isProcessing}

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -435,6 +435,7 @@ export default function Subscription({
                 <Page.H variant="h5">Manage my plan</Page.H>
                 <div className="h-full w-full pt-2">
                   <PricePlans
+                    owner={owner}
                     plan={plan}
                     onClickProPlan={onClickProPlan}
                     isProcessing={isProcessing}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5359
We were not passing the owner to the pricing table on the subscription page so it was not able to check the isBusiness metadata to adapt the pricing and plan name to display. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 