### PR TITLE
[extension] chore: Update handoff detection with agenticMessageData

### DIFF
--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -534,9 +534,9 @@ export function AgentMessage({
         .filter(
           (msg): msg is UserMessageType =>
             msg.type === "user_message" &&
-            msg.context.origin === "agent_handover"
+            msg.agenticMessageData?.type === "agent_handover"
         )
-        .map((msg) => msg.context.originMessageId)
+        .map((msg) => msg.agenticMessageData?.originMessageId)
     );
     const handingOver = handoverOrigins.has(message.sId);
 

--- a/extension/ui/components/conversation/ConversationViewer.tsx
+++ b/extension/ui/components/conversation/ConversationViewer.tsx
@@ -90,7 +90,7 @@ export function ConversationViewer({
     return messages.findLast(
       (message) =>
         message.type === "user_message" &&
-        message.context.origin !== "agent_handover" &&
+        message.agenticMessageData?.type !== "agent_handover" &&
         message.visibility !== "deleted" &&
         message.user?.sId === user.sId
     );

--- a/extension/ui/components/conversation/MessageGroup.tsx
+++ b/extension/ui/components/conversation/MessageGroup.tsx
@@ -57,7 +57,7 @@ export default function MessageGroup({
   const filteredMessages = messages.filter(
     (message) =>
       message.type !== "user_message" ||
-      message.context.origin !== "agent_handover"
+      message.agenticMessageData?.type !== "agent_handover"
   );
 
   return (


### PR DESCRIPTION
## Description

fixes: https://github.com/dust-tt/tasks/issues/5375

Use the agentMessageData instead of context.origin and parentMessageId to detct if a message is coming from handoff.
context.origin will return the root origin once new version of extension is broadly deployed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish extension
