### PR TITLE
[PPUL] Fix edge case when user subscribes and pays within 5 days

### DIFF
--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -418,9 +418,12 @@ export default function CreditsUsagePage({
           </ContentMessage>
         )}
 
+        {/* Purposefully not giving email since we want to test determination here and limit support requests, it's a very edgy case and most likely fraudulent. */}
         {subscription.trialing && (
           <ContentMessage title="Available after trial" variant="info">
-            Credit purchases are available once you upgrade to a paid plan.
+            Credit purchases are available once you upgrade to a paid plan. If
+            you would like to purchase credits before upgrading, please contact
+            support.
           </ContentMessage>
         )}
 


### PR DESCRIPTION
## Description
When a user subscribes and their first invoice is paid within 5 days, `countEligibleUsersForFreeCredits` could return 0 (no members had membership span >= 5 days ago). This caused an assertion failure since `creditAmountMicroUsd` became 0.

Changes:
- `countEligibleUsersForFreeCredits` now always returns at least 1 user
- Refactored `customerStatus` handling to use switch/case with `assertNever` for exhaustive type checking

## Risks
Blast radius: Free credits grant on subscription renewal
Risk: low (fixes a bug, adds type safety)

## Deploy Plan
- deploy front