### PR TITLE
[front] fix(Vanta): fix import from missing barrel file

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/vanta/api.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/vanta/api.ts
@@ -2,7 +2,7 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { untrustedFetch } from "@app/lib/egress";
+import { untrustedFetch } from "@app/lib/egress/server";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 


### PR DESCRIPTION
## Description

- The barrel file on the egress folder was removed in https://github.com/dust-tt/dust/pull/18746.
- The commit got crossed with https://github.com/dust-tt/dust/pull/18632, which added the Vanta MCP server.

## Tests

## Risk

- None.

## Deploy Plan

- Deploy front.
