### PR TITLE
update sparkle package

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.20",
-        "@dust-tt/sparkle": "^0.4.12",
+        "@dust-tt/sparkle": "^0.4.14",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1286,9 +1286,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.12.tgz",
-      "integrity": "sha512-Tl1jJSrcIVNkIN6p/9HnwlZUPPY90iuK+LwHjQ5kNCsKcuCxmlDRJDppD/JwGUR1Xz+4JOBx/uDAikxTK2+2rQ==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.14.tgz",
+      "integrity": "sha512-eSVbCyiFaexnY/HI7OtE6cefhEwVrsa1EeAfLQdtcq/r7s3daLf68qW0bbtlhIu5xTT1Mx4kM26m+y+npnqJEA==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.20",
-    "@dust-tt/sparkle": "^0.4.12",
+    "@dust-tt/sparkle": "^0.4.14",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.12",
+        "@dust-tt/sparkle": "^0.4.14",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1330,9 +1330,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.12.tgz",
-      "integrity": "sha512-Tl1jJSrcIVNkIN6p/9HnwlZUPPY90iuK+LwHjQ5kNCsKcuCxmlDRJDppD/JwGUR1Xz+4JOBx/uDAikxTK2+2rQ==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.14.tgz",
+      "integrity": "sha512-eSVbCyiFaexnY/HI7OtE6cefhEwVrsa1EeAfLQdtcq/r7s3daLf68qW0bbtlhIu5xTT1Mx4kM26m+y+npnqJEA==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -38,7 +38,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.12",
+    "@dust-tt/sparkle": "^0.4.14",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description
Updates the `@dust-tt/sparkle` package from version 0.4.12 to 0.4.14 in both the front and extension packages to include latest component library improvements.

## Risk
Low. This is a minor version bump of the internal component library.

## Tests
Local build verification.

## Deploy Plan
Run Front