### PR TITLE
feat(ppul): slack workflows as programmatic usage

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1017,6 +1017,8 @@ async function answerMessage(
     message = `:mention[${mention.agentName}]{sId=${mention.agentId}} ${message}`;
   }
 
+  const origin = slackBotId ? "slack_workflow" : "slack";
+
   const messageReqBody: PublicPostMessagesRequestBody = {
     content: message,
     mentions: [{ configurationId: mention.agentId }],
@@ -1027,7 +1029,7 @@ async function answerMessage(
         slackChatBotMessage.slackFullName || slackChatBotMessage.slackUserName,
       email: slackChatBotMessage.slackEmail,
       profilePictureUrl: slackChatBotMessage.slackAvatar || null,
-      origin: "slack" as const,
+      origin,
     },
     skipToolsValidation,
   };

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -111,6 +111,10 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
     color: "text-golden-500 dark:text-golden-500-night",
   },
   slack: { label: "Slack", color: "text-green-500 dark:text-green-500-night" },
+  slack_workflow: {
+    label: "Slack",
+    color: "text-green-500 dark:text-green-500-night",
+  },
   teams: {
     label: "Teams",
     color: "text-highlight-muted dark:text-highlight-muted-night",

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -35,6 +35,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   raycast: "user",
   run_agent: "user",
   slack: "user",
+  slack_workflow: "programmatic",
   teams: "user",
   transcript: "user",
   triggered_programmatic: "programmatic",

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -54,6 +54,7 @@ export const shouldSendNotificationForAgentAnswer = (
     case "raycast":
     case "run_agent":
     case "slack":
+    case "slack_workflow":
     case "teams":
     case "transcript":
     case "triggered_programmatic":

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -86,6 +86,7 @@ export type UserMessageOrigin =
   | "raycast"
   | "run_agent" // soon to be removed (not a fitting origin).
   | "slack"
+  | "slack_workflow"
   | "teams"
   | "transcript"
   | "triggered_programmatic"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -316,6 +316,7 @@ const UserMessageOriginSchema = FlexibleEnumSchema<
   | "raycast"
   | "run_agent"
   | "slack"
+  | "slack_workflow"
   | "teams"
   | "transcript"
   | "triggered_programmatic"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Low complexity solution to count slack workflows as programmatic.

There's a more involved option that would be adding metadata to the PublicPostMessageRequestBodyType, that we can check on the other side to see if we should count as programmatic or not, but is really more involved and IMHO not worth it. This solution is fairly simple and not really high maintenance thanks to the type system. 

Workflows still appear as Slack origin in the observability. No change for the end user.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.