### PR TITLE
Add Vanta MCP server initial tool

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -166,6 +166,7 @@ pub mod oauth {
         pub mod salesforce;
         pub mod slack;
         pub mod utils;
+        pub mod vanta;
         pub mod zendesk;
     }
 

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -14,7 +14,7 @@ use crate::oauth::{
         microsoft_tools::MicrosoftToolsConnectionProvider, mock::MockConnectionProvider,
         monday::MondayConnectionProvider, notion::NotionConnectionProvider,
         salesforce::SalesforceConnectionProvider, slack::SlackConnectionProvider,
-        zendesk::ZendeskConnectionProvider,
+        vanta::VantaConnectionProvider, zendesk::ZendeskConnectionProvider,
     },
     store::OAuthStore,
 };
@@ -119,6 +119,7 @@ pub enum ConnectionProvider {
     Zendesk,
     Salesforce,
     Hubspot,
+    Vanta,
     Mcp,
     McpStatic,
 }
@@ -265,6 +266,7 @@ pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
         ConnectionProvider::Zendesk => Box::new(ZendeskConnectionProvider::new()),
         ConnectionProvider::Salesforce => Box::new(SalesforceConnectionProvider::new()),
         ConnectionProvider::Hubspot => Box::new(HubspotConnectionProvider::new()),
+        ConnectionProvider::Vanta => Box::new(VantaConnectionProvider::new()),
         ConnectionProvider::Mcp => Box::new(MCPConnectionProvider::new()),
         // MCP Static is the same as MCP but does not require the discovery process on the front end.
         ConnectionProvider::McpStatic => Box::new(MCPStaticConnectionProvider::new()),

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -32,6 +32,7 @@ pub enum CredentialProvider {
     Notion,
     Freshservice,
     Databricks,
+    Vanta,
 }
 
 impl From<ConnectionProvider> for CredentialProvider {
@@ -47,6 +48,7 @@ impl From<ConnectionProvider> for CredentialProvider {
             ConnectionProvider::McpStatic => CredentialProvider::McpStatic,
             ConnectionProvider::Freshservice => CredentialProvider::Freshservice,
             ConnectionProvider::Databricks => CredentialProvider::Databricks,
+            ConnectionProvider::Vanta => CredentialProvider::Vanta,
             _ => panic!("Unsupported provider: {:?}", provider),
         }
     }
@@ -242,6 +244,9 @@ impl Credential {
                 vec!["freshservice_domain"]
             }
             CredentialProvider::Databricks => {
+                vec!["client_id", "client_secret"]
+            }
+            CredentialProvider::Vanta => {
                 vec!["client_id", "client_secret"]
             }
         };

