### PR TITLE
Restrict agents publishing to builders & admins

### DIFF
--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -44,6 +44,8 @@ export function AccessSection() {
   const restrictAgentsPublishing = featureFlags.includes(
     "restrict_agents_publishing"
   );
+  const publishingToggleDisabled =
+    restrictAgentsPublishing && !isBuilder(owner);
 
   const getDisplayValue = () => {
     return scope.value === "visible" ? "Published" : "Unpublished";
@@ -72,7 +74,12 @@ export function AccessSection() {
               label={getDisplayValue()}
               isSelect
               type="button"
-              disabled={restrictAgentsPublishing && !isBuilder(owner)}
+              disabled={publishingToggleDisabled}
+              tooltip={
+                publishingToggleDisabled
+                  ? "Publishing agents is restricted to builders and admins"
+                  : undefined
+              }
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
@@ -81,14 +88,14 @@ export function AccessSection() {
               description="Visible & usable by all members of the workspace."
               icon={EyeIcon}
               onClick={() => scope.onChange("visible")}
-              disabled={restrictAgentsPublishing && !isBuilder(owner)}
+              disabled={publishingToggleDisabled}
             />
             <DropdownMenuItem
               label="Unpublished"
               description="Visible & usable by editors only."
               icon={EyeSlashIcon}
               onClick={() => scope.onChange("hidden")}
-              disabled={restrictAgentsPublishing && !isBuilder(owner)}
+              disabled={publishingToggleDisabled}
             />
           </DropdownMenuContent>
         </DropdownMenu>

--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -12,11 +12,14 @@ import { useState } from "react";
 import React from "react";
 import { useController } from "react-hook-form";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
 import { EditorsSheet } from "@app/components/agent_builder/settings/EditorsSheet";
 import { SlackSettingsSheet } from "@app/components/agent_builder/settings/SlackSettingsSheet";
 import { SettingSectionContainer } from "@app/components/agent_builder/shared/SettingSectionContainer";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { isBuilder } from "@app/types";
 
 export function AccessSection() {
   const { field: scope } = useController<
@@ -35,6 +38,12 @@ export function AccessSection() {
   const [showSlackSettings, setShowSlackSettings] = useState(false);
 
   const { supportedDataSourceViews } = useDataSourceViewsContext();
+  const { owner } = useAgentBuilderContext();
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+
+  const restrictAgentsPublishing = featureFlags.includes(
+    "restrict_agents_publishing"
+  );
 
   const getDisplayValue = () => {
     return scope.value === "visible" ? "Published" : "Unpublished";
@@ -63,6 +72,7 @@ export function AccessSection() {
               label={getDisplayValue()}
               isSelect
               type="button"
+              disabled={restrictAgentsPublishing && !isBuilder(owner)}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
@@ -71,12 +81,14 @@ export function AccessSection() {
               description="Visible & usable by all members of the workspace."
               icon={EyeIcon}
               onClick={() => scope.onChange("visible")}
+              disabled={restrictAgentsPublishing && !isBuilder(owner)}
             />
             <DropdownMenuItem
               label="Unpublished"
               description="Visible & usable by editors only."
               icon={EyeSlashIcon}
               onClick={() => scope.onChange("hidden")}
+              disabled={restrictAgentsPublishing && !isBuilder(owner)}
             />
           </DropdownMenuContent>
         </DropdownMenu>

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1283,9 +1283,6 @@ export async function updateAgentPermissions(
   }
 }
 
-export const PUBLISHING_RESTRICTION_ERROR_MESSAGE =
-  "Publishing agents is restricted to builders and admins.";
-
 export async function canPublishAgent(auth: Authenticator): Promise<boolean> {
   const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
 

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -7,6 +7,7 @@ import {
   DiscordLogo,
   GlobeAltIcon,
   Input,
+  LockIcon,
   MicIcon,
   MicrosoftLogo,
   Page,
@@ -270,6 +271,9 @@ export default function WorkspaceAdmin({
             <div className="h-full border-b border-border dark:border-border-night" />
             <InteractiveContentSharingToggle owner={owner} />
             <VoiceTranscriptionToggle owner={owner} />
+            {featureFlags.includes("restrict_agents_publishing") && (
+              <RestrictAgentsPublishingCapability />
+            )}
           </ContextItem.List>
         </Page.Vertical>
         <Page.Vertical align="stretch" gap="md">
@@ -549,6 +553,20 @@ function VoiceTranscriptionToggle({ owner }: { owner: WorkspaceType }) {
           disabled={isChanging}
           onClick={doToggleVoiceTranscription}
         />
+      }
+    />
+  );
+}
+
+function RestrictAgentsPublishingCapability() {
+  return (
+    <ContextItem
+      title="Restricted agents publication"
+      subElement="Publishing agents is restricted to builders and admins"
+      visual={<LockIcon className="h-6 w-6" />}
+      hasSeparatorIfLast={true}
+      action={
+        <SliderToggle selected={true} disabled={true} onClick={() => {}} />
       }
     />
   );

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -64,6 +64,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Prevent users from creating agents, allowing only admins and builders",
     stage: "on_demand",
   },
+  restrict_agents_publishing: {
+    description: "Restrict publishing agents to builders and admins",
+    stage: "on_demand",
+  },
   google_sheets_tool: {
     description: "Google Sheets MCP tool",
     stage: "rolling_out",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -678,6 +678,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_high_reasoning_feature"
   | "openai_usage_mcp"
   | "ppul"
+  | "restrict_agents_publishing"
   | "salesforce_synced_queries"
   | "salesforce_tool"
   | "salesforce_tool_write"


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/5263

Introduce feature-flag `restrict_agents_publishing` which restricts agent publication to builders and admins.

When set:
- the dropdown is disabled in the agent builder (with tooltip)
- for admin: a capability is set to true (cannot be disabled in the worksace settings)

<img width="1168" height="574" alt="Screenshot 2025-12-02 at 14 59 44" src="https://github.com/user-attachments/assets/3eea619b-b828-4720-a851-b4db950b8b37" />
<img width="1173" height="1044" alt="Screenshot 2025-12-02 at 15 01 45" src="https://github.com/user-attachments/assets/c0e3d803-0472-4169-a52f-77a072c14c6a" />


## Tests

Tested locally

## Risk

Low, feature flag

## Deploy Plan

- deploy `front`