### PR TITLE
Allow popup to escape frames sandbox

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -399,7 +399,7 @@ export const VisualizationActionIframe = forwardRef<
                     ref={combinedRef}
                     className={cn("h-full w-full", !errorMessage && "min-h-96")}
                     src={vizUrl}
-                    sandbox="allow-scripts allow-popups"
+                    sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
                   />
                 </div>
               )}

--- a/viz/app/components/NavigationProvider.tsx
+++ b/viz/app/components/NavigationProvider.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { useNavigationWarning } from "@viz/app/components/NavigationWarningDialog";
+
+/**
+ * NavigationProvider - Best Effort Security for External Link Navigation
+ * 
+ * This provider intercepts window.open calls to warn users before navigating to external links.
+ * It's a best-effort approach to improve security by:
+ * - Allowing trusted domains to navigate without confirmation
+ * - Showing a warning dialog for external/untrusted domains
+ * - Displaying URL details to help users make informed decisions
+ * 
+ * Note: This is not a complete security solution and can be bypassed by:
+ * - Direct DOM manipulation
+ * - Other navigation methods (location.href, etc.)
+ * - Malicious code that overrides our window.open wrapper
+ * 
+ * This should be used as part of a broader security strategy.
+ */
+
+interface NavigationProviderProps {
+  children: React.ReactNode;
+  trustedDomains: string[];
+}
+
+export function NavigationProvider({
+  children,
+  trustedDomains,
+}: NavigationProviderProps) {
+  const { showWarning, DialogComponent } = useNavigationWarning();
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const originalOpen = window.open;
+
+    window.open = function (url, target, features) {
+      if (!url) {
+        return originalOpen.call(window, url, target, features);
+      }
+
+      try {
+        const urlObj = new URL(url, window.location.href);
+
+        // Allow trusted domains.
+        if (trustedDomains.some((domain) => urlObj.hostname.endsWith(domain))) {
+          return originalOpen.call(window, url, target, features);
+        }
+
+        // Show custom dialog for external links.
+        showWarning(urlObj.href).then((confirmed) => {
+          if (confirmed) {
+            originalOpen.call(window, url, target, features);
+          }
+        });
+
+        return null;
+      } catch (err) {
+        // Invalid URL, let it fail naturally.
+        return originalOpen.call(window, url, target, features);
+      }
+    };
+
+    // Cleanup function to restore original window.open.
+    return () => {
+      window.open = originalOpen;
+    };
+  }, [showWarning, trustedDomains]);
+
+  return (
+    <>
+      {children}
+      <DialogComponent />
+    </>
+  );
+}

--- a/viz/app/components/NavigationWarningDialog.tsx
+++ b/viz/app/components/NavigationWarningDialog.tsx
@@ -34,8 +34,8 @@ export function NavigationWarningDialog({
   }, [url]);
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onCancel(); }}>
-      <DialogContent className='sm:max-w-md'>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent className='sm:max-w-md' showCloseButton={false}>
         <DialogHeader>
           <div className='flex items-center gap-3'>
             <div className='flex h-10 w-10 items-center justify-center rounded-full bg-amber-100'>

--- a/viz/app/components/NavigationWarningDialog.tsx
+++ b/viz/app/components/NavigationWarningDialog.tsx
@@ -34,8 +34,8 @@ export function NavigationWarningDialog({
   }, [url]);
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && onCancel()}>
-      <DialogContent className='sm:max-w-md' showCloseButton={false}>
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onCancel(); }}>
+      <DialogContent className='sm:max-w-md'>
         <DialogHeader>
           <div className='flex items-center gap-3'>
             <div className='flex h-10 w-10 items-center justify-center rounded-full bg-amber-100'>