--- a/core/src/oauth/providers/vanta.rs
+++ b/core/src/oauth/providers/vanta.rs
@@ -1,0 +1,153 @@
+use crate::{
+    oauth::{
+        connection::{
+            Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
+            PROVIDER_TIMEOUT_SECONDS,
+        },
+        credential::{Credential, CredentialProvider},
+        providers::utils::execute_request,
+    },
+    utils,
+};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::json;
+
+use super::utils::ProviderHttpRequestError;
+
+const VANTA_TOKEN_ENDPOINT: &str = "https://api.vanta.com/oauth/token";
+const VANTA_SCOPE: &str = "vanta-api.all:read";
+
+pub struct VantaConnectionProvider {}
+
+impl VantaConnectionProvider {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    async fn get_credentials(credentials: Option<Credential>) -> Result<(String, String)> {
+        let credentials =
+            credentials.ok_or_else(|| anyhow!("Missing credentials for Vanta connection"))?;
+
+        let content = credentials.unseal_encrypted_content()?;
+        let provider = credentials.provider();
+
+        if provider != CredentialProvider::Vanta {
+            return Err(anyhow!(
+                "Invalid credential provider: {:?}, expected Vanta",
+                provider
+            ));
+        }
+
+        let client_id = content
+            .get("client_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing client_id in Vanta credential"))?;
+
+        let client_secret = content
+            .get("client_secret")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing client_secret in Vanta credential"))?;
+
+        Ok((client_id.to_string(), client_secret.to_string()))
+    }
+
+    async fn request_token(
+        &self,
+        client_id: &str,
+        client_secret: &str,
+    ) -> Result<serde_json::Value, ProviderError> {
+        let body = json!({
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "scope": VANTA_SCOPE,
+            "grant_type": "client_credentials",
+        });
+
+        let req = self
+            .reqwest_client()
+            .post(VANTA_TOKEN_ENDPOINT)
+            .header("Content-Type", "application/json")
+            .json(&body);
+
+        execute_request(ConnectionProvider::Vanta, req)
+            .await
+            .map_err(|e| self.handle_provider_request_error(e))
+    }
+}
+
+#[async_trait]
+impl Provider for VantaConnectionProvider {
+    fn id(&self) -> ConnectionProvider {
+        ConnectionProvider::Vanta
+    }
+
+    async fn finalize(
+        &self,
+        _connection: &Connection,
+        related_credentials: Option<Credential>,
+        code: &str,
+        redirect_uri: &str,
+    ) -> Result<FinalizeResult, ProviderError> {
+        let (client_id, client_secret) = Self::get_credentials(related_credentials).await?;
+        let raw_json = self.request_token(&client_id, &client_secret).await?;
+
+        let access_token = raw_json["access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing `access_token` in response from Vanta"))?;
+        let expires_in = raw_json["expires_in"]
+            .as_u64()
+            .ok_or_else(|| anyhow!("Missing `expires_in` in response from Vanta"))?;
+
+        Ok(FinalizeResult {
+            redirect_uri: redirect_uri.to_string(),
+            code: code.to_string(),
+            access_token: access_token.to_string(),
+            access_token_expiry: Some(
+                utils::now() + (expires_in.saturating_sub(PROVIDER_TIMEOUT_SECONDS)) * 1000,
+            ),
+            refresh_token: None,
+            raw_json,
+            extra_metadata: None,
+        })
+    }
+
+    async fn refresh(
+        &self,
+        _connection: &Connection,
+        related_credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
+        let (client_id, client_secret) = Self::get_credentials(related_credentials).await?;
+        let raw_json = self.request_token(&client_id, &client_secret).await?;
+
+        let access_token = raw_json["access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing `access_token` in response from Vanta"))?;
+        let expires_in = raw_json["expires_in"]
+            .as_u64()
+            .ok_or_else(|| anyhow!("Missing `expires_in` in response from Vanta"))?;
+
+        Ok(RefreshResult {
+            access_token: access_token.to_string(),
+            access_token_expiry: Some(
+                utils::now() + (expires_in.saturating_sub(PROVIDER_TIMEOUT_SECONDS)) * 1000,
+            ),
+            refresh_token: None,
+            raw_json,
+        })
+    }
+
+    fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> Result<serde_json::Value> {
+        let mut map = match raw_json.clone() {
+            serde_json::Value::Object(map) => map,
+            _ => Err(anyhow!("Invalid raw_json, not an object"))?,
+        };
+        map.remove("access_token");
+        map.remove("expires_in");
+        Ok(serde_json::Value::Object(map))
+    }
+
+    fn handle_provider_request_error(&self, error: ProviderHttpRequestError) -> ProviderError {
+        self.default_handle_provider_request_error(error)
+    }
+}

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -116,6 +116,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "speech_generator",
   "toolsets",
   "val_town",
+  "vanta",
   "front",
   "web_search_&_browse",
   "zendesk",
@@ -1316,6 +1317,33 @@ The directive should be used to display a clickable version of the agent name in
       description: "Search and read from your Slab knowledge base",
       authorization: null,
       icon: "ActionDocumentTextIcon",
