### PR TITLE
[Connectors] feat(slack-connector): update connector deletion to use customer credentials

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -152,7 +152,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       if (newTeamId !== currentSlackConfig.slackTeamId) {
         const configurations = await SlackConfigurationResource.listForTeamId(
           newTeamId,
-          c.type
+          "slack"
         );
 
         // Revoke the token if no other slack connector is active on the same slackTeamId.
@@ -247,7 +247,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
     const configurations = await SlackConfigurationResource.listForTeamId(
       configuration.slackTeamId,
-      connector.type
+      "slack"
     );
 
     // We deactivate our connections only if we are the only live slack connection for this team.

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -166,10 +166,8 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
             `Attempting Slack app deactivation [updateSlackConnector/team_id_mismatch]`
           );
 
-          const credentialsRes = await getSlackClientCredentials(
-            currentSlackConfig,
-            c.id
-          );
+          const credentialsRes =
+            await getSlackClientCredentials(currentSlackConfig);
           if (credentialsRes.isErr()) {
             throw credentialsRes.error;
           }
@@ -263,10 +261,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         `Attempting Slack app deactivation [cleanupSlackConnector]`
       );
 
-      const credentialsRes = await getSlackClientCredentials(
-        configuration,
-        connector.id
-      );
+      const credentialsRes = await getSlackClientCredentials(configuration);
       if (credentialsRes.isErr()) {
         if (!force) {
           return credentialsRes;
@@ -750,8 +745,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
  * Retrieves Slack client credentials from either customer-specific credentials or environment variables.
  */
 async function getSlackClientCredentials(
-  configuration: SlackConfigurationResource,
-  connectorId: number
+  configuration: SlackConfigurationResource
 ): Promise<
   Result<{ slackClientId: string; slackClientSecret: string }, Error>
 > {
@@ -788,7 +782,7 @@ async function getSlackClientCredentials(
 
     logger.info(
       {
-        connectorId,
+        connectorId: configuration.connectorId,
         credentialId: configuration.privateIntegrationCredentialId,
       },
       "Using customer-specific Slack credentials"
@@ -798,7 +792,7 @@ async function getSlackClientCredentials(
     slackClientSecret = slackConfig.getRequiredSlackClientSecret();
 
     logger.info(
-      { connectorId },
+      { connectorId: configuration.connectorId },
       "Using environment variable credentials for Slack (legacy connector)"
     );
   }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -11,6 +11,7 @@ import {
   BaseConnectorManager,
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
+import { connectorsConfig } from "@connectors/connectors/shared/config";
 import {
   autoReadChannel,
   findMatchingChannelPatterns,
@@ -29,9 +30,11 @@ import {
 } from "@connectors/connectors/slack/lib/slack_client";
 import { slackChannelIdFromInternalId } from "@connectors/connectors/slack/lib/utils";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client.js";
+import { apiConfig } from "@connectors/lib/api/config";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
+import { WebhookRouterConfigService } from "@connectors/lib/webhook_router_config";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
@@ -42,12 +45,14 @@ import type {
   ModelId,
   SlackConfigurationType,
 } from "@connectors/types";
+import type { SlackCredentials } from "@connectors/types";
 import {
   concurrentExecutor,
   isSlackAutoReadPatterns,
   normalizeError,
   safeParseJSON,
 } from "@connectors/types";
+import { getConnectionCredentials } from "@connectors/types/oauth/client/credentials";
 
 export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurationType> {
   readonly provider: ConnectorProvider = "slack";
@@ -145,8 +150,10 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
       const newTeamId = teamInfoRes.team.id;
       if (newTeamId !== currentSlackConfig.slackTeamId) {
-        const configurations =
-          await SlackConfigurationResource.listForTeamId(newTeamId);
+        const configurations = await SlackConfigurationResource.listForTeamId(
+          newTeamId,
+          c.type
+        );
 
         // Revoke the token if no other slack connector is active on the same slackTeamId.
         if (configurations.length == 0) {
@@ -158,10 +165,21 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
             },
             `Attempting Slack app deactivation [updateSlackConnector/team_id_mismatch]`
           );
+
+          const credentialsRes = await getSlackClientCredentials(
+            currentSlackConfig,
+            c.id
+          );
+          if (credentialsRes.isErr()) {
+            throw credentialsRes.error;
+          }
+
+          const { slackClientId, slackClientSecret } = credentialsRes.value;
+
           const uninstallRes = await uninstallSlack(
             connectionId,
-            slackConfig.getRequiredSlackClientId(),
-            slackConfig.getRequiredSlackClientSecret()
+            slackClientId,
+            slackClientSecret
           );
 
           if (uninstallRes.isErr()) {
@@ -230,7 +248,8 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     }
 
     const configurations = await SlackConfigurationResource.listForTeamId(
-      configuration.slackTeamId
+      configuration.slackTeamId,
+      connector.type
     );
 
     // We deactivate our connections only if we are the only live slack connection for this team.
@@ -244,29 +263,44 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         `Attempting Slack app deactivation [cleanupSlackConnector]`
       );
 
-      try {
+      const credentialsRes = await getSlackClientCredentials(
+        configuration,
+        connector.id
+      );
+      if (credentialsRes.isErr()) {
+        if (!force) {
+          return credentialsRes;
+        }
+        logger.error(
+          {
+            connectorId: connector.id,
+            error: credentialsRes.error,
+          },
+          "Failed to retrieve Slack credentials, continuing due to force flag"
+        );
+      } else {
+        const { slackClientId, slackClientSecret } = credentialsRes.value;
+
         const uninstallRes = await uninstallSlack(
           connector.connectionId,
-          slackConfig.getRequiredSlackClientId(),
-          slackConfig.getRequiredSlackClientSecret()
+          slackClientId,
+          slackClientSecret
         );
 
         if (uninstallRes.isErr() && !force) {
           return uninstallRes;
         }
-      } catch (e) {
-        if (!force) {
-          throw e;
+
+        if (uninstallRes.isOk()) {
+          logger.info(
+            {
+              connectorId: connector.id,
+              slackTeamId: configuration.slackTeamId,
+            },
+            `Deactivated Slack app [cleanupSlackConnector]`
+          );
         }
       }
-
-      logger.info(
-        {
-          connectorId: connector.id,
-          slackTeamId: configuration.slackTeamId,
-        },
-        `Deactivated Slack app [cleanupSlackConnector]`
-      );
     } else {
       logger.info(
         {
@@ -276,6 +310,16 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         },
         `Skipping deactivation of the Slack app [cleanupSlackConnector]`
       );
+    }
+
+    // Resync webhook router configuration to remove deleted connector entry
+    const webhookUpdateRes = await resyncWebhookRouterConfig(
+      connector.id,
+      configuration.slackTeamId,
+      configurations
+    );
+    if (webhookUpdateRes.isErr() && !force) {
+      return webhookUpdateRes;
     }
 
     const res = await connector.delete();
@@ -699,6 +743,123 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
   async configure(): Promise<Result<void, Error>> {
     throw new Error("Method not implemented.");
+  }
+}
+
+/**
+ * Retrieves Slack client credentials from either customer-specific credentials or environment variables.
+ */
+async function getSlackClientCredentials(
+  configuration: SlackConfigurationResource,
+  connectorId: number
+): Promise<
+  Result<{ slackClientId: string; slackClientSecret: string }, Error>
+> {
+  let slackClientId: string | undefined;
+  let slackClientSecret: string | undefined;
+
+  if (configuration.privateIntegrationCredentialId) {
+    const credentialsRes = await getConnectionCredentials({
+      config: apiConfig.getOAuthAPIConfig(),
+      logger,
+      credentialsId: configuration.privateIntegrationCredentialId,
+    });
+
+    if (credentialsRes.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to retrieve customer credentials: ${credentialsRes.error.message}`
+        )
+      );
+    }
+
+    const credentials = credentialsRes.value.credential;
+    if (credentials.provider !== "slack") {
+      return new Err(
+        new Error(
+          `Invalid credential provider: expected 'slack', got '${credentials.provider}'`
+        )
+      );
+    }
+
+    const slackCredentials = credentials.content as SlackCredentials;
+    slackClientId = slackCredentials.client_id;
+    slackClientSecret = slackCredentials.client_secret;
+
+    logger.info(
+      {
+        connectorId,
+        credentialId: configuration.privateIntegrationCredentialId,
+      },
+      "Using customer-specific Slack credentials"
+    );
+  } else {
+    slackClientId = slackConfig.getRequiredSlackClientId();
+    slackClientSecret = slackConfig.getRequiredSlackClientSecret();
+
+    logger.info(
+      { connectorId },
+      "Using environment variable credentials for Slack (legacy connector)"
+    );
+  }
+
+  if (!slackClientId || !slackClientSecret) {
+    return new Err(new Error("Slack client credentials are not available"));
+  }
+
+  return new Ok({ slackClientId, slackClientSecret });
+}
+
+/**
+ * Resyncs webhook router configuration for a Slack team.
+ * Removes this connector from the list of active connectors for the region.
+ * If this is the last connector, the region entry is removed entirely.
+ */
+async function resyncWebhookRouterConfig(
+  connectorId: number,
+  slackTeamId: string,
+  configurations: SlackConfigurationResource[]
+): Promise<Result<undefined, Error>> {
+  try {
+    const webhookService = new WebhookRouterConfigService();
+    const currentRegion = connectorsConfig.getCurrentRegion();
+
+    const remainingConnectorIds = configurations
+      .filter((c) => c.connectorId !== connectorId)
+      .map((c) => c.connectorId);
+
+    await webhookService.syncEntry(
+      "slack",
+      slackTeamId,
+      undefined,
+      currentRegion,
+      remainingConnectorIds
+    );
+
+    logger.info(
+      {
+        connectorId,
+        slackTeamId,
+        region: currentRegion,
+        remainingConnectors: remainingConnectorIds.length,
+        isLastConnector: remainingConnectorIds.length === 0,
+      },
+      remainingConnectorIds.length === 0
+        ? "Resynced webhook router: removed region entry (last connector)"
+        : "Resynced webhook router: updated with remaining connectors"
+    );
+
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      {
+        connectorId,
+        slackTeamId,
+        error: normalizeError(e),
+      },
+      "Failed to resync webhook router configuration"
+    );
+    return new Err(normalizeError(e));
   }
 }
 

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -226,8 +226,14 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
 
   static async listForTeamId(
     slackTeamId: string,
-    provider?: Extract<ConnectorProvider, "slack_bot" | "slack">
+    provider?: ConnectorProvider
   ): Promise<SlackConfigurationResource[]> {
+    if (provider && provider !== "slack" && provider !== "slack_bot") {
+      throw new Error(
+        `Invalid provider type for Slack configuration: expected 'slack' or 'slack_bot', got '${provider}'`
+      );
+    }
+
     const blobs = await this.model.findAll({
       where: {
         slackTeamId,

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -226,14 +226,8 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
 
   static async listForTeamId(
     slackTeamId: string,
-    provider?: ConnectorProvider
+    provider?: Extract<ConnectorProvider, "slack" | "slack_bot">
   ): Promise<SlackConfigurationResource[]> {
-    if (provider && provider !== "slack" && provider !== "slack_bot") {
-      throw new Error(
-        `Invalid provider type for Slack configuration: expected 'slack' or 'slack_bot', got '${provider}'`
-      );
-    }
-
     const blobs = await this.model.findAll({
       where: {
         slackTeamId,


### PR DESCRIPTION
## Description

Refactors Slack connector credential retrieval and webhook router management to eliminate code duplication and improve maintainability. This is step 4 of the customer-specific credentials implementation.

**Key changes:**
- Update `clean()` method to use customer credentials and always resync webhook router
- Filter configurations by connector type (slack/slack_bot) to prevent cross-contamination

**Context**
Step 4. of https://github.com/dust-tt/tasks/issues/5272

## Tests

Manual

## Risk

Low - deletion flow is not a user flow but triggered from poke

## Deploy Plan

connectors
