### PR TITLE
[front] - refactor: move BaseFormFieldSection to shared components

### DIFF
--- a/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
@@ -1,7 +1,7 @@
 import { TextArea } from "@dust-tt/sparkle";
 import { useFormContext } from "react-hook-form";
 
-import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
+import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 
 interface DescriptionSectionProps {
   title: string;

--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -1,7 +1,8 @@
-import { Input } from "@dust-tt/sparkle";
 import { forwardRef } from "react";
 
-import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
+import { Input } from "@dust-tt/sparkle";
+
+import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 
 interface NameSectionProps {
   title?: string;

--- a/front/components/shared/BaseFormFieldSection.tsx
+++ b/front/components/shared/BaseFormFieldSection.tsx
@@ -86,3 +86,4 @@ export function BaseFormFieldSection<
     </div>
   );
 }
+

--- a/front/components/skill_builder/SkillBuilderDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderDescriptionSection.tsx
@@ -1,6 +1,6 @@
 import { TextArea } from "@dust-tt/sparkle";
 
-import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
+import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 
 const DESCRIPTION_FIELD_NAME = "description";
 

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -1,6 +1,6 @@
 import { TextArea } from "@dust-tt/sparkle";
 
-import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
+import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -1,6 +1,6 @@
 import { Input } from "@dust-tt/sparkle";
 
-import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
+import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 
 export function SkillBuilderSettingsSection() {
   return (


### PR DESCRIPTION
## Description

This PR refactored the location of BaseFormFieldSection for better reusability across different builder components

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
