### PR TITLE
[front] fix(ppul): Open payment in new window

### DIFF
--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -131,9 +131,10 @@ export function usePurchaseCredits({ workspaceId }: { workspaceId: string }) {
 
         const responseData = await response.json();
 
-        // If payment requires additional action, redirect to Stripe's hosted invoice page.
+        // If payment requires additional action, open Stripe's hosted invoice page in a new window.
+        // This keeps the current page open so users can return to it after payment.
         if (responseData.paymentUrl) {
-          window.location.href = responseData.paymentUrl;
+          window.open(responseData.paymentUrl, "_blank", "noopener,noreferrer");
           return true;
         }
 


### PR DESCRIPTION
## Description
related to : https://github.com/dust-tt/tasks/issues/5442

If payment fails when buying credit on pro, we are redirectd to a payment page - but no way to go back. Open in a new window.
Note : return_url in metadata cannot be used when making an invoice
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
