### PR TITLE
[front] chore(skills): add `SKILL_ICON` variable

### DIFF
--- a/front/components/assistant/ManageDropdownMenu.tsx
+++ b/front/components/assistant/ManageDropdownMenu.tsx
@@ -8,10 +8,9 @@ import {
   RobotIcon,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
-
-import { SKILL_ICON } from "@app/lib/skill";
 import { useState } from "react";
 
+import { SKILL_ICON } from "@app/lib/skill";
 import {
   getAgentBuilderRoute,
   getSkillBuilderRoute,

--- a/front/components/assistant/ManageDropdownMenu.tsx
+++ b/front/components/assistant/ManageDropdownMenu.tsx
@@ -7,8 +7,9 @@ import {
   DropdownMenuTrigger,
   RobotIcon,
 } from "@dust-tt/sparkle";
-import { PuzzleIcon } from "lucide-react";
 import { useRouter } from "next/router";
+
+import { SKILL_ICON } from "@app/lib/skill";
 import { useState } from "react";
 
 import {
@@ -31,7 +32,6 @@ export const ManageDropdownMenu = ({ owner }: ManageDropdownMenuProps) => {
         <Button
           variant="primary"
           label="Manage"
-          // TODO(skills 2025-12-05): use the right icon
           icon={ContactsRobotIcon}
           size="sm"
           isSelect
@@ -50,8 +50,7 @@ export const ManageDropdownMenu = ({ owner }: ManageDropdownMenuProps) => {
         />
         <DropdownMenuItem
           label="skills"
-          // TODO(skills 2025-12-05): use the right icon
-          icon={PuzzleIcon}
+          icon={SKILL_ICON}
           onClick={() => {
             setIsLoading(true);
             void router.push(getSkillBuilderRoute(owner.sId, "manage"));

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -32,7 +32,6 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { PuzzleIcon } from "lucide-react";
 import moment from "moment";
 import type { NextRouter } from "next/router";
 import { useRouter } from "next/router";
@@ -65,6 +64,7 @@ import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversation
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
+import { SKILL_ICON } from "@app/lib/skill";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useConversations,
@@ -477,8 +477,7 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
                             />
                             <DropdownMenuItem
                               href={getSkillBuilderRoute(owner.sId, "manage")}
-                              // TODO(skills 2025-12-05): use the right icon
-                              icon={PuzzleIcon}
+                              icon={SKILL_ICON}
                               label="Skills"
                             />
                           </DropdownMenuSubContent>

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -1,0 +1,4 @@
+import { PuzzleIcon } from "lucide-react";
+
+// TODO(skills 2025-12-05): use the right icon
+export const SKILL_ICON = PuzzleIcon;

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -1,5 +1,4 @@
 import { Button, Page, PlusIcon } from "@dust-tt/sparkle";
-import { PuzzleIcon } from "lucide-react";
 import type { InferGetServerSidePropsType } from "next";
 import Head from "next/head";
 
@@ -10,6 +9,7 @@ import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { SKILL_ICON } from "@app/lib/skill";
 import { useSkillConfigurations } from "@app/lib/swr/skill_configurations";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
@@ -66,8 +66,7 @@ export default function WorkspaceSkills({
           <title>Dust - Manage Skills</title>
         </Head>
         <div className="flex w-full flex-col gap-8 pt-2 lg:pt-8">
-          {/* TODO(skills 2025-12-05): use the right icon */}
-          <Page.Header title="Manage Skills" icon={PuzzleIcon} />
+          <Page.Header title="Manage Skills" icon={SKILL_ICON} />
           <Page.Vertical gap="md" align="stretch">
             <div className="flex justify-end">
               <Button


### PR DESCRIPTION
## Description

- This PR introduces a global variable `SKILL_ICON` that controls the icon used to identify the skills visually throughout the product.
- We currently have the same TODO about updating the icon scattered at several places, now we'll only have 1 location.

## Tests

- Tested locally.

## Risk

- None.

## Deploy Plan

- Deploy front.
