### PR TITLE
Don't clear ParentsLastUpdatedAt in update orphaned workflow

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows/admins.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/admins.ts
@@ -272,8 +272,6 @@ export async function updateOrphanedResourcesParentsWorkflow({
 
     cursor = nextCursor;
   } while (cursor);
-
-  await clearParentsLastUpdatedAt({ connectorId });
 }
 
 async function upsertParent({

--- a/connectors/src/connectors/notion/temporal/workflows/admins.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/admins.ts
@@ -38,7 +38,6 @@ const {
   updateSingleDocumentParents,
   getParentPageOrDb,
   maybeUpdateOrphaneResourcesParents,
-  clearParentsLastUpdatedAt,
   getAllOrphanedResources,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minute",

--- a/connectors/src/connectors/notion/temporal/workflows/garbage_collection.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/garbage_collection.ts
@@ -1,6 +1,6 @@
 import {
   continueAsNew,
-  patched,
+  deprecatePatch,
   proxyActivities,
   sleep,
   workflowInfo,
@@ -10,7 +10,6 @@ import PQueue from "p-queue";
 import type * as activities from "@connectors/connectors/notion/temporal/activities";
 import {
   INTERVAL_BETWEEN_GC_SYNCS_MS,
-  INTERVAL_BETWEEN_SYNCS_MS,
   MAX_CONCURRENT_CHILD_WORKFLOWS,
   MAX_PENDING_GARBAGE_COLLECTION_ACTIVITIES,
   MAX_SEARCH_PAGE_GARBAGE_COLLECTION_INDEX,
@@ -243,15 +242,9 @@ export async function notionGarbageCollectionWorkflow({
   // Once done, clear all the redis keys used for garbage collection
   await completeGarbageCollectionRun(connectorId, nbOfBatches);
 
-  if (patched("one-hour-gc-interval")) {
-    if (patched("12-hour-gc-interval")) {
-      await sleep(INTERVAL_BETWEEN_GC_SYNCS_MS);
-    } else {
-      await sleep(1000 * 60 * 60); // 1 hour, which was the previous value of INTERVAL_BETWEEN_GC_SYNCS_MS
-    }
-  } else {
-    await sleep(INTERVAL_BETWEEN_SYNCS_MS);
-  }
+  deprecatePatch("one-hour-gc-interval");
+  deprecatePatch("12-hour-gc-interval");
+  await sleep(INTERVAL_BETWEEN_GC_SYNCS_MS);
 
   await continueAsNew<typeof notionGarbageCollectionWorkflow>({
     connectorId,


### PR DESCRIPTION
## Description

The call to clearParentsLastUpdatedAt() at the end of updateOrphanedResourcesParentsWorkflow is I believe unnecessary, because the nodes that we update already get an updated lastCreatedOrMovedRunTs, meaning they'll get processed in notionUpdateAllParentsFieldsWorkflow in the next incremental sync.

And setting clearParentsLastUpdatedAt() makes the plugin massively more expensive, because it causes all nodes to be reprocessed. Besides we have another plugin to call it if needed (unstuck syncing nodes).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Minimal, plugin only.

## Deploy Plan

Connectors