### PR TITLE
Fix kimi-k2-instruct model support on Fireworks

### DIFF
--- a/core/src/providers/fireworks.rs
+++ b/core/src/providers/fireworks.rs
@@ -26,7 +26,7 @@ const MODEL_IDS_WITH_TOOLS_SUPPORT: &[&str] = &[
     "accounts/fireworks/models/qwen2p5-72b-instruct",
     "accounts/fireworks/models/firefunction-v2",
     "accounts/fireworks/models/firefunction-v1",
-    "accounts/fireworks/models/kimi-k2-instruct",
+    "accounts/fireworks/models/kimi-k2-instruct-0905",
     "accounts/fireworks/models/deepseek-v3p2",
 ];
 

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -233,7 +233,7 @@ const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
     input: 1.2,
     output: 1.2,
   },
-  "accounts/fireworks/models/kimi-k2-instruct": {
+  "accounts/fireworks/models/kimi-k2-instruct-0905": {
     input: 0.4,
     output: 0.4,
   },

--- a/front/types/assistant/models/fireworks.ts
+++ b/front/types/assistant/models/fireworks.ts
@@ -5,7 +5,7 @@ export const FIREWORKS_DEEPSEEK_R1_MODEL_ID =
 export const FIREWORKS_DEEPSEEK_V3P2_MODEL_ID =
   "accounts/fireworks/models/deepseek-v3p2" as const;
 export const FIREWORKS_KIMI_K2_INSTRUCT_MODEL_ID =
-  "accounts/fireworks/models/kimi-k2-instruct" as const;
+  "accounts/fireworks/models/kimi-k2-instruct-0905" as const;
 export const FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
   modelId: FIREWORKS_DEEPSEEK_R1_MODEL_ID,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -79,7 +79,8 @@ const ModelLLMIdSchema = FlexibleEnumSchema<
   | "deepseek-reasoner" // deepseek api
   | "accounts/fireworks/models/deepseek-r1-0528" // fireworks
   | "accounts/fireworks/models/deepseek-v3p2" // fireworks
-  | "accounts/fireworks/models/kimi-k2-instruct" // fireworks
+  | "accounts/fireworks/models/kimi-k2-instruct" // fireworks - not supported anymore
+  | "accounts/fireworks/models/kimi-k2-instruct-0905" // fireworks
   | "grok-3-latest" // xAI
   | "grok-3-mini-latest" // xAI
   | "grok-4-latest" // xAI


### PR DESCRIPTION
## Description

Fireworks stopped support for modelId `accounts/fireworks/models/kimi-k2-instruct`.
They require adding a tag, in our case `accounts/fireworks/models/kimi-k2-instruct-0905`

Once deployed, script to be ran from front is :

```
npx tsx scripts/update_agent_models.ts --fromModel accounts/fireworks/models/kimi-k2-instruct --toModel accounts/fireworks/models/kimi-k2-instruct-0905 --execute
```

## Tests

Local

## Risk

no: currently broken

## Deploy Plan

front
