### PR TITLE
[Connectors] fix(slack-feedback): fix slack feedback submission using response_url

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot_interaction.ts
@@ -368,6 +368,7 @@ const _webhookSlackBotInteractionsAPIHandler = async (
               slackChannelId: payload.container.channel_id,
               slackMessageTs: payload.container.message_ts,
               slackThreadTs: payload.container.thread_ts,
+              responseUrl,
             });
           } catch (error) {
             logger.error(
@@ -402,6 +403,7 @@ async function handleViewSubmission(
       slackChannelId: string;
       slackMessageTs: string;
       slackThreadTs: string;
+      responseUrl: string;
     };
 
     // Extract feedback values from the modal
@@ -430,6 +432,7 @@ async function handleViewSubmission(
         slackChannelId: metadata.slackChannelId,
         slackMessageTs: metadata.slackMessageTs,
         slackThreadTs: metadata.slackThreadTs,
+        responseUrl: metadata.responseUrl,
       });
     }
   }

--- a/connectors/src/connectors/slack/feedback_api.ts
+++ b/connectors/src/connectors/slack/feedback_api.ts
@@ -1,51 +1,13 @@
-import type { Block, KnownBlock } from "@slack/web-api";
-
 import { makeFeedbackSubmittedBlock } from "@connectors/connectors/slack/chat/blocks";
 import {
   getSlackClient,
   getSlackUserInfoMemoized,
 } from "@connectors/connectors/slack/lib/slack_client";
