### PR TITLE
[front] - feature(messages): allow admins to delete user messages

### DIFF
--- a/front/hooks/useDeleteMessage.ts
+++ b/front/hooks/useDeleteMessage.ts
@@ -33,7 +33,7 @@ export function useDeleteMessage({
 
       sendNotification({
         title: "Message deleted",
-        description: "Your message has been deleted successfully.",
+        description: "Message has been deleted successfully.",
         type: "success",
       });
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -759,7 +759,7 @@ export async function softDeleteUserMessage(
     return new Err(new ConversationError("message_not_found"));
   }
 
-  if (message.userMessage.userId !== user.id) {
+  if (!auth.isAdmin() && message.userMessage.userId !== user.id) {
     return new Err(new ConversationError("message_deletion_not_authorized"));
   }
 
@@ -778,7 +778,7 @@ export async function softDeleteUserMessage(
       conversationId: conversation.sId,
       messageId: message.sId,
     },
-    "User deleted their message"
+    auth.isAdmin() ? "Admin deleted a user message" : "User deleted their message"
   );
 
   return new Ok({ success: true });


### PR DESCRIPTION
## Description

This PR extends message deletion capabilities to workspace administrators. Previously, users could only delete their own messages. Now, admins can delete any user message in conversations.

**References:**
- https://github.com/dust-tt/tasks/issues/5278

## Risk

Medium - extends message deletion

## Tests

- [x] Locally
- [x] front-edge
