### PR TITLE
[slackstorm] Add isLegacySlack info in connector UI

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -661,12 +661,10 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       }
 
       case "privateIntegrationCredentialId": {
-        const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
+        const credentialId = await getPrivateIntegrationCredentialId(
           this.connectorId
         );
-        return slackConfig
-          ? new Ok(slackConfig.privateIntegrationCredentialId ?? null)
-          : new Ok(null);
+        return credentialId;
       }
 
       default:
@@ -791,6 +789,21 @@ export async function getRestrictedSpaceAgentsEnabled(
   }
 
   return new Ok(slackConfiguration.restrictedSpaceAgentsEnabled.toString());
+}
+
+export async function getPrivateIntegrationCredentialId(
+  connectorId: ModelId
+): Promise<Result<string | null, Error>> {
+  const slackConfig =
+    await SlackConfigurationResource.fetchByConnectorId(connectorId);
+  if (!slackConfig) {
+    return new Err(
+      new Error(
+        `Failed to find a Slack configuration for connector ${connectorId}`
+      )
+    );
+  }
+  return new Ok(slackConfig.privateIntegrationCredentialId ?? null);
 }
 
 async function getFilteredChannels(

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -660,6 +660,15 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         return restrictedSpaceAgentsEnabled;
       }
 
+      case "privateIntegrationCredentialId": {
+        const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
+          this.connectorId
+        );
+        return slackConfig
+          ? new Ok(slackConfig.privateIntegrationCredentialId ?? null)
+          : new Ok(null);
+      }
+
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -275,7 +275,7 @@ function UpdateConnectionOAuthModal({
     disabled: !isSlack,
   });
 
