### PR TITLE
Handle Snowflake "user disabled" error

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -114,6 +114,25 @@ function isSnowflakeSuspendedError(
   );
 }
 
+interface SnowflakeUserAccessDisabledError extends Error {
+  name: "OperationFailedError";
+}
+
+function isSnowflakeUserAccessDisabledError(
+  err: unknown
+): err is SnowflakeUserAccessDisabledError {
+  const userDisabledError = err as {
+    name: "OperationFailedError";
+    message: string;
+  };
+  return (
+    "name" in userDisabledError &&
+    userDisabledError.name === "OperationFailedError" &&
+    "message" in userDisabledError &&
+    userDisabledError.message.includes("User access disabled")
+  );
+}
+
 export class SnowflakeCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -131,7 +150,8 @@ export class SnowflakeCastKnownErrorsInterceptor
         isSnowflakeAccountLockedError(err) ||
         isSnowflakeIncorrectCredentialsError(err) ||
         isSnowflakeRoleNotFoundError(err) ||
-        isSnowflakeSuspendedError(err)
+        isSnowflakeSuspendedError(err) ||
+        isSnowflakeUserAccessDisabledError(err)
       ) {
         throw new ExternalOAuthTokenError(err);
       }


### PR DESCRIPTION
## Description

We don't handle properly the Snowflakes "User disabled" error. When we get that error, the activity is retried instead of being paused.

This PR will prevent the connector from getting stuck by throwing an ExternalOAuthTokenError in this situation, which will mark the connector as errored and pause it.

See [Datadog](https://app.datadoghq.eu/dashboard/eza-jyh-pwy/stuck-connectors-worker?query=%28%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1%20%40level%3Aerror%20%40workflowId%3A%2A%29%20AND%20%40workflowId%3Asnowflake-sync-26144&event=AwAAAZruAKZtp5FAzAAAABhBWnJ1QUswLUFBQnlZd2JDZlVzdlFRQUIAAAAkZjE5YWVlMDAtYzEyOC00OWFjLWI0N2YtMTZkOWM1MGEzZGYwAAADxg&fromUser=false&index=%2A&panelFrom=1764915252434&panelStorageType=hot&panelTo=1764929652434&panelType=logs&refresh_mode=sliding&from_ts=1764915245326&to_ts=1764929645326&live=true)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy connectors
