### PR TITLE
Fix Workspace Isolation Violation on Groups

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -662,6 +662,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         id: {
           [Op.in]: agentGroups.map((ag) => ag.groupId),
         },
+        kind: "agent_editors",
       },
     });
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes the `workspace_isolation_violation` warnings we are seeing on groups. They are all linked to the `GroupAgent` model. We split the include/join on the SQL query to do two queries like we do for the spaces.

⚠️ While refactoring, I noticed that none of the group agent related method are checking the `canRead` method of the group. I added them.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