-import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { apiConfig } from "@connectors/lib/api/config";
-import { throttleWithRedis } from "@connectors/lib/throttle";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import { getHeaderFromUserEmail } from "@connectors/types";
-
-// Helper to check if block is feedback question block
-function isFeedbackQuestionBlock(block: unknown): boolean {
-  if (typeof block !== "object" || block === null) {
-    return false;
-  }
-
-  const b = block as Record<string, unknown>;
-  if (b.type !== "context" || !Array.isArray(b.elements)) {
-    return false;
-  }
-
-  const elements = b.elements as unknown[];
-  if (elements.length === 0) {
-    return false;
-  }
-
-  const firstElement = elements[0];
-  if (typeof firstElement !== "object" || firstElement === null) {
-    return false;
-  }
-
-  const el = firstElement as Record<string, unknown>;
-  return el.type === "mrkdwn" && el.text === "Was this answer helpful?";
-}
-
-function isValidSlackBlock(block: unknown): block is Block | KnownBlock {
-  return (
-    typeof block === "object" &&
-    block !== null &&
-    "type" in block &&
-    typeof (block as Record<string, unknown>).type === "string"
-  );
-}
 
 export async function submitFeedbackToAPI({
   conversationId,
@@ -58,6 +20,7 @@ export async function submitFeedbackToAPI({
   slackChannelId,
   slackMessageTs,
   slackThreadTs,
+  responseUrl,
 }: {
   conversationId: string;
   messageId: string;
@@ -69,6 +32,7 @@ export async function submitFeedbackToAPI({
   slackChannelId: string;
   slackMessageTs: string;
   slackThreadTs: string;
+  responseUrl: string;
 }) {
   try {
     const slackConfig =
@@ -160,79 +124,18 @@ export async function submitFeedbackToAPI({
     );
 
     // Update the Slack message to show feedback has been submitted
+    // Using response_url works for both regular and ephemeral messages
     try {
-      const slackClient = await getSlackClient(connector.id);
-      const threadResult = await slackClient.conversations.replies({
-        channel: slackChannelId,
-        ts: slackThreadTs,
+      await fetch(responseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          replace_original: true,
+          blocks: makeFeedbackSubmittedBlock(),
+        }),
       });
-
-      if (threadResult.messages) {
-        const currentMessage = threadResult.messages.find(
-          (msg) => msg.ts === slackMessageTs
-        );
-
-        if (currentMessage) {
-          const currentBlocks = currentMessage.blocks || [];
-          const updatedBlocks: (Block | KnownBlock)[] = [];
-          let skipNextAction = false;
-
-          for (let i = 0; i < currentBlocks.length; i++) {
-            const block = currentBlocks[i];
-
-            if (!block) {
-              continue;
-            }
-
-            if (isFeedbackQuestionBlock(block)) {
-              const feedbackBlocks = makeFeedbackSubmittedBlock();
-              for (const feedbackBlock of feedbackBlocks) {
-                if (isValidSlackBlock(feedbackBlock)) {
-                  updatedBlocks.push(feedbackBlock);
-                }
-              }
-              skipNextAction = true;
-              continue;
-            }
-
-            const blockObj = block as Record<string, unknown>;
-            if (skipNextAction && blockObj.type === "actions") {
-              skipNextAction = false;
-              continue;
-            }
-
-            // Keep all other blocks (message content, footnotes, footer, etc.)
-            if (isValidSlackBlock(block)) {
-              updatedBlocks.push(block);
-            }
-          }
-
-          await throttleWithRedis(
-            RATE_LIMITS["chat.update"],
-            `${connector.id}-chat-update`,
-            { canBeIgnored: false },
-            async () =>
-              slackClient.chat.update({
-                channel: slackChannelId,
-                ts: slackMessageTs,
-                blocks: updatedBlocks,
-                text: currentMessage.text || "",
-              }),
-            { source: "submitFeedbackToAPI" }
-          );
-        } else {
-          logger.warn(
-            {
-              slackChannelId,
-              slackMessageTs,
-              slackThreadTs,
-              conversationId,
-              messageId,
-            },
-            "Could not find message to update after feedback submission"
-          );
-        }
-      }
     } catch (error) {
       logger.error(
         {

--- a/connectors/src/connectors/slack/feedback_modal.ts
+++ b/connectors/src/connectors/slack/feedback_modal.ts
@@ -15,6 +15,7 @@ export interface FeedbackModalMetadata {
   slackChannelId: string;
   slackMessageTs: string;
   slackThreadTs: string;
+  responseUrl: string;
 }
 
 export async function openFeedbackModal({
@@ -28,6 +29,7 @@ export async function openFeedbackModal({
   slackChannelId,
   slackMessageTs,
   slackThreadTs,
+  responseUrl,
 }: {
   slackClient: WebClient;
   triggerId: string;
@@ -39,6 +41,7 @@ export async function openFeedbackModal({
   slackChannelId: string;
   slackMessageTs: string;
   slackThreadTs: string;
+  responseUrl: string;
 }) {
   try {
     const metadata: FeedbackModalMetadata = {
@@ -50,6 +53,7 @@ export async function openFeedbackModal({
       slackChannelId,
       slackMessageTs,
       slackThreadTs,
+      responseUrl,
     };
 
     await slackClient.views.open({


### PR DESCRIPTION
## Context

Issue: [Feedback thumbs up/down buttons don't provide visual confirmation](https://github.com/dust-tt/tasks/issues/5224) 

Summary: When clicking on the 👍 or 👎 feedback buttons on Dust messages in Slack, the message didn't disappear and there was no visual confirmation (like "✅ Feedback submitted") that the feedback was registered. This created uncertainty for users about whether their feedback was successfully submitted.

## Description

Fixes Slack feedback submission by using `response_url` for updating messages after feedback is submitted, working for both normal and ephemeral messages.

**Retrocompatible with previously generated feedback blocks as `response_url` was already passed !**

**Changes:**
- Use Slack's response_url to update messages after feedback submission
- Works for both regular and ephemeral messages
- Remove complex message fetching and block filtering logic
- Clean up unused validation schemas and helper functions

## Tests

Local
When feedback is visible to all :

https://github.com/user-attachments/assets/518c03ed-e1e6-472f-8a39-8470d5fea4f4

When feedback is visible to author only :

https://github.com/user-attachments/assets/ad42a7af-289f-4da3-9134-36b25fc816bb

When feedback was generated *before* my changes (retrocompatibility test)

https://github.com/user-attachments/assets/97d1b551-741b-47b7-9f34-093b69810d24

## Risk

Low

## Deploy Plan

Connectors
