### PR TITLE
[front] - feat(UserMessage): ability to delete

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.18",
-        "@dust-tt/sparkle": "^0.4.8",
+        "@dust-tt/sparkle": "^0.4.9",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1285,10 +1285,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.8.tgz",
-      "integrity": "sha512-5U6rNh/0nAUFXd+7JrFZiUVGBLbb5EBfGBvC6YdCutWQY/lM9W2GhJEF9GpEnAD/pRu08bMwjD2LrojyNghoCw==",
-      "license": "ISC",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.9.tgz",
+      "integrity": "sha512-wTjl2Xeas9UMBOeXxcJwl810qhbcItyWY+yqsQc3WWQO4cOYkePBNl9uVUF0WvjwpMOh6vJ7y0FGKWhfjw4/eA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.18",
-    "@dust-tt/sparkle": "^0.4.8",
+    "@dust-tt/sparkle": "^0.4.9",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/assistant/conversation/NewConversationMessage.tsx
+++ b/front/components/assistant/conversation/NewConversationMessage.tsx
@@ -1,5 +1,15 @@
-import type { Button } from "@dust-tt/sparkle";
-import { Avatar, CitationGrid, cn } from "@dust-tt/sparkle";
+import type { Button, ConversationMessageAction } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  CitationGrid,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  IconButton,
+  MoreIcon,
+} from "@dust-tt/sparkle";
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
 import React from "react";
