### PR TITLE
[Programmatic Usage] Ship

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -174,7 +174,7 @@ export const subNavigationAdmin = ({
   current,
   subMenuLabel,
   subMenu,
-  featureFlags,
+  featureFlags: _featureFlags,
 }: {
   owner: WorkspaceType;
   current: SubNavigationAdminId;

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -188,8 +188,6 @@ export const subNavigationAdmin = ({
     return nav;
   }
 
-  const hasApiAndProgrammaticSection = featureFlags.includes("ppul");
-
   if (isAdmin(owner)) {
     nav.push({
       id: "workspace",
@@ -235,35 +233,31 @@ export const subNavigationAdmin = ({
       ],
     });
 
-    // API & Programmatic section (feature flagged)
-    if (hasApiAndProgrammaticSection) {
-      nav.push({
-        id: "api",
-        label: "API & Programmatic",
-        variant: "primary",
-        menus: [
-          {
-            id: "api_keys",
-            label: "API Keys",
-            icon: LockIcon,
-            href: `/w/${owner.sId}/developers/api-keys`,
-            current: current === "api_keys",
-            subMenuLabel: current === "api_keys" ? subMenuLabel : undefined,
-            subMenu: current === "api_keys" ? subMenu : undefined,
-          },
-          {
-            id: "credits_usage",
-            label: "Programmatic usage",
-            icon: CardIcon,
-            href: `/w/${owner.sId}/developers/credits-usage`,
-            current: current === "credits_usage",
-            subMenuLabel:
-              current === "credits_usage" ? subMenuLabel : undefined,
-            subMenu: current === "credits_usage" ? subMenu : undefined,
-          },
-        ],
-      });
-    }
+    nav.push({
+      id: "api",
+      label: "API & Programmatic",
+      variant: "primary",
+      menus: [
+        {
+          id: "api_keys",
+          label: "API Keys",
+          icon: LockIcon,
+          href: `/w/${owner.sId}/developers/api-keys`,
+          current: current === "api_keys",
+          subMenuLabel: current === "api_keys" ? subMenuLabel : undefined,
+          subMenu: current === "api_keys" ? subMenu : undefined,
+        },
+        {
+          id: "credits_usage",
+          label: "Programmatic usage",
+          icon: CardIcon,
+          href: `/w/${owner.sId}/developers/credits-usage`,
+          current: current === "credits_usage",
+          subMenuLabel: current === "credits_usage" ? subMenuLabel : undefined,
+          subMenu: current === "credits_usage" ? subMenu : undefined,
+        },
+      ],
+    });
 
     nav.push({
       id: "developers",
@@ -279,20 +273,6 @@ export const subNavigationAdmin = ({
           subMenuLabel: current === "providers" ? subMenuLabel : undefined,
           subMenu: current === "providers" ? subMenu : undefined,
         },
-        // Only show API keys here if the new section is not enabled
-        ...(hasApiAndProgrammaticSection
-          ? []
-          : [
-              {
-                id: "api_keys" as const,
-                label: "API Keys",
-                icon: LockIcon,
-                href: `/w/${owner.sId}/developers/api-keys`,
-                current: current === "api_keys",
-                subMenuLabel: current === "api_keys" ? subMenuLabel : undefined,
-                subMenu: current === "api_keys" ? subMenu : undefined,
-              },
-            ]),
         {
           id: "dev_secrets",
           label: "Secrets",

--- a/front/knip.ts
+++ b/front/knip.ts
@@ -9,7 +9,11 @@ const config: KnipConfig = {
     "mailing/**/*.{ts,js}",
     "next-sitemap.config.js",
   ],
-  ignoreFiles: ["**/vite.config.js", "**/esbuild.worker.ts"],
+  ignoreFiles: [
+    "**/vite.config.js",
+    "**/esbuild.worker.ts",
+    "temporal/credit_alerts/**/*.ts",
+  ],
   project: ["**/*.{js,jsx,ts,tsx}"],
   rules: {
     binaries: "off",

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1227,15 +1227,11 @@ async function isMessagesLimitReached(
 ): Promise<MessageLimit> {
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
-  const featureFlags = await getFeatureFlags(owner);
 
   // For programmatic usage, apply credit-based rate limiting.
   // This prevents close-to-0 credit attacks where many messages are sent simultaneously
   // before token usage is computed. Rate limit is based on total credit amount in dollars.
-  if (
-    featureFlags.includes("ppul") &&
-    isProgrammaticUsage(auth, { userMessageOrigin: context.origin })
-  ) {
+  if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
     const activeCredits = await CreditResource.listActive(auth);
 
     // Calculate total remaining credits in dollars (micro USD / 1,000,000).

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -4,7 +4,6 @@ import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 import type { RedisClientType } from "redis";
 
-import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { runOnRedis } from "@app/lib/api/redis";
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
@@ -12,13 +11,11 @@ import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import { launchCreditAlertWorkflow } from "@app/temporal/credit_alerts/client";
 import type {
   LightWorkspaceType,
   PublicAPILimitsType,
   UserMessageOrigin,
 } from "@app/types";
-import { isString } from "@app/types";
 
 export const USAGE_ORIGINS_CLASSIFICATION: Record<
   UserMessageOrigin,
@@ -65,7 +62,6 @@ const PROGRAMMATIC_USAGE_ORIGINS = Object.keys(
 // Programmatic usage tracking: keep Redis key name for backward compatibility.
 const PROGRAMMATIC_USAGE_REMAINING_CREDITS_KEY = "public_api_remaining_credits";
 const REDIS_ORIGIN = "public_api_limits";
-const CREDIT_ALERT_THRESHOLD_PERCENT = 80;
 
 function getRedisKey(workspace: LightWorkspaceType): string {
   return `${PROGRAMMATIC_USAGE_REMAINING_CREDITS_KEY}:${workspace.id}`;

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -8,7 +8,6 @@ import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { runOnRedis } from "@app/lib/api/redis";
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -321,6 +321,8 @@ export async function trackProgrammaticCost(
     amountMicroUsd: runsCostMicroUsd,
   });
 
+  // TODO(PPUL): re-enable this after shipping.
+  /*
   const costWithMarkupMicroUsd = Math.ceil(
     runsCostMicroUsd * (1 + DUST_MARKUP_PERCENT / 100)
   );
@@ -352,7 +354,7 @@ export async function trackProgrammaticCost(
         totalConsumedMicroUsd,
       });
     }
-  }
+  }*/
 }
 
 export async function resetCredits(

--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -3,7 +3,6 @@ import type { MockInstance } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   calculateFreeCreditAmountMicroUsd,
   countEligibleUsersForFreeCredits,

--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -297,7 +297,6 @@ describe("grantFreeCreditsOnSubscriptionRenewal", () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     auth = authenticator;
 
-    vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
     vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
     vi.mocked(getSubscriptionInvoices).mockResolvedValue([
       makeInvoice(NOW - MONTH_SECONDS * 0.5),

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -231,20 +231,6 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
   const periodStart = new Date(stripeSubscription.current_period_start * 1000);
   const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
 
-  const featureFlags = await getFeatureFlags(workspace);
-  if (!featureFlags.includes("ppul")) {
-    logger.info(
-      {
-        workspaceId: workspaceSId,
-        creditAmountMicroUsd,
-        periodStart,
-        periodEnd,
-      },
-      "[Free Credits] PPUL flag OFF - stopping here."
-    );
-    return new Ok(undefined);
-  }
-
   const credit = await CreditResource.makeNew(auth, {
     type: "free",
     initialAmountMicroUsd: creditAmountMicroUsd,

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -2,7 +2,6 @@ import assert from "assert";
 import type Stripe from "stripe";
 
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   getSubscriptionInvoices,
   isEnterpriseSubscription,

--- a/front/lib/credits/payg.test.ts
+++ b/front/lib/credits/payg.test.ts
@@ -151,7 +151,6 @@ describe("isPAYGEnabled", () => {
     vi.clearAllMocks();
     const { authenticator } = await createResourceTest({ role: "admin" });
     auth = authenticator;
-    vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
   });
 
   it("should return false when no programmatic config exists", async () => {
@@ -193,7 +192,6 @@ describe("allocatePAYGCreditsOnCycleRenewal", () => {
       role: "admin",
     });
     auth = authenticator;
-    vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
   });
 
   afterEach(() => {
@@ -307,7 +305,6 @@ describe("startOrResumeEnterprisePAYG", () => {
       role: "admin",
     });
     auth = authenticator;
-    vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
     vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
   });
 
@@ -429,7 +426,6 @@ describe("stopEnterprisePAYG", () => {
       role: "admin",
     });
     auth = authenticator;
-    vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
   });
 
   afterEach(() => {
@@ -512,7 +508,6 @@ describe("invoiceEnterprisePAYGCredits", () => {
       role: "admin",
     });
     auth = authenticator;
-    vi.mocked(getFeatureFlags).mockResolvedValue(["ppul"]);
     vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
     vi.mocked(makeAndFinalizeCreditsPAYGInvoice).mockResolvedValue(
       new Ok({ id: "inv_test" } as Stripe.Invoice)

--- a/front/lib/credits/payg.test.ts
+++ b/front/lib/credits/payg.test.ts
@@ -2,7 +2,6 @@ import type Stripe from "stripe";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   allocatePAYGCreditsOnCycleRenewal,
   invoiceEnterprisePAYGCredits,

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -85,20 +85,6 @@ export async function allocatePAYGCreditsOnCycleRenewal({
   const nextPeriodStartDate = new Date(nextPeriodStartSeconds * 1000);
   const nextPeriodEndDate = new Date(nextPeriodEndSeconds * 1000);
 
-  const featureFlags = await getFeatureFlags(workspace);
-  if (!featureFlags.includes("ppul")) {
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        initialAmountMicroUsd: config.paygCapMicroUsd,
-        periodStart: nextPeriodStartDate.toISOString(),
-        periodEnd: nextPeriodEndDate.toISOString(),
-      },
-      "[Credit PAYG] PPUL flag OFF - stopping here."
-    );
-    return;
-  }
-
   const result = await createPAYGCreditForPeriod({
     auth,
     paygCapMicroUsd: config.paygCapMicroUsd,
@@ -127,10 +113,6 @@ export async function allocatePAYGCreditsOnCycleRenewal({
 }
 
 export async function isPAYGEnabled(auth: Authenticator): Promise<boolean> {
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-  if (!featureFlags.includes("ppul")) {
-    return false;
-  }
   const config =
     await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
   return config !== null && config.paygCapMicroUsd !== null;
@@ -167,15 +149,6 @@ export async function startOrResumeEnterprisePAYG({
   });
   if (updateResult.isErr()) {
     return updateResult;
-  }
-
-  const featureFlags = await getFeatureFlags(workspace);
-  if (!featureFlags.includes("ppul")) {
-    logger.info(
-      { workspaceId: workspace.sId },
-      "[Credit PAYG] PPUL flag OFF - config updated but no credit created"
-    );
-    return new Ok(undefined);
   }
 
   const currentPeriodStart = new Date(

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -3,7 +3,6 @@ import type Stripe from "stripe";
 
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   ENTERPRISE_N30_PAYMENTS_DAYS,
   isEnterpriseSubscription,

--- a/front/pages/api/v1/viz/files/fileId.test.ts
+++ b/front/pages/api/v1/viz/files/fileId.test.ts
@@ -689,6 +689,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         workspace,
         key,
       } = await createPublicApiMockRequest({
+        systemKey: true,
         method: "POST",
       });
 
@@ -724,6 +725,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
 
       const { req: conversationBReq, res: conversationBRes } =
         await createPublicApiMockRequest({
+          systemKey: true,
           method: "POST",
         });
 

--- a/front/pages/api/w/[wId]/credits/index.ts
+++ b/front/pages/api/w/[wId]/credits/index.ts
@@ -2,7 +2,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -24,20 +23,6 @@ async function handler(
         type: "workspace_auth_error",
         message:
           "Only users that are `admins` for the current workspace can view credits.",
-      },
-    });
-  }
-
-  // Check feature flag.
-  const workspace = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(workspace);
-
-  if (!featureFlags.includes("ppul")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "This feature is not enabled for your workspace.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -6,7 +6,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   createEnterpriseCreditPurchase,
   createProCreditPurchase,
@@ -60,19 +59,7 @@ async function handler(
     });
   }
 
-  // Check feature flag.
   const workspace = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(workspace);
-
-  if (!featureFlags.includes("ppul")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "This feature is not enabled for your workspace.",
-      },
-    });
-  }
 
   switch (req.method) {
     case "POST": {

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -314,7 +314,7 @@ export default function CreditsUsagePage({
   creditPricing,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
-  const { hasFeature, featureFlags } = useFeatureFlags({
+  const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
   });
   const { credits, isCreditsLoading } = useCredits({

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -15,7 +15,6 @@ import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { BuyCreditDialog } from "@app/components/workspace/BuyCreditDialog";
 import { CreditsList } from "@app/components/workspace/CreditsList";
 import { ProgrammaticCostChart } from "@app/components/workspace/ProgrammaticCostChart";
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   getBillingCycle,
   getPriceAsString,
@@ -47,12 +46,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const subscription = auth.getNonNullableSubscription();
 
   if (!auth.isAdmin()) {
-    return { notFound: true };
-  }
-
-  // Check if the feature flag is enabled
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("ppul")) {
     return { notFound: true };
   }
 
@@ -324,10 +317,8 @@ export default function CreditsUsagePage({
   const { hasFeature, featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
   });
-  const isApiAndProgrammaticEnabled = hasFeature("ppul");
   const { credits, isCreditsLoading } = useCredits({
     workspaceId: owner.sId,
-    disabled: !isApiAndProgrammaticEnabled,
   });
 
   // Get the billing cycle start day from the subscription start date

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -113,11 +113,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "OpenAI tool for tracking API consumption and costs",
     stage: "on_demand",
   },
-  ppul: {
-    description:
-      "Enable the API & Programmatic section in the admin panel with credits purchase flow, usage metrics, and cost charts",
-    stage: "dust_only",
-  },
   salesforce_synced_queries: {
     description: "Salesforce Connection: retrieval on Synchronized queries",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -680,7 +680,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_feature"
   | "openai_o1_high_reasoning_feature"
   | "openai_usage_mcp"
-  | "ppul"
   | "restrict_agents_publishing"
   | "salesforce_synced_queries"
   | "salesforce_tool"


### PR DESCRIPTION
## Description

Removes the `ppul` feature flag and ships the Programmatic Usage feature to all workspaces. This makes the "API & Programmatic" section in the admin panel (credits purchase flow, usage metrics, cost charts) available to all admins.

Sending email has been manually disabled since it needs the script to be run first but will be re-enabled after ship

## Risks

Blast radius: All workspaces now see programmatic usage section and have credit-based rate limiting enabled
Risk: high. Team to be on alert

## Deploy Plan
- add $5 free credits to all expiring tomorrow (to avoid blockages in between deploy and backfill)
- deploy front
- run backfill_credits
- remove $5 free credits
- re-enable sending email