### PR TITLE
Slack: `slack_tools` provider

### DIFF
--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -26,6 +26,7 @@ import { MondayOAuthProvider } from "@app/lib/api/oauth/providers/monday";
 import { NotionOAuthProvider } from "@app/lib/api/oauth/providers/notion";
 import { SalesforceOAuthProvider } from "@app/lib/api/oauth/providers/salesforce";
 import { SlackOAuthProvider } from "@app/lib/api/oauth/providers/slack";
+import { SlackToolsOAuthProvider } from "@app/lib/api/oauth/providers/slack_tools";
 import { VantaOAuthProvider } from "@app/lib/api/oauth/providers/vanta";
 import { ZendeskOAuthProvider } from "@app/lib/api/oauth/providers/zendesk";
 import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
@@ -73,6 +74,7 @@ const _PROVIDER_STRATEGIES: Record<OAuthProvider, BaseOAuthStrategyProvider> = {
   notion: new NotionOAuthProvider(),
   salesforce: new SalesforceOAuthProvider(),
   slack: new SlackOAuthProvider(),
+  slack_tools: new SlackToolsOAuthProvider(),
   zendesk: new ZendeskOAuthProvider(),
   vanta: new VantaOAuthProvider(),
 };

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -112,12 +112,13 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
           };
         case "labs_transcripts":
           assert(
+            false,
             "Unreachable useCase `labs_transcripts` in SlackOAuthProvider"
           );
-          return { user_scopes: [], bot_scopes: [] };
+          break;
         case "webhooks":
-          assert("Unreachable useCase `webhooks` in SlackOAuthProvider");
-          return { user_scopes: [], bot_scopes: [] };
+          assert(false, "Unreachable useCase `webhooks` in SlackOAuthProvider");
+          break;
         default:
           assertNever(useCase);
       }
@@ -139,14 +140,6 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
         case "bot":
         case "platform_actions":
           return config.getOAuthSlackBotClientId();
