### PR TITLE
[front] enh: Migrate analytics to microdollars

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -29,7 +29,7 @@ export const LATENCY_LEGEND = [
 ] as const;
 
 export const COST_PALETTE = {
-  costCents: "text-blue-400 dark:text-blue-400-night",
+  costMicroUsd: "text-blue-400 dark:text-blue-400-night",
   totalCredits: "text-green-500 dark:text-green-500-night",
 } as const;
 

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -64,7 +64,6 @@ type ChartDataPoint = {
   date: string;
   timestamp: number;
   totalInitialCreditsCents: number;
-  programmaticCostCents?: number;
   [key: string]: string | number | undefined;
 };
 
@@ -88,7 +87,7 @@ function getColorClassName(
   groups: string[]
 ): string {
   if (!groupBy) {
-    return COST_PALETTE.costCents;
+    return COST_PALETTE.costMicroUsd;
   } else if (groupBy === "origin" && isUserMessageOrigin(groupName)) {
     return getSourceColor(groupName);
   } else {
@@ -139,7 +138,7 @@ function GroupedTooltip(
 
       return {
         label,
-        value: `$${(p.value / 100).toFixed(2)}`,
+        value: `$${(p.value / 1_000_000).toFixed(2)}`,
         colorClassName,
       };
     });
@@ -344,7 +343,7 @@ export function BaseProgrammaticCostChart({
     // Add each group's cumulative cost to the data point using labels from availableGroups
     // Keep undefined values as-is so Recharts doesn't render those points
     point.groups.forEach((g) => {
-      dataPoint[g.groupKey] = g.cumulatedCostCents;
+      dataPoint[g.groupKey] = g.cumulatedCostMicroUsd;
     });
 
     return dataPoint;
@@ -530,7 +529,7 @@ export function BaseProgrammaticCostChart({
           tickLine={false}
           axisLine={false}
           tickMargin={8}
-          tickFormatter={(value) => `$${(value / 100).toFixed(0)}`}
+          tickFormatter={(value) => `$${(value / 1_000_000).toFixed(0)}`}
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) =>

--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -53,8 +53,8 @@
           "cached": {
             "type": "integer"
           },
-          "cost_cents": {
-            "type": "short"
+          "cost_micro_usd": {
+            "type": "long"
           }
         }
       },

--- a/front/lib/analytics/migrations/20251202_add_cost_micro_usd.http
+++ b/front/lib/analytics/migrations/20251202_add_cost_micro_usd.http
@@ -1,0 +1,8 @@
+PUT /front.agent_message_analytics_2/_mapping
+{
+  "properties": {
+    "tokens.cost_micro_usd": {
+      "type": "long"
+    }
+  }
+}

--- a/front/lib/analytics/migrations/20251202_migrate_to_micro_usd.http
+++ b/front/lib/analytics/migrations/20251202_migrate_to_micro_usd.http
@@ -1,0 +1,25 @@
+POST /front.agent_message_analytics_2/_update_by_query
+{
+  "script": {
+    "source": "ctx._source.tokens.cost_micro_usd = ctx._source.tokens.cost_cents * 10000L",
+    "lang": "painless"
+  },
+  "query": {
+        "bool": {
+      "must": [
+        {
+          "exists": {
+            "field": "tokens.cost_cents"
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "exists": {
+            "field": "tokens.cost_micro_usd"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/front/lib/analytics/migrations/20251202_migrate_to_micro_usd.http
+++ b/front/lib/analytics/migrations/20251202_migrate_to_micro_usd.http
@@ -5,7 +5,7 @@ POST /front.agent_message_analytics_2/_update_by_query
     "lang": "painless"
   },
   "query": {
-        "bool": {
+    "bool": {
       "must": [
         {
           "exists": {

--- a/front/lib/api/assistant/observability/messages_metrics.ts
+++ b/front/lib/api/assistant/observability/messages_metrics.ts
@@ -9,7 +9,7 @@ const DEFAULT_METRIC_VALUE = 0;
 const DEFAULT_SELECTED_METRICS = [
   "conversations",
   "activeUsers",
-  "costCents",
+  "costMicroUsd",
 ] as const satisfies readonly (keyof MessageMetricsPoint)[];
 
 type BaseMetricsPoint = {
@@ -20,7 +20,7 @@ type BaseMetricsPoint = {
 type Metrics = {
   conversations: number;
   activeUsers: number;
-  costCents: number;
+  costMicroUsd: number;
   avgLatencyMs: number;
   percentilesLatencyMs: number;
   failedMessages: number;
@@ -47,7 +47,7 @@ export type MetricsBucket = {
   doc_count: number;
   unique_conversations?: estypes.AggregationsCardinalityAggregate;
   active_users?: estypes.AggregationsCardinalityAggregate;
-  cost_cents?: estypes.AggregationsSumAggregate;
+  cost_micro_usd?: estypes.AggregationsSumAggregate;
   avg_latency_ms?: estypes.AggregationsCardinalityAggregate;
   percentiles_latency_ms?: KeyedTDigestPercentiles;
   failed_messages?: estypes.AggregationsFilterAggregate;
@@ -80,8 +80,8 @@ export function buildMetricAggregates<K extends readonly MetricName[]>(
     aggregates.active_users = { cardinality: { field: "user_id" } };
   }
 
-  if (metrics.includes("costCents")) {
-    aggregates.cost_cents = { sum: { field: "tokens.cost_cents" } };
+  if (metrics.includes("costMicroUsd")) {
+    aggregates.cost_micro_usd = { sum: { field: "tokens.cost_micro_usd" } };
   }
 
   if (metrics.includes("avgLatencyMs")) {
@@ -131,9 +131,9 @@ export function parseMetricsFromBucket<K extends readonly MetricName[]>(
     );
   }
 
-  if (metrics.includes("costCents")) {
-    point.costCents = Math.round(
-      bucket.cost_cents?.value ?? DEFAULT_METRIC_VALUE
+  if (metrics.includes("costMicroUsd")) {
+    point.costMicroUsd = Math.round(
+      bucket.cost_micro_usd?.value ?? DEFAULT_METRIC_VALUE
     );
   }
 

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -152,7 +152,7 @@ export function formatUTCDateFromMillis(ms: number): string {
  *
  * @param groups - Array of groups with parsed points, already sorted by priority (e.g., by total cost)
  * @param max - Maximum number of groups to return (default: 5)
- * @param valueKey - Key of the numeric value to aggregate (e.g., "costCents")
+ * @param valueKey - Key of the numeric value to aggregate (e.g., "costMicroUsd")
  * @returns Array with at most N groups (top N-1 + optional "others" group)
  */
 export function ensureAtMostNGroups<

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -196,7 +196,7 @@ async function collectTokenUsage(
       completion: 0,
       reasoning: 0,
       cached: 0,
-      cost_cents: 0,
+      cost_micro_usd: 0,
     };
   }
 
@@ -210,12 +210,6 @@ async function collectTokenUsage(
     { concurrency: 5 }
   );
 
-  const usageCostMicroUsd = runUsages
-    .flat()
-    .reduce((acc, usage) => acc + usage.costMicroUsd, 0);
-  const usageCostCents =
-    usageCostMicroUsd > 0 ? Math.ceil(usageCostMicroUsd / 10_000) : 0;
-
   return runUsages.flat().reduce(
     (acc, usage) => {
       return {
@@ -223,7 +217,7 @@ async function collectTokenUsage(
         completion: acc.completion + usage.completionTokens,
         reasoning: acc.reasoning, // No reasoning tokens in RunUsageType yet.
         cached: acc.cached + (usage.cachedTokens ?? 0),
-        cost_cents: acc.cost_cents,
+        cost_micro_usd: acc.cost_micro_usd + usage.costMicroUsd,
       };
     },
     {
@@ -231,7 +225,7 @@ async function collectTokenUsage(
       completion: 0,
       reasoning: 0,
       cached: 0,
-      cost_cents: usageCostCents,
+      cost_micro_usd: 0,
     }
   );
 }

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -11,7 +11,7 @@ export interface AgentMessageAnalyticsTokens {
   completion: number;
   reasoning: number;
   cached: number;
-  cost_cents: number;
+  cost_micro_usd: number;
 }
 
 export interface AgentMessageAnalyticsToolUsed {


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/5247

Change the analytics to use microUSD instead of cents. 
- Update the ES mapping to store data in microUSD (no double write)
- Update the ES queries and the graph to show the units correctly (still displayed in $ )

The provided backfill take the message costs in cents and convert to microUSD. This keep the cent-rounded value, but is imo ok for analytics - running a complete backfill to recalculate the exact cost with microUSD precision will take much more time. This can also be run later if needed.


## Tests

locally

## Risk

analytics only

## Deploy Plan

run mapping change : front/lib/analytics/migrations/20251202_add_cost_micro_usd.http
deploy front
run backfill : front/lib/analytics/migrations/20251202_migrate_to_micro_usd.http