### PR TITLE
chore(webhook-router): interpolate bucket name from project id env

### DIFF
--- a/firebase-functions/webhook-router/deploy.sh
+++ b/firebase-functions/webhook-router/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Check required environment variables.
-if [[ -z "$GCP_US_PROJECT_ID" || -z "$GCP_EU_PROJECT_ID" || -z "$GCP_GLOBAL_PROJECT_ID" || -z "$GCP_WEBHOOK_ROUTER_CONFIG_BUCKET" ]]; then
+if [[ -z "$GCP_US_PROJECT_ID" || -z "$GCP_EU_PROJECT_ID" || -z "$GCP_GLOBAL_PROJECT_ID" ]]; then
   echo "❌ Error: Missing required environment variables"
   echo "   Please set: GCP_US_PROJECT_ID, GCP_EU_PROJECT_ID, and GCP_GLOBAL_PROJECT_ID"
   exit 1
@@ -20,7 +20,7 @@ GCP_GLOBAL_PROJECT_ID=$GCP_GLOBAL_PROJECT_ID
 GCP_US_PROJECT_ID=$GCP_US_PROJECT_ID
 GCP_EU_PROJECT_ID=$GCP_EU_PROJECT_ID
 SERVICE_ACCOUNT=webhook-router-sa@$GCP_GLOBAL_PROJECT_ID.iam.gserviceaccount.com
-GCP_WEBHOOK_ROUTER_CONFIG_BUCKET=$GCP_WEBHOOK_ROUTER_CONFIG_BUCKET
+GCP_WEBHOOK_ROUTER_CONFIG_BUCKET=bkt-$GCP_GLOBAL_PROJECT_ID-webhook-router-config
 EOF
 
 echo "🏗️ Building TypeScript..."


### PR DESCRIPTION
## Description

With current setup `deploy.sh` script is using env to retrieve the bucket name directly.
This can cause issue if the set env is development bucket name (local storage emulator name)

Change : interpolate the bucket name in the script directly using global project id

## Tests

Local. Env is correctly set

## Risk

None

## Deploy Plan

None