### PR TITLE
fix(logs): set providerWorkspaceId correctly in notion signature verification

### DIFF
--- a/firebase-functions/webhook-router/src/notion/verification.ts
+++ b/firebase-functions/webhook-router/src/notion/verification.ts
@@ -108,7 +108,7 @@ export function createNotionVerificationMiddleware(
       if (useClientCredentials) {
         // It's a private client integration, so get the signing secret and regions from
         // the webhook router config.
-        const { providerWorkspaceId } = req.params;
+        providerWorkspaceId = req.params.providerWorkspaceId;
         const notionWebhookConfig = await webhookRouterConfigManager.getEntry(
           "notion",
           providerWorkspaceId


### PR DESCRIPTION


## Description

Hotfix of https://github.com/dust-tt/dust/pull/18650
Id was not properly set in notion verification logic.

## Tests

None

## Risk

Low

## Deploy Plan

Firebase function