### PR TITLE
[slackstorm] run the firebase webhook router process in a docker

### DIFF
--- a/firebase-functions/webhook-router/.gitignore
+++ b/firebase-functions/webhook-router/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 # Environment variables
 .env
 !.env.local
+
+# Firebase emulator data
+.emulator-data/

--- a/firebase-functions/webhook-router/Dockerfile
+++ b/firebase-functions/webhook-router/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20
+
+# Install Java 21 (required for Firebase storage/database emulators)
+# Add Adoptium repo
+RUN wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add - \
+    && echo "deb https://packages.adoptium.net/artifactory/deb bookworm main" \
+       > /etc/apt/sources.list.d/adoptium.list
+
+# Install Temurin JDK 21
+RUN apt-get update && apt-get install -y temurin-21-jdk
+
+# Install Firebase tools globally
+RUN npm install -g firebase-tools
+
+WORKDIR /app

--- a/firebase-functions/webhook-router/docker-compose.yml
+++ b/firebase-functions/webhook-router/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  firebase-emulators:
+    build: .
+    working_dir: /app
+    init: true
+    stop_grace_period: 30s
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+      - firebase-cache:/root/.cache/firebase
+    ports:
+      - "5001:5001" # functions
+      - "9000:9000" # database
+      - "9199:9199" # storage
+      - "4000:4000" # emulator UI
+    command: ./docker-entrypoint.sh
+
+volumes:
+  node_modules:
+  firebase-cache:

--- a/firebase-functions/webhook-router/docker-entrypoint.sh
+++ b/firebase-functions/webhook-router/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+npm install
+
+# Build
+npm run build
+
+# We need to gracefully stop the firebase process so it exports on exit
+
+# Trap SIGTERM and SIGINT to gracefully shutdown
+trap 'kill -TERM $PID; wait $PID' TERM INT
+
+# Start emulators in background
+firebase emulators:start --only functions,storage,database --import=.emulator-data --export-on-exit=.emulator-data &
+PID=$!
+
+# Wait for the process
+wait $PID

--- a/firebase-functions/webhook-router/docker-entrypoint.sh
+++ b/firebase-functions/webhook-router/docker-entrypoint.sh
@@ -3,8 +3,11 @@ set -e
 
 npm install
 
-# Build
+# Initial build (blocking) to ensure dist/ exists
 npm run build
+
+# Start watch mode for subsequent changes
+npm run build:watch &
 
 # We need to gracefully stop the firebase process so it exports on exit
 

--- a/firebase-functions/webhook-router/firebase.json
+++ b/firebase-functions/webhook-router/firebase.json
@@ -17,19 +17,25 @@
   },
   "emulators": {
     "functions": {
+      "host": "0.0.0.0",
       "port": 5001
     },
     "database": {
+      "host": "0.0.0.0",
       "port": 9000
     },
     "hosting": {
+      "host": "0.0.0.0",
       "port": 5000
     },
     "storage": {
+      "host": "0.0.0.0",
       "port": 9199
     },
     "ui": {
-      "enabled": true
+      "enabled": true,
+      "host": "0.0.0.0",
+      "port": 4000
     },
     "singleProjectMode": true
   },

--- a/firebase-functions/webhook-router/package.json
+++ b/firebase-functions/webhook-router/package.json
@@ -6,6 +6,7 @@
   "main": "dist/firebase.js",
   "scripts": {
     "build": "tsc",
+    "build:watch": "tsc --watch",
     "start": "npm run build && firebase emulators:start --only functions,storage,database",
     "dev": "npm run start",
     "lint": "eslint src/**/*.ts",

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -83,9 +83,7 @@ procs:
 
   firebase-webhook-router:
     cwd: "<CONFIG_DIR>/../firebase-functions/webhook-router"
-    shell: |
-      set -euo pipefail
-      source ~/.nvm/nvm.sh && nvm install && npm install && npm run dev
+    shell: "docker-compose up --build"
     autostart: false
 
   novu:


### PR DESCRIPTION
## Description

 - move the process to a docker so we don't need to install java
 - use this docker compose in the mprocs so it is easy to start
 - persists the storage data so restarting mprocs is not an issue

## Tests

manual tests

## Risk
low

## Deploy Plan
no