+      documentationUrl: null,
+      instructions: null,
+    },
+  },
+  vanta: {
+    id: 44,
+    availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("vanta_tool");
+    },
+    isPreview: true,
+    tools_stakes: {
+      list_tests: "never_ask",
+    },
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "vanta",
+      version: "1.0.0",
+      description:
+        "Review compliance posture powered by Vanta's security platform.",
+      authorization: {
+        provider: "vanta" as const,
+        supported_use_cases: ["platform_actions"] as const,
+      },
+      icon: "ActionScanIcon",
       documentationUrl: null,
       instructions: null,
     },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -56,6 +56,7 @@ import { default as speechGenerator } from "@app/lib/actions/mcp_internal_action
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query";
 import { default as toolsetsServer } from "@app/lib/actions/mcp_internal_actions/servers/toolsets";
 import { default as valtownServer } from "@app/lib/actions/mcp_internal_actions/servers/valtown";
+import { default as vantaServer } from "@app/lib/actions/mcp_internal_actions/servers/vanta";
 import { default as webtoolsServer } from "@app/lib/actions/mcp_internal_actions/servers/webtools";
 import { default as zendeskServer } from "@app/lib/actions/mcp_internal_actions/servers/zendesk";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -203,6 +204,8 @@ export async function getInternalMCPServer(
       return toolsetsServer(auth, agentLoopContext);
     case "val_town":
       return valtownServer(auth, agentLoopContext);
+    case "vanta":
+      return vantaServer(auth, agentLoopContext);
     case "deep_dive":
       return deepDiveServer(auth, agentLoopContext);
     case "http_client":

--- a/front/lib/actions/mcp_internal_actions/servers/vanta/api.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/vanta/api.ts
@@ -1,0 +1,68 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { untrustedFetch } from "@app/lib/egress";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+const VANTA_BASE_URL = "https://api.vanta.com";
+
+type VantaRequestOptions = {
+  path: string;
+  query?: Record<string, string>;
+  authInfo?: AuthInfo;
+};
+
+export async function vantaGet<T = unknown>({
+  path,
+  query,
+  authInfo,
+}: VantaRequestOptions): Promise<Result<T, MCPError>> {
+  const token = authInfo?.token;
+  if (!token) {
+    return new Err(
+      new MCPError(
+        "Missing Vanta access token. Connect the Vanta account to this workspace first.",
+        { tracked: false }
+      )
+    );
+  }
+
+  const url = buildUrl(VANTA_BASE_URL, path, query);
+
+  const response = await untrustedFetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    return new Err(
+      new MCPError(
+        `Vanta API error (${response.status}): ${response.statusText}`
+      )
+    );
+  }
+
+  const payload = await response.json();
+  return new Ok(payload as T);
+}
+
+function buildUrl(
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string>
+): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(normalizedPath, baseUrl);
+
+  if (query) {
+    Object.entries(query).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+  }
+
+  return url.toString();
+}

