### PR TITLE
Make userId optional in Tool Approve Execution

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -144,9 +144,17 @@ export function BlockedActionsProvider({
 
   const getBlockedActions = useCallback(
     (userId: string) => {
-      return blockedActionsQueue
-        .filter((action) => action.blockedAction.userId === userId)
-        .map((action) => action.blockedAction);
+      return (
+        blockedActionsQueue
+          // Either actions associated to the user or actions created through the Public API and not
+          // associated to any user.
+          .filter(
+            (action) =>
+              action.blockedAction.userId === userId ||
+              !action.blockedAction.userId
+          )
+          .map((action) => action.blockedAction)
+      );
     },
     [blockedActionsQueue]
   );

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -152,7 +152,8 @@ export type ToolExecution = {
 };
 
 export type BlockedToolExecution = ToolExecution & {
-  userId: string;
+  // User might be undefined if the run was initiated through the public API using an API key.
+  userId?: string;
 } & (
     | {
         status: "blocked_validation_required";
@@ -177,7 +178,7 @@ export type BlockedToolExecution = ToolExecution & {
 // TODO(durable-agents): cleanup the types of the events.
 export type MCPApproveExecutionEvent = ToolExecution & {
   type: "tool_approve_execution";
-  userId: string;
+  userId?: string;
   created: number;
   configurationId: string;
   isLastBlockingEventForStep?: boolean;

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -255,7 +255,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
             {
               model: UserModel,
               as: "user",
-              required: true,
             },
           ],
         },
@@ -349,14 +348,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       const parentUserMessage =
         parentUserMessageById[agentMessage.message.parentId!];
 
-      assert(parentUserMessage.userMessage?.user?.sId, "User not found.");
+      assert(parentUserMessage.userMessage, "Parent user message not found.");
 
       const baseActionParams: Omit<
         BlockedToolExecution,
         "status" | "authorizationInfo"
       > = {
         messageId: agentMessage.message.sId,
-        userId: parentUserMessage.userMessage.user.sId,
+        userId: parentUserMessage.userMessage?.user?.sId,
         conversationId: conversation.sId,
         actionId: this.modelIdToSId({
           id: action.id,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -229,14 +229,14 @@ async function createActionForTool(
       status === "blocked_validation_required"
         ? {
             type: "tool_approve_execution",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            userId: auth.getNonNullableUser().sId,
-            messageId: agentMessage.sId,
-            conversationId: conversation.sId,
             actionId: action.sId,
+            configurationId: agentConfiguration.sId,
+            conversationId: conversation.sId,
+            created: Date.now(),
             inputs: action.augmentedInputs,
+            messageId: agentMessage.sId,
             stake: actionConfiguration.permission,
+            userId: auth.user()?.sId,
             metadata: {
               toolName: actionConfiguration.originalName,
               mcpServerName: actionConfiguration.mcpServerName,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1281,7 +1281,7 @@ export type BlockedActionExecutionType = z.infer<
 
 const MCPApproveExecutionEventSchema = ToolExecutionMetadataSchema.extend({
   type: z.literal("tool_approve_execution"),
-  userId: z.string(),
+  userId: z.string().optional(),
   configurationId: z.string(),
   conversationId: z.string(),
   created: z.number(),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/18707.

This PR removes the `auth.getNonNullableUser()` from the agent loop. Agents used through the public API with an API Key can't be associated to a specific user. This was causing some errors ([logs](https://app.datadoghq.eu/logs?query=%22Unexpected%20unauthenticated%20call%20to%20%60getNonNullableUser%60.%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764594635492&to_ts=1765199435492&live=true)) this PR makes `userId` optional in the action types.

New flow is as following:
i. action is associated to a user -> only this specific user can approve
ii. action is not associated to a user -> all conversation participants can take an action 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