--- a/viz/app/components/NavigationWarningDialog.tsx
+++ b/viz/app/components/NavigationWarningDialog.tsx
@@ -1,0 +1,146 @@
+import * as React from "react";
+import { ExternalLinkIcon, AlertTriangleIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@viz/components/ui/dialog";
+import { Button } from "@viz/components/ui/button";
+
+interface NavigationWarningDialogProps {
+  isOpen: boolean;
+  url: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function NavigationWarningDialog({
+  isOpen,
+  url,
+  onCancel,
+  onConfirm,
+}: NavigationWarningDialogProps) {
+  const [urlObj, setUrlObj] = React.useState<URL | null>(null);
+
+  React.useEffect(() => {
+    try {
+      setUrlObj(new URL(url));
+    } catch {
+      setUrlObj(null);
+    }
+  }, [url]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent className='sm:max-w-md' showCloseButton={false}>
+        <DialogHeader>
+          <div className='flex items-center gap-3'>
+            <div className='flex h-10 w-10 items-center justify-center rounded-full bg-amber-100'>
+              <AlertTriangleIcon className='h-5 w-5 text-amber-600' />
+            </div>
+            <DialogTitle className='text-left'>
+              External Link Warning
+            </DialogTitle>
+          </div>
+          <DialogDescription className='text-left'>
+            You are about to navigate to an external website. Please verify the
+            URL before proceeding.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className='space-y-4'>
+          <div className='rounded-md border bg-gray-50 p-3'>
+            <div className='flex items-center gap-2 text-sm text-gray-600 mb-1'>
+              <ExternalLinkIcon className='h-4 w-4' />
+              Destination URL:
+            </div>
+            <div className='font-mono text-sm break-all bg-white p-2 rounded border'>
+              {url}
+            </div>
+          </div>
+
+          {urlObj && (
+            <div className='text-sm text-gray-600'>
+              <div className='flex items-center gap-2'>
+                <span>Domain:</span>
+                <span className='font-medium text-gray-900'>
+                  {urlObj.hostname}
+                </span>
+              </div>
+              {urlObj.protocol !== "https:" && (
+                <div className='flex items-center gap-1 mt-1 text-amber-600'>
+                  <AlertTriangleIcon className='h-3 w-3' />
+                  <span className='text-xs'>This connection is not secure</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className='flex-row justify-end gap-2'>
+          <Button variant='outline' onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} className='gap-2'>
+            <ExternalLinkIcon className='h-4 w-4' />
+            Continue
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export interface NavigationWarningState {
+  isOpen: boolean;
+  url: string;
+  resolve: ((confirmed: boolean) => void) | null;
+}
+
+export function useNavigationWarning() {
+  const [state, setState] = React.useState<NavigationWarningState>({
+    isOpen: false,
+    url: "",
+    resolve: null,
+  });
+
+  const showWarning = React.useCallback((url: string): Promise<boolean> => {
+    return new Promise((resolve) => {
+      setState({
+        isOpen: true,
+        url,
+        resolve,
+      });
+    });
+  }, []);
+
+  const handleConfirm = React.useCallback(() => {
+    state.resolve?.(true);
+    setState({ isOpen: false, url: "", resolve: null });
+  }, [state]);
+
+  const handleCancel = React.useCallback(() => {
+    state.resolve?.(false);
+    setState({ isOpen: false, url: "", resolve: null });
+  }, [state]);
+
+  const DialogComponent = React.useCallback(
+    () => (
+      <NavigationWarningDialog
+        isOpen={state.isOpen}
+        url={state.url}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    ),
+    [state.isOpen, state.url, handleConfirm, handleCancel]
+  );
+
+  return {
+    showWarning,
+    DialogComponent,
+  };
+}

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -12,12 +12,12 @@ interface ServerSideVisualizationWrapperProps {
 
 /**
  * Server-side visualization wrapper for JWT-authenticated public frames
- * 
+ *
  * This component runs on the server and:
  * 1. Pre-fetches visualization code using the JWT access token
  * 2. Extracts file IDs from the code and pre-fetches all referenced files
  * 3. Passes the pre-fetched plain data to the client wrapper
- * 
+ *
  * This approach avoids the React Server Component serialization boundary issue
  * by passing plain objects instead of class instances to the client component.
  */

--- a/viz/app/content/ServerVisualizationWrapperClient.tsx
+++ b/viz/app/content/ServerVisualizationWrapperClient.tsx
@@ -7,6 +7,11 @@ import {
 } from "@viz/app/lib/data-apis/cache-data-api";
 import type { VisualizationConfig } from "@viz/app/lib/visualization-api";
 import { useMemo } from "react";
+import { NavigationProvider } from "@viz/app/components/NavigationProvider";
+
+// Domains that are trusted and don't require user confirmation before navigation.
+// These are Dust platform domains that are considered safe for automatic navigation.
+const TRUSTED_NAVIGATION_DOMAINS = ["dust.tt", "eu.dust.tt"];
 
 interface ServerVisualizationWrapperClientProps {
   allowedOrigins: string[];
@@ -47,5 +52,9 @@ export function ServerVisualizationWrapperClient({
     isFullHeight,
   };
 
-  return <VisualizationWrapperWithErrorBoundary config={config} />;
+  return (
+    <NavigationProvider trustedDomains={TRUSTED_NAVIGATION_DOMAINS}>
+      <VisualizationWrapperWithErrorBoundary config={config} />
+    </NavigationProvider>
+  );
 }

--- a/viz/app/lib/parseFileIds.ts
+++ b/viz/app/lib/parseFileIds.ts
@@ -13,6 +13,7 @@ export function extractFileIds(code: string): string[] {
     });
 
     traverse(ast, {
+      // Extract useFile() calls.
       CallExpression(path) {
         // Look for: useFile("fil_xxx").
         if (

--- a/viz/components/ui/dialog.tsx
+++ b/viz/components/ui/dialog.tsx
@@ -1,121 +1,141 @@
-"use client";
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
 
-import * as React from "react";
-import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { X } from "lucide-react";
-import { cn } from "@viz/lib/utils";
+import { cn } from "@viz/lib/utils"
 
-const Dialog = DialogPrimitive.Root;
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
 
-const DialogTrigger = DialogPrimitive.Trigger;
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
 
-const DialogPortal = DialogPrimitive.Portal;
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
 
-const DialogClose = DialogPrimitive.Close;
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
 
-const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
-    )}
-    {...props}
-  />
-));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
-
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className
       )}
       {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className='absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground'>
-        <X className='h-4 w-4' />
-        <span className='sr-only'>Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
-DialogContent.displayName = DialogPrimitive.Content.displayName;
+    />
+  )
+}
 
-const DialogHeader = ({
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
-    )}
-    {...props}
-  />
-);
-DialogHeader.displayName = "DialogHeader";
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
 
-const DialogFooter = ({
+function DialogDescription({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-);
-DialogFooter.displayName = "DialogFooter";
-
-const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
-    )}
-    {...props}
-  />
-));
-DialogTitle.displayName = DialogPrimitive.Title.displayName;
-
-const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-));
-DialogDescription.displayName = DialogPrimitive.Description.displayName;
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
 
 export {
   Dialog,
-  DialogPortal,
-  DialogOverlay,
-  DialogTrigger,
   DialogClose,
   DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
   DialogDescription,
-};
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/viz/components/ui/dialog.tsx
+++ b/viz/components/ui/dialog.tsx
@@ -1,141 +1,121 @@
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
+"use client";
 
-import { cn } from "@viz/lib/utils"
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@viz/lib/utils";
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
-}
+const Dialog = DialogPrimitive.Root;
 
