### PR TITLE
Slack: switch to use  for Slack Tools MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -582,7 +582,7 @@ export const INTERNAL_MCP_SERVERS = {
       version: "1.0.0",
       description: "Slack tools for searching and posting messages.",
       authorization: {
-        provider: "slack" as const,
+        provider: "slack_tools" as const,
         supported_use_cases: ["personal_actions"] as const,
       },
       icon: "SlackLogo",


### PR DESCRIPTION
## Description

Switch to using `slack_tools` provider. Once rolled-out the connections associated with some MCP Servers will still be erroneous (pointing still to `slack` instead of `slack_tools`). We will evaluate then the number of them and decide on how to proceed with fixing their state or communicating with them.

## Tests

Test protocol local:

- Without this code
  - [x] Setup Slack Tools MCP Server
  - [x] Confirm that as admin owner of it, it fails to be used due to the bug
  - [x] Confirm that as another user it works
  - [x] Run migration in `core/oauth`
  - [x] Check that as as non-owner user it still works without this code

- Checkout this code
  - [x] Setup Slack Tools MCP Server
  - [x] Confirm that as admin owner of it, it can be used without re-auth
  - [x] Confirm that as another user it works
  
## Risk

Once tested locally. Low.

## Deploy Plan

- run `platform_actions` and `personal_actions` migrations in `core/oauth`
- deploy `front`