### PR TITLE
Folder: table support in multi-upload

### DIFF
--- a/front/components/data_source/MultipleDocumentsUpload.tsx
+++ b/front/components/data_source/MultipleDocumentsUpload.tsx
@@ -32,15 +32,6 @@ import {
   isSupportedDelimitedTextContentType,
 } from "@app/types";
 
-// Helper to strip extension and slugify filename for table names
-function stripTableName(name: string): string {
-  return name
-    .replace(/\.(csv|tsv|xls|xlsx)$/i, "")
-    .replace(/[^a-z0-9]/gi, "_")
-    .toLowerCase()
-    .slice(0, 32);
-}
-
 // Helper to check if a file should be treated as a table based on its MIME type
 function isDelimitedFile(file: File): boolean {
   const contentType = file.type || "application/octet-stream";
@@ -207,15 +198,14 @@ export const MultipleDocumentsUpload = ({
           await concurrentExecutor(
             tableBlobs,
             async (blob: FileBlobWithFileId) => {
-              // For tables, we need to provide table-specific upsert args
-              const tableName = stripTableName(blob.filename);
+              const tableName = blob.filename;
               await doUpsertFileAsDataSourceEntry({
                 fileId: blob.fileId,
                 upsertArgs: {
                   title: blob.filename,
                   tableId: blob.fileId,
                   name: tableName,
-                  description: `Table uploaded from ${blob.filename}`,
+                  description: `Upload of ${blob.filename}`,
                 },
               });
 

--- a/front/components/data_source/MultipleFilesUpload.tsx
+++ b/front/components/data_source/MultipleFilesUpload.tsx
@@ -38,7 +38,7 @@ function isDelimitedFile(file: File): boolean {
   return isSupportedDelimitedTextContentType(contentType);
 }
 
-type MultipleDocumentsUploadProps = {
+type MultipleFilesUploadProps = {
   dataSourceView: DataSourceViewType;
   existingNodes: ContentNode[];
   isOpen: boolean;
@@ -48,7 +48,7 @@ type MultipleDocumentsUploadProps = {
   plan: PlanType;
 };
 
-export const MultipleDocumentsUpload = ({
+export const MultipleFilesUpload = ({
   dataSourceView,
   existingNodes,
   isOpen,
@@ -56,7 +56,7 @@ export const MultipleDocumentsUpload = ({
   owner,
   totalNodesCount,
   plan,
-}: MultipleDocumentsUploadProps) => {
+}: MultipleFilesUploadProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isLimitPopupOpen, setIsLimitPopupOpen] = useState(false);
   const [wasOpened, setWasOpened] = useState(isOpen);

--- a/front/components/data_source/MultipleFilesUpload.tsx
+++ b/front/components/data_source/MultipleFilesUpload.tsx
@@ -112,8 +112,8 @@ export const MultipleFilesUpload = ({
       // Check for duplicates unless explicitly skipped
       if (!skipDuplicateCheck) {
         const existingTitles = new Set(existingNodes.map((node) => node.title));
-        const duplicates = files.filter((file) =>
-          existingTitles.has(file.name)
+        const duplicates = files.filter(
+          (file) => existingTitles.has(file.name) && !isDelimitedFile(file)
         );
 
         if (duplicates.length > 0) {

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -13,7 +13,7 @@ import React, { useCallback, useImperativeHandle, useState } from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import { DocumentUploadOrEditModal } from "@app/components/data_source/DocumentUploadOrEditModal";
-import { MultipleDocumentsUpload } from "@app/components/data_source/MultipleDocumentsUpload";
+import { MultipleFilesUpload } from "@app/components/data_source/MultipleFilesUpload";
 import { TableUploadOrEditModal } from "@app/components/data_source/TableUploadOrEditModal";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
 import {
@@ -38,7 +38,7 @@ export type UploadOrEditContentActionKey =
 
 export type ContentActionKey =
   | UploadOrEditContentActionKey
-  | "MultipleDocumentsUpload"
+  | "MultipleFilesUpload"
   | "DeleteContentNode";
 
 export type ContentAction = {
@@ -131,10 +131,10 @@ export const ContentActions = React.forwardRef<
         ) : (
           <DocumentUploadOrEditModal {...modalProps} />
         )}
-        <MultipleDocumentsUpload
+        <MultipleFilesUpload
           dataSourceView={dataSourceView}
           existingNodes={existingNodes}
-          isOpen={currentAction.action === "MultipleDocumentsUpload"}
+          isOpen={currentAction.action === "MultipleFilesUpload"}
           onClose={onClose}
           owner={owner}
           totalNodesCount={totalNodesCount}

--- a/front/components/spaces/FoldersHeaderMenu.tsx
+++ b/front/components/spaces/FoldersHeaderMenu.tsx
@@ -129,9 +129,9 @@ const AddDataDropDownButton = ({
           <DropdownMenuItem
             icon={CloudArrowUpIcon}
             onClick={() => {
-              contentActionsRef.current?.callAction("MultipleDocumentsUpload");
+              contentActionsRef.current?.callAction("MultipleFilesUpload");
             }}
-            label="Upload multiple documents"
+            label="Upload multiple files"
           />
         </DropdownMenuContent>
       )}

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -543,11 +543,10 @@ export const SpaceDataSourceViewContentList = ({
 
       if (
         action === "DocumentUploadOrEdit" ||
-        action === "MultipleDocumentsUpload"
+        action === "MultipleDocumentsUpload" ||
+        action === "TableUploadOrEdit"
       ) {
-        handleViewTypeChange("document");
-      } else if (action === "TableUploadOrEdit") {
-        handleViewTypeChange("table");
+        handleViewTypeChange("all");
       }
     },
     [handleViewTypeChange, mutateContentNodes, startPeriodicRefresh]

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -543,7 +543,7 @@ export const SpaceDataSourceViewContentList = ({
 
       if (
         action === "DocumentUploadOrEdit" ||
-        action === "MultipleDocumentsUpload" ||
+        action === "MultipleFilesUpload" ||
         action === "TableUploadOrEdit"
       ) {
         handleViewTypeChange("all");
@@ -667,7 +667,7 @@ export const SpaceDataSourceViewContentList = ({
   );
 
   return (
-    // MultipleDocumentsUpload listens to the file drop context and uploads the files.
+    // MultipleFilesUpload listens to the file drop context and uploads the files.
     <FileDropProvider>
       <DropzoneContainer
         description="Drag and drop your files here."

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -356,20 +356,18 @@ export const SpaceDataSourceViewContentList = ({
 
   const { startPeriodicRefresh } = usePeriodicRefresh(mutateContentNodes);
 
-  const { hasContent: hasDocuments, isNodesValidating: isDocumentsValidating } =
-    useStaticDataSourceViewHasContent({
-      owner,
-      dataSourceView,
-      parentId,
-      viewType: "document",
-    });
-  const { hasContent: hasTables, isNodesValidating: isTablesValidating } =
-    useStaticDataSourceViewHasContent({
-      owner,
-      dataSourceView,
-      parentId,
-      viewType: "table",
-    });
+  const { hasContent: hasDocuments } = useStaticDataSourceViewHasContent({
+    owner,
+    dataSourceView,
+    parentId,
+    viewType: "document",
+  });
+  const { hasContent: hasTables } = useStaticDataSourceViewHasContent({
+    owner,
+    dataSourceView,
+    parentId,
+    viewType: "table",
+  });
 
   useEffect(() => {
     if (childrenNodes.length === 0) {
@@ -378,8 +376,6 @@ export const SpaceDataSourceViewContentList = ({
       setIsSearchDisabled(false);
     }
   }, [childrenNodes.length, setIsSearchDisabled]);
-
-  const isDataSourceManaged = isManaged(dataSourceView.dataSource);
 
   const addToSpace = useCallback(
     async (contentNode: DataSourceViewContentNode, spaceSId: string) => {
@@ -450,28 +446,6 @@ export const SpaceDataSourceViewContentList = ({
       sendNotification,
     ]
   );
-
-  useEffect(() => {
-    if (!isTablesValidating && !isDocumentsValidating) {
-      // If the view only has content in one of the two views, we switch to that view.
-      // if both views have content, or neither view has content, we default to documents.
-      if (hasTables && !hasDocuments) {
-        handleViewTypeChange("table");
-      } else if (!hasTables && hasDocuments) {
-        handleViewTypeChange("document");
-      } else if (!viewType) {
-        handleViewTypeChange(DEFAULT_VIEW_TYPE);
-      }
-    }
-  }, [
-    hasDocuments,
-    hasTables,
-    handleViewTypeChange,
-    viewType,
-    isTablesValidating,
-    isDocumentsValidating,
-    isDataSourceManaged,
-  ]);
 
   const rows: RowData[] = useMemo(
     () =>
@@ -606,6 +580,10 @@ export const SpaceDataSourceViewContentList = ({
                 <DropdownMenuItem
                   label="Tables"
                   onClick={() => handleViewTypeChange("table")}
+                />
+                <DropdownMenuItem
+                  label="All"
+                  onClick={() => handleViewTypeChange("all")}
                 />
               </DropdownMenuContent>
             </DropdownMenu>

--- a/front/components/spaces/SpaceFolderModal.tsx
+++ b/front/components/spaces/SpaceFolderModal.tsx
@@ -171,7 +171,7 @@ export default function SpaceFolderModal({
                   setDescription(e.target.value);
                 }}
                 showErrorLabel
-                minRows={2}
+                minRows={6}
               />
 
               {dataSourceView && (


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5334

Document/Table uploads would still reidrect to table/upload specific views. Fixed that I think we should remove the documnent/table views but that's for later us.

<img width="1016" height="648" alt="Screenshot 2025-12-04 at 13 50 08" src="https://github.com/user-attachments/assets/e6d07f19-93e8-46cc-a182-42ccd22d0911" />
<img width="1019" height="674" alt="Screenshot 2025-12-04 at 13 50 13" src="https://github.com/user-attachments/assets/e53e171f-0fdc-44f1-bcb4-1405d4b84b17" />
<img width="1016" height="1110" alt="Screenshot 2025-12-04 at 13 50 23" src="https://github.com/user-attachments/assets/31f0ccee-7f04-45b7-95db-def442c94da6" />
<img width="1010" height="1096" alt="Screenshot 2025-12-04 at 13 50 27" src="https://github.com/user-attachments/assets/efeab726-e431-46b2-a004-83af50415192" />
<img width="1020" height="861" alt="Screenshot 2025-12-04 at 13 50 38" src="https://github.com/user-attachments/assets/eaddaed5-ff5d-45fb-aa1a-c2de14e7a85b" />

## Tests

Local tests

## Risk

Low

## Deploy Plan

- deploy `front`