### PR TITLE
Doubled header component in mobile conversation view

### DIFF
--- a/front/components/assistant/conversation/NewConversationMessage.tsx
+++ b/front/components/assistant/conversation/NewConversationMessage.tsx
@@ -277,9 +277,12 @@ const ConversationMessageTitle = React.forwardRef<
     completionStatus,
     renderName,
     actions,
+    className,
   }) => {
     return (
-      <div className="inline-flex w-full justify-between gap-0.5">
+      <div
+        className={cn("inline-flex w-full justify-between gap-0.5", className)}
+      >
         <div className="inline-flex items-baseline gap-2 text-foreground dark:text-foreground-night">
           <span className="heading-sm">{renderName(name)}</span>
           <span className="heading-xs text-muted-foreground dark:text-muted-foreground-night">


### PR DESCRIPTION
## Description

Fixes a visual bug on mobile where the message header (username + timestamp) was appearing twice in the conversation view. The component was rendering two `ConversationMessageTitle` instances - one for mobile (@sm:hidden) and one for desktop (hidden @sm:block) - but the desktop version wasn't properly accepting the `className` prop to apply its visibility rules, causing both to render on mobile screens.

The fix adds the className prop to the ConversationMessageTitle component and uses the cn() utility to merge it with the component's base classes.

Eng-runner issue: https://github.com/dust-tt/tasks/issues/5382

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
