### PR TITLE
[front] feat: PPUL - discard failed credit purchases

### DIFF
--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -10,6 +10,7 @@ import {
   isEnterpriseSubscription,
   makeOneOffInvoice,
   payInvoice,
+  voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import logger from "@app/logger/logger";
@@ -91,6 +92,45 @@ export async function startCreditFromProOneOffInvoice({
     "[Credit Purchase] Successfully activated credit for Pro subscription"
   );
   return new Ok(undefined);
+}
+
+export async function handleFailedProCreditPurchaseInvoice({
+  auth,
+  invoice,
+}: {
+  auth: Authenticator;
+  invoice: Stripe.Invoice;
+}): Promise<Result<{ voided: boolean }, Error>> {
+  if (invoice.attempt_count < 3) {
+    return new Ok({ voided: false });
+  }
+
+  const voidResult = await voidInvoiceWithReason(
+    invoice.id,
+    "failed_upfront_pro_credit_purchase"
+  );
+  if (voidResult.isErr()) {
+    return new Err(voidResult.error);
+  }
+
+  const credit = await CreditResource.fetchByInvoiceOrLineItemId(
+    auth,
+    invoice.id
+  );
+  if (credit) {
+    await credit.delete(auth, {});
+  }
+
+  logger.info(
+    {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      invoiceId: invoice.id,
+      attemptCount: invoice.attempt_count,
+    },
+    "[Credit Purchase] Voided failed invoice and deleted pending credit"
+  );
+
+  return new Ok({ voided: true });
 }
 
 export async function createEnterpriseCreditPurchase({

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -89,6 +89,11 @@ const SUPPORTED_PAYMENT_METHODS = ["card", "sepa_debit"] as const;
 
 export const ENTERPRISE_N30_PAYMENTS_DAYS = 30;
 
+// We allow for 3 retries of invoices (not counting first payment)
+// before we give up, void the invoice and remove resources pending payment on Dust
+// At the time of writing, this is only used for Credit Purchase self-serve flow
+export const MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED = 3;
+
 type SupportedPaymentMethod = (typeof SUPPORTED_PAYMENT_METHODS)[number];
 
 /**

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -512,6 +512,22 @@ export function getCreditAmountFromInvoice(
   return amountCents;
 }
 
+export async function voidInvoiceWithReason(
+  invoiceId: string,
+  voidReason: string
+): Promise<Result<Stripe.Invoice, Error>> {
+  const stripe = getStripeClient();
+  try {
+    const voidedInvoice = await stripe.invoices.voidInvoice(invoiceId);
+    await stripe.invoices.update(invoiceId, {
+      metadata: { void_reason: voidReason },
+    });
+    return new Ok(voidedInvoice);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
 export function makeCreditPurchaseOnceCouponId(percentOff: number): string {
   return `programmatic-usage-credits-once-${percentOff}`;
 }

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -509,6 +509,11 @@ async function handler(
                 invoice,
               });
               if (result.isErr()) {
+                // For eng-oncall
+                // This case is supposed to be extremely rare, as there are not a lot of things that can fail
+                // during an invoice void, you will need to inspect the invoice directly in stripe to see what
+                // happened, and invoice it by hand, with the added metadata put in `voidFailedProCreditPurchase`
+                // contact Stripe owners in case of doubt
                 logger.error(
                   {
                     error: result.error,


### PR DESCRIPTION
## Description

- When an invoice for credit purchase from a pro customer keeps failing (attempt >= 3, FYI we retry 4 times over 1 month), we discard the purchase by voiding the invoice and deleting the credit
- This is safe because we only make the credit consumable (credit.start()) once we get a PAID invoice.t

## Tests

[Tested manually
](https://dashboard.stripe.com/acct_1NZyRbDKd2JRwZF6/test/invoices/in_1SZvYqDKd2JRwZF6YseeESmY)

## Risk

Low
Blast radius: invoice.payment_failed webhook might fail, retried and become noise for oncall

## Deploy Plan

- [ ] Deploy front