### PR TITLE
[front] fix(Zendesk): use `untrustedFetch` in ZendeskClient

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/zendesk/client.ts
@@ -19,6 +19,7 @@ import {
   ZendeskTicketResponseSchema,
   ZendeskUsersResponseSchema,
 } from "@app/lib/actions/mcp_internal_actions/servers/zendesk/types";
+import { untrustedFetch } from "@app/lib/egress/server";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -93,7 +94,7 @@ class ZendeskClient {
     }
   ): Promise<Result<z.infer<T>, Error>> {
     const url = `https://${this.subdomain}.zendesk.com/api/v2/${endpoint}`;
-    const response = await fetch(url, {
+    const response = await untrustedFetch(url, {
       method,
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Description

- This PR replace the fetch to Zendesk's API to use `untrustedFetch`, which goes through a proxy.
- Rationale is that the url we hit depends on a user-defined subdomain.
- No evidence of a possible attach vector (the subdomain has to be a valid one since you have to do an OAuth flow) but seems like a generally good idea.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
