### PR TITLE
feat(poke): favorites

### DIFF
--- a/front/components/poke/PokeFavorites.tsx
+++ b/front/components/poke/PokeFavorites.tsx
@@ -1,0 +1,120 @@
+import {
+  Chip,
+  IconButton,
+  StarIcon,
+  StarStrokeIcon,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+
+import { createFavorite, usePokeFavorites } from "@app/poke/swr/favorites";
+
+interface PokeFavoriteButtonProps {
+  title: string;
+}
+
+export function PokeFavoriteButton({ title }: PokeFavoriteButtonProps) {
+  const router = useRouter();
+  const { isFavorite, toggleFavorite } = usePokeFavorites();
+
+  const url = router.asPath;
+  const isCurrentlyFavorite = isFavorite(url);
+
+  const handleToggle = useCallback(() => {
+    toggleFavorite(createFavorite(url, title));
+  }, [toggleFavorite, url, title]);
+
+  // Keyboard shortcut: Cmd+D (Mac) or Ctrl+D (Windows/Linux)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "d" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleToggle();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleToggle]);
+
+  return (
+    <IconButton
+      icon={isCurrentlyFavorite ? StarIcon : StarStrokeIcon}
+      onClick={handleToggle}
+      variant="outline"
+      size="sm"
+      tooltip={
+        isCurrentlyFavorite
+          ? "Remove from favorites (⌘D)"
+          : "Add to favorites (⌘D)"
+      }
+    />
+  );
+}
+
+const COLLAPSED_LIMIT = 12;
+
+export function PokeFavoritesList() {
+  const { favorites, removeFavorite } = usePokeFavorites();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (favorites.length === 0) {
+    return (
+      <div className="border-structure-200 bg-structure-50 dark:border-structure-200-night dark:bg-structure-50-night mb-6 rounded-lg border p-4">
+        <p className="text-element-600 dark:text-element-600-night text-sm">
+          No favorites yet. Use the star button or press{" "}
+          <kbd className="bg-structure-100 dark:bg-structure-100-night rounded px-1.5 py-0.5 font-mono text-xs">
+            ⌘D
+          </kbd>{" "}
+          on any page to add it here.
+        </p>
+      </div>
+    );
+  }
+
+  const shouldCollapse = favorites.length > COLLAPSED_LIMIT;
+  const displayedFavorites =
+    shouldCollapse && !isExpanded
+      ? favorites.slice(0, COLLAPSED_LIMIT)
+      : favorites;
+  const hiddenCount = favorites.length - COLLAPSED_LIMIT;
+
+  return (
+    <>
+      <h1 className="mb-4 text-2xl font-bold">Favorites</h1>
+      <div className="mb-6 flex flex-wrap gap-2">
+        {displayedFavorites.map((favorite) => (
+          <div
+            key={favorite.url}
+            className="border-structure-200 dark:border-structure-200-night dark:bg-structure-100-night group flex items-center gap-2 rounded-md border bg-white p-2"
+          >
+            <Chip size="xs" color="primary">
+              {favorite.data.type}
+            </Chip>
+            <Link
+              href={favorite.url}
+              className="text-element-800 hover:text-action-500 dark:text-element-800-night dark:hover:text-action-500-night text-sm"
+            >
+              {favorite.data.name}
+            </Link>
+            <IconButton
+              icon={XMarkIcon}
+              onClick={() => removeFavorite(favorite.url)}
+              size="xs"
+              tooltip="Remove from favorites"
+            />
+          </div>
+        ))}
+        {shouldCollapse && (
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="border-structure-200 text-element-600 hover:bg-structure-100 dark:border-structure-200-night dark:bg-structure-100-night dark:text-element-600-night dark:hover:bg-structure-200-night rounded-md border bg-white p-1 text-sm"
+          >
+            {isExpanded ? "Show less" : `+${hiddenCount} more`}
+          </button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/front/components/poke/PokeLayout.tsx
+++ b/front/components/poke/PokeLayout.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import React from "react";
+import React, { createContext, useContext } from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
@@ -8,6 +8,12 @@ import { usePokeRegion } from "@app/lib/swr/poke";
 
 export interface PokeLayoutProps {
   currentRegion: RegionType;
+}
+
+const PokePageTitleContext = createContext<string>("");
+
+export function usePokePageTitle() {
+  return useContext(PokePageTitleContext);
 }
 
 export default function PokeLayout({
@@ -19,10 +25,12 @@ export default function PokeLayout({
 }) {
   return (
     <ThemeProvider>
-      <Head>
-        <title>{"Poke - " + title}</title>
-      </Head>
-      <PokeLayoutContent>{children}</PokeLayoutContent>
+      <PokePageTitleContext.Provider value={title}>
+        <Head>
+          <title>{"Poke - " + title}</title>
+        </Head>
+        <PokeLayoutContent>{children}</PokeLayoutContent>
+      </PokePageTitleContext.Provider>
     </ThemeProvider>
   );
 }

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import type { ComponentProps } from "react";
 import { useEffect, useState } from "react";
 
+import { PokeFavoriteButton } from "@app/components/poke/PokeFavorites";
+import { usePokePageTitle } from "@app/components/poke/PokeLayout";
 import { PokeRegionDropdown } from "@app/components/poke/PokeRegionDropdown";
 import {
   PokeCommandDialog,
@@ -41,6 +43,8 @@ function getPokeItemChipColor(
 }
 
 function PokeNavbar({ currentRegion, regionUrls }: PokeNavbarProps) {
+  const title = usePokePageTitle();
+
   return (
     <nav
       className={classNames(
@@ -60,7 +64,8 @@ function PokeNavbar({ currentRegion, regionUrls }: PokeNavbarProps) {
           <Button href="/poke/pokefy" variant="ghost" label="Pokefy URL" />
         </div>
       </div>
-      <div className="items-right flex gap-6">
+      <div className="items-right flex items-center gap-4">
+        <PokeFavoriteButton title={title} />
         {currentRegion && (
           <PokeRegionDropdown
             currentRegion={currentRegion}

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { ChangeEvent, ReactElement } from "react";
 import React, { useState } from "react";
 
+import { PokeFavoritesList } from "@app/components/poke/PokeFavorites";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import {
   PokeTable,
@@ -134,6 +135,7 @@ const Dashboard = () => {
 
   return (
     <>
+      <PokeFavoritesList />
       <h1 className="mb-4 text-2xl font-bold">Search in Workspaces</h1>
       <Input
         type="text"

--- a/front/poke/swr/favorites.ts
+++ b/front/poke/swr/favorites.ts
@@ -1,0 +1,136 @@
+import { useCallback, useState } from "react";
+
+const POKE_FAVORITES_KEY = "poke-favorites";
+
+export interface PokeFavorite {
+  url: string;
+  data: {
+    type: string;
+    name: string;
+  };
+}
+
+function inferTypeFromUrl(url: string): string {
+  if (url.includes("/assistants/")) {
+    return "Agent";
+  }
+  if (url.includes("/data_source_views/")) {
+    return "Data Source View";
+  }
+  if (url.includes("/data_sources/")) {
+    return "Data Source";
+  }
+  if (url.includes("/triggers/")) {
+    return "Trigger";
+  }
+  if (url.includes("/spaces/")) {
+    return "Space";
+  }
+  if (url.includes("/conversations/")) {
+    return "Conversation";
+  }
+  if (url.includes("/plugins/")) {
+    return "Plugin";
+  }
+  if (url.includes("/memberships")) {
+    return "Members";
+  }
+  if (url.includes("/groups/")) {
+    return "Group";
+  }
+  if (url.includes("/mcp_server_views/")) {
+    return "MCP Server";
+  }
+  if (url.includes("/apps/")) {
+    return "App";
+  }
+  if (url.match(/\/poke\/[^/]+$/)) {
+    return "Workspace";
+  }
+  return "Page";
+}
+
+export function createFavorite(url: string, name: string): PokeFavorite {
+  return {
+    url,
+    data: {
+      type: inferTypeFromUrl(url),
+      name,
+    },
+  };
+}
+
+function getFavoritesFromStorage(): PokeFavorite[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+  try {
+    const stored = localStorage.getItem(POKE_FAVORITES_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveFavoritesToStorage(favorites: PokeFavorite[]): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    localStorage.setItem(POKE_FAVORITES_KEY, JSON.stringify(favorites));
+  } catch {
+    // Silently fail if localStorage is not available
+  }
+}
+
+export function usePokeFavorites() {
+  const [favorites, setFavorites] = useState<PokeFavorite[]>(
+    getFavoritesFromStorage
+  );
+
+  const addFavorite = useCallback((favorite: PokeFavorite) => {
+    setFavorites((prev) => {
+      // Don't add duplicates
+      if (prev.some((f) => f.url === favorite.url)) {
+        return prev;
+      }
+      const updated = [...prev, favorite];
+      saveFavoritesToStorage(updated);
+      return updated;
+    });
+  }, []);
+
+  const removeFavorite = useCallback((url: string) => {
+    setFavorites((prev) => {
+      const updated = prev.filter((f) => f.url !== url);
+      saveFavoritesToStorage(updated);
+      return updated;
+    });
+  }, []);
+
+  const isFavorite = useCallback(
+    (url: string) => {
+      return favorites.some((f) => f.url === url);
+    },
+    [favorites]
+  );
+
+  const toggleFavorite = useCallback(
+    (favorite: PokeFavorite) => {
+      if (isFavorite(favorite.url)) {
+        removeFavorite(favorite.url);
+      } else {
+        addFavorite(favorite);
+      }
+    },
+    [isFavorite, removeFavorite, addFavorite]
+  );
+
+  return {
+    favorites,
+    addFavorite,
+    removeFavorite,
+    isFavorite,
+    toggleFavorite,
+  };
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Add a favorites feature to Poke backoffice, allowing users to star pages for quick access.

  - Star button in navbar (or press ⌘D) to add/remove current page from favorites
  - Favorites list displayed on the main /poke page with resource type chips (Workspace, Agent, Data Source, etc.)
  - Type automatically inferred from URL patterns
  - Stored in localStorage as { url, data: { type, name } }
  - Collapsible list after 12 entries with "show more/less" toggle

<img width="1608" height="1044" alt="Capture d’écran 2025-12-04 à 09 54 36" src="https://github.com/user-attachments/assets/7306d1b4-e87c-4f43-844d-3e9edd5d85f2" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low - internal

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front