### PR TITLE
[front] Make `constructPromptMultiActions` sync

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -31,7 +31,7 @@ import { CHAIN_OF_THOUGHT_META_PROMPT } from "@app/types/assistant/chain_of_thou
  * doesn't need that replacement, and needs to avoid a dependency on
  * getAgentConfigurations here, so it passes null.
  */
-export async function constructPromptMultiActions(
+export function constructPromptMultiActions(
   auth: Authenticator,
   {
     userMessage,

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -228,7 +228,7 @@ async function handler(
           })
         : null;
 
-      const prompt = await constructPromptMultiActions(auth, {
+      const prompt = constructPromptMultiActions(auth, {
         userMessage,
         agentConfiguration,
         fallbackPrompt,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -244,7 +244,7 @@ export async function runModelActivity(
       })
     : null;
 
-  const prompt = await constructPromptMultiActions(auth, {
+  const prompt = constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
     fallbackPrompt,


### PR DESCRIPTION
## Description

- `constructPromptMultiActions` is currently defined as being async but is actually sync (no async operation).
- This PR makes it sync.
- Flagging this as when doing skills we'll want to do the async operations (e.g. fetching skills) ahead of calling `constructPromptMultiActions` and keep it sync.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
