### PR TITLE
[front] chore(skills): remove model IDs from serialized objects

### DIFF
--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -8,7 +8,7 @@ import type { UserType } from "@app/types";
 import type { SkillConfigurationWithAuthorType } from "@app/types/skill_configuration";
 
 type RowData = {
-  id: number;
+  sId: string;
   name: string;
   description: string;
   author: SkillConfigurationWithAuthorType["author"];

--- a/front/lib/resources/skill_configuration_resource.ts
+++ b/front/lib/resources/skill_configuration_resource.ts
@@ -168,10 +168,8 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
     if (this.author) {
       return {
         sId: this.sId,
-        id: this.id,
         createdAt: this.createdAt,
         updatedAt: this.updatedAt,
-        workspaceId: this.workspaceId,
         version: this.version,
         status: this.status,
         scope: this.scope,
@@ -195,17 +193,14 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
 
     return {
       sId: this.sId,
-      id: this.id,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
-      workspaceId: this.workspaceId,
       version: this.version,
       status: this.status,
       scope: this.scope,
       name: this.name,
       description: this.description,
       instructions: this.instructions,
-      authorId: this.authorId,
       requestedSpaceIds: this.requestedSpaceIds,
     };
   }

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
@@ -114,7 +114,6 @@ async function handler(
 
       return res.status(200).json({
         skillConfiguration: {
-          id: skillConfiguration.id,
           sId: makeSId("skill", {
             id: skillConfiguration.id,
             workspaceId: skillConfiguration.workspaceId,

--- a/front/types/skill_configuration.ts
+++ b/front/types/skill_configuration.ts
@@ -5,23 +5,17 @@ export type SkillScope = "private" | "workspace";
 
 export type SkillConfigurationType = {
   sId: string;
-  id: number;
   createdAt: Date;
   updatedAt: Date;
-  workspaceId: number;
   version: number;
   status: SkillStatus;
   scope: SkillScope;
   name: string;
   description: string;
   instructions: string;
-  authorId: number;
   requestedSpaceIds: number[];
 };
 
-export type SkillConfigurationWithAuthorType = Omit<
-  SkillConfigurationType,
-  "authorId"
-> & {
+export type SkillConfigurationWithAuthorType = SkillConfiguration & {
   author: Omit<UserType, "lastLoginAt" | "provider">;
 };

--- a/front/types/skill_configuration.ts
+++ b/front/types/skill_configuration.ts
@@ -17,6 +17,6 @@ export type SkillConfigurationType = {
   requestedSpaceIds: ModelId[];
 };
 
-export type SkillConfigurationWithAuthorType = SkillConfiguration & {
+export type SkillConfigurationWithAuthorType = SkillConfigurationType & {
   author: Omit<UserType, "lastLoginAt" | "provider">;
 };

--- a/front/types/skill_configuration.ts
+++ b/front/types/skill_configuration.ts
@@ -1,3 +1,4 @@
+import type { ModelId } from "./shared/model_id";
 import type { UserType } from "./user";
 
 export type SkillStatus = "active" | "archived";
@@ -13,7 +14,7 @@ export type SkillConfigurationType = {
   name: string;
   description: string;
   instructions: string;
-  requestedSpaceIds: number[];
+  requestedSpaceIds: ModelId[];
 };
 
 export type SkillConfigurationWithAuthorType = SkillConfiguration & {


### PR DESCRIPTION
## Description

- This PR removes the model IDs in the serialized object for a skill configuration.
- Rationale is that we ideally don't expose those to the front-end, and have it rely on sqids exclusively.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
