### PR TITLE
[front] - refacto(SkillBuilder): align w/ AgentBuilder

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -9,24 +9,24 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
 import { useState } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 
+import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import { SkillBuilderDescriptionSection } from "@app/components/skill_builder/SkillBuilderDescriptionSection";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { skillBuilderFormSchema } from "@app/components/skill_builder/SkillBuilderFormContext";
+import {
+  SkillBuilderFormContext,
+  skillBuilderFormSchema,
+} from "@app/components/skill_builder/SkillBuilderFormContext";
 import { SkillBuilderInstructionsSection } from "@app/components/skill_builder/SkillBuilderInstructionsSection";
 import { SkillBuilderSettingsSection } from "@app/components/skill_builder/SkillBuilderSettingsSection";
 import { submitSkillBuilderForm } from "@app/components/skill_builder/submitSkillBuilderForm";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
+import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { UserType, WorkspaceType } from "@app/types";
 
-interface SkillBuilderProps {
-  owner: WorkspaceType;
-  user: UserType;
-}
-
-export default function SkillBuilder({ owner }: SkillBuilderProps) {
+export default function SkillBuilder() {
+  const { owner } = useSkillBuilderContext();
   const router = useRouter();
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
@@ -76,57 +76,59 @@ export default function SkillBuilder({ owner }: SkillBuilderProps) {
   };
 
   return (
-    <FormProvider {...form}>
-      <div
-        className={cn(
-          "h-dvh flex flex-row",
-          "bg-background text-foreground",
-          "dark:bg-background-night dark:text-foreground-night"
-        )}
-      >
-        <div className="flex h-full w-full flex-col">
-          <BarHeader
-            variant="default"
-            className="mx-4"
-            title="Create new skill"
-            rightActions={
-              <Button
-                icon={XMarkIcon}
-                onClick={handleCancel}
-                variant="ghost"
-                type="button"
-              />
-            }
-          />
-          <ScrollArea className="flex-1">
-            <div className="mx-auto space-y-10 p-4 2xl:max-w-5xl">
-              <SkillBuilderDescriptionSection />
-              <SkillBuilderInstructionsSection />
-              <SkillBuilderSettingsSection />
-            </div>
-          </ScrollArea>
-          <BarFooter
-            variant="default"
-            className="mx-4 justify-between"
-            leftActions={
-              <Button
-                variant="outline"
-                label="Cancel"
-                onClick={handleCancel}
-                type="button"
-              />
-            }
-            rightActions={
-              <Button
-                variant="highlight"
-                label={isSaving ? "Saving..." : "Save"}
-                onClick={handleSave}
-                disabled={isSaving}
-              />
-            }
-          />
+    <SkillBuilderFormContext.Provider value={form}>
+      <FormProvider form={form} asForm={false}>
+        <div
+          className={cn(
+            "h-dvh flex flex-row",
+            "bg-background text-foreground",
+            "dark:bg-background-night dark:text-foreground-night"
+          )}
+        >
+          <div className="flex h-full w-full flex-col">
+            <BarHeader
+              variant="default"
+              className="mx-4"
+              title="Create new skill"
+              rightActions={
+                <Button
+                  icon={XMarkIcon}
+                  onClick={handleCancel}
+                  variant="ghost"
+                  type="button"
+                />
+              }
+            />
+            <ScrollArea className="flex-1">
+              <div className="mx-auto space-y-10 p-4 2xl:max-w-5xl">
+                <SkillBuilderDescriptionSection />
+                <SkillBuilderInstructionsSection />
+                <SkillBuilderSettingsSection />
+              </div>
+            </ScrollArea>
+            <BarFooter
+              variant="default"
+              className="mx-4 justify-between"
+              leftActions={
+                <Button
+                  variant="outline"
+                  label="Cancel"
+                  onClick={handleCancel}
+                  type="button"
+                />
+              }
+              rightActions={
+                <Button
+                  variant="highlight"
+                  label={isSaving ? "Saving..." : "Save"}
+                  onClick={handleSave}
+                  disabled={isSaving}
+                />
+              }
+            />
+          </div>
         </div>
-      </div>
-    </FormProvider>
+      </FormProvider>
+    </SkillBuilderFormContext.Provider>
   );
 }

--- a/front/components/skill_builder/SkillBuilderContext.tsx
+++ b/front/components/skill_builder/SkillBuilderContext.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { createContext, useContext } from "react";
+
+import type { UserType, WorkspaceType } from "@app/types";
+
+type SkillBuilderContextType = {
+  owner: WorkspaceType;
+  user: UserType;
+};
+
+const SkillBuilderContext = createContext<SkillBuilderContextType | null>(null);
+
+interface SkillBuilderProviderProps {
+  owner: WorkspaceType;
+  user: UserType;
+  children: ReactNode;
+}
+
+export function SkillBuilderProvider({
+  owner,
+  user,
+  children,
+}: SkillBuilderProviderProps) {
+  return (
+    <SkillBuilderContext.Provider value={{ owner, user }}>
+      {children}
+    </SkillBuilderContext.Provider>
+  );
+}
+
+export function useSkillBuilderContext(): SkillBuilderContextType {
+  const context = useContext(SkillBuilderContext);
+
+  if (!context) {
+    throw new Error(
+      "useSkillBuilderContext must be used within a SkillBuilderProvider"
+    );
+  }
+
+  return context;
+}

--- a/front/components/skill_builder/SkillBuilderDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderDescriptionSection.tsx
@@ -2,26 +2,23 @@ import { TextArea } from "@dust-tt/sparkle";
 
 import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
 
-// TODO(skills): see if we can reuse DescriptionSection more or less directly.
-
 const DESCRIPTION_FIELD_NAME = "description";
 
 export function SkillBuilderDescriptionSection() {
   return (
     <BaseFormFieldSection
-      // TODO(skills): double check the copy.
       title="What will this skill be used for?"
       fieldName={DESCRIPTION_FIELD_NAME}
       triggerValidationOnChange={false}
     >
-      {({ registerRef, registerProps, onChange, errorMessage }) => (
+      {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
         <TextArea
           ref={registerRef}
           placeholder="When should this skill be used? What will this skill be good for?"
           className="min-h-24"
           onChange={onChange}
-          error={errorMessage}
-          showErrorLabel
+          error={hasError ? errorMessage : undefined}
+          showErrorLabel={hasError}
           {...registerProps}
         />
       )}

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -1,3 +1,5 @@
+import { createContext } from "react";
+import type { UseFormReturn } from "react-hook-form";
 import { z } from "zod";
 
 export const skillBuilderFormSchema = z.object({
@@ -10,3 +12,6 @@ export const skillBuilderFormSchema = z.object({
 });
 
 export type SkillBuilderFormData = z.infer<typeof skillBuilderFormSchema>;
+
+export const SkillBuilderFormContext =
+  createContext<UseFormReturn<SkillBuilderFormData> | null>(null);

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -11,14 +11,14 @@ export function SkillBuilderInstructionsSection() {
       triggerValidationOnChange={false}
       fieldName={INSTRUCTIONS_FIELD_NAME}
     >
-      {({ registerRef, registerProps, onChange, errorMessage }) => (
+      {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
         <TextArea
           ref={registerRef}
           placeholder="What does this skill do? How should it behave?"
           className="min-h-40"
           onChange={onChange}
-          error={errorMessage}
-          showErrorLabel
+          error={hasError ? errorMessage : undefined}
+          showErrorLabel={hasError}
           {...registerProps}
         />
       )}

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -4,28 +4,22 @@ import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities
 
 export function SkillBuilderSettingsSection() {
   return (
-    <section className="flex flex-col gap-4">
-      <div>
-        <h2 className="heading-lg text-foreground dark:text-foreground-night">
-          Skill settings
-        </h2>
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Specialized tools that agents can use to accomplish their tasks.
-        </p>
-      </div>
-      <BaseFormFieldSection<HTMLInputElement> fieldName="name">
-        {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
-          <Input
-            ref={registerRef}
-            label="Skill name"
-            placeholder="Enter skill name"
-            onChange={onChange}
-            message={errorMessage}
-            messageStatus={hasError ? "error" : "default"}
-            {...registerProps}
-          />
-        )}
-      </BaseFormFieldSection>
-    </section>
+    <BaseFormFieldSection
+      title="Skill settings"
+      fieldName="name"
+      description="Specialized tools that agents can use to accomplish their tasks."
+    >
+      {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
+        <Input
+          ref={registerRef}
+          label="Skill name"
+          placeholder="Enter skill name"
+          onChange={onChange}
+          message={errorMessage}
+          messageStatus={hasError ? "error" : "default"}
+          {...registerProps}
+        />
+      )}
+    </BaseFormFieldSection>
   );
 }

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -8,6 +8,7 @@ export function SkillBuilderSettingsSection() {
       title="Skill settings"
       fieldName="name"
       description="Specialized tools that agents can use to accomplish their tasks."
+      triggerValidationOnChange={false}
     >
       {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
         <Input

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import React from "react";
 
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
+import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -45,12 +46,14 @@ export default function CreateSkill({
   user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
-    <>
-      <Head>
-        <title>Dust - New Skill</title>
-      </Head>
-      <SkillBuilder owner={owner} user={user} />
-    </>
+    <SkillBuilderProvider owner={owner} user={user}>
+      <>
+        <Head>
+          <title>Dust - New Skill</title>
+        </Head>
+        <SkillBuilder />
+      </>
+    </SkillBuilderProvider>
   );
 }
 


### PR DESCRIPTION
## Description

Refactors the SkillBuilder component to align with the AgentBuilder architecture pattern by introducing a dedicated context provider and form context. The main change replaces direct prop passing with a `SkillBuilderProvider` that wraps the page and provides `owner` and `user` through context. The form instance is now exposed through a dedicated `SkillBuilderFormContext` (similar to `AgentBuilderFormContext`), and `FormProvider` is configured with `asForm={false}` to avoid nested form elements. Additionally, error display logic in form sections now conditionally shows errors only when they exist (`hasError` check), and `SkillBuilderSettingsSection` has been simplified to use `BaseFormFieldSection` directly instead of custom layout code.

## Risk

Low - this is a refactoring that aligns SkillBuilder with established AgentBuilder patterns without changing functionality.

## Tests

Locally
## Deploy Plan

Deploy front