--- a/front/lib/actions/mcp_internal_actions/servers/vanta/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/vanta/index.ts
@@ -1,0 +1,133 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+import { Ok } from "@app/types";
+
+import { vantaGet } from "./api";
+import type { VantaTestsResponse } from "./renderers";
+import { renderTests } from "./renderers";
+
+const ListTestsInput = z.object({
+  statusFilter: z
+    .enum([
+      "OK",
+      "DEACTIVATED",
+      "NEEDS_ATTENTION",
+      "IN_PROGRESS",
+      "INVALID",
+      "NOT_APPLICABLE",
+    ])
+    .describe(
+      "Filter tests by status. Possible values: OK (Test passed), DEACTIVATED (Test deactivated), NEEDS_ATTENTION (Test failed), IN_PROGRESS (Test in progress), INVALID (Test invalid), NOT_APPLICABLE (Test not applicable)."
+    )
+    .optional(),
+  categoryFilter: z
+    .enum([
+      "ACCOUNTS_ACCESS",
+      "ACCOUNT_SECURITY",
+      "ACCOUNT_SETUP",
+      "COMPUTERS",
+      "CUSTOM",
+      "DATA_STORAGE",
+      "EMPLOYEES",
+      "INFRASTRUCTURE",
+      "IT",
+      "LOGGING",
+      "MONITORING_ALERTS",
+      "PEOPLE",
+      "POLICIES",
+      "RISK_ANALYSIS",
+      "SECURITY_ALERT_MANAGEMENT",
+      "SOFTWARE_DEVELOPMENT",
+      "VENDORS",
+      "VULNERABILITY_MANAGEMENT",
+    ])
+    .describe("Filter tests by category.")
+    .optional(),
+  frameworkFilter: z
+    .string()
+    .describe("Filter tests by framework ID.")
+    .optional(),
+  integrationFilter: z
+    .string()
+    .describe("Filter tests by integration ID.")
+    .optional(),
+  pageSize: z
+    .number()
+    .min(1)
+    .max(100)
+    .describe(
+      "Maximum number of results to return per page (1-100). Default is 10."
+    )
+    .optional(),
+  pageCursor: z
+    .string()
+    .describe(
+      "Pagination cursor from a previous response. Leave blank to start from the first page."
+    )
+    .optional(),
+});
+
+export default function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("vanta");
+
+  server.tool(
+    "list_tests",
+    "List Vanta's automated security and compliance tests with optional filtering",
+    ListTestsInput.shape,
+    withToolLogging<z.infer<typeof ListTestsInput>>(
+      auth,
+      {
+        toolNameForMonitoring: "vanta_list_tests",
+        agentLoopContext,
+      },
+      async (params, { authInfo }) => {
+        const query = buildQuery(params);
+
+        const result = await vantaGet<VantaTestsResponse>({
+          path: "/v1/tests",
+          query,
+          authInfo,
+        });
+
+        if (result.isErr()) {
+          return result;
+        }
+
+        const text = renderTests(result.value);
+
+        return new Ok([{ type: "text" as const, text }]);
+      }
+    )
+  );
+
+  return server;
+}
+
+function buildQuery(
+  params: Record<string, unknown>
+): Record<string, string> | undefined {
+  const query: Record<string, string> = {};
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") {
+      return;
+    }
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        return;
+      }
+      query[key] = value.join(",");
+      return;
+    }
+    query[key] = typeof value === "string" ? value : String(value);
+  });
+
+  return Object.keys(query).length ? query : undefined;
+}

--- a/front/lib/actions/mcp_internal_actions/servers/vanta/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/vanta/index.ts
@@ -8,8 +8,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { Ok } from "@app/types";
 
 import { vantaGet } from "./api";
