### PR TITLE
Migrate customer stories industry to multiple choice industries

### DIFF
--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -76,6 +76,7 @@ export interface CustomerStoryFields {
   companyName: string;
   body: Document;
   industry: string;
+  industries?: string[];
   department: string[];
 
   // Customer info (optional)
@@ -125,6 +126,7 @@ export interface CustomerStory {
   headlineMetric: string | null;
   keyHighlight: Document | null;
   industry: string;
+  industries: string[];
   department: string[];
   companySize: string | null;
   region: string[];
@@ -147,6 +149,7 @@ export interface CustomerStorySummary {
   description: string | null;
   heroImage: BlogImage | null;
   industry: string;
+  industries: string[];
   department: string[];
   companySize: string | null;
   region: string[];
@@ -156,6 +159,7 @@ export interface CustomerStorySummary {
 
 export interface CustomerStoryFilters {
   industry?: string[];
+  industries?: string[];
   department?: string[];
   companySize?: string[];
   region?: string[];

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -74,7 +74,7 @@ export const getStaticProps: GetStaticProps<CustomerStoryPageProps> = async (
 
   const relatedStoriesResult = await getRelatedCustomerStories(
     slug,
-    story.industry,
+    story.industries,
     story.department,
     3,
     resolvedUrl
@@ -211,9 +211,14 @@ export default function CustomerStoryPage({
             </Link>
 
             <div className="mb-4 flex flex-wrap gap-2">
-              <span className="rounded-full bg-highlight/10 px-3 py-1 text-sm font-medium text-highlight">
-                {story.industry}
-              </span>
+              {story.industries.map((ind) => (
+                <span
+                  key={ind}
+                  className="rounded-full bg-highlight/10 px-3 py-1 text-sm font-medium text-highlight"
+                >
+                  {ind}
+                </span>
+              ))}
               {story.department.map((dept) => (
                 <span
                   key={dept}
@@ -304,14 +309,18 @@ export default function CustomerStoryPage({
 
                 <div className="p-6">
                   <dl className="space-y-4">
-                    <div className="flex items-start justify-between">
-                      <dt className="text-sm text-muted-foreground">
-                        Industry
-                      </dt>
-                      <dd className="text-right text-sm font-medium text-foreground">
-                        {story.industry}
-                      </dd>
-                    </div>
+                    {story.industries.length > 0 && (
+                      <div className="flex items-start justify-between">
+                        <dt className="text-sm text-muted-foreground">
+                          {story.industries.length > 1
+                            ? "Industries"
+                            : "Industry"}
+                        </dt>
+                        <dd className="text-right text-sm font-medium text-foreground">
+                          {story.industries.join(", ")}
+                        </dd>
+                      </div>
+                    )}
                     {story.companySize && (
                       <div className="flex items-start justify-between">
                         <dt className="text-sm text-muted-foreground">

--- a/front/pages/customers/index.tsx
+++ b/front/pages/customers/index.tsx
@@ -42,8 +42,8 @@ function extractFilterOptions(
   const regions = new Set<string>();
 
   for (const story of stories) {
-    if (story.industry) {
-      industries.add(story.industry);
+    for (const ind of story.industries) {
+      industries.add(ind);
     }
     for (const dept of story.department) {
       departments.add(dept);
@@ -246,7 +246,7 @@ export default function CustomerStoriesListing({
     return stories.filter((story) => {
       if (
         selectedIndustries.length > 0 &&
-        !selectedIndustries.includes(story.industry)
+        !story.industries.some((ind) => selectedIndustries.includes(ind))
       ) {
         return false;
       }
@@ -412,9 +412,14 @@ export default function CustomerStoriesListing({
                         )}
                         {/* Tags */}
                         <div className="absolute right-3 top-3 flex flex-wrap justify-end gap-2">
-                          <span className="rounded-full bg-white/90 px-3 py-1 text-xs font-medium text-gray-900 shadow-sm backdrop-blur-sm">
-                            {story.industry}
-                          </span>
+                          {story.industries.slice(0, 2).map((ind) => (
+                            <span
+                              key={ind}
+                              className="rounded-full bg-white/90 px-3 py-1 text-xs font-medium text-gray-900 shadow-sm backdrop-blur-sm"
+                            >
+                              {ind}
+                            </span>
+                          ))}
                           {story.department.slice(0, 2).map((dept) => (
                             <span
                               key={dept}


### PR DESCRIPTION





## Description
Migrates customer stories from a single `industry` field to a multiple-choice `industries` array field in Contentful. Customer stories can now be tagged with multiple industries instead of just one, improving discoverability and filtering accuracy. The change updates the schema, query building logic, filtering UI, and display components to handle multiple industries per story.

## Risk
Low. The change is backward compatible as the old `industry` field remains in the schema for legacy support. The UI gracefully handles both single and multiple industries, and all filtering logic has been updated to use the new `industries` field.
