### PR TITLE
[front] feat: Add programmatic usage credits backfill script

### DIFF
--- a/front/scripts/backfill_credits.ts
+++ b/front/scripts/backfill_credits.ts
@@ -109,7 +109,7 @@ async function backfillFreeCredits(
     });
 
     if (result.isErr()) {
-      logger.info(
+      logger.error(
         {
           workspaceId: workspaceSId,
           error: result.error.message,

--- a/front/scripts/backfill_credits.ts
+++ b/front/scripts/backfill_credits.ts
@@ -1,0 +1,177 @@
+import type Stripe from "stripe";
+
+import { Authenticator } from "@app/lib/auth";
+import { grantFreeCreditsOnSubscriptionRenewal } from "@app/lib/credits/free";
+import { startOrResumeEnterprisePAYG } from "@app/lib/credits/payg";
+import {
+  getStripeSubscription,
+  isEnterpriseSubscription,
+} from "@app/lib/plans/stripe";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+async function reconcilePAYGConfig(
+  auth: Authenticator,
+  workspaceSId: string,
+  stripeSubscription: Stripe.Subscription | null,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const config =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  if (!config || config.paygCapCents === null) {
+    return;
+  }
+
+  const isEnterprise =
+    stripeSubscription && isEnterpriseSubscription(stripeSubscription);
+
+  if (!isEnterprise) {
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        paygCapCents: config.paygCapCents,
+        hasStripeSubscription: !!stripeSubscription,
+        execute,
+      },
+      execute
+        ? "[Backfill credits] Removing paygCapCents from non-Enterprise workspace"
+        : "[Backfill credits] [DRY RUN] Would remove paygCapCents from non-Enterprise workspace"
+    );
+
+    if (execute) {
+      await config.updateConfiguration(auth, { paygCapCents: null });
+    }
+    return;
+  }
+
+  logger.info(
+    {
+      workspaceId: workspaceSId,
+      paygCapCents: config.paygCapCents,
+      execute,
+    },
+    execute
+      ? "[Backfill credits] Ensuring PAYG credit exists for Enterprise workspace"
+      : "[Backfill credits] [DRY RUN] Would ensure PAYG credit exists for Enterprise workspace"
+  );
+
+  if (execute) {
+    const result = await startOrResumeEnterprisePAYG({
+      auth,
+      stripeSubscription,
+      paygCapCents: config.paygCapCents,
+    });
+
+    if (result.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspaceSId,
+          error: result.error.message,
+        },
+        "[Backfill credits] Failed to ensure PAYG credit"
+      );
+    }
+  }
+}
+
+async function backfillFreeCredits(
+  auth: Authenticator,
+  workspaceSId: string,
+  stripeSubscription: Stripe.Subscription | null,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  if (!stripeSubscription) {
+    return;
+  }
+
+  logger.info(
+    {
+      workspaceId: workspaceSId,
+      execute,
+    },
+    execute
+      ? "[Backfill credits] Granting free credits"
+      : "[Backfill credits] [DRY RUN] Would grant free credits"
+  );
+
+  if (execute) {
+    const result = await grantFreeCreditsOnSubscriptionRenewal({
+      auth,
+      stripeSubscription,
+    });
+
+    if (result.isErr()) {
+      logger.info(
+        {
+          workspaceId: workspaceSId,
+          error: result.error.message,
+        },
+        "[Backfill credits] Free credits grant result"
+      );
+    }
+  }
+}
+
+async function reconcileWorkspaceCredits(
+  workspaceSId: string,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceSId);
+
+  const workspace = auth.getNonNullableWorkspace();
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+
+  const subscription =
+    await SubscriptionResource.fetchActiveByWorkspace(lightWorkspace);
+
+  const stripeSubscription = subscription.stripeSubscriptionId
+    ? await getStripeSubscription(subscription.stripeSubscriptionId)
+    : null;
+
+  await reconcilePAYGConfig(
+    auth,
+    workspaceSId,
+    stripeSubscription,
+    execute,
+    logger
+  );
+  await backfillFreeCredits(
+    auth,
+    workspaceSId,
+    stripeSubscription,
+    execute,
+    logger
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    if (workspaceId) {
+      await reconcileWorkspaceCredits(workspaceId, execute, logger);
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await reconcileWorkspaceCredits(workspace.sId, execute, logger);
+        },
+        { concurrency: 8 }
+      );
+    }
+  }
+);


### PR DESCRIPTION
## Description

Adds a script to backfill PAYG credits and free credits to kickstart productised programmatic usage
Fixes https://github.com/dust-tt/tasks/issues/5294

## Tests

Tested manually

## Risk

Blast radius: Future stripe webhook, usage tracking and consumption
Risk: Low

## Deploy Plan

- Progressive rollout, lift the feature flag for a selected few, run the backfill script before EOW
- Next week rollout GA, run the script again
