### PR TITLE
[front] feat: Freeze credit when purchase is disputed

### DIFF
--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -544,8 +544,8 @@ async function handler(
             : dispute.charge;
 
           if (!charge.invoice) {
-            logger.info(
-              { disputeId: dispute.id, chargeId: charge.id },
+            logger.warn(
+              { disputeId: dispute.id, chargeId: charge.id, stripeError: true },
               "[Stripe Webhook] Dispute charge has no associated invoice."
             );
             break;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5373

When a charge is disputed (`dispute.created`), we retrieve it, and if it is linked to a credit purchase invoice, we freeze it (i.e we don't delete the credit but it cannot be consumed anymore)

## Tests

Tested manually

## Risk

Low
Blast radius: small - disputes.created webhook

## Deploy Plan

- [ ] Deploy front