### PR TITLE
Add info on Check Slack Channel plugin

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -29,6 +29,7 @@ import { SlackConfigurationResource } from "@connectors/resources/slack_configur
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import type {
   AdminSuccessResponseType,
+  SlackCheckChannelResponseType,
   SlackCommandType,
   SlackJoinResponseType as SlackJoinResponseType,
 } from "@connectors/types";
@@ -61,7 +62,9 @@ export const slack = async ({
   command,
   args,
 }: SlackCommandType): Promise<
-  AdminSuccessResponseType | SlackJoinResponseType
+  | AdminSuccessResponseType
+  | SlackCheckChannelResponseType
+  | SlackJoinResponseType
 > => {
   const logger = topLogger.child({ majorCommand: "slack", command, args });
   switch (command) {
@@ -864,7 +867,13 @@ export const slack = async ({
         throw new Error(`Could not find the channel ${args.channelId}`);
       }
 
-      return { success: true };
+      return {
+        success: true,
+        channel: {
+          name: remoteChannel.name,
+          isPrivate: remoteChannel.is_private,
+        },
+      };
     }
 
     default:

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -619,6 +619,17 @@ export const SlackJoinResponseSchema = t.type({
 });
 export type SlackJoinResponseType = t.TypeOf<typeof SlackJoinResponseSchema>;
 
+export const SlackCheckChannelResponseSchema = t.type({
+  success: t.literal(true),
+  channel: t.type({
+    name: t.union([t.string, t.undefined]),
+    isPrivate: t.union([t.boolean, t.undefined]),
+  }),
+});
+export type SlackCheckChannelResponseType = t.TypeOf<
+  typeof SlackCheckChannelResponseSchema
+>;
+
 /**
  * </Slack>
  */
@@ -871,6 +882,7 @@ export const AdminResponseSchema = t.union([
   NotionMeResponseSchema,
   NotionSearchPagesResponseSchema,
   NotionUpsertResponseSchema,
+  SlackCheckChannelResponseSchema,
   SlackJoinResponseSchema,
   SalesforceCheckConnectionResponseSchema,
   SalesforceRunSoqlResponseSchema,

--- a/front/lib/api/poke/plugins/data_sources/check_slack_channel.ts
+++ b/front/lib/api/poke/plugins/data_sources/check_slack_channel.ts
@@ -1,7 +1,11 @@
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import logger from "@app/logger/logger";
-import type { AdminCommandType } from "@app/types";
+import type {
+  AdminCommandType,
+  ConnectorsAPIResponse,
+  SlackCheckChannelResponseType,
+} from "@app/types";
 import { ConnectorsAPI, Err, Ok } from "@app/types";
 
 export const checkSlackChannelPlugin = createPlugin({
@@ -56,16 +60,20 @@ export const checkSlackChannelPlugin = createPlugin({
       },
     };
 
-    const result = await connectorsAPI.admin(checkChannelCmd);
+    const result = (await connectorsAPI.admin(
+      checkChannelCmd
+    )) as ConnectorsAPIResponse<SlackCheckChannelResponseType>;
     if (result.isErr()) {
       return new Err(
         new Error(`Failed to check channel: ${result.error.message}`)
       );
     }
 
+    const { name, isPrivate } = result.value.channel;
+
     return new Ok({
       display: "text",
-      value: `Channel ${channelId} exists and is accessible by the connector`,
+      value: `${isPrivate ? "Private" : "Public"} channel ${channelId} (${name ? `#${name}` : ""}) exists and is accessible by the connector`,
     });
   },
 });

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -592,6 +592,17 @@ export const SlackJoinResponseSchema = t.type({
   processed: t.number,
 });
 export type SlackJoinResponseType = t.TypeOf<typeof SlackJoinResponseSchema>;
+
+export const SlackCheckChannelResponseSchema = t.type({
+  success: t.literal(true),
+  channel: t.type({
+    name: t.union([t.string, t.undefined]),
+    isPrivate: t.union([t.boolean, t.undefined]),
+  }),
+});
+export type SlackCheckChannelResponseType = t.TypeOf<
+  typeof SlackCheckChannelResponseSchema
+>;
 /**
  * </Slack>
  */
@@ -843,6 +854,7 @@ export const AdminResponseSchema = t.union([
   NotionMeResponseSchema,
   NotionSearchPagesResponseSchema,
   NotionUpsertResponseSchema,
+  SlackCheckChannelResponseSchema,
   SalesforceCheckConnectionResponseSchema,
   SalesforceRunSoqlResponseSchema,
   SalesforceSetupSyncedQueryResponseSchema,


### PR DESCRIPTION
## Description

Enhances the "Check Slack Channel" poke plugin to return additional information about the channel (name and privacy status) instead of just a success boolean. The plugin now displays whether the channel is public or private, along with its name.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front and connector
