### PR TITLE
Allow sheets tool to use workspace credentials

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -625,7 +625,7 @@ The directive should be used to display a clickable version of the agent name in
       description: "Work with spreadsheet data and tables.",
       authorization: {
         provider: "gmail",
-        supported_use_cases: ["personal_actions"] as const,
+        supported_use_cases: ["personal_actions", "platform_actions"] as const,
         scope:
           "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive.readonly" as const,
       },


### PR DESCRIPTION
## Description

* Allow workspace credentials use case for sheets tool. This oauth implementation already allows this so shouldn't require any other changes

## Tests

* Created a workspace credential tool locally

## Risk

* Low - tool still behind FF

## Deploy Plan

* Deploy front