### PR TITLE
Cleanup user context origin

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -75,10 +75,6 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
     label: "GitHub Copilot Chat",
     color: "text-blue-500 dark:text-blue-500-night",
   },
-  agent_handover: {
-    label: "Agent handover",
-    color: "text-gray-300 dark:text-gray-300-night",
-  },
   api: { label: "API", color: "text-blue-300 dark:text-blue-300-night" },
   cli: { label: "CLI", color: "text-gray-500 dark:text-gray-500-night" },
   cli_programmatic: {
@@ -110,10 +106,6 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
   raycast: {
     label: "Raycast",
     color: "rose-500 dark:rose-500-night",
-  },
-  run_agent: {
-    label: "Sub-agent",
-    color: "text-golden-500 dark:text-golden-500-night",
   },
   slack: { label: "Slack", color: "text-green-500 dark:text-green-500-night" },
   slack_workflow: {

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -146,17 +146,6 @@ export async function getOrCreateConversation(
 
   parentOrigin = parentMessage.context.origin ?? null;
 
-  if (parentOrigin === "run_agent" || parentOrigin === "agent_handover") {
-    logger.error(
-      {
-        parentMessage: parentMessage?.sId,
-        origin: parentOrigin,
-        originMessageId: originMessage.sId,
-      },
-      "Invalid parent origin."
-    );
-  }
-
   if (conversationId) {
     const agenticMessageType =
       mainConversation.sId !== conversationId ? "run_agent" : "agent_handover";

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -505,16 +505,6 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
 
       let parentAgentMessage: MessageModel | null = null;
 
-      // TODO(2025-11-24 PPUL): Remove this block once data has been backfilled
-      if (
-        userMessage.userContextOrigin === "agent_handover" &&
-        userMessage.userContextOriginMessageId
-      ) {
-        parentAgentMessage =
-          messagesBySId.get(userMessage.userContextOriginMessageId) ?? null;
-      }
-      // END TODO
-
       if (
         userMessage.agenticMessageType === "agent_handover" &&
         userMessage.agenticOriginMessageId

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -27,7 +27,6 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   UserMessageOrigin,
   "programmatic" | "user"
 > = {
-  agent_handover: "user",
   api: "programmatic",
   cli: "user",
   cli_programmatic: "programmatic",
@@ -40,7 +39,6 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   n8n: "programmatic",
   powerpoint: "programmatic",
   raycast: "user",
-  run_agent: "user",
   slack: "user",
   slack_workflow: "programmatic",
   teams: "user",

--- a/front/lib/api/viz/files.ts
+++ b/front/lib/api/viz/files.ts
@@ -58,10 +58,7 @@ async function isAncestorConversation(
     ],
   });
 
-  // TODO(2025-11-24 PPUL): Rely on agenticOriginMessageId only once data has been backfilled
-  const originMessageId =
-    firstUserMessage?.userMessage?.userContextOriginMessageId ??
-    firstUserMessage?.userMessage?.agenticOriginMessageId;
+  const originMessageId = firstUserMessage?.userMessage?.agenticOriginMessageId;
   if (!originMessageId) {
     return false;
   }

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -214,8 +214,6 @@ export class UserMessageModel extends WorkspaceAwareModel<UserMessageModel> {
   declare userContextEmail: string | null;
   declare userContextProfilePictureUrl: string | null;
   declare userContextOrigin: UserMessageOrigin;
-  // TODO(2025-11-24 PPUL): Remove this once data has been backfilled
-  declare userContextOriginMessageId: string | null;
 
   declare agenticMessageType: "run_agent" | "agent_handover" | null;
   declare agenticOriginMessageId: string | null;
@@ -277,11 +275,6 @@ UserMessageModel.init(
     userContextOrigin: {
       type: DataTypes.STRING,
       allowNull: false,
-    },
-    // TODO: Remove this once backfilled
-    userContextOriginMessageId: {
-      type: DataTypes.STRING(32),
-      allowNull: true,
     },
     userContextLastTriggerRunAt: {
       type: DataTypes.DATE,

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -37,7 +37,6 @@ export const shouldSendNotificationForAgentAnswer = (
 ): boolean => {
   switch (userMessageOrigin) {
     case "web":
-    case "agent_handover":
     case "extension":
       return true;
     case "onboarding_conversation":
@@ -54,7 +53,6 @@ export const shouldSendNotificationForAgentAnswer = (
     case "n8n":
     case "powerpoint":
     case "raycast":
-    case "run_agent":
     case "slack":
     case "slack_workflow":
     case "teams":

--- a/front/lib/plans/usage/mau.ts
+++ b/front/lib/plans/usage/mau.ts
@@ -23,7 +23,6 @@ async function countActiveUsersForPeriodInWorkspace({
   workspace: LightWorkspaceType;
 }): Promise<number> {
   // Use the replica database to compute this avoid impacting production performances.
-  // TODO(2025-11-24 PPUL): Remove constraints on userContextOrigin once backfilled.
   const result = await getFrontReplicaDbConnection().query(
     `
     SELECT "user_messages"."userId", COUNT(mentions.id) AS count
@@ -32,8 +31,6 @@ async function countActiveUsersForPeriodInWorkspace({
     INNER JOIN mentions ON mentions."messageId" = messages.id
     WHERE messages."workspaceId" = :workspaceId
     AND "user_messages"."userId" IS NOT NULL
-    AND "user_messages"."userContextOrigin" != 'run_agent'
-    AND "user_messages"."userContextOrigin" != 'agent_handover'
     AND "user_messages"."agenticMessageType" IS NULL
     AND "mentions"."createdAt" BETWEEN :startDate AND :endDate
     GROUP BY "user_messages"."userId"

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -9,8 +9,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { PatchConversationResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
+
 import type { WithAPIErrorResponse } from "@app/types";
-import { isUserMessageType } from "@app/types";
 
 /**
  * @swagger

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -132,16 +132,6 @@ async function handler(
 
   const conversation = conversationRes.value;
 
-  // TODO(2025-11-26 PPUL): Remove this once extension is fully migrated.
-  // This is returning run_agent/agent_handover as origins in the context, as expected by the old SDKs.
-  conversation.content.flat().forEach((content) => {
-    if (isUserMessageType(content) && content.agenticMessageData) {
-      content.context.origin = content.agenticMessageData.type;
-      content.context.originMessageId =
-        content.agenticMessageData.originMessageId;
-    }
-  });
-
   switch (req.method) {
     case "GET": {
       return res.status(200).json({

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -9,7 +9,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { PatchConversationResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
-
 import type { WithAPIErrorResponse } from "@app/types";
 
 /**

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -190,26 +190,11 @@ async function handler(
         });
       }
 
-      if (
-        context.origin === "agent_handover" ||
-        context.origin === "run_agent" ||
-        context.originMessageId
-      ) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "use agenticMessageData instead of origin.",
-          },
-        });
-      }
-
       const ctx: UserMessageContext = {
         clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
         email: context.email?.toLowerCase() ?? null,
         fullName: context.fullName ?? null,
         origin,
-        originMessageId: context.originMessageId ?? null,
         profilePictureUrl: context.profilePictureUrl ?? null,
         timezone: context.timezone,
         username: context.username,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -28,7 +28,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
   AgenticMessageData,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -230,21 +230,6 @@ async function handler(
             },
           });
         }
-
-        if (
-          message.context.origin === "agent_handover" ||
-          message.context.origin === "run_agent" ||
-          message.context.originMessageId
-        ) {
-          logger.error(
-            {
-              panic: true,
-              origin: message.context.origin,
-              originMessageId: message.context.originMessageId,
-            },
-            "use agenticMessageData instead of origin."
-          );
-        }
       }
 
       if (depth && depth >= MAX_CONVERSATION_DEPTH) {

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -132,6 +132,19 @@
  *             - github-copilot-chat
  *             - extension
  *             - email
+ *         agenticMessageData:
+ *           type: object
+ *           properties:
+ *             type:
+ *               type: string
+ *               enum:
+ *                 - run_agent
+ *                 - agent_handover
+ *               description: Type of the agentic message
+ *             originMessageId:
+ *               type: string
+ *               description: ID of the origin message
+ *               example: "2b8e4f6a0c"
  *     AgentConfiguration:
  *       type: object
  *       properties:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -4982,6 +4982,24 @@
               "extension",
               "email"
             ]
+          },
+          "agenticMessageData": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "run_agent",
+                  "agent_handover"
+                ],
+                "description": "Type of the agentic message"
+              },
+              "originMessageId": {
+                "type": "string",
+                "description": "ID of the origin message",
+                "example": "2b8e4f6a0c"
+              }
+            }
           }
         }
       },

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -71,8 +71,6 @@ export type LightMessageType =
  *
  */
 export type UserMessageOrigin =
-  // TODO(2025-11-24 PPUL): Remove run_agent and agent_handover from allowed origin values.
-  | "agent_handover" // soon to be removed (not a fitting origin).
   // "api" is Custom API usage, while e.g. extension, gsheets and many other origins
   // below are API usages dedicated to standard product features.
   | "api"
@@ -87,7 +85,6 @@ export type UserMessageOrigin =
   | "n8n"
   | "powerpoint"
   | "raycast"
-  | "run_agent" // soon to be removed (not a fitting origin).
   | "slack"
   | "slack_workflow"
   | "teams"
@@ -106,7 +103,6 @@ export type UserMessageContext = {
   email: string | null;
   profilePictureUrl: string | null;
   origin: UserMessageOrigin;
-  originMessageId?: string | null;
   lastTriggerRunAt?: number | null;
   clientSideMCPServerIds?: string[];
   selectedMCPServerViewIds?: string[];

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.22",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.1.22",
+      "version": "1.2.0",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.22",
+  "version": "1.2.0",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -298,7 +298,6 @@ export function isSupportedAudioContentType(
 }
 
 const UserMessageOriginSchema = FlexibleEnumSchema<
-  | "agent_handover"
   | "api"
   | "cli"
   | "cli_programmatic"
@@ -311,7 +310,6 @@ const UserMessageOriginSchema = FlexibleEnumSchema<
   | "n8n"
   | "powerpoint"
   | "raycast"
-  | "run_agent"
   | "slack"
   | "slack_workflow"
   | "teams"
@@ -979,7 +977,6 @@ const UserMessageContextSchema = z.object({
   email: z.string().optional().nullable(),
   profilePictureUrl: z.string().optional().nullable(),
   origin: UserMessageOriginSchema,
-  originMessageId: z.string().optional().nullable(),
   clientSideMCPServerIds: z.array(z.string()).optional().nullable(),
   selectedMCPServerViewIds: z.array(z.string()).optional().nullable(),
   lastTriggerRunAt: z.number().optional().nullable(),


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/5466

## Description

followup https://github.com/dust-tt/tasks/issues/5375

Cleanup user context origin - remove run_agent and agent_handover from possible values.
Remove userContextOriginMessageId which is now replaced by agenticOriginMessageId .

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Break sdk users who would rely on origin/originMessageId . 
@Fraggle are we ok with raycast extension ?

## Deploy Plan

This is to be deployed once all extensions have been migrated, and we're sure usages of old sdk are ok. Users should not expect to get an originMessageId in user context , or agent_handover/run_agent values in user origin. 
then -> deploy front