-import type { VantaTestsResponse } from "./renderers";
-import { renderTests } from "./renderers";
+import { renderTests, VantaTestsResponseSchema } from "./renderers";
 
 const ListTestsInput = z.object({
   statusFilter: z
@@ -91,8 +90,9 @@ export default function createServer(
       async (params, { authInfo }) => {
         const query = buildQuery(params);
 
-        const result = await vantaGet<VantaTestsResponse>({
+        const result = await vantaGet({
           path: "/v1/tests",
+          schema: VantaTestsResponseSchema,
           query,
           authInfo,
         });

--- a/front/lib/actions/mcp_internal_actions/servers/vanta/renderers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/vanta/renderers.ts
@@ -1,46 +1,55 @@
+import { z } from "zod";
+
 import { pluralize } from "@app/types";
 
-export interface VantaTestsResponse {
-  results: {
-    pageInfo: {
-      totalCount: number;
-      endCursor: string | null;
-    };
-    data: VantaTest[];
-  };
-}
+const VantaIntegrationSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+});
 
-interface VantaTest {
-  id: string;
-  name: string;
-  status: string;
-  category: string;
-  description?: string;
-  failureDescription?: string;
-  remediationDescription?: string;
-  lastTestRunDate?: string;
-  integrations?: VantaIntegration[];
-  owner?: VantaOwner;
-  deactivatedStatusInfo?: {
-    isDeactivated: boolean;
-    deactivatedReason?: string;
-  };
-  remediationStatusInfo?: {
-    status: string;
-    itemCount?: number;
-  };
-}
+const VantaOwnerSchema = z.object({
+  id: z.string(),
+  displayName: z.string().optional(),
+  emailAddress: z.string().optional(),
+});
 
-interface VantaIntegration {
-  id: string;
-  name?: string;
-}
+const VantaTestSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.string(),
+  category: z.string(),
+  description: z.string().optional(),
+  failureDescription: z.string().optional(),
+  remediationDescription: z.string().optional(),
+  lastTestRunDate: z.string().optional(),
+  integrations: z.array(VantaIntegrationSchema).optional(),
+  owner: VantaOwnerSchema.optional(),
+  deactivatedStatusInfo: z
+    .object({
+      isDeactivated: z.boolean(),
+      deactivatedReason: z.string().optional(),
+    })
+    .optional(),
+  remediationStatusInfo: z
+    .object({
+      status: z.string(),
+      itemCount: z.number().optional(),
+    })
+    .optional(),
+});
 
-interface VantaOwner {
-  id: string;
-  displayName?: string;
-  emailAddress?: string;
-}
+export const VantaTestsResponseSchema = z.object({
+  results: z.object({
+    pageInfo: z.object({
+      totalCount: z.number(),
+      endCursor: z.string().nullable(),
+    }),
+    data: z.array(VantaTestSchema),
+  }),
+});
+
+export type VantaTestsResponse = z.infer<typeof VantaTestsResponseSchema>;
+type VantaTest = z.infer<typeof VantaTestSchema>;
 
 export function renderTests(response: VantaTestsResponse): string {
   const { results } = response;

--- a/front/lib/actions/mcp_internal_actions/servers/vanta/renderers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/vanta/renderers.ts
@@ -1,0 +1,159 @@
+import { pluralize } from "@app/types";
+
+export interface VantaTestsResponse {
+  results: {
+    pageInfo: {
+      totalCount: number;
+      endCursor: string | null;
+    };
+    data: VantaTest[];
+  };
+}
+
+interface VantaTest {
+  id: string;
+  name: string;
+  status: string;
+  category: string;
+  description?: string;
+  failureDescription?: string;
+  remediationDescription?: string;
+  lastTestRunDate?: string;
+  integrations?: VantaIntegration[];
+  owner?: VantaOwner;
+  deactivatedStatusInfo?: {
+    isDeactivated: boolean;
+    deactivatedReason?: string;
+  };
+  remediationStatusInfo?: {
+    status: string;
+    itemCount?: number;
+  };
+}
+
+interface VantaIntegration {
+  id: string;
+  name?: string;
+}
+
+interface VantaOwner {
+  id: string;
+  displayName?: string;
+  emailAddress?: string;
+}
+
+export function renderTests(response: VantaTestsResponse): string {
+  const { results } = response;
+  const tests = results.data;
+  const { totalCount, endCursor } = results.pageInfo;
+
+  if (!tests.length) {
+    return "No tests found.";
+  }
+
+  const lines: string[] = [];
+  lines.push(`Found ${totalCount} test${pluralize(totalCount)}`);
+
+  if (endCursor) {
+    lines.push(`Next page cursor: ${endCursor}`);
+  }
+
+  lines.push("");
+  lines.push("---");
+
+  tests.forEach((test, index) => {
+    lines.push("");
+    lines.push(formatTest(test, index + 1));
+    lines.push("\n---");
+  });
+
+  return lines.join("\n").trim();
+}
+
+function formatTest(test: VantaTest, index: number): string {
+  const parts: string[] = [];
+
+  parts.push(`Test #${index}`);
+  parts.push(`Name: ${test.name}`);
+  parts.push(`ID: ${test.id}`);
+  parts.push(`Status: ${test.status}`);
+  parts.push(`Category: ${test.category}`);
+
+  if (test.description) {
+    parts.push(`Description: ${cleanText(test.description)}`);
+  }
+
+  if (test.failureDescription) {
+    parts.push(`Failure Info: ${cleanText(test.failureDescription)}`);
+  }
+
+  if (test.remediationDescription) {
+    parts.push(`Remediation: ${cleanText(test.remediationDescription)}`);
+  }
+
+  if (test.integrations?.length) {
+    parts.push(
+      `Integrations: ${test.integrations.map((i) => i.name ?? i.id).join(", ")}`
+    );
+  }
+
+  if (test.owner) {
+    const ownerName =
+      test.owner.displayName ?? test.owner.emailAddress ?? test.owner.id;
+    parts.push(`Owner: ${ownerName}`);
+  }
+
+  if (test.deactivatedStatusInfo?.isDeactivated) {
+    const reason =
+      test.deactivatedStatusInfo.deactivatedReason ?? "No reason provided";
+    parts.push(`Deactivated: Yes (${reason})`);
+  }
+
+  if (
+    test.remediationStatusInfo?.status &&
+    test.remediationStatusInfo.status !== "PASS" &&
+    test.remediationStatusInfo.status !== "DISABLED"
+  ) {
+    const count = test.remediationStatusInfo.itemCount ?? 0;
+    parts.push(
+      `Remediation Status: ${test.remediationStatusInfo.status} (${count} items)`
+    );
+  }
+
+  if (test.lastTestRunDate) {
+    parts.push(`Last Run: ${formatDate(test.lastTestRunDate)}`);
+  }
+
+  return parts.join("\n");
+}
+
+function cleanText(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\(\/policies\/[^)]+\)/g, '"$1" policy (in Vanta)')
+    .replace(/\[([^\]]+)\]\(\/documents\/[^)]+\)/g, '"$1" document (in Vanta)')
+    .replace(/\[([^\]]+)\]\(\/people[^)]*\)/g, '"$1" page (in Vanta)')
+    .replace(
+      /\[([^\]]+)\]\(\/integrations[^)]*\)/g,
+      '"$1" integration (in Vanta)'
+    )
+    .replace(/\[([^\]]+)\]\(\/controls[^)]*\)/g, '"$1" control (in Vanta)')
+    .replace(/\[([^\]]+)\]\(\/tests[^)]*\)/g, '"$1" test (in Vanta)')
+    .replace(/\[([^\]]+)\]\(\/frameworks[^)]*\)/g, '"$1" framework (in Vanta)')
+    .replace(/\[([^\]]+)\]\(\/[^)]+\)/g, '"$1" (in Vanta)')
+    .replace(/\s+\/policies\/\S+/g, " (see Vanta policies)")
+    .replace(/\s+\/documents\/\S+/g, " (see Vanta documents)")
+    .replace(/\s+\/people\S*/g, " (see Vanta people page)");
+}
+
+function formatDate(isoDate: string): string {
+  try {
+    const date = new Date(isoDate);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return isoDate;
+  }
+}

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -26,6 +26,7 @@ import { MondayOAuthProvider } from "@app/lib/api/oauth/providers/monday";
 import { NotionOAuthProvider } from "@app/lib/api/oauth/providers/notion";
 import { SalesforceOAuthProvider } from "@app/lib/api/oauth/providers/salesforce";
 import { SlackOAuthProvider } from "@app/lib/api/oauth/providers/slack";
