### PR TITLE
Extension: Bump latest version of the SDK, use SDK to display file in convo

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
-        "@dust-tt/client": "^1.1.18",
+        "@dust-tt/client": "^1.1.19",
         "@dust-tt/sparkle": "^0.4.9",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
@@ -264,9 +264,9 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.18.tgz",
-      "integrity": "sha512-N2O8dL61qVFBE82azcVJUeiegIFS9tIPeGkVmUh3la/mt+2M7nKVYbcnxZI6faxg8Qf03jR8Ex06vbIs9ADLlw==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.19.tgz",
+      "integrity": "sha512-KH/Wvi56j8fxbwv1XOrH5W2yx/r8Ow8G9Kk2frsvnhqNcN/ZUtT4MVaYBjd2n2W73RRicCd1maUbYpFy+VA2mw==",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
-    "@dust-tt/client": "^1.1.18",
+    "@dust-tt/client": "^1.1.19",
     "@dust-tt/sparkle": "^0.4.9",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -435,7 +435,7 @@ export function AgentMessage({
       sup: CiteBlock,
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: AgentMentionBlock,
-      dustimg: getImgPlugin(owner, user),
+      dustimg: getImgPlugin(),
     }),
     [owner, conversationId, message.sId, agentConfiguration.sId, user]
   );


### PR DESCRIPTION
## Description

Bumping the SDK on the extension to use the new `getFileContent` method.

## Tests

Works locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Merge. 
Can't deploy now as there are many errors related to citations or mentions since the SDK has been updated which I'm going to redirect to the valid person to fix!
Hence I'm not bumping the extension version here, but it's safe to merge since it's extension code only. 
