### PR TITLE
Catch Microsoft "Item not found" error

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -999,12 +999,25 @@ export async function fetchDeltaForRootNodesInDrive({
     }
   }
 
-  const { results, deltaLink } = await getDeltaData({
-    logger,
-    client,
-    node,
-    heartbeat,
-  });
+  let results: DriveItem[] = [];
+  let deltaLink = "";
+  try {
+    const { results: resultsFromDelta, deltaLink: deltaLinkFromDelta } =
+      await getDeltaData({
+        logger,
+        client,
+        node,
+        heartbeat,
+      });
+    results = resultsFromDelta;
+    deltaLink = deltaLinkFromDelta;
+  } catch (error) {
+    if (isItemNotFoundError(error)) {
+      logger.info({ error: error.message }, "Node not found, skipping");
+      return { gcsFilePath: null };
+    }
+    throw error;
+  }
 
   // Generate a unique GCS file path for this delta sync
   const timestamp = Date.now();


### PR DESCRIPTION
## Description

In the `fetchDeltaForRootNodesInDrive` activity, we get "Item not found" errors.
It's coming from the initial call to get the delta. The "Item not found" error is not catched and properly ignored
See logs in [Datadog](https://app.datadoghq.eu/dashboard/eza-jyh-pwy?query=%28%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1%20%40level%3Aerror%20%40workflowId%3A%2A%29%20AND%20%40workflowId%3Amicrosoft-incrementalSync-27767&fromUser=true&index=%2A&overlay=events&overlayQuery=%28%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aeu-front-worker%20region%3Aus-central1%20%40level%3Aerror%20%40workflowId%3A%2A%29&panelFrom=1765205672979&panelStorageType=hot&panelTo=1765207472979&panelType=logs&refresh_mode=sliding&storage=hot&from_ts=1765203444967&to_ts=1765205244967&live=true)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low
## Deploy Plan

Deploy connectors
