### PR TITLE
[Programmatic Usage] Enable programmatic classification after user notification

### DIFF
--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -67,8 +67,6 @@ function getRedisKey(workspace: LightWorkspaceType): string {
   return `${PROGRAMMATIC_USAGE_REMAINING_CREDITS_KEY}:${workspace.id}`;
 }
 
-const USERS_HAVE_BEEN_WARNED = false;
-
 export function isProgrammaticUsage(
   auth: Authenticator,
   { userMessageOrigin }: { userMessageOrigin?: UserMessageOrigin | null } = {}
@@ -91,10 +89,7 @@ export function isProgrammaticUsage(
 
   if (
     auth.authMethod() === "api_key" ||
-    // TODO(PPUL): remove this after notifying users.
-    (USERS_HAVE_BEEN_WARNED &&
-      USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic") ||
-    userMessageOrigin === "triggered_programmatic"
+    USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic"
   ) {
     return true;
   }


### PR DESCRIPTION
## Description

Users have been notified about programmatic usage billing. This PR removes the `USERS_HAVE_BEEN_WARNED` flag and simplifies the condition to directly use `USAGE_ORIGINS_CLASSIFICATION` for all programmatic origins, not just `triggered_programmatic`.

## Risks

Blast radius: programmatic usage detection for all workspaces using API integrations (Slack workflows, Zapier, etc.)
Risk: standard

## Deploy Plan

- deploy front