### PR TITLE
[front] refactor(skills): use resource in duplicate check

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -22,6 +22,7 @@ import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
@@ -140,7 +141,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    */
   static async makeNewSkillEditorsGroup(
     auth: Authenticator,
-    skill: SkillConfigurationModel,
+    skill: SkillConfigurationResource,
     { transaction }: { transaction?: Transaction } = {}
   ) {
     const user = auth.getNonNullableUser();

--- a/front/lib/resources/skill_configuration_resource.ts
+++ b/front/lib/resources/skill_configuration_resource.ts
@@ -197,6 +197,25 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
     return customSkills.map((skill) => new this(this.model, skill.get()));
   }
 
+  static async fetchActiveByName(
+    auth: Authenticator,
+    name: string
+  ): Promise<SkillConfigurationResource | null> {
+    const resources = await this.baseFetch(auth, {
+      where: {
+        name,
+        status: "active",
+      },
+      limit: 1,
+    });
+
+    if (resources.length === 0) {
+      return null;
+    }
+
+    return resources[0];
+  }
+
   get sId(): string {
     return SkillConfigurationResource.modelIdToSId({
       id: this.id,

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.test.ts
@@ -220,7 +220,7 @@ describe("GET /api/w/[wId]/assistant/skill_configurations", () => {
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(403);
+    expect(res._getStatusCode()).toBe(400);
     const data = res._getJSONData();
     expect(data.error.type).toBe("invalid_request_error");
     expect(data.error.message).toBe("Invalid agent configuration ID.");

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.test.ts
@@ -183,8 +183,8 @@ describe("GET /api/w/[wId]/assistant/skill_configurations", () => {
     expect(data.skills[0].name).toBe("Workspace Skill");
   });
 
-  it("should work for different user roles (user, builder, admin)", async () => {
-    for (const role of ["user", "builder", "admin"] as const) {
+  it("should work for builder roles (builder, admin)", async () => {
+    for (const role of ["builder", "admin"] as const) {
       const { req, res, workspace, user } = await setupTest("GET", role);
 
       const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -220,7 +220,7 @@ describe("GET /api/w/[wId]/assistant/skill_configurations", () => {
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(400);
+    expect(res._getStatusCode()).toBe(403);
     const data = res._getJSONData();
     expect(data.error.type).toBe("invalid_request_error");
     expect(data.error.message).toBe("Invalid agent configuration ID.");

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.test.ts
@@ -21,7 +21,7 @@ import handler from "./index";
 
 async function setupTest(
   method: RequestMethod = "GET",
-  role: MembershipRoleType = "user"
+  role: MembershipRoleType = "builder"
 ) {
   const mockRequest = await createPrivateApiMockRequest({
     method,

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
@@ -14,7 +14,6 @@ import {
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
-import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -22,15 +21,7 @@ import { isGlobalAgentId, isString } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/skill_configuration";
 
 export type PostSkillConfigurationResponseBody = {
-  skillConfiguration: Omit<
-    SkillConfigurationType,
-    | "author"
-    | "requestedSpaceIds"
-    | "workspaceId"
-    | "createdAt"
-    | "updatedAt"
-    | "authorId"
-  >;
+  skillConfiguration: SkillConfigurationType;
 };
 
 export interface GetAgentSkillsResponseBody {
@@ -150,8 +141,10 @@ async function handler(
 
       const body: PostSkillConfigurationRequestBody = bodyValidation.right;
 
-      const existingSkill =
-        await SkillConfigurationResource.fetchActiveByName(auth, body.name);
+      const existingSkill = await SkillConfigurationResource.fetchActiveByName(
+        auth,
+        body.name
+      );
 
       if (existingSkill) {
         return apiError(req, res, {
@@ -220,16 +213,7 @@ async function handler(
       });
 
       return res.status(200).json({
-        skillConfiguration: {
-          sId: skillConfiguration.sId,
-          name: skillConfiguration.name,
-          description: skillConfiguration.description,
-          instructions: skillConfiguration.instructions,
-          status: skillConfiguration.status,
-          scope: skillConfiguration.scope,
-          version: skillConfiguration.version,
-          tools: body.tools,
-        },
+        skillConfiguration: skillConfiguration.toJSON(),
       });
     }
 

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
@@ -15,6 +15,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isGlobalAgentId, isString } from "@app/types";

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
@@ -14,7 +14,7 @@ import {
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
-import { makeSId } from "@app/lib/resources/string_ids";
+import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -150,15 +150,8 @@ async function handler(
 
       const body: PostSkillConfigurationRequestBody = bodyValidation.right;
 
-      // Check for existing active skill with the same name.
-      // TODO(skills): consolidate this kind of db interaction within a resource.
-      const existingSkill = await SkillConfigurationModel.findOne({
-        where: {
-          workspaceId: owner.id,
-          name: body.name,
-          status: "active",
-        },
-      });
+      const existingSkill =
+        await SkillConfigurationResource.fetchActiveByName(auth, body.name);
 
       if (existingSkill) {
         return apiError(req, res, {
@@ -191,7 +184,7 @@ async function handler(
 
       // Use a transaction to ensure all creates succeed or all are rolled back
       const skillConfiguration = await withTransaction(async (transaction) => {
-        const skill = await SkillConfigurationModel.create(
+        const skill = await SkillConfigurationResource.makeNew(
           {
             workspaceId: owner.id,
             version: 0,
@@ -228,10 +221,7 @@ async function handler(
 
       return res.status(200).json({
         skillConfiguration: {
-          sId: makeSId("skill", {
-            id: skillConfiguration.id,
-            workspaceId: skillConfiguration.workspaceId,
-          }),
+          sId: skillConfiguration.sId,
           name: skillConfiguration.name,
           description: skillConfiguration.description,
           instructions: skillConfiguration.instructions,

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
@@ -196,6 +196,7 @@ async function handler(
 
         // Create MCP server configurations (tools) for this skill
         for (const mcpServerView of mcpServerViews) {
+          // TODO(skills 2025-12-09): move this to the makeNew.
           await SkillMCPServerConfigurationModel.create(
             {
               workspaceId: owner.id,
@@ -210,7 +211,10 @@ async function handler(
       });
 
       return res.status(200).json({
-        skillConfiguration: skillConfiguration.toJSON(),
+        skillConfiguration: {
+          ...skillConfiguration.toJSON(),
+          tools: body.tools,
+        },
       });
     }
 

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
@@ -7,15 +7,11 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import {
-  SkillConfigurationModel,
-  SkillMCPServerConfigurationModel,
-} from "@app/lib/models/skill";
+import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isGlobalAgentId, isString } from "@app/types";


### PR DESCRIPTION
## Description

- This PR refactors the response of the `/skill_configurations` endpoint to rely on the `SkillConfigurationResource` when performing the name unicity check.

## Tests

- Tested locally.

## Risk

- Low, behind FF.

## Deploy Plan

- Deploy front.
