### PR TITLE
[front] feat: Send an email when programmatic usage has been reached

### DIFF
--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -162,6 +162,47 @@ export async function sendProactiveTrialCancelledEmail(
   });
 }
 
+export async function sendCreditUsageAlertEmail({
+  email,
+  workspaceName,
+  workspaceSId,
+  percentUsed,
+  totalInitialMicroUsd,
+  totalConsumedMicroUsd,
+}: {
+  email: string;
+  workspaceName: string;
+  workspaceSId: string;
+  percentUsed: number;
+  totalInitialMicroUsd: number;
+  totalConsumedMicroUsd: number;
+}): Promise<void> {
+  const remainingMicroUsd = totalInitialMicroUsd - totalConsumedMicroUsd;
+  const formatCents = (microUsd: number) =>
+    `$${(microUsd / 1_000_000).toFixed(2)}`;
+
+  await sendEmailWithTemplate({
+    to: email,
+    from: config.getSupportEmailAddress(),
+    subject: `[Dust] Credit usage alert - ${percentUsed}% of your credits consumed`,
+    body: `
+      <p>You're receiving this as Admin of the Dust workspace <strong>${workspaceName}</strong>.</p>
+      <p>Your workspace has consumed <strong>${percentUsed}%</strong> of its available Programmatic Usage credits.</p>
+      <ul>
+        <li>Total credits: ${formatCents(totalInitialMicroUsd)}</li>
+        <li>Consumed: ${formatCents(totalConsumedMicroUsd)}</li>
+        <li>Remaining: ${formatCents(remainingMicroUsd)}</li>
+      </ul>
+      <p>To avoid service interruption, consider:</p>
+      <ul>
+        <li>Purchasing additional credits</li>
+        <li>Reviewing your programmatic API usage</li>
+      </ul>
+      <p>View your usage details at: <a href="https://dust.tt/w/${workspaceSId}/developers/credits-usage">https://dust.tt/w/${workspaceSId}/developers/credits-usage</a></p>
+      <p>Please reply to this email if you have any questions.</p>`,
+  });
+}
+
 // Avoid using this function directly, use sendEmailWithTemplate instead.
 export async function sendEmail(email: string, message: any) {
   const msg = { ...message, to: email };

--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -160,7 +160,10 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
         invoiceOrLineItemId: idempotencyKey,
       });
 
-      const startResult = await credit.start(startDate, expirationDate);
+      const startResult = await credit.start(auth, {
+        startDate,
+        expirationDate,
+      });
       if (startResult.isErr()) {
         return new Err(startResult.error);
       }

--- a/front/lib/api/programmatic_usage_tracking.test.ts
+++ b/front/lib/api/programmatic_usage_tracking.test.ts
@@ -169,7 +169,10 @@ describe("decreaseProgrammaticCreditsV2", () => {
     });
     // Use a start date clearly in the past to avoid timing issues
     const startDate = new Date(Date.now() - 1000);
