### PR TITLE
[front] fix: Fix free credit routine for customers on 2nd paid cycle

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -299,7 +299,8 @@ export async function getSubscriptionInvoices(
   return invoices.data.filter(
     (inv) =>
       inv.billing_reason === "subscription_cycle" ||
-      inv.billing_reason === "subscription_create"
+      inv.billing_reason === "subscription_create" ||
+      inv.billing_reason === "subscription_update"
   );
 }
 

--- a/front/lib/types/stripe/events.ts
+++ b/front/lib/types/stripe/events.ts
@@ -1,0 +1,38 @@
+import type Stripe from "stripe";
+
+type StripeSubscriptionEvent =
+  | Stripe.CustomerSubscriptionCreatedEvent
+  | Stripe.CustomerSubscriptionDeletedEvent
+  | Stripe.CustomerSubscriptionPausedEvent
+  | Stripe.CustomerSubscriptionPendingUpdateAppliedEvent
+  | Stripe.CustomerSubscriptionPendingUpdateExpiredEvent
+  | Stripe.CustomerSubscriptionResumedEvent
+  | Stripe.CustomerSubscriptionTrialWillEndEvent
+  | Stripe.CustomerSubscriptionUpdatedEvent;
+
+type StripeInvoiceEvent =
+  | Stripe.InvoiceCreatedEvent
+  | Stripe.InvoiceDeletedEvent
+  | Stripe.InvoiceFinalizationFailedEvent
+  | Stripe.InvoiceFinalizedEvent
+  | Stripe.InvoiceMarkedUncollectibleEvent
+  | Stripe.InvoicePaidEvent
+  | Stripe.InvoicePaymentActionRequiredEvent
+  | Stripe.InvoicePaymentFailedEvent
+  | Stripe.InvoicePaymentSucceededEvent
+  | Stripe.InvoiceSentEvent
+  | Stripe.InvoiceUpcomingEvent
+  | Stripe.InvoiceUpdatedEvent
+  | Stripe.InvoiceVoidedEvent;
+
+export function isStripeSubscriptionEvent(
+  event: Stripe.Event
+): event is StripeSubscriptionEvent {
+  return event.type.startsWith("customer.subscription.");
+}
+
+export function isStripeInvoiceEvent(
+  event: Stripe.Event
+): event is StripeInvoiceEvent {
+  return event.type.startsWith("invoice.");
+}

--- a/front/scripts/inspect_stripe_state.ts
+++ b/front/scripts/inspect_stripe_state.ts
@@ -1,0 +1,94 @@
+import type Stripe from "stripe";
+
+import { getCustomerStatus } from "@app/lib/credits/free";
+import { Subscription } from "@app/lib/models/plan";
+import {
+  getStripeClient,
+  getStripeSubscription,
+  getSubscriptionInvoices,
+} from "@app/lib/plans/stripe";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { makeScript } from "@app/scripts/helpers";
+
+async function inspectFromEvent(eventId: string, logger: any) {
+  const stripe = getStripeClient();
+
+  const event = await stripe.events.retrieve(eventId);
+  logger.info(`Event type: ${event.type}`);
+
+  const eventData = event.data.object as Stripe.Subscription | Stripe.Invoice;
+  let stripeSubscriptionId: string;
+
+  if ("subscription" in eventData && eventData.subscription) {
+    stripeSubscriptionId =
+      typeof eventData.subscription === "string"
+        ? eventData.subscription
+        : eventData.subscription.id;
+  } else if (
+    "id" in eventData &&
+    event.type.startsWith("customer.subscription")
+  ) {
+    stripeSubscriptionId = eventData.id;
+  } else {
+    logger.error("Could not extract subscription ID from event");
+    return;
+  }
+
+  logger.info(`Stripe Subscription ID: ${stripeSubscriptionId}`);
+
+  const stripeSubscription = await getStripeSubscription(stripeSubscriptionId);
+  if (!stripeSubscription) {
+    logger.warn("Stripe Subscription not found");
+    return;
+  }
+
+  const workspaceId = stripeSubscription.metadata?.workspaceId;
+  logger.info(`Workspace ID from Stripe metadata: ${workspaceId}`);
+
+  const dustSubscription = await Subscription.findOne({
+    where: { stripeSubscriptionId },
+  });
+  if (!dustSubscription) {
+    logger.warn("Dust Subscription not found");
+    return;
+  }
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.warn("Workspace not found");
+    return;
+  }
+
+  logger.info(`Workspace sId: ${workspace.sId}, name: ${workspace.name}`);
+  logger.info(`Dust Subscription status: ${dustSubscription.status}`);
+  logger.info(
+    `Customer status: ${await getCustomerStatus(stripeSubscription)}`
+  );
+
+  const paidInvoices = await getSubscriptionInvoices(stripeSubscription.id, {
+    status: "paid",
+    limit: 1,
+  });
+  if (paidInvoices && paidInvoices.length > 0) {
+    const mostRecentInvoice = paidInvoices[0];
+    const currentPeriodStartSec = stripeSubscription.current_period_start;
+    const invoicePeriodEndSec = mostRecentInvoice.period_end;
+    const ageSec = currentPeriodStartSec - invoicePeriodEndSec;
+    logger.info(
+      { mostRecentInvoice, currentPeriodStartSec, invoicePeriodEndSec, ageSec },
+      "Most recent paid invoice"
+    );
+  }
+}
+
+makeScript(
+  {
+    eventId: {
+      type: "string",
+      demandOption: true,
+    },
+  },
+  async ({ eventId }, logger) => {
+    await inspectFromEvent(eventId, logger);
+  }
+);

--- a/front/scripts/inspect_stripe_state.ts
+++ b/front/scripts/inspect_stripe_state.ts
@@ -21,7 +21,7 @@ async function inspectFromEvent(eventId: string, logger: any) {
 
   if ("subscription" in eventData && eventData.subscription) {
     stripeSubscriptionId =
-      typeof eventData.subscription === "string"
+      isString(eventData.subscription)
         ? eventData.subscription
         : eventData.subscription.id;
   } else if (


### PR DESCRIPTION
## Description

- When a customer transitions from trial to paid, the first invoice for the subscription will have a `billing_reason = "subscription_update"` which was filtered out when retrieving invoices to asses whether "you are a good payer"
This is now taking into account

- Also added a small script to inspect a customer/stripe based on stripe eventId

## Tests

N/A

## Risk

- Low

## Deploy Plan

- [ ] Deploy front