### PR TITLE
chore(logs): improve signature verification observability on private integrations

### DIFF
--- a/firebase-functions/webhook-router/src/notion/verification.ts
+++ b/firebase-functions/webhook-router/src/notion/verification.ts
@@ -72,6 +72,9 @@ export function createNotionVerificationMiddleware(
     res: express.Response,
     next: express.NextFunction
   ): Promise<void> => {
+    let providerWorkspaceId: string | undefined;
+    let connectorIdsByRegion: Record<string, number[]> | undefined;
+
     try {
       // Get the raw body for Notion signature verification.
       const stringBody = await parseExpressRequestRawBody(req);
@@ -114,6 +117,8 @@ export function createNotionVerificationMiddleware(
         req.regions = Object.keys(notionWebhookConfig.regions).filter(
           (key): key is Region => ALL_REGIONS.includes(key as Region)
         );
+        // Extract connectorIds by region for potential error logging
+        connectorIdsByRegion = notionWebhookConfig.regions;
         signingSecret = notionWebhookConfig.signingSecret;
       } else {
         // Get secrets for Notion signature verification (webhook secret already validated)
@@ -133,6 +138,8 @@ export function createNotionVerificationMiddleware(
         console.error("Notion request verification failed", {
           component: "notion-verification",
           error: error.message,
+          ...(providerWorkspaceId && { providerWorkspaceId }),
+          ...(connectorIdsByRegion && { connectorIdsByRegion }),
         });
         res.status(401).send();
         return;
@@ -141,6 +148,8 @@ export function createNotionVerificationMiddleware(
       console.error("Notion request verification failed", {
         component: "notion-verification",
         error: error instanceof Error ? error.message : String(error),
+        ...(providerWorkspaceId && { providerWorkspaceId }),
+        ...(connectorIdsByRegion && { connectorIdsByRegion }),
       });
       res.status(400).send();
       return;


### PR DESCRIPTION
## Description

We previously added providerWorkspaceId and connectorIds in the webhook router configuration file.
Let's add them to logs for better traceability in case of signature verification failure

## Tests

Local
<img width="510" height="124" alt="image" src="https://github.com/user-attachments/assets/6d311477-9825-4023-b1d2-5f30abd451fe" />

## Risk

Low

## Deploy Plan

Firebase function