### PR TITLE
Add Data Source Bulk Search Endpoint

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -194,6 +194,10 @@ fn main() {
             post(data_sources::data_sources_search),
         )
         .route(
+            "/data_sources/search/bulk",
+            post(data_sources::data_sources_search_bulk),
+        )
+        .route(
             "/projects/{project_id}/data_sources/{data_source_id}/documents",
             get(data_sources::data_sources_documents_list),
         )

--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -5,11 +5,15 @@ use axum::{
 use hyper::http::StatusCode;
 use regex::Regex;
 use serde_json::json;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{error, info};
 
-use crate::api::api_state::APIState;
+use crate::{
+    api::api_state::APIState,
+    data_sources::data_source::{DataSource, Document},
+    providers::embedder::EmbedderRequest,
+};
 use crate::{
     data_sources::{
         data_source::{self, Section},
@@ -345,6 +349,165 @@ pub async fn data_sources_search(
     }
 }
 
+// Perform a bulk search on several data sources.
+
+#[derive(serde::Deserialize)]
+pub struct DataSourceSearchRequest {
+    pub project_id: i64,
+    pub data_source_id: String,
+    pub top_k: usize,
+    pub filter: Option<SearchFilter>,
+    pub view_filter: Option<SearchFilter>,
+    pub target_document_tokens: Option<usize>,
+}
+
+#[derive(serde::Deserialize)]
+pub struct DataSourcesSearchBulkPayload {
+    pub query: String,
+    pub searches: Vec<DataSourceSearchRequest>,
+    pub full_text: bool,
+    pub credentials: run::Credentials,
+}
+
+#[derive(serde::Serialize)]
+pub struct DataSourceSearchResultItem {
+    pub project_id: i64,
+    pub data_source_id: String,
+    pub documents: Vec<Document>,
+    pub error: Option<String>,
+}
+
+pub async fn data_sources_search_bulk(
+    State(state): State<Arc<APIState>>,
+    Json(payload): Json<DataSourcesSearchBulkPayload>,
+) -> (StatusCode, Json<APIResponse>) {
+    // Load all data sources.
+    let project_data_sources: Vec<(i64, String)> = payload
+        .searches
+        .iter()
+        .map(|s| (s.project_id, s.data_source_id.clone()))
+        .collect();
+
+    let data_sources = match state.store.load_data_sources(project_data_sources).await {
+        Ok(ds) => ds,
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_server_error",
+                "Failed to load data sources",
+                Some(e),
+            );
+        }
+    };
+
+    // Group by embedder model_id.
+    let mut groups: HashMap<String, Vec<(DataSourceSearchRequest, DataSource)>> = HashMap::new();
+
+    for (search_req, ds) in payload.searches.into_iter().zip(data_sources.into_iter()) {
+        let model_id = ds.embedder_config().model_id.clone();
+        groups
+            .entry(model_id)
+            .or_insert_with(Vec::new)
+            .push((search_req, ds));
+    }
+
+    // Embed and search for each group.
+    let mut all_results: Vec<DataSourceSearchResultItem> = Vec::new();
+
+    for (model_id, group) in groups {
+        // Get embedder from first data source in group.
+        let first_ds = &group[0].1;
+        let embedder_config = first_ds.embedder_config();
+        let credentials = payload.credentials.clone();
+
+        // Embed query once per group.
+        let embedder_request = EmbedderRequest::new(
+            embedder_config.provider_id,
+            &model_id,
+            vec![&payload.query],
+            first_ds.config().extras.clone(),
+        );
+
+        // If any embedding fails, fail the entire request immediately.
+        let query_vector = match embedder_request.execute(credentials).await {
+            Ok(v) => {
+                assert!(v.len() == 1);
+                Some(v[0].vector.iter().map(|v| *v as f32).collect::<Vec<f32>>())
+            }
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "embedding_error",
+                    &format!("Failed to embed query with model {}", model_id),
+                    Some(e),
+                );
+            }
+        };
+
+        // Search all data sources in this group with the same vector.
+        let search_futures: Vec<_> = group
+            .into_iter()
+            .map(|(search_req, ds)| {
+                let vector = query_vector.clone();
+                let store = state.store.clone();
+                let qdrant_clients = state.qdrant_clients.clone();
+                let full_text = payload.full_text;
+
+                async move {
+                    let filter = match search_req.filter {
+                        Some(f) => Some(f.postprocess_for_data_source(&search_req.data_source_id)),
+                        None => None,
+                    };
+
+                    let view_filter = match search_req.view_filter {
+                        Some(f) => Some(f.postprocess_for_data_source(&search_req.data_source_id)),
+                        None => None,
+                    };
+
+                    match ds
+                        .search_with_vector(
+                            store,
+                            qdrant_clients,
+                            vector,
+                            search_req.top_k,
+                            filter,
+                            view_filter,
+                            full_text,
+                            search_req.target_document_tokens,
+                        )
+                        .await
+                    {
+                        Ok(documents) => DataSourceSearchResultItem {
+                            project_id: search_req.project_id,
+                            data_source_id: search_req.data_source_id.clone(),
+                            documents,
+                            error: None,
+                        },
+                        Err(e) => DataSourceSearchResultItem {
+                            project_id: search_req.project_id,
+                            data_source_id: search_req.data_source_id.clone(),
+                            documents: vec![],
+                            error: Some(format!("{}", e)),
+                        },
+                    }
+                }
+            })
+            .collect();
+
+        let results = futures::future::join_all(search_futures).await;
+        all_results.extend(results);
+    }
+
+    (
+        StatusCode::OK,
+        Json(APIResponse {
+            error: None,
+            response: Some(json!({
+                "results": all_results,
+            })),
+        }),
+    )
+}
 /// Update tags of a document in a data source.
 
 #[derive(serde::Deserialize)]

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1218,6 +1218,72 @@ impl DataSource {
         full_text: bool,
         target_document_tokens: Option<usize>,
     ) -> Result<Vec<Document>> {
+        // We ensure that we have not left a `parents.is_in_map`` in the filters.
+        match &filter {
+            Some(filter) => {
+                filter.ensure_postprocessed()?;
+            }
+            None => (),
+        }
+        match &view_filter {
+            Some(filter) => {
+                filter.ensure_postprocessed()?;
+            }
+            None => (),
+        }
+
+        if top_k > DataSource::MAX_TOP_K_SEARCH {
+            return Err(anyhow!("top_k must be <= {}", DataSource::MAX_TOP_K_SEARCH));
+        }
+
+        let query = match query {
+            Some(q) => match q.len() {
+                0 => None,
+                _ => Some(q),
+            },
+            None => None,
+        };
+
+        let vector = match query {
+            None => None,
+            Some(q) => {
+                let r = EmbedderRequest::new(
+                    self.embedder_config().provider_id,
+                    &self.embedder_config().model_id,
+                    vec![&q],
+                    self.config.extras.clone(),
+                );
+                let v = r.execute(credentials).await?;
+                assert!(v.len() == 1);
+
+                Some(v[0].vector.iter().map(|v| *v as f32).collect::<Vec<f32>>())
+            }
+        };
+
+        self.search_with_vector(
+            store,
+            qdrant_clients,
+            vector,
+            top_k,
+            filter,
+            view_filter,
+            full_text,
+            target_document_tokens,
+        )
+        .await
+    }
+
+    pub async fn search_with_vector(
+        &self,
+        store: Box<dyn Store + Sync + Send>,
+        qdrant_clients: QdrantClients,
+        vector: Option<Vec<f32>>,
+        top_k: usize,
+        filter: Option<SearchFilter>,
+        view_filter: Option<SearchFilter>,
+        full_text: bool,
+        target_document_tokens: Option<usize>,
+    ) -> Result<Vec<Document>> {
         let time_search_start = utils::now();
 
         let qdrant_client = self.main_qdrant_client(&qdrant_clients);
@@ -1241,18 +1307,10 @@ impl DataSource {
         }
 
         let time_qdrant_start = utils::now();
-        let mut embedding_duration: u64 = 0;
         let qdrant_search_duration: u64;
+        let has_vector = vector.is_some();
 
-        let query = match query {
-            Some(q) => match q.len() {
-                0 => None,
-                _ => Some(q),
-            },
-            None => None,
-        };
-
-        let chunks = match query {
+        let chunks = match vector {
             None => {
                 let store = store.clone();
                 if !target_document_tokens.is_none() {
@@ -1272,18 +1330,7 @@ impl DataSource {
                 qdrant_search_duration = utils::now() - time_qdrant_start;
                 chunks
             }
-            Some(q) => {
-                let r = EmbedderRequest::new(
-                    self.embedder_config().provider_id,
-                    &self.embedder_config().model_id,
-                    vec![&q],
-                    self.config.extras.clone(),
-                );
-                let v = r.execute(credentials).await?;
-                assert!(v.len() == 1);
-
-                embedding_duration = utils::now() - time_qdrant_start;
-
+            Some(vec) => {
                 // Construct the filters for the search query if specified.
                 let f = build_qdrant_filter(&filter, &view_filter);
 
@@ -1292,7 +1339,7 @@ impl DataSource {
                     .search_points(
                         self.embedder_config(),
                         &self.internal_id,
-                        v[0].vector.iter().map(|v| *v as f32).collect::<Vec<f32>>(),
+                        vec,
                         f,
                         top_k as u64,
                         Some(true.into()),
@@ -1579,7 +1626,7 @@ impl DataSource {
 
         let qdrant_scroll_duration = utils::now() - time_qdrant_scroll_start;
 
-        if !query.is_none() {
+        if !has_vector {
             // Sort the documents by the score of the first chunk (guaranteed ordered).
             documents.sort_by(|a, b| {
                 let b_score = b.chunks.first().unwrap().score.unwrap_or(0.0);
@@ -1603,8 +1650,7 @@ impl DataSource {
             data_source_internal_id = self.internal_id(),
             document_count = documents.len(),
             chunk_count = documents.iter().map(|d| d.chunks.len()).sum::<usize>(),
-            with_query = query.is_some(),
-            embedding_duration = embedding_duration,
+            with_query = has_vector,
             qdrant_search_duration = qdrant_search_duration,
             store_duration = store_duration,
             qdrant_scroll_duration = qdrant_scroll_duration,

--- a/core/src/data_sources/data_source.rs
+++ b/core/src/data_sources/data_source.rs
@@ -1254,7 +1254,12 @@ impl DataSource {
                     self.config.extras.clone(),
                 );
                 let v = r.execute(credentials).await?;
-                assert!(v.len() == 1);
+                if v.len() != 1 {
+                    return Err(anyhow!(
+                        "Expected exactly one embedding vector, got {}",
+                        v.len()
+                    ));
+                }
 
                 Some(v[0].vector.iter().map(|v| *v as f32).collect::<Vec<f32>>())
             }

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -129,7 +129,7 @@ export async function searchFunction({
   }
 
   // Now we can search each data source.
-  const searchResults = await coreAPI.searchDataSources(
+  const searchResults = await coreAPI.bulkSearchDataSources(
     query,
     retrievalTopK,
     credentials,

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
@@ -215,7 +215,7 @@ async function searchCallback(
     return new Err(new MCPError(conflictingTags, { tracked: false }));
   }
 
-  const searchResults = await coreAPI.searchDataSources(
+  const searchResults = await coreAPI.bulkSearchDataSources(
     query,
     retrievalTopK,
     credentials,

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1025,12 +1025,6 @@ export class CoreAPI {
           }
         );
 
-        console.log(
-          "Search result for data source",
-          search.dataSourceId,
-          JSON.stringify(r, null, 2)
-        );
-
         return r;
       },
       { concurrency: 10 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C05DP58UKR7/p1764859054665289).

When `@dust` searches through company data sources, the current implementation has significant performance issues:

### Current Flow
1. **N separate HTTP requests**: One request per data source to core API (`POST /projects/{id}/data_sources/{id}/search`)
2. **Limited parallelization**: Only 10 concurrent requests at a time
3. **N redundant embeddings**: Same query text is embedded N times (once per data source)
   - 99.9% of workspaces use a single embedding model (`text-embedding-3-large-1536`)
   - Each embedding call counts toward OpenAI's RPM rate limit
4. **Blocking agent loop**: All searches must complete before agent continues

### Performance Impact
- **Embedding latency**: Sometimes 8+ seconds for query embedding (highly variable)
- **Typical search**: 5-15 data sources → 5-15× redundant embedding calls
- **Total overhead**: Multiple seconds wasted on redundant work per agent search

Example: Searching 15 data sources means:
- 15 HTTP requests
- 15 identical embedding API calls to OpenAI
- 15× rate limit consumption
- Only 1 embedding actually needed

## Solution

This PR introduces a **bulk data source search endpoint** that embeds the query once and reuses the vector across all data sources.

### New Flow
1. **Single HTTP request**: `POST /data_sources/search/bulk` with all data sources
2. **Load all data sources** in parallel
3. **Group by embedder model**: Handle rare cases where data sources use different models
4. **Embed once per model**: Typically 1 embedding call total (vs N previously)
5. **Parallel vector search**: Search all data sources concurrently with shared embedding vector
6. **Return aggregated results**: Individual errors don't fail entire request

⚠️ We might want to split the data sources into smaller batch in the future.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] First deploy core
- [ ] Wait for core deployment to be out
- [ ] Deploy front
