### PR TITLE
[slackstorm] slack bot is no longer automatically enabled when creating slack connector

### DIFF
--- a/connectors/src/resources/connector/slack.ts
+++ b/connectors/src/resources/connector/slack.ts
@@ -28,6 +28,7 @@ export class SlackConnectorStrategy
       restrictedSpaceAgentsEnabled: blob.restrictedSpaceAgentsEnabled,
       privateIntegrationCredentialId: blob.privateIntegrationCredentialId,
       connectorId,
+      botEnabled: blob.botEnabled,
       transaction,
     });
   }

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -50,6 +50,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     restrictedSpaceAgentsEnabled,
     feedbackVisibleToAuthorOnly,
     privateIntegrationCredentialId,
+    botEnabled,
     transaction,
   }: {
     slackTeamId: string;
@@ -59,6 +60,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     restrictedSpaceAgentsEnabled?: boolean;
     feedbackVisibleToAuthorOnly?: boolean;
     privateIntegrationCredentialId?: string | null;
+    botEnabled: boolean;
     transaction: Transaction;
   }) {
     const otherSlackConfigurationWithBotEnabled =
@@ -73,7 +75,8 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     const model = await SlackConfigurationModel.create(
       {
         autoReadChannelPatterns: autoReadChannelPatterns ?? [],
-        botEnabled: otherSlackConfigurationWithBotEnabled ? false : true,
+        // We want at most 1 Slack bot enabled per team id.
+        botEnabled: otherSlackConfigurationWithBotEnabled ? false : botEnabled,
         connectorId,
         slackTeamId,
         restrictedSpaceAgentsEnabled: restrictedSpaceAgentsEnabled ?? true,


### PR DESCRIPTION
## Description

There is no button to pick enabled or not, so now by default it is disabled on creation.

## Tests

Tested locally.
We can still switch between enabled and disabled.

## Risk
low

## Deploy Plan

deploy connector