### PR TITLE
Skip too large files for Microsoft connectors

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -36,6 +36,7 @@ import {
   upsertDataSourceDocument,
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
+import { DataSourceQuotaExceededError } from "@connectors/lib/error";
 import type { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
 import { heartbeat } from "@connectors/lib/temporal";
 import logger, { getActivityLogger } from "@connectors/logger/logger";
@@ -408,6 +409,21 @@ export async function syncOneFile({
             ? new Date(upsertTimestampMs)
             : null;
         } catch (error) {
+          if (error instanceof DataSourceQuotaExceededError) {
+            localLogger.warn(
+              {
+                connectorId,
+                error,
+                documentId,
+                fileName: file.name,
+                internalId: documentId,
+                webUrl: file.webUrl,
+              },
+              "Microsoft file exceeding plan document size limit, marking as skipped"
+            );
+            return false;
+          }
+
           if (
             error instanceof WithRetriesError &&
             error.errors.every(


### PR DESCRIPTION
## Description

This PR catches `DataSourceQuotaExceededError` during Microsoft file sync and marks files exceeding plan document size limits as skipped instead of retrying indefinitely. This prevents stuck workflows when files are too large for the workspace's plan limits.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy connectors
