### PR TITLE
Add key highlights on customer stories and make sure the department is the first filter

### DIFF
--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -531,8 +531,11 @@ function contentfulEntryToCustomerStory(
   const parsed = result.data;
   const slug = parsed.slug ?? slugify(parsed.title);
 
-  // Check assets directly
+  // Check assets and rich text fields
   const body = isContentfulDocument(fields.body) ? fields.body : EMPTY_DOCUMENT;
+  const keyHighlight = isContentfulDocument(fields.keyHighlight)
+    ? fields.keyHighlight
+    : null;
   const heroImage = isContentfulAsset(fields.heroImage)
     ? fields.heroImage
     : undefined;
@@ -557,6 +560,7 @@ function contentfulEntryToCustomerStory(
     contactTitle: parsed.contactTitle ?? null,
     contactPhoto: contentfulAssetToBlogImage(contactPhoto, "Contact photo"),
     headlineMetric: parsed.headlineMetric ?? null,
+    keyHighlight,
     industry: parsed.industry,
     department: parsed.department,
     companySize: parsed.companySize ?? null,

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -89,6 +89,7 @@ export interface CustomerStoryFields {
 
   // Metrics (optional)
   headlineMetric?: string;
+  keyHighlight?: Document;
 
   // Filtering (optional)
   companySize?: string;
@@ -122,6 +123,7 @@ export interface CustomerStory {
   contactTitle: string | null;
   contactPhoto: BlogImage | null;
   headlineMetric: string | null;
+  keyHighlight: Document | null;
   industry: string;
   department: string[];
   companySize: string | null;

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -202,7 +202,6 @@ export default function CustomerStoryPage({
 
       <article>
         <Grid>
-          {/* Header */}
           <header className={classNames(WIDE_CLASSES, "pt-16")}>
             <Link
               href="/customers"
@@ -211,7 +210,6 @@ export default function CustomerStoryPage({
               <span>&larr;</span> All Customer Stories
             </Link>
 
-            {/* Tags */}
             <div className="mb-4 flex flex-wrap gap-2">
               <span className="rounded-full bg-highlight/10 px-3 py-1 text-sm font-medium text-highlight">
                 {story.industry}
@@ -228,7 +226,6 @@ export default function CustomerStoryPage({
 
             <H1 mono>{story.title}</H1>
 
-            {/* Headline metric */}
             {story.headlineMetric && (
               <div className="mt-6">
                 <span className="inline-block rounded-lg bg-emerald-50 px-4 py-2 text-xl font-bold text-emerald-600">
@@ -238,7 +235,6 @@ export default function CustomerStoryPage({
             )}
           </header>
 
-          {/* Hero image */}
           {story.heroImage && (
             <div className={classNames(WIDE_CLASSES, "mt-8")}>
               <Image
@@ -252,9 +248,7 @@ export default function CustomerStoryPage({
             </div>
           )}
 
-          {/* Main content and sidebar */}
           <div className={classNames(CONTENT_CLASSES, "mt-12")}>
-            {/* Key highlight box */}
             {story.keyHighlight && (
               <div className="mb-8 rounded-2xl border border-highlight/20 bg-highlight/5 p-6">
                 <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-highlight">

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -254,6 +254,18 @@ export default function CustomerStoryPage({
 
           {/* Main content and sidebar */}
           <div className={classNames(CONTENT_CLASSES, "mt-12")}>
+            {/* Key highlight box */}
+            {story.keyHighlight && (
+              <div className="mb-8 rounded-2xl border border-highlight/20 bg-highlight/5 p-6">
+                <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-highlight">
+                  Key Highlights
+                </h3>
+                <div className="prose prose-highlight max-w-none">
+                  {renderRichTextFromContentful(story.keyHighlight)}
+                </div>
+              </div>
+            )}
+
             {/* Rich text body */}
             {renderRichTextFromContentful(story.body)}
 

--- a/front/pages/customers/index.tsx
+++ b/front/pages/customers/index.tsx
@@ -336,18 +336,18 @@ export default function CustomerStoriesListing({
               </div>
 
               <FilterSection
-                title="Industry"
-                options={filterOptions.industries}
-                selected={selectedIndustries}
-                onChange={(values) => updateFilters("industry", values)}
-                defaultOpen={true}
-              />
-
-              <FilterSection
                 title="Department"
                 options={filterOptions.departments}
                 selected={selectedDepartments}
                 onChange={(values) => updateFilters("department", values)}
+                defaultOpen={true}
+              />
+
+              <FilterSection
+                title="Industry"
+                options={filterOptions.industries}
+                selected={selectedIndustries}
+                onChange={(values) => updateFilters("industry", values)}
               />
 
               <FilterSection


### PR DESCRIPTION

<img width="1604" height="539" alt="Screenshot 2025-12-08 at 12 15 05" src="https://github.com/user-attachments/assets/29959888-f93f-475e-b15a-2b1d17057ccc" />







## Description

Adds a "Key Highlights" section to customer story pages by introducing a new `keyHighlight` rich text field in Contentful. The key highlights display in a styled box with border and background before the main content. Also reorders the customer stories listing filters to prioritize Department over Industry, making Department the first filter with `defaultOpen={true}` to better align with user browsing patterns.

## Risk

None. Changes only affect the public customer stories pages and are purely additive (the `keyHighlight` field is optional and displays only when present).
