### PR TITLE
Unpause connectors on subscription

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -82,8 +82,8 @@ export function PluginForm({
               key,
               arg.async && asyncArgs?.[key] !== undefined
                 ? (asyncArgs[key] as AsyncEnumValues)
-                  .filter((v) => v.checked)
-                  .map((v) => v.value)
+                    .filter((v) => v.checked)
+                    .map((v) => v.value)
                 : arg.values.filter((v) => v.checked).map((v) => v.value),
             ];
           case "date":
@@ -163,7 +163,7 @@ export function PluginForm({
           }
           const fieldDescription =
             arg.asyncDescription &&
-              asyncArgs?.[`${key}_description`] !== undefined
+            asyncArgs?.[`${key}_description`] !== undefined
               ? String(asyncArgs[`${key}_description`])
               : arg.description;
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -630,9 +630,6 @@ export async function restoreWorkspaceAfterSubscription(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-  if (!owner) {
-    throw new Error("Missing workspace on auth.");
-  }
 
   // Terminate the scheduled workspace scrub workflow if any
   const scrubCancelRes = await terminateScheduleWorkspaceScrubWorkflow({

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -1,6 +1,8 @@
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
+import apiConfig from "@app/lib/api/config";
+import { getDataSources } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { Plan, Subscription } from "@app/lib/models/plan";
@@ -14,12 +16,14 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { SearchMembersPaginationParams } from "@app/lib/resources/user_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchDeleteWorkspaceWorkflow } from "@app/poke/temporal/client";
+import { terminateScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import type {
   GroupKind,
   LightWorkspaceType,
@@ -37,6 +41,7 @@ import type {
 import {
   ACTIVE_ROLES,
   assertNever,
+  ConnectorsAPI,
   Err,
   md5,
   Ok,
@@ -605,4 +610,62 @@ export async function findWorkspaceByWorkOSOrganizationId(
   }
 
   return renderLightWorkspaceType({ workspace });
+}
+
+/**
+ * Restores a workspace to full functionality after subscription activation/reactivation.
+ * This function is called when:
+ * - A new subscription is created (Stripe checkout or manual upgrade)
+ * - A subscription is reactivated after cancellation
+ *
+ * It performs the following actions:
+ * - Terminates the scheduled workspace scrub workflow (if any)
+ * - Unpauses all connectors (including webcrawler connectors)
+ * - Re-enables all triggers that point to non-archived agents
+ */
+export async function restoreWorkspaceAfterSubscription(
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Missing workspace on auth.");
+  }
+
+  // Terminate the scheduled workspace scrub workflow if any
+  const scrubCancelRes = await terminateScheduleWorkspaceScrubWorkflow({
+    workspaceId: owner.sId,
+  });
+  if (scrubCancelRes.isErr()) {
+    logger.error(
+      { error: scrubCancelRes.error, workspaceId: owner.sId },
+      "Error terminating scrub workspace workflow."
+    );
+  }
+
+  // Unpause all connectors
+  const dataSources = await getDataSources(auth);
+  const connectorIds = removeNulls(dataSources.map((ds) => ds.connectorId));
+  const connectorsApi = new ConnectorsAPI(
+    apiConfig.getConnectorsAPIConfig(),
+    logger
+  );
+  for (const connectorId of connectorIds) {
+    const r = await connectorsApi.unpauseConnector(connectorId);
+    if (r.isErr()) {
+      logger.error(
+        { connectorId, workspaceId: owner.sId, error: r.error },
+        "Error unpausing connector after subscription activation."
+      );
+    }
+  }
+
+  // Re-enable all triggers that point to non-archived agents
+  const enableTriggersRes = await TriggerResource.enableAllForWorkspace(auth);
+  if (enableTriggersRes.isErr()) {
+    logger.error(
+      { workspaceId: owner.sId, error: enableTriggersRes.error },
+      "Error re-enabling workspace triggers on subscription activation"
+    );
+    // Don't throw error here - we want the function to continue even if trigger re-enabling fails
+  }
 }

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -2,7 +2,10 @@ import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 import apiConfig from "@app/lib/api/config";
-import { getDataSources } from "@app/lib/api/data_sources";
+import {
+  getDataSources,
+  unpauseAllManagedDataSources,
+} from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { Plan, Subscription } from "@app/lib/models/plan";
@@ -626,7 +629,7 @@ export async function findWorkspaceByWorkOSOrganizationId(
 export async function restoreWorkspaceAfterSubscription(
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.workspace();
+  const owner = auth.getNonNullableWorkspace();
   if (!owner) {
     throw new Error("Missing workspace on auth.");
   }
@@ -643,20 +646,13 @@ export async function restoreWorkspaceAfterSubscription(
   }
 
   // Unpause all connectors
-  const dataSources = await getDataSources(auth);
-  const connectorIds = removeNulls(dataSources.map((ds) => ds.connectorId));
-  const connectorsApi = new ConnectorsAPI(
-    apiConfig.getConnectorsAPIConfig(),
-    logger
-  );
-  for (const connectorId of connectorIds) {
-    const r = await connectorsApi.unpauseConnector(connectorId);
-    if (r.isErr()) {
-      logger.error(
-        { connectorId, workspaceId: owner.sId, error: r.error },
-        "Error unpausing connector after subscription activation."
-      );
-    }
+  const unpauseConnectorsRes = await unpauseAllManagedDataSources(auth);
+  if (unpauseConnectorsRes.isErr()) {
+    logger.error(
+      { workspaceId: owner.sId, error: unpauseConnectorsRes.error.message },
+      "Failed to unpause connectors after subscription activation."
+    );
+    return;
   }
 
   // Re-enable all triggers that point to non-archived agents

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -5,7 +5,10 @@ import type Stripe from "stripe";
 
 import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
-import { getWorkspaceInfos } from "@app/lib/api/workspace";
+import {
+  getWorkspaceInfos,
+  restoreWorkspaceAfterSubscription,
+} from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
@@ -407,6 +410,9 @@ export class SubscriptionResource extends BaseResource<Subscription> {
       stripeSubscriptionId: enterpriseDetails.stripeSubscriptionId,
       endDate: null,
     });
+
+    // Restore workspace functionality: unpause connectors, re-enable triggers, cancel scrub workflow
+    await restoreWorkspaceAfterSubscription(auth);
   }
 
   /**
@@ -496,6 +502,9 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     if (isUpgraded(newSubscription.getPlan())) {
       await getOrCreateWorkOSOrganization(owner);
     }
+
+    // Restore workspace functionality: unpause connectors, re-enable triggers, cancel scrub workflow
+    await restoreWorkspaceAfterSubscription(auth);
   }
 
   static async maybeCancelInactiveTrials(

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -5,6 +5,7 @@ import type Stripe from "stripe";
 import { promisify } from "util";
 import { z } from "zod";
 
+import apiConfig from "@app/lib/api/config";
 import {
   sendAdminSubscriptionPaymentFailedEmail,
   sendCancelSubscriptionEmail,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -5,14 +5,15 @@ import type Stripe from "stripe";
 import { promisify } from "util";
 import { z } from "zod";
 
-import apiConfig from "@app/lib/api/config";
-import { getDataSources } from "@app/lib/api/data_sources";
 import {
   sendAdminSubscriptionPaymentFailedEmail,
   sendCancelSubscriptionEmail,
   sendReactivateSubscriptionEmail,
 } from "@app/lib/api/email";
-import { getMembers } from "@app/lib/api/workspace";
+import {
+  getMembers,
+  restoreWorkspaceAfterSubscription,
+} from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { startCreditFromProOneOffInvoice } from "@app/lib/credits/committed";
 import { grantFreeCreditsOnSubscriptionRenewal } from "@app/lib/credits/free";
@@ -34,7 +35,6 @@ import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -42,13 +42,10 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import {
-  launchScheduleWorkspaceScrubWorkflow,
-  terminateScheduleWorkspaceScrubWorkflow,
-} from "@app/temporal/scrub_workspace/client";
+import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever, ConnectorsAPI, removeNulls } from "@app/types";
+import { assertNever } from "@app/types";
 
 export type GetResponseBody = {
   success: boolean;
@@ -281,7 +278,7 @@ async function handler(
                 subscriptionStartAt: now,
               });
             }
-            await onCancelScrub(
+            await restoreWorkspaceAfterSubscription(
               await Authenticator.internalAdminForWorkspace(workspace.sId)
             );
 
@@ -698,7 +695,7 @@ async function handler(
             );
             if (!endDate) {
               // Subscription is re-activated, so we need to unpause the connectors and re-enable triggers.
-              await onCancelScrub(auth);
+              await restoreWorkspaceAfterSubscription(auth);
 
               ServerSideTracking.trackSubscriptionReactivated({
                 workspace: renderLightWorkspaceType({
@@ -968,53 +965,6 @@ function _returnStripeApiError(
       message: `[Stripe Webhook][${event}] ${message}`,
     },
   });
-}
-
-/**
- * When a subscription is re-activated, we need to:
- * - Terminate the scheduled workspace scrub workflow (if any)
- * - Unpause all connectors
- * - Re-enable all triggers that point to non-archived agents
- */
-async function onCancelScrub(auth: Authenticator) {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Missing workspace on auth.");
-  }
-  const scrubCancelRes = await terminateScheduleWorkspaceScrubWorkflow({
-    workspaceId: owner.sId,
-  });
-  if (scrubCancelRes.isErr()) {
-    logger.error(
-      { stripeError: true, error: scrubCancelRes.error },
-      "Error terminating scrub workspace workflow."
-    );
-  }
-  const dataSources = await getDataSources(auth);
-  const connectorIds = removeNulls(dataSources.map((ds) => ds.connectorId));
-  const connectorsApi = new ConnectorsAPI(
-    apiConfig.getConnectorsAPIConfig(),
-    logger
-  );
-  for (const connectorId of connectorIds) {
-    const r = await connectorsApi.unpauseConnector(connectorId);
-    if (r.isErr()) {
-      logger.error(
-        { connectorId, stripeError: true, error: r.error },
-        "Error unpausing connector after subscription reactivation."
-      );
-    }
-  }
-
-  // Re-enable all triggers that point to non-archived agents
-  const enableTriggersRes = await TriggerResource.enableAllForWorkspace(auth);
-  if (enableTriggersRes.isErr()) {
-    logger.error(
-      { stripeError: true, error: enableTriggersRes.error },
-      "Error re-enabling workspace triggers on subscription reactivation"
-    );
-    // Don't throw error here - we want the function to continue even if trigger re-enabling fails
-  }
 }
 
 export default withLogging(handler);


### PR DESCRIPTION
## Description

Refactors workspace restoration logic by extracting the `onCancelScrub` function from the Stripe webhook handler into a reusable `restoreWorkspaceAfterSubscription` function in the workspace API. 
This function is now called consistently whenever a subscription is created or reactivated (Stripe checkout, manual enterprise subscription creation, or subscription reactivation after cancellation).

Existing connectors were not unpaused when restarting a subscription from Poke (see [error](https://app.datadoghq.eu/logs?query=%22Production%20check%20failed%22%20region%3Aus-central1%20-%40errorMessage%3A%22Google%20Drive%20documents%20not%20properly%20Garbage%20collected%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZrjWksE1sx2GgAAABhBWnJqV2xpYUFBRGhjOWxlT2dqQnNBRHEAAAAkZjE5YWUzNWItMmI3Ni00MTg4LTljMjQtOTRhMGQxNDhmYWE3AAOWwA&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764747057000&to_ts=1764750957000&live=false)).

## Tests

- Choose a test workspace
- Remove the subscription and check in the db (`connectors` table) that the connectors are paused (`pausedAt != null`)
- Upgrade to a plan again and check that the connectors are unpaused

## Risk

Low risk refactoring that consolidates existing functionality. The logic itself remains unchanged, we're just making it reusable and calling it in additional subscription activation scenarios where it was previously missing.

## Deploy Plan

Deploy front
