### PR TITLE
Fix upgrade from Pro to Business

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -21,22 +21,25 @@ import type {
 } from "@app/types";
 import { Err, isDevelopment, normalizeError, Ok } from "@app/types";
 
-export function getProPlanStripeProductId(owner: WorkspaceType) {
-  const isBusiness = owner.metadata?.isBusiness;
+const DEV_PRO_PLAN_PRODUCT_ID = "prod_OwKvN4XrUwFw5a";
+const DEV_BUSINESS_PRO_PLAN_PRODUCT_ID = "prod_RkNr4qbHJD3oUp";
 
-  const devProPlanProductId = "prod_OwKvN4XrUwFw5a";
-  const devBusinessProPlanProductId = "prod_RkNr4qbHJD3oUp";
+const PROD_PRO_PLAN_PRODUCT_ID = "prod_OwALjyfxfi2mln";
+const PROD_BUSINESS_PRO_PLAN_PRODUCT_ID = "prod_RkPFpfBzLo79gd";
 
-  const prodProPlanProductId = "prod_OwALjyfxfi2mln";
-  const prodBusinessProPlanProductId = "prod_RkPFpfBzLo79gd";
+export function getProPlanProductId() {
+  return isDevelopment() ? DEV_PRO_PLAN_PRODUCT_ID : PROD_PRO_PLAN_PRODUCT_ID;
+}
 
+export function getBusinessProPlanProductId() {
   return isDevelopment()
-    ? isBusiness
-      ? devBusinessProPlanProductId
-      : devProPlanProductId
-    : isBusiness
-      ? prodBusinessProPlanProductId
-      : prodProPlanProductId;
+    ? DEV_BUSINESS_PRO_PLAN_PRODUCT_ID
+    : PROD_BUSINESS_PRO_PLAN_PRODUCT_ID;
+}
+
+export function getStripeCheckoutSessionProductId(owner: WorkspaceType) {
+  const isBusiness = owner.metadata?.isBusiness;
+  return isBusiness ? getBusinessProPlanProductId() : getProPlanProductId();
 }
 
 export function getCreditPurchasePriceId() {
@@ -125,7 +128,7 @@ export const createProPlanCheckoutSession = async ({
     );
   }
 
-  const stripeProductId = getProPlanStripeProductId(owner);
+  const stripeProductId = getStripeCheckoutSessionProductId(owner);
   let priceId: string | null = null;
 
   if (billingPeriod === "yearly") {
@@ -451,7 +454,7 @@ export async function upgradeProSubscriptionToBusiness({
     return new Err(new Error("Subscription not found"));
   }
 
-  const businessProductId = getProPlanStripeProductId(owner);
+  const businessProductId = getBusinessProPlanProductId();
   const newPriceId = await getDefautPriceFromMetadata(
     businessProductId,
     "IS_DEFAULT_MONHTLY_PRICE"


### PR DESCRIPTION
## Description

Bugfix: I was getting a 400 "Workspace is not on a pro plan" because `isSubscriptionOnProPlan` was returning false after having the business metadata activated because this method was fetching the business plan instead of the pro plan if this metadata is activated. 

I clarified with: 
- getProPlanStripeProductId -> getStripeCheckoutSessionProductId
- getProPlanProductId -> returns the Pro plan
- getBusinessProPlanProductId -> returns the Business plan.
- isSubscriptionOnProPlan -> isSubscriptionOnProOrBusinessPlan

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 