### PR TITLE
[front] enh(ppul): Use microdollars for token usages cost

### DIFF
--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -420,7 +420,7 @@ const DEFAULT_PRICING = MODEL_PRICING[DEFAULT_PRICING_MODEL_ID];
  * Note: promptTokens currently includes cached read and cache write tokens for some providers.
  * To avoid double counting, price all promptTokens at base input rate, then adjust with deltas.
  */
-export function calculateTokenUsageCostForUsageInMicroUsd({
+export function computeTokensCostForUsageInMicroUsd({
   modelId,
   promptTokens,
   completionTokens,
@@ -453,7 +453,7 @@ export function calculateTokenUsageCostInMicroUsd(
   usages: RunUsageType[]
 ): number {
   return usages.reduce(
-    (acc, usage) => acc + calculateTokenUsageCostForUsageInMicroUsd(usage),
+    (acc, usage) => acc + computeTokensCostForUsageInMicroUsd(usage),
     0
   );
 }

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -1,16 +1,17 @@
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { ModelIdType as BaseModelIdType, ModelIdType } from "@app/types";
 
+// All pricing are in USD per million tokens (equivalent to micro-USD per token).
 type PricingEntry = {
   input: number;
   output: number;
-  // Optional cached-token pricing (micro USD per token).
+  // Optional cached-token pricing.
   cache_creation_input_tokens?: number;
   cache_read_input_tokens?: number;
 };
 
 export const DUST_MARKUP_PERCENT = 30;
-// Pricing in micro USD per token for current models.
+// Pricing for current models (USD per million tokens - equivalent to micro-USD per token)
 // This record must contain all BaseModelIdType values.
 const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
   // https://openai.com/api/pricing

--- a/front/lib/api/programmatic_usage_tracking.test.ts
+++ b/front/lib/api/programmatic_usage_tracking.test.ts
@@ -194,7 +194,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
 
       const refreshed = await refreshCredit(credit);
       expect(refreshed.consumedAmountCents).toBe(300);
@@ -207,14 +207,14 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 1000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 100000000 });
 
       const refreshed = await refreshCredit(credit);
       expect(refreshed.consumedAmountCents).toBe(500);
     });
 
     it("should not throw when no credits are available", async () => {
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 1000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 100000000 });
       // Should complete without error
     });
 
@@ -225,7 +225,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 0 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 0 });
 
       const refreshed = await refreshCredit(credit);
       expect(refreshed.consumedAmountCents).toBe(0);
@@ -245,7 +245,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
 
       const refreshedFree = await refreshCredit(freeCredit);
       const refreshedPayg = await refreshCredit(paygCredit);
@@ -266,7 +266,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
 
       const refreshedCommitted = await refreshCredit(committedCredit);
       const refreshedPayg = await refreshCredit(paygCredit);
@@ -296,7 +296,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
       // 1. freeCredit (200)
       // 2. committedCredit (200)
       // 3. paygCredit (100)
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 500 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 50000000 });
 
       const refreshedFree = await refreshCredit(freeCredit);
       const refreshedCommitted = await refreshCredit(committedCredit);
@@ -321,7 +321,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + TWO_MONTHS)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
 
       const refreshedEarlier = await refreshCredit(earlierCredit);
       const refreshedLater = await refreshCredit(laterCredit);
@@ -342,7 +342,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + TWO_MONTHS)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 500 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 50000000 });
 
       const refreshedEarlier = await refreshCredit(earlierCredit);
       const refreshedLater = await refreshCredit(laterCredit);
@@ -366,7 +366,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + 6 * ONE_MONTH)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 300 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
 
       const refreshedPayg = await refreshCredit(paygCredit);
       const refreshedFree = await refreshCredit(freeCredit);
@@ -409,7 +409,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
       // 2. freeLater (100)
       // 3. committedEarlier (100)
       // 4. paygEarlier (50)
-      await decreaseProgrammaticCreditsV2(auth, { amountCents: 350 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 35000000 });
 
       const refreshedFreeEarlier = await refreshCredit(freeEarlier);
       const refreshedFreeLater = await refreshCredit(freeLater);

--- a/front/lib/api/programmatic_usage_tracking.test.ts
+++ b/front/lib/api/programmatic_usage_tracking.test.ts
@@ -193,7 +193,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         1000,
         new Date(Date.now() + ONE_YEAR)
       );
-      console.log("credit", credit);
+
       await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 3000000 });
 
       const refreshed = await refreshCredit(credit);

--- a/front/lib/api/programmatic_usage_tracking.test.ts
+++ b/front/lib/api/programmatic_usage_tracking.test.ts
@@ -193,8 +193,8 @@ describe("decreaseProgrammaticCreditsV2", () => {
         1000,
         new Date(Date.now() + ONE_YEAR)
       );
-
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
+      console.log("credit", credit);
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 3000000 });
 
       const refreshed = await refreshCredit(credit);
       expect(refreshed.consumedAmountCents).toBe(300);
