### PR TITLE
[Poke] Fix subscription sort by date

### DIFF
--- a/front/components/poke/subscriptions/columns.tsx
+++ b/front/components/poke/subscriptions/columns.tsx
@@ -1,6 +1,6 @@
 import { IconButton } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, Row } from "@tanstack/react-table";
 
 export type SubscriptionsDisplayType = {
   id: string;
@@ -8,6 +8,26 @@ export type SubscriptionsDisplayType = {
   status: string;
   startDate: string | null;
   endDate: string | null;
+  startDateValue: number | null; // timestamp for sorting
+  endDateValue: number | null; // timestamp for sorting
+};
+
+const sortDate = (
+  rowA: Row<SubscriptionsDisplayType>,
+  rowB: Row<SubscriptionsDisplayType>
+) => {
+  const a = rowA.original.startDateValue;
+  const b = rowB.original.startDateValue;
+  if (a === null && b === null) {
+    return 0;
+  }
+  if (a === null) {
+    return 1;
+  }
+  if (b === null) {
+    return -1;
+  }
+  return a - b;
 };
 
 export function makeColumnsForSubscriptions(): ColumnDef<SubscriptionsDisplayType>[] {
@@ -82,6 +102,7 @@ export function makeColumnsForSubscriptions(): ColumnDef<SubscriptionsDisplayTyp
     },
     {
       accessorKey: "startDate",
+      sortingFn: sortDate,
       header: ({ column }) => {
         return (
           <div className="flex space-x-2">
@@ -99,6 +120,7 @@ export function makeColumnsForSubscriptions(): ColumnDef<SubscriptionsDisplayTyp
     },
     {
       accessorKey: "endDate",
+      sortingFn: sortDate,
       header: ({ column }) => {
         return (
           <div className="flex space-x-2">

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -63,6 +63,8 @@ function prepareSubscriptionsForDisplay(
             s.endDate
           ).toLocaleTimeString()}`
         : null,
+      startDateValue: s.startDate ? new Date(s.startDate).getTime() : null,
+      endDateValue: s.endDate ? new Date(s.endDate).getTime() : null,
     };
   });
 }


### PR DESCRIPTION
## Description

The sort by start date or end date is broken in the history of subscriptions in Poke.
The dates were being formatted as locale-specific strings, but TanStack Table is trying to sort them as strings. Since `toLocaleDateString()` can produce different formats (dd/mm/yyyy vs mm/dd/yyyy), the alphabetical sorting doesn't work correctly. The solution is to add a custom `sortingFn` for the date columns that compares the actual date values.

example: History of subscription of [Electra](https://eu.dust.tt/poke/WowdF1qZIb) sorted by start date
<img width="715" height="426" alt="image" src="https://github.com/user-attachments/assets/0ee91366-3481-47a6-bdf4-8c748aba44b2" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
