### PR TITLE
[front] feat(webhooks): add option to specify provider-specific instructions

### DIFF
--- a/front/lib/triggers/built-in-webhooks/fathom/preset.ts
+++ b/front/lib/triggers/built-in-webhooks/fathom/preset.ts
@@ -27,6 +27,7 @@ export const FATHOM_WEBHOOK_PRESET: PresetWebhook<"fathom"> = {
   icon: "FathomLogo",
   description:
     "Receive events from Fathom when meeting recordings are ready with transcripts, summaries, and action items.",
+  filterGenerationInstructions: null,
   webhookPageUrl: "https://app.fathom.video/settings/api",
   webhookService: new FathomWebhookService(),
   components: {

--- a/front/lib/triggers/built-in-webhooks/github/preset.ts
+++ b/front/lib/triggers/built-in-webhooks/github/preset.ts
@@ -87,6 +87,7 @@ export const GITHUB_WEBHOOK_PRESET: PresetWebhook<"github"> = {
   icon: "GithubLogo",
   description:
     "Receive events from GitHub such as creation or edition of issues or pull requests.",
+  filterGenerationInstructions: null,
   webhookPageUrl: `https://github.com/settings/connections/applications/${process.env.NEXT_PUBLIC_OAUTH_GITHUB_APP_WEBHOOKS_CLIENT_ID}`,
   webhookService: new GitHubWebhookService(),
   components: {

--- a/front/lib/triggers/built-in-webhooks/jira/preset.ts
+++ b/front/lib/triggers/built-in-webhooks/jira/preset.ts
@@ -52,6 +52,7 @@ export const JIRA_WEBHOOK_PRESET: PresetWebhook<"jira"> = {
   ],
   icon: "JiraLogo",
   description: "Receive events from Jira such as creation of issues.",
+  filterGenerationInstructions: null,
   webhookPageUrl: `https://id.atlassian.com/manage-profile/security/api-tokens`,
   webhookService: new JiraWebhookService(),
   components: {

--- a/front/lib/triggers/built-in-webhooks/linear/preset.ts
+++ b/front/lib/triggers/built-in-webhooks/linear/preset.ts
@@ -33,6 +33,7 @@ export const LINEAR_WEBHOOK_PRESET: PresetWebhook<"linear"> = {
   events: [LINEAR_ISSUE_EVENT, LINEAR_PROJECT_EVENT],
   icon: "LinearLogo",
   description: "Receive events from Linear.",
+  filterGenerationInstructions: null,
   webhookPageUrl: "https://linear.app/settings/api",
   webhookService: new LinearWebhookService(),
   components: {

--- a/front/lib/triggers/built-in-webhooks/zendesk/preset.ts
+++ b/front/lib/triggers/built-in-webhooks/zendesk/preset.ts
@@ -16,6 +16,7 @@ export const ZENDESK_WEBHOOK_PRESET: PresetWebhook<"zendesk"> = {
   description:
     "Receive events from Zendesk such as ticket creation or modification",
   webhookService: new ZendeskWebhookService(),
+  filterGenerationInstructions: null,
   components: {
     detailsComponent: WebhookSourceZendeskDetails,
     createFormComponent: CreateWebhookZendeskConnection,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -72,24 +72,24 @@ async function handler(
         });
       }
 
-      const r = await getWebhookFilterGeneration(auth, {
+      const filterGenerationResult = await getWebhookFilterGeneration(auth, {
         naturalDescription,
         event,
         providerSpecificInstructions,
       });
 
-      if (r.isErr()) {
+      if (filterGenerationResult.isErr()) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: r.error.message,
+            message: filterGenerationResult.error.message,
           },
         });
       }
 
       return res.status(200).json({
-        filter: r.value.filter,
+        filter: filterGenerationResult.value.filter,
       });
     }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/webhook_filter_generator.ts
@@ -55,9 +55,12 @@ async function handler(
         provider,
       } = bodyValidation.data;
 
-      const event = WEBHOOK_PRESETS[provider].events.find(
-        (event) => event.value === eventValue
-      );
+      const {
+        filterGenerationInstructions: providerSpecificInstructions,
+        events,
+      } = WEBHOOK_PRESETS[provider];
+
+      const event = events.find((event) => event.value === eventValue);
 
       if (!event) {
         return apiError(req, res, {
@@ -72,6 +75,7 @@ async function handler(
       const r = await getWebhookFilterGeneration(auth, {
         naturalDescription,
         event,
+        providerSpecificInstructions,
       });
 
       if (r.isErr()) {

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -45,6 +45,9 @@ export type PresetWebhook<P extends WebhookProvider = WebhookProvider> = {
   // For example, GitHub uses a specific header "X-GitHub-Event" to indicate the event type.
   eventCheck: EventCheck | null;
   events: WebhookEvent[];
+
+  // Optional instructions to help the LLM generate better webhook filters for this provider.
+  filterGenerationInstructions: string | null;
   // List of event values to ignore. For example, GitHub sends a "ping" event when a webhook is created.
   // We will not want to implement it, and don't want to throw errors when receiving it.
   event_blacklist?: string[];


### PR DESCRIPTION
## Description

- This PR adds a field `filterGenerationInstructions` on a webhook provider preset that will be appended to the filter generation dust app's instructions.

## Tests

- Tested locally (trace [here](https://ffed480854d2a33d3217ed5dc2c1277e1a773f9a2b9942b283733a4-apidata.googleusercontent.com/download/storage/v1/b/dust-llm-traces-test/o/TVMoDoBJfb%2Fllm_trace_6c35d378-8403-45d4-bdb5-c08426853a76.json?jk=AYaVEGNqw1D7ifThAQppcSZjNurlPmx83ozMtC5HOSwrypJJE17-tix6deKhTZCPs8ae19JWAeDpljFCDtJu7c8emleKKLq27C9ccIPWo1noGqWC-EiZXTJZYSUxF4PnzXS82GrkiPLT92LNe-G95V7L7iO0yL7Bm_11TPsRvtL0SHo8Q3NM0L17IQZCaPsbzLoKeiutd-Gahp-yynYL_BpCUvZjyue0E3jVQx4QeFwxk4VMW_6UH98oAs5X09bN9VNVl_KZkLI9akK__kWJf1lwwKsdurMac2D7fAyYLo4j82yF9Wc28o5ickS0LQnH6n3-yuoSfSZCZP18zYdP4ktLbCyTAD2jf4VTQHJOmAyZv1vrdSSbE-YAtDy1xYUktm4KJ3bzGXhdt2--w5dwQQQ_C8Vek_os9tTIjEueUMCdWBg22Nev7SNY7iwBAC3ZN5bNLOX5LI5WjzT_F1xZcWalRp7eGR5R9pm5UciAQ4fbTtD93Z7gV4z7-zJWejJX1SEEgnc9lAzUVjQmT9L0gK1o0jOSPRvD42nav-9JytDHBqKPSr5BjIDgp51VeBReR3Bae085feuT3gedHEpAWjKZ0CfdlJcjFQKnVrUsdYkAuF0FYV3kbz7G9f2CWjvwB-LeFa4gUzLEG3F6DLr0PZEx1eS7oWlXeYKeGZkZzbu3twdbns1_jugxI-pJYKJDgmWtqFx300pRYedpGdLviKU7vg10sya_I7upJ0MTKZMor-GWQ5ZrwK-ummN4-9KZkazaq1kzluRj5phPwY69sZGTd6Z5YsaQkzcn3wsd-yVfp-RB7Ev_E5PwV3wrnIc0ng97RNo6KbspLGqL1BckvFaEGxqyr4HhKf0yluXWudIczA2tQHlU32RwWSNM_Wb3BnVxJAsYpuaqZOEoIXGx_fSxflojNI-AP09_t-2KK9KEEg0x3H7-ZEE2DuKWnWo3vvYB3WB9MjwyZTO_VMu_aEeOwjyAFy--8Q-BdEJuvkEoNusSAncw5TNermzXSvR0lMw_btZXkSgfLKkd3gSrjR6c_LjLItkT_JtGCD0eUjpEq3gmZqd5oIbNfGdS8GG19TaWd71ASV7UgTyS8W0deKFnDNB8-Tk58WwVSatgH7ONvI48PECOGxMQY4ZQxrN-p9Z6b1TpMQx1i35_sTBzJaE7hzMx7CCT8QQedf0dmxC-QiCIFHEoV3yBY0Zoc948gtTWcFSIYkEPtF5qZxnJXxgLzPth-ftJwqRTpgCpPt4z--O3Phyi9ZFIniMBl9FySK1yHEOOlpwVlMIOLMxjL-FpMhBm9tiGbkYtKPF8i4n9qwU&isca=1)).

## Risk

- Low.

## Deploy Plan

- Deploy front.
