### PR TITLE
Make approval and personal connexion requests visible only to the original user.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -98,7 +98,7 @@ function createServer(
         }
 
         const response = makeMCPToolExit({
-          message: `Handoff from ${serializeMention(agentConfiguration)} to ${serializeMention({ name: DEEP_DIVE_NAME, sId: GLOBAL_AGENTS_SID.DEEP_DIVE })}successfully launched.`,
+          message: `Handoff from ${serializeMention(agentConfiguration)} to ${serializeMention({ name: DEEP_DIVE_NAME, sId: GLOBAL_AGENTS_SID.DEEP_DIVE })} successfully launched.`,
           isError: false,
         });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -668,6 +668,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         where: {
           conversationId: conversation.id,
           workspaceId: auth.getNonNullableWorkspace().id,
+          userId: auth.getNonNullableUser().id,
         },
       }
     );


### PR DESCRIPTION
## Description

Only show the tool approvals & connexions requests to the original user.

## Tests

Added a few + local

## Risk

Low

## Deploy Plan

Deploy front