### PR TITLE
Slack: inject dust_system instructions when origin of message is slack

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -269,7 +269,7 @@ export function renderUserMessage(m: UserMessageType): UserMessageTypeModel {
     metadataItems.push(`- Source: ${m.context.origin}`);
     if (m.context.origin === "slack") {
       additionalInstructions +=
-        "This message originated from Slack: make sure to retrieve the context from the attached Slack thread content.";
+        "This message originated from Slack: make sure to retrieve the context from the attached thread content.";
     }
   }
 

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -218,6 +218,7 @@ export function renderUserMessage(m: UserMessageType): UserMessageTypeModel {
   const content = replaceMentionsWithAt(m.content);
 
   const metadataItems: string[] = [];
+  let additionalInstructions = "";
 
   const identityTokens: string[] = [];
   if (m.context.fullName) {
@@ -266,12 +267,23 @@ export function renderUserMessage(m: UserMessageType): UserMessageTypeModel {
     }
   } else if (m.context.origin) {
     metadataItems.push(`- Source: ${m.context.origin}`);
+    if (m.context.origin === "slack") {
+      additionalInstructions +=
+        "This message originated from Slack: make sure to retrieve the context from the attached Slack thread content.";
+    }
   }
 
-  let systemContext = "";
+  const systemContext = [];
   if (metadataItems.length > 0) {
-    systemContext = `<dust_system>\n${metadataItems.join("\n")}\n</dust_system>\n\n`;
+    systemContext.push(`${metadataItems.join("\n")}`);
   }
+  if (additionalInstructions.length > 0) {
+    systemContext.push(`${additionalInstructions}`);
+  }
+  const systemContextInstructions =
+    systemContext.length > 0
+      ? `<dust_system>\n${systemContext.join("\n\n")}\n</dust_system>\n\n`
+      : "";
 
   return {
     role: "user" as const,
@@ -280,7 +292,7 @@ export function renderUserMessage(m: UserMessageType): UserMessageTypeModel {
     content: [
       {
         type: "text",
-        text: systemContext + content,
+        text: systemContextInstructions + content,
       },
     ],
   };


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/4912

This is not system prompt, this is the user-message dust_system. From:
```
<dust_system>
- Sender: Stanislas Polu (@spolu) <spolu@dust.tt>
- Sent at: Dec 03, 2025, 10:44:34 GMT+1
- Source: slack
</dust_system>
```
to
```
<dust_system>
- Sender: Stanislas Polu (@spolu) <spolu@dust.tt>
- Sent at: Dec 03, 2025, 10:44:34 GMT+1
- Source: slack

This message originated from Slack: make sure to retrieve the context from the attached thread content.
</dust_system>
```

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`