### PR TITLE
Do not update conversation_participant when marking unread if already unread

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -742,6 +742,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           conversationId: conversation.id,
           workspaceId: auth.getNonNullableWorkspace().id,
           ...(excludedUser ? { userId: { [Op.ne]: excludedUser.id } } : {}),
+          unread: false,
         },
       }
     );


### PR DESCRIPTION
## Description

Do not update row when marking unread someone already unread.
Will be used to improve notifications content.

## Tests

Added

## Risk

Low

## Deploy Plan

Deploy front.