### PR TITLE
nit(poke): save current tab in url

### DIFF
--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -62,7 +62,7 @@ import type {
   WorkspaceSegmentationType,
   WorkspaceType,
 } from "@app/types";
-import { WHITELISTABLE_FEATURES } from "@app/types";
+import { isString, WHITELISTABLE_FEATURES } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   activeSubscription: SubscriptionType;
@@ -140,6 +140,21 @@ const WorkspacePage = ({
   workosEnvironmentId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
+
+  const currentTab = !isString(router.query.tab)
+    ? "datasources"
+    : router.query.tab;
+
+  const handleTabChange = (value: string) => {
+    void router.push(
+      {
+        pathname: router.pathname,
+        query: { ...router.query, tab: value },
+      },
+      undefined,
+      { shallow: true }
+    );
+  };
 
   const { submit: onWorkspaceUpdate } = useSubmitFunction(
     async (segmentation: WorkspaceSegmentationType) => {
@@ -268,7 +283,11 @@ const WorkspacePage = ({
               />
             </div>
           </div>
-          <Tabs defaultValue="datasources" className="min-h-[1024px] w-full">
+          <Tabs
+            value={currentTab}
+            onValueChange={handleTabChange}
+            className="min-h-[1024px] w-full"
+          >
             <TabsList>
               <TabsTrigger value="agents" label="Agents" />
               <TabsTrigger value="apps" label="Apps" />


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

I'm annoyed of reloading a workspace's poke page and being brought back to data sources, so this saves the current poke tab in URL.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front