### PR TITLE
Add ref to cat tool citations

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -82,8 +82,8 @@ export function PluginForm({
               key,
               arg.async && asyncArgs?.[key] !== undefined
                 ? (asyncArgs[key] as AsyncEnumValues)
-                  .filter((v) => v.checked)
-                  .map((v) => v.value)
+                    .filter((v) => v.checked)
+                    .map((v) => v.value)
                 : arg.values.filter((v) => v.checked).map((v) => v.value),
             ];
           case "date":
@@ -163,7 +163,7 @@ export function PluginForm({
           }
           const fieldDescription =
             arg.asyncDescription &&
-              asyncArgs?.[`${key}_description`] !== undefined
+            asyncArgs?.[`${key}_description`] !== undefined
               ? String(asyncArgs[`${key}_description`])
               : arg.description;
 

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -689,6 +689,7 @@ export const DataSourceNodeContentSchema = z.object({
   uri: z.string(),
   text: z.string(),
   metadata: RenderedNodeSchema,
+  ref: z.string(),
 });
 
 export type DataSourceNodeContentType = z.infer<

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -689,7 +689,7 @@ export const DataSourceNodeContentSchema = z.object({
   uri: z.string(),
   text: z.string(),
   metadata: RenderedNodeSchema,
-  ref: z.string(),
+  ref: z.string().optional(),
 });
 
 export type DataSourceNodeContentType = z.infer<

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -75,6 +75,10 @@ export function registerCatTool(
         enableAlerting: true,
       },
       async ({ dataSources, nodeId, offset, limit, grep }) => {
+        if (!agentLoopContext?.runContext) {
+          return new Err(new MCPError("No conversation context available"));
+        }
+
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
         // Gather data source configurations.
@@ -174,10 +178,6 @@ export function registerCatTool(
               }
             )
           );
-        }
-
-        if (!agentLoopContext?.runContext) {
-          return new Err(new MCPError("No conversation context available"));
         }
 
         const { citationsOffset } = agentLoopContext.runContext.stepContext;

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -166,6 +166,15 @@ export function isMCPInternalDataSourceFileSystem(
   );
 }
 
+export function isMCPInternalCatTool(
+  arg: MCPToolConfigurationType
+): arg is ServerSideMCPToolConfigurationType {
+  if (!isMCPInternalDataSourceFileSystem(arg)) {
+    return false;
+  }
+  return arg.originalName === "cat";
+}
+
 export function isMCPInternalWebsearch(
   arg: MCPToolConfigurationType
 ): arg is ServerSideMCPToolConfigurationType {

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -4,6 +4,7 @@ import type { ActionSpecification } from "@app/components/agent_builder/types";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { StepContext } from "@app/lib/actions/types";
 import {
+  isMCPInternalCatTool,
   isMCPInternalDataSourceFileSystem,
   isMCPInternalInclude,
   isMCPInternalNotion,
@@ -124,6 +125,10 @@ export function getCitationsCount({
 
   if (isMCPInternalRunAgent(action)) {
     return RUN_AGENT_ACTION_NUM_RESULTS;
+  }
+
+  if (isMCPInternalCatTool(action)) {
+    return 1;
   }
 
   return getRetrievalTopK({

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -1,4 +1,5 @@
 import {
+  isDataSourceNodeContentType,
   isRunAgentResultResourceType,
   isSearchResultResourceType,
   isWebsearchResultResourceType,
@@ -113,10 +114,27 @@ export function getCitationsFromActions(
     }
   });
 
+  const dataSourceNodeContentResults = removeNulls(
+    actions.flatMap((action) =>
+      action.output?.filter(isDataSourceNodeContentType).map((o) => o.resource)
+    )
+  );
+
+  const dataSourceNodeContentRefs: Record<string, CitationType> = {};
+  dataSourceNodeContentResults.forEach((d) => {
+    dataSourceNodeContentRefs[d.ref] = {
+      href: d.uri,
+      title: d.metadata.title,
+      provider: d.metadata.connectorProvider ?? "document",
+      contentType: d.mimeType,
+    };
+  });
+
   return {
     ...searchRefs,
     ...websearchRefs,
     ...runAgentRefs,
+    ...dataSourceNodeContentRefs,
   };
 }
 

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -122,6 +122,9 @@ export function getCitationsFromActions(
 
   const dataSourceNodeContentRefs: Record<string, CitationType> = {};
   dataSourceNodeContentResults.forEach((d) => {
+    if (!d.ref) {
+      return;
+    }
     dataSourceNodeContentRefs[d.ref] = {
       href: d.uri,
       title: d.metadata.title,

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -386,7 +386,8 @@ export type AllSupportedFileContentType =
 export type AllSupportedWithDustSpecificFileContentType =
   | AllSupportedFileContentType
   | "application/vnd.dust.tool-output.data-source-search-result"
-  | "application/vnd.dust.tool-output.websearch-result";
+  | "application/vnd.dust.tool-output.websearch-result"
+  | "application/vnd.dust.tool-output.data-source-node-content";
 
 export type SupportedImageContentType = {
   [K in keyof typeof FILE_FORMATS]: (typeof FILE_FORMATS)[K] extends {


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/5090
* I believe that if the file system cat tool is used to obtain a file that it would never be included in the citations because we did not return a ref attribute.

## Tests

I now see the citation:

<img width="776" height="481" alt="Screenshot 2025-12-02 at 5 32 24 PM" src="https://github.com/user-attachments/assets/32ab909d-40ce-4867-8fa3-ac14cded1098" />

## Risk

* Minimal

## Deploy Plan

* Deploy front