+import { VantaOAuthProvider } from "@app/lib/api/oauth/providers/vanta";
 import { ZendeskOAuthProvider } from "@app/lib/api/oauth/providers/zendesk";
 import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -73,6 +74,7 @@ const _PROVIDER_STRATEGIES: Record<OAuthProvider, BaseOAuthStrategyProvider> = {
   salesforce: new SalesforceOAuthProvider(),
   slack: new SlackOAuthProvider(),
   zendesk: new ZendeskOAuthProvider(),
+  vanta: new VantaOAuthProvider(),
 };
 
 function getProviderStrategy(

--- a/front/lib/api/oauth/providers/vanta.ts
+++ b/front/lib/api/oauth/providers/vanta.ts
@@ -1,0 +1,60 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import type {
+  BaseOAuthStrategyProvider,
+  RelatedCredential,
+} from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class VantaOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({ connection }: { connection: OAuthConnectionType }) {
+    const finalizeUrl = new URL(finalizeUriForProvider("vanta"));
+    finalizeUrl.searchParams.set("state", connection.connection_id);
+    finalizeUrl.searchParams.set("code", "client_credentials");
+    return finalizeUrl.toString();
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType, _useCase: OAuthUseCase) {
+    return Boolean(extraConfig.client_id && extraConfig.client_secret);
+  }
+
+  async getRelatedCredential(
+    _auth: unknown,
+    {
+      extraConfig,
+      workspaceId,
+      userId,
+    }: {
+      extraConfig: ExtraConfigType;
+      workspaceId: string;
+      userId: string;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<RelatedCredential> {
+    return {
+      content: {
+        client_id: extraConfig.client_id as string,
+        client_secret: extraConfig.client_secret as string,
+      },
+      metadata: { workspace_id: workspaceId, user_id: userId },
+    };
+  }
+
+  async getUpdatedExtraConfig(): Promise<ExtraConfigType> {
+    // Remove sensitive data from config
+    return {};
+  }
+}

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -47,6 +47,7 @@ export const OAUTH_PROVIDERS = [
   "hubspot",
   "mcp", // MCP is a special provider for MCP servers.
   "mcp_static", // MCP static is a special provider for MCP servers requiring static OAuth credentials.
+  "vanta",
 ] as const;
 
 export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
@@ -72,6 +73,7 @@ export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
   hubspot: "Hubspot",
   mcp: "MCP",
   mcp_static: "MCP",
+  vanta: "Vanta",
 };
 
 const SUPPORTED_OAUTH_CREDENTIALS = [
@@ -217,6 +219,23 @@ export const getProviderRequiredOAuthCredentialInputs = async ({
     case "discord":
     case "fathom":
       return null;
+    case "vanta": {
+      const result: OAuthCredentialInputs = {
+        client_id: {
+          label: "Vanta Client ID",
+          value: undefined,
+          helpMessage: "The client ID from your Vanta application.",
+          validator: isValidClientIdOrSecret,
+        },
+        client_secret: {
+          label: "Vanta Client Secret",
+          value: undefined,
+          helpMessage: "The client secret from your Vanta application.",
+          validator: isValidClientIdOrSecret,
+        },
+      };
+      return result;
+    }
     case "mcp_static":
       if (useCase === "personal_actions" || useCase === "platform_actions") {
         const result: OAuthCredentialInputs = {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -200,6 +200,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Slab MCP server",
     stage: "on_demand",
   },
+  vanta_tool: {
+    description: "Vanta MCP tool for security and compliance testing",
+    stage: "dust_only",
+  },
   web_summarization: {
     description: "AI-powered web page summarization in the web browser tool",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -698,6 +698,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "usage_data_api"
   | "web_summarization"
   | "xai_feature"
+  | "vanta_tool"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;
@@ -2860,6 +2861,7 @@ const OAuthProviderSchema = FlexibleEnumSchema<
   | "hubspot"
   | "mcp"
   | "mcp_static"
+  | "vanta"
 >();
 
 const InternalAllowedIconSchema = FlexibleEnumSchema<


### PR DESCRIPTION
## Description

* Adding Vanta MCP server currently with a single tool to list tests (the rest of the tools will be added in a follow-up PR)
* See Vanta Authentication: https://developer.vanta.com/docs/api-access-setup - Expectation for now is that users will create a developer application and provide client id / secret when configuring the application. We will use those values to obtain/refresh the bearer token as instructed.

## Tests

* Validated test listing for our internal Vanta account

## Risk

* Low - still behind FF until discussing with Vanta team

## Deploy Plan

1. Deploy oauth
2. Deploy front