### PR TITLE
[PPUL] Fix credits not counted on their start day in usage graph

### DIFF
--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -116,19 +116,22 @@ function calculateCreditTotalsPerTimestamp(
     }
   >();
 
+  const now = Date.now();
+
   for (const timestamp of timestamps) {
     const dayStart = new Date(timestamp);
     dayStart.setUTCHours(0, 0, 0, 0);
-    const dayStartTime = dayStart.getTime();
+    // Use current time for today so credits created today are included.
+    const cutoffTime = dayStart.getTime() === new Date().setUTCHours(0, 0, 0, 0) ? now : dayStart.getTime();
 
     const activeCredits = credits.filter((credit) => {
-      if (!credit.startDate || credit.startDate.getTime() > dayStartTime) {
+      if (!credit.startDate || credit.startDate.getTime() > cutoffTime) {
         return false;
       }
 
       if (
         credit.expirationDate &&
-        credit.expirationDate.getTime() <= dayStartTime
+        credit.expirationDate.getTime() <= cutoffTime
       ) {
         return false;
       }


### PR DESCRIPTION
## Description

Credits starting on day D were only shown on day D+1 in the usage graph. The issue was that the comparison used the credit's exact `startDate` timestamp against midnight UTC of each day, so credits created after midnight weren't counted until the next day. Same for expiration.
Before:
<img width="1177" height="433" alt="image" src="https://github.com/user-attachments/assets/847f66e0-9e80-437f-abfb-c6cf8f8eedf3" />

After:
<img width="1177" height="433" alt="image" src="https://github.com/user-attachments/assets/83df4e7b-5046-4d64-b961-db45e33396f4" />

## Risks

Blast radius: credits usage graph display on /w/[wId]/developers/credits-usage page
Risk: low

## Deploy Plan

- deploy front
- pmrr