### PR TITLE
[DX] Add no-cycle eslint rule for IDE check

### DIFF
--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Format Check
         working-directory: front
         run: |
-          npm run format:check &
+          npm run format:check
       - name: Knip
         uses: ./.github/actions/knip
         with:

--- a/front/eslint.config.ts
+++ b/front/eslint.config.ts
@@ -130,6 +130,7 @@ export default defineConfig(
         },
       ],
       "simple-import-sort/exports": "error",
+      "import/no-cycle": ["error", { maxDepth: 1, ignoreExternal: true }],
 
       // TypeScript rules
       "@typescript-eslint/consistent-type-imports": "error",

--- a/front/migrations/20251128_backfill_free_credits.ts
+++ b/front/migrations/20251128_backfill_free_credits.ts
@@ -191,7 +191,11 @@ async function removeFreeCredits(
     "Removing free credits"
   );
 
-  const whereClause: { type: "free"; expirationDate?: Date; workspaceId?: number } = { type: "free" };
+  const whereClause: {
+    type: "free";
+    expirationDate?: Date;
+    workspaceId?: number;
+  } = { type: "free" };
   if (!isAll) {
     whereClause.expirationDate = expirationDate;
   }
@@ -258,8 +262,7 @@ makeScript(
     wId: {
       type: "string",
       demandOption: false,
-      describe:
-        "Workspace sId to process (optional, processes all if omitted)",
+      describe: "Workspace sId to process (optional, processes all if omitted)",
     },
   },
   async ({ execute, action, amountCents, endDate, wId }) => {

--- a/front/package.json
+++ b/front/package.json
@@ -13,7 +13,7 @@
     "dev:worker": "./admin/dev_worker.sh",
     "lint:circular": "biome lint",
     "lint:test-filenames": "BAD_FILES=$(find pages -type f -name '*.test.ts' | grep -E '/[^/]*(\\[|\\])[^/]*$'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: Found .test.ts files in 'pages' directory with brackets [] in their names (this can break endpoints):\"; echo \"$BAD_FILES\"; exit 1; else echo \"Filename check: OK. No .test.ts files with brackets found in 'pages'.\"; exit 0; fi",
-    "lint": "npm run lint:test-filenames && NODE_OPTIONS='--max-old-space-size=8192' eslint --cache --cache-location .cache/eslint --cache-strategy content .",
+    "lint": "npm run lint:test-filenames && NODE_OPTIONS='--max-old-space-size=8192' eslint --rule 'import/no-cycle: off' --cache --cache-location .cache/eslint --cache-strategy content .",
     "docs": "npx next-swagger-doc-cli swagger.json 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "docs:check": "npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "format": "prettier --write .",

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -51,7 +51,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   let isEnterprise = false;
   if (subscription.stripeSubscriptionId) {
     const stripeSubscription = await getStripeSubscription(
-      subscription.stripeSubscriptionId,
+      subscription.stripeSubscriptionId
     );
     if (stripeSubscription) {
       isEnterprise = isEnterpriseSubscription(stripeSubscription);
@@ -92,7 +92,7 @@ function ProgressBar({ consumed, total }: ProgressBarProps) {
           "h-full rounded-full transition-all",
           percentage > 80
             ? "bg-warning-700"
-            : "bg-primary dark:bg-primary-night",
+            : "bg-primary dark:bg-primary-night"
         )}
         style={{ width: `${percentage}%` }}
       />
@@ -173,7 +173,7 @@ function UsageSection({
 }: UsageSectionProps) {
   const billingCycle = useMemo(
     () => getBillingCycle(subscription.startDate),
-    [subscription.startDate],
+    [subscription.startDate]
   );
 
   const formatDateShort = (date: Date) => {
@@ -235,7 +235,7 @@ function UsageSection({
           <Page.P variant="secondary">
             {formatDateShort(billingCycle.cycleStart)} →{" "}
             {formatDateShort(
-              new Date(billingCycle.cycleEnd.getTime() - 24 * 60 * 60 * 1000),
+              new Date(billingCycle.cycleEnd.getTime() - 24 * 60 * 60 * 1000)
             )}
           </Page.P>
         )}
@@ -266,7 +266,7 @@ function UsageSection({
           consumed={creditsByType.committed.consumed}
           total={creditsByType.committed.total}
           renewalDate={formatExpirationDate(
-            creditsByType.committed.expirationDate,
+            creditsByType.committed.expirationDate
           )}
           action={
             !subscription.trialing && (


### PR DESCRIPTION
## Description

`import/no-cycle` eslint rule has been replaced by Biome for circular dependency check.
This PR re-adds it for IDE warnings (disabling it in command `npm run lint`)

## Tests

local

## Risk

no

## Deploy Plan

no
