### PR TITLE
[front, extension] - chore: improve MentionDropdown scrollable for better UX

### DIFF
--- a/extension/ui/components/input_bar/editor/MentionDropdown.tsx
+++ b/extension/ui/components/input_bar/editor/MentionDropdown.tsx
@@ -78,7 +78,7 @@ export const MentionDropdown = ({
             <Spinner />
           </div>
         ) : suggestions.length > 0 ? (
-          <div className="flex flex-col gap-y-1 p-1">
+          <div className="max-h-60 overflow-y-auto flex flex-col gap-y-1 p-1">
             {suggestions.map((suggestion, index) => (
               <div key={suggestion.id}>
                 <button

--- a/extension/ui/components/input_bar/editor/suggestion.ts
+++ b/extension/ui/components/input_bar/editor/suggestion.ts
@@ -19,7 +19,7 @@ export interface EditorSuggestions {
   isLoading: boolean;
 }
 
-const SUGGESTION_DISPLAY_LIMIT = 7;
+const SUGGESTION_DISPLAY_LIMIT = 20;
 
 const SUGGESTION_PRIORITY: Record<string, number> = {
   [GLOBAL_AGENTS_SID.DUST]: 1,

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -140,7 +140,7 @@ export const MentionDropdown = forwardRef<
             <Spinner />
           </div>
         ) : suggestions.length > 0 ? (
-          <div className="flex flex-col gap-y-1 p-1">
+          <div className="flex max-h-60 flex-col gap-y-1 overflow-y-auto p-1">
             {suggestions.map((suggestion, index) => (
               <div key={suggestion.id}>
                 <button

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -7,7 +7,7 @@ import type { RedisClientType } from "redis";
 import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { runOnRedis } from "@app/lib/api/redis";
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
-import type {Authenticator} from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";

--- a/front/lib/mentions/editor/suggestion.ts
+++ b/front/lib/mentions/editor/suggestion.ts
@@ -6,7 +6,7 @@ import { compareForFuzzySort, subFilter } from "../../utils";
 /**
  * Maximum number of suggestions to display in the autocomplete dropdown.
  */
-export const SUGGESTION_DISPLAY_LIMIT = 7;
+export const SUGGESTION_DISPLAY_LIMIT = 20;
 
 /**
  * Priority order for specific agent suggestions.


### PR DESCRIPTION
## Description

This PR:
 - Added an overflow-y-auto class to MentionDropdown to enable scrolling for long lists of suggestions
 - Increased suggestion display limit from 7 to 20 entries to show more options without scrolling

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front