### PR TITLE
Send userId of blocked action.

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -201,6 +201,7 @@ export function AgentMessage({
                 messageId: eventPayload.data.messageId,
                 conversationId: eventPayload.data.conversationId,
                 actionId: eventPayload.data.actionId,
+                userId: eventPayload.data.userId,
                 inputs: eventPayload.data.inputs,
                 stake: eventPayload.data.stake,
                 metadata: eventPayload.data.metadata,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -151,8 +151,9 @@ export type ToolExecution = {
   };
 };
 
-export type BlockedToolExecution = ToolExecution &
-  (
+export type BlockedToolExecution = ToolExecution & {
+  userId: string;
+} & (
     | {
         status: "blocked_validation_required";
         authorizationInfo: AuthorizationInfo | null;
@@ -176,6 +177,7 @@ export type BlockedToolExecution = ToolExecution &
 // TODO(durable-agents): cleanup the types of the events.
 export type MCPApproveExecutionEvent = ToolExecution & {
   type: "tool_approve_execution";
+  userId: string;
   created: number;
   configurationId: string;
   isLastBlockingEventForStep?: boolean;

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -231,6 +231,7 @@ async function createActionForTool(
             type: "tool_approve_execution",
             created: Date.now(),
             configurationId: agentConfiguration.sId,
+            userId: auth.getNonNullableUser().sId,
             messageId: agentMessage.sId,
             conversationId: conversation.sId,
             actionId: action.sId,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1279,6 +1279,7 @@ export type BlockedActionExecutionType = z.infer<
 
 const MCPApproveExecutionEventSchema = ToolExecutionMetadataSchema.extend({
   type: z.literal("tool_approve_execution"),
+  userId: z.string(),
   configurationId: z.string(),
   conversationId: z.string(),
   created: z.number(),


### PR DESCRIPTION
## Description

Send userId associated with a blocked action to easily identify who is supposed to react to it (without going back to the parent message manually).

## Tests

Local

## Risk

Seems relatively harmless

## Deploy Plan

Deploy front