### PR TITLE
fix(cli): MCP server 401 unauthorized errors

### DIFF
--- a/cli/src/mcp/servers/fsServer.ts
+++ b/cli/src/mcp/servers/fsServer.ts
@@ -88,12 +88,7 @@ export const useFileSystemServer = async (
     },
     "fs-cli",
     false,
-    365 * 24 * 60 * 60 * 1000
-    // TODO: This is kind of a hack that is ok for now,
-    // the reason we need this is because we have yaffle's event source polyfill,
-    // which doesnt allow us to turn off timeouts, so we would need to continuously
-    // send keep alive messages from server, but there is currently an
-    // optimization to stop those messages from sever when mcp tools are not being used.
+    3 * 60 * 1000 // 3 minutes
   );
 
   try {

--- a/cli/src/utils/authService.ts
+++ b/cli/src/utils/authService.ts
@@ -105,7 +105,7 @@ export const AuthService = {
     const currentTime = Math.floor(Date.now() / 1000);
     const timeUntilExpiry = (decoded.exp ?? 0) - currentTime;
 
-    if (timeUntilExpiry < 30) {
+    if (timeUntilExpiry < 120) {
       const refreshed = await this.refreshTokens();
       if (refreshed.isOk()) {
         return new Ok(await TokenStorage.getAccessToken());


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Fix MCP server 401 Unauthorized errors in CLI by aligning token refresh behavior with the Front extension (which uses the DustMCPTransport and works).

Changes:
  - cli/src/mcp/servers/fsServer.ts: Reduced heartbeat timeout from 1 year to 3 minutes, allowing reconnections to refresh OAuth tokens before they expire (5 min lifetime)
  - cli/src/utils/authService.ts: Increased proactive token refresh threshold from 30 seconds to 2 minutes, ensuring fresh tokens are available during reconnection

  Root cause: The CLI used an extremely long heartbeat timeout to avoid reconnection noise, but this prevented the SSE reconnection flow from refreshing expired OAuth headers. The Front extension works because it uses shorter timeouts that trigger the onerror → connectToRequestsStream() → getMCPRequestsConnectionDetails() flow, which fetches fresh auth headers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, waiting for 20 minutes in the CLI, and had no errors.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy CLI version