### PR TITLE
Inline latex support: bump sparkle + tweak instructions

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.20",
-    "@dust-tt/sparkle": "^0.4.9",
+    "@dust-tt/sparkle": "^0.4.11",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -183,7 +183,7 @@ export async function constructPromptMultiActions(
     "\n## GENERATING LATEX FORMULAS\n" +
     "Every latex formula should be inside double dollars $$ blocks." +
     " Parentheses cannot be used to enclose mathematical formulas: BAD: \\( \\Delta \\), GOOD: $$ \\Delta $$." +
-    " To avoid ambiguity with $ used as escape sequence, make sure to escape the $ sign when not used as an escape sequence (when used as currency or env variable prefix as an example).\n";
+    " To avoid ambiguity, make sure to escape the $ sign when not used as an escape sequence (examples: currency or env variable prefix).\n";
 
   guidelinesSection +=
     "\n## RENDERING MARKDOWN IMAGES\n" +

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -181,9 +181,9 @@ export async function constructPromptMultiActions(
 
   guidelinesSection +=
     "\n## GENERATING LATEX FORMULAS\n" +
-    "When generating latex formulas, ALWAYS rely on the $$ escape sequence, single $ latex sequences are not supported." +
-    "\nEvery latex formula should be inside double dollars $$ blocks." +
-    "\nParentheses cannot be used to enclose mathematical formulas: BAD: \\( \\Delta \\), GOOD: $$ \\Delta $$.\n";
+    "Every latex formula should be inside double dollars $$ blocks." +
+    " Parentheses cannot be used to enclose mathematical formulas: BAD: \\( \\Delta \\), GOOD: $$ \\Delta $$." +
+    " To avoid ambiguity with $ used as escape sequence, make sure to escape the $ sign when not used as an escape sequence (when used as currency or env variable prefix as an example).\n";
 
   guidelinesSection +=
     "\n## RENDERING MARKDOWN IMAGES\n" +

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -778,7 +778,9 @@ export async function softDeleteUserMessage(
       conversationId: conversation.sId,
       messageId: message.sId,
     },
-    auth.isAdmin() ? "Admin deleted a user message" : "User deleted their message"
+    auth.isAdmin()
+      ? "Admin deleted a user message"
+      : "User deleted their message"
   );
 
   return new Ok({ success: true });

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.9",
+        "@dust-tt/sparkle": "^0.4.11",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1330,9 +1330,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.9.tgz",
-      "integrity": "sha512-wTjl2Xeas9UMBOeXxcJwl810qhbcItyWY+yqsQc3WWQO4cOYkePBNl9uVUF0WvjwpMOh6vJ7y0FGKWhfjw4/eA==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.11.tgz",
+      "integrity": "sha512-RoMRRUU+MZ/vLtTczkxY99idLk7x2PBy/W4OczxMBm3RsCeH9KLtv/8FQPW22gzfhtj7SjtzpNzs6f5xKiXv5w==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
@@ -12688,9 +12688,9 @@
       }
     },
     "node_modules/@workos-inc/node": {
-      "version": "7.74.2",
-      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-7.74.2.tgz",
-      "integrity": "sha512-uXLEUqNo7AkM8oBzVPY29uyEpU0r8Jt2SppL2KzwFWB3f0hLLzp51wrIQ4PNJgd9qI5L/+kP62SoZFc8byI+4g==",
+      "version": "7.75.1",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-7.75.1.tgz",
+      "integrity": "sha512-KqqUzjyCXWmEyrHbxF9zmUpQSfYJy+UD4KbF23qBfL7peWxCf3ALnB6IgF9jNkdohu0Xfnk09eKyv+fd8/PaZQ==",
       "license": "MIT",
       "dependencies": {
         "iron-session": "~6.3.1",
@@ -19464,7 +19464,9 @@
       }
     },
     "node_modules/hast-util-raw/node_modules/mdast-util-to-hast": {
-      "version": "13.1.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -19736,7 +19738,9 @@
       }
     },
     "node_modules/hast-util-to-html/node_modules/mdast-util-to-hast": {
-      "version": "13.1.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -31995,9 +31999,9 @@
       "peer": true
     },
     "node_modules/validator": {
-      "version": "13.15.20",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
-      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/front/package.json
+++ b/front/package.json
@@ -39,7 +39,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.9",
+    "@dust-tt/sparkle": "^0.4.11",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

We now support well $ escaped math sequence so we can be a bit less stringent about it + invite to escape non escape sequence $ signs.

See: #18336 

Fixes: https://github.com/dust-tt/tasks/issues/5266 (despite instructions models do do use singel $ escape sequences)

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`