### PR TITLE
[front] refactor: replace direct `fetch` with `clientFetch` in front-end

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -17,6 +17,7 @@ import {
   requiresBearerTokenConfiguration,
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { clientFetch } from "@app/lib/egress";
 import { useMCPServers, useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import datadogLogger from "@app/logger/datadogLogger";
@@ -95,7 +96,7 @@ export function MCPServerDetails({
     }>
   ) => {
     for (const change of toolChanges) {
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/w/${owner.sId}/mcp/${mcpServerView?.server.sId}/tools/${change.toolName}`,
         {
           method: "PATCH",
@@ -130,7 +131,7 @@ export function MCPServerDetails({
       }
 
       if (change.action === "add") {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views`,
           {
             method: "POST",
@@ -149,7 +150,7 @@ export function MCPServerDetails({
           (v) => v.spaceId === space.sId
         );
         if (view) {
-          const response = await fetch(
+          const response = await clientFetch(
             `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views/${view.sId}`,
             {
               method: "DELETE",
@@ -185,7 +186,7 @@ export function MCPServerDetails({
 
     // Patch the server view if needed.
     if (diff.serverView) {
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/w/${owner.sId}/mcp/views/${mcpServerView?.sId}`,
         {
           method: "PATCH",
@@ -212,7 +213,7 @@ export function MCPServerDetails({
         patchBody.customHeaders = diff.authCustomHeaders;
       }
 
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/w/${owner.sId}/mcp/${mcpServerView?.server.sId}`,
         {
           method: "PATCH",

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -17,7 +17,7 @@ import {
   requiresBearerTokenConfiguration,
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useMCPServers, useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import datadogLogger from "@app/logger/datadogLogger";

--- a/front/components/agent_builder/capabilities/shared/JsonSchemaSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/JsonSchemaSection.tsx
@@ -6,6 +6,7 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import { ConfigurationSectionContainer } from "@app/components/agent_builder/capabilities/shared/ConfigurationSectionContainer";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { clientFetch } from "@app/lib/egress";
 
 interface JsonSchemaSectionProps {
   getAgentInstructions: () => string;
@@ -48,7 +49,7 @@ export function JsonSchemaSection({
         fullInstructions += `\n\nTool description:\n${toolDescription}`;
       }
 
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/assistant/builder/process/generate_schema`,
         {
           method: "POST",

--- a/front/components/agent_builder/capabilities/shared/JsonSchemaSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/JsonSchemaSection.tsx
@@ -6,7 +6,7 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import { ConfigurationSectionContainer } from "@app/components/agent_builder/capabilities/shared/ConfigurationSectionContainer";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { validateConfiguredJsonSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 
 interface JsonSchemaSectionProps {
   getAgentInstructions: () => string;

--- a/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
+++ b/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useWatch } from "react-hook-form";
 
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   APIError,
   BuilderSuggestionsType,

--- a/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
+++ b/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
@@ -1,17 +1,17 @@
 import {
+  Button,
   ContentMessage,
+  LightbulbIcon,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
   Spinner,
 } from "@dust-tt/sparkle";
-import { LightbulbIcon } from "@dust-tt/sparkle";
-import { Button } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useRef, useState } from "react";
-import React from "react";
 import { useWatch } from "react-hook-form";
 
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { clientFetch } from "@app/lib/egress";
 import type {
   APIError,
   BuilderSuggestionsType,
@@ -179,19 +179,22 @@ async function getRankedSuggestions({
   currentInstructions: string;
   formerSuggestions: string[];
 }): Promise<Result<BuilderSuggestionsType, APIError>> {
-  const res = await fetch(`/api/w/${owner.sId}/assistant/builder/suggestions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      type: "instructions",
-      inputs: {
-        current_instructions: currentInstructions,
-        former_suggestions: formerSuggestions,
+  const res = await clientFetch(
+    `/api/w/${owner.sId}/assistant/builder/suggestions`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
       },
-    }),
-  });
+      body: JSON.stringify({
+        type: "instructions",
+        inputs: {
+          current_instructions: currentInstructions,
+          former_suggestions: formerSuggestions,
+        },
+      }),
+    }
+  );
 
   if (!res.ok) {
     return new Err({

--- a/front/components/agent_builder/settings/avatar_picker/AgentBuilderCustomUpload.tsx
+++ b/front/components/agent_builder/settings/avatar_picker/AgentBuilderCustomUpload.tsx
@@ -6,7 +6,7 @@ import { centerCrop, makeAspectCrop, ReactCrop } from "react-image-crop";
 
 import type { AvatarPickerTabElement } from "@app/components/agent_builder/settings/avatar_picker/types";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { classNames } from "@app/lib/utils";
 import type { WorkspaceType } from "@app/types";
 

--- a/front/components/agent_builder/settings/avatar_picker/AgentBuilderCustomUpload.tsx
+++ b/front/components/agent_builder/settings/avatar_picker/AgentBuilderCustomUpload.tsx
@@ -1,12 +1,12 @@
 import { ArrowUpOnSquareIcon, Button } from "@dust-tt/sparkle";
 import type { ChangeEvent } from "react";
-import { useImperativeHandle, useRef, useState } from "react";
-import React from "react";
+import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 import type { Crop } from "react-image-crop";
 import { centerCrop, makeAspectCrop, ReactCrop } from "react-image-crop";
 
 import type { AvatarPickerTabElement } from "@app/components/agent_builder/settings/avatar_picker/types";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
+import { clientFetch } from "@app/lib/egress";
 import { classNames } from "@app/lib/utils";
 import type { WorkspaceType } from "@app/types";
 
@@ -23,7 +23,7 @@ interface AgentBuilderCustomUploadProps {
   owner: WorkspaceType;
 }
 
-const AgentBuilderCustomUpload = React.forwardRef<
+const AgentBuilderCustomUpload = forwardRef<
   AvatarPickerTabElement,
   AgentBuilderCustomUploadProps
 >(function CustomUploadAvatar(
@@ -52,7 +52,7 @@ const AgentBuilderCustomUpload = React.forwardRef<
         if (imageRef.current && crop.width && crop.height) {
           // eslint-disable-next-line react-hooks/immutability
           const croppedImageUrl = await getCroppedImg(imageRef.current, crop);
-          const response = await fetch(croppedImageUrl);
+          const response = await clientFetch(croppedImageUrl);
 
           const blob = await response.blob();
           const f = new File([blob], "avatar.jpeg", { type: "image/jpeg" });

--- a/front/components/agent_builder/settings/utils.ts
+++ b/front/components/agent_builder/settings/utils.ts
@@ -1,4 +1,4 @@
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   APIError,
   BuilderSuggestionsType,

--- a/front/components/agent_builder/settings/utils.ts
+++ b/front/components/agent_builder/settings/utils.ts
@@ -108,7 +108,7 @@ export async function fetchWithErr<T>(
   init?: RequestInit
 ): Promise<Result<T, APIError>> {
   try {
-    const response = await fetch(input, init);
+    const response = await clientFetch(input, init);
     if (!response.ok) {
       const errorText = await response.text();
       let errorMessage;

--- a/front/components/agent_builder/settings/utils.ts
+++ b/front/components/agent_builder/settings/utils.ts
@@ -1,3 +1,4 @@
+import { clientFetch } from "@app/lib/egress";
 import type {
   APIError,
   BuilderSuggestionsType,
@@ -16,7 +17,7 @@ export async function getNameSuggestions({
   description: string;
 }): Promise<Result<BuilderSuggestionsType, APIError>> {
   try {
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/assistant/builder/suggestions`,
       {
         method: "POST",
@@ -64,7 +65,7 @@ export async function getDescriptionSuggestion({
   name: string;
 }): Promise<Result<BuilderSuggestionsType, APIError>> {
   try {
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/assistant/builder/suggestions`,
       {
         method: "POST",

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -8,7 +8,7 @@ import {
   getTableIdForContentNode,
 } from "@app/components/agent_builder/shared/tables";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { AdditionalConfigurationType } from "@app/lib/models/agent/actions/mcp";
 import { fetcherWithBody } from "@app/lib/swr/swr";
 import {

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -8,6 +8,7 @@ import {
   getTableIdForContentNode,
 } from "@app/components/agent_builder/shared/tables";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
+import { clientFetch } from "@app/lib/egress";
 import type { AdditionalConfigurationType } from "@app/lib/models/agent/actions/mcp";
 import { fetcherWithBody } from "@app/lib/swr/swr";
 import {
@@ -241,7 +242,7 @@ async function processTriggers({
   // Process triggers in order: DELETE -> PATCH -> POST (batch operations)
   // 1. Batch delete triggers
   if (formData.triggersToDelete.length > 0) {
-    const deleteRes = await fetch(
+    const deleteRes = await clientFetch(
       `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/triggers`,
       {
         method: "DELETE",
@@ -272,7 +273,7 @@ async function processTriggers({
 
   // 2. Batch update existing triggers
   if (formData.triggersToUpdate.length > 0) {
-    const updateRes = await fetch(
+    const updateRes = await clientFetch(
       `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/triggers`,
       {
         method: "PATCH",
@@ -324,7 +325,7 @@ async function processTriggers({
 
   // 3. Batch create new triggers
   if (formData.triggersToCreate.length > 0) {
-    const createRes = await fetch(
+    const createRes = await clientFetch(
       `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/triggers`,
       {
         method: "POST",
@@ -490,7 +491,7 @@ export async function submitAgentBuilderForm({
   const method = agentConfigurationId ? "PATCH" : "POST";
 
   try {
-    const response = await fetch(endpoint, {
+    const response = await clientFetch(endpoint, {
       method,
       headers: {
         "Content-Type": "application/json",
@@ -578,7 +579,7 @@ export async function submitAgentBuilderForm({
         ),
         auto_respond_without_mention: autoRespondWithoutMention,
       });
-      const slackLinkRes = await fetch(
+      const slackLinkRes = await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/linked_slack_channels`,
         {
           method: "PATCH",

--- a/front/components/app/blocks/Input.tsx
+++ b/front/components/app/blocks/Input.tsx
@@ -15,7 +15,7 @@ import { useState } from "react";
 import DatasetPicker from "@app/components/app/DatasetPicker";
 import DatasetView from "@app/components/app/DatasetView";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useDataset } from "@app/lib/swr/datasets";
 import { shallowBlockClone } from "@app/lib/utils";
 import type {

--- a/front/components/app/blocks/Input.tsx
+++ b/front/components/app/blocks/Input.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 import DatasetPicker from "@app/components/app/DatasetPicker";
 import DatasetView from "@app/components/app/DatasetView";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useDataset } from "@app/lib/swr/datasets";
 import { shallowBlockClone } from "@app/lib/utils";
 import type {
@@ -83,7 +84,7 @@ export default function Input({
     setIsDatasetModalOpen(false);
     setDatasetModalData(null);
     if (dataset) {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets/${block.config.dataset}`,
         {
           method: "POST",
@@ -137,16 +138,14 @@ export default function Input({
                   onDatasetUpdate={handleSetDataset}
                   readOnly={readOnly}
                 />
-                {block.config && block.config.dataset ? (
-                  <>
-                    <Button
-                      variant="outline"
-                      onClick={() => setIsDatasetModalOpen(true)}
-                      icon={readOnly ? EyeIcon : PencilSquareIcon}
-                      label={readOnly ? "View" : "Edit"}
-                      size="xs"
-                    />
-                  </>
+                {block.config?.dataset ? (
+                  <Button
+                    variant="outline"
+                    onClick={() => setIsDatasetModalOpen(true)}
+                    icon={readOnly ? EyeIcon : PencilSquareIcon}
+                    label={readOnly ? "View" : "Edit"}
+                    size="xs"
+                  />
                 ) : null}
               </div>
             ) : null}

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -20,6 +20,7 @@ import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { serializeMention } from "@app/lib/mentions/format";
 import {
   useAgentConfigurations,
@@ -94,7 +95,7 @@ export function AgentSuggestion({
       const editedContent = contentStartsWithLineStartMarkdown
         ? `${serializeMention(agent)}\n\n${userMessage.content}`
         : `${serializeMention(agent)} ${userMessage.content}`;
-      const mRes = await fetch(
+      const mRes = await clientFetch(
         `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${userMessage.sId}/edit`,
         {
           method: "POST",

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -20,7 +20,7 @@ import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { serializeMention } from "@app/lib/mentions/format";
 import {
   useAgentConfigurations,

--- a/front/components/assistant/conversation/EditConversationTitleDialog.tsx
+++ b/front/components/assistant/conversation/EditConversationTitleDialog.tsx
@@ -11,7 +11,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 
 type EditConversationTitleDialogProps = {
   isOpen: boolean;

--- a/front/components/assistant/conversation/EditConversationTitleDialog.tsx
+++ b/front/components/assistant/conversation/EditConversationTitleDialog.tsx
@@ -11,6 +11,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 
 type EditConversationTitleDialogProps = {
   isOpen: boolean;
@@ -44,7 +45,7 @@ export const EditConversationTitleDialog = ({
 
   const editTitle = useCallback(async () => {
     try {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${ownerId}/assistant/conversations/${conversationId}`,
         {
           method: "PATCH",

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -20,7 +20,7 @@ import {
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { classNames } from "@app/lib/utils";
 

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -20,6 +20,7 @@ import {
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { classNames } from "@app/lib/utils";
 
@@ -57,7 +58,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           feedbackContent: string | null;
           isConversationShared: boolean;
         }) => {
-          const res = await fetch(
+          const res = await clientFetch(
             `/api/w/${context.owner.sId}/assistant/conversations/${context.conversationId}/messages/${sId}/feedbacks`,
             {
               method: shouldRemoveExistingFeedback ? "DELETE" : "POST",

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -23,7 +23,7 @@ import React, {
 } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useVisualizationRetry } from "@app/lib/swr/conversations";
 import datadogLogger from "@app/logger/datadogLogger";
 import type {

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -23,6 +23,7 @@ import React, {
 } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useVisualizationRetry } from "@app/lib/swr/conversations";
 import datadogLogger from "@app/logger/datadogLogger";
 import type {
@@ -278,7 +279,7 @@ export const VisualizationActionIframe = forwardRef<
 
   const getFileBlob = useCallback(
     async (fileId: string) => {
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/w/${workspaceId}/files/${fileId}?action=view`
       );
       if (!response.ok) {

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -2,6 +2,7 @@ import type { NotificationType } from "@dust-tt/sparkle";
 import type * as t from "io-ts";
 
 import type { MessageTemporaryState } from "@app/components/assistant/conversation/types";
+import { clientFetch } from "@app/lib/egress";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type { PostMessagesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";
@@ -210,7 +211,7 @@ export async function submitMessage({
   ) {
     const contentFragmentsRes = await Promise.all([
       ...contentFragments.uploaded.map((contentFragment) => {
-        return fetch(
+        return clientFetch(
           `/api/w/${owner.sId}/assistant/conversations/${conversationId}/content_fragment`,
           {
             method: "POST",
@@ -230,7 +231,7 @@ export async function submitMessage({
         );
       }),
       ...contentFragments.contentNodes.map((contentFragment) => {
-        return fetch(
+        return clientFetch(
           `/api/w/${owner.sId}/assistant/conversations/${conversationId}/content_fragment`,
           {
             method: "POST",
@@ -267,7 +268,7 @@ export async function submitMessage({
   }
 
   // Create a new user message.
-  const mRes = await fetch(
+  const mRes = await clientFetch(
     `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages`,
     {
       method: "POST",
@@ -318,7 +319,7 @@ export async function deleteConversation({
   conversationId: string;
   sendNotification: (notification: NotificationType) => void;
 }) {
-  const res = await fetch(
+  const res = await clientFetch(
     `/api/w/${workspaceId}/assistant/conversations/${conversationId}`,
     {
       method: "DELETE",
@@ -412,13 +413,16 @@ export async function createConversationWithMessage({
   };
 
   // Create new conversation and post the initial message at the same time.
-  const cRes = await fetch(`/api/w/${owner.sId}/assistant/conversations`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
+  const cRes = await clientFetch(
+    `/api/w/${owner.sId}/assistant/conversations`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
 
   if (!cRes.ok) {
     const data = await cRes.json();

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -2,7 +2,7 @@ import type { NotificationType } from "@dust-tt/sparkle";
 import type * as t from "io-ts";
 
 import type { MessageTemporaryState } from "@app/components/assistant/conversation/types";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type { PostMessagesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -21,6 +21,7 @@ import { useState } from "react";
 import { DeleteAgentDialog } from "@app/components/assistant/DeleteAgentDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
+import { clientFetch } from "@app/lib/egress";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -180,7 +181,7 @@ export function AgentDetailsDropdownMenu({
 
   const handleExportToYAML = async () => {
     setIsExporting(true);
-    const response = await fetch(
+    const response = await clientFetch(
       `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration?.sId}/export/yaml`
     );
 

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -21,7 +21,7 @@ import { useState } from "react";
 import { DeleteAgentDialog } from "@app/components/assistant/DeleteAgentDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";

--- a/front/components/data_source/BigQueryUseMetadataForDBMLView.tsx
+++ b/front/components/data_source/BigQueryUseMetadataForDBMLView.tsx
@@ -2,6 +2,7 @@ import { BigQueryLogo, ContextItem, SliderToggle } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { APIError, DataSourceType, WorkspaceType } from "@app/types";
 
@@ -28,7 +29,7 @@ export function BigQueryUseMetadataForDBMLView({
 
   const handleSetUseMetadataForDBML = async (useMetadataForDBML: boolean) => {
     setLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/useMetadataForDBML`,
       {
         headers: {

--- a/front/components/data_source/BigQueryUseMetadataForDBMLView.tsx
+++ b/front/components/data_source/BigQueryUseMetadataForDBMLView.tsx
@@ -2,7 +2,7 @@ import { BigQueryLogo, ContextItem, SliderToggle } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { APIError, DataSourceType, WorkspaceType } from "@app/types";
 

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -138,7 +138,7 @@ export async function handleUpdatePermissions(
 
   // Slack connectors will rely on customer credentials, we need to set a reference to it on the connector to be able to properly uninstall the app on connector deletion
   if (connector.type === "slack" && connectionRes.value.relatedCredentialId) {
-    const credentialRes = await fetch(
+    const credentialRes = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/privateIntegrationCredentialId`,
       {
         method: "POST",
@@ -499,7 +499,7 @@ function DataSourceDeletionModal({
 
   const handleDelete = async () => {
     setIsLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${systemSpace.sId}/data_sources/${dataSource.sId}`,
       {
         method: "DELETE",
@@ -751,7 +751,7 @@ export function ConnectorPermissionsModal({
     setSaving(true);
     try {
       if (Object.keys(selectedNodes).length) {
-        const r = await fetch(
+        const r = await clientFetch(
           `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/permissions`,
           {
             method: "POST",

--- a/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
@@ -27,6 +27,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
+import { clientFetch } from "@app/lib/egress";
 import { useBigQueryLocations } from "@app/lib/swr/bigquery";
 import type { PostCredentialsBody } from "@app/pages/api/w/[wId]/credentials";
 import type {
@@ -173,7 +174,7 @@ export function CreateOrUpdateConnectionBigQueryModal({
     setIsLoading(true);
 
     // First we post the credentials to OAuth service.
-    const createCredentialsRes = await fetch(
+    const createCredentialsRes = await clientFetch(
       `/api/w/${owner.sId}/credentials`,
       {
         method: "POST",
@@ -247,19 +248,22 @@ export function CreateOrUpdateConnectionBigQueryModal({
     setIsLoading(true);
 
     // First we post the credentials to OAuth service.
-    const credentialsRes = await fetch(`/api/w/${owner.sId}/credentials`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        provider: "bigquery",
-        credentials: {
-          ...credentialsState.credentials,
-          location: selectedLocation,
-        } as BigQueryCredentialsWithLocation,
-      }),
-    });
+    const credentialsRes = await clientFetch(
+      `/api/w/${owner.sId}/credentials`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          provider: "bigquery",
+          credentials: {
+            ...credentialsState.credentials,
+            location: selectedLocation,
+          } as BigQueryCredentialsWithLocation,
+        }),
+      }
+    );
 
     if (!credentialsRes.ok) {
       setError("Failed to update connection: cannot verify those credentials.");
@@ -269,7 +273,7 @@ export function CreateOrUpdateConnectionBigQueryModal({
 
     const data = await credentialsRes.json();
 
-    const updateConnectorRes = await fetch(
+    const updateConnectorRes = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSourceToUpdate.sId}/managed/update`,
       {
         method: "POST",

--- a/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
@@ -27,7 +27,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useBigQueryLocations } from "@app/lib/swr/bigquery";
 import type { PostCredentialsBody } from "@app/pages/api/w/[wId]/credentials";
 import type {

--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -23,7 +23,7 @@ import { useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   ConnectorProvider,
   ConnectorType,

--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -23,6 +23,7 @@ import { useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
+import { clientFetch } from "@app/lib/egress";
 import type {
   ConnectorProvider,
   ConnectorType,
@@ -142,7 +143,7 @@ export function CreateOrUpdateConnectionSnowflakeModal({
     setIsLoading(true);
 
     // First we post the credentials to OAuth service.
-    const createCredentialsRes = await fetch(
+    const createCredentialsRes = await clientFetch(
       `/api/w/${owner.sId}/credentials`,
       {
         method: "POST",
@@ -207,16 +208,19 @@ export function CreateOrUpdateConnectionSnowflakeModal({
     setIsLoading(true);
 
     // First we post the credentials to OAuth service.
-    const credentialsRes = await fetch(`/api/w/${owner.sId}/credentials`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        provider: "snowflake",
-        credentials,
-      }),
-    });
+    const credentialsRes = await clientFetch(
+      `/api/w/${owner.sId}/credentials`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          provider: "snowflake",
+          credentials,
+        }),
+      }
+    );
 
     if (!credentialsRes.ok) {
       setError("Failed to update connection: cannot verify those credentials.");
@@ -226,7 +230,7 @@ export function CreateOrUpdateConnectionSnowflakeModal({
 
     const data = await credentialsRes.json();
 
-    const updateConnectorRes = await fetch(
+    const updateConnectorRes = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSourceToUpdate.sId}/managed/update`,
       {
         method: "POST",

--- a/front/components/data_source/DocumentOrTableDeleteDialog.tsx
+++ b/front/components/data_source/DocumentOrTableDeleteDialog.tsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useQueryParams } from "@app/hooks/useQueryParams";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   DataSourceViewType,
   LightContentNode,

--- a/front/components/data_source/DocumentOrTableDeleteDialog.tsx
+++ b/front/components/data_source/DocumentOrTableDeleteDialog.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useQueryParams } from "@app/hooks/useQueryParams";
+import { clientFetch } from "@app/lib/egress";
 import type {
   DataSourceViewType,
   LightContentNode,
@@ -74,7 +75,7 @@ export const DocumentOrTableDeleteDialog = ({
       setIsLoading(true);
       const endpoint = `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_sources/${dataSourceView.dataSource.sId}/${contentNode.type}s/${encodeURIComponent(contentNode.internalId)}`;
 
-      const res = await fetch(endpoint, { method: "DELETE" });
+      const res = await clientFetch(endpoint, { method: "DELETE" });
       if (!res.ok) {
         throw new Error(`Failed to delete ${contentNode.type}`);
       }

--- a/front/components/data_source/GithubCodeEnableView.tsx
+++ b/front/components/data_source/GithubCodeEnableView.tsx
@@ -2,7 +2,7 @@ import { ContextItem, GithubLogo, SliderToggle } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { APIError, DataSourceType, WorkspaceType } from "@app/types";
 

--- a/front/components/data_source/GithubCodeEnableView.tsx
+++ b/front/components/data_source/GithubCodeEnableView.tsx
@@ -2,6 +2,7 @@ import { ContextItem, GithubLogo, SliderToggle } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { APIError, DataSourceType, WorkspaceType } from "@app/types";
 
@@ -28,7 +29,7 @@ export function GithubCodeEnableView({
 
   const handleSetCodeSyncEnabled = async (codeSyncEnabled: boolean) => {
     setLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/codeSyncEnabled`,
       {
         headers: {

--- a/front/components/data_source/IntercomConfigView.tsx
+++ b/front/components/data_source/IntercomConfigView.tsx
@@ -2,7 +2,7 @@ import { ContextItem, IntercomLogo, SliderToggle } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { APIError, DataSourceType, WorkspaceType } from "@app/types";
 

--- a/front/components/data_source/IntercomConfigView.tsx
+++ b/front/components/data_source/IntercomConfigView.tsx
@@ -2,6 +2,7 @@ import { ContextItem, IntercomLogo, SliderToggle } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { APIError, DataSourceType, WorkspaceType } from "@app/types";
 
@@ -30,7 +31,7 @@ export function IntercomConfigView({
 
   const handleSetNewConfig = async (configValue: boolean) => {
     setLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
       {
         headers: {

--- a/front/components/data_source/SetupNotionPrivateIntegrationModal.tsx
+++ b/front/components/data_source/SetupNotionPrivateIntegrationModal.tsx
@@ -15,6 +15,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
+import { clientFetch } from "@app/lib/egress";
 import type { GetNotionWebhookConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/notion/webhook_config";
 import type { DataSourceType, LightWorkspaceType } from "@app/types";
 
@@ -52,7 +53,7 @@ export function SetupNotionPrivateIntegrationModal({
     const fetchWebhookConfig = async () => {
       setIsLoadingWebhookConfig(true);
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/notion/webhook_config`
         );
 
@@ -81,7 +82,7 @@ export function SetupNotionPrivateIntegrationModal({
     setError(null);
 
     try {
-      const response = await fetch(`/api/w/${owner.sId}/credentials`, {
+      const response = await clientFetch(`/api/w/${owner.sId}/credentials`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -104,7 +105,7 @@ export function SetupNotionPrivateIntegrationModal({
       const credentialId = data.credentials.id;
 
       // Set the credential ID on the connector
-      const configRes = await fetch(
+      const configRes = await clientFetch(
         `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/privateIntegrationCredentialId`,
         {
           method: "POST",

--- a/front/components/data_source/SetupNotionPrivateIntegrationModal.tsx
+++ b/front/components/data_source/SetupNotionPrivateIntegrationModal.tsx
@@ -15,7 +15,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { GetNotionWebhookConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/notion/webhook_config";
 import type { DataSourceType, LightWorkspaceType } from "@app/types";
 

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -15,6 +15,7 @@ import { ZendeskTicketTagFilters } from "@app/components/data_source/ZendeskTick
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
+import { clientFetch } from "@app/lib/egress";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
@@ -72,7 +73,7 @@ export function ZendeskConfigView({
     configValue: boolean | number
   ) => {
     setLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
       {
         headers: { "Content-Type": "application/json" },

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -15,7 +15,7 @@ import { ZendeskTicketTagFilters } from "@app/components/data_source/ZendeskTick
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -12,6 +12,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
+import { clientFetch } from "@app/lib/egress";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 import { safeParseJSON } from "@app/types";
@@ -93,7 +94,7 @@ export function ZendeskCustomFieldFilters({
       const currentFieldIds = customFields.map((field) => field.id);
       const updatedFieldIds = [...currentFieldIds, numericFieldId];
 
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${ZENDESK_CONFIG_KEYS.CUSTOM_FIELDS_CONFIG}`,
         {
           headers: { "Content-Type": "application/json" },
@@ -147,7 +148,7 @@ export function ZendeskCustomFieldFilters({
         .filter((field) => field.id !== fieldId)
         .map((field) => field.id);
 
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${ZENDESK_CONFIG_KEYS.CUSTOM_FIELDS_CONFIG}`,
         {
           headers: { "Content-Type": "application/json" },

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -12,7 +12,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 import { safeParseJSON } from "@app/types";

--- a/front/components/data_source/ZendeskRateLimitConfig.tsx
+++ b/front/components/data_source/ZendeskRateLimitConfig.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 

--- a/front/components/data_source/ZendeskRateLimitConfig.tsx
+++ b/front/components/data_source/ZendeskRateLimitConfig.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
+import { clientFetch } from "@app/lib/egress";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
@@ -53,7 +54,7 @@ export function ZendeskRateLimitConfig({
     configValue: number | string
   ) => {
     setLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
       {
         headers: { "Content-Type": "application/json" },

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -9,7 +9,7 @@ import {
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 import { normalizeError } from "@app/types";

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -9,6 +9,7 @@ import {
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 import { normalizeError } from "@app/types";
@@ -89,7 +90,7 @@ export function GongOptionComponent({
     }
 
     setLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
       {
         headers: { "Content-Type": "application/json" },

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -5,7 +5,7 @@ import { Plugin, TextSelection } from "@tiptap/pm/state";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 
 import { MentionComponent } from "@app/components/editor/input_bar/MentionComponent";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   AGENT_MENTION_REGEX_BEGINNING,
   USER_MENTION_REGEX_BEGINNING,

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -5,6 +5,7 @@ import { Plugin, TextSelection } from "@tiptap/pm/state";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 
 import { MentionComponent } from "@app/components/editor/input_bar/MentionComponent";
+import { clientFetch } from "@app/lib/egress";
 import {
   AGENT_MENTION_REGEX_BEGINNING,
   USER_MENTION_REGEX_BEGINNING,
@@ -271,13 +272,16 @@ async function parseMentionsOnBackend(
     return text;
   }
 
-  const response = await fetch(`/api/w/${ownerSId}/assistant/mentions/parse`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ markdown: text }),
-  });
+  const response = await clientFetch(
+    `/api/w/${ownerSId}/assistant/mentions/parse`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ markdown: text }),
+    }
+  );
 
   if (!response.ok) {
     throw new Error("Failed to parse mentions");

--- a/front/components/labs/transcripts/ProviderSelection.tsx
+++ b/front/components/labs/transcripts/ProviderSelection.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from "react";
 import type { KeyedMutator } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import {
   useLabsTranscriptsDefaultConfiguration,
   useLabsTranscriptsIsConnectorConnected,
@@ -61,17 +62,20 @@ export function ProviderSelection({
       useConnectorConnection?: boolean
     ) => {
       try {
-        const response = await fetch(`/api/w/${owner.sId}/labs/transcripts`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            connectionId,
-            provider,
-            useConnectorConnection,
-          }),
-        });
+        const response = await clientFetch(
+          `/api/w/${owner.sId}/labs/transcripts`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              connectionId,
+              provider,
+              useConnectorConnection,
+            }),
+          }
+        );
         if (!response.ok) {
           sendNotification({
             type: "error",
@@ -127,16 +131,19 @@ export function ProviderSelection({
 
   const saveApiConnection = useCallback(
     async (apiKey: string, provider: string) => {
-      const response = await fetch(`/api/w/${owner.sId}/labs/transcripts`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          apiKey,
-          provider,
-        }),
-      });
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/labs/transcripts`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            apiKey,
+            provider,
+          }),
+        }
+      );
 
       return response;
     },
@@ -145,13 +152,16 @@ export function ProviderSelection({
 
   const saveConnectorConnection = useCallback(
     async (provider: string) => {
-      const response = await fetch(`/api/w/${owner.sId}/labs/transcripts`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ provider, useConnectorConnection: true }),
-      });
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/labs/transcripts`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ provider, useConnectorConnection: true }),
+        }
+      );
       return response;
     },
     [owner.sId]

--- a/front/components/labs/transcripts/ProviderSelection.tsx
+++ b/front/components/labs/transcripts/ProviderSelection.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 import type { KeyedMutator } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   useLabsTranscriptsDefaultConfiguration,
   useLabsTranscriptsIsConnectorConnected,

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -21,6 +21,7 @@ import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { useChangeMembersRoles } from "@app/hooks/useChangeMembersRoles";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getPriceAsString } from "@app/lib/client/subscription";
+import { clientFetch } from "@app/lib/egress";
 import {
   MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY,
   sendInvitations,
@@ -94,7 +95,7 @@ export function InviteEmailButtonWithModal({
 
     const existingMembersResponses = await Promise.all(
       inviteEmailsList.map(async (email) => {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${owner.sId}/members/search?searchTerm=${encodeURIComponent(email)}`
         );
         if (!response.ok) {

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -21,7 +21,7 @@ import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { useChangeMembersRoles } from "@app/hooks/useChangeMembersRoles";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getPriceAsString } from "@app/lib/client/subscription";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY,
   sendInvitations,

--- a/front/components/poke/PokeSlackChannelPatternInput.tsx
+++ b/front/components/poke/PokeSlackChannelPatternInput.tsx
@@ -12,6 +12,7 @@ import { useCallback, useMemo, useState } from "react";
 import { SlackAutoReadPatternsTable } from "@app/components/poke/data_sources/slack/table";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { usePokeSpaces } from "@app/poke/swr/spaces";
 import type {
   DataSourceType,
@@ -42,7 +43,7 @@ export function SlackChannelPatternInput({
 
   const { submit: updatePatterns } = useSubmitFunction(
     async (patterns: SlackAutoReadPattern[]) => {
-      const r = await fetch(
+      const r = await clientFetch(
         `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/config`,
         {
           method: "POST",

--- a/front/components/poke/PokeSlackChannelPatternInput.tsx
+++ b/front/components/poke/PokeSlackChannelPatternInput.tsx
@@ -12,7 +12,7 @@ import { useCallback, useMemo, useState } from "react";
 import { SlackAutoReadPatternsTable } from "@app/components/poke/data_sources/slack/table";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { usePokeSpaces } from "@app/poke/swr/spaces";
 import type {
   DataSourceType,

--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -10,6 +10,7 @@ import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 import Link from "next/link";
 
+import { clientFetch } from "@app/lib/egress";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { LightWorkspaceType } from "@app/types";
 
@@ -165,7 +166,7 @@ async function archiveAssistant(
   }
 
   try {
-    const r = await fetch(
+    const r = await clientFetch(
       `/api/poke/workspaces/${owner.sId}/agent_configurations/${agentConfiguration.sId}`,
       {
         method: "DELETE",
@@ -199,7 +200,7 @@ async function restoreAssistant(
   }
 
   try {
-    const r = await fetch(
+    const r = await clientFetch(
       `/api/poke/workspaces/${owner.sId}/agent_configurations/${agentConfiguration.sId}/restore`,
       {
         method: "POST",

--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -10,7 +10,7 @@ import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 import Link from "next/link";
 
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { LightWorkspaceType } from "@app/types";
 

--- a/front/components/poke/assistants/table.tsx
+++ b/front/components/poke/assistants/table.tsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 import { makeColumnsForAssistants } from "@app/components/poke/assistants/columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
 import type {

--- a/front/components/poke/assistants/table.tsx
+++ b/front/components/poke/assistants/table.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { makeColumnsForAssistants } from "@app/components/poke/assistants/columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { clientFetch } from "@app/lib/egress";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
 import type {
@@ -51,7 +52,7 @@ const importAssistant = async (
     }
     setImporting(true);
     const fileContent = await file.text();
-    const response = await fetch(
+    const response = await clientFetch(
       `/api/poke/workspaces/${owner.sId}/agent_configurations/import`,
       {
         method: "POST",

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -33,6 +33,7 @@ import {
 } from "@app/components/poke/shadcn/ui/table";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { isWebhookBasedProvider } from "@app/lib/connector_providers";
+import { clientFetch } from "@app/lib/egress";
 import {
   decodeSqids,
   formatTimestampToFriendlyDate,
@@ -338,7 +339,7 @@ function CopyTokenButton({ owner, dsId }: CopyTokenButtonProps) {
 
     setIsLoading(true);
     setError(null);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/poke/workspaces/${owner.sId}/data_sources/${dsId}/token`
     );
     if (!res.ok) {
@@ -462,7 +463,7 @@ function CheckConnectorStuck({
   const checkStuck = async () => {
     setIsLoading(true);
     try {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/poke/workspaces/${owner.sId}/data_sources/${dsId}/check-stuck`
       );
       if (!res.ok) {

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -33,7 +33,7 @@ import {
 } from "@app/components/poke/shadcn/ui/table";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { isWebhookBasedProvider } from "@app/lib/connector_providers";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   decodeSqids,
   formatTimestampToFriendlyDate,

--- a/front/components/poke/invitations/table.tsx
+++ b/front/components/poke/invitations/table.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   MembershipInvitationTypeWithLink,
   WorkspaceType,

--- a/front/components/poke/invitations/table.tsx
+++ b/front/components/poke/invitations/table.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { clientFetch } from "@app/lib/egress";
 import type {
   MembershipInvitationTypeWithLink,
   WorkspaceType,
@@ -24,15 +25,18 @@ export function InvitationsDataTable({
     }
 
     try {
-      const r = await fetch(`/api/poke/workspaces/${owner.sId}/invitations`, {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          email,
-        }),
-      });
+      const r = await clientFetch(
+        `/api/poke/workspaces/${owner.sId}/invitations`,
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email,
+          }),
+        }
+      );
       if (!r.ok) {
         throw new Error(`Failed to revoke invitation: ${r.statusText}`);
       }

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import type { MemberDisplayType } from "@app/components/poke/members/columns";
 import { makeColumnsForMembers } from "@app/components/poke/members/columns";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   RoleType,
   UserTypeWithWorkspaces,

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import type { MemberDisplayType } from "@app/components/poke/members/columns";
 import { makeColumnsForMembers } from "@app/components/poke/members/columns";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { clientFetch } from "@app/lib/egress";
 import type {
   RoleType,
   UserTypeWithWorkspaces,
@@ -47,7 +48,7 @@ export function MembersDataTable({
     }
 
     try {
-      const r = await fetch(`/api/poke/workspaces/${owner.sId}/revoke`, {
+      const r = await clientFetch(`/api/poke/workspaces/${owner.sId}/revoke`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -76,7 +77,7 @@ export function MembersDataTable({
     }
 
     try {
-      const r = await fetch(`/api/poke/workspaces/${owner.sId}/roles`, {
+      const r = await clientFetch(`/api/poke/workspaces/${owner.sId}/roles`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -20,7 +20,7 @@ import {
   InputField,
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { EnterpriseUpgradeFormType, WorkspaceType } from "@app/types";

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -20,6 +20,7 @@ import {
   InputField,
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
+import { clientFetch } from "@app/lib/egress";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { EnterpriseUpgradeFormType, WorkspaceType } from "@app/types";
@@ -66,7 +67,7 @@ export default function EnterpriseUpgradeDialog({
         setIsSubmitting(true);
         setError(null);
         try {
-          const r = await fetch(
+          const r = await clientFetch(
             `/api/poke/workspaces/${owner.sId}/upgrade_enterprise`,
             {
               method: "POST",

--- a/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
@@ -20,7 +20,7 @@ import {
   InputField,
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { FreePlanUpgradeFormType, WorkspaceType } from "@app/types";

--- a/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
@@ -20,6 +20,7 @@ import {
   InputField,
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
+import { clientFetch } from "@app/lib/egress";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { FreePlanUpgradeFormType, WorkspaceType } from "@app/types";
@@ -65,13 +66,16 @@ export default function FreePlanUpgradeDialog({
       setIsSubmitting(true);
       setError(null);
       try {
-        const r = await fetch(`/api/poke/workspaces/${owner.sId}/upgrade`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(cleanedValues),
-        });
+        const r = await clientFetch(
+          `/api/poke/workspaces/${owner.sId}/upgrade`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(cleanedValues),
+          }
+        );
 
         if (!r.ok) {
           throw new Error(

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -33,6 +33,7 @@ import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/
 import EnterpriseUpgradeDialog from "@app/components/poke/subscriptions/EnterpriseUpgradeDialog";
 import FreePlanUpgradeDialog from "@app/components/poke/subscriptions/FreePlanUpgradeDialog";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { FREE_NO_PLAN_CODE, isProPlanPrefix } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { PlanType, SubscriptionType, WorkspaceType } from "@app/types";
@@ -310,12 +311,15 @@ function UpgradeDowngradeModal({
       return;
     }
     try {
-      const r = await fetch(`/api/poke/workspaces/${owner.sId}/downgrade`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+      const r = await clientFetch(
+        `/api/poke/workspaces/${owner.sId}/downgrade`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
       if (!r.ok) {
         throw new Error("Failed to downgrade workspace.");
       }
@@ -336,15 +340,18 @@ function UpgradeDowngradeModal({
         return;
       }
       try {
-        const r = await fetch(`/api/poke/workspaces/${owner.sId}/upgrade`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            planCode: plan.code,
-          }),
-        });
+        const r = await clientFetch(
+          `/api/poke/workspaces/${owner.sId}/upgrade`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              planCode: plan.code,
+            }),
+          }
+        );
         if (!r.ok) {
           throw new Error("Failed to upgrade workspace to plan.");
         }

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -33,7 +33,7 @@ import { makeColumnsForSubscriptions } from "@app/components/poke/subscriptions/
 import EnterpriseUpgradeDialog from "@app/components/poke/subscriptions/EnterpriseUpgradeDialog";
 import FreePlanUpgradeDialog from "@app/components/poke/subscriptions/FreePlanUpgradeDialog";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { FREE_NO_PLAN_CODE, isProPlanPrefix } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { PlanType, SubscriptionType, WorkspaceType } from "@app/types";

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -2,6 +2,7 @@ import { IconButton, LinkWrapper, TrashIcon } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { clientFetch } from "@app/lib/egress";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { TriggerWithProviderType } from "@app/pages/api/poke/workspaces/[wId]/triggers";
 import type {
@@ -199,7 +200,7 @@ async function deleteTrigger(
   }
 
   try {
-    const r = await fetch(
+    const r = await clientFetch(
       `/api/poke/workspaces/${owner.sId}/triggers?tId=${trigger.sId}`,
       {
         method: "DELETE",

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -2,7 +2,7 @@ import { IconButton, LinkWrapper, TrashIcon } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { TriggerWithProviderType } from "@app/pages/api/poke/workspaces/[wId]/triggers";
 import type {

--- a/front/components/providers/ProviderSetup.tsx
+++ b/front/components/providers/ProviderSetup.tsx
@@ -12,6 +12,7 @@ import type { MouseEvent } from "react";
 import React, { useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
+import { clientFetch } from "@app/lib/egress";
 import { checkProvider } from "@app/lib/providers";
 import type { WorkspaceType } from "@app/types";
 
@@ -348,7 +349,7 @@ export function ProviderSetup({
       payload[field.name] = values[field.name];
     }
 
-    await fetch(`/api/w/${owner.sId}/providers/${providerId}`, {
+    await clientFetch(`/api/w/${owner.sId}/providers/${providerId}`, {
       headers: { "Content-Type": "application/json" },
       method: "POST",
       body: JSON.stringify({ config: JSON.stringify(payload) }),
@@ -359,7 +360,7 @@ export function ProviderSetup({
   };
 
   const handleDisable = async () => {
-    await fetch(`/api/w/${owner.sId}/providers/${providerId}`, {
+    await clientFetch(`/api/w/${owner.sId}/providers/${providerId}`, {
       method: "DELETE",
     });
     await mutate(`/api/w/${owner.sId}/providers`);

--- a/front/components/providers/ProviderSetup.tsx
+++ b/front/components/providers/ProviderSetup.tsx
@@ -12,7 +12,7 @@ import type { MouseEvent } from "react";
 import React, { useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { checkProvider } from "@app/lib/providers";
 import type { WorkspaceType } from "@app/types";
 

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -1,5 +1,5 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { SkillConfigurationType } from "@app/pages/api/w/[wId]/assistant/skill_configurations";
 import type { Result, WorkspaceType } from "@app/types";
 import { Err, Ok } from "@app/types";

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -1,4 +1,5 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { clientFetch } from "@app/lib/egress";
 import type { SkillConfigurationType } from "@app/pages/api/w/[wId]/assistant/skill_configurations";
 import type { Result, WorkspaceType } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -10,7 +11,7 @@ export async function submitSkillBuilderForm({
   formData: SkillBuilderFormData;
   owner: WorkspaceType;
 }): Promise<Result<SkillConfigurationType, Error>> {
-  const response = await fetch(
+  const response = await clientFetch(
     `/api/w/${owner.sId}/assistant/skill_configurations`,
     {
       method: "POST",

--- a/front/components/spaces/AdvancedNotionManagement.tsx
+++ b/front/components/spaces/AdvancedNotionManagement.tsx
@@ -15,6 +15,7 @@ import type { CellContext } from "@tanstack/react-table";
 import { isLeft } from "fp-ts/lib/Either";
 import { useCallback, useState } from "react";
 
+import { clientFetch } from "@app/lib/egress";
 import { useNotionLastSyncedUrls } from "@app/lib/swr/data_sources";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 import { GetPostNotionSyncResponseBodySchema } from "@app/types";
@@ -196,7 +197,7 @@ export function AdvancedNotionManagement({
     setUrlStatus(null);
 
     try {
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/notion_url_status`,
         {
           method: "POST",
@@ -236,7 +237,7 @@ export function AdvancedNotionManagement({
 
     try {
       if (trimmedUrls.length && validateUrls(trimmedUrls)) {
-        const r = await fetch(
+        const r = await clientFetch(
           `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/notion_url_sync`,
           {
             method: "POST",

--- a/front/components/spaces/AdvancedNotionManagement.tsx
+++ b/front/components/spaces/AdvancedNotionManagement.tsx
@@ -15,7 +15,7 @@ import type { CellContext } from "@tanstack/react-table";
 import { isLeft } from "fp-ts/lib/Either";
 import { useCallback, useState } from "react";
 
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useNotionLastSyncedUrls } from "@app/lib/swr/data_sources";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 import { GetPostNotionSyncResponseBodySchema } from "@app/types";

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -28,7 +28,7 @@ import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getDisplayNameForDataSource, isManaged } from "@app/lib/data_sources";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import {
   useSpaceDataSourceViews,

--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -28,6 +28,7 @@ import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getDisplayNameForDataSource, isManaged } from "@app/lib/data_sources";
+import { clientFetch } from "@app/lib/egress";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import {
   useSpaceDataSourceViews,
@@ -186,7 +187,7 @@ export function EditSpaceManagedDataSourcesViews({
     const deletePromisesErrors = await Promise.all(
       deletedViews.map(async (deletedView) => {
         try {
-          const res = await fetch(
+          const res = await clientFetch(
             `/api/w/${owner.sId}/spaces/${space.sId}/data_source_views/${deletedView.sId}?force=true`,
             {
               method: "DELETE",
@@ -238,7 +239,7 @@ export function EditSpaceManagedDataSourcesViews({
                     "it should have been removed. Action: check the DataSourceViewSelector component."
                 );
               } else {
-                res = await fetch(
+                res = await clientFetch(
                   `/api/w/${owner.sId}/spaces/${space.sId}/data_source_views/${existingViewForDs.sId}`,
                   {
                     method: "PATCH",
@@ -250,7 +251,7 @@ export function EditSpaceManagedDataSourcesViews({
                 );
               }
             } else {
-              res = await fetch(
+              res = await clientFetch(
                 `/api/w/${owner.sId}/spaces/${space.sId}/data_source_views`,
                 {
                   method: "POST",

--- a/front/components/spaces/SpaceCreateAppModal.tsx
+++ b/front/components/spaces/SpaceCreateAppModal.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useApps } from "@app/lib/swr/apps";
 import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 import type { PostAppResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps";
@@ -63,16 +64,19 @@ export const SpaceCreateAppModal = ({
     // Validation is already done in onChange handlers and Save button disabled logic
     // Only proceed if all validations pass (button wouldn't be enabled otherwise)
     if (name.trim() && description.trim() && !nameError) {
-      const res = await fetch(`/api/w/${owner.sId}/spaces/${space.sId}/apps`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: name.slice(0, MODELS_STRING_MAX_LENGTH),
-          description: description.slice(0, MODELS_STRING_MAX_LENGTH),
-        }),
-      });
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${space.sId}/apps`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            name: name.slice(0, MODELS_STRING_MAX_LENGTH),
+            description: description.slice(0, MODELS_STRING_MAX_LENGTH),
+          }),
+        }
+      );
       if (res.ok) {
         await mutateApps();
         const response: PostAppResponseBody = await res.json();

--- a/front/components/spaces/SpaceCreateAppModal.tsx
+++ b/front/components/spaces/SpaceCreateAppModal.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useApps } from "@app/lib/swr/apps";
 import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
 import type { PostAppResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps";

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -51,7 +51,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { usePeriodicRefresh } from "@app/hooks/usePeriodicRefresh";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   useDataSourceViewContentNodes,
   useDataSourceViews,

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -51,6 +51,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { usePeriodicRefresh } from "@app/hooks/usePeriodicRefresh";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
+import { clientFetch } from "@app/lib/egress";
 import {
   useDataSourceViewContentNodes,
   useDataSourceViews,
@@ -388,7 +389,7 @@ export const SpaceDataSourceViewContentList = ({
       try {
         let res;
         if (existingViewForSpace) {
-          res = await fetch(
+          res = await clientFetch(
             `/api/w/${owner.sId}/spaces/${spaceSId}/data_source_views/${existingViewForSpace.sId}`,
             {
               method: "PATCH",
@@ -401,7 +402,7 @@ export const SpaceDataSourceViewContentList = ({
             }
           );
         } else {
-          res = await fetch(
+          res = await clientFetch(
             `/api/w/${owner.sId}/spaces/${spaceSId}/data_source_views`,
             {
               method: "POST",

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -37,7 +37,7 @@ import {
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViews } from "@app/lib/swr/data_source_views";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import type {

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -37,6 +37,7 @@ import {
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import { clientFetch } from "@app/lib/egress";
 import { useDataSourceViews } from "@app/lib/swr/data_source_views";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import type {
@@ -599,7 +600,7 @@ function SearchResultsTable({
       try {
         let res;
         if (existingViewForSpace) {
-          res = await fetch(
+          res = await clientFetch(
             `/api/w/${owner.sId}/spaces/${spaceId}/data_source_views/${existingViewForSpace.sId}`,
             {
               method: "PATCH",
@@ -612,7 +613,7 @@ function SearchResultsTable({
             }
           );
         } else {
-          res = await fetch(
+          res = await clientFetch(
             `/api/w/${owner.sId}/spaces/${spaceId}/data_source_views`,
             {
               method: "POST",

--- a/front/components/spaces/websites/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/websites/SpaceWebsiteModal.tsx
@@ -15,7 +15,7 @@ import { DeleteStaticDataSourceDialog } from "@app/components/data_source/Delete
 import { SpaceWebsiteForm } from "@app/components/spaces/websites/SpaceWebsiteForm";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { createWebsite, updateWebsite } from "@app/lib/api/website";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewConnectorConfiguration } from "@app/lib/swr/data_source_views";
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 import { urlToDataSourceName } from "@app/lib/webcrawler";

--- a/front/components/spaces/websites/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/websites/SpaceWebsiteModal.tsx
@@ -15,6 +15,7 @@ import { DeleteStaticDataSourceDialog } from "@app/components/data_source/Delete
 import { SpaceWebsiteForm } from "@app/components/spaces/websites/SpaceWebsiteForm";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { createWebsite, updateWebsite } from "@app/lib/api/website";
+import { clientFetch } from "@app/lib/egress";
 import { useDataSourceViewConnectorConfiguration } from "@app/lib/swr/data_source_views";
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 import { urlToDataSourceName } from "@app/lib/webcrawler";
@@ -268,7 +269,7 @@ export default function SpaceWebsiteModal({
     }
     setIsSaving(true);
     try {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/spaces/${space.sId}/data_sources/${dataSourceView.dataSource.sId}`,
         { method: "DELETE" }
       );

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -36,6 +36,7 @@ import { WebhookSourceDetailsInfo } from "@app/components/triggers/WebhookSource
 import { WebhookSourceDetailsSharing } from "@app/components/triggers/WebhookSourceDetailsSharing";
 import { WebhookSourceViewIcon } from "@app/components/triggers/WebhookSourceViewIcon";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import {
   useCreateWebhookSource,
@@ -284,7 +285,7 @@ function WebhookSourceSheetContent({
         }
 
         if (change.action === "add") {
-          const response = await fetch(
+          const response = await clientFetch(
             `/api/w/${owner.sId}/spaces/${space.sId}/webhook_source_views`,
             {
               method: "POST",
@@ -303,7 +304,7 @@ function WebhookSourceSheetContent({
             (v) => v.spaceId === space.sId
           );
           if (view) {
-            const response = await fetch(
+            const response = await clientFetch(
               `/api/w/${owner.sId}/spaces/${space.sId}/webhook_source_views/${view.sId}`,
               {
                 method: "DELETE",
@@ -334,7 +335,7 @@ function WebhookSourceSheetContent({
           const diff = diffWebhookSourceForm(editDefaults, values);
 
           if (diff.requestBody) {
-            const response = await fetch(
+            const response = await clientFetch(
               `/api/w/${owner.sId}/webhook_sources/views/${systemView.sId}`,
               {
                 method: "PATCH",

--- a/front/components/triggers/WebhookSourceSheet.tsx
+++ b/front/components/triggers/WebhookSourceSheet.tsx
@@ -36,7 +36,7 @@ import { WebhookSourceDetailsInfo } from "@app/components/triggers/WebhookSource
 import { WebhookSourceDetailsSharing } from "@app/components/triggers/WebhookSourceDetailsSharing";
 import { WebhookSourceViewIcon } from "@app/components/triggers/WebhookSourceViewIcon";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import {
   useCreateWebhookSource,

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -28,7 +28,7 @@ import {
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { canUseModel } from "@app/lib/assistant";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useFeatureFlags, useWorkspace } from "@app/lib/swr/workspaces";
 import type { ModelProviderIdType, PlanType, WorkspaceType } from "@app/types";
 import { EMBEDDING_PROVIDER_IDS, MODEL_PROVIDER_IDS } from "@app/types";

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -28,6 +28,7 @@ import {
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { canUseModel } from "@app/lib/assistant";
+import { clientFetch } from "@app/lib/egress";
 import { useFeatureFlags, useWorkspace } from "@app/lib/swr/workspaces";
 import type { ModelProviderIdType, PlanType, WorkspaceType } from "@app/types";
 import { EMBEDDING_PROVIDER_IDS, MODEL_PROVIDER_IDS } from "@app/types";
@@ -150,7 +151,7 @@ export function ProviderManagementModal({
       });
     } else {
       try {
-        const response = await fetch(`/api/w/${owner.sId}`, {
+        const response = await clientFetch(`/api/w/${owner.sId}`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/front/components/workspace/sso/AutoJoinToggle.tsx
+++ b/front/components/workspace/sso/AutoJoinToggle.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 
 import { UpgradePlanDialog } from "@app/components/workspace/UpgradePlanDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import type { PlanType, WorkspaceDomain, WorkspaceType } from "@app/types";
 import { pluralize } from "@app/types";
@@ -51,7 +52,7 @@ function DomainAutoJoinModal({
   );
 
   async function handleUpdateWorkspace(): Promise<void> {
-    const res = await fetch(`/api/w/${owner.sId}`, {
+    const res = await clientFetch(`/api/w/${owner.sId}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/front/components/workspace/sso/AutoJoinToggle.tsx
+++ b/front/components/workspace/sso/AutoJoinToggle.tsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 
 import { UpgradePlanDialog } from "@app/components/workspace/UpgradePlanDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import type { PlanType, WorkspaceDomain, WorkspaceType } from "@app/types";
 import { pluralize } from "@app/types";

--- a/front/components/workspace/sso/Toggle.tsx
+++ b/front/components/workspace/sso/Toggle.tsx
@@ -9,6 +9,7 @@ import {
 import React from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import type { WorkspaceType } from "@app/types";
 
 export function ToggleEnforceEnterpriseConnectionModal({
@@ -41,7 +42,7 @@ export function ToggleEnforceEnterpriseConnectionModal({
 
   const handleToggleSsoEnforced = React.useCallback(
     async (ssoEnforced: boolean) => {
-      const res = await fetch(`/api/w/${owner.sId}`, {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/components/workspace/sso/Toggle.tsx
+++ b/front/components/workspace/sso/Toggle.tsx
@@ -9,7 +9,7 @@ import {
 import React from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { WorkspaceType } from "@app/types";
 
 export function ToggleEnforceEnterpriseConnectionModal({

--- a/front/hooks/useChangeMembersRoles.ts
+++ b/front/hooks/useChangeMembersRoles.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
 import { useMembers, useSearchMembers } from "@app/lib/swr/memberships";
 import type {
   LightWorkspaceType,
@@ -47,7 +48,7 @@ export function useChangeMembersRoles({
       }
 
       const promises = members.map((member) =>
-        fetch(`/api/w/${owner.sId}/members/${member.sId}`, {
+        clientFetch(`/api/w/${owner.sId}/members/${member.sId}`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/front/hooks/useDeleteAgentMessage.ts
+++ b/front/hooks/useDeleteAgentMessage.ts
@@ -2,7 +2,7 @@ import { useSWRConfig } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { normalizeError } from "@app/types";
 
 export function useDeleteAgentMessage({

--- a/front/hooks/useDeleteAgentMessage.ts
+++ b/front/hooks/useDeleteAgentMessage.ts
@@ -2,6 +2,7 @@ import { useSWRConfig } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { normalizeError } from "@app/types";
 
 export function useDeleteAgentMessage({
@@ -16,7 +17,7 @@ export function useDeleteAgentMessage({
 
   const { submit: deleteAgentMessage, isSubmitting } = useSubmitFunction(
     async (messageId: string) => {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}`,
         {
           method: "DELETE",

--- a/front/hooks/useDeleteMessage.ts
+++ b/front/hooks/useDeleteMessage.ts
@@ -2,7 +2,7 @@ import { useSWRConfig } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { normalizeError } from "@app/types";
 
 export function useDeleteMessage({

--- a/front/hooks/useDeleteMessage.ts
+++ b/front/hooks/useDeleteMessage.ts
@@ -2,6 +2,7 @@ import { useSWRConfig } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { normalizeError } from "@app/types";
 
 export function useDeleteMessage({
@@ -16,7 +17,7 @@ export function useDeleteMessage({
 
   const { submit: deleteMessage, isSubmitting } = useSubmitFunction(
     async (messageId: string) => {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}`,
         {
           method: "DELETE",

--- a/front/hooks/useDismissFeedback.ts
+++ b/front/hooks/useDismissFeedback.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 
 export function useDismissFeedback({
   workspaceId,

--- a/front/hooks/useDismissFeedback.ts
+++ b/front/hooks/useDismissFeedback.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 
 export function useDismissFeedback({
   workspaceId,
@@ -19,7 +20,7 @@ export function useDismissFeedback({
   const toggleDismiss = useCallback(
     async (dismissed: boolean) => {
       setIsDismissing(true);
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/feedbacks/${feedbackId}`,
         {
           method: "PATCH",

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -2,6 +2,7 @@ import type { ChangeEvent } from "react";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
 import type { FileUploadedRequestResponseBody } from "@app/pages/api/w/[wId]/files/[fileId]";
@@ -185,7 +186,7 @@ export function useFileUploaderService({
         // Get upload URL from server.
         let uploadResponse;
         try {
-          uploadResponse = await fetch(`/api/w/${owner.sId}/files`, {
+          uploadResponse = await clientFetch(`/api/w/${owner.sId}/files`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -234,7 +235,7 @@ export function useFileUploaderService({
         // Upload a file to the obtained URL.
         let uploadResult;
         try {
-          uploadResult = await fetch(file.uploadUrl, {
+          uploadResult = await clientFetch(file.uploadUrl, {
             method: "POST",
             body: formData,
           });

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -2,7 +2,7 @@ import type { ChangeEvent } from "react";
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
 import type { FileUploadedRequestResponseBody } from "@app/pages/api/w/[wId]/files/[fileId]";

--- a/front/hooks/useFrameSharingToggle.ts
+++ b/front/hooks/useFrameSharingToggle.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import type { LightWorkspaceType } from "@app/types";
 
 interface UseFrameSharingToggleProps {
@@ -21,7 +22,7 @@ export function useFrameSharingToggle({ owner }: UseFrameSharingToggleProps) {
   const doToggleInteractiveContentSharing = async () => {
     setIsChanging(true);
     try {
-      const res = await fetch(`/api/w/${owner.sId}`, {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/hooks/useFrameSharingToggle.ts
+++ b/front/hooks/useFrameSharingToggle.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { LightWorkspaceType } from "@app/types";
 
 interface UseFrameSharingToggleProps {

--- a/front/hooks/useValidateAction.ts
+++ b/front/hooks/useValidateAction.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
+import { clientFetch } from "@app/lib/egress";
 import type {
   ConversationWithoutContentType,
   LightWorkspaceType,
@@ -34,7 +35,7 @@ export function useValidateAction({
 
       try {
         // Validate the action.
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${owner.sId}/assistant/conversations/${validationRequest.conversationId}/messages/${validationRequest.messageId}/validate-action`,
           {
             method: "POST",
@@ -70,7 +71,7 @@ export function useValidateAction({
           messageId &&
           conversation.sId !== validationRequest.conversationId
         ) {
-          const response = await fetch(
+          const response = await clientFetch(
             `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}/messages/${messageId}/retry?blocked_only=true`,
             {
               method: "POST",

--- a/front/hooks/useValidateAction.ts
+++ b/front/hooks/useValidateAction.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   ConversationWithoutContentType,
   LightWorkspaceType,

--- a/front/hooks/useVoiceTranscriberService.ts
+++ b/front/hooks/useVoiceTranscriberService.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { AugmentedMessage } from "@app/lib/utils/find_agents_in_message";
 import type { LightWorkspaceType } from "@app/types";
 import { normalizeError } from "@app/types";

--- a/front/hooks/useVoiceTranscriberService.ts
+++ b/front/hooks/useVoiceTranscriberService.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import type { AugmentedMessage } from "@app/lib/utils/find_agents_in_message";
 import type { LightWorkspaceType } from "@app/types";
 import { normalizeError } from "@app/types";
@@ -180,10 +181,13 @@ export function useVoiceTranscriberService({
       const form = new FormData();
       form.append("file", file);
 
-      const resp = await fetch(`/api/w/${owner.sId}/services/transcribe`, {
-        method: "POST",
-        body: form,
-      });
+      const resp = await clientFetch(
+        `/api/w/${owner.sId}/services/transcribe`,
+        {
+          method: "POST",
+          body: form,
+        }
+      );
 
       if (!resp.ok) {
         const msg = await resp.text();

--- a/front/hooks/useVoiceTranscriptionToggle.ts
+++ b/front/hooks/useVoiceTranscriptionToggle.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { LightWorkspaceType } from "@app/types";
 
 interface UseVoiceTranscriptionToggleProps {

--- a/front/hooks/useVoiceTranscriptionToggle.ts
+++ b/front/hooks/useVoiceTranscriptionToggle.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import type { LightWorkspaceType } from "@app/types";
 
 interface UseVoiceTranscriptionToggleProps {
@@ -19,7 +20,7 @@ export function useVoiceTranscriptionToggle({
   const doToggleVoiceTranscription = async () => {
     setIsChanging(true);
     try {
-      const res = await fetch(`/api/w/${owner.sId}`, {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/hooks/useYAMLUpload.ts
+++ b/front/hooks/useYAMLUpload.ts
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import {
   trackEvent,
   TRACKING_ACTIONS,
@@ -39,7 +40,7 @@ export function useYAMLUpload({ owner }: UseYAMLUploadOptions) {
 
       setIsUploading(true);
       const yamlContent = await file.text();
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/new/yaml`,
         {
           method: "POST",

--- a/front/hooks/useYAMLUpload.ts
+++ b/front/hooks/useYAMLUpload.ts
@@ -2,7 +2,7 @@ import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   trackEvent,
   TRACKING_ACTIONS,

--- a/front/hooks/useZendeskOrganizationTagFilters.ts
+++ b/front/hooks/useZendeskOrganizationTagFilters.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
+import { clientFetch } from "@app/lib/egress";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
@@ -62,7 +63,7 @@ export function useZendeskOrganizationTagFilters({
         }
 
         const newTags = [...currentTags, tag];
-        const res = await fetch(
+        const res = await clientFetch(
           `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
           {
             headers: { "Content-Type": "application/json" },
@@ -132,7 +133,7 @@ export function useZendeskOrganizationTagFilters({
         }
 
         const newTags = currentTags.filter((t: string) => t !== tag);
-        const res = await fetch(
+        const res = await clientFetch(
           `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
           {
             headers: { "Content-Type": "application/json" },

--- a/front/hooks/useZendeskOrganizationTagFilters.ts
+++ b/front/hooks/useZendeskOrganizationTagFilters.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 

--- a/front/hooks/useZendeskTicketTagFilters.ts
+++ b/front/hooks/useZendeskTicketTagFilters.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
+import { clientFetch } from "@app/lib/egress";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
@@ -56,7 +57,7 @@ export function useZendeskTicketTagFilters({
         }
 
         const newTags = [...currentTags, tag];
-        const res = await fetch(
+        const res = await clientFetch(
           `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
           {
             headers: { "Content-Type": "application/json" },
@@ -126,7 +127,7 @@ export function useZendeskTicketTagFilters({
         }
 
         const newTags = currentTags.filter((t: string) => t !== tag);
-        const res = await fetch(
+        const res = await clientFetch(
           `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
           {
             headers: { "Content-Type": "application/json" },

--- a/front/hooks/useZendeskTicketTagFilters.ts
+++ b/front/hooks/useZendeskTicketTagFilters.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 

--- a/front/lib/api/status/status_page.ts
+++ b/front/lib/api/status/status_page.ts
@@ -2,6 +2,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
+import { clientFetch } from "@app/lib/egress";
 import logger from "@app/logger/logger";
 
 const StatusPageUnresolvedIncident = t.type({
@@ -26,7 +27,7 @@ export async function getUnresolvedIncidents({
   pageId: string;
 }): Promise<StatusPageReponseType> {
   try {
-    const res = await fetch(
+    const res = await clientFetch(
       `https://api.statuspage.io/v1/pages/${pageId}/incidents/unresolved`,
       {
         headers: {

--- a/front/lib/api/status/status_page.ts
+++ b/front/lib/api/status/status_page.ts
@@ -2,7 +2,6 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
-import { clientFetch } from "@app/lib/egress";
 import logger from "@app/logger/logger";
 
 const StatusPageUnresolvedIncident = t.type({
@@ -27,7 +26,7 @@ export async function getUnresolvedIncidents({
   pageId: string;
 }): Promise<StatusPageReponseType> {
   try {
-    const res = await clientFetch(
+    const res = await fetch(
       `https://api.statuspage.io/v1/pages/${pageId}/incidents/unresolved`,
       {
         headers: {

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,4 +1,4 @@
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   LightWorkspaceType,
   UserType,

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -1,3 +1,4 @@
+import { clientFetch } from "@app/lib/egress";
 import type {
   LightWorkspaceType,
   UserType,
@@ -24,16 +25,19 @@ export async function forceUserRole(
     return new Err(`Already in the role ${role}`);
   }
 
-  const response = await fetch(`/api/w/${owner.sId}/members/${user.sId}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      role,
-      force: "true",
-    }),
-  });
+  const response = await clientFetch(
+    `/api/w/${owner.sId}/members/${user.sId}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        role,
+        force: "true",
+      }),
+    }
+  );
 
   if (response.ok) {
     return new Ok(`Role updated to ` + role);

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -1,3 +1,4 @@
+import { clientFetch } from "@app/lib/egress";
 import type { PostRequestAccessBody } from "@app/pages/api/w/[wId]/data_sources/request_access";
 import type { PostRequestFeatureAccessBody } from "@app/pages/api/w/[wId]/labs/request_access";
 import type { PostRequestActionsAccessBody } from "@app/pages/api/w/[wId]/mcp/request_access";
@@ -17,13 +18,16 @@ export async function sendRequestDataSourceEmail({
     dataSourceId,
   };
 
-  const res = await fetch(`/api/w/${owner.sId}/data_sources/request_access`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(emailBlob),
-  });
+  const res = await clientFetch(
+    `/api/w/${owner.sId}/data_sources/request_access`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(emailBlob),
+    }
+  );
 
   if (!res.ok) {
     const errorData = await res.json();
@@ -48,7 +52,7 @@ export async function sendRequestFeatureAccessEmail({
     featureName,
   };
 
-  const res = await fetch(`/api/w/${owner.sId}/labs/request_access`, {
+  const res = await clientFetch(`/api/w/${owner.sId}/labs/request_access`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -79,7 +83,7 @@ export async function sendRequestActionsAccessEmail({
     mcpServerViewId,
   };
 
-  const res = await fetch(`/api/w/${owner.sId}/mcp/request_access`, {
+  const res = await clientFetch(`/api/w/${owner.sId}/mcp/request_access`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -1,4 +1,4 @@
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { PostRequestAccessBody } from "@app/pages/api/w/[wId]/data_sources/request_access";
 import type { PostRequestFeatureAccessBody } from "@app/pages/api/w/[wId]/labs/request_access";
 import type { PostRequestActionsAccessBody } from "@app/pages/api/w/[wId]/mcp/request_access";

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -1,8 +1,9 @@
-// Maxmimum allowed number of unconsumed invitations per workspace per day.
+// Maximum allowed number of unconsumed invitations per workspace per day.
 import type { NotificationType } from "@dust-tt/sparkle";
 import { mutate } from "swr";
 
 import type { ConfirmDataType } from "@app/components/Confirm";
+import { clientFetch } from "@app/lib/egress";
 import type {
   PostInvitationRequestBody,
   PostInvitationResponseBody,
@@ -46,13 +47,16 @@ export async function updateInvitation({
     initialRole: newRole ?? invitation.initialRole,
   };
 
-  const res = await fetch(`/api/w/${owner.sId}/invitations/${invitation.sId}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
+  const res = await clientFetch(
+    `/api/w/${owner.sId}/invitations/${invitation.sId}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
 
   if (!res.ok) {
     const error: { error: { message: string } } = await res.json();
@@ -96,7 +100,7 @@ export async function sendInvitations({
     role: invitationRole,
   }));
 
-  const res = await fetch(`/api/w/${owner.sId}/invitations`, {
+  const res = await clientFetch(`/api/w/${owner.sId}/invitations`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -3,7 +3,7 @@ import type { NotificationType } from "@dust-tt/sparkle";
 import { mutate } from "swr";
 
 import type { ConfirmDataType } from "@app/components/Confirm";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   PostInvitationRequestBody,
   PostInvitationResponseBody,

--- a/front/lib/providers.ts
+++ b/front/lib/providers.ts
@@ -1,4 +1,4 @@
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { GetProvidersCheckResponseBody } from "@app/pages/api/w/[wId]/providers/[pId]/check";
 import type { WorkspaceType } from "@app/types";
 

--- a/front/lib/providers.ts
+++ b/front/lib/providers.ts
@@ -1,3 +1,4 @@
+import { clientFetch } from "@app/lib/egress";
 import type { GetProvidersCheckResponseBody } from "@app/pages/api/w/[wId]/providers/[pId]/check";
 import type { WorkspaceType } from "@app/types";
 
@@ -133,7 +134,7 @@ export async function checkProvider(
   config: object
 ): Promise<GetProvidersCheckResponseBody> {
   try {
-    const result = await fetch(
+    const result = await clientFetch(
       `/api/w/${owner.sId}/providers/${providerId}/check`,
       {
         method: "POST",
@@ -185,7 +186,7 @@ export async function getProviderLLMModels(
   chat: boolean,
   embed: boolean
 ): Promise<{ models?: any[]; error?: any }> {
-  const modelsRes = await fetch(
+  const modelsRes = await clientFetch(
     `/api/w/${owner.sId}/providers/${providerId}/models?chat=${chat}&embed=${embed}`
   );
   if (!modelsRes.ok) {

--- a/front/lib/swr/agent_memories.ts
+++ b/front/lib/swr/agent_memories.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentMemoriesResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories";
 import type { PatchAgentMemoryRequestBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]";
@@ -50,7 +51,7 @@ export function useUpdateAgentMemory({
 
   const updateMemory = useCallback(
     async (memoryId: string, body: PatchAgentMemoryRequestBody) => {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/memories/${memoryId}`,
         {
           method: "PATCH",
@@ -103,7 +104,7 @@ export function useDeleteAgentMemory({
 
   const deleteMemory = useCallback(
     async (memoryId: string) => {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/memories/${memoryId}`,
         {
           method: "DELETE",

--- a/front/lib/swr/agent_memories.ts
+++ b/front/lib/swr/agent_memories.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetAgentMemoriesResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories";
 import type { PatchAgentMemoryRequestBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]";

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { parseMatcherExpression } from "@app/lib/matcher";
 import {
   emptyArray,
@@ -202,7 +203,7 @@ export function useAddTriggerSubscriber({
   const addSubscriber = useCallback(
     async (triggerId: string): Promise<boolean> => {
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/triggers/${triggerId}/subscribers`,
           {
             method: "POST",
@@ -272,7 +273,7 @@ export function useRemoveTriggerSubscriber({
         triggerAgentConfigurationId || agentConfigurationId;
 
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/agent_configurations/${targetAgentConfigurationId}/triggers/${triggerId}/subscribers`,
           {
             method: "DELETE",

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { parseMatcherExpression } from "@app/lib/matcher";
 import {
   emptyArray,

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,5 +1,6 @@
 import type { Fetcher } from "swr";
 
+import { clientFetch } from "@app/lib/egress";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
@@ -177,7 +178,7 @@ export function useCancelRun({
 }) {
   const doCancel = async (runId: string): Promise<boolean> => {
     try {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/runs/${runId}/cancel`,
         {
           method: "POST",

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -8,6 +8,7 @@ import type {
   AgentMessageFeedbackType,
   AgentMessageFeedbackWithMetadataType,
 } from "@app/lib/api/assistant/feedback";
+import { clientFetch } from "@app/lib/egress";
 import {
   emptyArray,
   fetcher,
@@ -563,7 +564,7 @@ export function useDeleteAgentConfiguration({
     if (!agentConfiguration) {
       return;
     }
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}`,
       {
         method: "DELETE",
@@ -613,7 +614,7 @@ export function useBatchDeleteAgentConfigurations({
     if (agentConfigurationIds.length === 0) {
       return;
     }
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/assistant/agent_configurations/delete`,
       {
         method: "POST",
@@ -679,7 +680,7 @@ export function useUpdateUserFavorite({
           userFavorite: userFavorite,
         };
 
-        const res = await fetch(
+        const res = await clientFetch(
           `/api/w/${owner.sId}/members/me/agent_favorite`,
           {
             method: "POST",
@@ -758,7 +759,7 @@ export function useRestoreAgentConfiguration({
     if (!agentConfiguration) {
       return;
     }
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/restore`,
       {
         method: "POST",
@@ -799,7 +800,7 @@ export function useBatchUpdateAgentTags({
       agentIds: string[],
       body: { addTagIds?: string[]; removeTagIds?: string[] }
     ) => {
-      await fetch(
+      await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/batch_update_tags`,
         {
           method: "POST",
@@ -826,7 +827,7 @@ export function useBatchUpdateAgentScope({
 }) {
   const batchUpdateAgentScope = useCallback(
     async (agentIds: string[], body: { scope: "visible" | "hidden" }) => {
-      await fetch(
+      await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/batch_update_scope`,
         {
           method: "POST",

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -8,7 +8,7 @@ import type {
   AgentMessageFeedbackType,
   AgentMessageFeedbackWithMetadataType,
 } from "@app/lib/api/assistant/feedback";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
   fetcher,

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   fetcher,
   getErrorFromResponse,

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import {
   fetcher,
   getErrorFromResponse,
@@ -140,7 +141,7 @@ export function useToggleChatBot({
   }
 
   const doToggle = async (botEnabled: boolean) => {
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/botEnabled`,
       {
         headers: {
@@ -212,7 +213,7 @@ export function useToggleDiscordChatBot({
   }
 
   const doToggle = async (botEnabled: boolean) => {
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/botEnabled`,
       {
         headers: {
@@ -289,7 +290,7 @@ export function useTogglePdfEnabled({
 
   const doToggle = async (pdfEnabled: boolean) => {
     setIsLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/pdfEnabled`,
       {
         headers: {

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -2,8 +2,8 @@ import { useCallback, useSyncExternalStore } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { emptyArray } from "@app/lib/swr/swr";
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { clientFetch } from "@app/lib/egress";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetCreditsResponseBody } from "@app/types/credits";
 
 // Global state for tracking purchase loading status per workspace
@@ -104,13 +104,16 @@ export function usePurchaseCredits({ workspaceId }: { workspaceId: string }) {
       setPurchaseLoading(workspaceId, true);
 
       try {
-        const response = await fetch(`/api/w/${workspaceId}/credits/purchase`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ amountDollars }),
-        });
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/credits/purchase`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ amountDollars }),
+          }
+        );
 
         if (!response.ok) {
           const errorData = await response.json();

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -2,7 +2,7 @@ import { useCallback, useSyncExternalStore } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetCreditsResponseBody } from "@app/types/credits";
 

--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -1,7 +1,7 @@
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   fetcher,

--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -1,6 +1,7 @@
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   fetcher,
@@ -78,7 +79,7 @@ export function useUpdateDataSourceViewDocument(
     const patchUrl =
       `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/` +
       `data_sources/${dataSourceView.dataSource.sId}/documents/${encodeURIComponent(documentId)}`;
-    const res = await fetch(patchUrl, {
+    const res = await clientFetch(patchUrl, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
@@ -128,7 +129,7 @@ export function useCreateDataSourceViewDocument(
     const createUrl =
       `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/` +
       `data_sources/${dataSourceView.dataSource.sId}/documents`;
-    const res = await fetch(createUrl, {
+    const res = await clientFetch(createUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -1,7 +1,7 @@
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   emptyArray,

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -1,6 +1,7 @@
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   emptyArray,
@@ -127,7 +128,7 @@ export function useUpdateDataSourceViewTable(
 
   const doUpdate = async (body: PatchDataSourceTableRequestBody) => {
     const tableUrl = `/api/w/${owner.sId}/spaces/${dataSourceView.spaceId}/data_sources/${dataSourceView.dataSource.sId}/tables/${encodeURIComponent(tableId)}`;
-    const res = await fetch(tableUrl, {
+    const res = await clientFetch(tableUrl, {
       method: "PATCH",
       body: JSON.stringify(body),
       headers: {

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GetAgentEditorsResponseBody,

--- a/front/lib/swr/editors.ts
+++ b/front/lib/swr/editors.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GetAgentEditorsResponseBody,
@@ -56,7 +57,7 @@ export function useUpdateEditors({
 
   const updateAgentEditors = useCallback(
     async (body: PatchAgentEditorsRequestBody) => {
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/editors`,
         {
           method: "PATCH",

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -2,6 +2,7 @@ import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePeriodicRefresh } from "@app/hooks/usePeriodicRefresh";
+import { clientFetch } from "@app/lib/egress";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   fetcher,
@@ -60,7 +61,7 @@ export function useFileProcessedContent({
     // Stream fetcher -> don't try to parse the stream.
     // Wait for initial response to trigger swr error handling.
     async (...args) => {
-      const response = await fetch(...args, { redirect: "manual" });
+      const response = await clientFetch(...args, { redirect: "manual" });
 
       // File is not safe to display -> opaque redirect response. Return null.
       if (response.type === "opaqueredirect") {
@@ -102,7 +103,7 @@ export function useUpsertFileAsDatasourceEntry(
 
   const doCreate = async (body: UpsertFileToDataSourceRequestBody) => {
     const upsertUrl = `/api/w/${owner.sId}/data_sources/${dataSourceView.dataSource.sId}/files`;
-    const res = await fetch(upsertUrl, {
+    const res = await clientFetch(upsertUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -188,7 +189,7 @@ export function useFileContent({
     swrKey,
     async (url: string) => {
       // Use custom fetcher to parse as text.
-      const response = await fetch(url);
+      const response = await clientFetch(url);
 
       return response.text();
     },
@@ -219,7 +220,7 @@ export function useShareInteractiveContentFile({
   const { data, error, mutate } = useSWRWithDefaults(swrKey, fileShareFetcher);
 
   const doShare = async (shareScope: FileShareScope) => {
-    const res = await fetch(`/api/w/${owner.sId}/files/${fileId}/share`, {
+    const res = await clientFetch(`/api/w/${owner.sId}/files/${fileId}/share`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -2,7 +2,7 @@ import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePeriodicRefresh } from "@app/hooks/usePeriodicRefresh";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   fetcher,

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -3,7 +3,7 @@
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -3,6 +3,7 @@
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
@@ -96,7 +97,7 @@ export function useUpdateTranscriptsConfiguration({
   const doUpdate = async (
     data: Partial<PatchTranscriptsConfiguration>
   ): Promise<Result<undefined, Error>> => {
-    const response = await fetch(
+    const response = await clientFetch(
       `/api/w/${owner.sId}/labs/transcripts/${transcriptsConfiguration.sId}`,
       {
         method: "PATCH",

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -15,7 +15,7 @@ import type {
   MCPServerTypeWithViews,
   MCPServerViewType,
 } from "@app/lib/api/mcp";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type {
   MCPServerConnectionConnectionType,
   MCPServerConnectionType,

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -1,5 +1,6 @@
 import type { Fetcher } from "swr";
 
+import { clientFetch } from "@app/lib/egress";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetSlackClientIdResponseBody } from "@app/pages/api/w/[wId]/credentials/slack_is_legacy";
 import type {
@@ -25,7 +26,7 @@ export const useFinalize = () => {
       }
     }
 
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/oauth/${provider}/finalize?${params.toString()}`
     );
 

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetSlackClientIdResponseBody } from "@app/pages/api/w/[wId]/credentials/slack_is_legacy";
 import type {

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -7,7 +7,7 @@ import type {
   SortingParams,
 } from "@app/lib/api/pagination";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { getSpaceName } from "@app/lib/spaces";
 import {
   emptyArray,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -7,6 +7,7 @@ import type {
   SortingParams,
 } from "@app/lib/api/pagination";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import { clientFetch } from "@app/lib/egress";
 import { getSpaceName } from "@app/lib/spaces";
 import {
   emptyArray,
@@ -243,7 +244,7 @@ export function useCreateFolder({
       return null;
     }
 
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${spaceId}/data_sources`,
       {
         method: "POST",
@@ -296,7 +297,7 @@ export function useUpdateFolder({
     if (!dataSourceView || !description) {
       return false;
     }
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${spaceId}/data_sources/${dataSourceView.dataSource.sId}`,
       {
         method: "PATCH",
@@ -351,7 +352,7 @@ export function useDeleteFolderOrWebsite({
     if (!dataSourceView) {
       return false;
     }
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${spaceId}/data_sources/${dataSourceView.dataSource.sId}`,
       { method: "DELETE" }
     );
@@ -431,7 +432,7 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
         return null;
       }
 
-      res = await fetch(url, {
+      res = await clientFetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -445,7 +446,7 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
         }),
       });
     } else {
-      res = await fetch(url, {
+      res = await clientFetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -623,7 +624,7 @@ export function useDeleteSpace({
       return false;
     }
     const url = `/api/w/${owner.sId}/spaces/${space.sId}?force=${force}`;
-    const res = await fetch(url, {
+    const res = await clientFetch(url, {
       method: "DELETE",
     });
 

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -15,7 +15,7 @@ import type {
 import useSWRInfinite from "swr/infinite";
 
 import { COMMIT_HASH } from "@app/lib/commit-hash";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { isAPIErrorResponse, safeParseJSON } from "@app/types";
 
 const EMPTY_ARRAY = Object.freeze([]);

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -15,6 +15,7 @@ import type {
 import useSWRInfinite from "swr/infinite";
 
 import { COMMIT_HASH } from "@app/lib/commit-hash";
+import { clientFetch } from "@app/lib/egress";
 import { isAPIErrorResponse, safeParseJSON } from "@app/types";
 
 const EMPTY_ARRAY = Object.freeze([]);
@@ -163,7 +164,7 @@ const resHandler = async (res: Response) => {
 
 export const fetcher = async (...args: Parameters<typeof fetch>) => {
   const [url, config] = args;
-  const res = await fetch(url, {
+  const res = await clientFetch(url, {
     ...config,
     headers: addCommitHashToHeaders(config?.headers),
   });
@@ -175,7 +176,7 @@ export const fetcherWithBody = async ([url, body, method]: [
   object,
   string,
 ]) => {
-  const res = await fetch(url, {
+  const res = await clientFetch(url, {
     method,
     headers: addCommitHashToHeaders({
       "Content-Type": "application/json",

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PatchAgentTagsRequestBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags";
 import type { GetTagsResponseBody } from "@app/pages/api/w/[wId]/tags";

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PatchAgentTagsRequestBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags";
 import type { GetTagsResponseBody } from "@app/pages/api/w/[wId]/tags";
@@ -96,7 +97,7 @@ export function useCreateTag({ owner }: { owner: LightWorkspaceType }) {
     name: string,
     agentIds?: string[]
   ): Promise<TagType | null> => {
-    const res = await fetch(`/api/w/${owner.sId}/tags`, {
+    const res = await clientFetch(`/api/w/${owner.sId}/tags`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -133,7 +134,7 @@ export function useDeleteTag({ owner }: { owner: LightWorkspaceType }) {
   const { mutateTagsUsage } = useTagsUsage({ owner, disabled: true });
 
   const deleteTag = async (tagId: string) => {
-    const res = await fetch(`/api/w/${owner.sId}/tags/${tagId}`, {
+    const res = await clientFetch(`/api/w/${owner.sId}/tags/${tagId}`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
@@ -179,7 +180,7 @@ export function useUpdateTag({
   const { mutateTagsUsage } = useTagsUsage({ owner, disabled: true });
 
   const updateTag = async ({ name, kind }: { name: string; kind: TagKind }) => {
-    const res = await fetch(`/api/w/${owner.sId}/tags/${tagId}`, {
+    const res = await clientFetch(`/api/w/${owner.sId}/tags/${tagId}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -219,7 +220,7 @@ export function useUpdateTag({
 export function useUpdateAgentTags({ owner }: { owner: LightWorkspaceType }) {
   const updateAgentTags = useCallback(
     async (agentConfigurationId: string, body: PatchAgentTagsRequestBody) => {
-      await fetch(
+      await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationId}/tags`,
         {
           method: "PATCH",

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,7 +1,7 @@
 import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   fetcher,
   getErrorFromResponse,

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,6 +1,7 @@
 import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import {
   fetcher,
   getErrorFromResponse,
@@ -106,7 +107,7 @@ export function usePatchUser() {
     jobType?: JobType,
     imageUrl?: string | null
   ) => {
-    const res = await fetch("/api/user", {
+    const res = await clientFetch("/api/user", {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import {
   emptyArray,
   fetcher,
@@ -128,7 +129,7 @@ export function useCreateWebhookSource({
   const createWebhookSource = async (
     input: PostWebhookSourcesBody
   ): Promise<WebhookSourceForAdminType | null> => {
-    const response = await fetch(`/api/w/${owner.sId}/webhook_sources`, {
+    const response = await clientFetch(`/api/w/${owner.sId}/webhook_sources`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -174,7 +175,7 @@ export function useUpdateWebhookSourceView({
       updates: { name: string; description?: string; icon?: string }
     ): Promise<boolean> => {
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${owner.sId}/webhook_sources/views/${webhookSourceViewId}`,
           {
             method: "PATCH",
@@ -232,7 +233,7 @@ export function useDeleteWebhookSource({
       setIsDeleting(true);
 
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${owner.sId}/webhook_sources/${webhookSourceId}`,
           {
             method: "DELETE",
@@ -326,7 +327,7 @@ export function useAddWebhookSourceViewToSpace({
       webhookSource: WebhookSourceForAdminType;
     }): Promise<void> => {
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${owner.sId}/spaces/${space.sId}/webhook_source_views`,
           {
             method: "POST",
@@ -383,7 +384,7 @@ export function useRemoveWebhookSourceViewFromSpace({
       space: SpaceType;
     }): Promise<void> => {
       try {
-        const response = await fetch(
+        const response = await clientFetch(
           `/api/w/${owner.sId}/spaces/${space.sId}/webhook_source_views/${webhookSourceView.sId}`,
           {
             method: "DELETE",

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
   fetcher,

--- a/front/lib/swr/workos.ts
+++ b/front/lib/swr/workos.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
   fetcher,

--- a/front/lib/swr/workos.ts
+++ b/front/lib/swr/workos.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import {
   emptyArray,
   fetcher,
@@ -49,7 +50,7 @@ export function useRemoveWorkspaceDomain({
   const sendNotification = useSendNotification();
 
   const doRemoveWorkspaceDomain = async (domain: string) => {
-    const response = await fetch(`/api/w/${owner.sId}/domains`, {
+    const response = await clientFetch(`/api/w/${owner.sId}/domains`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
@@ -115,7 +116,7 @@ export function useDisableWorkOSSSOConnection({
   const sendNotification = useSendNotification();
 
   const doDisableWorkOSSSOConnection = async () => {
-    const response = await fetch(`/api/w/${owner.sId}/sso`, {
+    const response = await clientFetch(`/api/w/${owner.sId}/sso`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
@@ -180,7 +181,7 @@ export function useDisableWorkOSDirectorySyncConnection({
   const sendNotification = useSendNotification();
 
   const doDisableWorkOSDirectorySyncConnection = async () => {
-    const response = await fetch(`/api/w/${owner.sId}/dsync`, {
+    const response = await clientFetch(`/api/w/${owner.sId}/dsync`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",

--- a/front/lib/user.ts
+++ b/front/lib/user.ts
@@ -1,4 +1,4 @@
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import type { UserMetadataType } from "@app/types";
 
 export async function setUserMetadataFromClient(metadata: UserMetadataType) {

--- a/front/lib/user.ts
+++ b/front/lib/user.ts
@@ -1,7 +1,8 @@
+import { clientFetch } from "@app/lib/egress";
 import type { UserMetadataType } from "@app/types";
 
 export async function setUserMetadataFromClient(metadata: UserMetadataType) {
-  const res = await fetch(
+  const res = await clientFetch(
     `/api/user/metadata/${encodeURIComponent(metadata.key)}`,
     {
       method: "POST",

--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -3,7 +3,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
-import { clientFetch } from "@app/lib/egress";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import logger from "@app/logger/logger";
@@ -47,7 +46,7 @@ async function handler(
   switch (req.method) {
     case "POST":
       const mainRegionUrl = config.getDustRegionSyncMasterUrl();
-      const response = await clientFetch(`${mainRegionUrl}/api/templates`, {
+      const response = await fetch(`${mainRegionUrl}/api/templates`, {
         method: "GET",
       });
 
@@ -66,7 +65,7 @@ async function handler(
       let count = 0;
 
       for (const templateFromList of templatesResponse.templates) {
-        const templateResponse = await clientFetch(
+        const templateResponse = await fetch(
           `${mainRegionUrl}/api/templates/${templateFromList.sId}`,
           {
             method: "GET",

--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
+import { clientFetch } from "@app/lib/egress";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import logger from "@app/logger/logger";
@@ -46,7 +47,7 @@ async function handler(
   switch (req.method) {
     case "POST":
       const mainRegionUrl = config.getDustRegionSyncMasterUrl();
-      const response = await fetch(`${mainRegionUrl}/api/templates`, {
+      const response = await clientFetch(`${mainRegionUrl}/api/templates`, {
         method: "GET",
       });
 
@@ -65,7 +66,7 @@ async function handler(
       let count = 0;
 
       for (const templateFromList of templatesResponse.templates) {
-        const templateResponse = await fetch(
+        const templateResponse = await clientFetch(
           `${mainRegionUrl}/api/templates/${templateFromList.sId}`,
           {
             method: "GET",

--- a/front/pages/poke/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversation/[cId]/index.tsx
@@ -24,7 +24,7 @@ import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import type { Action } from "@app/lib/registry";
 import { getDustProdAction } from "@app/lib/registry";

--- a/front/pages/poke/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversation/[cId]/index.tsx
@@ -24,6 +24,7 @@ import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import type { Action } from "@app/lib/registry";
 import { getDustProdAction } from "@app/lib/registry";
@@ -368,7 +369,7 @@ const ConversationPage = ({
     setRenderError(null);
     setRenderResult(null);
     try {
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/poke/workspaces/${workspaceId}/conversations/${conversationId}/render`,
         {
           method: "POST",

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -32,6 +32,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -810,7 +811,7 @@ async function handleCheckOrFindNotionUrl(
   dsId: string,
   command: "check-url" | "find-url"
 ): Promise<NotionCheckUrlResponseType | NotionFindUrlResponseType | null> {
-  const res = await fetch(`/api/poke/admin`, {
+  const res = await clientFetch(`/api/poke/admin`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -843,7 +844,7 @@ async function handleCheckZendeskTicket(
     | { brandId: number | null; ticketId: number; wId: string; dsId: string }
     | { ticketUrl: string; wId: string; dsId: string }
 ): Promise<ZendeskFetchTicketResponseType | null> {
-  const res = await fetch(`/api/poke/admin`, {
+  const res = await clientFetch(`/api/poke/admin`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -1214,7 +1215,7 @@ const ConfigToggle = ({
 
   const { isSubmitting, submit: onToggle } = useSubmitFunction(async () => {
     try {
-      const r = await fetch(
+      const r = await clientFetch(
         `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/config`,
         {
           method: "POST",

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -32,7 +32,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";

--- a/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { DataSourceType, WorkspaceType } from "@app/types";
@@ -91,7 +92,7 @@ export default function NotionRequestsPage({
     setResponse(null);
 
     try {
-      const res = await fetch(`/api/poke/admin`, {
+      const res = await clientFetch(`/api/poke/admin`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { DataSourceType, WorkspaceType } from "@app/types";

--- a/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
@@ -4,7 +4,7 @@ import type { ReactElement } from "react";
 import { useState } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { usePokeTables } from "@app/poke/swr";

--- a/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from "react";
 import { useState } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { usePokeTables } from "@app/poke/swr";
@@ -93,7 +94,7 @@ export default function DataSourceQueryPage({
     setQueryResult(null);
 
     try {
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/query`,
         {
           method: "POST",

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
@@ -99,7 +100,7 @@ export default function DataSourceView({
       searchParams.append("top_k", "10");
       searchParams.append("full_text", "false");
 
-      const searchRes = await fetch(
+      const searchRes = await clientFetch(
         `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/search?` +
           searchParams.toString(),
         {

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { classNames, timeAgoFrom } from "@app/lib/utils";

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -47,7 +47,7 @@ import config from "@app/lib/api/config";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
 import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -47,6 +47,7 @@ import config from "@app/lib/api/config";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
 import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
@@ -144,7 +145,7 @@ const WorkspacePage = ({
   const { submit: onWorkspaceUpdate } = useSubmitFunction(
     async (segmentation: WorkspaceSegmentationType) => {
       try {
-        const r = await fetch(`/api/poke/workspaces/${owner.sId}`, {
+        const r = await clientFetch(`/api/poke/workspaces/${owner.sId}`, {
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",

--- a/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
@@ -17,6 +17,7 @@ import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import config from "@app/lib/api/config";
 import { cleanSpecificationFromCore, getSpecification } from "@app/lib/api/run";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { BaseDustProdActionRegistry } from "@app/lib/registry";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -149,7 +150,7 @@ function AppSpecification({
         config[block.name] = block.config;
       }
 
-      const r = await fetch(
+      const r = await clientFetch(
         `/api/poke/workspaces/${owner.sId}/apps/${app.sId}/state`,
         {
           method: "POST",

--- a/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
@@ -17,7 +17,7 @@ import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import config from "@app/lib/api/config";
 import { cleanSpecificationFromCore, getSpecification } from "@app/lib/api/run";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { BaseDustProdActionRegistry } from "@app/lib/registry";
 import { AppResource } from "@app/lib/resources/app_resource";

--- a/front/pages/poke/kill.tsx
+++ b/front/pages/poke/kill.tsx
@@ -5,7 +5,7 @@ import { useSWRConfig } from "swr/_internal";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import type { KillSwitchType } from "@app/lib/poke/types";
 import { usePokeKillSwitches } from "@app/poke/swr/kill";

--- a/front/pages/poke/kill.tsx
+++ b/front/pages/poke/kill.tsx
@@ -5,6 +5,7 @@ import { useSWRConfig } from "swr/_internal";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import type { KillSwitchType } from "@app/lib/poke/types";
 import { usePokeKillSwitches } from "@app/poke/swr/kill";
@@ -60,7 +61,7 @@ const KillPage = () => {
       }
     }
 
-    const res = await fetch(`/api/poke/kill`, {
+    const res = await clientFetch(`/api/poke/kill`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -22,7 +22,7 @@ import {
 } from "@app/components/poke/plans/form";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { PlanTypeSchema } from "@app/pages/api/poke/plans";

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -22,6 +22,7 @@ import {
 } from "@app/components/poke/plans/form";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { PlanTypeSchema } from "@app/pages/api/poke/plans";
@@ -91,7 +92,7 @@ const PlansPage = () => {
 
     const requestBody: PlanType = toPlanType(editingPlan);
 
-    const r = await fetch("/api/poke/plans", {
+    const r = await clientFetch("/api/poke/plans", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -46,6 +46,7 @@ import {
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeAssistantTemplate } from "@app/poke/swr";
 import type { CreateTemplateFormType, TemplateTagCodeType } from "@app/types";
@@ -479,7 +480,7 @@ function TemplatesPage({
           const url = assistantTemplate
             ? `/api/poke/templates/${assistantTemplate.sId}`
             : "/api/poke/templates";
-          const r = await fetch(url, {
+          const r = await clientFetch(url, {
             method,
             headers: {
               "Content-Type": "application/json",
@@ -530,12 +531,15 @@ function TemplatesPage({
       return;
     }
     try {
-      const r = await fetch(`/api/poke/templates/${assistantTemplate.sId}`, {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+      const r = await clientFetch(
+        `/api/poke/templates/${assistantTemplate.sId}`,
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
       if (!r.ok) {
         throw new Error("Failed to delete template.");
       }

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -46,7 +46,7 @@ import {
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeAssistantTemplate } from "@app/poke/swr";
 import type { CreateTemplateFormType, TemplateTagCodeType } from "@app/types";

--- a/front/pages/w/[wId]/analytics/index.tsx
+++ b/front/pages/w/[wId]/analytics/index.tsx
@@ -7,7 +7,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { ActivityReport } from "@app/components/workspace/ActivityReport";
 import { QuickInsights } from "@app/components/workspace/Analytics";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
   useFeatureFlags,

--- a/front/pages/w/[wId]/analytics/index.tsx
+++ b/front/pages/w/[wId]/analytics/index.tsx
@@ -7,6 +7,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { ActivityReport } from "@app/components/workspace/ActivityReport";
 import { QuickInsights } from "@app/components/workspace/Analytics";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
   useFeatureFlags,
@@ -63,7 +64,7 @@ export default function Analytics({
 
     setDownloadingMonth(selectedMonth);
     try {
-      const response = await fetch(
+      const response = await clientFetch(
         `/api/w/${owner.sId}/workspace-usage?${queryParams.toString()}`
       );
 

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -28,6 +28,7 @@ import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { isRestrictedFromAgentCreation } from "@app/lib/auth";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
@@ -233,7 +234,7 @@ export default function WorkspaceAssistants({
       setShowDisabledFreeWorkspacePopup(agent.sId);
       return;
     }
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/assistant/global_agents/${agent.sId}`,
       {
         method: "PATCH",

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -28,7 +28,7 @@ import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { isRestrictedFromAgentCreation } from "@app/lib/auth";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -39,6 +39,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { useKeys } from "@app/lib/swr/apps";
@@ -118,7 +119,7 @@ export function APIKeys({
     useSubmitFunction(
       async ({ name, group }: { name: string; group: GroupType | null }) => {
         const globalGroup = groups.find((g) => g.kind === "global");
-        const response = await fetch(`/api/w/${owner.sId}/keys`, {
+        const response = await clientFetch(`/api/w/${owner.sId}/keys`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -152,7 +153,7 @@ export function APIKeys({
 
   const { submit: handleRevoke, isSubmitting: isRevoking } = useSubmitFunction(
     async (key: KeyType) => {
-      await fetch(`/api/w/${owner.sId}/keys/${key.id}/disable`, {
+      await clientFetch(`/api/w/${owner.sId}/keys/${key.id}/disable`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -39,7 +39,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { useKeys } from "@app/lib/swr/apps";

--- a/front/pages/w/[wId]/developers/dev-secrets.tsx
+++ b/front/pages/w/[wId]/developers/dev-secrets.tsx
@@ -24,7 +24,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useDustAppSecrets } from "@app/lib/swr/apps";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";

--- a/front/pages/w/[wId]/developers/dev-secrets.tsx
+++ b/front/pages/w/[wId]/developers/dev-secrets.tsx
@@ -24,6 +24,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useDustAppSecrets } from "@app/lib/swr/apps";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -77,7 +78,7 @@ export default function SecretsPage({
 
   const { submit: handleGenerate, isSubmitting: isGenerating } =
     useSubmitFunction(async (secret: DustAppSecretType) => {
-      const r = await fetch(`/api/w/${owner.sId}/dust_app_secrets`, {
+      const r = await clientFetch(`/api/w/${owner.sId}/dust_app_secrets`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -105,7 +106,7 @@ export default function SecretsPage({
 
   const { submit: handleRevoke, isSubmitting: isRevoking } = useSubmitFunction(
     async (secret: DustAppSecretType) => {
-      await fetch(
+      await clientFetch(
         `/api/w/${owner.sId}/dust_app_secrets/${secret.name}/destroy`,
         {
           method: "DELETE",

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -12,6 +12,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getFeatureFlags } from "@app/lib/auth";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
@@ -93,7 +94,7 @@ export default function LabsTranscriptsIndex({
       return;
     }
 
-    const response = await fetch(
+    const response = await clientFetch(
       `/api/w/${owner.sId}/labs/transcripts/${transcriptConfigurationId}`,
       {
         method: "DELETE",

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -12,7 +12,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getFeatureFlags } from "@app/lib/auth";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
@@ -11,7 +11,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getDatasetHash, getDatasetSchema } from "@app/lib/api/datasets";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
@@ -11,6 +11,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getDatasetHash, getDatasetSchema } from "@app/lib/api/datasets";
+import { clientFetch } from "@app/lib/egress";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -145,7 +146,7 @@ export default function ViewDatasetView({
 
   const handleSubmit = async () => {
     setLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets/${dataset.name}`,
       {
         method: "POST",

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.tsx
@@ -8,7 +8,7 @@ import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getDatasets } from "@app/lib/api/datasets";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { classNames } from "@app/lib/utils";

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.tsx
@@ -8,6 +8,7 @@ import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getDatasets } from "@app/lib/api/datasets";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { classNames } from "@app/lib/utils";
@@ -72,7 +73,7 @@ export default function DatasetsView({
         validateVariant: "warning",
       })
     ) {
-      await fetch(
+      await clientFetch(
         `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets/${datasetName}`,
         {
           method: "DELETE",

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
@@ -9,6 +9,7 @@ import DatasetView from "@app/components/app/DatasetView";
 import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getDatasets } from "@app/lib/api/datasets";
+import { clientFetch } from "@app/lib/egress";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -101,7 +102,7 @@ export default function NewDatasetView({
 
   const handleSubmit = async () => {
     setLoading(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets`,
       {
         method: "POST",

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
@@ -9,7 +9,7 @@ import DatasetView from "@app/components/app/DatasetView";
 import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getDatasets } from "@app/lib/api/datasets";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -16,6 +16,7 @@ import { ViewAppAPIModal } from "@app/components/app/ViewAppAPIModal";
 import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { extractConfig } from "@app/lib/config";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -199,7 +200,7 @@ export default function AppView({
 
     saveTimeout = setTimeout(async () => {
       if (!readOnly) {
-        await fetch(
+        await clientFetch(
           `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/state`,
           {
             method: "POST",

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -16,7 +16,7 @@ import { ViewAppAPIModal } from "@app/components/app/ViewAppAPIModal";
 import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { extractConfig } from "@app/lib/config";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.tsx
@@ -8,6 +8,7 @@ import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { cleanSpecificationFromCore, getRun } from "@app/lib/api/run";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type {
@@ -104,7 +105,7 @@ export default function AppRun({
 
     cleanSpecificationFromCore(specCopy);
 
-    await fetch(
+    await clientFetch(
       `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/state`,
       {
         method: "POST",

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.tsx
@@ -8,7 +8,7 @@ import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { cleanSpecificationFromCore, getRun } from "@app/lib/api/run";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type {

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
@@ -7,7 +7,7 @@ import { useEffect } from "react";
 import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { dustAppsListUrl } from "@app/lib/spaces";

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
@@ -7,6 +7,7 @@ import { useEffect } from "react";
 import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { dustAppsListUrl } from "@app/lib/spaces";
@@ -105,7 +106,7 @@ export default function SettingsView({
       })
     ) {
       setIsDeleting(true);
-      const res = await fetch(
+      const res = await clientFetch(
         `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}`,
         {
           method: "DELETE",
@@ -128,7 +129,7 @@ export default function SettingsView({
 
   const handleUpdate = async () => {
     setIsUpdating(true);
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}`,
       {
         method: "POST",

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -9,7 +9,7 @@ import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useUser } from "@app/lib/swr/user";

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -9,6 +9,7 @@ import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useUser } from "@app/lib/swr/user";
@@ -59,7 +60,7 @@ export default function Subscribe({
 
   const { submit: handleSubscribePlan } = useSubmitFunction(
     async (billingPeriod) => {
-      const res = await fetch(`/api/w/${owner.sId}/subscriptions`, {
+      const res = await clientFetch(`/api/w/${owner.sId}/subscriptions`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -27,7 +27,7 @@ import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import {

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -27,6 +27,7 @@ import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import {
@@ -140,7 +141,7 @@ export default function Subscription({
 
   const { submit: handleSubscribePlan, isSubmitting: isSubscribingPlan } =
     useSubmitFunction(async () => {
-      const res = await fetch(`/api/w/${owner.sId}/subscriptions`, {
+      const res = await clientFetch(`/api/w/${owner.sId}/subscriptions`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -185,7 +186,7 @@ export default function Subscription({
     submit: handleUpgradeToBusiness,
     isSubmitting: isUpgradingToBusiness,
   } = useSubmitFunction(async () => {
-    const res = await fetch(`/api/w/${owner.sId}/subscriptions`, {
+    const res = await clientFetch(`/api/w/${owner.sId}/subscriptions`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
@@ -215,7 +216,7 @@ export default function Subscription({
   const { submit: skipFreeTrial, isSubmitting: skipFreeTrialIsSubmitting } =
     useSubmitFunction(async () => {
       try {
-        const res = await fetch(`/api/w/${owner.sId}/subscriptions`, {
+        const res = await clientFetch(`/api/w/${owner.sId}/subscriptions`, {
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",
@@ -247,7 +248,7 @@ export default function Subscription({
   const { submit: cancelFreeTrial, isSubmitting: cancelFreeTrialSubmitting } =
     useSubmitFunction(async () => {
       try {
-        const res = await fetch(`/api/w/${owner.sId}/subscriptions`, {
+        const res = await clientFetch(`/api/w/${owner.sId}/subscriptions`, {
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",

--- a/front/pages/w/[wId]/subscription/manage.tsx
+++ b/front/pages/w/[wId]/subscription/manage.tsx
@@ -3,7 +3,7 @@ import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import type { WorkspaceType } from "@app/types";
 

--- a/front/pages/w/[wId]/subscription/manage.tsx
+++ b/front/pages/w/[wId]/subscription/manage.tsx
@@ -3,6 +3,7 @@ import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import type { WorkspaceType } from "@app/types";
 
@@ -30,7 +31,7 @@ export default function ManageSubscription({
 
   useEffect(() => {
     async function redirectToStripePortal() {
-      const res = await fetch("/api/stripe/portal", {
+      const res = await clientFetch("/api/stripe/portal", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -36,6 +36,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceTranscriptionToggle } from "@app/hooks/useVoiceTranscriptionToggle";
 import config from "@app/lib/api/config";
 import { getFeatureFlags } from "@app/lib/auth";
+import { clientFetch } from "@app/lib/egress";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -166,7 +167,7 @@ export default function WorkspaceAdmin({
 
   const handleUpdateWorkspace = async () => {
     setUpdating(true);
-    const res = await fetch(`/api/w/${owner.sId}`, {
+    const res = await clientFetch(`/api/w/${owner.sId}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -387,7 +388,7 @@ function BotToggle({
 
     const connectionId = cRes.value.connection_id;
 
-    const res = await fetch(
+    const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${systemSpace.sId}/data_sources`,
       {
         method: "POST",

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -36,7 +36,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceTranscriptionToggle } from "@app/hooks/useVoiceTranscriptionToggle";
 import config from "@app/lib/api/config";
 import { getFeatureFlags } from "@app/lib/auth";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -3,6 +3,7 @@ import type { Fetcher } from "swr";
 import useSWR from "swr";
 
 import type { LLMTrace } from "@app/lib/api/llm/traces/types";
+import { clientFetch } from "@app/lib/egress";
 import { emptyArray, fetcher } from "@app/lib/swr/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
 import type { PullTemplatesResponseBody } from "@app/pages/api/poke/templates/pull";
@@ -21,7 +22,7 @@ export function usePokePullTemplates() {
 
   const doPull = useCallback(async () => {
     setIsPulling(true);
-    const response = await fetch("/api/poke/templates/pull", {
+    const response = await clientFetch("/api/poke/templates/pull", {
       method: "POST",
     });
 

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -3,7 +3,7 @@ import type { Fetcher } from "swr";
 import useSWR from "swr";
 
 import type { LLMTrace } from "@app/lib/api/llm/traces/types";
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, fetcher } from "@app/lib/swr/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
 import type { PullTemplatesResponseBody } from "@app/pages/api/poke/templates/pull";

--- a/front/poke/swr/plugins.ts
+++ b/front/poke/swr/plugins.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { clientFetch } from "@app/lib/egress";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
   fetcher,

--- a/front/poke/swr/plugins.ts
+++ b/front/poke/swr/plugins.ts
@@ -1,5 +1,6 @@
 import type { Fetcher } from "swr";
 
+import { clientFetch } from "@app/lib/egress";
 import {
   emptyArray,
   fetcher,
@@ -141,7 +142,7 @@ export function useRunPokePlugin({
         formData.append(key, value);
       });
 
-      res = await fetch(
+      res = await clientFetch(
         `/api/poke/plugins/${pluginId}/run?${urlSearchParams.toString()}`,
         {
           method: "POST",
@@ -150,7 +151,7 @@ export function useRunPokePlugin({
       );
     } else {
       // Use JSON when no files are present
-      res = await fetch(
+      res = await clientFetch(
         `/api/poke/plugins/${pluginId}/run?${urlSearchParams.toString()}`,
         {
           method: "POST",


### PR DESCRIPTION
## Description

- This PR replaces direct `fetch` with `clientFetch` in the browser, which is actually a no-op.
- Only affects files in `/components`, `/hooks`, `/pages` excluding `/pages/api`, a little in `/lib`, mostly in `/lib/swr` and `poke/swr`.
- Got this warning on every PR recently.

## Tests

## Risk

- Low, actually same behavior.
- Main risk is readability for future us.

## Deploy Plan

- Deploy front.
