### PR TITLE
Unpause connector on subscription

### DIFF
--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -1,0 +1,59 @@
+import apiConfig from "@app/lib/api/config";
+import { getDataSources } from "@app/lib/api/data_sources";
+import type { Authenticator } from "@app/lib/auth";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import logger from "@app/logger/logger";
+import { terminateScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
+import { ConnectorsAPI, removeNulls } from "@app/types";
+
+/**
+ * Restores a workspace to full functionality after subscription activation/reactivation.
+ * This function is called when:
+ * - A new subscription is created (Stripe checkout or manual upgrade)
+ * - A subscription is reactivated after cancellation
+ *
+ * It performs the following actions:
+ * - Terminates the scheduled workspace scrub workflow (if any)
+ * - Unpauses all connectors (including webcrawler connectors)
+ * - Re-enables all triggers that point to non-archived agents
+ */
+export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {
+  const owner = auth.workspace();
+  if (!owner) {
+    throw new Error("Missing workspace on auth.");
+  }
+  const scrubCancelRes = await terminateScheduleWorkspaceScrubWorkflow({
+    workspaceId: owner.sId,
+  });
+  if (scrubCancelRes.isErr()) {
+    logger.error(
+      { stripeError: true, error: scrubCancelRes.error },
+      "Error terminating scrub workspace workflow."
+    );
+  }
+  const dataSources = await getDataSources(auth);
+  const connectorIds = removeNulls(dataSources.map((ds) => ds.connectorId));
+  const connectorsApi = new ConnectorsAPI(
+    apiConfig.getConnectorsAPIConfig(),
+    logger
+  );
+  for (const connectorId of connectorIds) {
+    const r = await connectorsApi.unpauseConnector(connectorId);
+    if (r.isErr()) {
+      logger.error(
+        { connectorId, stripeError: true, error: r.error },
+        "Error unpausing connector after subscription reactivation."
+      );
+    }
+  }
+
+  // Re-enable all triggers that point to non-archived agents
+  const enableTriggersRes = await TriggerResource.enableAllForWorkspace(auth);
+  if (enableTriggersRes.isErr()) {
+    logger.error(
+      { stripeError: true, error: enableTriggersRes.error },
+      "Error re-enabling workspace triggers on subscription reactivation"
+    );
+    // Don't throw error here - we want the function to continue even if trigger re-enabling fails
+  }
+}

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
@@ -86,6 +87,9 @@ async function handler(
         planCode,
         endDate: endDate ? new Date(endDate) : null,
       });
+
+      // Restore workspace functionality after subscription upgrade
+      await restoreWorkspaceAfterSubscription(auth);
 
       await pluginRun.recordResult({
         display: "text",

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import {
@@ -155,6 +156,8 @@ async function handler(
       // If yes, we will create the new plan and attach it to the workspace with a new subscription
       try {
         await SubscriptionResource.pokeUpgradeWorkspaceToEnterprise(auth, body);
+        // Restore workspace functionality after subscription upgrade
+        await restoreWorkspaceAfterSubscription(auth);
       } catch (error) {
         const errorString =
           error instanceof Error

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -37,7 +37,6 @@ import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -45,13 +44,10 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import {
-  launchScheduleWorkspaceScrubWorkflow,
-  terminateScheduleWorkspaceScrubWorkflow,
-} from "@app/temporal/scrub_workspace/client";
+import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever, ConnectorsAPI, removeNulls } from "@app/types";
+import { assertNever } from "@app/types";
 
 export type GetResponseBody = {
   success: boolean;


### PR DESCRIPTION
⚠️ This PR has the same goal as this [one](https://github.com/dust-tt/dust/pull/18595).
The old PR has been reverted [here](https://github.com/dust-tt/dust/pull/18784) because of circular dependencies. To avoid that, this new PR defines the `restoreWorkspaceAfterSubscription` function in a new file `subscription.ts` AND calls this function in the api handler level.

## Description

Refactors workspace restoration logic by extracting the `onCancelScrub` function from the Stripe webhook handler into a reusable `restoreWorkspaceAfterSubscription` function in the subscription API.
This function is now called consistently whenever a subscription is created or reactivated (Stripe checkout, manual enterprise subscription creation, or subscription reactivation after cancellation).

Existing connectors were not unpaused when restarting a subscription from Poke (see [error](https://app.datadoghq.eu/logs?query=%22Production%20check%20failed%22%20region%3Aus-central1%20-%40errorMessage%3A%22Google%20Drive%20documents%20not%20properly%20Garbage%20collected%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZrjWksE1sx2GgAAABhBWnJqV2xpYUFBRGhjOWxlT2dqQnNBRHEAAAAkZjE5YWUzNWItMmI3Ni00MTg4LTljMjQtOTRhMGQxNDhmYWE3AAOWwA&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764747057000&to_ts=1764750957000&live=false)).

## Tests

- Choose a test workspace
- Remove the subscription and check in the db (connectors table) that the connectors are paused (pausedAt != null)
- Upgrade to a plan again and check that the connectors are unpaused

## Risk

Low risk refactoring that consolidates existing functionality. The logic itself remains unchanged, we're just making it reusable and calling it in additional subscription activation scenarios where it was previously missing.

## Deploy Plan

Deploy front 
