### PR TITLE
[PPUL] Add optional workspace ID argument to backfill_free_credits script

### DIFF
--- a/front/migrations/20251128_backfill_free_credits.ts
+++ b/front/migrations/20251128_backfill_free_credits.ts
@@ -3,6 +3,8 @@ import readline from "readline";
 import { Authenticator } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { CreditModel } from "@app/lib/resources/storage/models/credits";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
@@ -100,7 +102,8 @@ async function addCreditToWorkspace(
 async function addFreeCredits(
   execute: boolean,
   amountCents: number,
-  expirationDate: Date
+  expirationDate: Date,
+  wId?: string
 ) {
   logger.info(
     {
@@ -108,9 +111,36 @@ async function addFreeCredits(
       amountCents,
       expirationDate: expirationDate.toISOString(),
       concurrency: CONCURRENCY,
+      workspaceId: wId ?? "all",
     },
     "Adding free credits"
   );
+
+  if (wId) {
+    const workspace = await WorkspaceModel.findOne({ where: { sId: wId } });
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${wId}`);
+    }
+
+    if (execute) {
+      const confirmed = await confirmExecution(
+        `About to add free credits (${amountCents}¢) to workspace ${wId}. Continue?`
+      );
+      if (!confirmed) {
+        logger.info("Aborted.");
+        return;
+      }
+    }
+
+    const result = await addCreditToWorkspace(
+      renderLightWorkspaceType({ workspace }),
+      amountCents,
+      expirationDate,
+      execute
+    );
+    logger.info({ result }, "Done");
+    return;
+  }
 
   if (execute) {
     const confirmed = await confirmExecution(
@@ -147,7 +177,8 @@ async function addFreeCredits(
 
 async function removeFreeCredits(
   execute: boolean,
-  expirationDate: Date | "all"
+  expirationDate: Date | "all",
+  wId?: string
 ) {
   const isAll = expirationDate === "all";
 
@@ -155,13 +186,22 @@ async function removeFreeCredits(
     {
       execute,
       expirationDate: isAll ? "all" : expirationDate.toISOString(),
+      workspaceId: wId ?? "all",
     },
     "Removing free credits"
   );
 
-  const whereClause: { type: "free"; expirationDate?: Date } = { type: "free" };
+  const whereClause: { type: "free"; expirationDate?: Date; workspaceId?: number } = { type: "free" };
   if (!isAll) {
     whereClause.expirationDate = expirationDate;
+  }
+
+  if (wId) {
+    const workspace = await WorkspaceModel.findOne({ where: { sId: wId } });
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${wId}`);
+    }
+    whereClause.workspaceId = workspace.id;
   }
 
   const creditsToRemove = await CreditModel.findAll({
@@ -215,8 +255,14 @@ makeScript(
       type: "string",
       describe: `Expiration date YYYY-MM-DD for 'add' (default: ${DEFAULT_EXPIRATION_DAYS} days from now), or exact expiration date to match for 'remove' (use 'all' to remove all free credits)`,
     },
+    wId: {
+      type: "string",
+      demandOption: false,
+      describe:
+        "Workspace sId to process (optional, processes all if omitted)",
+    },
   },
-  async ({ execute, action, amountCents, endDate }) => {
+  async ({ execute, action, amountCents, endDate, wId }) => {
     // eslint-disable-next-line no-console
     console.log(DISCLAIMER);
 
@@ -229,7 +275,7 @@ makeScript(
         ? parseDate(endDate)
         : new Date(Date.now() + DEFAULT_EXPIRATION_DAYS * 24 * 60 * 60 * 1000);
 
-      await addFreeCredits(execute, amountCents, expirationDate);
+      await addFreeCredits(execute, amountCents, expirationDate, wId);
     } else if (action === "remove") {
       if (!endDate) {
         throw new Error(
@@ -238,7 +284,7 @@ makeScript(
       }
 
       const expirationDate = endDate === "all" ? "all" : parseDate(endDate);
-      await removeFreeCredits(execute, expirationDate);
+      await removeFreeCredits(execute, expirationDate, wId);
     } else {
       throw new Error(`Unknown action: ${action}. Use 'add' or 'remove'.`);
     }


### PR DESCRIPTION
## Description

Adds an optional `--wId` parameter to the backfill_free_credits migration script, allowing it to target a single workspace instead of processing all workspaces. This follows the same pattern as other scripts like `20251126_backfill_programmatic_usage_configurations.ts`.

Both `add` and `remove` actions now support the `--wId` parameter.

## Risks

Blast radius: backfill_free_credits script (PPUL testing tool)
Risk: none

## Deploy Plan
- pmrr
- No deployment needed (migration script only)