### PR TITLE
[front] Add `skills` feature flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -221,6 +221,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable notifications",
     stage: "dust_only",
   },
+  skills: {
+    description:
+      "Access to Skills, which are packaged sets of instructions and tools",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -685,6 +685,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesloft_tool"
   | "self_created_slack_app_connector_rollout"
   | "show_debug_tools"
+  | "skills"
   | "slack_bot_mcp"
   | "slack_enhanced_default_agent"
   | "slack_message_splitting"


### PR DESCRIPTION
## Description

- This PR adds a new Dust-only `skills` feature flag.
- This feature flag will hide all new features relative to skills.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
