### PR TITLE
[PPUL] Cap discount to maximum that does not sell below cost

### DIFF
--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -11,6 +11,15 @@ type PricingEntry = {
 };
 
 export const DUST_MARKUP_PERCENT = 30;
+
+// Maximum discount percent that can be applied to credit purchases.
+// A discount above this threshold would result in selling below cost.
+// Formula: (1 - 1 / (1 + MARKUP/100)) * 100
+// With 30% markup: (1 - 1/1.30) * 100 ≈ 23.08%
+export const MAX_DISCOUNT_PERCENT = Math.floor(
+  (1 - 1 / (1 + DUST_MARKUP_PERCENT / 100)) * 100
+);
+
 // Pricing for current models (USD per million tokens - equivalent to micro-USD per token)
 // This record must contain all BaseModelIdType values.
 const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {

--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -2,6 +2,7 @@ import { addYears, format } from "date-fns";
 import { z } from "zod";
 import { fromZodError } from "zod-validation-error";
 
+import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { createEnterpriseCreditPurchase } from "@app/lib/credits/committed";
 import {
@@ -22,7 +23,10 @@ const BuyCreditPurchaseArgsSchema = z.object({
   discountPercent: z
     .number()
     .min(0, "Discount must be at least 0%")
-    .max(100, "Discount must be at most 100%")
+    .max(
+      MAX_DISCOUNT_PERCENT,
+      `Discount cannot exceed ${MAX_DISCOUNT_PERCENT}% (would result in selling below cost)`
+    )
     .finite("Discount must be a valid number"),
   confirm: z.boolean().refine((val) => val === true, {
     message: "Please confirm the purchase by checking the confirmation box",

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import type Stripe from "stripe";
 import { z } from "zod";
 
+import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { createPlugin } from "@app/lib/api/poke/types";
 import {
   calculateFreeCreditAmount,
@@ -35,7 +36,10 @@ const ManageProgrammaticUsageConfigurationSchema = z
     defaultDiscountPercent: z
       .number()
       .min(0, "Discount percentage must be at least 0")
-      .max(100, "Discount percentage cannot exceed 100")
+      .max(
+        MAX_DISCOUNT_PERCENT,
+        `Discount cannot exceed ${MAX_DISCOUNT_PERCENT}% (would result in selling below cost)`
+      )
       .optional()
       .default(0),
     paygEnabled: z.boolean(),

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -1,5 +1,6 @@
 import type Stripe from "stripe";
 
+import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import type { Authenticator } from "@app/lib/auth";
 import {
   ENTERPRISE_N30_PAYMENTS_DAYS,
@@ -161,6 +162,14 @@ export async function createEnterpriseCreditPurchase({
 }): Promise<
   Result<{ credit: CreditResource; invoiceOrLineItemId: string }, Error>
 > {
+  if (discountPercent !== undefined && discountPercent > MAX_DISCOUNT_PERCENT) {
+    return new Err(
+      new Error(
+        `Discount cannot exceed ${MAX_DISCOUNT_PERCENT}% (would result in selling below cost)`
+      )
+    );
+  }
+
   const workspace = auth.getNonNullableWorkspace();
 
   let couponId;
@@ -266,6 +275,14 @@ export async function createProCreditPurchase({
   amountCents: number;
   discountPercent?: number;
 }): Promise<Result<{ invoiceId: string; paymentUrl: string | null }, Error>> {
+  if (discountPercent !== undefined && discountPercent > MAX_DISCOUNT_PERCENT) {
+    return new Err(
+      new Error(
+        `Discount cannot exceed ${MAX_DISCOUNT_PERCENT}% (would result in selling below cost)`
+      )
+    );
+  }
+
   const workspace = auth.getNonNullableWorkspace();
 
   let couponId;

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import type Stripe from "stripe";
 
+import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import {
@@ -27,6 +28,14 @@ async function createPAYGCreditForPeriod({
   periodStart: Date;
   periodEnd: Date;
 }): Promise<Result<CreditResource, Error>> {
+  if (discountPercent > MAX_DISCOUNT_PERCENT) {
+    return new Err(
+      new Error(
+        `Discount cannot exceed ${MAX_DISCOUNT_PERCENT}% (would result in selling below cost)`
+      )
+    );
+  }
+
   const existingCredit = await CreditResource.fetchByTypeAndDates(
     auth,
     "payg",

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -3,8 +3,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import {

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -136,7 +136,10 @@ async function handler(
           : undefined;
 
       // Validate discount does not exceed maximum (should be enforced at config level, but double-check).
-      if (discountPercent !== undefined && discountPercent > MAX_DISCOUNT_PERCENT) {
+      if (
+        discountPercent !== undefined &&
+        discountPercent > MAX_DISCOUNT_PERCENT
+      ) {
         logger.error(
           {
             workspaceId: workspace.sId,


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5413

Adds validation to ensure discounts on credit purchases cannot exceed the maximum discount percent derived from the markup. With a 30% markup, the maximum discount is 23% (computed as `(1 - 1/(1 + MARKUP/100)) * 100`).

Validation is added in multiple layers:
- Poke plugins (buy credits, manage programmatic usage config)
- Core credit functions (committed.ts, payg.ts)
- Purchase API endpoint (double-check with fallback to no discount)

## Risks
Blast radius: Credit purchase and programmatic usage configuration
Risk: low (adds validation constraints, does not change existing behavior for valid inputs)

## Deploy Plan
- deploy front