### PR TITLE
[Programmatic Usage] Re-enable credit alert workflow

### DIFF
--- a/front/knip.ts
+++ b/front/knip.ts
@@ -9,11 +9,7 @@ const config: KnipConfig = {
     "mailing/**/*.{ts,js}",
     "next-sitemap.config.js",
   ],
-  ignoreFiles: [
-    "**/vite.config.js",
-    "**/esbuild.worker.ts",
-    "temporal/credit_alerts/**/*.ts",
-  ],
+  ignoreFiles: ["**/vite.config.js", "**/esbuild.worker.ts"],
   project: ["**/*.{js,jsx,ts,tsx}"],
   rules: {
     binaries: "off",


### PR DESCRIPTION
## Description

Re-enables the credit alert workflow that was temporarily disabled in #18811 while the backfill script was running.

Now that the backfill has completed and all workspaces have the required `creditAlertIdempotencyKey` metadata, the alert workflow can be safely re-enabled.

## Risks

Blast radius: Workspaces using programmatic usage will receive alerts when reaching 80% credit consumption
Risk: low

## Deploy Plan
- pmrr
- deploy front