### PR TITLE
[front] - feat(message): delete agent message

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -26,6 +26,7 @@ import { AgentMessageInteractiveContentGeneratedFiles } from "@app/components/as
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
@@ -677,9 +678,7 @@ export function AgentMessage({
         actions={actions}
       >
         {isDeleted ? (
-          <div className="italic text-muted-foreground">
-            This message has been deleted
-          </div>
+          <DeletedMessage />
         ) : (
           <AgentMessageContent
             onQuickReplySend={handleQuickReply}
@@ -726,9 +725,7 @@ export function AgentMessage({
       actions={actions}
     >
       {isDeleted ? (
-        <div className="italic text-muted-foreground">
-          This message has been deleted
-        </div>
+        <DeletedMessage />
       ) : (
         <AgentMessageContent
           owner={owner}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -10,11 +10,12 @@ import {
   Markdown,
   Separator,
   StopIcon,
+  TrashIcon,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
 import { marked } from "marked";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useContext, useMemo } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
@@ -43,7 +44,9 @@ import {
   getMessageSId,
   isHandoverUserMessage,
   isMessageTemporayState,
+  isUserMessage,
 } from "@app/components/assistant/conversation/types";
+import { ConfirmContext } from "@app/components/Confirm";
 import {
   CitationsContext,
   CiteBlock,
@@ -65,6 +68,7 @@ import {
   visualizationDirective,
 } from "@app/components/markdown/VisualizationBlock";
 import { useAgentMessageStream } from "@app/hooks/useAgentMessageStream";
+import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { isImageProgressOutput } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { DustError } from "@app/lib/error";
@@ -121,6 +125,7 @@ export function AgentMessage({
   messageStreamState,
   messageFeedback,
   owner,
+  user,
   handleSubmit,
 }: AgentMessageProps) {
   const sId = getMessageSId(messageStreamState);
@@ -133,6 +138,7 @@ export function AgentMessage({
   >([]);
   const [isCopied, copy] = useCopyToClipboard();
   const sendNotification = useSendNotification();
+  const confirm = useContext(ConfirmContext);
 
   const isGlobalAgent = Object.values(GLOBAL_AGENTS_SID).includes(
     messageStreamState.message.configuration.sId as GLOBAL_AGENTS_SID
@@ -209,6 +215,7 @@ export function AgentMessage({
     message: messageStreamState.message,
     messageStreamState: messageStreamState,
   });
+  const isDeleted = agentMessageToRender.visibility === "deleted";
   const cancelMessage = useCancelMessage({ owner, conversationId });
 
   const references = useMemo(
@@ -359,8 +366,9 @@ export function AgentMessage({
   }
 
   const copyAndRetryButtonGroup: React.ReactElement[] = [];
-  // Show copy & feedback buttons only when streaming is done and it didn't fail
+  // Show copy & feedback buttons only when streaming is done, it didn't fail, and the message is not deleted
   if (
+    !isDeleted &&
     agentMessageToRender.status !== "created" &&
     agentMessageToRender.status !== "failed"
   ) {
@@ -397,6 +405,7 @@ export function AgentMessage({
     );
 
   if (
+    !isDeleted &&
     agentMessageToRender.status !== "created" &&
     agentMessageToRender.status !== "failed" &&
     !shouldStream &&
@@ -424,6 +433,24 @@ export function AgentMessage({
     copyAndRetryButtonGroup.push(retryButton);
   }
 
+  const isTriggeredByCurrentUser = useMemo(() => {
+    const parentMessageId = agentMessageToRender.parentMessageId;
+    const messages = methods.data.get();
+    const parentUserMessage = messages.find(
+      (m) => isUserMessage(m) && m.sId === parentMessageId
+    );
+    if (!parentUserMessage || !isUserMessage(parentUserMessage)) {
+      return false;
+    }
+
+    return parentUserMessage.user?.sId === user.sId;
+  }, [agentMessageToRender.parentMessageId, methods.data, user.sId]);
+
+  const canDeleteAgentMessage =
+    !isDeleted &&
+    agentMessageToRender.status !== "created" &&
+    isTriggeredByCurrentUser;
+
   if (copyAndRetryButtonGroup.length > 0) {
     buttonGroups.push(
       <ButtonGroup key="first-button-group" variant="outline">
@@ -434,6 +461,7 @@ export function AgentMessage({
 
   // Add feedback buttons in the end of the array if the agent is not global nor in draft (= inside agent builder)
   if (
+    !isDeleted &&
     agentMessageToRender.status !== "created" &&
     agentMessageToRender.status !== "failed" &&
     !isGlobalAgent &&
@@ -562,6 +590,67 @@ export function AgentMessage({
 
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   const userMentionsEnabled = hasFeature("mentions_v2");
+
+  const { deleteAgentMessage, isDeleting } = useDeleteAgentMessage({
+    owner,
+    conversationId,
+  });
+
+  const handleDeleteAgentMessage = useCallback(async () => {
+    if (isDeleted || !canDeleteAgentMessage || isDeleting) {
+      return;
+    }
+
+    const confirmed = await confirm({
+      title: "Delete message",
+      message:
+        "Are you sure you want to delete this message? This action cannot be undone.",
+      validateLabel: "Delete",
+      validateVariant: "warning",
+    });
+
+    if (!confirmed) {
+      return;
+    }
+
+    await deleteAgentMessage(agentMessageToRender.sId);
+
+    methods.data.map((m) => {
+      if (
+        isMessageTemporayState(m) &&
+        getMessageSId(m) === agentMessageToRender.sId
+      ) {
+        return {
+          ...m,
+          message: {
+            ...m.message,
+            visibility: "deleted" as const,
+          },
+        };
+      }
+      return m;
+    });
+  }, [
+    agentMessageToRender.sId,
+    canDeleteAgentMessage,
+    confirm,
+    isDeleted,
+    deleteAgentMessage,
+    isDeleting,
+    methods.data,
+  ]);
+
+  const actions =
+    canDeleteAgentMessage && userMentionsEnabled
+      ? [
+          {
+            icon: TrashIcon,
+            label: "Delete message",
+            onClick: handleDeleteAgentMessage,
+          },
+        ]
+      : [];
+
   if (userMentionsEnabled) {
     return (
       <NewConversationMessage
@@ -579,26 +668,35 @@ export function AgentMessage({
               )
         }
         completionStatus={
-          <AgentMessageCompletionStatus agentMessage={agentMessageToRender} />
+          isDeleted ? undefined : (
+            <AgentMessageCompletionStatus agentMessage={agentMessageToRender} />
+          )
         }
         type="agent"
-        citations={citations}
+        citations={isDeleted ? undefined : citations}
+        actions={actions}
       >
-        <AgentMessageContent
-          onQuickReplySend={handleQuickReply}
-          owner={owner}
-          conversationId={conversationId}
-          retryHandler={retryHandler}
-          isLastMessage={isLastMessage}
-          messageStreamState={messageStreamState}
-          references={references}
-          streaming={shouldStream}
-          lastTokenClassification={
-            messageStreamState.agentState === "thinking" ? "tokens" : null
-          }
-          activeReferences={activeReferences}
-          setActiveReferences={setActiveReferences}
-        />
+        {isDeleted ? (
+          <div className="italic text-muted-foreground">
+            This message has been deleted
+          </div>
+        ) : (
+          <AgentMessageContent
+            onQuickReplySend={handleQuickReply}
+            owner={owner}
+            conversationId={conversationId}
+            retryHandler={retryHandler}
+            isLastMessage={isLastMessage}
+            messageStreamState={messageStreamState}
+            references={references}
+            streaming={shouldStream}
+            lastTokenClassification={
+              messageStreamState.agentState === "thinking" ? "tokens" : null
+            }
+            activeReferences={activeReferences}
+            setActiveReferences={setActiveReferences}
+          />
+        )}
       </NewConversationMessage>
     );
   }
@@ -619,26 +717,35 @@ export function AgentMessage({
             )
       }
       completionStatus={
-        <AgentMessageCompletionStatus agentMessage={agentMessageToRender} />
+        isDeleted ? undefined : (
+          <AgentMessageCompletionStatus agentMessage={agentMessageToRender} />
+        )
       }
       type="agent"
-      citations={citations}
+      citations={isDeleted ? undefined : citations}
+      actions={actions}
     >
-      <AgentMessageContent
-        owner={owner}
-        conversationId={conversationId}
-        retryHandler={retryHandler}
-        isLastMessage={isLastMessage}
-        messageStreamState={messageStreamState}
-        references={references}
-        onQuickReplySend={handleQuickReply}
-        streaming={shouldStream}
-        lastTokenClassification={
-          messageStreamState.agentState === "thinking" ? "tokens" : null
-        }
-        activeReferences={activeReferences}
-        setActiveReferences={setActiveReferences}
-      />
+      {isDeleted ? (
+        <div className="italic text-muted-foreground">
+          This message has been deleted
+        </div>
+      ) : (
+        <AgentMessageContent
+          owner={owner}
+          conversationId={conversationId}
+          retryHandler={retryHandler}
+          isLastMessage={isLastMessage}
+          messageStreamState={messageStreamState}
+          references={references}
+          onQuickReplySend={handleQuickReply}
+          streaming={shouldStream}
+          lastTokenClassification={
+            messageStreamState.agentState === "thinking" ? "tokens" : null
+          }
+          activeReferences={activeReferences}
+          setActiveReferences={setActiveReferences}
+        />
+      )}
     </ConversationMessage>
   );
 }

--- a/front/components/assistant/conversation/DeletedMessage.tsx
+++ b/front/components/assistant/conversation/DeletedMessage.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const DeletedMessage = () => (
+  <div className="italic text-muted-foreground">
+    This message has been deleted
+  </div>
+);

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -14,6 +14,7 @@ import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
 import { AgentSuggestion } from "@app/components/assistant/conversation/AgentSuggestion";
+import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
 import { NewConversationMessage } from "@app/components/assistant/conversation/NewConversationMessage";
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
 import {
@@ -182,9 +183,7 @@ export function UserMessage({
             actions={actions}
           >
             {isDeleted ? (
-              <div className="italic text-muted-foreground">
-                This message has been deleted
-              </div>
+              <DeletedMessage />
             ) : (
               <Markdown
                 content={message.content}
@@ -228,9 +227,7 @@ export function UserMessage({
           actions={actions}
         >
           {isDeleted ? (
-            <div className="italic text-muted-foreground">
-              This message has been deleted
-            </div>
+            <DeletedMessage />
           ) : (
             <Markdown
               content={message.content}

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -5,7 +5,6 @@ import type { MessageTemporaryState } from "@app/components/assistant/conversati
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type { PostMessagesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";
-import type { MentionType, RichMention } from "@app/types";
 import type {
   ContentFragmentsType,
   ContentFragmentType,
@@ -13,7 +12,9 @@ import type {
   ConversationVisibility,
   FileContentFragmentType,
   InternalPostConversationsRequestBodySchema,
+  MentionType,
   Result,
+  RichMention,
   SubmitMessageError,
   SupportedContentFragmentType,
   SupportedContentNodeContentType,
@@ -27,12 +28,6 @@ import {
   Ok,
   toMentionType,
 } from "@app/types";
-
-export type ContentFragmentInput = {
-  title: string;
-  content: string;
-  file: File;
-};
 
 export function createPlaceholderUserMessage({
   input,
@@ -165,6 +160,7 @@ export function createPlaceholderAgentMessage({
       completedTs: null,
       parentMessageId: userMessage.sId,
       parentAgentMessageId: null,
+      visibility: "visible",
       status: "created",
       content: null,
       chainOfThought: null,

--- a/front/hooks/useDeleteAgentMessage.ts
+++ b/front/hooks/useDeleteAgentMessage.ts
@@ -1,0 +1,54 @@
+import { useSWRConfig } from "swr";
+
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import { normalizeError } from "@app/types";
+
+export function useDeleteAgentMessage({
+  owner,
+  conversationId,
+}: {
+  owner: { sId: string };
+  conversationId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRConfig();
+
+  const { submit: deleteAgentMessage, isSubmitting } = useSubmitFunction(
+    async (messageId: string) => {
+      const res = await fetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}`,
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await res.json();
+        throw normalizeError(errorData);
+      }
+
+      sendNotification({
+        title: "Message deleted",
+        description: "The agent message has been deleted successfully.",
+        type: "success",
+      });
+
+      await mutate(
+        (key) =>
+          typeof key === "string" &&
+          key.includes(
+            `/api/w/${owner.sId}/assistant/conversations/${conversationId}`
+          )
+      );
+    }
+  );
+
+  return {
+    deleteAgentMessage,
+    isDeleting: isSubmitting,
+  };
+}

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -132,6 +132,7 @@ export function getLightAgentMessageFromAgentMessage(
     rank: agentMessage.rank,
     parentMessageId: agentMessage.parentMessageId,
     parentAgentMessageId: agentMessage.parentAgentMessageId,
+    visibility: agentMessage.visibility,
     content: agentMessage.content,
     chainOfThought: agentMessage.chainOfThought,
     error: agentMessage.error,

--- a/front/lib/api/assistant/conversation/getRelatedContentFragments.test.ts
+++ b/front/lib/api/assistant/conversation/getRelatedContentFragments.test.ts
@@ -76,6 +76,7 @@ function createMockAgentMessage(rank: number) {
     completedTs: null,
     parentMessageId: null,
     parentAgentMessageId: null,
+    visibility: "visible" as const,
     status: "succeeded" as const,
     content: "Agent response",
     chainOfThought: null,

--- a/front/lib/api/assistant/messages.test.ts
+++ b/front/lib/api/assistant/messages.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { batchRenderMessages } from "@app/lib/api/assistant/messages";
-import type { Authenticator } from "@app/lib/auth";
+import {
+  batchRenderMessages,
+  softDeleteAgentMessage,
+} from "@app/lib/api/assistant/messages";
+import { Authenticator } from "@app/lib/auth";
 import {
   AgentMessage,
   Message,
@@ -11,7 +14,14 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import type { AgentMessageType, LightAgentConfigurationType } from "@app/types";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type {
+  AgentMessageType,
+  ConversationWithoutContentType,
+  LightAgentConfigurationType,
+} from "@app/types";
+import { ConversationError } from "@app/types";
 
 describe("batchRenderMessages", () => {
   let auth: Authenticator;
@@ -235,5 +245,135 @@ describe("batchRenderMessages", () => {
         expect(renderedAgentMessage).toBeDefined();
       }
     });
+  });
+});
+
+describe("softDeleteAgentMessage", () => {
+  let auth: Authenticator;
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let conversation: ConversationWithoutContentType;
+  let agentConfig: LightAgentConfigurationType;
+  let agentMessageModel: Message;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+
+    agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const allMessages = await Message.findAll({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: workspace.id,
+      },
+      include: [
+        {
+          model: UserMessage,
+          as: "userMessage",
+          required: false,
+        },
+        {
+          model: AgentMessage,
+          as: "agentMessage",
+          required: false,
+        },
+      ],
+      order: [["rank", "ASC"]],
+    });
+
+    const foundAgentMessage = allMessages.find((m) => !!m.agentMessage);
+    expect(foundAgentMessage).toBeDefined();
+    agentMessageModel = foundAgentMessage!;
+  });
+
+  it("allows the user who sent the parent message to soft delete the agent message", async () => {
+    const initialMessage = await Message.findByPk(agentMessageModel.id);
+    expect(initialMessage?.visibility).toBe("visible");
+
+    const result = await softDeleteAgentMessage(auth, {
+      messageId: agentMessageModel.sId,
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.success).toBe(true);
+    }
+
+    const updatedMessage = await Message.findByPk(agentMessageModel.id);
+    expect(updatedMessage).not.toBeNull();
+    expect(updatedMessage?.visibility).toBe("deleted");
+
+    const secondResult = await softDeleteAgentMessage(auth, {
+      messageId: agentMessageModel.sId,
+      conversation,
+    });
+    expect(secondResult.isOk()).toBe(true);
+  });
+
+  it("returns message_not_found when the message does not exist", async () => {
+    const result = await softDeleteAgentMessage(auth, {
+      messageId: "non-existent-message-id",
+      conversation,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ConversationError);
+      expect(result.error.type).toBe("message_not_found");
+    }
+  });
+
+  it("returns message_deletion_not_authorized when the agent message has no parent user message", async () => {
+    const orphanAgentMessage =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 10,
+        agentConfigurationId: agentConfig.sId,
+      });
+
+    const result = await softDeleteAgentMessage(auth, {
+      messageId: orphanAgentMessage.sId,
+      conversation,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ConversationError);
+      expect(result.error.type).toBe("message_deletion_not_authorized");
+    }
+  });
+
+  it("returns message_deletion_not_authorized when a different user tries to delete the agent message", async () => {
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, {
+      role: "user",
+    });
+
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+
+    const result = await softDeleteAgentMessage(otherAuth, {
+      messageId: agentMessageModel.sId,
+      conversation,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ConversationError);
+      expect(result.error.type).toBe("message_deletion_not_authorized");
+    }
   });
 });

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -797,20 +797,11 @@ export async function softDeleteAgentMessage(
   const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
 
-  const message = await Message.findOne({
-    where: {
-      conversationId: conversation.id,
-      sId: messageId,
-      workspaceId: owner.id,
-    },
-    include: [
-      {
-        model: AgentMessage,
-        as: "agentMessage",
-        required: true,
-      },
-    ],
-  });
+  const message = await fetchMessageInConversation(
+    auth,
+    conversation,
+    messageId
+  );
 
   if (!message || !message.agentMessage) {
     return new Err(new ConversationError("message_not_found"));

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -783,3 +783,82 @@ export async function softDeleteUserMessage(
 
   return new Ok({ success: true });
 }
+
+export async function softDeleteAgentMessage(
+  auth: Authenticator,
+  {
+    messageId,
+    conversation,
+  }: {
+    messageId: string;
+    conversation: ConversationWithoutContentType;
+  }
+): Promise<Result<{ success: true }, ConversationError>> {
+  const user = auth.getNonNullableUser();
+  const owner = auth.getNonNullableWorkspace();
+
+  const message = await Message.findOne({
+    where: {
+      conversationId: conversation.id,
+      sId: messageId,
+      workspaceId: owner.id,
+    },
+    include: [
+      {
+        model: AgentMessage,
+        as: "agentMessage",
+        required: true,
+      },
+    ],
+  });
+
+  if (!message || !message.agentMessage) {
+    return new Err(new ConversationError("message_not_found"));
+  }
+
+  if (!message.parentId) {
+    return new Err(new ConversationError("message_deletion_not_authorized"));
+  }
+
+  const parentMessage = await Message.findOne({
+    where: {
+      id: message.parentId,
+      workspaceId: owner.id,
+    },
+    include: [
+      {
+        model: UserMessage,
+        as: "userMessage",
+        required: false,
+      },
+    ],
+  });
+
+  if (!parentMessage || !parentMessage.userMessage) {
+    return new Err(new ConversationError("message_deletion_not_authorized"));
+  }
+
+  if (parentMessage.userMessage.userId !== user.id) {
+    return new Err(new ConversationError("message_deletion_not_authorized"));
+  }
+
+  if (message.visibility === "deleted") {
+    return new Ok({ success: true });
+  }
+
+  await message.update({
+    visibility: "deleted",
+  });
+
+  auditLog(
+    {
+      workspaceId: owner.sId,
+      userId: user.sId,
+      conversationId: conversation.sId,
+      messageId: message.sId,
+    },
+    "User deleted an agent message"
+  );
+
+  return new Ok({ success: true });
+}

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -181,6 +181,7 @@ export type BaseAgentMessageType = {
   content: string | null;
   chainOfThought: string | null;
   error: GenericErrorContent | null;
+  visibility: MessageVisibility;
 };
 
 export type ParsedContentItem =


### PR DESCRIPTION
## Description

This PR implements the ability for users to delete agent messages they triggered. Users can now delete agent messages through a trash icon action in the message menu. Users can only delete agent messages if they triggered them by sending the parent user message.

**References:**
- https://github.com/dust-tt/tasks/issues/5279

## Risk

Moderate - introduces soft deletion for agent messages, even though behind FF

## Tests

- [x] Locally
- [x] Front-edge

## Deploy Plan
Deploy front
