### PR TITLE
Catch channel_not_found Slack error

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1316,6 +1316,8 @@ export async function autoReadChannelActivity(
       isWebAPIPlatformError(error) &&
       error.data.error === "channel_not_found"
     ) {
+      // If the channel is not found, we can't auto-read it.
+      // We gracefully exit the activity in this case, with a warning log.
       logger.warn(
         {
           connectorId,
@@ -1323,7 +1325,6 @@ export async function autoReadChannelActivity(
         },
         "Channel not found, skipping auto-read activity."
       );
-      // We gracefully exit the activity if the channel is not found.
       return false;
     }
     throw error;


### PR DESCRIPTION
## Description

 - The Slack auto-read workflows get stuck when the channel is not found.
 - This PR handles this specific error coming from the Slack api by catching it and gracefully terminating the workflow instead of retrying it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy connectors
