### PR TITLE
[front] fix: Add missing deleteAllForWorkspace on poke deleteWorkspace

### DIFF
--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -328,4 +328,12 @@ export class CreditResource extends BaseResource<CreditModel> {
       invoiceOrLineItemId: this.invoiceOrLineItemId,
     };
   }
+
+  static async deleteAllForWorkspace(auth: Authenticator) {
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
 }

--- a/front/lib/resources/programmatic_usage_configuration_resource.ts
+++ b/front/lib/resources/programmatic_usage_configuration_resource.ts
@@ -164,4 +164,12 @@ export class ProgrammaticUsageConfigurationResource extends BaseResource<Program
       paygCapCents: this.paygCapCents,
     };
   }
+
+  static async deleteAllForWorkspace(auth: Authenticator) {
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
 }

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -29,6 +29,7 @@ import { MembershipInvitationModel } from "@app/lib/models/membership_invitation
 import { Subscription } from "@app/lib/models/plan";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AppResource } from "@app/lib/resources/app_resource";
+import { CreditResource } from "@app/lib/resources/credit_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
@@ -40,6 +41,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resource";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -630,6 +632,8 @@ export async function deleteWorkspaceActivity({
   await RemoteMCPServerToolMetadataModel.destroy({
     where: { workspaceId: workspace.id },
   });
+  await CreditResource.deleteAllForWorkspace(auth);
+  await ProgrammaticUsageConfigurationResource.deleteAllForWorkspace(auth);
 
   hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 


### PR DESCRIPTION
## Description

- Add hooks to delete credit resources and programmatic usage config rows on workspace delete activity.

## Tests

- N/A

## Risk

Low

## Deploy Plan

- [ ] Deploy Front