### PR TITLE
[front] - chore(AgentMessage): prettify action buttons

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.20",
-        "@dust-tt/sparkle": "^0.4.9",
+        "@dust-tt/sparkle": "^0.4.12",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1286,9 +1286,10 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.9.tgz",
-      "integrity": "sha512-wTjl2Xeas9UMBOeXxcJwl810qhbcItyWY+yqsQc3WWQO4cOYkePBNl9uVUF0WvjwpMOh6vJ7y0FGKWhfjw4/eA==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.12.tgz",
+      "integrity": "sha512-Tl1jJSrcIVNkIN6p/9HnwlZUPPY90iuK+LwHjQ5kNCsKcuCxmlDRJDppD/JwGUR1Xz+4JOBx/uDAikxTK2+2rQ==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.20",
-    "@dust-tt/sparkle": "^0.4.11",
+    "@dust-tt/sparkle": "^0.4.12",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -500,7 +500,6 @@ export function AgentMessage({
         key="feedback-selector"
         {...messageFeedback}
         getPopoverInfo={PopoverContent}
-        owner={owner}
       />
     );
   }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1,15 +1,14 @@
-import type { ButtonGroupItem } from "@dust-tt/sparkle";
 import {
   ArrowPathIcon,
   Button,
   ButtonGroup,
-  ChevronDownIcon,
   Chip,
   ClipboardCheckIcon,
   ClipboardIcon,
   ConversationMessage,
   InteractiveImageGrid,
   Markdown,
+  MoreIcon,
   Separator,
   StopIcon,
   TrashIcon,
@@ -521,7 +520,6 @@ export function AgentMessage({
               size: "xs",
               onClick: handleCopyToClipboard,
               icon: isCopied ? ClipboardCheckIcon : ClipboardIcon,
-              className: "text-muted-foreground",
             },
           },
           {
@@ -529,8 +527,7 @@ export function AgentMessage({
             triggerProps: {
               variant: "ghost-secondary",
               size: "xs",
-              icon: ChevronDownIcon,
-              className: "text-muted-foreground",
+              icon: MoreIcon,
             },
             dropdownProps: {
               items: dropdownItems,

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -43,7 +43,6 @@ export function FeedbackSelector({
   owner,
 }: FeedbackSelectorProps) {
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
-  const userMentionsEnabled = hasFeature("mentions_v2");
 
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ButtonGroup,
   Checkbox,
   HandThumbDownIcon,
   HandThumbUpIcon,
@@ -139,43 +138,26 @@ export function FeedbackSelector({
     lastSelectedThumb,
   ]);
 
-  const ThumbUpButton = (
-    <Button
-      tooltip="I found this helpful"
-      variant={feedback?.thumb === "up" ? "primary" : "ghost-secondary"}
-      size="xs"
-      disabled={isSubmittingThumb}
-      onClick={handleThumbUp}
-      icon={HandThumbUpIcon}
-      // We enforce written feedback for thumbs down.
-      // -> Not saving the reaction until then.
-      className={feedback?.thumb === "up" ? "" : "text-muted-foreground"}
-    />
-  );
-
-  const ThumbDownButton = (
-    <Button
-      tooltip="Report an issue with this answer"
-      variant={feedback?.thumb === "down" ? "primary" : "ghost-secondary"}
-      size="xs"
-      disabled={isSubmittingThumb}
-      onClick={handleThumbDown}
-      icon={HandThumbDownIcon}
-      // We enforce written feedback for thumbs down.
-      // -> Not saving the reaction until then.
-      className={feedback?.thumb === "down" ? "" : "text-muted-foreground"}
-    />
-  );
-
-  const ThumbButtons = userMentionsEnabled ? (
-    <ButtonGroup variant="outline">
-      {ThumbUpButton}
-      {ThumbDownButton}
-    </ButtonGroup>
-  ) : (
+  const ThumbButtons = (
     <div className="flex items-center gap-0.5">
-      {ThumbUpButton}
-      {ThumbDownButton}
+      <Button
+        tooltip="I found this helpful"
+        variant={feedback?.thumb === "up" ? "primary" : "ghost-secondary"}
+        size="xs"
+        disabled={isSubmittingThumb}
+        onClick={handleThumbUp}
+        icon={HandThumbUpIcon}
+        className={feedback?.thumb === "up" ? "" : "text-muted-foreground"}
+      />
+      <Button
+        tooltip="Report an issue with this answer"
+        variant={feedback?.thumb === "down" ? "primary" : "ghost-secondary"}
+        size="xs"
+        disabled={isSubmittingThumb}
+        onClick={handleThumbDown}
+        icon={HandThumbDownIcon}
+        className={feedback?.thumb === "down" ? "" : "text-muted-foreground"}
+      />
     </div>
   );
 

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -12,7 +12,6 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useCallback, useEffect, useRef } from "react";
 
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { WorkspaceType } from "@app/types";
 
 export type ThumbReaction = "up" | "down";
@@ -40,10 +39,7 @@ export function FeedbackSelector({
   onSubmitThumb,
   isSubmittingThumb,
   getPopoverInfo,
-  owner,
 }: FeedbackSelectorProps) {
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
-
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const [localFeedbackContent, setLocalFeedbackContent] = React.useState<

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.12-rc-3",
+        "@dust-tt/sparkle": "^0.4.12",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1330,9 +1330,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.12-rc-3",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.12-rc-3.tgz",
-      "integrity": "sha512-YvevDgfc9rV70xRKdoWZMwsL1xSQ0+tORZ9W3w1qvr5aVnrLX04JxFieMngJ21YvaN5YPwnXanl9p6oKbvzxbQ==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.12.tgz",
+      "integrity": "sha512-Tl1jJSrcIVNkIN6p/9HnwlZUPPY90iuK+LwHjQ5kNCsKcuCxmlDRJDppD/JwGUR1Xz+4JOBx/uDAikxTK2+2rQ==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.11",
+        "@dust-tt/sparkle": "^0.4.12-rc-3",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1330,9 +1330,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.11.tgz",
-      "integrity": "sha512-RoMRRUU+MZ/vLtTczkxY99idLk7x2PBy/W4OczxMBm3RsCeH9KLtv/8FQPW22gzfhtj7SjtzpNzs6f5xKiXv5w==",
+      "version": "0.4.12-rc-3",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.12-rc-3.tgz",
+      "integrity": "sha512-YvevDgfc9rV70xRKdoWZMwsL1xSQ0+tORZ9W3w1qvr5aVnrLX04JxFieMngJ21YvaN5YPwnXanl9p6oKbvzxbQ==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -39,7 +39,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.12-rc-3",
+    "@dust-tt/sparkle": "^0.4.12",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",

--- a/front/package.json
+++ b/front/package.json
@@ -39,7 +39,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.11",
+    "@dust-tt/sparkle": "^0.4.12-rc-3",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

Consolidates agent message action buttons into a cleaner, more organized UI. Replaces separate button groups with a single streamlined button array and introduces a split button pattern that combines the copy button with a dropdown menu containing retry and delete actions.

<img width="812" height="426" alt="Screenshot 2025-12-04 at 15 18 58" src="https://github.com/user-attachments/assets/6929e043-b5d6-4d41-b387-d80a3c84217d" />

## Risk

Low

## Tests

Locally

## Deploy plan

- Front
