### PR TITLE
[front] feat: Improve buy credits modal

### DIFF
--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -18,12 +18,9 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
-import type { StripePricingData } from "@app/lib/types/stripe/pricing";
 import { usePurchaseCredits } from "@app/lib/swr/credits";
-import {
-  CURRENCY_SYMBOLS,
-  isSupportedCurrency,
-} from "@app/types/currency";
+import type { StripePricingData } from "@app/lib/types/stripe/pricing";
+import { CURRENCY_SYMBOLS, isSupportedCurrency } from "@app/types/currency";
 
 type PurchaseState = "idle" | "processing" | "success" | "redirect" | "error";
 

--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -1,4 +1,7 @@
 import {
+  Button,
+  Checkbox,
+  CheckCircleIcon,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -6,17 +9,37 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  ExternalLinkIcon,
+  Hoverable,
+  Icon,
   Input,
+  Spinner,
+  XCircleIcon,
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 import { usePurchaseCredits } from "@app/lib/swr/credits";
+
+// Conversion rates for displaying estimated amounts (credits are always in USD)
+const CURRENCY_CONVERSION_RATES: Record<string, number> = {
+  usd: 1,
+  eur: 0.86,
+};
+
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  usd: "$",
+  eur: "€",
+};
+
+type PurchaseState = "idle" | "processing" | "success" | "redirect" | "error";
 
 interface BuyCreditDialogProps {
   isOpen: boolean;
   onClose: () => void;
   workspaceId: string;
   isEnterprise: boolean;
+  currency: string;
+  discountPercent: number;
 }
 
 export function BuyCreditDialog({
@@ -24,22 +47,341 @@ export function BuyCreditDialog({
   onClose,
   workspaceId,
   isEnterprise,
+  currency,
+  discountPercent,
 }: BuyCreditDialogProps) {
   const [amountDollars, setAmountDollars] = useState<string>("");
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
+  const [acceptedNonRefundable, setAcceptedNonRefundable] = useState(false);
+  const [purchaseState, setPurchaseState] = useState<PurchaseState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [paymentUrl, setPaymentUrl] = useState<string | null>(null);
   const { purchaseCredits } = usePurchaseCredits({ workspaceId });
 
-  // Reset state when dialog opens
   useEffect(() => {
     if (isOpen) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+      /* eslint-disable react-hooks/set-state-in-effect */
       setAmountDollars("");
+      setAcceptedTerms(false);
+      setAcceptedNonRefundable(false);
+      setPurchaseState("idle");
+      setErrorMessage("");
+      setPaymentUrl(null);
+      /* eslint-enable react-hooks/set-state-in-effect */
     }
   }, [isOpen]);
 
   const handlePurchase = async () => {
-    const amount = parseFloat(amountDollars);
-    await purchaseCredits(amount);
-    onClose();
+    setPurchaseState("processing");
+    const result = await purchaseCredits(parseFloat(amountDollars));
+
+    switch (result.status) {
+      case "success":
+        setPurchaseState("success");
+        break;
+      case "redirect":
+        setPaymentUrl(result.paymentUrl);
+        setPurchaseState("redirect");
+        break;
+      case "error":
+        setErrorMessage(result.message);
+        setPurchaseState("error");
+        break;
+    }
+  };
+
+  const parsedAmount = parseFloat(amountDollars) || 0;
+  const isValidAmount = parsedAmount > 0;
+
+  const effectiveDiscount = discountPercent || 0;
+  const conversionRate = CURRENCY_CONVERSION_RATES[currency] || 1;
+  const currencySymbol = CURRENCY_SYMBOLS[currency] || "$";
+  const needsConversion = currency !== "usd";
+
+  // Convert to customer currency
+  const creditsInCurrency = parsedAmount * conversionRate;
+  const discountInCurrency = creditsInCurrency * (effectiveDiscount / 100);
+  const totalInCurrency = creditsInCurrency - discountInCurrency;
+
+  const canPurchase = isValidAmount && acceptedTerms && acceptedNonRefundable;
+
+  const renderContent = () => {
+    switch (purchaseState) {
+      case "processing":
+        return (
+          <div className="flex flex-col items-center justify-center gap-4 py-8">
+            <Spinner size="lg" />
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Processing purchase...
+            </p>
+          </div>
+        );
+
+      case "success":
+        return (
+          <div className="flex flex-col items-center justify-center gap-4 py-8">
+            <Icon
+              visual={CheckCircleIcon}
+              size="lg"
+              className="text-success-500"
+            />
+            <div className="text-center">
+              <p className="text-lg font-medium text-foreground dark:text-foreground-night">
+                Credits purchased successfully!
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                Your credits are now available.
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                <span className="font-semibold">
+                  Invoice has been sent by email.
+                </span>
+              </p>
+            </div>
+          </div>
+        );
+
+      case "redirect":
+        return (
+          <div className="flex flex-col items-center justify-center gap-4 py-8">
+            <Icon
+              visual={ExternalLinkIcon}
+              size="lg"
+              className="text-primary dark:text-primary-night"
+            />
+            <div className="text-center">
+              <p className="text-lg font-medium text-foreground dark:text-foreground-night">
+                Payment confirmation required
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                Please complete the payment to finalize your credit purchase.
+              </p>
+            </div>
+          </div>
+        );
+
+      case "error":
+        return (
+          <div className="flex flex-col items-center justify-center gap-4 py-8">
+            <Icon visual={XCircleIcon} size="lg" className="text-warning-500" />
+            <div className="text-center">
+              <p className="text-lg font-medium text-foreground dark:text-foreground-night">
+                Something went wrong
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                {errorMessage}
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
+                Please contact support if the issue persists.
+              </p>
+            </div>
+          </div>
+        );
+
+      default:
+        return (
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <label
+                htmlFor="amount"
+                className="text-sm font-medium text-foreground dark:text-foreground-night"
+              >
+                Credits amount
+              </label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                  $
+                </span>
+                <Input
+                  id="amount"
+                  type="number"
+                  placeholder="10"
+                  value={amountDollars}
+                  onChange={(e) => setAmountDollars(e.target.value)}
+                  min="0"
+                  step="1"
+                  className="pl-7 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                />
+              </div>
+            </div>
+
+            {isValidAmount && (
+              <div className="flex flex-col gap-1 rounded-md border border-border bg-muted-background p-3 text-sm dark:border-border-night dark:bg-muted-background-night">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground dark:text-muted-foreground-night">
+                    Credits
+                  </span>
+                  <span className="font-medium text-foreground dark:text-foreground-night">
+                    ${parsedAmount.toFixed(2)}
+                  </span>
+                </div>
+                {needsConversion && (
+                  <div className="flex justify-between">
+                    <span></span>
+                    <span className="text-muted-foreground dark:text-muted-foreground-night">
+                      {currencySymbol}
+                      {creditsInCurrency.toFixed(2)}
+                    </span>
+                  </div>
+                )}
+                {effectiveDiscount > 0 && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground dark:text-muted-foreground-night">
+                      Discount ({effectiveDiscount}%)
+                    </span>
+                    <span className="font-medium text-success-500">
+                      -{currencySymbol}
+                      {discountInCurrency.toFixed(2)}
+                    </span>
+                  </div>
+                )}
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground dark:text-muted-foreground-night">
+                    Tax
+                  </span>
+                  <span className="text-muted-foreground dark:text-muted-foreground-night">
+                    Calculated on invoice
+                  </span>
+                </div>
+                <div className="mt-1 flex justify-between border-t border-border pt-2 dark:border-border-night">
+                  <span className="font-medium text-foreground dark:text-foreground-night">
+                    Total
+                  </span>
+                  <span className="font-medium text-foreground dark:text-foreground-night">
+                    {currencySymbol}
+                    {totalInCurrency.toFixed(2)}
+                    <span className="ml-1 text-xs text-muted-foreground dark:text-muted-foreground-night">
+                      (excl. tax)
+                    </span>
+                  </span>
+                </div>
+              </div>
+            )}
+
+            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {isEnterprise ? (
+                <p>
+                  Credits will be added immediately and invoiced at the end of
+                  your billing cycle.
+                </p>
+              ) : (
+                <p>Credits will be charged immediately.</p>
+              )}
+              <p>Unused credits will expire one year from purchase date.</p>
+            </div>
+
+            <div className="flex flex-col gap-3 border-t border-border pt-4 dark:border-border-night">
+              <label className="flex cursor-pointer items-start gap-3">
+                <Checkbox
+                  checked={acceptedTerms}
+                  onCheckedChange={() => setAcceptedTerms(!acceptedTerms)}
+                />
+                <span className="text-sm text-foreground dark:text-foreground-night">
+                  I agree to the{" "}
+                  <Hoverable
+                    href="https://dust.tt/terms"
+                    variant="highlight"
+                    target="_blank"
+                  >
+                    Terms & Conditions
+                  </Hoverable>{" "}
+                  and{" "}
+                  <Hoverable
+                    href="https://dust.tt/privacy"
+                    variant="highlight"
+                    target="_blank"
+                  >
+                    Privacy Policy
+                  </Hoverable>
+                </span>
+              </label>
+
+              <label className="flex cursor-pointer items-start gap-3">
+                <Checkbox
+                  checked={acceptedNonRefundable}
+                  onCheckedChange={() =>
+                    setAcceptedNonRefundable(!acceptedNonRefundable)
+                  }
+                />
+                <span className="text-sm text-foreground dark:text-foreground-night">
+                  I understand credits are non-refundable after purchase
+                </span>
+              </label>
+            </div>
+          </div>
+        );
+    }
+  };
+
+  const renderFooter = () => {
+    switch (purchaseState) {
+      case "processing":
+        return (
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              disabled: true,
+            }}
+            rightButtonProps={{
+              label: "Processing...",
+              variant: "primary",
+              disabled: true,
+            }}
+          />
+        );
+      case "success":
+        return (
+          <DialogFooter
+            rightButtonProps={{
+              label: "Close",
+              variant: "primary",
+              onClick: onClose,
+            }}
+          />
+        );
+      case "redirect":
+        return (
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: onClose,
+            }}
+            rightButtonProps={{
+              label: "Go to Payment",
+              variant: "primary",
+              onClick: () => {
+                if (paymentUrl) {
+                  window.open(paymentUrl, "_blank")?.focus();
+                }
+              },
+            }}
+          />
+        );
+      case "error":
+        return (
+          <DialogFooter
+            rightButtonProps={{
+              label: "Close",
+              variant: "outline",
+              onClick: onClose,
+            }}
+          />
+        );
+      default:
+        return (
+          <DialogFooter>
+            <Button label="Cancel" variant="outline" onClick={onClose} />
+            <Button
+              label="Purchase Credits"
+              variant="primary"
+              onClick={handlePurchase}
+              disabled={!canPurchase}
+            />
+          </DialogFooter>
+        );
+    }
   };
 
   return (
@@ -51,51 +393,8 @@ export function BuyCreditDialog({
             Purchase credits for programmatic API usage and integrations.
           </DialogDescription>
         </DialogHeader>
-        <DialogContainer>
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor="amount"
-                className="text-element-800 text-sm font-medium"
-              >
-                Amount (USD)
-              </label>
-              <Input
-                id="amount"
-                type="number"
-                placeholder="10"
-                value={amountDollars}
-                onChange={(e) => setAmountDollars(e.target.value)}
-                min="0"
-                step="1"
-              />
-            </div>
-
-            <div className="text-element-700 text-xs">
-              {isEnterprise ? (
-                <p>
-                  Credits will be added immediately and invoiced at the end of
-                  your billing cycle.
-                </p>
-              ) : (
-                <p>Credits will be charged immediately.</p>
-              )}
-            </div>
-          </div>
-        </DialogContainer>
-        <DialogFooter
-          leftButtonProps={{
-            label: "Cancel",
-            variant: "outline",
-            onClick: onClose,
-          }}
-          rightButtonProps={{
-            label: "Purchase Credits",
-            variant: "primary",
-            onClick: handlePurchase,
-            disabled: !amountDollars,
-          }}
-        />
+        <DialogContainer>{renderContent()}</DialogContainer>
+        {renderFooter()}
       </DialogContent>
     </Dialog>
   );

--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -264,13 +264,15 @@ export function BuyCreditDialog({
             <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
               {isEnterprise ? (
                 <p>
-                  Credits will be added immediately and invoiced at the end of
-                  your billing cycle.
+                  Credits will be added immediately, will be invoiced at the end
+                  of your billing cycle, and expire one year after purchase.
                 </p>
               ) : (
-                <p>Credits will be charged immediately.</p>
+                <p>
+                  Credits will be charged immediately, and expire one year after
+                  purchase.
+                </p>
               )}
-              <p>Unused credits will expire one year from purchase date.</p>
             </div>
 
             <div className="flex flex-col gap-3 border-t border-border pt-4 dark:border-border-night">
@@ -393,7 +395,7 @@ export function BuyCreditDialog({
         <DialogHeader>
           <DialogTitle>Purchase Programmatic Credits</DialogTitle>
           <DialogDescription>
-            Purchase credits for programmatic API usage and integrations.
+            Purchase credits for programmatic API usage.
           </DialogDescription>
         </DialogHeader>
         <DialogContainer>{renderContent()}</DialogContainer>

--- a/front/lib/credits/committed.test.ts
+++ b/front/lib/credits/committed.test.ts
@@ -493,6 +493,7 @@ describe("createProCreditPurchase", () => {
       amountMicroUsd: 100_000_000,
       couponId: undefined,
       collectionMethod: "charge_automatically",
+      requestThreeDSecure: "challenge",
     });
   });
 

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -313,6 +313,7 @@ export async function createProCreditPurchase({
     amountMicroUsd,
     couponId,
     collectionMethod: "charge_automatically",
+    requestThreeDSecure: "challenge",
   });
 
   if (invoiceResult.isErr()) {

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -674,6 +674,9 @@ async function makeInvoice({
     collection_method: collectionParams.collectionMethod,
     metadata,
     auto_advance: true,
+    automatic_tax: {
+      enabled: true,
+    },
   };
 
   if (collectionParams.collectionMethod === "send_invoice") {

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,6 +1,8 @@
 import { Stripe } from "stripe";
 
 import config from "@app/lib/api/config";
+import type { StripePricingData } from "@app/lib/types/stripe/pricing";
+import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
@@ -62,6 +64,57 @@ export const getStripeClient = () => {
     typescript: true,
   });
 };
+
+export async function getCreditPurchasePricing(): Promise<StripePricingData | null> {
+  const stripe = getStripeClient();
+  const priceId = getCreditPurchasePriceId();
+
+  try {
+    const price = await stripe.prices.retrieve(priceId, {
+      expand: ["currency_options"],
+    });
+
+    if (!price.unit_amount || !price.currency_options) {
+      logger.error(
+        { priceId },
+        "[Stripe] Credit purchase price missing unit_amount or currency_options"
+      );
+      return null;
+    }
+
+    const currencyOptions: StripePricingData["currencyOptions"] = {
+      usd: { unitAmount: price.unit_amount },
+      eur: { unitAmount: price.unit_amount },
+    };
+
+    for (const currency of SUPPORTED_CURRENCIES) {
+      if (currency === "usd") {
+        continue;
+      }
+      const option = price.currency_options[currency];
+      if (option?.unit_amount) {
+        currencyOptions[currency] = { unitAmount: option.unit_amount };
+      } else {
+        logger.warn(
+          { priceId, currency },
+          "[Stripe] Currency option not configured, using USD amount"
+        );
+      }
+    }
+
+    return { currencyOptions };
+  } catch (error) {
+    logger.error(
+      {
+        priceId,
+        error: normalizeError(error).message,
+        stripeError: true,
+      },
+      "[Stripe] Failed to fetch credit purchase pricing"
+    );
+    return null;
+  }
+}
 
 /**
  * Calls the Stripe API to get the price ID for a given product ID.

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,8 +1,6 @@
 import { Stripe } from "stripe";
 
 import config from "@app/lib/api/config";
-import type { StripePricingData } from "@app/lib/types/stripe/pricing";
-import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
@@ -12,6 +10,7 @@ import {
   isSupportedReportUsage,
   SUPPORTED_REPORT_USAGE,
 } from "@app/lib/plans/usage/types";
+import type { StripePricingData } from "@app/lib/types/stripe/pricing";
 import logger from "@app/logger/logger";
 import type {
   BillingPeriod,
@@ -22,6 +21,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Err, isDevelopment, normalizeError, Ok } from "@app/types";
+import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 
 const DEV_PRO_PLAN_PRODUCT_ID = "prod_OwKvN4XrUwFw5a";
 const DEV_BUSINESS_PRO_PLAN_PRODUCT_ID = "prod_RkNr4qbHJD3oUp";
@@ -65,9 +65,10 @@ export const getStripeClient = () => {
   });
 };
 
-export async function getCreditPurchasePricing(): Promise<StripePricingData | null> {
+export async function getStripePricingData(
+  priceId: string
+): Promise<StripePricingData | null> {
   const stripe = getStripeClient();
-  const priceId = getCreditPurchasePriceId();
 
   try {
     const price = await stripe.prices.retrieve(priceId, {

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -90,9 +90,12 @@ export async function getStripePricingData(
 
   for (const currency of SUPPORTED_CURRENCIES) {
     const currencyOption = price.currency_options[currency];
-    if (currencyOption?.unit_amount) {
+    const unitAmount = Number(
+      currencyOption.unit_amount ?? currencyOption.unit_amount_decimal
+    );
+    if (unitAmount) {
       currencyOptions[currency] = {
-        unitAmount: currencyOption.unit_amount,
+        unitAmount,
       };
     } else {
       logger.error(

--- a/front/lib/types/stripe/pricing.ts
+++ b/front/lib/types/stripe/pricing.ts
@@ -1,0 +1,5 @@
+import type { SupportedCurrency } from "@app/types/currency";
+
+export type StripePricingData = {
+  currencyOptions: Record<SupportedCurrency, { unitAmount: number }>;
+};

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -22,17 +22,18 @@ import {
 } from "@app/lib/client/subscription";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import {
-  getCreditPurchasePricing,
+  getCreditPurchasePriceId,
+  getStripePricingData,
   getStripeSubscription,
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
-import type { StripePricingData } from "@app/lib/types/stripe/pricing";
-import { isSupportedCurrency } from "@app/types/currency";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { useCredits } from "@app/lib/swr/credits";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { StripePricingData } from "@app/lib/types/stripe/pricing";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
 import type { CreditDisplayData, CreditType } from "@app/types/credits";
+import { isSupportedCurrency } from "@app/types/currency";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -73,7 +74,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
   const discountPercent = programmaticConfig?.defaultDiscountPercent ?? 0;
 
-  const creditPricing = await getCreditPurchasePricing();
+  const creditPricing = await getStripePricingData(getCreditPurchasePriceId());
 
   return {
     props: {

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -25,7 +25,8 @@ import {
   getStripeSubscription,
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
-import { useCredits, usePurchaseCredits } from "@app/lib/swr/credits";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { useCredits } from "@app/lib/swr/credits";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
 import type { CreditDisplayData, CreditType } from "@app/types/credits";
@@ -34,6 +35,8 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   subscription: SubscriptionType;
   isEnterprise: boolean;
+  currency: string;
+  discountPercent: number;
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscription();
@@ -49,20 +52,28 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   let isEnterprise = false;
+  let currency = "usd";
   if (subscription.stripeSubscriptionId) {
     const stripeSubscription = await getStripeSubscription(
       subscription.stripeSubscriptionId
     );
     if (stripeSubscription) {
       isEnterprise = isEnterpriseSubscription(stripeSubscription);
+      currency = stripeSubscription.currency;
     }
   }
+
+  const programmaticConfig =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const discountPercent = programmaticConfig?.defaultDiscountPercent ?? 0;
 
   return {
     props: {
       owner,
       subscription,
       isEnterprise,
+      currency,
+      discountPercent,
     },
   };
 });
@@ -157,7 +168,6 @@ interface UsageSectionProps {
   totalConsumed: number;
   totalCredits: number;
   isLoading: boolean;
-  isPurchasingCredits: boolean;
   setShowBuyCreditDialog: (show: boolean) => void;
 }
 
@@ -168,7 +178,6 @@ function UsageSection({
   totalConsumed,
   totalCredits,
   isLoading,
-  isPurchasingCredits,
   setShowBuyCreditDialog,
 }: UsageSectionProps) {
   const billingCycle = useMemo(
@@ -274,8 +283,6 @@ function UsageSection({
                 label="Buy credits"
                 variant="outline"
                 size="xs"
-                disabled={isPurchasingCredits}
-                isLoading={isPurchasingCredits}
                 onClick={() => setShowBuyCreditDialog(true)}
               />
             )
@@ -299,6 +306,8 @@ export default function CreditsUsagePage({
   owner,
   subscription,
   isEnterprise,
+  currency,
+  discountPercent,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const { hasFeature, featureFlags } = useFeatureFlags({
@@ -308,9 +317,6 @@ export default function CreditsUsagePage({
   const { credits, isCreditsLoading } = useCredits({
     workspaceId: owner.sId,
     disabled: !isApiAndProgrammaticEnabled,
-  });
-  const { isLoading: isPurchasingCredits } = usePurchaseCredits({
-    workspaceId: owner.sId,
   });
 
   // Get the billing cycle start day from the subscription start date
@@ -382,6 +388,8 @@ export default function CreditsUsagePage({
         onClose={() => setShowBuyCreditDialog(false)}
         workspaceId={owner.sId}
         isEnterprise={isEnterprise}
+        currency={currency}
+        discountPercent={discountPercent}
       />
 
       <Page.Vertical gap="xl" align="stretch">
@@ -403,8 +411,6 @@ export default function CreditsUsagePage({
               <Button
                 label="Buy credits"
                 variant="primary"
-                disabled={isPurchasingCredits}
-                isLoading={isPurchasingCredits}
                 onClick={() => setShowBuyCreditDialog(true)}
               />
             </div>
@@ -428,7 +434,6 @@ export default function CreditsUsagePage({
           totalConsumed={totalConsumed}
           totalCredits={totalCredits}
           isLoading={isCreditsLoading}
-          isPurchasingCredits={isPurchasingCredits}
           setShowBuyCreditDialog={setShowBuyCreditDialog}
         />
 

--- a/front/types/currency.ts
+++ b/front/types/currency.ts
@@ -1,0 +1,11 @@
+export const SUPPORTED_CURRENCIES = ["usd", "eur"] as const;
+export type SupportedCurrency = (typeof SUPPORTED_CURRENCIES)[number];
+
+export function isSupportedCurrency(value: string): value is SupportedCurrency {
+  return SUPPORTED_CURRENCIES.includes(value as SupportedCurrency);
+}
+
+export const CURRENCY_SYMBOLS: Record<SupportedCurrency, string> = {
+  usd: "$",
+  eur: "€",
+};


### PR DESCRIPTION
## Description

Update buy credit modal, improving the flow, look and feel, and compliance.
Moreover, for pro customers, we always require a confirmation on a stripe page before charging and if 3DS is made available by the customer's bank it will be done by Stripe.

<details><summary>Pro flow</summary>
<p>

<img width="464" height="542" alt="image" src="https://github.com/user-attachments/assets/5b54cf17-0055-458c-bce4-6b9ce1235d49" />
<img width="458" height="287" alt="image" src="https://github.com/user-attachments/assets/45c336d9-4733-4636-a50d-43f2a09fd0a6" />
<img width="460" height="323" alt="image" src="https://github.com/user-attachments/assets/9151c6f9-8358-483a-94a0-a47b39434cf0" />

</p>
</details> 

<details><summary>Enterprise flow</summary>
<p>

<img width="465" height="546" alt="image" src="https://github.com/user-attachments/assets/7ef86ea1-645b-437f-922f-803fbc12d299" />
<img width="460" height="286" alt="image" src="https://github.com/user-attachments/assets/cca5b9b1-1178-4a3f-a263-723575f96f59" />
<img width="458" height="355" alt="image" src="https://github.com/user-attachments/assets/8a11f19e-79d9-4a6a-b686-61c48de2fc87" />

</p>
</details> 

## Tests

Tested manually + unit tests

## Risk

Low
Blast radius: Buy credits flow

## Deploy Plan

- [ ] Deploy front