-        case "labs_transcripts":
-          assert(
-            "Unreachable useCase `labs_transcripts` in SlackOAuthProvider"
-          );
-          return "";
-        case "webhooks":
-          assert("Unreachable useCase `webhooks` in SlackOAuthProvider");
-          return "";
         default:
           assertNever(useCase);
       }

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -1,0 +1,181 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import { Err, OAuthAPI, Ok } from "@app/types";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+/**
+ * OAuth provider for Slack Tools MCP server.
+ *
+ * This is a dedicated provider separate from the main `slack` provider to ensure
+ * the Slack Tools MCP always uses the correct Slack App (Dust Slack Tools - A09361B9ULB)
+ * for both platform_actions and personal_actions use cases.
+ *
+ * This separation was needed because the slack_bot MCP server reused the `slack` provider's
+ * platform_actions with a different Slack App (the bot app), which broke the assumption that
+ * the workspace connection could be reused for personal actions.
+ */
+export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+    useCase,
+    extraConfig,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+    extraConfig?: ExtraConfigType;
+  }) {
+    const user_scopes = (() => {
+      switch (useCase) {
+        case "personal_actions":
+        case "platform_actions":
+          return [
+            // Write permissions.
+            "chat:write",
+            // Get and read chat and thread in any channels.
+            "channels:history",
+            "groups:history",
+            "im:history",
+            "mpim:history",
+            "channels:read",
+            "files:write",
+            "groups:read",
+            "im:read",
+            "mpim:read",
+            // Semantic search scopes.
+            "search:read.public",
+            "search:read.private",
+            // User info scopes.
+            "users:read.email",
+            "users:read",
+          ];
+        default:
+          throw new Error(
+            `Unsupported useCase "${useCase}" in SlackToolsOAuthProvider`
+          );
+      }
+    })();
+
+    const clientId = config.getOAuthSlackToolsClientId();
+
+    return (
+      `https://slack.com/oauth/v2/authorize?` +
+      `client_id=${clientId}` +
+      `&user_scope=${encodeURIComponent(user_scopes.join(" "))}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("slack_tools"))}` +
+      // Force the team id to be the same as the admin-setup.
+      // Edge-case: if the user is not in the team or not logged in, they might still connect to the wrong team.
+      // We catch it in the `checkConnectionValidPostFinalize` method.
+      (extraConfig?.requested_team_id
+        ? `&team=${extraConfig.requested_team_id}`
+        : "") +
+      `&state=${connection.connection_id}`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<ExtraConfigType> {
+    if (useCase === "personal_actions") {
+      // For personal actions we fetch the team id of the admin-setup (workspace connection)
+      // to enforce the team id to be the same as the admin-setup.
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id) {
+        const mcpServerConnectionRes =
+          await MCPServerConnectionResource.findByMCPServer(auth, {
+            mcpServerId: mcp_server_id,
+            connectionType: "workspace",
+          });
+
+        if (mcpServerConnectionRes.isErr()) {
+          throw new Error(
+            "Failed to find MCP server connection: " +
+              mcpServerConnectionRes.error.message
+          );
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getConnectionMetadata({
+          connectionId: mcpServerConnectionRes.value.connectionId,
+        });
+        if (connectionRes.isErr()) {
+          logger.error(
+            "Failed to get access token for admin-setup connection when updating the config for personal actions",
+            {
+              error: connectionRes.error,
+            }
+          );
+          throw new Error(
+            "Failed to get connection metadata: " + connectionRes.error.message
+          );
+        }
+
+        const teamId = connectionRes.value.connection.metadata.team_id;
+        const teamName = connectionRes.value.connection.metadata.team_name;
+
+        return {
+          ...restConfig,
+          requested_team_id: teamId,
+          requested_team_name: teamName,
+        };
+      }
+    }
+
+    return extraConfig;
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions") {
+      return (
+        Object.keys(extraConfig).length === 1 && "mcp_server_id" in extraConfig
+      );
+    }
+    // For platform_actions, no extra config is required.
+    return Object.keys(extraConfig).length === 0;
+  }
+
+  checkConnectionValidPostFinalize(connection: OAuthConnectionType) {
+    // If a team was requested, we need to check that the team id is the same as the requested team id.
+    if ("requested_team_id" in connection.metadata) {
+      if (
+        connection.metadata.team_id === connection.metadata.requested_team_id
+      ) {
+        return new Ok(undefined);
+      }
+      return new Err({
+        message:
+          "You must select `" +
+          connection.metadata.requested_team_name +
+          "` as the team to connect, instead of `" +
+          connection.metadata.team_name +
+          "`.",
+      });
+    }
+    return new Ok(undefined);
+  }
+}

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
@@ -59,7 +60,8 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
             "users:read",
           ];
         default:
-          throw new Error(
+          assert(
+            false,
             `Unsupported useCase "${useCase}" in SlackToolsOAuthProvider`
           );
       }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -271,9 +271,11 @@
         "@types/event-source-polyfill": "^1.0.5",
         "@types/node": "^22.7.5",
         "@types/uuid": "^9.0.7",
-        "dts-cli": "^2.0.5",
+        "esbuild": "^0.24.0",
         "eslint-plugin-simple-import-sort": "^12.1.0",
+        "npm-watch": "^0.11.0",
         "tslib": "^2.6.2",
+        "tsx": "^4.19.1",
         "typescript": "^5.4.5"
       },
       "engines": {

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -39,6 +39,7 @@ export const OAUTH_PROVIDERS = [
   "monday",
   "notion",
   "slack",
+  "slack_tools",
   "gong",
   "microsoft",
   "microsoft_tools",
@@ -65,6 +66,7 @@ export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
   monday: "Monday",
   notion: "Notion",
   slack: "Slack",
+  slack_tools: "Slack Tools",
   gong: "Gong",
   microsoft: "Microsoft",
   microsoft_tools: "Microsoft Tools",
@@ -203,6 +205,7 @@ export const getProviderRequiredOAuthCredentialInputs = async ({
       return null;
     case "hubspot":
     case "slack":
+    case "slack_tools":
     case "gong":
     case "microsoft":
     case "microsoft_tools":

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2876,6 +2876,7 @@ const OAuthProviderSchema = FlexibleEnumSchema<
   | "monday"
   | "notion"
   | "slack"
+  | "slack_tools"
   | "gong"
   | "microsoft"
   | "microsoft_tools"


### PR DESCRIPTION
## Description

Related to: https://github.com/dust-tt/tasks/issues/5397
Follow-up to: https://github.com/dust-tt/dust/pull/18803

Adds the `slack_tools` provider to `front` but does not use it yet.

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `front` (no-op)