@@ -207,14 +207,14 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 100000000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 10000000 });
 
       const refreshed = await refreshCredit(credit);
       expect(refreshed.consumedAmountCents).toBe(500);
     });
 
     it("should not throw when no credits are available", async () => {
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 100000000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 10000000 });
       // Should complete without error
     });
 
@@ -245,7 +245,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 3000000 });
 
       const refreshedFree = await refreshCredit(freeCredit);
       const refreshedPayg = await refreshCredit(paygCredit);
@@ -266,7 +266,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 3000000 });
 
       const refreshedCommitted = await refreshCredit(committedCredit);
       const refreshedPayg = await refreshCredit(paygCredit);
@@ -296,7 +296,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
       // 1. freeCredit (200)
       // 2. committedCredit (200)
       // 3. paygCredit (100)
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 50000000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 5000000 });
 
       const refreshedFree = await refreshCredit(freeCredit);
       const refreshedCommitted = await refreshCredit(committedCredit);
@@ -321,7 +321,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + TWO_MONTHS)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 3000000 });
 
       const refreshedEarlier = await refreshCredit(earlierCredit);
       const refreshedLater = await refreshCredit(laterCredit);
@@ -342,7 +342,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + TWO_MONTHS)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 50000000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 5000000 });
 
       const refreshedEarlier = await refreshCredit(earlierCredit);
       const refreshedLater = await refreshCredit(laterCredit);
@@ -366,7 +366,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + 6 * ONE_MONTH)
       );
 
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 30000000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 3000000 });
 
       const refreshedPayg = await refreshCredit(paygCredit);
       const refreshedFree = await refreshCredit(freeCredit);
@@ -409,7 +409,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
       // 2. freeLater (100)
       // 3. committedEarlier (100)
       // 4. paygEarlier (50)
