### PR TITLE
show draft status in agent message analytics

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -217,6 +217,7 @@ export async function getMessageUsageData(
              COALESCE(ac."sId", am."agentConfigurationId")               AS "assistant_id",
              COALESCE(ac."name", am."agentConfigurationId")              AS "assistant_name",
              CASE
+             	 WHEN ac."status" = 'draft' THEN 'draft'
                WHEN ac."scope" = 'visible' THEN 'published'
                WHEN ac."scope" = 'hidden' THEN 'unpublished'
                ELSE 'unknown'


### PR DESCRIPTION
## Description

Solves https://github.com/dust-tt/tasks/issues/5484

in the self-serve analytics export, specifically in export_dust_assistant_messages : 
- draft messages are correctly accounted for (they create a new row)
- but assistant_settings column currently not accounting for messages sent in "draft" status of the agent, it displays "published"


## Tests

Ran the query manually on [metabase](https://eu.metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InRlbXBsYXRlLXRhZ3MiOnt9LCJxdWVyeSI6IlNFTEVDVCBhbS5cImlkXCIgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFTIFwibWVzc2FnZV9pZFwiLFxuICAgICAgIFRPX0NIQVIoYW0uXCJjcmVhdGVkQXRcIjo6dGltZXN0YW1wLCAnWVlZWS1NTS1ERCBISDI0Ok1JOlNTJykgQVMgXCJjcmVhdGVkQXRcIixcbiAgICAgICBDT0FMRVNDRShhYy5cInNJZFwiLCBhbS5cImFnZW50Q29uZmlndXJhdGlvbklkXCIpICAgICAgICAgICAgICAgQVMgXCJhc3Npc3RhbnRfaWRcIixcbiAgICAgICBDT0FMRVNDRShhYy5cIm5hbWVcIiwgYW0uXCJhZ2VudENvbmZpZ3VyYXRpb25JZFwiKSAgICAgICAgICAgICAgQVMgXCJhc3Npc3RhbnRfbmFtZVwiLFxuICAgICAgIENBU0Vcblx0XHQgIFdIRU4gYWMuXCJzdGF0dXNcIiA9ICdkcmFmdCcgVEhFTiAnZHJhZnQnXG5cdFx0ICBXSEVOIGFjLlwic2NvcGVcIiA9ICd2aXNpYmxlJyBUSEVOICdwdWJsaXNoZWQnXG5cdFx0ICBXSEVOIGFjLlwic2NvcGVcIiA9ICdoaWRkZW4nIFRIRU4gJ3VucHVibGlzaGVkJ1xuXHRcdCAgRUxTRSAndW5rbm93bidcblx0XHRFTkQgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBBUyBcImFzc2lzdGFudF9zZXR0aW5nc1wiLFxuICAgICAgIHcuXCJpZFwiICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFTIFwid29ya3NwYWNlX2lkXCIsXG4gICAgICAgdy5cIm5hbWVcIiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgQVMgXCJ3b3Jrc3BhY2VfbmFtZVwiLFxuICAgICAgIGMuXCJpZFwiICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFTIFwiY29udmVyc2F0aW9uX2lkXCIsXG4gICAgICAgbS5cInBhcmVudElkXCIgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgQVMgXCJwYXJlbnRfbWVzc2FnZV9pZFwiLFxuICAgICAgIHVtLlwiaWRcIiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFTIFwidXNlcl9tZXNzYWdlX2lkXCIsXG4gICAgICAgdW0uXCJ1c2VySWRcIiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgQVMgXCJ1c2VyX2lkXCIsXG4gICAgICAgTE9XRVIodW0uXCJ1c2VyQ29udGV4dEVtYWlsXCIpICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgQVMgXCJ1c2VyX2VtYWlsXCIsXG4gICAgICAgdW0uXCJ1c2VyQ29udGV4dE9yaWdpblwiICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgQVMgXCJzb3VyY2VcIlxuRlJPTSBcImFnZW50X21lc3NhZ2VzXCIgYW1cbiAgICAgICBKT0lOIFwibWVzc2FnZXNcIiBtIE9OIGFtLlwiaWRcIiA9IG0uXCJhZ2VudE1lc3NhZ2VJZFwiXG4gICAgICAgSk9JTiBcImNvbnZlcnNhdGlvbnNcIiBjIE9OIG0uXCJjb252ZXJzYXRpb25JZFwiID0gYy5cImlkXCJcbiAgICAgICBKT0lOIFwid29ya3NwYWNlc1wiIHcgT04gYy5cIndvcmtzcGFjZUlkXCIgPSB3LlwiaWRcIlxuICAgICAgIExFRlQgSk9JTiBcImFnZW50X2NvbmZpZ3VyYXRpb25zXCIgYWNcbiAgICAgICAgIE9OIGFtLlwiYWdlbnRDb25maWd1cmF0aW9uSWRcIiA9IGFjLlwic0lkXCIgXG4gICAgICAgICBBTkQgYW0uXCJhZ2VudENvbmZpZ3VyYXRpb25WZXJzaW9uXCIgPSBhYy5cInZlcnNpb25cIlxuICAgICAgIExFRlQgSk9JTiBcIm1lc3NhZ2VzXCIgbTIgT04gbS5cInBhcmVudElkXCIgPSBtMi5cImlkXCJcbiAgICAgICBMRUZUIEpPSU4gXCJ1c2VyX21lc3NhZ2VzXCIgdW0gT04gbTIuXCJ1c2VyTWVzc2FnZUlkXCIgPSB1bS5cImlkXCJcbldIRVJFIGFtLlwic3RhdHVzXCIgPSAnc3VjY2VlZGVkJ1xuICBBTkQgdy5cImlkXCIgPSAyNzQ4Nzc5MDY5ODNcbiAgQU5EIGFtLlwiY3JlYXRlZEF0XCIgQkVUV0VFTiAnMjAyNS0xMS0xOFQwMDowMDowMCcgQU5EICcyMDI1LTExLTE4VDIzOjU5OjU5JyBcbm9yZGVyIGJ5IGFzc2lzdGFudF9uYW1lIEFTQyJ9fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9LCJ0eXBlIjoicXVlc3Rpb24ifQ==)

## Risk

low

## Deploy Plan

front only
