### PR TITLE
[PPUL] Fix: hasReachedProgrammaticUsageLimits bypassed for system key calls

### DIFF
--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -128,13 +128,8 @@ export function getShouldTrackTokenUsageCostsESFilter(
 }
 
 export async function hasReachedProgrammaticUsageLimits(
-  auth: Authenticator,
-  shouldTrack: boolean = false
+  auth: Authenticator
 ): Promise<boolean> {
-  if (!isProgrammaticUsage(auth) && !shouldTrack) {
-    return false;
-  }
-
   const owner = auth.getNonNullableWorkspace();
   const featureFlags = await getFeatureFlags(owner);
   if (featureFlags.includes("ppul")) {

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -274,8 +274,7 @@ async function checkWorkspaceRateLimit({
       errorMessage = message;
     }
   } else {
-    const publicAPILimit = await hasReachedProgrammaticUsageLimits(auth, true);
-    if (publicAPILimit) {
+    if (await hasReachedProgrammaticUsageLimits(auth)) {
       errorMessage =
         "Workspace has reached its public API limits for the current billing period.";
     }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -12,7 +12,10 @@ import {
 } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { hasReachedProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage_tracking";
+import {
+  hasReachedProgrammaticUsageLimits,
+  isProgrammaticUsage,
+} from "@app/lib/api/programmatic_usage_tracking";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
@@ -103,7 +106,11 @@ async function handler(
         });
       }
 
-      const hasReachedLimits = await hasReachedProgrammaticUsageLimits(auth);
+      const hasReachedLimits = isProgrammaticUsage(auth, {
+        userMessageOrigin: r.data.context.origin,
+      })
+        ? await hasReachedProgrammaticUsageLimits(auth)
+        : false;
       if (hasReachedLimits) {
         return apiError(req, res, {
           status_code: 429,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -20,7 +20,10 @@ import {
 } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { hasReachedProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage_tracking";
+import {
+  hasReachedProgrammaticUsageLimits,
+  isProgrammaticUsage,
+} from "@app/lib/api/programmatic_usage_tracking";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -141,7 +144,10 @@ async function handler(
         blocking,
       } = r.data;
 
-      const hasReachedLimits = await hasReachedProgrammaticUsageLimits(auth);
+      const hasReachedLimits =
+        isProgrammaticUsage(auth, {
+          userMessageOrigin: message?.context.origin,
+        }) && (await hasReachedProgrammaticUsageLimits(auth));
       if (hasReachedLimits) {
         return apiError(req, res, {
           status_code: 429,


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/5349

`hasReachedProgrammaticUsageLimits` called `isProgrammaticUsage(auth)` without a `userMessageOrigin`. Since `isProgrammaticUsage` returns `false` when no origin is provided (logging a warning), **programmatic usage limits were bypassed entirely for system key API calls**.

Fix: move the `isProgrammaticUsage` check to call sites where message context (`userMessageOrigin`) is available, keeping `hasReachedProgrammaticUsageLimits` focused on workspace-level limit checking.

## Risks

Blast radius: programmatic usage limits enforcement on public API
Risk: low (fixes a bug, restores intended behavior)

## Deploy Plan

- deploy front
- pmrr