### PR TITLE
[core] fix(`cat`): replace slice with char count

### DIFF
--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -1082,7 +1082,7 @@ pub async fn data_sources_documents_retrieve_text(
         document_id = document_id,
         offset_limit_duration = offset_limit_duration,
         total_char_count = char_count,
-        slice_char_count = text_slice.chars().count()
+        slice_char_count = text_slice.chars().count(),
         "[RETRIEVE_TEXT] Applied offset/limit"
     );
 

--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -1078,11 +1078,12 @@ pub async fn data_sources_documents_retrieve_text(
     };
 
     let offset_limit_duration = utils::now() - offset_limit_start;
+    let slice_char_count = text_slice.chars().count();
     info!(
         document_id = document_id,
         offset_limit_duration = offset_limit_duration,
         total_char_count = char_count,
-        slice_char_count = text_slice.chars().count(),
+        slice_char_count = slice_char_count,
         "[RETRIEVE_TEXT] Applied offset/limit"
     );
 

--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -1082,7 +1082,7 @@ pub async fn data_sources_documents_retrieve_text(
         document_id = document_id,
         offset_limit_duration = offset_limit_duration,
         total_char_count = char_count,
-        slice_char_count = text_slice.chars().count(),
+        slice_char_count = text_slice.chars().count()
         "[RETRIEVE_TEXT] Applied offset/limit"
     );
 

--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -1069,12 +1069,12 @@ pub async fn data_sources_documents_retrieve_text(
 
     // First apply character-based offset and limit
     let offset_limit_start = utils::now();
-    let offset = query.offset.unwrap_or(0);
-    let limit = query.limit;
 
-    let text_slice: String = match limit {
-        Some(l) => text.chars().skip(offset).take(l).collect(),
-        None => text.chars().skip(offset).collect(),
+    let text_slice: String = match (query.offset, query.limit) {
+        (Some(o), Some(l)) => text.chars().skip(o).take(l).collect(),
+        (Some(o), None) => text.chars().skip(o).collect(),
+        (None, Some(l)) => text.chars().take(l).collect(),
+        (None, None) => text.to_string(),
     };
     let slice_char_count = text_slice.chars().count();
 
@@ -1127,8 +1127,8 @@ pub async fn data_sources_documents_retrieve_text(
             response: Some(json!({
                 "text": filtered_text,
                 "total_characters": char_count,
-                "offset": offset,
-                "limit": limit,
+                "offset": query.offset,
+                "limit": query.limit,
             })),
         }),
     )

--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -1076,13 +1076,12 @@ pub async fn data_sources_documents_retrieve_text(
         (None, Some(l)) => text.chars().take(l).collect(),
         (None, None) => text.to_string(),
     };
-    let slice_char_count = text_slice.chars().count();
 
     let offset_limit_duration = utils::now() - offset_limit_start;
     info!(
         document_id = document_id,
         offset_limit_duration = offset_limit_duration,
-        slice_char_count = slice_char_count,
+        slice_char_count = text_slice.chars().count(),
         "[RETRIEVE_TEXT] Applied offset/limit"
     );
 

--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -1081,6 +1081,7 @@ pub async fn data_sources_documents_retrieve_text(
     info!(
         document_id = document_id,
         offset_limit_duration = offset_limit_duration,
+        total_char_count = char_count,
         slice_char_count = text_slice.chars().count(),
         "[RETRIEVE_TEXT] Applied offset/limit"
     );

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1150,7 +1150,7 @@ export class CoreAPI {
     CoreAPIResponse<{
       text: string;
       total_characters: number;
-      offset: number;
+      offset: number | null;
       limit: number | null;
     }>
   > {


### PR DESCRIPTION
## Description

- We have observed issues with the cat tool where we successfully download the blob from GCS but don't see the log for successful offset/limit applying, example [here](https://app.datadoghq.eu/logs?query=service%3Acore%20%40http.route%3A%22%2Fprojects%2F%7Bproject_id%7D%2Fdata_sources%2F%7Bdata_source_id%7D%2Fdocuments%2F%7Bdocument_id%7D%2Ftext%22%20%40url.path%3A%2Anotion-71f48613-40c9-4aa4-974a-93c5854b2c17%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZrq5gcVbqvLfQAAABhBWnJxNWlEOUFBQ0pzYXNhaExlTWFnSXAAAAAkZjE5YWVhZWYtNDRjYy00YzFiLThiOTQtYmVjODdlY2U2ZmI3AAg8oA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764799323308&to_ts=1764885723308&live=true).
- Looking into this example: [log](https://app.datadoghq.eu/logs?query=region%3Aeurope-west1%20%40toolName%3Acat%20%22Tool%20execution%20error%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764876960000&to_ts=1764878160000&live=false), [blob](https://console.cloud.google.com/storage/browser/_details/bkt-prj-dust-europe-west1-data-sources/274877933194/e48789d689ee977145fdf7396cc9e38893797024656b4140ccb7ac11d6c4a39a/0e321b154422264ddc43eab7dbc72e233c8fb24ec27eccccd21f3e0f7a7dfecf/1764693871965_f92155e37bc2f1b993d17105d47d1c97ac1f04affb441d7a668c7c6cca8e59be.json;tab=live_object?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%257B_22k_22_3A_22_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22274877933194%252Fe48789d689ee977145fdf7396cc9e38893797024656b4140ccb7ac11d6c4a39a%252F0e321b154422264ddc43eab7dbc72e233c8fb24ec27eccccd21f3e0f7a7dfecf%252F1764693871965_f92155e37bc2f1b993d17105d47d1c97ac1f04affb441d7a668c7c6cca8e59be.json_5C_22_22%257D%255D%22))&inv=1&invt=AbpYpQ&project=prj-dust-europe-west1).
- There are actually some unicode characters that can potentially get cut in two incorrectly.
- This PR fixes the slicing to operate on a character-count basis.

## Tests

- Retried on the same example.

## Risk

- Medium.

## Deploy Plan

- Deploy core.
