### PR TITLE
feat(ppul): billing period aware graph

### DIFF
--- a/front/components/poke/credits/PokeProgrammaticCostChart.tsx
+++ b/front/components/poke/credits/PokeProgrammaticCostChart.tsx
@@ -10,6 +10,7 @@ import type { WorkspaceType } from "@app/types";
 
 interface PokeProgrammaticCostChartProps {
   owner: WorkspaceType;
+  billingCycleStartDay: number;
 }
 
 /**
@@ -18,6 +19,7 @@ interface PokeProgrammaticCostChartProps {
  */
 export function PokeProgrammaticCostChart({
   owner,
+  billingCycleStartDay,
 }: PokeProgrammaticCostChartProps) {
   const [groupBy, setGroupBy] = useState<GroupByType | undefined>(undefined);
   const [filter, setFilter] = useState<Partial<Record<GroupByType, string[]>>>(
@@ -34,6 +36,7 @@ export function PokeProgrammaticCostChart({
   } = usePokeProgrammaticCost({
     owner,
     selectedMonth,
+    billingCycleStartDay,
     groupBy,
     filter,
   });
@@ -49,6 +52,7 @@ export function PokeProgrammaticCostChart({
       setFilter={setFilter}
       selectedMonth={selectedMonth}
       setSelectedMonth={setSelectedMonth}
+      billingCycleStartDay={billingCycleStartDay}
     />
   );
 }

--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -4,10 +4,11 @@ import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditio
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import { usePokeCredits } from "@app/poke/swr/credits";
-import type { WorkspaceType } from "@app/types";
+import type { SubscriptionType, WorkspaceType } from "@app/types";
 
 interface CreditsDataTableProps {
   owner: WorkspaceType;
+  subscription: SubscriptionType;
   loadOnInit?: boolean;
 }
 
@@ -30,7 +31,16 @@ function sortByExpirationDate(credits: PokeCreditType[]): PokeCreditType[] {
   });
 }
 
-export function CreditsDataTable({ owner, loadOnInit }: CreditsDataTableProps) {
+export function CreditsDataTable({
+  owner,
+  subscription,
+  loadOnInit,
+}: CreditsDataTableProps) {
+  // Get the billing cycle start day from the subscription start date
+  const billingCycleStartDay = subscription.startDate
+    ? new Date(subscription.startDate).getDate()
+    : null;
+
   return (
     <>
       <PokeDataTableConditionalFetch
@@ -48,7 +58,12 @@ export function CreditsDataTable({ owner, loadOnInit }: CreditsDataTableProps) {
         )}
       </PokeDataTableConditionalFetch>
 
-      <PokeProgrammaticCostChart owner={owner} />
+      {billingCycleStartDay && (
+        <PokeProgrammaticCostChart
+          owner={owner}
+          billingCycleStartDay={billingCycleStartDay}
+        />
+      )}
     </>
   );
 }

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -40,10 +40,12 @@ import type {
   GetWorkspaceProgrammaticCostResponse,
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
+import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import { useWorkspaceProgrammaticCost } from "@app/lib/swr/workspaces";
 
 interface ProgrammaticCostChartProps {
   workspaceId: string;
+  billingCycleStartDay: number;
 }
 
 export interface BaseProgrammaticCostChartProps {
@@ -58,6 +60,7 @@ export interface BaseProgrammaticCostChartProps {
   >;
   selectedMonth: string;
   setSelectedMonth: (month: string) => void;
+  billingCycleStartDay: number;
 }
 
 type ChartDataPoint = {
@@ -171,6 +174,7 @@ export function BaseProgrammaticCostChart({
   setFilter,
   selectedMonth,
   setSelectedMonth,
+  billingCycleStartDay,
 }: BaseProgrammaticCostChartProps) {
   // Cache labels for each groupBy type so they persist when switching modes
   const [labelCache, setLabelCache] = useState<
@@ -180,31 +184,42 @@ export function BaseProgrammaticCostChart({
   const now = new Date();
   const currentDate = new Date(selectedMonth);
 
-  // Get current month name
-  const currentMonth = currentDate.toLocaleDateString("en-US", {
-    month: "long",
-    year: "numeric",
-  });
+  // Calculate the billing cycle for the selected month
+  const billingCycle = getBillingCycleFromDay(
+    billingCycleStartDay,
+    currentDate,
+    false
+  );
 
-  // Calculate next and previous month dates
-  const nextMonthDate = new Date(
+  const formatDate = (date: Date) =>
+    date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+
+  // Format period label based on billing cycle
+  const periodLabel = `${formatDate(billingCycle.cycleStart)} → ${formatDate(billingCycle.cycleEnd)}`;
+
+  // Calculate next and previous period dates
+  const nextPeriodDate = new Date(
     Date.UTC(currentDate.getUTCFullYear(), currentDate.getUTCMonth() + 1, 1)
   );
-  const previousMonthDate = new Date(
+  const previousPeriodDate = new Date(
     Date.UTC(currentDate.getUTCFullYear(), currentDate.getUTCMonth() - 1, 1)
   );
 
-  // Check if we can go to next month (not in the future)
-  const canGoNext = nextMonthDate.getTime() <= now.getTime();
+  // Check if we can go to next period (not in the future)
+  const canGoNext = billingCycle.cycleEnd.getTime() <= now.getTime();
 
-  // Navigate to next month
-  const handleNextMonth = () => {
-    setSelectedMonth(formatMonth(nextMonthDate));
+  // Navigate to next period
+  const handleNextPeriod = () => {
+    setSelectedMonth(formatMonth(nextPeriodDate));
   };
 
-  // Navigate to previous month
-  const handlePreviousMonth = () => {
-    setSelectedMonth(formatMonth(previousMonthDate));
+  // Navigate to previous period
+  const handlePreviousPeriod = () => {
+    setSelectedMonth(formatMonth(previousPeriodDate));
   };
 
   // Group by change
@@ -413,30 +428,30 @@ export function BaseProgrammaticCostChart({
     <ChartContainer
       title={
         <div className="flex items-center gap-2">
-          <span>Programmatic Cost</span>
+          <span>Usage Graph</span>
           <Button
             icon={ChevronLeftIcon}
             size="xs"
             variant="ghost"
-            onClick={handlePreviousMonth}
-            tooltip="Previous month"
+            onClick={handlePreviousPeriod}
+            tooltip="Previous period"
           />
 
           <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            {currentMonth}
+            {periodLabel}
           </span>
           {canGoNext && (
             <Button
               icon={ChevronRightIcon}
               size="xs"
               variant="ghost"
-              onClick={handleNextMonth}
-              tooltip="Next month"
+              onClick={handleNextPeriod}
+              tooltip="Next period"
             />
           )}
         </div>
       }
-      description="Total cost accumulated since the start of the month."
+      description="Total cost accumulated. Filter by clicking on legend items."
       isLoading={isProgrammaticCostLoading}
       errorMessage={
         isProgrammaticCostError
@@ -599,6 +614,7 @@ export function BaseProgrammaticCostChart({
  */
 export function ProgrammaticCostChart({
   workspaceId,
+  billingCycleStartDay,
 }: ProgrammaticCostChartProps) {
   const [groupBy, setGroupBy] = useState<GroupByType | undefined>(undefined);
   const [filter, setFilter] = useState<Partial<Record<GroupByType, string[]>>>(
@@ -615,6 +631,7 @@ export function ProgrammaticCostChart({
   } = useWorkspaceProgrammaticCost({
     workspaceId,
     selectedMonth,
+    billingCycleStartDay,
     groupBy,
     filter,
   });
@@ -630,6 +647,7 @@ export function ProgrammaticCostChart({
       setFilter={setFilter}
       selectedMonth={selectedMonth}
       setSelectedMonth={setSelectedMonth}
+      billingCycleStartDay={billingCycleStartDay}
     />
   );
 }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -157,18 +157,21 @@ export function useWorkspaceProgrammaticCost({
   workspaceId,
   groupBy,
   selectedMonth,
+  billingCycleStartDay,
   filter,
   disabled,
 }: {
   workspaceId: string;
   groupBy?: GroupByType;
   selectedMonth?: string;
+  billingCycleStartDay: number;
   filter?: Partial<Record<GroupByType, string[]>>;
   disabled?: boolean;
 }) {
   const fetcherFn: Fetcher<GetWorkspaceProgrammaticCostResponse> = fetcher;
 
   const queryParams = new URLSearchParams();
+  queryParams.set("billingCycleStartDay", billingCycleStartDay.toString());
   if (selectedMonth) {
     queryParams.set("selectedMonth", selectedMonth);
   }
@@ -179,7 +182,7 @@ export function useWorkspaceProgrammaticCost({
     queryParams.set("filter", JSON.stringify(filter));
   }
   const queryString = queryParams.toString();
-  const key = `/api/w/${workspaceId}/analytics/programmatic-cost${queryString ? `?${queryString}` : ""}`;
+  const key = `/api/w/${workspaceId}/analytics/programmatic-cost?${queryString}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -320,7 +320,11 @@ const WorkspacePage = ({
               <TriggerDataTable owner={owner} loadOnInit />
             </TabsContent>
             <TabsContent value="credits">
-              <CreditsDataTable owner={owner} loadOnInit />
+              <CreditsDataTable
+                owner={owner}
+                subscription={activeSubscription}
+                loadOnInit
+              />
             </TabsContent>
           </Tabs>
         </div>

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -29,16 +29,19 @@ export function usePokeProgrammaticCost({
   owner,
   groupBy,
   selectedMonth,
+  billingCycleStartDay,
   filter,
   disabled,
 }: PokeConditionalFetchProps & {
   groupBy?: GroupByType;
   selectedMonth?: string;
+  billingCycleStartDay: number;
   filter?: Partial<Record<GroupByType, string[]>>;
 }) {
   const fetcherFn: Fetcher<GetWorkspaceProgrammaticCostResponse> = fetcher;
 
   const queryParams = new URLSearchParams();
+  queryParams.set("billingCycleStartDay", billingCycleStartDay.toString());
   if (selectedMonth) {
     queryParams.set("selectedMonth", selectedMonth);
   }
@@ -49,7 +52,7 @@ export function usePokeProgrammaticCost({
     queryParams.set("filter", JSON.stringify(filter));
   }
   const queryString = queryParams.toString();
-  const key = `/api/poke/workspaces/${owner.sId}/analytics/programmatic-cost${queryString ? `?${queryString}` : ""}`;
+  const key = `/api/poke/workspaces/${owner.sId}/analytics/programmatic-cost?${queryString}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR aligns usage graph with billing cycles and fix period navigation

  - Billing cycle alignment: Usage graph now displays data aligned with subscription billing cycles (e.g., 4th→4th) instead of calendar months
  - UI updates: Renamed "Programmatic Cost" to "Usage Graph", updated section header from "Usage" to "Available credits", improved description text
  - refactor: Extracted getBillingCycleFromDay() utility in lib/client/subscription.ts with UTC support, removing duplicated billing cycle logic from both frontend and backend
  - API change: Made billingCycleStartDay a required parameter in the programmatic cost API

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front