-      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 35000000 });
+      await decreaseProgrammaticCreditsV2(auth, { amountMicroUsd: 3500000 });
 
       const refreshedFreeEarlier = await refreshCredit(freeEarlier);
       const refreshedFreeLater = await refreshCredit(freeLater);

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -191,7 +191,7 @@ export class CreditResource extends BaseResource<CreditModel> {
    * Over-consumption should however stay minimal
    */
   async consume(
-    amountInCents: number,
+    { amountInCents }: { amountInCents: number },
     { transaction }: { transaction?: Transaction } = {}
   ) {
     if (amountInCents <= 0) {

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -8,7 +8,7 @@ import type {
 } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
-import { calculateTokenUsageCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
+import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import type { TokenUsage } from "@app/lib/api/llm/types/events";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -294,7 +294,7 @@ export class RunResource extends BaseResource<RunModel> {
       return;
     }
 
-    const usageCostMicroUsd = calculateTokenUsageCostForUsageInMicroUsd({
+    const usageCostMicroUsd = computeTokensCostForUsageInMicroUsd({
       modelId: modelConfig.modelId,
       promptTokens: usage.inputTokens,
       completionTokens: usage.outputTokens,

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -8,7 +8,7 @@ import type {
 } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
-import { calculateTokenUsageCostForUsage } from "@app/lib/api/assistant/token_pricing";
+import { calculateTokenUsageCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import type { TokenUsage } from "@app/lib/api/llm/types/events";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -267,7 +267,7 @@ export class RunResource extends BaseResource<RunModel> {
           completionTokens,
           cachedTokens,
           cacheCreationTokens,
-          costUsd,
+          costMicroUsd,
         }) => ({
           runId: this.id,
           workspaceId: this.workspaceId,
@@ -277,7 +277,8 @@ export class RunResource extends BaseResource<RunModel> {
           completionTokens,
           cachedTokens,
           cacheCreationTokens: cacheCreationTokens ?? null,
-          costUsd,
+          costUsd: costMicroUsd / 1_000_000,
+          costMicroUsd,
         })
       )
     );
@@ -293,7 +294,7 @@ export class RunResource extends BaseResource<RunModel> {
       return;
     }
 
-    const usageCostUsd = calculateTokenUsageCostForUsage({
+    const usageCostMicroUsd = calculateTokenUsageCostForUsageInMicroUsd({
       modelId: modelConfig.modelId,
       promptTokens: usage.inputTokens,
       completionTokens: usage.outputTokens,
@@ -309,7 +310,7 @@ export class RunResource extends BaseResource<RunModel> {
         modelId: modelConfig.modelId,
         promptTokens: usage.inputTokens,
         providerId: modelConfig.providerId,
-        costUsd: usageCostUsd,
+        costMicroUsd: usageCostMicroUsd,
       },
     ]);
   }
@@ -329,7 +330,7 @@ export class RunResource extends BaseResource<RunModel> {
       providerId: usage.providerId as ModelProviderIdType,
       cachedTokens: usage.cachedTokens,
       cacheCreationTokens: usage.cacheCreationTokens,
-      costUsd: usage.costUsd,
+      costMicroUsd: usage.costMicroUsd,
     }));
   }
 }
@@ -351,5 +352,5 @@ export interface RunUsageType {
   cachedTokens: number | null;
   // Optional: tokens spent writing to cache (e.g., Anthropic cache creation)
   cacheCreationTokens?: number | null;
-  costUsd: number;
+  costMicroUsd: number;
 }

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -74,6 +74,7 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
   declare cacheCreationTokens: number | null;
 
   declare costUsd: number;
+  declare costMicroUsd: number;
 }
 
 RunUsageModel.init(
@@ -106,6 +107,11 @@ RunUsageModel.init(
     },
     costUsd: {
       type: DataTypes.FLOAT,
+      defaultValue: 0,
+      allowNull: false,
+    },
+    costMicroUsd: {
+      type: DataTypes.BIGINT,
       defaultValue: 0,
       allowNull: false,
     },

--- a/front/migrations/db/migration_420.sql
+++ b/front/migrations/db/migration_420.sql
@@ -1,0 +1,3 @@
+-- Migration created on Dec 02, 2025
+ALTER TABLE "public"."run_usages"
+ADD COLUMN "costMicroUsd" BIGINT NOT NULL DEFAULT 0;

--- a/front/migrations/db/migration_421.sql
+++ b/front/migrations/db/migration_421.sql
@@ -1,0 +1,6 @@
+UPDATE "public"."run_usages"
+SET
+    "costMicroUsd" = "costUsd" * 1000000
+WHERE
+    "costUsd" > 0
+    AND "costMicroUsd" = 0;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -2,7 +2,7 @@ import type { RunAppResponseType } from "@dust-tt/client";
 import { createParser } from "eventsource-parser";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { calculateTokenUsageCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
+import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
@@ -75,7 +75,7 @@ function extractUsageFromExecutions(
           const cachedTokens = token_usage.cached_tokens;
           const cacheCreationTokens = token_usage.cache_creation_input_tokens;
 
-          const usageCostMicroUsd = calculateTokenUsageCostForUsageInMicroUsd({
+          const usageCostMicroUsd = computeTokensCostForUsageInMicroUsd({
             modelId: block.model_id,
             promptTokens,
             completionTokens,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -2,7 +2,7 @@ import type { RunAppResponseType } from "@dust-tt/client";
 import { createParser } from "eventsource-parser";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { calculateTokenUsageCostForUsage } from "@app/lib/api/assistant/token_pricing";
+import { calculateTokenUsageCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
@@ -75,7 +75,7 @@ function extractUsageFromExecutions(
           const cachedTokens = token_usage.cached_tokens;
           const cacheCreationTokens = token_usage.cache_creation_input_tokens;
 
-          const usageCostUsd = calculateTokenUsageCostForUsage({
+          const usageCostMicroUsd = calculateTokenUsageCostForUsageInMicroUsd({
             modelId: block.model_id,
             promptTokens,
             completionTokens,
@@ -90,7 +90,7 @@ function extractUsageFromExecutions(
             completionTokens,
             cachedTokens: cachedTokens ?? null,
             cacheCreationTokens: cacheCreationTokens ?? null,
-            costUsd: usageCostUsd,
+            costMicroUsd: usageCostMicroUsd,
           });
         }
       }

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -210,10 +210,11 @@ async function collectTokenUsage(
     { concurrency: 5 }
   );
 
-  const usageCostUsd = runUsages
+  const usageCostMicroUsd = runUsages
     .flat()
-    .reduce((acc, usage) => acc + usage.costUsd, 0);
-  const usageCostCents = usageCostUsd > 0 ? Math.ceil(usageCostUsd * 100) : 0;
+    .reduce((acc, usage) => acc + usage.costMicroUsd, 0);
+  const usageCostCents =
+    usageCostMicroUsd > 0 ? Math.ceil(usageCostMicroUsd / 10_000) : 0;
 
   return runUsages.flat().reduce(
     (acc, usage) => {

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -43,7 +43,7 @@ export function isActiveRoleType(role: string): role is ActiveRoleType {
 type PublicAPILimitsEnabled = {
   enabled: true;
   markup: number;
-  monthlyLimit: number;
+  monthlyLimit: number; // in USD
   billingDay: number; // Best-effort, represents the day of the month when the billing period starts.
 };
 


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/5247

Pricing is being calculated in microUsd and stored as in run_usages. Double store in usd and microusd.
RunUsageType now exposes cost in microUsd only.

## Tests

Unit tests updated

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

add column : front/migrations/db/migration_420.sql
deploy front
migrate data : front/migrations/db/migration_421.sql