### PR TITLE
[DX] Fix and improve front tests in CI

### DIFF
--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -14,6 +14,11 @@ permissions:
 
 jobs:
   tests:
+    name: Test Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }}
+    strategy:
+      matrix:
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -41,16 +46,16 @@ jobs:
           REDIS_CACHE_URI: "redis://localhost:5434"
           REDIS_URI: "redis://localhost:5434"
           NODE_ENV: test
-        run: npx tsx admin/db.ts && npm run test:ci
+        run: npx tsx admin/db.ts && npm run test:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --outputFile=junit-shard-${{ matrix.shardIndex }}.xml
       - name: Build Tests Report
         if: always()
         uses: mikepenz/action-junit-report@v5
         with:
-          report_paths: "**/front/junit*.xml"
+          report_paths: "front/junit-shard-${{ matrix.shardIndex }}.xml"
           detailed_summary: true
           flaky_summary: true
           group_suite: true
-          check_name: Tests Report
+          check_name: Tests Report (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
   tsc:
     runs-on: ubuntu-latest
     steps:
@@ -130,7 +135,7 @@ jobs:
           2. Maintenance burden: Unused files still need to be updated during refactors, migrations, or dependency upgrades
           3. Confusion: Makes it unclear what's actually part of the application vs. legacy/dead code, slowing down onboarding
           4. Bloat: Increases repository size, IDE indexing time, and potentially bundle size if not properly tree-shaken
-          
+
           EOF
           )
           npm run knip -- --include files || (echo "You have some unused files. **Please remove them, or add them in the knip.ts file in the ignoreFiles array**\n\n${explanations}" >&2; false)

--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -41,7 +41,7 @@ jobs:
           REDIS_CACHE_URI: "redis://localhost:5434"
           REDIS_URI: "redis://localhost:5434"
           NODE_ENV: test
-        run: npx tsx admin/db.ts && npm run test:ci -- --changed=main
+        run: npx tsx admin/db.ts && npm run test:ci
       - name: Build Tests Report
         if: always()
         uses: mikepenz/action-junit-report@v5

--- a/.github/workflows/scheduled-tests-front.yml
+++ b/.github/workflows/scheduled-tests-front.yml
@@ -1,4 +1,4 @@
-name: Scheduled Tests & Lint (front)
+name: Scheduled Lint (front)
 
 on:
   schedule:
@@ -42,38 +42,6 @@ jobs:
       - name: Install Front dependencies
         working-directory: front
         run: npm ci
-      - name: Install Redis
-        uses: chenjuneking/redis-setup-action@v1
-        with:
-          version: "7.2.5"
-          hostPort: 5434
-          containerPort: 6379
-      - name: Install Postgres
-        uses: dust-tt/postgresql-action@6730e69fe23f4f2989c19edf9e6e0d7ffeb0a05c
-        with:
-          postgresql docker image: mirror.gcr.io/postgres
-          postgresql version: "14.13"
-          postgresql db: front_test
-          postgresql user: test
-          postgresql password: test
-          postgresql port: 5433
-      - name: Run All Tests
-        working-directory: front
-        env:
-          FRONT_DATABASE_URI: "postgres://test:test@localhost:5433/front_test"
-          REDIS_CACHE_URI: "redis://localhost:5434"
-          REDIS_URI: "redis://localhost:5434"
-          NODE_ENV: test
-        run: npx tsx admin/db.ts && npm run test:ci
-      - name: Build Tests Report
-        if: always()
-        uses: mikepenz/action-junit-report@v5
-        with:
-          report_paths: "**/front/junit*.xml"
-          detailed_summary: true
-          flaky_summary: true
-          group_suite: true
-          check_name: Scheduled Tests Report
       - name: Run Biome Lint (Full Codebase)
         working-directory: front
         run: npm run lint:circular

--- a/.github/workflows/scheduled-tests-front.yml
+++ b/.github/workflows/scheduled-tests-front.yml
@@ -2,8 +2,8 @@ name: Scheduled Lint (front)
 
 on:
   schedule:
-    # Run every hour
-    - cron: "0 * * * *"
+    # Run twice a day at 8 AM and 8 PM UTC
+    - cron: "0 8,20 * * *"
   workflow_dispatch: # Allow manual triggering
 
 permissions:

--- a/front/package.json
+++ b/front/package.json
@@ -22,7 +22,7 @@
     "tsgo": "tsgo",
     "test": "FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI vitest --run",
     "test:watch": "FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI vitest --watch",
-    "test:ci": "vitest --reporter=junit --outputFile=junit.xml --watch=false",
+    "test:ci": "vitest --reporter=junit --watch=false",
     "coverage": "vitest --coverage",
     "initdb": "./admin/init_db.sh",
     "create-db-migration": "./create_db_migration_file.sh",


### PR DESCRIPTION
## Description

**Context**
`Lint & Build & Test (front)` workflow updates introduced a regression:
- `--changed` option was not working and tests were simply not running at all (rather than running only tests related to updated files)
- Even with a fix, updating only one file made running 112 out of 120 text files because of barrel files, so no obvious gain in performance

**What I did**
- Re-run all tests in `Lint & Build & Test (front)` workflow
- Use vitest sharding to split the test files to run in 3 (CI run lasts ~2min10s)
- Remove running test from scheduled workflow (but keep linting)

## Tests

CI

## Risk

no

## Deploy Plan

no