-    await credit.start(startDate, expirationDate);
+    await credit.start(auth, {
+      startDate,
+      expirationDate,
+    });
     return credit;
   }
 

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -360,19 +360,19 @@ export async function trackProgrammaticCost(
       const workspace = auth.getNonNullableWorkspace();
       const featureFlags = await getFeatureFlags(workspace);
       if (featureFlags.includes("ppul")) {
-        const thresholdId = workspace.metadata?.creditAlertThresholdId;
+        const idempotencyKey = workspace.metadata?.creditAlertIdempotencyKey;
         // For eng-oncall:
         // If you get this, you can defer to programmatic usage owners right away
-        // Every customer should have this key defined
+        // Every workspace should have this key defined
         // If not, it means they will not get alerted
         // when they reached their usage threshold
         assert(
-          isString(thresholdId),
+          isString(idempotencyKey),
           "creditAlertThresholdId must be set when credits exist"
         );
         void launchCreditAlertWorkflow({
           workspaceId: workspace.sId,
-          thresholdId,
+          idempotencyKey: idempotencyKey,
           totalInitialMicroUsd,
           totalConsumedMicroUsd,
         });

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -404,7 +404,7 @@ export interface WorkspaceMetadata {
   allowVoiceTranscription?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;
   disableManualInvitations?: boolean;
-  creditAlertThresholdId?: string;
+  creditAlertIdempotencyKey?: string;
 }
 
 export async function updateWorkspaceMetadata(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -404,6 +404,7 @@ export interface WorkspaceMetadata {
   allowVoiceTranscription?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;
   disableManualInvitations?: boolean;
+  creditAlertThresholdId?: string;
 }
 
 export async function updateWorkspaceMetadata(

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -244,6 +244,7 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
     );
     return new Ok(undefined);
   }
+
   const credit = await CreditResource.makeNew(auth, {
     type: "free",
     initialAmountMicroUsd: creditAmountMicroUsd,
@@ -264,8 +265,10 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
   );
 
   // Start the credit at beginning of billing cycle.
-  const startResult = await credit.start(periodStart, periodEnd);
-
+  const startResult = await credit.start(auth, {
+    startDate: periodStart,
+    expirationDate: periodEnd,
+  });
   if (startResult.isErr()) {
     logger.error(
       {

--- a/front/lib/credits/payg.test.ts
+++ b/front/lib/credits/payg.test.ts
@@ -72,7 +72,9 @@ describe("PAYG Credits Database Tests", () => {
   let auth: Authenticator;
 
   beforeEach(async () => {
-    const { authenticator } = await createResourceTest({ role: "admin" });
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+    });
     auth = authenticator;
   });
 
@@ -89,7 +91,10 @@ describe("PAYG Credits Database Tests", () => {
         initialAmountMicroUsd: 100_000_000,
         consumedAmountMicroUsd: 0,
       });
-      await credit1.start(startDate, expirationDate);
+      await credit1.start(auth, {
+        startDate,
+        expirationDate,
+      });
 
       const credit2 = await CreditResource.makeNew(auth, {
         type: "payg",
@@ -97,9 +102,12 @@ describe("PAYG Credits Database Tests", () => {
         consumedAmountMicroUsd: 0,
       });
 
-      await expect(credit2.start(startDate, expirationDate)).rejects.toThrow(
-        /unique|Validation error/i
-      );
+      await expect(
+        credit2.start(auth, {
+          startDate,
+          expirationDate,
+        })
+      ).rejects.toThrow(/unique|Validation error/i);
     });
   });
 
@@ -115,7 +123,10 @@ describe("PAYG Credits Database Tests", () => {
         initialAmountMicroUsd: 100_000_000,
         consumedAmountMicroUsd: 0,
       });
-      await credit.start(startDate, expirationDate);
+      await credit.start(auth, {
+        startDate,
+        expirationDate,
+      });
 
       const lookupStartDate = new Date(startTimestampSeconds * 1000);
       const lookupExpirationDate = new Date(endTimestampSeconds * 1000);
@@ -178,7 +189,9 @@ describe("allocatePAYGCreditsOnCycleRenewal", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(NOW_MS);
-    const { authenticator } = await createResourceTest({ role: "admin" });
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+    });
     auth = authenticator;
     vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
   });
@@ -227,10 +240,10 @@ describe("allocatePAYGCreditsOnCycleRenewal", () => {
       initialAmountMicroUsd: 500_000_000,
       consumedAmountMicroUsd: 0,
     });
-    await existingCredit.start(
-      new Date(NOW * 1000),
-      new Date((NOW + MONTH_SECONDS) * 1000)
-    );
+    await existingCredit.start(auth, {
+      startDate: new Date(NOW * 1000),
+      expirationDate: new Date((NOW + MONTH_SECONDS) * 1000),
+    });
 
     await allocatePAYGCreditsOnCycleRenewal({
       auth,
@@ -290,7 +303,9 @@ describe("startOrResumeEnterprisePAYG", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(NOW_MS);
-    const { authenticator } = await createResourceTest({ role: "admin" });
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+    });
     auth = authenticator;
     vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
     vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
@@ -386,10 +401,10 @@ describe("startOrResumeEnterprisePAYG", () => {
       initialAmountMicroUsd: 500_000_000,
       consumedAmountMicroUsd: 0,
     });
-    await existingCredit.start(
-      new Date(subscription.current_period_start * 1000),
-      new Date(subscription.current_period_end * 1000)
-    );
+    await existingCredit.start(auth, {
+      startDate: new Date(subscription.current_period_start * 1000),
+      expirationDate: new Date(subscription.current_period_end * 1000),
+    });
 
     await startOrResumeEnterprisePAYG({
       auth,
@@ -410,7 +425,9 @@ describe("stopEnterprisePAYG", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(NOW_MS);
-    const { authenticator } = await createResourceTest({ role: "admin" });
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+    });
     auth = authenticator;
     vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
   });
@@ -426,10 +443,10 @@ describe("stopEnterprisePAYG", () => {
       initialAmountMicroUsd: 1_000_000_000,
       consumedAmountMicroUsd: 50_000_000,
     });
-    await credit.start(
-      new Date(subscription.current_period_start * 1000),
-      new Date(subscription.current_period_end * 1000)
-    );
+    await credit.start(auth, {
+      startDate: new Date(subscription.current_period_start * 1000),
+      expirationDate: new Date(subscription.current_period_end * 1000),
+    });
 
     const result = await stopEnterprisePAYG({
       auth,
@@ -491,7 +508,9 @@ describe("invoiceEnterprisePAYGCredits", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(NOW_MS);
-    const { authenticator } = await createResourceTest({ role: "admin" });
+    const { authenticator } = await createResourceTest({
+      role: "admin",
+    });
     auth = authenticator;
     vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
     vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
@@ -577,10 +596,10 @@ describe("invoiceEnterprisePAYGCredits", () => {
       initialAmountMicroUsd: 100_000_000,
       consumedAmountMicroUsd: 0,
     });
-    await credit.start(
-      new Date(previousStart * 1000),
-      new Date(previousEnd * 1000)
-    );
+    await credit.start(auth, {
+      startDate: new Date(previousStart * 1000),
+      expirationDate: new Date(previousEnd * 1000),
+    });
 
     const subscription = makeEnterpriseSubscription();
 
@@ -610,10 +629,10 @@ describe("invoiceEnterprisePAYGCredits", () => {
       initialAmountMicroUsd: 1_000_000_000,
       consumedAmountMicroUsd: 150_000_000,
     });
-    await credit.start(
-      new Date(previousStart * 1000),
-      new Date(previousEnd * 1000)
-    );
+    await credit.start(auth, {
+      startDate: new Date(previousStart * 1000),
+      expirationDate: new Date(previousEnd * 1000),
+    });
 
     const subscription = makeEnterpriseSubscription();
 
@@ -651,10 +670,10 @@ describe("invoiceEnterprisePAYGCredits", () => {
       initialAmountMicroUsd: 100_000_000,
       consumedAmountMicroUsd: 5_000_000,
     });
-    await credit.start(
-      new Date(previousStart * 1000),
-      new Date(previousEnd * 1000)
-    );
+    await credit.start(auth, {
+      startDate: new Date(previousStart * 1000),
+      expirationDate: new Date(previousEnd * 1000),
+    });
 
     const subscription = makeEnterpriseSubscription();
 
@@ -691,10 +710,10 @@ describe("invoiceEnterprisePAYGCredits", () => {
       initialAmountMicroUsd: 1_000_000_000,
       consumedAmountMicroUsd: 50_000_000,
     });
-    await credit.start(
-      new Date(previousStart * 1000),
-      new Date(previousEnd * 1000)
-    );
+    await credit.start(auth, {
+      startDate: new Date(previousStart * 1000),
+      expirationDate: new Date(previousEnd * 1000),
+    });
 
     const subscription = makeEnterpriseSubscription();
 
@@ -723,10 +742,10 @@ describe("invoiceEnterprisePAYGCredits", () => {
       initialAmountMicroUsd: 100_000_000,
       consumedAmountMicroUsd: 25_000_000,
     });
-    await credit.start(
-      new Date(previousStart * 1000),
-      new Date(previousEnd * 1000)
-    );
+    await credit.start(auth, {
+      startDate: new Date(previousStart * 1000),
+      expirationDate: new Date(previousEnd * 1000),
+    });
 
     const subscription = makeEnterpriseSubscription();
 
@@ -760,10 +779,10 @@ describe("invoiceEnterprisePAYGCredits", () => {
       initialAmountMicroUsd: 100_000_000,
       consumedAmountMicroUsd: 10_000_000,
     });
-    await credit.start(
-      new Date(previousStart * 1000),
-      new Date(previousEnd * 1000)
-    );
+    await credit.start(auth, {
+      startDate: new Date(previousStart * 1000),
+      expirationDate: new Date(previousEnd * 1000),
+    });
 
     const subscription = makeEnterpriseSubscription();
 

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -55,7 +55,13 @@ async function createPAYGCreditForPeriod({
     invoiceOrLineItemId: null,
   });
 
-  await credit.start(periodStart, periodEnd);
+  const startResult = await credit.start(auth, {
+    startDate: periodStart,
+    expirationDate: periodEnd,
+  });
+  if (startResult.isErr()) {
+    return new Err(startResult.error);
+  }
   return new Ok(credit);
 }
 
@@ -240,10 +246,7 @@ export async function stopEnterprisePAYG({
   );
 
   if (paygCredit) {
-    const freezeResult = await CreditResource.freezePAYGCreditById(
-      auth,
-      paygCredit.id
-    );
+    const freezeResult = await paygCredit.freeze(auth);
     if (freezeResult.isErr()) {
       logger.warn(
         { workspaceId: workspace.sId, error: freezeResult.error.message },

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -215,15 +215,15 @@ export class CreditResource extends BaseResource<CreditModel> {
     );
   }
 
-  private async updateCreditAlertThresholdId(
+  private async updateCreditAlertIdempotencyKey(
     auth: Authenticator
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
-    const thresholdId = generateRandomModelSId("cra");
+    const idempotencyKey = generateRandomModelSId("cra");
     const previousMetadata = workspace.metadata ?? {};
     const newMetadata = {
       ...previousMetadata,
-      creditAlertThresholdId: thresholdId,
+      creditAlertIdempotencyKey: idempotencyKey,
     };
     await WorkspaceResource.updateMetadata(workspace.id, newMetadata);
   }
@@ -265,7 +265,7 @@ export class CreditResource extends BaseResource<CreditModel> {
       return new Err(new Error("Credit already started"));
     }
 
-    await this.updateCreditAlertThresholdId(auth);
+    await this.updateCreditAlertIdempotencyKey(auth);
     return new Ok(undefined);
   }
 
@@ -291,7 +291,7 @@ export class CreditResource extends BaseResource<CreditModel> {
       return new Err(new Error("Credit not found or already frozen"));
     }
 
-    await this.updateCreditAlertThresholdId(auth);
+    await this.updateCreditAlertIdempotencyKey(auth);
     return new Ok(undefined);
   }
 

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import type {
   Attributes,
   CreationAttributes,
@@ -10,11 +11,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { CreditModel } from "@app/lib/resources/storage/models/credits";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import { makeSId } from "@app/lib/resources/string_ids";
+import { generateRandomModelSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { Result } from "@app/types";
-import { Err, normalizeError, Ok, removeNulls } from "@app/types";
+import { Err, Ok, removeNulls } from "@app/types";
 import type { CreditDisplayData } from "@app/types/credits";
 import {
   CREDIT_EXPIRATION_DAYS,
@@ -61,39 +63,6 @@ export class CreditResource extends BaseResource<CreditModel> {
     );
 
     return new this(this.model, credit.get());
-  }
-
-  async start(
-    startDate?: Date,
-    expirationDate?: Date,
-    { transaction }: { transaction?: Transaction } = {}
-  ): Promise<Result<undefined, Error>> {
-    const effectiveStartDate = startDate ?? new Date();
-    const effectiveExpirationDate =
-      expirationDate ??
-      new Date(Date.now() + CREDIT_EXPIRATION_DAYS * 24 * 60 * 60 * 1000);
-
-    const [, affectedRows] = await this.model.update(
-      {
-        startDate: effectiveStartDate,
-        expirationDate: effectiveExpirationDate,
-      },
-      {
-        where: {
-          id: this.id,
-          workspaceId: this.workspaceId,
-          startDate: null,
-        },
-        transaction,
-        returning: true,
-      }
-    );
-
-    if (affectedRows.length === 0) {
-      return new Err(new Error("Credit already started"));
-    }
-
-    return new Ok(undefined);
   }
 
   private static async baseFetch(
@@ -246,20 +215,72 @@ export class CreditResource extends BaseResource<CreditModel> {
     );
   }
 
-  static async freezePAYGCreditById(
+  private async updateCreditAlertThresholdId(
+    auth: Authenticator
+  ): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
+    const thresholdId = generateRandomModelSId("cra");
+    const previousMetadata = workspace.metadata ?? {};
+    const newMetadata = {
+      ...previousMetadata,
+      creditAlertThresholdId: thresholdId,
+    };
+    await WorkspaceResource.updateMetadata(workspace.id, newMetadata);
+  }
+
+  async start(
     auth: Authenticator,
-    creditId: number,
+    {
+      startDate,
+      expirationDate,
+      transaction,
+    }: {
+      startDate?: Date;
+      expirationDate?: Date;
+      transaction?: Transaction;
+    } = {}
+  ): Promise<Result<void, Error>> {
+    const effectiveStartDate = startDate ?? new Date();
+    const effectiveExpirationDate =
+      expirationDate ??
+      new Date(Date.now() + CREDIT_EXPIRATION_DAYS * 24 * 60 * 60 * 1000);
+
+    const [, affectedRows] = await CreditModel.update(
+      {
+        startDate: effectiveStartDate,
+        expirationDate: effectiveExpirationDate,
+      },
+      {
+        where: {
+          id: this.id,
+          workspaceId: this.workspaceId,
+          startDate: null,
+        },
+        transaction,
+        returning: true,
+      }
+    );
+
+    if (affectedRows.length === 0) {
+      return new Err(new Error("Credit already started"));
+    }
+
+    await this.updateCreditAlertThresholdId(auth);
+    return new Ok(undefined);
+  }
+
+  async freeze(
+    auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
-    const [, affectedRows] = await this.model.update(
+    const [, affectedRows] = await CreditModel.update(
       {
         initialAmountMicroUsd: Sequelize.col("consumedAmountMicroUsd"),
       },
       {
         where: {
-          id: creditId,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          type: "payg",
+          id: this.id,
+          workspaceId: this.workspaceId,
         },
         transaction,
         returning: true,
@@ -270,6 +291,7 @@ export class CreditResource extends BaseResource<CreditModel> {
       return new Err(new Error("Credit not found or already frozen"));
     }
 
+    await this.updateCreditAlertThresholdId(auth);
     return new Ok(undefined);
   }
 
@@ -284,21 +306,6 @@ export class CreditResource extends BaseResource<CreditModel> {
       },
       transaction
     );
-  }
-
-  async delete(
-    _auth: Authenticator,
-    { transaction }: { transaction?: Transaction }
-  ): Promise<Result<undefined | number, Error>> {
-    try {
-      await this.model.destroy({
-        where: { id: this.id, workspaceId: this.workspaceId },
-        transaction,
-      });
-      return new Ok(undefined);
-    } catch (err) {
-      return new Err(normalizeError(err));
-    }
   }
 
   toJSON(): CreditDisplayData {
@@ -355,5 +362,21 @@ export class CreditResource extends BaseResource<CreditModel> {
         workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<number | undefined, Error>> {
+    assert(
+      this.startDate === null || this.type === "free",
+      "Cannot delete a credit that has been started. Use freeze() instead."
+    );
+
+    const deletedCount = await CreditModel.destroy({
+      where: { id: this.id, workspaceId: auth.getNonNullableWorkspace().id },
+      transaction,
+    });
+    return new Ok(deletedCount);
   }
 }

--- a/front/migrations/20251128_backfill_free_credits.ts
+++ b/front/migrations/20251128_backfill_free_credits.ts
@@ -78,6 +78,7 @@ async function addCreditToWorkspace(
   }
 
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
   const credit = await CreditResource.makeNew(auth, {
     type: "free",
     initialAmountMicroUsd: amountCents * 10_000,
@@ -86,7 +87,10 @@ async function addCreditToWorkspace(
     invoiceOrLineItemId: idempotencyKey,
   });
 
-  await credit.start(new Date(), expirationDate);
+  await credit.start(auth, {
+    startDate: new Date(),
+    expirationDate,
+  });
 
   logger.info(
     {

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -41,6 +41,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/triggers/webhook");
     case "analytics_queue":
       return path.join(baseDir, "temporal/analytics_queue");
+    case "credit_alerts":
+      return path.join(baseDir, "temporal/credit_alerts");
     case "data_retention":
       return path.join(baseDir, "temporal/data_retention");
     case "document_tracker":

--- a/front/temporal/credit_alerts/activities.ts
+++ b/front/temporal/credit_alerts/activities.ts
@@ -1,0 +1,63 @@
+import { sendCreditUsageAlertEmail } from "@app/lib/api/email";
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+
+export interface SendCreditAlertEmailActivityArgs {
+  workspaceId: string;
+  totalInitialMicroUsd: number;
+  totalConsumedMicroUsd: number;
+}
+
+export async function sendCreditAlertEmailActivity({
+  workspaceId,
+  totalInitialMicroUsd,
+  totalConsumedMicroUsd,
+}: SendCreditAlertEmailActivityArgs): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const workspace = auth.workspace();
+
+  if (!workspace) {
+    logger.error({ workspaceId }, "Workspace not found for credit alert email");
+    return;
+  }
+
+  const { members: admins } = await getMembers(auth, {
+    roles: ["admin"],
+    activeOnly: true,
+  });
+
+  if (admins.length === 0) {
+    logger.warn(
+      { workspaceId },
+      "No active admins found for credit alert email"
+    );
+    return;
+  }
+
+  const percentUsed = Math.round(
+    (totalConsumedMicroUsd / totalInitialMicroUsd) * 100
+  );
+
+  for (const admin of admins) {
+    await sendCreditUsageAlertEmail({
+      email: admin.email,
+      workspaceName: workspace.name,
+      workspaceSId: workspace.sId,
+      percentUsed,
+      totalInitialMicroUsd,
+      totalConsumedMicroUsd,
+    });
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      adminCount: admins.length,
+      percentUsed,
+      totalInitialMicroUsd,
+      totalConsumedMicroUsd,
+    },
+    "Sent credit usage alert emails to workspace admins"
+  );
+}

--- a/front/temporal/credit_alerts/client.ts
+++ b/front/temporal/credit_alerts/client.ts
@@ -1,0 +1,58 @@
+import {
+  WorkflowExecutionAlreadyStartedError,
+  WorkflowIdReusePolicy,
+} from "@temporalio/client";
+
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+
+import { QUEUE_NAME } from "./config";
+import { creditAlertWorkflow } from "./workflows";
+
+export interface LaunchCreditAlertWorkflowArgs {
+  workspaceId: string;
+  thresholdId: string;
+  totalInitialMicroUsd: number;
+  totalConsumedMicroUsd: number;
+}
+
+export async function launchCreditAlertWorkflow({
+  workspaceId,
+  thresholdId,
+  totalInitialMicroUsd: totalInitialCents,
+  totalConsumedMicroUsd: totalConsumedCents,
+}: LaunchCreditAlertWorkflowArgs): Promise<void> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = `credit-alert-${workspaceId}-${thresholdId}`;
+
+  try {
+    await client.workflow.start(creditAlertWorkflow, {
+      args: [{ workspaceId, totalInitialCents, totalConsumedCents }],
+      workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: {
+        workspaceId,
+        thresholdId,
+      },
+    });
+
+    logger.info(
+      { workflowId, workspaceId, thresholdId },
+      "Started credit alert workflow"
+    );
+  } catch (e) {
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        { workflowId, workspaceId, thresholdId },
+        "Credit alert workflow already started (idempotency check passed)"
+      );
+      return;
+    }
+    logger.error(
+      { workflowId, workspaceId, thresholdId, error: e },
+      "Failed to start credit alert workflow"
+    );
+    throw e;
+  }
+}

--- a/front/temporal/credit_alerts/config.ts
+++ b/front/temporal/credit_alerts/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `credit-alerts-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/credit_alerts/worker.ts
+++ b/front/temporal/credit_alerts/worker.ts
@@ -1,0 +1,41 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/credit_alerts/activities";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runCreditAlertsWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "credit_alerts",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 4,
+    connection,
+    namespace,
+    interceptors: {
+      activity: [
+        (ctx: Context) => {
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/credit_alerts/workflows.ts
+++ b/front/temporal/credit_alerts/workflows.ts
@@ -1,0 +1,25 @@
+import { proxyActivities } from "@temporalio/workflow";
+
+import type * as activities from "@app/temporal/credit_alerts/activities";
+
+const { sendCreditAlertEmailActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
+export interface CreditAlertWorkflowArgs {
+  workspaceId: string;
+  totalInitialCents: number;
+  totalConsumedCents: number;
+}
+
+export async function creditAlertWorkflow({
+  workspaceId,
+  totalInitialCents,
+  totalConsumedCents,
+}: CreditAlertWorkflowArgs): Promise<void> {
+  await sendCreditAlertEmailActivity({
+    workspaceId,
+    totalInitialMicroUsd: totalInitialCents,
+    totalConsumedMicroUsd: totalConsumedCents,
+  });
+}

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -1,6 +1,7 @@
 import { runPokeWorker } from "@app/poke/temporal/worker";
 import { runAgentLoopWorker } from "@app/temporal/agent_loop/worker";
 import { runAnalyticsWorker } from "@app/temporal/analytics_queue/worker";
+import { runCreditAlertsWorker } from "@app/temporal/credit_alerts/worker";
 import { runDataRetentionWorker } from "@app/temporal/data_retention/worker";
 import { runESIndexationQueueWorker } from "@app/temporal/es_indexation/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
@@ -26,6 +27,7 @@ export type WorkerName =
   | "agent_schedule"
   | "agent_trigger_webhook"
   | "analytics_queue"
+  | "credit_alerts"
   | "data_retention"
   | "document_tracker"
   | "es_indexation_queue"
@@ -48,6 +50,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   agent_schedule: runAgentTriggerWorker,
   agent_trigger_webhook: runAgentTriggerWebhookWorker,
   analytics_queue: runAnalyticsWorker,
+  credit_alerts: runCreditAlertsWorker,
   data_retention: runDataRetentionWorker,
   document_tracker: runTrackerWorker,
   hard_delete: runHardDeleteWorker,


### PR DESCRIPTION
# Description

Implements email notifications for workspace admins when programmatic usage credits reach 80% consumption, preventing unexpected service interruptions.
Fixes https://github.com/dust-tt/tasks/issues/5300

## Implementation Flow

1. **Tracking**: `decreaseProgrammaticCreditsV2` now returns `totalConsumedMicroUsd` and `totalInitialMicroUsd` calculated before current consumption
2. **Detection**: `trackProgrammaticCost` checks if consumption ≥ 80% threshold after each API call
3. **Alerting**: Triggers `launchCreditAlertWorkflow` (Temporal) with workspace-specific `creditAlertIdempotencyKey` for deduplication
4. **Email**: `sendCreditUsageAlertEmail` sends formatted alert with usage stats and dashboard link

## Architectural Choices

**Temporal workflow over direct email**: Provides async processing, built-in deduplication (via `thresholdId` + WorkflowIdReusePolicy), retry logic, and doesn't block the critical consumption path.

**Return consumption metrics**: Avoids extra DB queries and ensures data consistency at the exact moment of consumption.

**Feature flag gating** (`ppul`): Enables gradual rollout and quick rollback if needed.

**Metadata storage for `creditAlertIdempotencyKey`**: Flexible, no migration required, set during credit provisioning.

### ✋ Main decision to discuss
* Would we rather send alert threshold email twice or not at all ? I opted for twice, because it's less problematic imo than not getting alerted when crossing the threshold.
* Is it OK to potentially blast Temporal's API with startWorkflow requests and leverage their guarantees on workflow ids ? 
I'm heavily leaning on it to simplify implementation, but not sure it will scale well. We would at most try to launch once per agent-loop-workflow, so it's colinear to orders of magnitude we're already hitting temporal with. (not sure my sentence is plain english)

## Risks & Mitigations

| Risk | Mitigation |
|------|-----------|
| **Missing `creditAlertIdempotencyKey`** → No alerts | Assert with clear eng-oncall comment; should be set during provisioning |
| **Alert spam** → Multiple emails | Temporal deduplication via `thresholdId` |
| **Performance impact** → API slowdown | O(n) calculation where n=1-3 credits; workflow launched async with `void` |
| **Race conditions** → Duplicate workflows | Temporal handles deduplication |
| **Breaking changes** → Old `credit.start()` calls fail | All 5 call sites updated in this PR |

## Testing

**Manual checklist**:
✅ Consume credits to 79% (no email) → 80% (email sent) → 85% (no duplicate)
✅ Verify email formatting and dashboard link

<img width="611" height="551" alt="image" src="https://github.com/user-attachments/assets/7583d8b8-32c7-405e-bfe9-d00630f018b6" />


## Deploy Plan

1. Ensure all workspaces with active credits have `creditAlertIdempotencyKey` set => Need a backfill script
2. Merge
3. Run the script
4. Deploy