### PR TITLE
[Programmatic Usage] Enforce maximum for credit purchases

### DIFF
--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -308,14 +308,14 @@ export function BuyCreditDialog({
 
             {maxAmountFormatted && (
               <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                Purchase up to {maxAmountFormatted} worth of credits. Need more?{" "}
+                Purchase up to {maxAmountFormatted} worth of credits.
                 <a
                   href={`mailto:${SUPPORT_EMAIL}?subject=Higher%20credit%20limit%20request`}
                   className="text-action-500 hover:underline"
                 >
                   Contact support
-                </a>
-                .
+                </a>{" "}
+                if you need more.
               </p>
             )}
 

--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -16,14 +16,21 @@ import {
   Spinner,
   XCircleIcon,
 } from "@dust-tt/sparkle";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
+import { getPriceAsString } from "@app/lib/client/subscription";
+import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
 import { usePurchaseCredits } from "@app/lib/swr/credits";
 import type { StripePricingData } from "@app/lib/types/stripe/pricing";
 import { assertNever } from "@app/types";
 import { CURRENCY_SYMBOLS, isSupportedCurrency } from "@app/types/currency";
 
 type PurchaseState = "idle" | "processing" | "success" | "redirect" | "error";
+
+const SUPPORT_EMAIL = "support@dust.tt";
+
+// Minimum purchase amount in microUsd ($1).
+const MIN_PURCHASE_MICRO_USD = 1_000_000;
 
 interface BuyCreditDialogProps {
   isOpen: boolean;
@@ -33,6 +40,7 @@ interface BuyCreditDialogProps {
   currency: string;
   discountPercent: number;
   creditPricing: StripePricingData | null;
+  creditPurchaseLimits: CreditPurchaseLimits | null;
 }
 
 export function BuyCreditDialog({
@@ -43,6 +51,7 @@ export function BuyCreditDialog({
   currency,
   discountPercent,
   creditPricing,
+  creditPurchaseLimits,
 }: BuyCreditDialogProps) {
   const [amountDollars, setAmountDollars] = useState<string>("");
   const [acceptedTerms, setAcceptedTerms] = useState(false);
@@ -61,6 +70,31 @@ export function BuyCreditDialog({
     setPaymentUrl(null);
     onClose();
   }, [onClose]);
+
+  const maxAmountDollars = useMemo(() => {
+    if (!creditPurchaseLimits || !creditPurchaseLimits.canPurchase) {
+      return null;
+    }
+    return Math.floor(creditPurchaseLimits.maxAmountMicroUsd / 1_000_000);
+  }, [creditPurchaseLimits]);
+
+  const maxAmountFormatted = useMemo(() => {
+    if (!creditPurchaseLimits || !creditPurchaseLimits.canPurchase) {
+      return null;
+    }
+    return getPriceAsString({
+      currency: "usd",
+      priceInMicroUsd: creditPurchaseLimits.maxAmountMicroUsd,
+    });
+  }, [creditPurchaseLimits]);
+
+  const amountExceedsMax = useMemo(() => {
+    if (!maxAmountDollars) {
+      return false;
+    }
+    const amount = parseFloat(amountDollars);
+    return !isNaN(amount) && amount > maxAmountDollars;
+  }, [amountDollars, maxAmountDollars]);
 
   const handlePurchase = async () => {
     setPurchaseState("processing");
@@ -106,7 +140,8 @@ export function BuyCreditDialog({
   const discountInCurrency = creditsInCurrency * (effectiveDiscount / 100);
   const totalInCurrency = creditsInCurrency - discountInCurrency;
 
-  const canPurchase = isValidAmount && acceptedTerms && acceptedNonRefundable;
+  const canPurchase =
+    isValidAmount && acceptedTerms && acceptedNonRefundable && !amountExceedsMax;
 
   const renderContent = () => {
     switch (purchaseState) {
@@ -202,13 +237,20 @@ export function BuyCreditDialog({
                   value={amountDollars}
                   onChange={(e) => setAmountDollars(e.target.value)}
                   min="0"
+                  max={maxAmountDollars ?? undefined}
                   step="1"
                   className="pl-7 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                  isError={amountExceedsMax}
+                  message={
+                    amountExceedsMax
+                      ? `Maximum purchase amount is ${maxAmountFormatted}`
+                      : undefined
+                  }
                 />
               </div>
             </div>
 
-            {isValidAmount && (
+            {isValidAmount && !amountExceedsMax && (
               <div className="flex flex-col gap-1 rounded-md border border-border bg-muted-background p-3 text-sm dark:border-border-night dark:bg-muted-background-night">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground dark:text-muted-foreground-night">
@@ -259,6 +301,19 @@ export function BuyCreditDialog({
                   </span>
                 </div>
               </div>
+            )}
+
+            {maxAmountFormatted && (
+              <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                Purchase up to {maxAmountFormatted} worth of credits. Need more?{" "}
+                <a
+                  href={`mailto:${SUPPORT_EMAIL}?subject=Higher%20credit%20limit%20request`}
+                  className="text-action-500 hover:underline"
+                >
+                  Contact support
+                </a>
+                .
+              </p>
             )}
 
             <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
@@ -393,6 +448,145 @@ export function BuyCreditDialog({
     }
   };
 
+  // Cannot purchase: trialing.
+  if (
+    creditPurchaseLimits &&
+    !creditPurchaseLimits.canPurchase &&
+    creditPurchaseLimits.reason === "trialing"
+  ) {
+    return (
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent size="md">
+          <DialogHeader>
+            <DialogTitle>Purchase Programmatic Credits</DialogTitle>
+            <DialogDescription>
+              Credit purchases are not available during your trial period.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogContainer>
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground">
+                Credit purchases become available once you upgrade to a paid
+                plan. If you need credits during your trial, please contact our
+                support team.
+              </p>
+              <Button
+                label={`Contact ${SUPPORT_EMAIL}`}
+                variant="outline"
+                onClick={() =>
+                  window.open(
+                    `mailto:${SUPPORT_EMAIL}?subject=Credit%20purchase%20during%20trial`,
+                    "_blank"
+                  )
+                }
+              />
+            </div>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Close",
+              variant: "outline",
+              onClick: onClose,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // Cannot purchase: payment issue.
+  if (
+    creditPurchaseLimits &&
+    !creditPurchaseLimits.canPurchase &&
+    creditPurchaseLimits.reason === "payment_issue"
+  ) {
+    return (
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent size="md">
+          <DialogHeader>
+            <DialogTitle>Purchase Programmatic Credits</DialogTitle>
+            <DialogDescription>
+              Credit purchases require an active subscription.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogContainer>
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground">
+                Please ensure your subscription is active and your payment
+                method is up to date. If you need assistance, please contact our
+                support team.
+              </p>
+              <Button
+                label={`Contact ${SUPPORT_EMAIL}`}
+                variant="outline"
+                onClick={() =>
+                  window.open(
+                    `mailto:${SUPPORT_EMAIL}?subject=Credit%20purchase%20-%20payment%20issue`,
+                    "_blank"
+                  )
+                }
+              />
+            </div>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Close",
+              variant: "outline",
+              onClick: onClose,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // Limit exhausted for this billing cycle.
+  if (
+    creditPurchaseLimits &&
+    creditPurchaseLimits.canPurchase &&
+    creditPurchaseLimits.maxAmountMicroUsd < MIN_PURCHASE_MICRO_USD
+  ) {
+    return (
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent size="md">
+          <DialogHeader>
+            <DialogTitle>Purchase Programmatic Credits</DialogTitle>
+            <DialogDescription>
+              You've reached your credit limit for this billing cycle.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogContainer>
+            <div className="flex flex-col gap-4">
+              <p className="text-sm text-muted-foreground">
+                Your credit purchase limit resets at the start of your next
+                billing cycle. If you need additional credits before then,
+                please contact our support team.
+              </p>
+              <Button
+                label={`Contact ${SUPPORT_EMAIL}`}
+                variant="outline"
+                onClick={() =>
+                  window.open(
+                    `mailto:${SUPPORT_EMAIL}?subject=Credit%20purchase%20limit%20reached`,
+                    "_blank"
+                  )
+                }
+              />
+            </div>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Close",
+              variant: "outline",
+              onClick: onClose,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // Can purchase.
   return (
     <Dialog
       open={isOpen}

--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -141,7 +141,10 @@ export function BuyCreditDialog({
   const totalInCurrency = creditsInCurrency - discountInCurrency;
 
   const canPurchase =
-    isValidAmount && acceptedTerms && acceptedNonRefundable && !amountExceedsMax;
+    isValidAmount &&
+    acceptedTerms &&
+    acceptedNonRefundable &&
+    !amountExceedsMax;
 
   const renderContent = () => {
     switch (purchaseState) {

--- a/front/lib/credits/common.ts
+++ b/front/lib/credits/common.ts
@@ -1,0 +1,28 @@
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+
+// 5 days
+const USER_COUNT_CUTOFF_MS = 5 * 24 * 60 * 60 * 1000;
+
+/**
+ * This function counts "good" users, for credit-related logic depending on the
+ * number of users.
+ *
+ * The first goal is to make it not worth it for people to bump up / down the number of
+ * users before billing cycle renewal. Why 5 days ? At the current price of $30
+ * / month, pro-rated bump up from 5 days ago would be 5$.
+ *
+ * At minimum, we always count 1 user.
+ */
+
+export async function countEligibleUsersForCredits(
+  workspace: Parameters<typeof renderLightWorkspaceType>[0]["workspace"]
+): Promise<number> {
+  const cutoffDate = new Date(Date.now() - USER_COUNT_CUTOFF_MS);
+  const count = await MembershipResource.getMembersCountForWorkspace({
+    workspace: renderLightWorkspaceType({ workspace }),
+    activeOnly: true,
+    membershipSpan: { fromDate: cutoffDate, toDate: cutoffDate },
+  });
+  return Math.max(1, count);
+}

--- a/front/lib/credits/limits.test.ts
+++ b/front/lib/credits/limits.test.ts
@@ -1,0 +1,187 @@
+import type Stripe from "stripe";
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Authenticator } from "@app/lib/auth";
+import { getCustomerStatus } from "@app/lib/credits/free";
+import { getCreditPurchaseLimits } from "@app/lib/credits/limits";
+import { isEnterpriseSubscription } from "@app/lib/plans/stripe";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+
+vi.mock("@app/lib/plans/stripe", async () => {
+  const actual = await vi.importActual("@app/lib/plans/stripe");
+  return {
+    ...actual,
+    isEnterpriseSubscription: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/credits/free", async () => {
+  const actual = await vi.importActual("@app/lib/credits/free");
+  return {
+    ...actual,
+    getCustomerStatus: vi.fn(),
+  };
+});
+
+const MONTH_SECONDS = 30 * 24 * 60 * 60;
+const NOW = 1700000000;
+const NOW_MS = NOW * 1000;
+
+function makeSubscription(
+  overrides: Partial<Stripe.Subscription> = {}
+): Stripe.Subscription {
+  return {
+    id: "sub_test",
+    current_period_start: NOW,
+    current_period_end: NOW + MONTH_SECONDS,
+    start_date: NOW - MONTH_SECONDS * 3,
+    status: "active",
+    items: { data: [], has_more: false, object: "list", url: "" },
+    ...overrides,
+  } as Stripe.Subscription;
+}
+
+describe("getCreditPurchaseLimits", () => {
+  let auth: Authenticator;
+  let getMembersCountSpy: MockInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    auth = authenticator;
+
+    getMembersCountSpy = vi
+      .spyOn(MembershipResource, "getMembersCountForWorkspace")
+      .mockResolvedValue(10);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    getMembersCountSpy.mockRestore();
+  });
+
+  describe("Enterprise subscriptions", () => {
+    it("should allow purchase with $1000 limit for enterprise", async () => {
+      vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+
+      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(result).toEqual({
+        canPurchase: true,
+        maxAmountCents: 100_000,
+      });
+    });
+
+    it("should not call getCustomerStatus for enterprise", async () => {
+      vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+
+      await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(getCustomerStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Pro subscriptions - trialing", () => {
+    it("should not allow purchase for trialing customers", async () => {
+      vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
+      vi.mocked(getCustomerStatus).mockResolvedValue("trialing");
+
+      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(result).toEqual({
+        canPurchase: false,
+        reason: "trialing",
+      });
+    });
+
+    it("should not allow purchase for null customer status", async () => {
+      vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
+      vi.mocked(getCustomerStatus).mockResolvedValue(null);
+
+      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(result).toEqual({
+        canPurchase: false,
+        reason: "trialing",
+      });
+    });
+  });
+
+  describe("Pro subscriptions - paying", () => {
+    beforeEach(() => {
+      vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
+      vi.mocked(getCustomerStatus).mockResolvedValue("paying");
+    });
+
+    it("should calculate limit based on user count ($50/user)", async () => {
+      getMembersCountSpy.mockResolvedValue(10);
+
+      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(result).toEqual({
+        canPurchase: true,
+        maxAmountCents: 50_000, // 10 users * $50
+      });
+    });
+
+    it("should cap at $1000 for large teams", async () => {
+      getMembersCountSpy.mockResolvedValue(100);
+
+      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(result).toEqual({
+        canPurchase: true,
+        maxAmountCents: 100_000, // Capped at $1000
+      });
+    });
+
+    it("should allow $50 for single user", async () => {
+      getMembersCountSpy.mockResolvedValue(1);
+
+      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(result).toEqual({
+        canPurchase: true,
+        maxAmountCents: 5_000, // 1 user * $50
+      });
+    });
+
+    it("should allow $250 for 5 users", async () => {
+      getMembersCountSpy.mockResolvedValue(5);
+
+      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(result).toEqual({
+        canPurchase: true,
+        maxAmountCents: 25_000, // 5 users * $50
+      });
+    });
+
+    it("should cap exactly at $1000 for 20 users", async () => {
+      getMembersCountSpy.mockResolvedValue(20);
+
+      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(result).toEqual({
+        canPurchase: true,
+        maxAmountCents: 100_000, // 20 users * $50 = $1000 (exactly at cap)
+      });
+    });
+
+    it("should cap at $1000 for more than 20 users", async () => {
+      getMembersCountSpy.mockResolvedValue(25);
+
+      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+
+      expect(result).toEqual({
+        canPurchase: true,
+        maxAmountCents: 100_000, // Capped at $1000
+      });
+    });
+  });
+});

--- a/front/lib/credits/limits.ts
+++ b/front/lib/credits/limits.ts
@@ -1,0 +1,64 @@
+import type Stripe from "stripe";
+
+import type { Authenticator } from "@app/lib/auth";
+import {
+  countEligibleUsersForFreeCredits,
+  getCustomerStatus,
+} from "@app/lib/credits/free";
+import { isEnterpriseSubscription } from "@app/lib/plans/stripe";
+
+// $50 per user per month for Pro subscriptions.
+const MAX_PRO_CREDIT_PER_USER_CENTS = 5000;
+// $1000 absolute cap for Pro subscriptions.
+const MAX_PRO_CREDIT_TOTAL_CENTS = 100_000;
+// $1000 cap for Enterprise subscriptions.
+const MAX_ENTERPRISE_CREDIT_CENTS = 100_000;
+
+export type CreditPurchaseLimits =
+  | { canPurchase: false; reason: "trialing" }
+  | { canPurchase: true; maxAmountCents: number };
+
+/**
+ * Computes the maximum amount of credits a workspace can purchase.
+ *
+ * Rules:
+ * - Pro in trial: cannot purchase credits
+ * - Pro paying: $50/user/month, capped at $1000
+ * - Enterprise: $1000
+ */
+export async function getCreditPurchaseLimits(
+  auth: Authenticator,
+  stripeSubscription: Stripe.Subscription
+): Promise<CreditPurchaseLimits> {
+  const isEnterprise = isEnterpriseSubscription(stripeSubscription);
+
+  if (isEnterprise) {
+    return {
+      canPurchase: true,
+      maxAmountCents: MAX_ENTERPRISE_CREDIT_CENTS,
+    };
+  }
+
+  // For Pro subscriptions, check if they're paying or trialing.
+  const customerStatus = await getCustomerStatus(stripeSubscription);
+
+  if (customerStatus !== "paying") {
+    return {
+      canPurchase: false,
+      reason: "trialing",
+    };
+  }
+
+  // Pro paying: $50/user/month, capped at $1000.
+  const workspace = auth.getNonNullableWorkspace();
+  const userCount = await countEligibleUsersForFreeCredits(workspace);
+  const maxAmountCents = Math.min(
+    userCount * MAX_PRO_CREDIT_PER_USER_CENTS,
+    MAX_PRO_CREDIT_TOTAL_CENTS
+  );
+
+  return {
+    canPurchase: true,
+    maxAmountCents,
+  };
+}

--- a/front/lib/credits/limits.ts
+++ b/front/lib/credits/limits.ts
@@ -96,9 +96,7 @@ async function getAlreadyPurchasedInCycle(
   auth: Authenticator,
   stripeSubscription: Stripe.Subscription
 ): Promise<number> {
-  const periodStart = new Date(
-    stripeSubscription.current_period_start * 1000
-  );
+  const periodStart = new Date(stripeSubscription.current_period_start * 1000);
   const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
 
   return CreditResource.sumCommittedCreditsPurchasedInPeriod(

--- a/front/lib/credits/limits.ts
+++ b/front/lib/credits/limits.ts
@@ -5,13 +5,14 @@ import { countEligibleUsersForCredits } from "@app/lib/credits/common";
 import { getCustomerPaymentStatus } from "@app/lib/credits/free";
 import { isEnterpriseSubscription } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 
 // $50 per user per month for Pro subscriptions.
 const MAX_PRO_CREDIT_PER_USER_MICRO_USD = 50_000_000;
 // $1000 absolute cap for Pro subscriptions.
 const MAX_PRO_CREDIT_TOTAL_MICRO_USD = 1_000_000_000;
-// $1000 cap for Enterprise subscriptions.
-const MAX_ENTERPRISE_CREDIT_MICRO_USD = 1_000_000_000;
+// $1000 minimum cap for Enterprise subscriptions.
+const MIN_ENTERPRISE_CREDIT_MICRO_USD = 1_000_000_000;
 
 export type CreditPurchaseLimits =
   | { canPurchase: false; reason: "trialing" | "payment_issue" }
@@ -25,7 +26,7 @@ export type CreditPurchaseLimits =
  * - Pro in trial: cannot purchase credits
  * - Pro with payment issues: cannot purchase credits
  * - Pro paying: $50/user/month, capped at $1000 per billing cycle
- * - Enterprise: $1000 per billing cycle
+ * - Enterprise: max($1000, half of pay-as-you-go cap) per billing cycle
  *
  * The limits are per billing cycle. Already purchased committed credits
  * in the current billing cycle are subtracted from the maximum.
@@ -37,13 +38,22 @@ export async function getCreditPurchaseLimits(
   const isEnterprise = isEnterpriseSubscription(stripeSubscription);
 
   if (isEnterprise) {
+    // Enterprise limit: max($1000, half of pay-as-you-go cap).
+    const programmaticConfig =
+      await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+    const paygCapMicroUsd = programmaticConfig?.paygCapMicroUsd ?? 0;
+    const enterpriseMaxMicroUsd = Math.max(
+      MIN_ENTERPRISE_CREDIT_MICRO_USD,
+      Math.floor(paygCapMicroUsd / 2)
+    );
+
     const alreadyPurchased = await getAlreadyPurchasedInCycle(
       auth,
       stripeSubscription
     );
     const remainingMicroUsd = Math.max(
       0,
-      MAX_ENTERPRISE_CREDIT_MICRO_USD - alreadyPurchased
+      enterpriseMaxMicroUsd - alreadyPurchased
     );
     return {
       canPurchase: true,

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -117,22 +117,25 @@ async function handler(
       // Validate against purchase limits.
       const limits = await getCreditPurchaseLimits(auth, stripeSubscription);
       if (!limits.canPurchase) {
+        const message =
+          limits.reason === "trialing"
+            ? "Credit purchases are not available during trial. Please contact support."
+            : "Credit purchases require an active subscription. Please ensure your payment method is up to date.";
         return apiError(req, res, {
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message:
-              "Credit purchases are not available during trial. Please contact support.",
+            message,
           },
         });
       }
 
-      if (amountCents > limits.maxAmountCents) {
+      if (amountMicroUsd > limits.maxAmountMicroUsd) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Amount exceeds maximum allowed: $${limits.maxAmountCents / 100}. Please contact support for higher limits.`,
+            message: `Amount exceeds maximum allowed: $${limits.maxAmountMicroUsd / 1_000_000}. Please contact support for higher limits.`,
           },
         });
       }

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -19,6 +19,8 @@ import {
   getBillingCycle,
   getPriceAsString,
 } from "@app/lib/client/subscription";
+import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
+import { getCreditPurchaseLimits } from "@app/lib/credits/limits";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
   getCreditPurchasePriceId,
@@ -41,6 +43,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   currency: string;
   discountPercent: number;
   creditPricing: StripePricingData | null;
+  creditPurchaseLimits: CreditPurchaseLimits | null;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();
@@ -51,6 +54,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   let isEnterprise = false;
   let currency = "usd";
+  let creditPurchaseLimits: CreditPurchaseLimits | null = null;
+
   if (subscription.stripeSubscriptionId) {
     const stripeSubscription = await getStripeSubscription(
       subscription.stripeSubscriptionId
@@ -60,6 +65,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       currency = isSupportedCurrency(stripeSubscription.currency)
         ? stripeSubscription.currency
         : "usd";
+      creditPurchaseLimits = await getCreditPurchaseLimits(
+        auth,
+        stripeSubscription
+      );
     }
   }
 
@@ -77,6 +86,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       currency,
       discountPercent,
       creditPricing,
+      creditPurchaseLimits,
     },
   };
 });
@@ -174,6 +184,29 @@ interface UsageSectionProps {
   setShowBuyCreditDialog: (show: boolean) => void;
 }
 
+function formatDateShort(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatExpirationDate(timestamp: number | null): string | null {
+  if (!timestamp) {
+    return null;
+  }
+  const date = new Date(timestamp);
+  return `Expires ${formatDateShort(date)}`;
+}
+
+function formatRenewalDate(timestamp: number | null): string | null {
+  if (!timestamp) {
+    return null;
+  }
+  const date = new Date(timestamp);
+  return `Renews ${formatDateShort(date)}`;
+}
+
 function UsageSection({
   subscription,
   isEnterprise,
@@ -183,47 +216,19 @@ function UsageSection({
   isLoading,
   setShowBuyCreditDialog,
 }: UsageSectionProps) {
-  const billingCycle = useMemo(
-    () => getBillingCycle(subscription.startDate),
-    [subscription.startDate]
-  );
-
-  const formatDateShort = (date: Date) => {
-    return date.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-  };
-
-  const formatExpirationDate = (timestamp: number | null) => {
-    if (!timestamp) {
+  const billingCycle = useMemo(() => {
+    if (!subscription.startDate) {
       return null;
     }
-    return `Expires on ${new Date(timestamp).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    })}`;
-  };
-
-  const formatRenewalDate = (timestamp: number | null) => {
-    if (!timestamp) {
-      return null;
-    }
-    return `Renews on ${new Date(timestamp).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    })}`;
-  };
+    return getBillingCycle(new Date(subscription.startDate));
+  }, [subscription.startDate]);
 
   if (isLoading) {
     return (
-      <div className="flex flex-col gap-6 rounded-lg border border-border p-6 dark:border-border-night">
-        <div className="h-8 w-32 animate-pulse rounded bg-muted-foreground/20" />
-        <div className="h-24 w-full animate-pulse rounded bg-muted-foreground/20" />
-      </div>
+      <Page.Vertical gap="md">
+        <Page.H variant="h5">Available credits</Page.H>
+        <div className="h-32 animate-pulse rounded-lg bg-muted-background dark:bg-muted-background-night" />
+      </Page.Vertical>
     );
   }
 
@@ -231,13 +236,14 @@ function UsageSection({
     currency: "usd",
     priceInMicroUsd: totalConsumed,
   });
+
   const totalCreditsFormatted = getPriceAsString({
     currency: "usd",
     priceInMicroUsd: totalCredits,
   });
 
   return (
-    <div className="flex flex-col gap-6">
+    <Page.Vertical gap="md">
       {/* Usage Header */}
       <div className="flex items-center justify-between">
         <Page.Vertical gap="xs">
@@ -257,22 +263,18 @@ function UsageSection({
       <Page.Vertical>
         <Page.P variant="secondary">Total consumed</Page.P>
         <div className="flex items-baseline gap-2">
-          <span className="text-5xl font-bold">{totalConsumedFormatted}</span>
-          <span className="text-2xl text-muted-foreground dark:text-muted-foreground-night">
-            /{totalCreditsFormatted}
+          <span className="text-2xl font-bold text-foreground dark:text-foreground-night">
+            {totalConsumedFormatted}
+          </span>
+          <span className="text-muted-foreground dark:text-muted-foreground-night">
+            / {totalCreditsFormatted}
           </span>
         </div>
         <ProgressBar consumed={totalConsumed} total={totalCredits} />
       </Page.Vertical>
 
       {/* Credit Categories */}
-      <div className="grid grid-cols-3 gap-8 border-t border-border pt-6 dark:border-border-night">
-        <CreditCategoryBar
-          title="Monthly included credits"
-          consumed={creditsByType.free.consumed}
-          total={creditsByType.free.total}
-          renewalDate={formatRenewalDate(creditsByType.free.expirationDate)}
-        />
+      <div className="flex w-full flex-wrap gap-4">
         <CreditCategoryBar
           title="Purchased credits"
           consumed={creditsByType.committed.consumed}
@@ -300,8 +302,14 @@ function UsageSection({
             isCap
           />
         )}
+        <CreditCategoryBar
+          title="Free credits"
+          consumed={creditsByType.free.consumed}
+          total={creditsByType.free.total}
+          renewalDate={formatRenewalDate(creditsByType.free.expirationDate)}
+        />
       </div>
-    </div>
+    </Page.Vertical>
   );
 }
 
@@ -312,6 +320,7 @@ export default function CreditsUsagePage({
   currency,
   discountPercent,
   creditPricing,
+  creditPurchaseLimits,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const { featureFlags } = useFeatureFlags({
@@ -370,15 +379,17 @@ export default function CreditsUsagePage({
     );
   }, [creditsByType]);
 
-  const shouldShowLowCreditsWarning =
-    !isCreditsLoading &&
-    totalCredits > 0 &&
-    totalConsumed >= totalCredits * 0.8;
+  const shouldShowLowCreditsWarning = useMemo(() => {
+    if (totalCredits === 0) {
+      return false;
+    }
+    const percentUsed = (totalConsumed / totalCredits) * 100;
+    return percentUsed >= 80;
+  }, [totalConsumed, totalCredits]);
 
   return (
     <AppCenteredLayout
       subscription={subscription}
-      owner={owner}
       subNavigation={subNavigationAdmin({
         owner,
         current: "credits_usage",
@@ -393,6 +404,7 @@ export default function CreditsUsagePage({
         currency={currency}
         discountPercent={discountPercent}
         creditPricing={creditPricing}
+        creditPurchaseLimits={creditPurchaseLimits}
       />
 
       <Page.Vertical gap="xl" align="stretch">
@@ -421,13 +433,24 @@ export default function CreditsUsagePage({
         )}
 
         {/* Purposefully not giving email since we want to test determination here and limit support requests, it's a very edgy case and most likely fraudulent. */}
-        {subscription.trialing && (
-          <ContentMessage title="Available after trial" variant="info">
-            Credit purchases are available once you upgrade to a paid plan. If
-            you would like to purchase credits before upgrading, please contact
-            support.
-          </ContentMessage>
-        )}
+        {creditPurchaseLimits &&
+          !creditPurchaseLimits.canPurchase &&
+          creditPurchaseLimits.reason === "trialing" && (
+            <ContentMessage title="Available after trial" variant="info">
+              Credit purchases are available once you upgrade to a paid plan. If
+              you would like to purchase credits before upgrading, please
+              contact support.
+            </ContentMessage>
+          )}
+
+        {creditPurchaseLimits &&
+          !creditPurchaseLimits.canPurchase &&
+          creditPurchaseLimits.reason === "payment_issue" && (
+            <ContentMessage title="Subscription issue" variant="warning">
+              Credit purchases require an active subscription. Please ensure
+              your payment method is up to date.
+            </ContentMessage>
+          )}
 
         {/* Usage Section */}
         <UsageSection

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -185,9 +185,10 @@ interface UsageSectionProps {
 }
 
 function formatDateShort(date: Date): string {
-  return date.toLocaleDateString("en-US", {
+  return date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
+    year: "numeric",
   });
 }
 

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -243,7 +243,7 @@ function UsageSection({
   });
 
   return (
-    <Page.Vertical gap="md">
+    <div className="flex flex-col gap-6">
       {/* Usage Header */}
       <div className="flex items-center justify-between">
         <Page.Vertical gap="xs">
@@ -309,7 +309,7 @@ function UsageSection({
           renewalDate={formatRenewalDate(creditsByType.free.expirationDate)}
         />
       </div>
-    </Page.Vertical>
+    </div>
   );
 }
 

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -220,7 +220,7 @@ function UsageSection({
     if (!subscription.startDate) {
       return null;
     }
-    return getBillingCycle(new Date(subscription.startDate));
+    return getBillingCycle(subscription.startDate);
   }, [subscription.startDate]);
 
   if (isLoading) {
@@ -389,6 +389,7 @@ export default function CreditsUsagePage({
 
   return (
     <AppCenteredLayout
+      owner={owner}
       subscription={subscription}
       subNavigation={subNavigationAdmin({
         owner,

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -226,10 +226,10 @@ function UsageSection({
 
   if (isLoading) {
     return (
-      <Page.Vertical gap="md">
-        <Page.H variant="h5">Available credits</Page.H>
-        <div className="h-32 animate-pulse rounded-lg bg-muted-background dark:bg-muted-background-night" />
-      </Page.Vertical>
+      <div className="flex flex-col gap-6 rounded-lg border border-border p-6 dark:border-border-night">
+        <div className="h-8 w-32 animate-pulse rounded bg-muted-foreground/20" />
+        <div className="h-24 w-full animate-pulse rounded bg-muted-foreground/20" />
+      </div>
     );
   }
 
@@ -264,18 +264,22 @@ function UsageSection({
       <Page.Vertical>
         <Page.P variant="secondary">Total consumed</Page.P>
         <div className="flex items-baseline gap-2">
-          <span className="text-2xl font-bold text-foreground dark:text-foreground-night">
-            {totalConsumedFormatted}
-          </span>
-          <span className="text-muted-foreground dark:text-muted-foreground-night">
-            / {totalCreditsFormatted}
+          <span className="text-5xl font-bold">{totalConsumedFormatted}</span>
+          <span className="text-2xl text-muted-foreground dark:text-muted-foreground-night">
+            /{totalCreditsFormatted}
           </span>
         </div>
         <ProgressBar consumed={totalConsumed} total={totalCredits} />
       </Page.Vertical>
 
       {/* Credit Categories */}
-      <div className="flex w-full flex-wrap gap-4">
+      <div className="grid grid-cols-3 gap-8 border-t border-border pt-6 dark:border-border-night">
+        <CreditCategoryBar
+          title="Free credits"
+          consumed={creditsByType.free.consumed}
+          total={creditsByType.free.total}
+          renewalDate={formatRenewalDate(creditsByType.free.expirationDate)}
+        />
         <CreditCategoryBar
           title="Purchased credits"
           consumed={creditsByType.committed.consumed}
@@ -303,12 +307,6 @@ function UsageSection({
             isCap
           />
         )}
-        <CreditCategoryBar
-          title="Free credits"
-          consumed={creditsByType.free.consumed}
-          total={creditsByType.free.total}
-          renewalDate={formatRenewalDate(creditsByType.free.expirationDate)}
-        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5372

Enforces maximum limits for credit purchases **per billing cycle**:
- **Pro in trial**: Cannot buy credits. Shows a message prompting to contact support.
- **Pro with payment issues**: Cannot buy credits. Shows a message to check payment method.
- **Pro paying**: Maximum $50/user/month (using `countEligibleUsersForCredits`), capped at $1000 per billing cycle.
- **Enterprise**: Maximum of $1000 or half of pay-as-you-go cap (whichever is greater) per billing cycle.

### Implementation details
- Limits are computed server-side in `getServerSideProps` and passed to the UI
- The purchase API validates against these limits
- Already-purchased credits in the current billing cycle are subtracted from the limit
- When remaining limit is less than $1, shows "limit exhausted" message with option to contact support
- Different payment messages: Pro sees "charged immediately", Enterprise sees "added immediately, invoiced at end of billing cycle"

## Risks
Blast radius: Credit purchase functionality for Pro and Enterprise customers
Risk: low

## Deploy Plan
- deploy front