### PR TITLE
Improve data sources dates wording

### DIFF
--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -198,13 +198,14 @@ export function ViewDataSourceTable({
                       </PokeTableCell>
                     </PokeTableRow>
                     <PokeTableRow>
-                      <PokeTableCell>Paused at</PokeTableCell>
+                      <PokeTableCell>Paused</PokeTableCell>
                       <PokeTableCell>
                         {connector?.pausedAt ? (
                           <span className="font-bold text-green-600">
                             {timeAgoFrom(connector?.pausedAt, {
                               useLongFormat: true,
-                            })}
+                            })}{" "}
+                            ago
                           </span>
                         ) : (
                           "N/A"
@@ -241,7 +242,7 @@ export function ViewDataSourceTable({
                         {connector?.lastSyncStartTime ? (
                           timeAgoFrom(connector?.lastSyncStartTime, {
                             useLongFormat: true,
-                          })
+                          }) + " ago"
                         ) : (
                           <span className="font-bold text-warning-500">
                             never
@@ -255,7 +256,7 @@ export function ViewDataSourceTable({
                         {connector?.lastSyncFinishTime ? (
                           timeAgoFrom(connector?.lastSyncFinishTime, {
                             useLongFormat: true,
-                          })
+                          }) + " ago"
                         ) : (
                           <span className="font-bold text-warning-500">
                             never
@@ -289,7 +290,8 @@ export function ViewDataSourceTable({
                           <span className="font-bold text-green-600">
                             {timeAgoFrom(connector?.lastSyncSuccessfulTime, {
                               useLongFormat: true,
-                            })}
+                            })}{" "}
+                            ago
                           </span>
                         ) : (
                           <span className="font-bold text-warning-600">


### PR DESCRIPTION
## Description

The wording for dates in the data source view in Poke is not clear enough and can be confusing (especially "Paused at"). 

<img width="332" height="244" alt="image" src="https://github.com/user-attachments/assets/9c193b24-ed77-45af-b154-46af33d7beb4" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
