### PR TITLE
[front] - fix(conversation): console log

### DIFF
--- a/front/components/assistant/conversation/NewConversationMessage.tsx
+++ b/front/components/assistant/conversation/NewConversationMessage.tsx
@@ -270,18 +270,24 @@ const ConversationMessageTitle = React.forwardRef<
   HTMLDivElement,
   ConversationMessageTitleProps
 >(
-  ({
-    name = "",
-    timestamp,
-    infoChip,
-    completionStatus,
-    renderName,
-    actions,
-    className,
-  }) => {
+  (
+    {
+      name = "",
+      timestamp,
+      infoChip,
+      completionStatus,
+      renderName,
+      actions,
+      className,
+      ...props
+    },
+    ref
+  ) => {
     return (
       <div
+        ref={ref}
         className={cn("inline-flex w-full justify-between gap-0.5", className)}
+        {...props}
       >
         <div className="inline-flex items-baseline gap-2 text-foreground dark:text-foreground-night">
           <span className="heading-sm">{renderName(name)}</span>

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -7,7 +7,7 @@ import type { RedisClientType } from "redis";
 import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { runOnRedis } from "@app/lib/api/redis";
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
-import type {Authenticator} from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";


### PR DESCRIPTION
## Description

This PR aims at fixing the following console error:
```
  NewConversationMessage.tsx:269 Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
  ```

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front