### PR TITLE
Improve Langfuse observability tagging

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -24,7 +24,7 @@ import type {
   ReasoningEffort,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
-import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types";
+import { AGENT_CREATIVITY_LEVEL_TEMPERATURES, removeNulls } from "@app/types";
 
 export abstract class LLM {
   protected modelId: ModelIdType;
@@ -103,15 +103,21 @@ export abstract class LLM {
     );
 
     generation.updateTrace({
-      tags: [
-        `operationType:${this.context.operationType}`,
-        `workspaceId:${this.authenticator.getNonNullableWorkspace().sId}`,
+      tags: removeNulls([
+        this.authenticator.user()?.sId
+          ? `actualUserId:${this.authenticator.user()?.sId}`
+          : null,
+        this.authenticator.key()
+          ? `apiKeyId:${this.authenticator.key()?.id}`
+          : null,
         `authMethod:${this.authenticator.authMethod() ?? "unknown"}`,
-      ],
+        `operationType:${this.context.operationType}`,
+      ]),
       metadata: {
         dustTraceId: this.traceId,
       },
-      userId: this.authenticator.user()?.sId,
+      // In observability, userId maps to workspaceId for consistent grouping.
+      userId: this.authenticator.getNonNullableWorkspace().sId,
     });
 
     const startTime = Date.now();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR improves the tagging around LLM observability to map `workspaceId` in the default `userId` attribute on Langfuse side and also tag appropriately for api keys.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
