### PR TITLE
[connectors] enh: Add attributes to fix changes pagination

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -33,7 +33,7 @@ import type { Logger } from "@connectors/logger/logger";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
-import { WithRetriesError } from "@connectors/types";
+import { FILE_ATTRIBUTES_TO_FETCH, WithRetriesError } from "@connectors/types";
 import { redisClient } from "@connectors/types/shared/redis_client";
 
 export async function incrementalSync(
@@ -85,7 +85,7 @@ export async function incrementalSync(
     let opts: drive_v3.Params$Resource$Changes$List = {
       pageToken: nextPageToken,
       pageSize: 1000,
-      fields: "*",
+      fields: `nextPageToken, newStartPageToken, changes(changeType, fileId, time, removed, file(${FILE_ATTRIBUTES_TO_FETCH.join(",")}))`,
       includeItemsFromAllDrives: true,
       supportsAllDrives: true,
       includeLabels: labels.map((l) => l.id).join(","),


### PR DESCRIPTION
## Description

When using fields: "*" with Google Drive API's changes.list, the API caps page size at 50, even if you request 1000.

Replaced fields: "*" with explicit fields:

- Added import for FILE_ATTRIBUTES_TO_FETCH.
- Updated the fields parameter to include:
  - nextPageToken and newStartPageToken (for pagination)
  - changes with changeType, fileId, time, removed, and all file fields from FILE_ATTRIBUTES_TO_FETCH

This matches the pattern used elsewhere (e.g., sync_files.ts) and allows page sizes up to 1000. Pagination via nextPageToken remains unchanged.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy connectors
