### PR TITLE
[SKILLS] Add button to create a new skill

### DIFF
--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -1,4 +1,4 @@
-import { Page } from "@dust-tt/sparkle";
+import { Button, Page, PlusIcon } from "@dust-tt/sparkle";
 import { PuzzleIcon } from "lucide-react";
 import type { InferGetServerSidePropsType } from "next";
 import Head from "next/head";
@@ -11,7 +11,9 @@ import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useSkillConfigurations } from "@app/lib/swr/skill_configurations";
+import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
+import { isBuilder } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -28,7 +30,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("skills")) {
+  if (!featureFlags.includes("skills") || !isBuilder(owner)) {
     return {
       notFound: true,
     };
@@ -67,6 +69,14 @@ export default function WorkspaceSkills({
           {/* TODO(skills 2025-12-05): use the right icon */}
           <Page.Header title="Manage Skills" icon={PuzzleIcon} />
           <Page.Vertical gap="md" align="stretch">
+            <div className="flex justify-end">
+              <Button
+                label="Create skill"
+                href={getSkillBuilderRoute(owner.sId, "new")}
+                icon={PlusIcon}
+                tooltip="Create a new skill"
+              />
+            </div>
             <div className="flex flex-col pt-3">
               <SkillsTable skillsConfigurations={skillConfigurations} />
             </div>


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/5418
Add link to new Skill from Manage skills page

**Out of scope**
- Search bar

<img width="1674" height="406" alt="Screenshot 2025-12-08 at 17 54 42" src="https://github.com/user-attachments/assets/30869a38-8adf-4cbe-a520-f9282839f26c" />


## Tests

local

## Risk

no

## Deploy Plan

front
