### PR TITLE
[front] feat(fathom): add option to trigger on shared transcripts

### DIFF
--- a/front/lib/triggers/built-in-webhooks/fathom/constants.ts
+++ b/front/lib/triggers/built-in-webhooks/fathom/constants.ts
@@ -9,17 +9,16 @@ export const RECORDING_TYPE_OPTIONS = [
     label: "Shared External Recordings",
     description: "Recordings shared with you from outside your team",
   },
-  // Disabled until we can improve the filter generation to generate more selective filters.
-  // {
-  //   value: "my_shared_with_team_recordings",
-  //   label: "My Shared with Team Recordings",
-  //   description: "Your recordings shared with your team",
-  // },
-  // {
-  //   value: "shared_team_recordings",
-  //   label: "Shared Team Recordings",
-  //   description: "Recordings from your team members",
-  // },
+  {
+    value: "my_shared_with_team_recordings",
+    label: "My Shared with Team Recordings",
+    description: "Your recordings shared with your team",
+  },
+  {
+    value: "shared_team_recordings",
+    label: "Shared Team Recordings",
+    description: "Recordings from your team members",
+  },
 ] as const;
 
 export const RECORDING_TYPE_LABELS: Record<string, string> =


### PR DESCRIPTION
## Description

- This PR adds back the option to select "My Shared with Team Recordings" and "Shared Team Recordings" transcripts when configuring a Fathom webhook source.
- This option was removed to prevent creating a way to hit rate limits too often (predates some additional work on rate limits).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
