### PR TITLE
Allow upsell from Pro > Business if whitelisted

### DIFF
--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -19,9 +19,9 @@ import {
   PRO_PLAN_COST_YEARLY,
 } from "@app/lib/client/subscription";
 import {
-  PRO_PLAN_LARGE_FILES_CODE,
-  PRO_PLAN_SEAT_29_CODE,
-  PRO_PLAN_SEAT_39_CODE,
+  isProOrBusinessPlanCode,
+  isProPlan,
+  isWhitelistedBusinessPlan,
 } from "@app/lib/plans/plan_codes";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
@@ -93,14 +93,6 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
   },
 ];
 
-function isProPlanCode(plan?: PlanType) {
-  return (
-    plan?.code === PRO_PLAN_SEAT_29_CODE ||
-    plan?.code === PRO_PLAN_LARGE_FILES_CODE ||
-    plan?.code === PRO_PLAN_SEAT_39_CODE
-  );
-}
-
 interface PriceTableProps {
   billingPeriod?: BillingPeriod;
   display: PriceTableDisplay;
@@ -122,8 +114,7 @@ export function ProPriceTable({
 }: PriceTableProps) {
   const [isFairUseModalOpened, setIsFairUseModalOpened] = useState(false);
 
-  // If the owner has the business metadata, we show the BusinessPriceTable instead.
-  if (owner?.metadata?.isBusiness) {
+  if (isWhitelistedBusinessPlan(owner)) {
     return (
       <BusinessPriceTable
         display={display}
@@ -225,7 +216,7 @@ export function ProPriceTable({
         size={size}
         magnified={false}
       >
-        {onClick && (!plan || !isProPlanCode(plan)) && (
+        {onClick && (!plan || !isProOrBusinessPlanCode(plan)) && (
           <PriceTable.ActionContainer position="top">
             <Button
               variant="highlight"
@@ -353,7 +344,7 @@ export function BusinessPriceTable({
         size={size}
         magnified={false}
       >
-        {onClick && (!plan || !isProPlanCode(plan)) && (
+        {onClick && (!plan || !isProPlan(plan)) && (
           <PriceTable.ActionContainer position="top">
             <Button
               variant="highlight"

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -20,7 +20,7 @@ import {
   InputField,
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
-import { isEntreprisePlan } from "@app/lib/plans/plan_codes";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { EnterpriseUpgradeFormType, WorkspaceType } from "@app/types";
 import { EnterpriseUpgradeFormSchema, removeNulls } from "@app/types";
@@ -131,7 +131,7 @@ export default function EnterpriseUpgradeDialog({
                       name="planCode"
                       title="Enterprise Plan"
                       options={plans
-                        .filter((plan) => isEntreprisePlan(plan.code))
+                        .filter((plan) => isEntreprisePlanPrefix(plan.code))
                         .map((plan) => ({
                           value: plan.code,
                           display: `${plan.name} (${plan.code})`,

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -33,7 +33,7 @@ import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/
 import EnterpriseUpgradeDialog from "@app/components/poke/subscriptions/EnterpriseUpgradeDialog";
 import FreePlanUpgradeDialog from "@app/components/poke/subscriptions/FreePlanUpgradeDialog";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { FREE_NO_PLAN_CODE, isProPlan } from "@app/lib/plans/plan_codes";
+import { FREE_NO_PLAN_CODE, isProPlanPrefix } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { PlanType, SubscriptionType, WorkspaceType } from "@app/types";
 import { isDevelopment } from "@app/types";
@@ -396,7 +396,7 @@ function UpgradeDowngradeModal({
             <div>
               <EnterpriseUpgradeDialog owner={owner} />
             </div>
-            {isProPlan(subscription.plan.code) && (
+            {isProPlanPrefix(subscription.plan.code) && (
               <>
                 <Page.SectionHeader
                   title="Change the Pro Plan of this workspace"
@@ -404,7 +404,7 @@ function UpgradeDowngradeModal({
                 />
                 <div>
                   {plans
-                    .filter((p) => isProPlan(p.code))
+                    .filter((p) => isProPlanPrefix(p.code))
                     .map((p) => {
                       return (
                         <div key={p.code} className="pt-2">

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -14,7 +14,7 @@ import { CreateOrEditSpaceModal } from "@app/components/spaces/CreateOrEditSpace
 import { SpaceSearchInput } from "@app/components/spaces/SpaceSearchLayout";
 import SpaceSideBarMenu from "@app/components/spaces/SpaceSideBarMenu";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
-import { isEntreprisePlan } from "@app/lib/plans/plan_codes";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { isPrivateSpacesLimitReached } from "@app/lib/spaces";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import type {
@@ -75,7 +75,7 @@ export function SpaceLayout({
   });
 
   const isLimitReached = isPrivateSpacesLimitReached(spaces, plan);
-  const isEnterprise = isEntreprisePlan(plan.code);
+  const isEnterprise = isEntreprisePlanPrefix(plan.code);
 
   const closeSpaceCreationModal = useCallback(() => {
     setSpaceCreationModalState((prev) => ({ ...prev, isOpen: false }));

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -1,4 +1,4 @@
-import type { PlanType } from "@app/types";
+import type { PlanType, WorkspaceType } from "@app/types";
 
 // Current free plans:
 export const FREE_NO_PLAN_CODE = "FREE_NO_PLAN";
@@ -17,11 +17,12 @@ export const PRO_PLAN_SEAT_39_CODE = "PRO_PLAN_SEAT_39";
 export const ENT_PLAN_FAKE_CODE = "ENT_PLAN_FAKE_CODE";
 
 // If the plan code starts with ENT_, it's an entreprise plan
-export const isEntreprisePlan = (planCode: string) =>
+export const isEntreprisePlanPrefix = (planCode: string) =>
   planCode.startsWith("ENT_");
 
 // If the plan code starts with PRO_, it's a pro plan
-export const isProPlan = (planCode: string) => planCode.startsWith("PRO_");
+export const isProPlanPrefix = (planCode: string) =>
+  planCode.startsWith("PRO_");
 
 // If the plan code is FREE_FRIENDSAMILY, it's a free friends and family plan
 export const isFriendsAndFamilyPlan = (planCode: string) =>
@@ -29,11 +30,26 @@ export const isFriendsAndFamilyPlan = (planCode: string) =>
 
 // Everything else is free
 export const isFreePlan = (planCode: string) =>
-  !isEntreprisePlan(planCode) && !isProPlan(planCode);
+  !isEntreprisePlanPrefix(planCode) && !isProPlanPrefix(planCode);
 
 // Early plan when anyone could create a dust account
 export const isOldFreePlan = (planCode: string) =>
-  planCode === "FREE_TEST_PLAN";
+  planCode === FREE_TEST_PLAN_CODE;
+
+export function isProPlan(plan?: PlanType) {
+  return (
+    plan?.code === PRO_PLAN_SEAT_29_CODE ||
+    plan?.code === PRO_PLAN_LARGE_FILES_CODE
+  );
+}
+
+export function isBusinessPlan(plan?: PlanType) {
+  return plan?.code === PRO_PLAN_SEAT_39_CODE;
+}
+
+export function isProOrBusinessPlanCode(plan?: PlanType) {
+  return isProPlan(plan) || isBusinessPlan(plan);
+}
 
 /**
  * `isUpgraded` returns true if the plan has access to all features of Dust, including large
@@ -47,4 +63,11 @@ export const isUpgraded = (plan: PlanType | null): boolean => {
     return false;
   }
   return ![FREE_TEST_PLAN_CODE, FREE_NO_PLAN_CODE].includes(plan.code);
+};
+
+export const isWhitelistedBusinessPlan = (owner?: WorkspaceType) => {
+  if (!owner) {
+    return false;
+  }
+  return owner.metadata?.isBusiness === true;
 };

--- a/front/migrations/20251126_backfill_programmatic_usage_configurations.ts
+++ b/front/migrations/20251126_backfill_programmatic_usage_configurations.ts
@@ -1,6 +1,6 @@
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import { isEntreprisePlan } from "@app/lib/plans/plan_codes";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import {
   getStripeSubscription,
   isEnterpriseSubscription,

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -9,11 +9,11 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import {
-  isEntreprisePlan,
+  isEntreprisePlanPrefix,
   isFreePlan,
   isFriendsAndFamilyPlan,
   isOldFreePlan,
-  isProPlan,
+  isProPlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -47,7 +47,7 @@ export type GetPokeWorkspacesResponseBody = {
 };
 
 const getPlanPriority = (planCode: string) => {
-  if (isEntreprisePlan(planCode)) {
+  if (isEntreprisePlanPrefix(planCode)) {
     return 1;
   }
 
@@ -55,7 +55,7 @@ const getPlanPriority = (planCode: string) => {
     return 2;
   }
 
-  if (isProPlan(planCode)) {
+  if (isProPlanPrefix(planCode)) {
     return 3;
   }
 

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -14,11 +14,11 @@ import {
 } from "@app/components/poke/shadcn/ui/table";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import {
-  isEntreprisePlan,
+  isEntreprisePlanPrefix,
   isFreePlan,
   isFriendsAndFamilyPlan,
   isOldFreePlan,
-  isProPlan,
+  isProPlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import { usePokeWorkspaces } from "@app/lib/swr/poke";
 import { classNames } from "@app/lib/utils";
@@ -81,11 +81,11 @@ const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
                       <label
                         className={classNames(
                           "rounded px-1 text-sm text-gray-500 text-white",
-                          isEntreprisePlan(ws.subscription.plan.code) &&
+                          isEntreprisePlanPrefix(ws.subscription.plan.code) &&
                             "bg-red-500",
                           isFriendsAndFamilyPlan(ws.subscription.plan.code) &&
                             "bg-pink-500",
-                          isProPlan(ws.subscription.plan.code) &&
+                          isProPlanPrefix(ws.subscription.plan.code) &&
                             "bg-orange-500",
                           isFreePlan(ws.subscription.plan.code) &&
                             "bg-blue-500",

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -29,6 +29,10 @@ import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
+import {
+  isProPlan,
+  isWhitelistedBusinessPlan,
+} from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -177,6 +181,37 @@ export default function Subscription({
     window.open(`/w/${owner.sId}/subscription/manage`, "_blank");
   });
 
+  const {
+    submit: handleUpgradeToBusiness,
+    isSubmitting: isUpgradingToBusiness,
+  } = useSubmitFunction(async () => {
+    const res = await fetch(`/api/w/${owner.sId}/subscriptions`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        action: "upgrade_to_business",
+      } satisfies t.TypeOf<typeof PatchSubscriptionRequestBody>),
+    });
+
+    if (!res.ok) {
+      sendNotification({
+        type: "error",
+        title: "Upgrade failed",
+        description: "Failed to upgrade to Enterprise seat-based plan.",
+      });
+    } else {
+      sendNotification({
+        type: "success",
+        title: "Upgrade successful",
+        description:
+          "Your workspace has been upgraded to Enterprise seat-based plan.",
+      });
+      router.reload();
+    }
+  });
+
   const { submit: skipFreeTrial, isSubmitting: skipFreeTrialIsSubmitting } =
     useSubmitFunction(async () => {
       try {
@@ -240,9 +275,15 @@ export default function Subscription({
       }
     });
 
-  const isProcessing = isSubscribingPlan || isGoingToStripePortal;
-
   const plan = subscription.plan;
+  const isWorkspaceOnProPlan = isProPlan(plan);
+  const isWorkspaceWhitelistedBusinessPlan = isWhitelistedBusinessPlan(owner);
+  const canUpsellToBusinessPlan =
+    isWorkspaceOnProPlan && isWorkspaceWhitelistedBusinessPlan;
+
+  const isProcessing =
+    isSubscribingPlan || isGoingToStripePortal || isUpgradingToBusiness;
+
   const chipColor = !isUpgraded(plan) ? "green" : "blue";
 
   const onClickProPlan = async () => handleSubscribePlan();
@@ -423,6 +464,29 @@ export default function Subscription({
                     "subscription_stripe_portal",
                     () => {
                       void handleGoToStripePortal();
+                    }
+                  )}
+                />
+              </div>
+            </Page.Vertical>
+          )}
+          {canUpsellToBusinessPlan && (
+            <Page.Vertical gap="sm">
+              <Page.H variant="h5">Upgrade your plan</Page.H>
+              <Page.P>
+                You are eligible to upgrade to the Enteprise seat-based plan
+                with additional features.
+              </Page.P>
+              <div>
+                <Button
+                  label="Upgrade to Enterprise seat-based plan"
+                  variant="primary"
+                  disabled={isProcessing}
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "subscription_upgrade_to_business",
+                    () => {
+                      void handleUpgradeToBusiness();
                     }
                   )}
                 />


### PR DESCRIPTION
## Description

If the current plan is Pro and the workspace is whitelisted for business, we display a button to upgrade to business (on the subscription page). 
Clicking on the button automatically upsells, with prorata, and always selects the monthly billing period. 

## Tests

Tested locally on my workspace. 

## Risk

Break billing. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
