### PR TITLE
[front] feat: Skip fair-use rate-limit for programmatic usage

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -61,7 +61,6 @@ import type {
   LightAgentConfigurationType,
   MentionType,
   ModelId,
-  PlanType,
   Result,
   UserMessageContext,
   UserMessageType,
@@ -414,7 +413,6 @@ export async function postUserMessage(
 
   // Check plan and rate limit.
   const messageLimit = await isMessagesLimitReached(auth, {
-    plan,
     mentions,
     context,
   });
@@ -1218,16 +1216,15 @@ export interface MessageLimit {
 async function isMessagesLimitReached(
   auth: Authenticator,
   {
-    plan,
     mentions,
     context,
   }: {
-    plan: PlanType;
     mentions: MentionType[];
     context: UserMessageContext;
   }
 ): Promise<MessageLimit> {
   const owner = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
   const featureFlags = await getFeatureFlags(owner);
 
   // We block programmatic usage at the api level and track


### PR DESCRIPTION
## Description

Update the fair-use rate limiting put in postUserMessage to ignore programmatic usage cases.
⚠️  It is based on origin, which is known to have some holes.

Fixes https://github.com/dust-tt/tasks/issues/5101

### Currently, we use rateLimit in the following places

#### Messaging & Conversations
✅ This PR updates it
- [front/lib/api/assistant/conversation.ts#L1249](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/lib/api/assistant/conversation.ts#L1249) - 10 msgs/min × active seats, plus plan-based agent mention limits

#### Triggers

✅  Programmatic usage is handled [here](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/lib/triggers/webhook.ts#L277-L277)
- [front/lib/triggers/rate_limits.ts#L30](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/lib/triggers/rate_limits.ts#L30) - Webhook triggers (50% of workspace limit) and per-trigger daily limits

#### File & Document Operations

❌ Irrelevant for programmatic usage credit consumption.
- [front/pages/api/w/[wId]/files/index.ts#L88](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/pages/api/w/%5BwId%5D/files/index.ts#L88) - 40 uploads/60s
- [front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts#L391](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/pages/api/v1/w/%5BwId%5D/spaces/%5BspaceId%5D/data_sources/%5BdsId%5D/documents/%5BdocumentId%5D/index.ts#L391) - 120 upserts/60s

#### App Execution

❌ Irrelevant for programmatic usage credit consumption.
- [front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts#L302](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/pages/api/v1/w/%5BwId%5D/spaces/%5BspaceId%5D/apps/%5BaId%5D/runs/index.ts#L302) - 10,000 runs/day per app

#### Access Requests (all 30/day)

❌ Irrelevant for programmatic usage credit consumption.
- [front/pages/api/w/[wId]/data_sources/request_access.ts#L96](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/pages/api/w/%5BwId%5D/data_sources/request_access.ts#L96) - Data source access
- [front/pages/api/w/[wId]/labs/request_access.ts#L72](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/pages/api/w/%5BwId%5D/labs/request_access.ts#L72) - Labs features
- [front/pages/api/w/[wId]/mcp/request_access.ts#L98](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/pages/api/w/%5BwId%5D/mcp/request_access.ts#L98) - MCP tools

#### Security

❌ Irrelevant for programmatic usage credit consumption.
- [front/pages/api/w/[wId]/keys/index.ts#L88](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/pages/api/w/%5BwId%5D/keys/index.ts#L88) - 30 API keys/day
- [front/pages/api/w/[wId]/dust_app_secrets/index.ts#L46](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/pages/api/w/%5BwId%5D/dust_app_secrets/index.ts#L46) - 60 requests/60s

#### External Services

❌ Irrelevant for programmatic usage credit consumption.
- [front/lib/utils/email_provider_detection.ts#L121](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/lib/utils/email_provider_detection.ts#L121) - 10 DNS lookups/60s
- [front/lib/actions/mcp_internal_actions/servers/image_generation.ts#L92](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/lib/actions/mcp_internal_actions/servers/image_generation.ts#L92) - Plan-based weekly limit
- [front/tracking/customerio/server.ts#L234](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/tracking/customerio/server.ts#L234) - 1 workspace identification/day
- [front/temporal/usage_queue/client.ts#L13](https://github.com/dust-tt/dust/blob/jd/remove-programmatic-from-fair/front/temporal/usage_queue/client.ts#L13) - 1 usage computation/hour
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Blast Radius: Wide - All conversations
Risk: Low, we are gating the update behind a feature flag, and updating one method that is used in one place. 

## Deploy Plan

- [ ] Deploy front