### PR TITLE
[PPUL] Fix credits graph date range display and default period

### DIFF
--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -199,7 +199,10 @@ export function BaseProgrammaticCostChart({
     });
 
   // Format period label based on billing cycle
-  const periodLabel = `${formatDate(billingCycle.cycleStart)} → ${formatDate(billingCycle.cycleEnd)}`;
+  // cycleEnd is exclusive (first day of next cycle), so we subtract 1 day for display
+  const inclusiveEndDate = new Date(billingCycle.cycleEnd);
+  inclusiveEndDate.setDate(inclusiveEndDate.getDate() - 1);
+  const periodLabel = `${formatDate(billingCycle.cycleStart)} → ${formatDate(inclusiveEndDate)}`;
 
   // Calculate next and previous period dates
   const nextPeriodDate = new Date(
@@ -621,8 +624,19 @@ export function ProgrammaticCostChart({
     {}
   );
 
+  // Initialize selectedMonth to a date within the current billing cycle.
+  // Using just formatMonth(now) would create a date on the 1st of the month,
+  // which may fall in the previous billing cycle if billingCycleStartDay > 1.
+  // By using the billing cycle's start date, we ensure we're in the correct cycle.
   const now = new Date();
-  const [selectedMonth, setSelectedMonth] = useState<string>(formatMonth(now));
+  const currentBillingCycle = getBillingCycleFromDay(
+    billingCycleStartDay,
+    now,
+    false
+  );
+  const [selectedMonth, setSelectedMonth] = useState<string>(
+    formatMonth(currentBillingCycle.cycleStart)
+  );
 
   const {
     programmaticCostData,

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -182,7 +182,11 @@ export function BaseProgrammaticCostChart({
   >({});
 
   const now = new Date();
+  // selectedMonth is "YYYY-MM", so new Date(selectedMonth) creates day 1 of that month.
+  // To get the correct billing cycle, we need a date within that cycle, so we set
+  // the day to billingCycleStartDay.
   const currentDate = new Date(selectedMonth);
+  currentDate.setDate(billingCycleStartDay);
 
   // Calculate the billing cycle for the selected month
   const billingCycle = getBillingCycleFromDay(

--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -263,9 +263,14 @@ export async function handleProgrammaticCostRequest(
       } = q.data;
 
       // Get selected date range using shared billing cycle utility
+      // selectedMonth is "YYYY-MM", so new Date(selectedMonth) creates day 1 of that month.
+      // We need to set the day to billingCycleStartDay to get the correct billing cycle.
       const referenceDate = selectedMonth
         ? new Date(selectedMonth)
         : new Date();
+      if (selectedMonth) {
+        referenceDate.setUTCDate(billingCycleStartDay);
+      }
       const { cycleStart: periodStart, cycleEnd: periodEnd } =
         getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
 

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -234,7 +234,9 @@ function UsageSection({
         {billingCycle && (
           <Page.P variant="secondary">
             {formatDateShort(billingCycle.cycleStart)} →{" "}
-            {formatDateShort(billingCycle.cycleEnd)}
+            {formatDateShort(
+              new Date(billingCycle.cycleEnd.getTime() - 24 * 60 * 60 * 1000)
+            )}
           </Page.P>
         )}
       </div>


### PR DESCRIPTION
## Description

The credits usage graph had two issues:
1. Date range displayed end date as exclusive (e.g., "Nov 4 → Dec 4") instead of inclusive (e.g., "Nov 4 → Dec 3")
2. Default period showed previous billing cycle instead of current one when the billing cycle start day > 1 (e.g., if billing starts on day 4 and today is Dec 4, it showed Nov 4 → Dec 3 instead of Dec 4 → Jan 3)

## Risks

Blast radius: credits usage graph display on /w/[wId]/developers/credits-usage page
Risk: low

## Deploy Plan
- deploy front
- pmrr