### PR TITLE
[front] enh(Zendesk): untrack 422 errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
@@ -23,6 +23,18 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
+export class ZendeskApiError extends Error {
+  public readonly isInvalidInput: boolean;
+
+  constructor(
+    message: string,
+    { isInvalidInput }: { isInvalidInput: boolean }
+  ) {
+    super(message);
+    this.isInvalidInput = isInvalidInput;
+  }
+}
+
 const MAX_CUSTOM_FIELDS_TO_FETCH = 50;
 
 export function getUniqueCustomFieldIds(
@@ -105,8 +117,9 @@ class ZendeskClient {
     if (!response.ok) {
       const errorText = await response.text();
       return new Err(
-        new Error(
-          `Zendesk API error (${response.status}): ${errorText || response.statusText}`
+        new ZendeskApiError(
+          `Zendesk API error (${response.status}): ${errorText || response.statusText}`,
+          { isInvalidInput: response.status === 422 }
         )
       );
     }

--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/index.ts
@@ -5,6 +5,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   getUniqueCustomFieldIds,
   getZendeskClient,
+  ZendeskApiError,
 } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/client";
 import {
   renderTicket,
@@ -71,10 +72,14 @@ function createServer(
         const ticketResult = await client.getTicket(ticketId);
 
         if (ticketResult.isErr()) {
+          const { error } = ticketResult;
+          const tracked = !(
+            error instanceof ZendeskApiError && error.isInvalidInput
+          );
           return new Err(
-            new MCPError(
-              `Failed to retrieve ticket: ${ticketResult.error.message}`
-            )
+            new MCPError(`Failed to retrieve ticket: ${error.message}`, {
+              tracked,
+            })
           );
         }
 
@@ -89,9 +94,16 @@ function createServer(
           const metricsResult = await client.getTicketMetrics(ticketId);
 
           if (metricsResult.isErr()) {
+            const { error } = metricsResult;
+            const tracked = !(
+              error instanceof ZendeskApiError && error.isInvalidInput
+            );
             return new Err(
               new MCPError(
-                `Failed to retrieve ticket metrics: ${metricsResult.error.message}`
+                `Failed to retrieve ticket metrics: ${error.message}`,
+                {
+                  tracked,
+                }
               )
             );
           }
@@ -103,9 +115,14 @@ function createServer(
           const commentsResult = await client.getTicketComments(ticketId);
 
           if (commentsResult.isErr()) {
+            const { error } = commentsResult;
+            const tracked = !(
+              error instanceof ZendeskApiError && error.isInvalidInput
+            );
             return new Err(
               new MCPError(
-                `Failed to retrieve ticket conversation: ${commentsResult.error.message}`
+                `Failed to retrieve ticket conversation: ${error.message}`,
+                { tracked }
               )
             );
           }
@@ -184,8 +201,14 @@ function createServer(
         const result = await client.searchTickets(query, sortBy, sortOrder);
 
         if (result.isErr()) {
+          const { error } = result;
+          const tracked = !(
+            error instanceof ZendeskApiError && error.isInvalidInput
+          );
           return new Err(
-            new MCPError(`Failed to search tickets: ${result.error.message}`)
+            new MCPError(`Failed to search tickets: ${error.message}`, {
+              tracked,
+            })
           );
         }
 
@@ -252,8 +275,12 @@ function createServer(
         const result = await client.draftReply(ticketId, body);
 
         if (result.isErr()) {
+          const { error } = result;
+          const tracked = !(
+            error instanceof ZendeskApiError && error.isInvalidInput
+          );
           return new Err(
-            new MCPError(`Failed to draft reply: ${result.error.message}`)
+            new MCPError(`Failed to draft reply: ${error.message}`, { tracked })
           );
         }
 


### PR DESCRIPTION
## Description

- This PR untracks 422 errors in the Zendesk MCP server, unplugging the alerting since this is a user-side error (input could not be processed).
- The error message are actually very clear as is ([example](https://app.datadoghq.eu/logs?query=%22zendesk%20api%20error%22%20%40dd.env%3Aprod%20%40dd.service%3Afront-agent-loop-worker&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZrqURQdcI0e0gAAABhBWnJxVVI5TUFBQTVZVHBGRnZBdlBBQnYAAAAkZjE5YWVhNWItOTc2MC00ZDMyLTkwNjktZGE0NTM2YzAzNGI1AAV5Hw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764715135892&to_ts=1764887935892&live=true)) and Zendesk are quite consistent with error codes.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