-  const { isLegacy: isLegacySlackApp } = useSlackIsLegacy({
+  const { isLegacySlackApp } = useSlackIsLegacy({
     workspaceId: owner.sId,
     credentialId: slackCredentialId,
     disabled: !isSlack || !slackCredentialId,

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -57,7 +57,11 @@ import {
   getDisplayNameForDataSource,
   isRemoteDatabase,
 } from "@app/lib/data_sources";
-import { useConnectorPermissions } from "@app/lib/swr/connectors";
+import {
+  useConnectorConfig,
+  useConnectorPermissions,
+} from "@app/lib/swr/connectors";
+import { useSlackIsLegacy } from "@app/lib/swr/oauth";
 import { useSpaceDataSourceViews, useSystemSpace } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
 import {
@@ -261,12 +265,21 @@ function UpdateConnectionOAuthModal({
 
   const { connectorProvider, editedByUser } = dataSource;
 
-  useEffect(() => {
-    if (isOpen) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setExtraConfig({});
-    }
-  }, [isOpen]);
+  const isSlack = connectorProvider === "slack";
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+
+  const { configValue: slackCredentialId } = useConnectorConfig({
+    configKey: "privateIntegrationCredentialId",
+    dataSource,
+    owner,
+    disabled: !isSlack,
+  });
+
+  const { isLegacy: isLegacySlackApp } = useSlackIsLegacy({
+    workspaceId: owner.sId,
+    credentialId: slackCredentialId,
+    disabled: !isSlack || !slackCredentialId,
+  });
 
   if (!connectorProvider || !user) {
     return null;
@@ -279,6 +292,7 @@ function UpdateConnectionOAuthModal({
 
   const permissionsConfigurable =
     getConnectorPermissionsConfigurableBlocked(connectorProvider);
+
   return (
     <DataSourceManagementModal isOpen={isOpen} onClose={onClose}>
       <>
@@ -368,13 +382,18 @@ function UpdateConnectionOAuthModal({
                   .
                 </div>
               )}
+              {
+                isLegacySlackApp && "" // TODO(slackstorm) fabien: add message about legacy slack app
+              }
             </ContentMessage>
           </div>
         )}
         {connectorConfiguration.oauthExtraConfigComponent &&
-          // TODO(slackstorm) fabien: add extra config for Slack
-          // We must display the extra config without the possibility to edit the client id to not break the connector.
-          connectorConfiguration.connectorProvider !== "slack" && (
+          // TODO(slackstorm) fabien: remove flag and rely on isLegacySlackApp
+          !(
+            isSlack &&
+            !featureFlags.includes("self_created_slack_app_connector_rollout")
+          ) && (
             <connectorConfiguration.oauthExtraConfigComponent
               extraConfig={extraConfig}
               setExtraConfig={setExtraConfig}

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -778,7 +778,9 @@ export async function softDeleteUserMessage(
       conversationId: conversation.sId,
       messageId: message.sId,
     },
-    auth.isAdmin() ? "Admin deleted a user message" : "User deleted their message"
+    auth.isAdmin()
+      ? "Admin deleted a user message"
+      : "User deleted their message"
   );
 
   return new Ok({ success: true });

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -71,15 +71,9 @@ export function useSlackIsLegacy({
       disabled: disabled ?? !credentialId,
     }
   );
-  const isLegacy: boolean | null =
-    data !== undefined &&
-    "isLegacy" in data &&
-    typeof data.isLegacy === "boolean"
-      ? data.isLegacy
-      : null;
 
   return {
-    isLegacy,
+    isLegacySlackApp: data?.isLegacySlackApp ?? null,
     error,
     isLoading:
       !error && !data && !!credentialId && !(disabled ?? !credentialId),

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -1,3 +1,7 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetSlackClientIdResponseBody } from "@app/pages/api/w/[wId]/credentials/slack_is_legacy";
 import type {
   APIError,
   OAuthConnectionType,
@@ -44,3 +48,41 @@ export const useFinalize = () => {
 
   return doFinalize;
 };
+
+export function useSlackIsLegacy({
+  workspaceId,
+  credentialId,
+  disabled,
+}: {
+  workspaceId: string;
+  credentialId: string | null;
+  disabled?: boolean;
+}) {
+  const slackIsLegacyFetcher: Fetcher<GetSlackClientIdResponseBody> = fetcher;
+
+  const url = `/api/w/${workspaceId}/credentials/slack_is_legacy${
+    credentialId ? `?credentialId=${encodeURIComponent(credentialId)}` : ""
+  }`;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    url,
+    slackIsLegacyFetcher,
+    {
+      disabled: disabled ?? !credentialId,
+    }
+  );
+  const isLegacy: boolean | null =
+    data !== undefined &&
+    "isLegacy" in data &&
+    typeof data.isLegacy === "boolean"
+      ? data.isLegacy
+      : null;
+
+  return {
+    isLegacy,
+    error,
+    isLoading:
+      !error && !data && !!credentialId && !(disabled ?? !credentialId),
+    mutateIsLegacy: mutate,
+  };
+}

--- a/front/pages/api/w/[wId]/credentials/slack_is_legacy.ts
+++ b/front/pages/api/w/[wId]/credentials/slack_is_legacy.ts
@@ -1,0 +1,113 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import apiConfig from "@app/lib/api/config";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString, OAuthAPI } from "@app/types";
+
+export type GetSlackClientIdResponseBody = {
+  isLegacy: boolean;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetSlackClientIdResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can interact with credentials.",
+      },
+    });
+  }
+
+  const { credentialId } = req.query;
+  if (!isString(credentialId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid credential id.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const oauthApi = new OAuthAPI(apiConfig.getOAuthAPIConfig(), logger);
+      const credentialRes = await oauthApi.getCredentials({
+        credentialsId: credentialId,
+      });
+
+      if (credentialRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The credential you requested was not found.",
+          },
+        });
+      }
+
+      const { credential } = credentialRes.value;
+
+      if (credential.metadata.workspace_id !== owner.sId) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The credential you requested was not found.",
+          },
+        });
+      }
+
+      if (credential.provider !== "slack") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The credential provided is not a Slack credential.",
+          },
+        });
+      }
+
+      const clientId = getClientId(credential.content);
+      const oauthClientId = config.getOAuthSlackClientId();
+
+      return res.status(200).json({ isLegacy: clientId === oauthClientId });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+function getClientId(content: unknown): string | null {
+  if (
+    content !== null &&
+    typeof content === "object" &&
+    "client_id" in content &&
+    isString(content["client_id"])
+  ) {
+    return content["client_id"];
+  }
+  return null;
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -335,6 +335,7 @@ export const CREDENTIALS_PROVIDERS = [
   "bigquery",
   "salesforce",
   "notion",
+  "slack",
   // LABS
   "modjo",
 ] as const;


### PR DESCRIPTION
## Description

The Slack client id env variable is not available in the UI, only if front via OAUTH_SLACK_CLIENT_ID
This adds a new endpoint for the exposing whether a slack credentials is using the legacy app or not.
At the moment the isLegacySlack is not really used but will be as soon as we do the migration

related to https://github.com/dust-tt/tasks/issues/5187

## Tests

manually testing the value of the isLegacySlack variable

## Risk

low

## Deploy Plan

deploy connector 
deploy front