-function DialogTrigger({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
-}
+const DialogTrigger = DialogPrimitive.Trigger;
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
-}
+const DialogPortal = DialogPrimitive.Portal;
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
-}
+const DialogClose = DialogPrimitive.Close;
 
-function DialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
-  return (
-    <DialogPrimitive.Overlay
-      data-slot="dialog-overlay"
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}
-    />
-  )
-}
+    >
+      {children}
+      <DialogPrimitive.Close className='absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground'>
+        <X className='h-4 w-4' />
+        <span className='sr-only'>Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-function DialogContent({
-  className,
-  children,
-  showCloseButton = true,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
-}) {
-  return (
-    <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
-      <DialogPrimitive.Content
-        data-slot="dialog-content"
-        className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className
-        )}
-        {...props}
-      >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-          >
-            <XIcon />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Content>
-    </DialogPortal>
-  )
-}
-
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
-      {...props}
-    />
-  )
-}
-
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="dialog-footer"
-      className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
-      )}
-      {...props}
-    />
-  )
-}
-
-function DialogTitle({
+const DialogHeader = ({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
-  return (
-    <DialogPrimitive.Title
-      data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
-      {...props}
-    />
-  )
-}
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
 
-function DialogDescription({
+const DialogFooter = ({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
-  return (
-    <DialogPrimitive.Description
-      data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
-      {...props}
-    />
-  )
-}
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
   DialogClose,
   DialogContent,
-  DialogDescription,
-  DialogFooter,
   DialogHeader,
-  DialogOverlay,
-  DialogPortal,
+  DialogFooter,
   DialogTitle,
-  DialogTrigger,
-}
+  DialogDescription,
+};


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1763658896545929).

This PR updates the security policy of the `iframe` used to render our visualization code. One of the current issue reported, is that when a link from a frame is opened the page never load. This is happening because of the new page inheriting the current iframe restriction. We now add the [`allow-popups-to-escape-sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/sandbox#allow-popups-to-escape-sandbox) security policy to open a new window without preserving the iframe security policy.

Alongside this change, to ensure users get somewhat of a warning before browsing a link that does not belong to Dust, there is a best-effort attempt to capture the intent and wrap it around a dialog to surface that the user is about to leave the frame. This is a best effort as there is way to easily capture all way to open a new page. This one implementation focuses around the `window.open` exclusively.

<img width="499" height="389" alt="image" src="https://github.com/user-attachments/assets/78bb2c57-d682-4bac-914c-f47b7b174736" />

As we don't use our design system in Viz, the dialog is pretty standard.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
