### PR TITLE
Collapsible categories for customer stories

### DIFF
--- a/front/components/home/menu/config.ts
+++ b/front/components/home/menu/config.ts
@@ -254,7 +254,7 @@ const ExploreMenuConfig: MenuConfig = {
     },
     {
       title: "Customer Stories",
-      href: "/blog?tag=Customer%20Stories",
+      href: "/customers",
     },
   ],
 };

--- a/front/pages/customers/index.tsx
+++ b/front/pages/customers/index.tsx
@@ -1,3 +1,4 @@
+import { CollapsibleComponent } from "@dust-tt/sparkle";
 import type { GetStaticProps } from "next";
 import Head from "next/head";
 import Image from "next/image";
@@ -22,6 +23,16 @@ import type {
 import { classNames } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 
+function sortCompanySizes(sizes: string[]): string[] {
+  return [...sizes].sort((a, b) => {
+    const getFirstNumber = (size: string): number => {
+      const match = size.match(/^(\d+)/);
+      return match ? parseInt(match[1], 10) : 0;
+    };
+    return getFirstNumber(a) - getFirstNumber(b);
+  });
+}
+
 function extractFilterOptions(
   stories: CustomerStorySummary[]
 ): CustomerStoryFilterOptions {
@@ -44,7 +55,7 @@ function extractFilterOptions(
   return {
     industries: [...industries].sort(),
     departments: [...departments].sort(),
-    companySizes: [...companySizes].sort(),
+    companySizes: sortCompanySizes([...companySizes]),
   };
 }
 
@@ -105,6 +116,7 @@ interface FilterSectionProps {
   options: readonly string[];
   selected: string[];
   onChange: (selected: string[]) => void;
+  defaultOpen?: boolean;
 }
 
 function FilterSection({
@@ -112,6 +124,7 @@ function FilterSection({
   options,
   selected,
   onChange,
+  defaultOpen = false,
 }: FilterSectionProps) {
   const handleToggle = useCallback(
     (option: string, checked: boolean) => {
@@ -126,17 +139,25 @@ function FilterSection({
 
   return (
     <div className="mb-6">
-      <h3 className="mb-3 text-sm font-semibold text-foreground">{title}</h3>
-      <div className="flex flex-col gap-2">
-        {options.map((option) => (
-          <FilterCheckbox
-            key={option}
-            label={option}
-            checked={selected.includes(option)}
-            onChange={(checked) => handleToggle(option, checked)}
-          />
-        ))}
-      </div>
+      <CollapsibleComponent
+        rootProps={{ defaultOpen }}
+        triggerProps={{
+          label: title,
+          variant: "secondary",
+        }}
+        contentChildren={
+          <div className="flex flex-col gap-2">
+            {options.map((option) => (
+              <FilterCheckbox
+                key={option}
+                label={option}
+                checked={selected.includes(option)}
+                onChange={(checked) => handleToggle(option, checked)}
+              />
+            ))}
+          </div>
+        }
+      />
     </div>
   );
 }
@@ -283,6 +304,7 @@ export default function CustomerStoriesListing({
                 options={filterOptions.industries}
                 selected={selectedIndustries}
                 onChange={(values) => updateFilters("industry", values)}
+                defaultOpen={true}
               />
 
               <FilterSection


### PR DESCRIPTION
## Description

Makes filter categories collapsible on the customer stories listing page to improve UX when browsing with many filter options. The "Industry" filter opens by default while others start collapsed. Also fixes company size sorting to use numerical order (e.g., "1-50" before "500+") instead of alphabetical, and updates the header menu to link directly to `/customers` instead of the blog tag.

## Risk

Low. Changes only affect the public customer stories page UI and navigation.