@@ -10,6 +20,7 @@ type MessageType = "me" | "user" | "agent";
 interface NewConversationMessageProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof messageVariants> {
+  actions?: ConversationMessageAction[];
   avatarBusy?: boolean;
   buttons?: React.ReactElement<typeof Button>[];
   children?: React.ReactNode;
@@ -72,6 +83,7 @@ export const NewConversationMessage = React.forwardRef<
 >(
   (
     {
+      actions,
       avatarBusy = false,
       buttons,
       children,
@@ -120,6 +132,7 @@ export const NewConversationMessage = React.forwardRef<
               infoChip={infoChip}
               completionStatus={completionStatus}
               renderName={renderName}
+              actions={actions}
             />
           </div>
 
@@ -145,6 +158,7 @@ export const NewConversationMessage = React.forwardRef<
               infoChip={infoChip}
               completionStatus={completionStatus}
               renderName={renderName}
+              actions={actions}
             />
             <ConversationMessageContent citations={citations} type={type}>
               {children}
@@ -244,6 +258,7 @@ ConversationMessageAvatar.displayName = "ConversationMessageAvatar";
 
 interface ConversationMessageTitleProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  actions?: ConversationMessageAction[];
   name?: string;
   timestamp?: string;
   infoChip?: React.ReactNode;
@@ -254,19 +269,52 @@ interface ConversationMessageTitleProps
 const ConversationMessageTitle = React.forwardRef<
   HTMLDivElement,
   ConversationMessageTitleProps
->(({ name = "", timestamp, infoChip, completionStatus, renderName }) => {
-  return (
-    <div className="inline-flex w-full justify-between gap-0.5">
-      <div className="inline-flex items-baseline gap-2 text-foreground dark:text-foreground-night">
-        <span className="heading-sm">{renderName(name)}</span>
-        <span className="heading-xs text-muted-foreground dark:text-muted-foreground-night">
-          {timestamp}
-        </span>
-        {infoChip && infoChip}
+>(
+  ({
+    name = "",
+    timestamp,
+    infoChip,
+    completionStatus,
+    renderName,
+    actions,
+  }) => {
+    return (
+      <div className="inline-flex w-full justify-between gap-0.5">
+        <div className="inline-flex items-baseline gap-2 text-foreground dark:text-foreground-night">
+          <span className="heading-sm">{renderName(name)}</span>
+          <span className="heading-xs text-muted-foreground dark:text-muted-foreground-night">
+            {timestamp}
+          </span>
+          {infoChip && infoChip}
+        </div>
+        <div className="inline-flex items-center gap-2">
+          {completionStatus ?? null}
+          {actions && actions.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <IconButton
+                  icon={MoreIcon}
+                  size="xs"
+                  variant="highlight-secondary"
+                  aria-label="Message actions"
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                {actions.map((action, index) => (
+                  <DropdownMenuItem
+                    key={index}
+                    icon={action.icon}
+                    label={action.label}
+                    onClick={action.onClick}
+                  />
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
       </div>
-      {completionStatus ?? null}
-    </div>
-  );
-});
+    );
+  }
+);
 
 ConversationMessageTitle.displayName = "ConversationMessageTitle";

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -139,7 +139,7 @@ export function UserMessage({
   }, [isDeleting, isDeleted, confirm, deleteMessage, message.sId, methods]);
 
   const actions: ConversationMessageAction[] = useMemo(() => {
-    if (!isCurrentUser || isDeleted) {
+    if (!isCurrentUser || isDeleted || !userMentionsEnabled) {
       return [];
     }
 
@@ -150,7 +150,7 @@ export function UserMessage({
         onClick: handleDeleteMessage,
       },
     ];
-  }, [isCurrentUser, isDeleted, handleDeleteMessage]);
+  }, [isCurrentUser, isDeleted, userMentionsEnabled, handleDeleteMessage]);
 
   if (userMentionsEnabled) {
     return (

--- a/front/hooks/useDeleteMessage.ts
+++ b/front/hooks/useDeleteMessage.ts
@@ -2,6 +2,7 @@ import { useSWRConfig } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { normalizeError } from "@app/types";
 
 export function useDeleteMessage({
   owner,
@@ -27,7 +28,7 @@ export function useDeleteMessage({
 
       if (!res.ok) {
         const errorData = await res.json();
-        throw new Error(errorData.error?.message || "Failed to delete message");
+        throw normalizeError(errorData);
       }
 
       sendNotification({

--- a/front/hooks/useDeleteMessage.ts
+++ b/front/hooks/useDeleteMessage.ts
@@ -1,0 +1,53 @@
+import { useSWRConfig } from "swr";
+
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useSubmitFunction } from "@app/lib/client/utils";
+
+export function useDeleteMessage({
+  owner,
+  conversationId,
+}: {
+  owner: { sId: string };
+  conversationId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRConfig();
+
+  const { submit: deleteMessage, isSubmitting } = useSubmitFunction(
+    async (messageId: string) => {
+      const res = await fetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/delete`,
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw new Error(errorData.error?.message || "Failed to delete message");
+      }
+
+      sendNotification({
+        title: "Message deleted",
+        description: "Your message has been deleted successfully.",
+        type: "success",
+      });
+
+      await mutate(
+        (key) =>
+          typeof key === "string" &&
+          key.includes(
+            `/api/w/${owner.sId}/assistant/conversations/${conversationId}`
+          )
+      );
+    }
+  );
+
+  return {
+    deleteMessage,
+    isDeleting: isSubmitting,
+  };
+}

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -9,6 +9,8 @@ const STATUS_FOR_ERROR_TYPE: Record<ConversationErrorType, number> = {
   conversation_not_found: 404,
   conversation_with_unavailable_agent: 403,
   user_already_participant: 400,
+  message_not_found: 404,
+  message_deletion_not_authorized: 403,
 };
 
 export function apiErrorForConversation(

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -734,3 +734,52 @@ export async function fetchMessageInConversation(
     ],
   });
 }
+
+export async function softDeleteUserMessage(
+  auth: Authenticator,
+  {
+    messageId,
+    conversation,
+  }: {
+    messageId: string;
+    conversation: ConversationWithoutContentType;
+  }
+): Promise<Result<{ success: true }, ConversationError>> {
+  const user = auth.getNonNullableUser();
+  const owner = auth.getNonNullableWorkspace();
+
+  const message = await fetchMessageInConversation(
+    auth,
+    conversation,
+    messageId
+  );
+
+  if (!message || !message.userMessage) {
+    return new Err(new ConversationError("message_not_found"));
+  }
+
+  if (message.userMessage.userId !== user.id) {
+    return new Err(new ConversationError("message_deletion_not_authorized"));
+  }
+
+  if (message.visibility === "deleted") {
+    return new Ok({ success: true });
+  }
+
+  await message.update({
+    visibility: "deleted",
+  });
+
+  const { auditLog } = await import("@app/logger/logger");
+  auditLog(
+    {
+      workspaceId: owner.sId,
+      userId: user.sId,
+      conversationId: conversation.sId,
+      messageId: message.sId,
+    },
+    "User deleted their message"
+  );
+
+  return new Ok({ success: true });
+}

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -20,7 +20,7 @@ import { ContentFragmentResource } from "@app/lib/resources/content_fragment_res
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { UserResource } from "@app/lib/resources/user_resource";
-import logger from "@app/logger/logger";
+import logger, { auditLog } from "@app/logger/logger";
 import type {
   AgentMention,
   AgentMessageType,
@@ -637,6 +637,7 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
 }
 
 type MessageVariant = "legacy-light" | "light";
+
 export async function fetchConversationMessages<V extends MessageVariant>(
   auth: Authenticator,
   {
@@ -770,7 +771,6 @@ export async function softDeleteUserMessage(
     visibility: "deleted",
   });
 
-  const { auditLog } = await import("@app/logger/logger");
   auditLog(
     {
       workspaceId: owner.sId,

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.8",
+        "@dust-tt/sparkle": "^0.4.9",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1329,9 +1329,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.8.tgz",
-      "integrity": "sha512-5U6rNh/0nAUFXd+7JrFZiUVGBLbb5EBfGBvC6YdCutWQY/lM9W2GhJEF9GpEnAD/pRu08bMwjD2LrojyNghoCw==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.9.tgz",
+      "integrity": "sha512-wTjl2Xeas9UMBOeXxcJwl810qhbcItyWY+yqsQc3WWQO4cOYkePBNl9uVUF0WvjwpMOh6vJ7y0FGKWhfjw4/eA==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -39,7 +39,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.8",
+    "@dust-tt/sparkle": "^0.4.9",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/delete.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/delete.ts
@@ -1,0 +1,101 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { softDeleteUserMessage } from "@app/lib/api/assistant/messages";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<{ success: boolean }>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const conversation = conversationRes.value;
+
+  if (!(typeof req.query.mId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `mId` (string) is required.",
+      },
+    });
+  }
+
+  const messageId = req.query.mId;
+
+  switch (req.method) {
+    case "DELETE":
+      const deleteResult = await softDeleteUserMessage(auth, {
+        messageId,
+        conversation,
+      });
+
+      if (deleteResult.isErr()) {
+        const error = deleteResult.error;
+        if (error.type === "message_not_found") {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "message_not_found",
+              message: "The message you're trying to delete does not exist.",
+            },
+          });
+        }
+        if (error.type === "message_deletion_not_authorized") {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "message_deletion_not_authorized",
+              message: "You are not authorized to delete this message.",
+            },
+          });
+        }
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "An error occurred while deleting the message.",
+          },
+        });
+      }
+
+      res.status(200).json({ success: true });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -304,6 +304,8 @@ export const CONVERSATION_ERROR_TYPES = [
   "conversation_access_restricted",
   "conversation_with_unavailable_agent",
   "user_already_participant",
+  "message_not_found",
+  "message_deletion_not_authorized",
 ] as const;
 
 export type ConversationErrorType = (typeof CONVERSATION_ERROR_TYPES)[number];


### PR DESCRIPTION
## Description

Implements the ability for users to delete their own messages in conversations when the mentions v2 feature is enabled. This PR adds a delete action to user messages via a dropdown menu. The deletion is soft (sets visibility to "deleted") and shows "This message has been deleted" in place of the content. Users can only delete their own messages, and the feature is only available when `mentions_v2` is enabled.

<img width="823" height="460" alt="Screenshot 2025-12-02 at 16 06 46" src="https://github.com/user-attachments/assets/e4dca519-3975-4b35-b695-ce710328f9e9" />

**References:**
- https://github.com/dust-tt/tasks/issues/5277

## Risk

Moderated - soft deletion

## Tests

- [x] Locally
- [ ] Front-edge

## Deploy Plan

Deploy front