### PR TITLE
[Free Credits] Fix eligibility check for subscribers with committed credits

### DIFF
--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -101,7 +101,7 @@ describe("checkCustomerStatus", () => {
       expect(getSubscriptionInvoices).toHaveBeenCalledWith({
         subscriptionId: "sub_123",
         status: "paid",
-        createdSince: expect.any(Date),
+        createdSinceDate: expect.any(Date),
       });
     });
 

--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -98,7 +98,8 @@ describe("checkCustomerStatus", () => {
         makeSubscription(NOW, NOW - MONTH_SECONDS * 6)
       );
       expect(result).toBe("paying");
-      expect(getSubscriptionInvoices).toHaveBeenCalledWith("sub_123", {
+      expect(getSubscriptionInvoices).toHaveBeenCalledWith({
+        subscriptionId: "sub_123",
         status: "paid",
         createdSince: expect.any(Date),
       });

--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -7,7 +7,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import {
   calculateFreeCreditAmountMicroUsd,
   countEligibleUsersForFreeCredits,
-  getCustomerStatus,
+  getCustomerPaymentStatus,
   grantFreeCreditsFromSubscriptionStateChange,
 } from "@app/lib/credits/free";
 import {
@@ -94,13 +94,13 @@ describe("checkCustomerStatus", () => {
       vi.mocked(getSubscriptionInvoices).mockResolvedValue([
         makeInvoice(NOW - MONTH_SECONDS * 0.5),
       ]);
-      const result = await getCustomerStatus(
+      const result = await getCustomerPaymentStatus(
         makeSubscription(NOW, NOW - MONTH_SECONDS * 6)
       );
       expect(result).toBe("paying");
       expect(getSubscriptionInvoices).toHaveBeenCalledWith("sub_123", {
         status: "paid",
-        limit: 1,
+        createdSince: expect.any(Date),
       });
     });
 
@@ -108,7 +108,7 @@ describe("checkCustomerStatus", () => {
       vi.mocked(getSubscriptionInvoices).mockResolvedValue([
         makeInvoice(NOW - MONTH_SECONDS * 2),
       ]);
-      const result = await getCustomerStatus(
+      const result = await getCustomerPaymentStatus(
         makeSubscription(NOW, NOW - MONTH_SECONDS * 6)
       );
       expect(result).toBe("paying");
@@ -118,7 +118,7 @@ describe("checkCustomerStatus", () => {
       vi.mocked(getSubscriptionInvoices).mockResolvedValue([
         makeInvoice(NOW - MONTH_SECONDS * 0.5),
       ]);
-      const result = await getCustomerStatus(
+      const result = await getCustomerPaymentStatus(
         makeSubscription(NOW, NOW, "trialing")
       );
       expect(result).toBe("paying");
@@ -128,7 +128,7 @@ describe("checkCustomerStatus", () => {
       vi.mocked(getSubscriptionInvoices).mockResolvedValue([
         makeInvoice(NOW - MONTH_SECONDS * 0.5),
       ]);
-      const result = await getCustomerStatus(makeSubscription(NOW, NOW));
+      const result = await getCustomerPaymentStatus(makeSubscription(NOW, NOW));
       expect(result).toBe("paying");
     });
   });
@@ -136,13 +136,13 @@ describe("checkCustomerStatus", () => {
   describe("trialing customers (no paid invoice but trialing or new)", () => {
     it("returns 'trialing' for new subscription without paid invoices", async () => {
       vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
-      const result = await getCustomerStatus(makeSubscription(NOW, NOW));
+      const result = await getCustomerPaymentStatus(makeSubscription(NOW, NOW));
       expect(result).toBe("trialing");
     });
 
     it("returns 'trialing' for subscription started just under 1 month ago", async () => {
       vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
-      const result = await getCustomerStatus(
+      const result = await getCustomerPaymentStatus(
         makeSubscription(NOW, NOW - MONTH_SECONDS + 1)
       );
       expect(result).toBe("trialing");
@@ -150,7 +150,7 @@ describe("checkCustomerStatus", () => {
 
     it("returns 'trialing' for trialing subscription without paid invoices", async () => {
       vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
-      const result = await getCustomerStatus(
+      const result = await getCustomerPaymentStatus(
         makeSubscription(NOW, NOW - MONTH_SECONDS * 2, "trialing")
       );
       expect(result).toBe("trialing");
@@ -158,22 +158,32 @@ describe("checkCustomerStatus", () => {
   });
 
   describe("not eligible (no recent payment and not trialing/new)", () => {
-    it("returns null with old payment (more than 2 billing cycles ago)", async () => {
-      vi.mocked(getSubscriptionInvoices).mockResolvedValue([
-        makeInvoice(NOW - MONTH_SECONDS * 2.5),
-      ]);
-      const result = await getCustomerStatus(
+    it("returns 'not_paying' when no recent invoice (Stripe filters old ones)", async () => {
+      // Stripe's createdSince filter would exclude old invoices, so mock returns empty
+      vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+      const result = await getCustomerPaymentStatus(
         makeSubscription(NOW, NOW - MONTH_SECONDS * 6)
       );
-      expect(result).toBe(null);
+      expect(result).toBe("not_paying");
     });
 
-    it("returns null for old subscription with no paid invoices", async () => {
+    it("returns 'not_paying' for old subscription with no paid invoices", async () => {
       vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
-      const result = await getCustomerStatus(
+      const result = await getCustomerPaymentStatus(
         makeSubscription(NOW, NOW - MONTH_SECONDS * 2)
       );
-      expect(result).toBe(null);
+      expect(result).toBe("not_paying");
+    });
+  });
+
+  describe("enterprise subscriptions", () => {
+    it("returns 'paying' for enterprise subscriptions without checking invoices", async () => {
+      vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+      const result = await getCustomerPaymentStatus(
+        makeSubscription(NOW, NOW - MONTH_SECONDS * 6)
+      );
+      expect(result).toBe("paying");
+      expect(getSubscriptionInvoices).not.toHaveBeenCalled();
     });
   });
 });

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -112,7 +112,9 @@ export async function getCustomerPaymentStatus(
   const paidInvoices = await getSubscriptionInvoices({
     subscriptionId: stripeSubscription.id,
     status: "paid",
-    createdSince: new Date(Date.now() - MONTHLY_BILLING_CYCLE_SECONDS * 2 * 1000),
+    createdSince: new Date(
+      Date.now() - MONTHLY_BILLING_CYCLE_SECONDS * 2 * 1000
+    ),
   });
 
   if (paidInvoices && paidInvoices.length > 0) {

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -109,7 +109,8 @@ export async function getCustomerPaymentStatus(
     return "paying";
   }
 
-  const paidInvoices = await getSubscriptionInvoices(stripeSubscription.id, {
+  const paidInvoices = await getSubscriptionInvoices({
+    subscriptionId: stripeSubscription.id,
     status: "paid",
     createdSince: new Date(Date.now() - MONTHLY_BILLING_CYCLE_SECONDS * 2 * 1000),
   });

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -112,7 +112,7 @@ export async function getCustomerPaymentStatus(
   const paidInvoices = await getSubscriptionInvoices({
     subscriptionId: stripeSubscription.id,
     status: "paid",
-    createdSince: new Date(
+    createdSinceDate: new Date(
       Date.now() - MONTHLY_BILLING_CYCLE_SECONDS * 2 * 1000
     ),
   });
@@ -176,7 +176,11 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
   const programmaticConfig =
     await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-  if (programmaticConfig && programmaticConfig.freeCreditMicroUsd !== null) {
+  if (
+    programmaticConfig &&
+    programmaticConfig.freeCreditMicroUsd !== null &&
+    customerPaymentStatus === "paying"
+  ) {
     creditAmountMicroUsd = programmaticConfig.freeCreditMicroUsd;
     logger.info(
       {

--- a/front/lib/plans/stripe.test.ts
+++ b/front/lib/plans/stripe.test.ts
@@ -301,7 +301,7 @@ describe("getSubscriptionInvoices", () => {
     const result = await getSubscriptionInvoices({
       subscriptionId: "sub_123",
       status: "paid",
-      createdSince,
+      createdSinceDate: createdSince,
     });
 
     expect(mockInvoices.list).toHaveBeenCalledWith({
@@ -321,7 +321,7 @@ describe("getSubscriptionInvoices", () => {
     const createdSince = new Date("2024-01-01T00:00:00Z");
     await getSubscriptionInvoices({
       subscriptionId: "sub_123",
-      createdSince,
+      createdSinceDate: createdSince,
     });
 
     expect(mockInvoices.list).toHaveBeenCalledWith({

--- a/front/lib/plans/stripe.test.ts
+++ b/front/lib/plans/stripe.test.ts
@@ -297,16 +297,17 @@ describe("getSubscriptionInvoices", () => {
       ],
     });
 
-    const result = await getSubscriptionInvoices("sub_123", {
+    const createdSince = new Date("2024-01-01T00:00:00Z");
+    const result = await getSubscriptionInvoices({
+      subscriptionId: "sub_123",
       status: "paid",
-      limit: 10,
+      createdSince,
     });
 
     expect(mockInvoices.list).toHaveBeenCalledWith({
       subscription: "sub_123",
       status: "paid",
-      created: undefined,
-      limit: 10,
+      created: { gte: Math.floor(createdSince.getTime() / 1000) },
     });
     expect(result).toHaveLength(2);
     expect(result.map((i) => i.id)).toEqual(["in_1", "in_2"]);
@@ -318,13 +319,15 @@ describe("getSubscriptionInvoices", () => {
     });
 
     const createdSince = new Date("2024-01-01T00:00:00Z");
-    await getSubscriptionInvoices("sub_123", { createdSince });
+    await getSubscriptionInvoices({
+      subscriptionId: "sub_123",
+      createdSince,
+    });
 
     expect(mockInvoices.list).toHaveBeenCalledWith({
       subscription: "sub_123",
       status: undefined,
       created: { gte: Math.floor(createdSince.getTime() / 1000) },
-      limit: 100,
     });
   });
 });

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -287,22 +287,20 @@ export const getStripeSubscription = async (
   }
 };
 
-export async function getSubscriptionInvoices(
-  subscriptionId: string,
-  options?: {
-    status?: Stripe.InvoiceListParams["status"];
-    createdSince?: Date;
-    limit?: number;
-  }
-): Promise<Stripe.Invoice[]> {
+export async function getSubscriptionInvoices({
+  subscriptionId,
+  status,
+  createdSince,
+}: {
+  subscriptionId: string;
+  status?: Stripe.InvoiceListParams["status"];
+  createdSince: Date;
+}): Promise<Stripe.Invoice[]> {
   const stripe = getStripeClient();
   const invoices = await stripe.invoices.list({
     subscription: subscriptionId,
-    status: options?.status,
-    created: options?.createdSince
-      ? { gte: Math.floor(options.createdSince.getTime() / 1000) }
-      : undefined,
-    limit: options?.limit ?? 100,
+    status,
+    created: { gte: Math.floor(createdSince.getTime() / 1000) },
   });
   return invoices.data.filter(
     (inv) =>

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -290,17 +290,17 @@ export const getStripeSubscription = async (
 export async function getSubscriptionInvoices({
   subscriptionId,
   status,
-  createdSince,
+  createdSinceDate,
 }: {
   subscriptionId: string;
   status?: Stripe.InvoiceListParams["status"];
-  createdSince: Date;
+  createdSinceDate: Date;
 }): Promise<Stripe.Invoice[]> {
   const stripe = getStripeClient();
   const invoices = await stripe.invoices.list({
     subscription: subscriptionId,
     status,
-    created: { gte: Math.floor(createdSince.getTime() / 1000) },
+    created: { gte: Math.floor(createdSinceDate.getTime() / 1000) },
   });
   return invoices.data.filter(
     (inv) =>

--- a/front/scripts/inspect_stripe_state.ts
+++ b/front/scripts/inspect_stripe_state.ts
@@ -70,7 +70,7 @@ async function inspectFromEvent(eventId: string, logger: any) {
   const paidInvoices = await getSubscriptionInvoices({
     subscriptionId: stripeSubscription.id,
     status: "paid",
-    createdSince: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000), // 1 year
+    createdSinceDate: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000), // 1 year
   });
   if (paidInvoices && paidInvoices.length > 0) {
     const mostRecentInvoice = paidInvoices[0];

--- a/front/scripts/inspect_stripe_state.ts
+++ b/front/scripts/inspect_stripe_state.ts
@@ -67,9 +67,10 @@ async function inspectFromEvent(eventId: string, logger: any) {
     `Customer status: ${await getCustomerPaymentStatus(stripeSubscription)}`
   );
 
-  const paidInvoices = await getSubscriptionInvoices(stripeSubscription.id, {
+  const paidInvoices = await getSubscriptionInvoices({
+    subscriptionId: stripeSubscription.id,
     status: "paid",
-    limit: 1,
+    createdSince: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000), // 1 year
   });
   if (paidInvoices && paidInvoices.length > 0) {
     const mostRecentInvoice = paidInvoices[0];

--- a/front/scripts/inspect_stripe_state.ts
+++ b/front/scripts/inspect_stripe_state.ts
@@ -1,4 +1,4 @@
-import { getCustomerStatus } from "@app/lib/credits/free";
+import { getCustomerPaymentStatus } from "@app/lib/credits/free";
 import {
   getStripeClient,
   getStripeSubscription,
@@ -64,7 +64,7 @@ async function inspectFromEvent(eventId: string, logger: any) {
   logger.info(`Workspace sId: ${workspace.sId}, name: ${workspace.name}`);
   logger.info(`Dust Subscription status: ${dustSubscription.status}`);
   logger.info(
-    `Customer status: ${await getCustomerStatus(stripeSubscription)}`
+    `Customer status: ${await getCustomerPaymentStatus(stripeSubscription)}`
   );
 
   const paidInvoices = await getSubscriptionInvoices(stripeSubscription.id, {


### PR DESCRIPTION
## Description
Fixes an issue where a paying subscriber could be incorrectly marked as ineligible for free credits if their most recent Stripe invoice was for committed credits (which have no period_end).

Changes:
- Refactor getCustomerStatus to getCustomerPaymentStatus for clarity
- Refactor getSubscriptionInvoices to require createdSince parameter (prevents misuse with limit that could interfere with date filtering)
- Handle enterprise subscriptions inside getCustomerPaymentStatus for better encapsulation
- Return not_paying instead of null for clearer semantics

## Risks
Blast radius: Free credits eligibility determination, Stripe invoice fetching
Risk: low (logic change is straightforward, tests updated)

## Deploy Plan
- deploy front