### PR TITLE
[Credits] Skip workspaces without active subscription in backfill

### DIFF
--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -278,6 +278,11 @@ export async function handleRegularSignupFlow(
       await SubscriptionResource.fetchActiveByWorkspace(
         renderLightWorkspaceType({ workspace: existingWorkspace })
       );
+
+    if (!workspaceSubscription) {
+      throw new Error("Unreachable: Workspace subscription not found");
+    }
+
     const hasAvailableSeats = await evaluateWorkspaceSeatAvailability(
       existingWorkspace,
       workspaceSubscription.toJSON()

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -89,12 +89,12 @@ export class SubscriptionResource extends BaseResource<Subscription> {
   static async fetchActiveByWorkspace(
     workspace: LightWorkspaceType,
     transaction?: Transaction
-  ): Promise<SubscriptionResource> {
+  ): Promise<SubscriptionResource | null> {
     const res = await SubscriptionResource.fetchActiveByWorkspaces(
       [workspace],
       transaction
     );
-    return res[workspace.sId];
+    return res[workspace.sId] ?? null;
   }
 
   static async fetchActiveByWorkspaces(

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -224,6 +224,10 @@ export class CustomerioServerSideTracking {
     const subscription =
       await SubscriptionResource.fetchActiveByWorkspace(workspace);
 
+    if (!subscription) {
+      throw new Error("Unreachable: Workspace subscription not found");
+    }
+
     const planCode = workspace.planCode ?? subscription.getPlan().code;
     const seats =
       workspace.seats ?? (await countActiveSeatsInWorkspace(workspace.sId));

--- a/front/scripts/backfill_credits.ts
+++ b/front/scripts/backfill_credits.ts
@@ -133,7 +133,7 @@ async function reconcileWorkspaceCredits(
   const subscription =
     await SubscriptionResource.fetchActiveByWorkspace(lightWorkspace);
 
-  const stripeSubscription = subscription.stripeSubscriptionId
+  const stripeSubscription = subscription?.stripeSubscriptionId
     ? await getStripeSubscription(subscription.stripeSubscriptionId)
     : null;
 


### PR DESCRIPTION
## Description

Fixes backfill migration to skip workspaces without an active subscription when adding free credits. Also fixes `fetchActiveByWorkspace` return type to properly return `null` when no subscription exists (previously returned `undefined` silently which didn't match the declared return type).

## Risks

Blast radius: Free credits backfill script
Risk: low

## Deploy Plan
- deploy front