### PR TITLE
[slackstorm] Remove feature flag + display warning for legacy apps

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -270,16 +270,14 @@ function UpdateConnectionOAuthModal({
 
   const { connectorProvider, editedByUser } = dataSource;
 
+  // TODO(slackstorm): Remove this slack specific code when all legacy connectors have been migrated
   const isSlack = connectorProvider === "slack";
-  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
-
   const { configValue: slackCredentialId } = useConnectorConfig({
     configKey: "privateIntegrationCredentialId",
     dataSource,
     owner,
     disabled: !isSlack,
   });
-
   const { isLegacySlackApp } = useSlackIsLegacy({
     workspaceId: owner.sId,
     credentialId: slackCredentialId,
@@ -339,6 +337,28 @@ function UpdateConnectionOAuthModal({
               )}
             </div>
           )}
+          {isLegacySlackApp && (
+            <div className="mb-4 mt-8 w-full rounded-lg bg-info-50 p-3">
+              <div className="flex items-center gap-2 font-medium text-info-800">
+                <Icon visual={InformationCircleIcon} />
+                Migration required
+              </div>
+              <div className="copy-sm p-4 text-info-900">
+                You are using a legacy way to connect your Slack workspace.
+                Starting December 2025, all Slack connections require customers
+                to create their own Slack app. This change ensures optimal
+                performance and reliable real-time syncing. Please{" "}
+                <a
+                  href="https://docs.dust.tt/docs/slack-connection/"
+                  target="_blank"
+                  className="text-highlight-600"
+                >
+                  read the doc
+                </a>{" "}
+                to learn more and see how to migrate.
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="flex flex-col gap-2 border-t pb-4 pt-4">
@@ -389,24 +409,16 @@ function UpdateConnectionOAuthModal({
                   .
                 </div>
               )}
-              {
-                isLegacySlackApp && "" // TODO(slackstorm) fabien: add message about legacy slack app
-              }
             </ContentMessage>
           </div>
         )}
-        {connectorUIConfiguration.oauthExtraConfigComponent &&
-          // TODO(slackstorm) fabien: remove flag and rely on isLegacySlackApp
-          !(
-            isSlack &&
-            !featureFlags.includes("self_created_slack_app_connector_rollout")
-          ) && (
-            <connectorUIConfiguration.oauthExtraConfigComponent
-              extraConfig={extraConfig}
-              setExtraConfig={setExtraConfig}
-              setIsExtraConfigValid={setIsExtraConfigValid}
-            />
-          )}
+        {connectorUIConfiguration.oauthExtraConfigComponent && (
+          <connectorUIConfiguration.oauthExtraConfigComponent
+            extraConfig={extraConfig}
+            setExtraConfig={setExtraConfig}
+            setIsExtraConfigValid={setIsExtraConfigValid}
+          />
+        )}
 
         <div className="flex items-center justify-center">
           <Dialog>

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -203,12 +203,6 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
       return undefined;
     }
 
-    // Check if the feature flag is enabled
-    const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-    if (!featureFlags.includes("self_created_slack_app_connector_rollout")) {
-      return undefined;
-    }
-
     // Note: we don't store the signing secret as it's not needed for OAuth connections.
     // It is only used for webhook validation
     return {

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -39,8 +39,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
   slack: {
     name: "Slack",
     connectorProvider: "slack",
-    status: "rolling_out",
-    rollingOutFlag: "self_created_slack_app_connector_rollout",
+    status: "built",
     isDeletable: false,
   },
   slack_bot: {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -122,11 +122,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Salesforce Connection: retrieval on Synchronized queries",
     stage: "on_demand",
   },
-  self_created_slack_app_connector_rollout: {
-    description:
-      "Slack Connection: rollout for self-created Slack app connector",
-    stage: "rolling_out",
-  },
   salesforce_tool: {
     description:
       "Salesforce MCP tool (activated by default on most plans, FF to override the plan config)",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -685,7 +685,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool"
   | "salesforce_tool_write"
   | "salesloft_tool"
-  | "self_created_slack_app_connector_rollout"
   | "show_debug_tools"
   | "skills"
   | "slack_bot_mcp"


### PR DESCRIPTION
## Description

<img width="2270" height="1716" alt="image" src="https://github.com/user-attachments/assets/ab35c520-6db1-4546-91d8-c437fdc02f1e" />


## Tests

tested amnually the warning message is correctly disaplayed

## Risk

ok, feature flag is removed so every body can now create and edit slack connectors

## Deploy Plan

deploy front
