### PR TITLE
[connectors] fix(Zendesk): return 401 with `Could not authenticate you` as `ExternalOAuthTokenError`

### DIFF
--- a/connectors/src/connectors/zendesk/lib/errors.ts
+++ b/connectors/src/connectors/zendesk/lib/errors.ts
@@ -9,17 +9,28 @@ export class ZendeskApiError extends Error {
   }
 }
 
+function isZendesk401WithError(
+  err: ZendeskApiError,
+  errorMessage: string
+): boolean {
+  return (
+    err.status === 401 &&
+    typeof err.data === "object" &&
+    err.data !== null &&
+    "response" in err.data &&
+    typeof err.data.response === "object" &&
+    err.data.response !== null &&
+    "error" in err.data.response &&
+    err.data.response.error === errorMessage
+  );
+}
+
 export function isZendeskForbiddenError(err: unknown): err is ZendeskApiError {
   return (
     err instanceof ZendeskApiError &&
     (err.status === 403 ||
-      (err.status === 401 &&
-        typeof err.data === "object" &&
-        "response" in err.data &&
-        typeof err.data.response === "object" &&
-        err.data.response !== null &&
-        "error" in err.data.response &&
-        err.data?.response.error === "invalid_token"))
+      isZendesk401WithError(err, "invalid_token") ||
+      isZendesk401WithError(err, "Couldn't authenticate you"))
   );
 }
 


### PR DESCRIPTION
## Description

- We have had a connector stuck on 401 errors with the message `Could not authenticate you`, logs [here](https://app.datadoghq.eu/logs?query=%22zendesk%20api%20error%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZrqKb80zNpBMwAAABhBWnJxS2NZMUFBQnlZd2JDZlFkVWlnQm8AAAAkZjE5YWVhMzItODZkZC00MGQwLTk1OWMtNTU4MTE5NTdhM2FlAAGLNA&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764715135892&to_ts=1764887935892&live=true).
- This PR will prevent the connector from getting stuck by throwing an `ExternalOAuthTokenError` in this situation, which will mark the connector as errored and pause it.
- The implementation is suboptimal, ideally we catch closer to the API wrapper (currently will be done in zendesk's activity interceptor), but will do the work for now.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
