### PR TITLE
[front] - chore(mentions): improve mention suggestions

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -275,7 +275,7 @@ const InputBarContainer = ({
     onUrlDetected: handleUrlDetected,
     owner,
     conversationId,
-    preferredAgentId: selectedAgent?.configurationId ?? null,
+    preferredAgentId: selectedAgent?.id ?? null,
     onInlineText: handleInlineText,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -275,7 +275,7 @@ const InputBarContainer = ({
     onUrlDetected: handleUrlDetected,
     owner,
     conversationId,
-    preferredAgentId: selectedAgent?.sId ?? null,
+    preferredAgentId: selectedAgent?.configurationId ?? null,
     onInlineText: handleInlineText,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -275,6 +275,7 @@ const InputBarContainer = ({
     onUrlDetected: handleUrlDetected,
     owner,
     conversationId,
+    preferredAgentId: selectedAgent?.sId ?? null,
     onInlineText: handleInlineText,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -275,8 +275,7 @@ const InputBarContainer = ({
     onUrlDetected: handleUrlDetected,
     owner,
     conversationId,
-    preferredAgentId: userMentionsEnabled ? (selectedAgent?.id ?? null) : null,
-    userMentionsEnabled,
+    preferredAgentId: selectedAgent?.id ?? null,
     onInlineText: handleInlineText,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -275,7 +275,8 @@ const InputBarContainer = ({
     onUrlDetected: handleUrlDetected,
     owner,
     conversationId,
-    preferredAgentId: selectedAgent?.id ?? null,
+    preferredAgentId: userMentionsEnabled ? (selectedAgent?.id ?? null) : null,
+    userMentionsEnabled,
     onInlineText: handleInlineText,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -26,172 +26,200 @@ import { classNames } from "@app/lib/utils";
 export const MentionDropdown = forwardRef<
   MentionDropdownOnKeyDown,
   MentionDropdownProps
->(({ query, clientRect, command, onClose, owner, conversationId }, ref) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const triggerRect = useMemo(
-    () => (clientRect ? clientRect() : null),
-    [clientRect]
-  );
-
-  // Fetch suggestions from server using the query.
-  const { suggestions, isLoading } = useMentionSuggestions({
-    workspaceId: owner.sId,
-    conversationId,
-    query,
-    select: { agents: true, users: true },
-  });
-
-  const triggerRef = useRef<HTMLDivElement>(null);
-  const [virtualTriggerStyle, setVirtualTriggerStyle] =
-    useState<React.CSSProperties>({});
-
-  const selectItem = (index: number) => {
-    const item = suggestions[index];
-
-    if (item) {
-      command(item);
-    }
-  };
-
-  const updateTriggerPosition = useCallback(() => {
-    if (triggerRect && triggerRef.current) {
-      setVirtualTriggerStyle({
-        position: "fixed",
-        left: triggerRect.left,
-        // On iOS based browsers, the position is not correct without adding the offsetTop.
-        // Something related to the position calculation when there is a scrollable area.
-        top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
-        width: 1,
-        height: triggerRect.height || 1,
-        pointerEvents: "none",
-        zIndex: -1,
-      });
-    }
-  }, [triggerRect]);
-
-  useImperativeHandle(ref, () => ({
-    onKeyDown: ({ event }) => {
-      if (event.key === "ArrowUp") {
-        setSelectedIndex(
-          (selectedIndex + suggestions.length - 1) % suggestions.length
-        );
-        return true;
-      }
-
-      if (event.key === "ArrowDown") {
-        setSelectedIndex((selectedIndex + 1) % suggestions.length);
-        return true;
-      }
-
-      if (event.key === "Enter" || event.key === "Tab") {
-        selectItem(selectedIndex);
-        return true;
-      }
-
-      return false;
+>(
+  (
+    {
+      query,
+      clientRect,
+      command,
+      onClose,
+      owner,
+      conversationId,
+      preferredAgentId,
     },
-  }));
+    ref
+  ) => {
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const triggerRect = useMemo(
+      () => (clientRect ? clientRect() : null),
+      [clientRect]
+    );
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    updateTriggerPosition();
-  }, [updateTriggerPosition]);
+    // Fetch suggestions from server using the query.
+    const { suggestions, isLoading } = useMentionSuggestions({
+      workspaceId: owner.sId,
+      conversationId,
+      query,
+      select: { agents: true, users: true },
+    });
 
-  // Reset the selected index when items change (e.g., when query changes).
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSelectedIndex(0);
-  }, [suggestions]);
+    const triggerRef = useRef<HTMLDivElement>(null);
+    const [virtualTriggerStyle, setVirtualTriggerStyle] =
+      useState<React.CSSProperties>({});
 
-  // Only render the dropdown if we have a valid trigger.
-  if (!triggerRect) {
-    return null;
+    const orderedSuggestions = useMemo(() => {
+      if (!preferredAgentId) {
+        return suggestions;
+      }
+      const preferredIndex = suggestions.findIndex(
+        (s) => s.type === "agent" && s.id === preferredAgentId
+      );
+      if (preferredIndex <= 0) {
+        return suggestions;
+      }
+      const preferred = suggestions[preferredIndex];
+      return [preferred, ...suggestions.filter((_, i) => i !== preferredIndex)];
+    }, [suggestions, preferredAgentId]);
+
+    const selectItem = (index: number) => {
+      const item = orderedSuggestions[index];
+
+      if (item) {
+        command(item);
+      }
+    };
+
+    const updateTriggerPosition = useCallback(() => {
+      if (triggerRect && triggerRef.current) {
+        setVirtualTriggerStyle({
+          position: "fixed",
+          left: triggerRect.left,
+          // On iOS based browsers, the position is not correct without adding the offsetTop.
+          // Something related to the position calculation when there is a scrollable area.
+          top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
+          width: 1,
+          height: triggerRect.height || 1,
+          pointerEvents: "none",
+          zIndex: -1,
+        });
+      }
+    }, [triggerRect]);
+
+    useImperativeHandle(ref, () => ({
+      onKeyDown: ({ event }) => {
+        if (event.key === "ArrowUp") {
+          setSelectedIndex(
+            (selectedIndex + orderedSuggestions.length - 1) %
+              orderedSuggestions.length
+          );
+          return true;
+        }
+
+        if (event.key === "ArrowDown") {
+          setSelectedIndex((selectedIndex + 1) % suggestions.length);
+          return true;
+        }
+
+        if (event.key === "Enter" || event.key === "Tab") {
+          selectItem(selectedIndex);
+          return true;
+        }
+
+        return false;
+      },
+    }));
+
+    useEffect(() => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      updateTriggerPosition();
+    }, [updateTriggerPosition]);
+
+    // Reset the selected index when items change (e.g., when query changes).
+    useEffect(() => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSelectedIndex(0);
+    }, [suggestions]);
+
+    // Only render the dropdown if we have a valid trigger.
+    if (!triggerRect) {
+      return null;
+    }
+
+    // Generate a key based on content state to force remount when content size changes significantly.
+    // This ensures Radix UI recalculates collision detection and positioning.
+    const contentKey = isLoading
+      ? "loading"
+      : orderedSuggestions.length === 0
+        ? "empty"
+        : `results-${suggestions.length}`;
+
+    return (
+      <DropdownMenu open={true}>
+        <DropdownMenuTrigger asChild>
+          <div ref={triggerRef} style={virtualTriggerStyle} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          key={contentKey}
+          className="w-72"
+          align="start"
+          side="bottom"
+          sideOffset={4}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onEscapeKeyDown={() => {
+            onClose?.();
+          }}
+          onInteractOutside={() => {
+            onClose?.();
+          }}
+        >
+          {isLoading ? (
+            <div className="flex h-12 w-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : orderedSuggestions.length > 0 ? (
+            <div className="flex max-h-60 flex-col gap-y-1 overflow-y-auto p-1">
+              {orderedSuggestions.map((suggestion, index) => (
+                <div key={suggestion.id}>
+                  <button
+                    className={classNames(
+                      "flex items-center px-2 py-1",
+                      "w-full flex-initial cursor-pointer text-left text-sm",
+                      index === selectedIndex
+                        ? "text-highlight-500"
+                        : "text-foreground dark:text-foreground-night"
+                    )}
+                    onClick={() => {
+                      selectItem(index);
+                    }}
+                    onMouseEnter={() => {
+                      setSelectedIndex(index);
+                    }}
+                  >
+                    <div className="flex min-w-0 flex-1 items-center gap-x-2">
+                      <Avatar
+                        size="xs"
+                        visual={suggestion.pictureUrl}
+                        isRounded={suggestion.type === "user"}
+                      />
+                      <span
+                        className="truncate font-semibold"
+                        title={suggestion.label}
+                      >
+                        {suggestion.label}
+                      </span>
+                    </div>
+                    {suggestion.type === "user" && (
+                      <Chip
+                        size="mini"
+                        color="primary"
+                        label="User"
+                        className="ml-2 shrink-0"
+                      />
+                    )}
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex h-12 w-full items-center justify-center text-sm text-muted-foreground">
+              No result
+            </div>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
   }
-
-  // Generate a key based on content state to force remount when content size changes significantly.
-  // This ensures Radix UI recalculates collision detection and positioning.
-  const contentKey = isLoading
-    ? "loading"
-    : suggestions.length === 0
-      ? "empty"
-      : `results-${suggestions.length}`;
-
-  return (
-    <DropdownMenu open={true}>
-      <DropdownMenuTrigger asChild>
-        <div ref={triggerRef} style={virtualTriggerStyle} />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        key={contentKey}
-        className="w-72"
-        align="start"
-        side="bottom"
-        sideOffset={4}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        onEscapeKeyDown={() => {
-          onClose?.();
-        }}
-        onInteractOutside={() => {
-          onClose?.();
-        }}
-      >
-        {isLoading ? (
-          <div className="flex h-12 w-full items-center justify-center">
-            <Spinner />
-          </div>
-        ) : suggestions.length > 0 ? (
-          <div className="flex max-h-60 flex-col gap-y-1 overflow-y-auto p-1">
-            {suggestions.map((suggestion, index) => (
-              <div key={suggestion.id}>
-                <button
-                  className={classNames(
-                    "flex items-center px-2 py-1",
-                    "w-full flex-initial cursor-pointer text-left text-sm",
-                    index === selectedIndex
-                      ? "text-highlight-500"
-                      : "text-foreground dark:text-foreground-night"
-                  )}
-                  onClick={() => {
-                    selectItem(index);
-                  }}
-                  onMouseEnter={() => {
-                    setSelectedIndex(index);
-                  }}
-                >
-                  <div className="flex min-w-0 flex-1 items-center gap-x-2">
-                    <Avatar
-                      size="xs"
-                      visual={suggestion.pictureUrl}
-                      isRounded={suggestion.type === "user"}
-                    />
-                    <span
-                      className="truncate font-semibold"
-                      title={suggestion.label}
-                    >
-                      {suggestion.label}
-                    </span>
-                  </div>
-                  {suggestion.type === "user" && (
-                    <Chip
-                      size="mini"
-                      color="primary"
-                      label="User"
-                      className="ml-2 shrink-0"
-                    />
-                  )}
-                </button>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="flex h-12 w-full items-center justify-center text-sm text-muted-foreground">
-            No result
-          </div>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-});
+);
 
 MentionDropdown.displayName = "MentionDropdown";

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -1,5 +1,6 @@
 import {
   Avatar,
+  Chip,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
@@ -145,8 +146,8 @@ export const MentionDropdown = forwardRef<
               <div key={suggestion.id}>
                 <button
                   className={classNames(
-                    "flex items-center gap-x-2 px-2 py-1",
-                    "w-full flex-initial cursor-pointer text-left text-sm font-semibold",
+                    "flex items-center px-2 py-1",
+                    "w-full flex-initial cursor-pointer text-left text-sm",
                     index === selectedIndex
                       ? "text-highlight-500"
                       : "text-foreground dark:text-foreground-night"
@@ -158,14 +159,27 @@ export const MentionDropdown = forwardRef<
                     setSelectedIndex(index);
                   }}
                 >
-                  <Avatar
-                    size="xs"
-                    visual={suggestion.pictureUrl}
-                    isRounded={suggestion.type === "user"}
-                  />
-                  <span className="truncate" title={suggestion.label}>
-                    {suggestion.label}
-                  </span>
+                  <div className="flex min-w-0 flex-1 items-center gap-x-2">
+                    <Avatar
+                      size="xs"
+                      visual={suggestion.pictureUrl}
+                      isRounded={suggestion.type === "user"}
+                    />
+                    <span
+                      className="truncate font-semibold"
+                      title={suggestion.label}
+                    >
+                      {suggestion.label}
+                    </span>
+                  </div>
+                  {suggestion.type === "user" && (
+                    <Chip
+                      size="mini"
+                      color="primary"
+                      label="User"
+                      className="ml-2 shrink-0"
+                    />
+                  )}
                 </button>
               </div>
             ))}

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -84,7 +84,7 @@ export const MentionDropdown = forwardRef<
           .map((u) => ({
             type: "user" as const,
             id: u.sId,
-            label: u.fullName || u.username,
+            label: u.fullName ?? u.username,
             pictureUrl: u.pictureUrl ?? "/static/humanavatar/anonymous.png",
             description: u.username,
           }))

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -19,12 +19,10 @@ export function createMentionSuggestion({
   owner,
   conversationId,
   preferredAgentId,
-  userMentionsEnabled,
 }: {
   owner: WorkspaceType;
   conversationId: string | null;
   preferredAgentId?: string | null;
-  userMentionsEnabled?: boolean;
 }) {
   return {
     pluginKey: mentionPluginKey,
@@ -54,7 +52,6 @@ export function createMentionSuggestion({
               owner,
               conversationId,
               preferredAgentId,
-              userMentionsEnabled,
               onClose: closeDropdown,
             },
           });
@@ -69,7 +66,6 @@ export function createMentionSuggestion({
             owner,
             conversationId,
             preferredAgentId,
-            userMentionsEnabled,
           });
         },
 

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -19,10 +19,12 @@ export function createMentionSuggestion({
   owner,
   conversationId,
   preferredAgentId,
+  userMentionsEnabled,
 }: {
   owner: WorkspaceType;
   conversationId: string | null;
   preferredAgentId?: string | null;
+  userMentionsEnabled?: boolean;
 }) {
   return {
     pluginKey: mentionPluginKey,
@@ -52,6 +54,7 @@ export function createMentionSuggestion({
               owner,
               conversationId,
               preferredAgentId,
+              userMentionsEnabled,
               onClose: closeDropdown,
             },
           });
@@ -66,6 +69,7 @@ export function createMentionSuggestion({
             owner,
             conversationId,
             preferredAgentId,
+            userMentionsEnabled,
           });
         },
 

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -18,9 +18,11 @@ export const mentionPluginKey = new PluginKey("mention-suggestion");
 export function createMentionSuggestion({
   owner,
   conversationId,
+  preferredAgentId,
 }: {
   owner: WorkspaceType;
   conversationId: string | null;
+  preferredAgentId?: string | null;
 }) {
   return {
     pluginKey: mentionPluginKey,
@@ -49,6 +51,7 @@ export function createMentionSuggestion({
               ...props,
               owner,
               conversationId,
+              preferredAgentId,
               onClose: closeDropdown,
             },
           });
@@ -62,6 +65,7 @@ export function createMentionSuggestion({
             onClose: closeDropdown,
             owner,
             conversationId,
+            preferredAgentId,
           });
         },
 

--- a/front/components/editor/input_bar/types.ts
+++ b/front/components/editor/input_bar/types.ts
@@ -11,7 +11,6 @@ export interface MentionDropdownProps {
   owner: WorkspaceType;
   conversationId: string | null;
   preferredAgentId?: string | null;
-  userMentionsEnabled?: boolean;
   command: (item: RichMention) => void;
   clientRect?: (() => DOMRect | null) | null;
   onClose?: () => void;

--- a/front/components/editor/input_bar/types.ts
+++ b/front/components/editor/input_bar/types.ts
@@ -11,6 +11,7 @@ export interface MentionDropdownProps {
   owner: WorkspaceType;
   conversationId: string | null;
   preferredAgentId?: string | null;
+  userMentionsEnabled?: boolean;
   command: (item: RichMention) => void;
   clientRect?: (() => DOMRect | null) | null;
   onClose?: () => void;

--- a/front/components/editor/input_bar/types.ts
+++ b/front/components/editor/input_bar/types.ts
@@ -10,6 +10,7 @@ export interface MentionDropdownProps {
   query: string;
   owner: WorkspaceType;
   conversationId: string | null;
+  preferredAgentId?: string | null;
   command: (item: RichMention) => void;
   clientRect?: (() => DOMRect | null) | null;
   onClose?: () => void;

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -175,7 +175,6 @@ export interface CustomEditorProps {
   owner: WorkspaceType;
   conversationId: string | null;
   preferredAgentId?: string | null;
-  userMentionsEnabled?: boolean;
   // If provided, large pasted text will be routed to this callback along with selection bounds
   onLongTextPaste?: (payload: {
     text: string;
@@ -190,14 +189,12 @@ export const buildEditorExtensions = ({
   owner,
   conversationId,
   preferredAgentId,
-  userMentionsEnabled,
   onInlineText,
   onUrlDetected,
 }: {
   owner: WorkspaceType;
   conversationId: string | null;
   preferredAgentId?: string | null;
-  userMentionsEnabled?: boolean;
   onInlineText?: (fileId: string, textContent: string) => void;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
 }) => {
@@ -270,7 +267,6 @@ export const buildEditorExtensions = ({
         owner,
         conversationId,
         preferredAgentId,
-        userMentionsEnabled,
       }),
     }),
     Placeholder.configure({
@@ -301,7 +297,6 @@ const useCustomEditor = ({
   owner,
   conversationId,
   preferredAgentId,
-  userMentionsEnabled,
   onLongTextPaste,
   longTextPasteCharsThreshold,
   onInlineText,
@@ -312,7 +307,6 @@ const useCustomEditor = ({
       owner,
       conversationId,
       preferredAgentId,
-      userMentionsEnabled,
       onInlineText,
       onUrlDetected,
     }),

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -175,6 +175,7 @@ export interface CustomEditorProps {
   owner: WorkspaceType;
   conversationId: string | null;
   preferredAgentId?: string | null;
+  userMentionsEnabled?: boolean;
   // If provided, large pasted text will be routed to this callback along with selection bounds
   onLongTextPaste?: (payload: {
     text: string;
@@ -189,12 +190,14 @@ export const buildEditorExtensions = ({
   owner,
   conversationId,
   preferredAgentId,
+  userMentionsEnabled,
   onInlineText,
   onUrlDetected,
 }: {
   owner: WorkspaceType;
   conversationId: string | null;
   preferredAgentId?: string | null;
+  userMentionsEnabled?: boolean;
   onInlineText?: (fileId: string, textContent: string) => void;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
 }) => {
@@ -267,6 +270,7 @@ export const buildEditorExtensions = ({
         owner,
         conversationId,
         preferredAgentId,
+        userMentionsEnabled,
       }),
     }),
     Placeholder.configure({
@@ -297,6 +301,7 @@ const useCustomEditor = ({
   owner,
   conversationId,
   preferredAgentId,
+  userMentionsEnabled,
   onLongTextPaste,
   longTextPasteCharsThreshold,
   onInlineText,
@@ -307,6 +312,7 @@ const useCustomEditor = ({
       owner,
       conversationId,
       preferredAgentId,
+      userMentionsEnabled,
       onInlineText,
       onUrlDetected,
     }),

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -174,6 +174,7 @@ export interface CustomEditorProps {
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
   owner: WorkspaceType;
   conversationId: string | null;
+  preferredAgentId?: string | null;
   // If provided, large pasted text will be routed to this callback along with selection bounds
   onLongTextPaste?: (payload: {
     text: string;
@@ -187,11 +188,13 @@ export interface CustomEditorProps {
 export const buildEditorExtensions = ({
   owner,
   conversationId,
+  preferredAgentId,
   onInlineText,
   onUrlDetected,
 }: {
   owner: WorkspaceType;
   conversationId: string | null;
+  preferredAgentId?: string | null;
   onInlineText?: (fileId: string, textContent: string) => void;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
 }) => {
@@ -260,7 +263,11 @@ export const buildEditorExtensions = ({
         class:
           "min-w-0 px-0 py-0 border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0 text-highlight-500 font-semibold",
       },
-      suggestion: createMentionSuggestion({ owner, conversationId }),
+      suggestion: createMentionSuggestion({
+        owner,
+        conversationId,
+        preferredAgentId,
+      }),
     }),
     Placeholder.configure({
       placeholder: "Ask an @agent a question, or get some @help",
@@ -289,6 +296,7 @@ const useCustomEditor = ({
   onUrlDetected,
   owner,
   conversationId,
+  preferredAgentId,
   onLongTextPaste,
   longTextPasteCharsThreshold,
   onInlineText,
@@ -298,6 +306,7 @@ const useCustomEditor = ({
     extensions: buildEditorExtensions({
       owner,
       conversationId,
+      preferredAgentId,
       onInlineText,
       onUrlDetected,
     }),

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -1,3 +1,5 @@
+import shuffle from "lodash/shuffle";
+
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { fetchConversationParticipants } from "@app/lib/api/assistant/participants";
 import type { Authenticator } from "@app/lib/auth";
@@ -157,5 +159,19 @@ export const suggestionsOfMentions = async (
   const selectedUsers = userSuggestions.slice(0, targetUserCount);
   const selectedAgents = filteredAgents.slice(0, targetAgentCount);
 
-  return [...selectedUsers, ...selectedAgents];
+  // Mix users and agents with a simple shuffle while:
+  // - preserving the 30/70 counts
+  // - keeping the first item as a user when possible.
+  if (selectedUsers.length === 0) {
+    return [...selectedAgents];
+  }
+
+  const [firstUser, ...remainingUsers] = selectedUsers;
+
+  const rest: RichMention[] = shuffle<RichMention>([
+    ...remainingUsers,
+    ...selectedAgents,
+  ]);
+
+  return [firstUser, ...rest];
 };

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -35,10 +35,9 @@ export const suggestionsOfMentions = async (
   }
 ): Promise<RichMention[]> => {
   const normalizedQuery = query.toLowerCase();
-  const currentUserSId = auth.getNonNullableUser().sId;
 
   const agentSuggestions: RichAgentMention[] = [];
-  let userSuggestions: RichUserMention[] = [];
+  const userSuggestions: RichUserMention[] = [];
 
   if (select.agents) {
     // Fetch agent configurations.
@@ -73,7 +72,7 @@ export const suggestionsOfMentions = async (
     }
   }
 
-  let filteredAgents = filterAndSortEditorSuggestionAgents(
+  const filteredAgents = filterAndSortEditorSuggestionAgents(
     normalizedQuery,
     agentSuggestions
   );

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -1,7 +1,6 @@
 import shuffle from "lodash/shuffle";
 
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
-import { fetchConversationParticipants } from "@app/lib/api/assistant/participants";
 import type { Authenticator } from "@app/lib/auth";
 import {
   filterAndSortEditorSuggestionAgents,
@@ -9,7 +8,6 @@ import {
 } from "@app/lib/mentions/editor/suggestion";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
-  ConversationWithoutContentType,
   RichAgentMention,
   RichMention,
   RichUserMention,
@@ -20,28 +18,6 @@ import {
   toRichUserMentionType,
 } from "@app/types";
 
-function reorderByIds<T extends { id: string }>(
-  items: T[],
-  favoredIds: Set<string>
-): T[] {
-  if (favoredIds.size === 0 || items.length === 0) {
-    return items;
-  }
-
-  const favored: T[] = [];
-  const others: T[] = [];
-
-  for (const item of items) {
-    if (favoredIds.has(item.id)) {
-      favored.push(item);
-    } else {
-      others.push(item);
-    }
-  }
-
-  return [...favored, ...others];
-}
-
 export const suggestionsOfMentions = async (
   auth: Authenticator,
   {
@@ -50,14 +26,12 @@ export const suggestionsOfMentions = async (
       agents: true,
       users: true,
     },
-    conversation,
   }: {
     query: string;
     select?: {
       agents: boolean;
       users: boolean;
     };
-    conversation?: ConversationWithoutContentType | null;
   }
 ): Promise<RichMention[]> => {
   const normalizedQuery = query.toLowerCase();
@@ -104,64 +78,6 @@ export const suggestionsOfMentions = async (
     agentSuggestions
   );
 
-  // If we have a conversation context, favor participants (users and agents)
-  // by moving them to the top of their respective lists.
-  let participantUserIds: Set<string> | null = null;
-  let participantAgentIds: Set<string> | null = null;
-  if (conversation && (select.users || select.agents)) {
-    const participantsRes = await fetchConversationParticipants(
-      auth,
-      conversation
-    );
-
-    if (participantsRes.isOk()) {
-      const participants = participantsRes.value;
-
-      if (select.users) {
-        participantUserIds = new Set(
-          participants.users
-            .map((u) => u.sId)
-            .filter((id) => id !== currentUserSId)
-        );
-
-        const participantUserMentions: RichUserMention[] = participants.users
-          .filter((u) => u.sId !== currentUserSId)
-          .map(
-            (u) =>
-              ({
-                type: "user",
-                id: u.sId,
-                label: u.fullName || u.username,
-                pictureUrl: u.pictureUrl ?? "/static/humanavatar/anonymous.png",
-                description: u.username,
-              }) satisfies RichUserMention
-          )
-          .filter((m) =>
-            normalizedQuery
-              ? m.label.toLowerCase().includes(normalizedQuery)
-              : true
-          );
-
-        const existingUserIds = new Set(userSuggestions.map((u) => u.id));
-
-        const enrichedUsers: RichUserMention[] = [
-          ...participantUserMentions.filter((m) => !existingUserIds.has(m.id)),
-          ...userSuggestions,
-        ];
-
-        userSuggestions = reorderByIds(enrichedUsers, participantUserIds);
-      }
-
-      if (select.agents && filteredAgents.length > 0) {
-        participantAgentIds = new Set(
-          participants.agents.map((a) => a.configurationId)
-        );
-
-        filteredAgents = reorderByIds(filteredAgents, participantAgentIds);
-      }
-    }
-  }
-
   // If only one type is requested, keep the simple ordering.
   if (!select.agents && select.users) {
     return userSuggestions.slice(0, SUGGESTION_DISPLAY_LIMIT);
@@ -176,67 +92,35 @@ export const suggestionsOfMentions = async (
     return filteredAgents.slice(0, SUGGESTION_DISPLAY_LIMIT);
   }
 
-  // Build a participant tier (up to 5 items) when we have conversation context.
-  const participantMentions: RichMention[] = [];
-  const participantUserIdSet = participantUserIds ?? new Set<string>();
-  const participantAgentIdSet = participantAgentIds ?? new Set<string>();
+  // Compute a target 30% / 70% split over the first N items.
+  const totalAvailable = filteredAgents.length + userSuggestions.length;
+  const maxResults = Math.min(SUGGESTION_DISPLAY_LIMIT, totalAvailable);
 
-  if (conversation) {
-    const participantUsers =
-      participantUserIds === null
-        ? []
-        : userSuggestions.filter((u) => participantUserIdSet.has(u.id));
-    const participantAgents =
-      participantAgentIds === null
-        ? []
-        : filteredAgents.filter((a) => participantAgentIdSet.has(a.id));
+  const targetUserCount = Math.min(
+    userSuggestions.length,
+    Math.max(1, Math.round(0.3 * maxResults))
+  );
+  const targetAgentCount = Math.min(
+    filteredAgents.length,
+    maxResults - targetUserCount
+  );
 
-    participantMentions.push(...participantUsers, ...participantAgents);
+  const selectedUsers = userSuggestions.slice(0, targetUserCount);
+  const selectedAgents = filteredAgents.slice(0, targetAgentCount);
+
+  // Mix users and agents with a simple shuffle while:
+  // - preserving the 30/70 counts
+  // - keeping the first item as a user when possible.
+  if (selectedUsers.length === 0) {
+    return [...selectedAgents];
   }
 
-  const uniqueParticipantIds = new Set(
-    participantMentions.map((m) => `${m.type}:${m.id}`)
-  );
-
-  const cappedParticipantMentions = participantMentions.slice(
-    0,
-    Math.min(5, SUGGESTION_DISPLAY_LIMIT)
-  );
-
-  const remainingLimit =
-    SUGGESTION_DISPLAY_LIMIT - cappedParticipantMentions.length;
-  if (remainingLimit <= 0) {
-    return cappedParticipantMentions;
-  }
-
-  // Remove participants from the remaining pools to avoid duplicates.
-  const remainingUsers = userSuggestions.filter(
-    (u) => !uniqueParticipantIds.has(`user:${u.id}`)
-  );
-  const remainingAgents = filteredAgents.filter(
-    (a) => !uniqueParticipantIds.has(`agent:${a.id}`)
-  );
-
-  // Compute a target 30% / 70% split over the remaining slots.
-  const totalAvailableRest = remainingAgents.length + remainingUsers.length;
-  const maxResultsRest = Math.min(remainingLimit, totalAvailableRest);
-
-  const targetUserCountRest = Math.min(
-    remainingUsers.length,
-    Math.round(0.3 * maxResultsRest)
-  );
-  const targetAgentCountRest = Math.min(
-    remainingAgents.length,
-    maxResultsRest - targetUserCountRest
-  );
-
-  const selectedUsersRest = remainingUsers.slice(0, targetUserCountRest);
-  const selectedAgentsRest = remainingAgents.slice(0, targetAgentCountRest);
+  const [firstUser, ...remainingUsers] = selectedUsers;
 
   const rest: RichMention[] = shuffle<RichMention>([
-    ...selectedUsersRest,
-    ...selectedAgentsRest,
+    ...remainingUsers,
+    ...selectedAgents,
   ]);
 
-  return [...cappedParticipantMentions, ...rest];
+  return [firstUser, ...rest];
 };

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -13,12 +13,14 @@ export function useMentionSuggestions({
   workspaceId,
   conversationId,
   query = "",
+  preferredAgentId,
   select,
   disabled = false,
 }: {
   workspaceId: string;
   conversationId: string | null;
   query?: string;
+  preferredAgentId?: string | null;
   select: {
     agents: boolean;
     users: boolean;
@@ -45,6 +47,9 @@ export function useMentionSuggestions({
   }
   if (select.users) {
     searchParams.append("select", "users");
+  }
+  if (preferredAgentId) {
+    searchParams.append("preferredAgentId", preferredAgentId);
   }
 
   const url =

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -145,7 +145,7 @@ async function handler(
   const suggestions = await suggestionsOfMentions(auth, {
     query,
     select,
-    conversation: conversationRes,
+    conversation: conversationRes.toJSON(),
   });
 
   return res.status(200).json({ suggestions });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -145,6 +145,7 @@ async function handler(
   const suggestions = await suggestionsOfMentions(auth, {
     query,
     select,
+    conversation: conversationRes,
   });
 
   return res.status(200).json({ suggestions });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -145,7 +145,6 @@ async function handler(
   const suggestions = await suggestionsOfMentions(auth, {
     query,
     select,
-    conversation: conversationRes.toJSON(),
   });
 
   return res.status(200).json({ suggestions });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -54,6 +54,7 @@ async function handler(
         },
       });
     }
+    conversation = conversationRes;
   }
 
   const { select: selectParam } = req.query;

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -40,21 +40,18 @@ async function handler(
 
   const conversationId = req.query.cId;
 
-  if (conversationId) {
-    const conversationRes = await ConversationResource.fetchById(
-      auth,
-      conversationId
-    );
-    if (!conversationRes) {
-      return apiError(req, res, {
-        status_code: 404,
-        api_error: {
-          type: "conversation_not_found",
-          message: "Conversation not found",
-        },
-      });
-    }
-    conversation = conversationRes;
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found",
+      },
+    });
   }
 
   const { select: selectParam } = req.query;
@@ -82,6 +79,7 @@ async function handler(
   const suggestions = await suggestionsOfMentions(auth, {
     query,
     select,
+    conversation,
   });
 
   return res.status(200).json({ suggestions });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -40,11 +40,11 @@ async function handler(
 
   const conversationId = req.query.cId;
 
-  const conversation = await ConversationResource.fetchById(
+  const conversationRes = await ConversationResource.fetchById(
     auth,
     conversationId
   );
-  if (!conversation) {
+  if (!conversationRes) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -79,7 +79,7 @@ async function handler(
   const suggestions = await suggestionsOfMentions(auth, {
     query,
     select,
-    conversation,
+    conversation: conversationRes.toJSON(),
   });
 
   return res.status(200).json({ suggestions });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -76,8 +76,14 @@ async function handler(
     return { agents, users };
   })();
 
+  const { preferredAgentId: preferredAgentIdParam } = req.query;
+  const preferredAgentId =
+    typeof preferredAgentIdParam === "string" ? preferredAgentIdParam : null;
+
   const suggestions = await suggestionsOfMentions(auth, {
     query,
+    conversationId,
+    preferredAgentId,
     select,
   });
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -79,7 +79,6 @@ async function handler(
   const suggestions = await suggestionsOfMentions(auth, {
     query,
     select,
-    conversation: conversationRes.toJSON(),
   });
 
   return res.status(200).json({ suggestions });


### PR DESCRIPTION
## Description

This PR improves the mention suggestion dropdown to better prioritize relevant users and agents in conversations. 

The main changes include: prioritizing conversation participants (both users and agents) at the top of the dropdown with a cap of 5 total participants, implementing a 30/70 split between users and agents in suggestion results to ensure user visibility, filtering out the current user from suggestions to prevent self-mentions, promoting the preferred agent (last used) to the first position, and adding visual improvements like a "User" chip to distinguish user mentions and auto-scrolling of selected items.

**References:**
- https://github.com/dust-tt/tasks/issues/5328

## Risk

The logic for mixing and prioritizing suggestions has been significantly refactored in both the frontend (`MentionDropdown.tsx`) and backend (`mention_suggestions.ts`). There's a risk of edge cases in the ordering logic, particularly when handling conversations with few or no participants.

## Tests

- [x] Locally
- [x] front-edge 

## Deploy Plan

Deploy front