### PR TITLE
[Agent Loop] Lower runModel activity start-to-close timeout to 5mn

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -37,7 +37,7 @@ export const NOTIFICATION_DELAY_MS = 30000;
 const { runModelAndCreateActionsActivity } = proxyActivities<
   typeof runModelAndCreateWrapperActivities
 >({
-  startToCloseTimeout: "10 minutes",
+  startToCloseTimeout: "5 minutes",
 });
 
 const { runToolActivity } = proxyActivities<typeof runToolActivities>({


### PR DESCRIPTION
## Description

Context: [Slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1764688099780979)

Lowers the start-to-close timeout for `runModelAndCreateActionsActivity` from 10 minutes to 5 minutes. With a 3mn pod termination grace period during deploys, the 10mn STC could cause stalls of up to 7mn. With 5mn STC, worst case stall is 2mn while still allowing 4mn+ model calls.

## Risks

Blast radius: agent loop model calls
Risk: low

## Deploy Plan
- pmrr
- deploy front