### PR TITLE
[ppul] Limit usage graph to 5 days in the future

### DIFF
--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -285,7 +285,13 @@ export async function handleProgrammaticCostRequest(
       const { cycleStart: periodStart, cycleEnd: periodEnd } =
         getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
 
-      const timestamps = getTimestampsInRange(periodStart, periodEnd);
+      // Cap periodEnd to 5 days in the future to avoid empty chart areas.
+      const FIVE_DAYS_IN_MS = 5 * 24 * 60 * 60 * 1000;
+      const cappedPeriodEnd = new Date(
+        Math.min(periodEnd.getTime(), Date.now() + FIVE_DAYS_IN_MS)
+      );
+
+      const timestamps = getTimestampsInRange(periodStart, cappedPeriodEnd);
 
       // Fetch all credits for the workspace (including free credits and fully consumed ones)
       // We'll filter them per timestamp in calculateCreditTotalsPerTimestamp


### PR DESCRIPTION
## Description
Filter out data points more than 5 days in the future to prevent displaying large empty areas in the usage graph when viewing the current billing cycle.

## Risks
Blast radius: Usage graph display in workspace settings
Risk: low

## Deploy Plan
- deploy front