### PR TITLE
[front] chore(agent_router): remove server-level instructions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -309,9 +309,7 @@ export const INTERNAL_MCP_SERVERS = {
       icon: "ActionRobotIcon",
       authorization: null,
       documentationUrl: null,
-      instructions: `These tools provide discoverability to published agents available in the workspace.
-The tools return agents with their "mention" markdown directive.
-The directive should be used to display a clickable version of the agent name in the response.`,
+      instructions: null,
     },
   },
   include_data: {

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -29,7 +29,9 @@ function createServer(
 
   server.tool(
     LIST_ALL_AGENTS_TOOL_NAME,
-    "Returns a complete list of all published agents in the workspace.",
+    "Returns a complete list of all published agents in the workspace. " +
+      "Each agent includes its name, description, and mention directive " +
+      "(e.g., `:mention[agent-name]{sId=xyz}`) to display a clickable link to the agent.",
     {},
     withToolLogging(
       auth,
@@ -92,7 +94,9 @@ function createServer(
     SUGGEST_AGENTS_TOOL_NAME,
     "Analyzes a user query and returns relevant specialized agents that might be better " +
       "suited to handling specific requests. The tool uses semantic matching to find agents " +
-      "whose capabilities align with the query content.",
+      "whose capabilities align with the query content. Each suggested agent includes its " +
+      "mention directive (e.g., `:mention[agent-name]{sId=xyz}`) to display a clickable link, " +
+      "along with its description and instructions.",
     {
       userMessage: z.string().describe("The user's message."),
       conversationId: z.string().describe("The conversation id."),

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -70,7 +70,7 @@ function createServer(
         const agents = res.value;
         const formattedAgents = agents
           .map((agent) => {
-            let result = `\n\n## ${agent.name}\n`;
+            let result = `## ${agent.name}\n`;
             result += `\n**Mention:** ${serializeMention(agent)}`;
             result += `\n**Description:** ${agent.description}`;
             return result;
@@ -80,7 +80,7 @@ function createServer(
         return new Ok([
           {
             type: "text",
-            text: `# Published Agents${formattedAgents}`,
+            text: `# Published Agents\n\n${formattedAgents}`,
           },
         ]);
       }
@@ -155,7 +155,7 @@ function createServer(
                   " (truncated)"
                 : instructions;
 
-            let result = `\n\n## ${agent.name}\n`;
+            let result = `## ${agent.name}\n`;
             result += `\n**Mention:** ${serializeMention(agent)}`;
             result += `\n**Description:** ${agent.description}`;
             result += `\n**Instructions:** ${truncatedInstructions}`;
@@ -166,7 +166,7 @@ function createServer(
         return new Ok([
           {
             type: "text",
-            text: `# Suggested Agents${formattedSuggestedAgents}`,
+            text: `# Suggested Agents\n\n${formattedSuggestedAgents}`,
           },
         ]);
       }

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -68,22 +68,19 @@ function createServer(
         }
 
         const agents = res.value;
-        const formattedAgents = agents.map((agent) => {
-          return {
-            name: agent.name,
-            mention: serializeMention(agent),
-            description: agent.description,
-          };
-        });
+        const formattedAgents = agents
+          .map((agent) => {
+            let result = `\n\n## ${agent.name}\n`;
+            result += `\n**Mention:** ${serializeMention(agent)}`;
+            result += `\n**Description:** ${agent.description}`;
+            return result;
+          })
+          .join("\n\n");
 
         return new Ok([
           {
             type: "text",
-            text: "List of published agents successfully fetched",
-          },
-          {
-            type: "text",
-            text: JSON.stringify(formattedAgents),
+            text: `# Published Agents${formattedAgents}`,
           },
         ]);
       }
@@ -147,8 +144,7 @@ function createServer(
           );
         }
 
-        const suggestedAgents = suggestedAgentsRes.value;
-        const formattedSuggestedAgents = suggestedAgents
+        const formattedSuggestedAgents = suggestedAgentsRes.value
           .filter((agent) => agent.sId !== "dust")
           .map((agent) => {
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -159,21 +155,18 @@ function createServer(
                   " (truncated)"
                 : instructions;
 
-            return {
-              mention: serializeMention(agent),
-              description: agent.description,
-              instructions: truncatedInstructions,
-            };
-          });
+            let result = `\n\n## ${agent.name}\n`;
+            result += `\n**Mention:** ${serializeMention(agent)}`;
+            result += `\n**Description:** ${agent.description}`;
+            result += `\n**Instructions:** ${truncatedInstructions}`;
+            return result;
+          })
+          .join("\n\n");
 
         return new Ok([
           {
             type: "text",
-            text: "Suggested agents successfully fetched",
-          },
-          {
-            type: "text",
-            text: JSON.stringify(formattedSuggestedAgents),
+            text: `# Suggested Agents${formattedSuggestedAgents}`,
           },
         ]);
       }

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -70,12 +70,12 @@ function createServer(
         const agents = res.value;
         const formattedAgents = agents
           .map((agent) => {
-            let result = `## ${agent.name}\n`;
-            result += `\n**Mention:** ${serializeMention(agent)}`;
-            result += `\n**Description:** ${agent.description}`;
+            let result = `## ${agent.name}\n\n`;
+            result += `**Mention:** ${serializeMention(agent)}\n\n`;
+            result += `**Description:** ${agent.description}\n`;
             return result;
           })
-          .join("\n\n");
+          .join("\n");
 
         return new Ok([
           {
@@ -155,13 +155,13 @@ function createServer(
                   " (truncated)"
                 : instructions;
 
-            let result = `## ${agent.name}\n`;
-            result += `\n**Mention:** ${serializeMention(agent)}`;
-            result += `\n**Description:** ${agent.description}`;
-            result += `\n**Instructions:** ${truncatedInstructions}`;
+            let result = `## ${agent.name}\n\n`;
+            result += `**Mention:** ${serializeMention(agent)}\n\n`;
+            result += `**Description:** ${agent.description}\n\n`;
+            result += `**Instructions:** ${truncatedInstructions.trim()}\n`;
             return result;
           })
-          .join("\n\n");
+          .join("\n");
 
         return new Ok([
           {


### PR DESCRIPTION
## Description

- This PR removes instructions added on the `agent_router` toolset.
- Some information is moved to each tool, and the output format is more self-explanatory: instead of a stringified JSON we have a Markdown document.
- In the context of skills we'll remove most server-level instructions.

```Markdown
# Published Agents

## help

**Mention:** :mention[help]{sId=helper}

**Description:** Help on how to use Dust

## dust

**Mention:** :mention[dust]{sId=dust}

**Description:** An agent with context on your company data.

## deep-dive

**Mention:** :mention[deep-dive]{sId=deep-dive}

**Description:** Conducts comprehensive, in-depth analysis across all company data, databases, and web sources—thorough investigation that may take several minutes.

## gpt5

**Mention:** :mention[gpt5]{sId=gpt-5}

**Description:** OpenAI's GPT 5 model (400k context).

...
```

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
