### PR TITLE
[PPUL] Check credit limits via CreditResource for feature-flagged users

### DIFF
--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -7,7 +7,8 @@ import type { RedisClientType } from "redis";
 import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { runOnRedis } from "@app/lib/api/redis";
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
-import type { Authenticator } from "@app/lib/auth";
+import type {Authenticator} from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -135,6 +136,11 @@ export async function hasReachedProgrammaticUsageLimits(
   }
 
   const owner = auth.getNonNullableWorkspace();
+  const featureFlags = await getFeatureFlags(owner);
+  if (featureFlags.includes("ppul")) {
+    return (await CreditResource.listActive(auth)).length === 0;
+  }
+
   const limits = getWorkspacePublicAPILimits(owner);
   if (!limits?.enabled) {
     return false;


### PR DESCRIPTION
## Description
For workspaces with the `ppul` feature flag, use the new `CreditResource.listActive` method instead of the legacy Redis-based credit tracking to determine if programmatic usage limits have been reached.

Returns "limits reached" when there are no active credits remaining (i.e., `listActive().length === 0`).

## Risks
Blast radius: Programmatic API usage limits for PPUL-flagged workspaces
Risk: low (feature-flagged, existing behavior preserved for non-flagged workspaces)

## Deploy Plan
- deploy front