### PR TITLE
[front] fix: Do not send subscription cancel email for pro credits

### DIFF
--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -498,9 +498,6 @@ async function handler(
             // On the other hand credit purchase from enterprise are paid in arrears or with a 30days notice
             // Either way, we want to go through the usual flow for payment failures
           } else {
-            if (subscription.paymentFailingSince === null) {
-              await subscription.update({ paymentFailingSince: now });
-            }
             const owner = auth.workspace();
             const subscriptionType = auth.subscription();
 
@@ -512,6 +509,11 @@ async function handler(
                 "Couldn't get owner or subscription from `auth`."
               );
             }
+
+            if (subscription.paymentFailingSince === null) {
+              await subscription.update({ paymentFailingSince: now });
+            }
+
             const { members } = await getMembers(auth, {
               roles: ["admin"],
               activeOnly: true,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -433,12 +433,6 @@ async function handler(
             return res.status(200).json({ success: true });
           }
 
-          // If the invoice is for a credit purchase, we don't mark the
-          // subscription as payment failing.
-          if (isCreditPurchaseInvoice(invoice)) {
-            return res.status(200).json({ success: true });
-          }
-
           // TODO(2024-01-16 by flav) This line should be removed after all Stripe webhooks have been retried.
           // Previously, there was an error in how we handled the cancellation of subscriptions.
           // This change ensures that we return a success status if the subscription is already marked as "ended".

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -451,9 +451,10 @@ async function handler(
           );
 
           if (!stripeSubscription) {
-            logger.warn(
+            logger.error(
               {
                 event,
+                stripeError: true,
                 stripeSubscriptionId: invoice.subscription,
               },
               "[Stripe Webhook] Stripe Subscription not found."


### PR DESCRIPTION
## Description

- When you buy credits as a pro, we try to charge you immediately, but sometimes payments fail. 
- We have retries like any other invoice - 4 in the next 30 days.
- However, after 3rd try, we void the invoice because we don't want to put the subscription in `past_due`. This is because credits are not provisioned until paid.
- Right now, we put a billing alert and send an email about subscription cancel for this case, which is not true and not consistent with ⬆️ 

## Tests

Tested manually

## Risk

Low
Blast radius: Payment failed webhooks

## Deploy Plan

- [ ] Deploy front