### PR TITLE
[front] fix(skills): add builder check on skill creation

### DIFF
--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
@@ -58,6 +58,17 @@ async function handler(
     });
   }
 
+  if (!auth.isBuilder()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only users that are `builders` for the current workspace can manage skills.",
+      },
+    });
+  }
+
   switch (req.method) {
     case "POST": {
       const bodyValidation = PostSkillConfigurationRequestBodySchema.decode(

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -13,11 +13,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   user: UserType;
   subscription: SubscriptionType;
-}>(async (context, auth) => {
+}>(async (_, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
 
-  if (!owner || !auth.isUser() || !subscription) {
+  if (!owner || !auth.isBuilder() || !subscription) {
     return {
       notFound: true,
     };


### PR DESCRIPTION
## Description

- This PR checks that the user is a builder in the endpoint and on the page to create a skill.

## Tests

- Tested locally.

## Risk

- Low, behind FF.

## Deploy Plan

- Deploy front.
