### PR TITLE
[front] fix: Remove buy credits button when on trial

### DIFF
--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -51,7 +51,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   let isEnterprise = false;
   if (subscription.stripeSubscriptionId) {
     const stripeSubscription = await getStripeSubscription(
-      subscription.stripeSubscriptionId
+      subscription.stripeSubscriptionId,
     );
     if (stripeSubscription) {
       isEnterprise = isEnterpriseSubscription(stripeSubscription);
@@ -92,7 +92,7 @@ function ProgressBar({ consumed, total }: ProgressBarProps) {
           "h-full rounded-full transition-all",
           percentage > 80
             ? "bg-warning-700"
-            : "bg-primary dark:bg-primary-night"
+            : "bg-primary dark:bg-primary-night",
         )}
         style={{ width: `${percentage}%` }}
       />
@@ -173,7 +173,7 @@ function UsageSection({
 }: UsageSectionProps) {
   const billingCycle = useMemo(
     () => getBillingCycle(subscription.startDate),
-    [subscription.startDate]
+    [subscription.startDate],
   );
 
   const formatDateShort = (date: Date) => {
@@ -235,7 +235,7 @@ function UsageSection({
           <Page.P variant="secondary">
             {formatDateShort(billingCycle.cycleStart)} →{" "}
             {formatDateShort(
-              new Date(billingCycle.cycleEnd.getTime() - 24 * 60 * 60 * 1000)
+              new Date(billingCycle.cycleEnd.getTime() - 24 * 60 * 60 * 1000),
             )}
           </Page.P>
         )}
@@ -266,17 +266,19 @@ function UsageSection({
           consumed={creditsByType.committed.consumed}
           total={creditsByType.committed.total}
           renewalDate={formatExpirationDate(
-            creditsByType.committed.expirationDate
+            creditsByType.committed.expirationDate,
           )}
           action={
-            <Button
-              label="Buy credits"
-              variant="outline"
-              size="xs"
-              disabled={isPurchasingCredits}
-              isLoading={isPurchasingCredits}
-              onClick={() => setShowBuyCreditDialog(true)}
-            />
+            !subscription.trialing && (
+              <Button
+                label="Buy credits"
+                variant="outline"
+                size="xs"
+                disabled={isPurchasingCredits}
+                isLoading={isPurchasingCredits}
+                onClick={() => setShowBuyCreditDialog(true)}
+              />
+            )
           }
         />
         {isEnterprise && (


### PR DESCRIPTION
## Description

Make the UI consistent by hiding the buy credits button when on trial

<img width="1089" height="1145" alt="image" src="https://github.com/user-attachments/assets/b02b1849-6d0c-491b-900e-c1251d8b40a8" />


## Tests

Tested locally with trial subscription

## Risk

Low

## Deploy Plan

- [ ] Deploy front