### PR TITLE
[front] chore: add `Model` suffix to Sequelize models

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -14,7 +14,7 @@ import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_s
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import {
-  AgentConfiguration,
+  AgentConfigurationModel,
   AgentUserRelationModel,
   GlobalAgentSettingsModel,
 } from "@app/lib/models/agent/agent";
@@ -22,14 +22,14 @@ import { AgentDataRetentionModel } from "@app/lib/models/agent/agent_data_retent
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
-  AgentMessage,
   AgentMessageFeedbackModel,
+  AgentMessageModel,
   ConversationModel,
   ConversationParticipantModel,
-  Mention,
-  Message,
-  MessageReaction,
-  UserMessage,
+  MentionModel,
+  MessageModel,
+  MessageReactionModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
@@ -48,7 +48,7 @@ import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
 import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import {
   SkillConfigurationModel,
   SkillMCPServerConfigurationModel,
@@ -147,13 +147,13 @@ async function main() {
 
   await ExtensionConfigurationModel.sync({ alter: true });
 
-  await Plan.sync({ alter: true });
-  await Subscription.sync({ alter: true });
+  await PlanModel.sync({ alter: true });
+  await SubscriptionModel.sync({ alter: true });
   await TemplateModel.sync({ alter: true });
   await CreditModel.sync({ alter: true });
   await ProgrammaticUsageConfigurationModel.sync({ alter: true });
 
-  await AgentConfiguration.sync({ alter: true });
+  await AgentConfigurationModel.sync({ alter: true });
   await AgentUserRelationModel.sync({ alter: true });
   await GlobalAgentSettingsModel.sync({ alter: true });
   await TagAgentModel.sync({ alter: true });
@@ -173,13 +173,13 @@ async function main() {
 
   await AgentDataSourceConfigurationModel.sync({ alter: true });
 
-  await UserMessage.sync({ alter: true });
-  await AgentMessage.sync({ alter: true });
+  await UserMessageModel.sync({ alter: true });
+  await AgentMessageModel.sync({ alter: true });
   await AgentMessageFeedbackModel.sync({ alter: true });
   await ContentFragmentModel.sync({ alter: true });
-  await Message.sync({ alter: true });
-  await MessageReaction.sync({ alter: true });
-  await Mention.sync({ alter: true });
+  await MessageModel.sync({ alter: true });
+  await MessageReactionModel.sync({ alter: true });
+  await MentionModel.sync({ alter: true });
 
   await AgentDataRetentionModel.sync({ alter: true });
   await AgentStepContentModel.sync({ alter: true });

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -48,7 +48,7 @@ import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
 import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import {
   SkillConfigurationModel,
   SkillMCPServerConfigurationModel,

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -1,29 +1,29 @@
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { InternalMCPServerCredentialModel } from "@app/lib/models/agent/actions/internal_mcp_server_credentials";
 import {
-  AgentChildAgentConfiguration,
+  AgentChildAgentConfigurationModel,
   AgentMCPActionModel,
-  AgentMCPActionOutputItem,
-  AgentMCPServerConfiguration,
+  AgentMCPActionOutputItemModel,
+  AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { MCPServerConnection } from "@app/lib/models/agent/actions/mcp_server_connection";
+import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
-import { AgentReasoningConfiguration } from "@app/lib/models/agent/actions/reasoning";
+import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
 import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import {
   AgentConfiguration,
-  AgentUserRelation,
-  GlobalAgentSettings,
+  AgentUserRelationModel,
+  GlobalAgentSettingsModel,
 } from "@app/lib/models/agent/agent";
 import { AgentDataRetentionModel } from "@app/lib/models/agent/agent_data_retention";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
   AgentMessage,
-  AgentMessageFeedback,
+  AgentMessageFeedbackModel,
   ConversationModel,
   ConversationParticipantModel,
   Mention,
@@ -44,9 +44,9 @@ import {
   TrackerDataSourceConfigurationModel,
   TrackerGenerationModel,
 } from "@app/lib/models/doc_tracker";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
-import { FeatureFlag } from "@app/lib/models/feature_flag";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { Plan, Subscription } from "@app/lib/models/plan";
 import {
@@ -58,9 +58,9 @@ import { TagModel } from "@app/lib/models/tags";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
 import {
   AppModel,
-  Clone,
-  Dataset,
-  Provider,
+  CloneModel,
+  DatasetModel,
+  ProviderModel,
 } from "@app/lib/resources/storage/models/apps";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { CreditModel } from "@app/lib/resources/storage/models/credits";
@@ -116,13 +116,13 @@ async function main() {
 
   await SpaceModel.sync({ alter: true });
   await AppModel.sync({ alter: true });
-  await Dataset.sync({ alter: true });
-  await Provider.sync({ alter: true });
-  await Clone.sync({ alter: true });
+  await DatasetModel.sync({ alter: true });
+  await ProviderModel.sync({ alter: true });
+  await CloneModel.sync({ alter: true });
   await KeyModel.sync({ alter: true });
   await FileModel.sync({ alter: true });
   await ShareableFileModel.sync({ alter: true });
-  await DustAppSecret.sync({ alter: true });
+  await DustAppSecretModel.sync({ alter: true });
   await GroupSpaceModel.sync({ alter: true });
 
   await WebhookSourceModel.sync({ alter: true });
@@ -154,28 +154,28 @@ async function main() {
   await ProgrammaticUsageConfigurationModel.sync({ alter: true });
 
   await AgentConfiguration.sync({ alter: true });
-  await AgentUserRelation.sync({ alter: true });
-  await GlobalAgentSettings.sync({ alter: true });
+  await AgentUserRelationModel.sync({ alter: true });
+  await GlobalAgentSettingsModel.sync({ alter: true });
   await TagAgentModel.sync({ alter: true });
   await GroupAgentModel.sync({ alter: true });
 
   await RemoteMCPServerModel.sync({ alter: true });
   await MCPServerViewModel.sync({ alter: true });
-  await MCPServerConnection.sync({ alter: true });
+  await MCPServerConnectionModel.sync({ alter: true });
   await RemoteMCPServerToolMetadataModel.sync({ alter: true });
   await InternalMCPServerCredentialModel.sync({ alter: true });
 
   await ConversationMCPServerViewModel.sync({ alter: true });
 
-  await AgentMCPServerConfiguration.sync({ alter: true });
-  await AgentTablesQueryConfigurationTable.sync({ alter: true });
-  await AgentReasoningConfiguration.sync({ alter: true });
+  await AgentMCPServerConfigurationModel.sync({ alter: true });
+  await AgentTablesQueryConfigurationTableModel.sync({ alter: true });
+  await AgentReasoningConfigurationModel.sync({ alter: true });
 
-  await AgentDataSourceConfiguration.sync({ alter: true });
+  await AgentDataSourceConfigurationModel.sync({ alter: true });
 
   await UserMessage.sync({ alter: true });
   await AgentMessage.sync({ alter: true });
-  await AgentMessageFeedback.sync({ alter: true });
+  await AgentMessageFeedbackModel.sync({ alter: true });
   await ContentFragmentModel.sync({ alter: true });
   await Message.sync({ alter: true });
   await MessageReaction.sync({ alter: true });
@@ -184,10 +184,10 @@ async function main() {
   await AgentDataRetentionModel.sync({ alter: true });
   await AgentStepContentModel.sync({ alter: true });
   await AgentMCPActionModel.sync({ alter: true });
-  await AgentMCPActionOutputItem.sync({ alter: true });
-  await AgentChildAgentConfiguration.sync({ alter: true });
+  await AgentMCPActionOutputItemModel.sync({ alter: true });
+  await AgentChildAgentConfigurationModel.sync({ alter: true });
 
-  await FeatureFlag.sync({ alter: true });
+  await FeatureFlagModel.sync({ alter: true });
   await KillSwitchModel.sync({ alter: true });
 
   await LabsTranscriptsConfigurationModel.sync({ alter: true });

--- a/front/lib/actions/configuration/helpers.ts
+++ b/front/lib/actions/configuration/helpers.ts
@@ -3,8 +3,8 @@ import type {
   DataSourceFilter,
   TableDataSourceConfiguration,
 } from "@app/lib/api/assistant/configuration/types";
-import type { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
-import type { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import type { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
+import type { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 
@@ -17,7 +17,7 @@ export type RetrievalTimeframe =
     };
 
 export function renderDataSourceConfiguration(
-  dataSourceConfig: AgentDataSourceConfiguration
+  dataSourceConfig: AgentDataSourceConfigurationModel
 ): DataSourceConfiguration & { sId: string } {
   const { dataSourceView } = dataSourceConfig;
 
@@ -56,7 +56,7 @@ export function renderDataSourceConfiguration(
 }
 
 export function renderTableConfiguration(
-  table: AgentTablesQueryConfigurationTable
+  table: AgentTablesQueryConfigurationTableModel
 ): TableDataSourceConfiguration & { sId: string } {
   const { dataSourceView } = table;
 

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -11,13 +11,13 @@ import {
 } from "@app/lib/actions/configuration/helpers";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
-  AgentChildAgentConfiguration,
-  AgentMCPServerConfiguration,
+  AgentChildAgentConfigurationModel,
+  AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { AgentReasoningConfiguration } from "@app/lib/models/agent/actions/reasoning";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
@@ -40,12 +40,13 @@ export async function fetchMCPServerActionConfigurations(
     return new Map();
   }
 
-  const mcpServerConfigurations = await AgentMCPServerConfiguration.findAll({
-    where: {
-      agentConfigurationId: { [Op.in]: configurationIds },
-      workspaceId: auth.getNonNullableWorkspace().id,
-    },
-  });
+  const mcpServerConfigurations =
+    await AgentMCPServerConfigurationModel.findAll({
+      where: {
+        agentConfigurationId: { [Op.in]: configurationIds },
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
 
   if (mcpServerConfigurations.length === 0) {
     return new Map();
@@ -54,10 +55,10 @@ export async function fetchMCPServerActionConfigurations(
   const workspace = auth.getNonNullableWorkspace();
 
   const whereClause: WhereOptions<
-    AgentDataSourceConfiguration &
-      AgentTablesQueryConfigurationTable &
-      AgentReasoningConfiguration &
-      AgentChildAgentConfiguration
+    AgentDataSourceConfigurationModel &
+      AgentTablesQueryConfigurationTableModel &
+      AgentReasoningConfigurationModel &
+      AgentChildAgentConfigurationModel
   > = {
     workspaceId: workspace.id,
     mcpServerConfigurationId: {
@@ -84,26 +85,27 @@ export async function fetchMCPServerActionConfigurations(
 
   // Find the associated data sources configurations.
   const allDataSourceConfigurations =
-    await AgentDataSourceConfiguration.findAll({
+    await AgentDataSourceConfigurationModel.findAll({
       where: whereClause,
       include: includeDataSourceViewClause,
     });
 
   // Find the associated tables configurations.
   const allTablesConfigurations =
-    await AgentTablesQueryConfigurationTable.findAll({
+    await AgentTablesQueryConfigurationTableModel.findAll({
       where: whereClause,
       include: includeDataSourceViewClause,
     });
 
   // Find the associated reasoning configurations.
-  const allReasoningConfigurations = await AgentReasoningConfiguration.findAll({
-    where: whereClause,
-  });
+  const allReasoningConfigurations =
+    await AgentReasoningConfigurationModel.findAll({
+      where: whereClause,
+    });
 
   // Find the associated child agent configurations.
   const allChildAgentConfigurations =
-    await AgentChildAgentConfiguration.findAll({ where: whereClause });
+    await AgentChildAgentConfigurationModel.findAll({ where: whereClause });
 
   const actionsByConfigurationId = new Map<
     ModelId,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -30,7 +30,7 @@ import { handleBase64Upload } from "@app/lib/actions/mcp_utils";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPActionOutputItem } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -69,7 +69,7 @@ export async function processToolNotification(
 
   // Handle store_resource notifications by creating output items immediately
   if (isStoreResourceProgressOutput(output)) {
-    await AgentMCPActionOutputItem.bulkCreate(
+    await AgentMCPActionOutputItemModel.bulkCreate(
       output.contents.map((content) => ({
         workspaceId: action.workspaceId,
         agentMCPActionId: action.id,
@@ -126,7 +126,7 @@ export async function processToolResults(
     toolConfiguration: LightMCPToolConfigurationType;
   }
 ): Promise<{
-  outputItems: AgentMCPActionOutputItem[];
+  outputItems: AgentMCPActionOutputItemModel[];
   generatedFiles: ActionGeneratedFileType[];
 }> {
   const fileUseCase: FileUseCase = "conversation";
@@ -336,7 +336,7 @@ export async function processToolResults(
     }
   );
 
-  const outputItems = await AgentMCPActionOutputItem.bulkCreate(
+  const outputItems = await AgentMCPActionOutputItemModel.bulkCreate(
     cleanContent.map((c) => ({
       workspaceId: action.workspaceId,
       agentMCPActionId: action.id,

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/client.ts
@@ -17,7 +17,7 @@ import {
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { decrypt, Err, Ok } from "@app/types";
@@ -44,7 +44,7 @@ export async function getAshbyClient(
     );
   }
 
-  const secret = await DustAppSecret.findOne({
+  const secret = await DustAppSecretModel.findOne({
     where: {
       name: toolConfig.secretName,
       workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/actions/mcp_internal_actions/servers/front.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/front.ts
@@ -9,7 +9,7 @@ import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers"
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import logger from "@app/logger/logger";
 import { decrypt, Err, normalizeError, Ok } from "@app/types";
 
@@ -146,7 +146,7 @@ async function getFrontAPIToken(
     );
   }
 
-  const secret = await DustAppSecret.findOne({
+  const secret = await DustAppSecretModel.findOne({
     where: {
       name: toolConfig.secretName,
       workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/actions/mcp_internal_actions/servers/http_client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/http_client.ts
@@ -12,7 +12,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import { untrustedFetch } from "@app/lib/egress/server";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { decrypt, Err, normalizeError, Ok } from "@app/types";
 
 const MAX_RESPONSE_SIZE = 1_000_000; // 1MB
@@ -82,7 +82,7 @@ async function getBearerToken(
     return null;
   }
 
-  const secret = await DustAppSecret.findOne({
+  const secret = await DustAppSecretModel.findOne({
     where: {
       name: toolConfig.secretName,
       workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/actions/mcp_internal_actions/servers/openai_usage.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/openai_usage.ts
@@ -7,7 +7,7 @@ import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers"
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { decrypt, Err, Ok } from "@app/types";
 
 function createServer(
@@ -155,7 +155,7 @@ function createServer(
           );
         }
 
-        const secret = await DustAppSecret.findOne({
+        const secret = await DustAppSecretModel.findOne({
           where: {
             name: toolConfig.secretName,
             workspaceId: auth.getNonNullableWorkspace().id,
@@ -316,7 +316,7 @@ function createServer(
           );
         }
 
-        const secret = await DustAppSecret.findOne({
+        const secret = await DustAppSecretModel.findOne({
           where: {
             name: toolConfig.secretName,
             workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -44,7 +44,7 @@ import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getResourcePrefix } from "@app/lib/resources/string_ids";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
@@ -139,7 +139,7 @@ async function leakyGetAgentNameAndDescriptionForChildAgent(
 
   const owner = auth.getNonNullableWorkspace();
 
-  const agentConfiguration = await AgentConfiguration.findOne({
+  const agentConfiguration = await AgentConfigurationModel.findOne({
     where: {
       sId: agentId,
       workspaceId: owner.id,

--- a/front/lib/actions/mcp_internal_actions/servers/salesloft/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesloft/index.ts
@@ -9,7 +9,7 @@ import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers"
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { decrypt, Err, Ok } from "@app/types";
 
 async function getBearerToken(
@@ -25,7 +25,7 @@ async function getBearerToken(
     return null;
   }
 
-  const secret = await DustAppSecret.findOne({
+  const secret = await DustAppSecretModel.findOne({
     where: {
       name: toolConfig.secretName,
       workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/actions/mcp_internal_actions/servers/valtown.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/valtown.ts
@@ -9,7 +9,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import { untrustedFetch } from "@app/lib/egress/server";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { decrypt, Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -41,7 +41,7 @@ async function getValTownClient(
     return null;
   }
 
-  const secret = await DustAppSecret.findOne({
+  const secret = await DustAppSecretModel.findOne({
     where: {
       name: toolConfig.secretName,
       workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/actions/mcp_internal_actions/tools/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.test.ts
@@ -2,8 +2,8 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { setupAgentOwner } from "@app/pages/api/w/[wId]/assistant/agent_configurations/index.test";
@@ -42,7 +42,7 @@ describe("MCP Internal Actions Server Utils", () => {
         await AgentMCPServerConfigurationFactory.create(auth, globalSpace);
 
       // Create a table configuration in a different workspace
-      const tableConfig = await AgentTablesQueryConfigurationTable.create({
+      const tableConfig = await AgentTablesQueryConfigurationTableModel.create({
         workspaceId: otherWorkspace.id,
         tableId: "test_table",
         dataSourceId: otherFolder.dataSource.id,
@@ -113,7 +113,7 @@ describe("MCP Internal Actions Server Utils", () => {
         await AgentMCPServerConfigurationFactory.create(auth, space);
 
       // Create a table configuration in the workspace
-      const tableConfig = await AgentTablesQueryConfigurationTable.create({
+      const tableConfig = await AgentTablesQueryConfigurationTableModel.create({
         workspaceId: workspace.id,
         tableId: "test_table",
         dataSourceId: folder.dataSource.id,
@@ -128,7 +128,7 @@ describe("MCP Internal Actions Server Utils", () => {
         otherWorkspace,
         otherSpace
       );
-      await AgentTablesQueryConfigurationTable.create({
+      await AgentTablesQueryConfigurationTableModel.create({
         workspaceId: otherWorkspace.id,
         tableId: "test_table",
         dataSourceId: otherFolder.dataSource.id,
@@ -197,7 +197,7 @@ describe("MCP Internal Actions Server Utils", () => {
         otherSpace
       );
 
-      const dataSourceConfig = await AgentDataSourceConfiguration.create({
+      const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
         workspaceId: otherWorkspace.id,
         dataSourceId: otherFolder.dataSource.id,
         dataSourceViewId: otherFolder.id,
@@ -244,7 +244,7 @@ describe("MCP Internal Actions Server Utils", () => {
       const space = await SpaceFactory.global(workspace);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
-      const dataSourceConfig = await AgentDataSourceConfiguration.create({
+      const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
         workspaceId: workspace.id,
         dataSourceId: folder.dataSource.id,
         dataSourceViewId: folder.id,
@@ -260,7 +260,7 @@ describe("MCP Internal Actions Server Utils", () => {
         otherWorkspace,
         otherSpace
       );
-      await AgentDataSourceConfiguration.create({
+      await AgentDataSourceConfigurationModel.create({
         workspaceId: otherWorkspace.id,
         dataSourceId: otherFolder.dataSource.id,
         dataSourceViewId: otherFolder.id,

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -13,8 +13,8 @@ import type {
   TableDataSourceConfiguration,
 } from "@app/lib/api/assistant/configuration/types";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
@@ -75,7 +75,7 @@ export function makeCoreSearchNodesFilters({
 
 async function fetchAgentDataSourceConfiguration(
   dataSourceConfigSId: string
-): Promise<Result<AgentDataSourceConfiguration, Error>> {
+): Promise<Result<AgentDataSourceConfigurationModel, Error>> {
   const sIdParts = getResourceNameAndIdFromSId(dataSourceConfigSId);
   if (!sIdParts) {
     return new Err(
@@ -91,7 +91,7 @@ async function fetchAgentDataSourceConfiguration(
   }
 
   const agentDataSourceConfiguration =
-    await AgentDataSourceConfiguration.findOne({
+    await AgentDataSourceConfigurationModel.findOne({
       where: {
         id: sIdParts.resourceModelId,
         workspaceId: sIdParts.workspaceModelId,
@@ -157,7 +157,7 @@ export async function fetchTableDataSourceConfigurations(
       }
 
       const agentTableConfiguration =
-        await AgentTablesQueryConfigurationTable.findOne({
+        await AgentTablesQueryConfigurationTableModel.findOne({
           where: {
             id: sIdParts.resourceModelId,
             workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -19,7 +19,7 @@ import type {
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMCPActionOutputItem } from "@app/lib/models/agent/actions/mcp";
+import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type {
   AgentConfigurationType,
@@ -96,7 +96,7 @@ export async function getExitOrPauseEvents(
     agentMessage,
     conversation,
   }: {
-    outputItems: AgentMCPActionOutputItem[];
+    outputItems: AgentMCPActionOutputItemModel[];
     action: AgentMCPActionResource;
     agentConfiguration: AgentConfigurationType;
     agentMessage: AgentMessageType;

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -19,7 +19,7 @@ import {
   uploadBase64ImageToFileStorage,
 } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMCPActionOutputItem } from "@app/lib/models/agent/actions/mcp";
+import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import type {
@@ -41,7 +41,7 @@ export function hideFileFromActionOutput({
   fileId,
   content,
   workspaceId,
-}: AgentMCPActionOutputItem): CallToolResult["content"][number] | null {
+}: AgentMCPActionOutputItemModel): CallToolResult["content"][number] | null {
   // For tool-generated files and non-file content, we keep the resource as is.
   if (!fileId || isToolGeneratedFile(content)) {
     return content;

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -4,7 +4,7 @@ import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { AgentsUsageType, ModelId } from "@app/types";
 
@@ -62,7 +62,7 @@ export async function getToolsUsage(
     ],
   });
 
-  const res = (await AgentConfiguration.findAll({
+  const res = (await AgentConfigurationModel.findAll({
     raw: true,
     group: [
       "mcpServerConfigurations->mcpServerView.internalMCPServerId",

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -2,7 +2,7 @@ import { Op, Sequelize } from "sequelize";
 
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -95,7 +95,7 @@ export async function getToolsUsage(
     ],
     include: [
       {
-        model: AgentMCPServerConfiguration,
+        model: AgentMCPServerConfigurationModel,
         as: "mcpServerConfigurations",
         attributes: [],
         required: true,

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -8,7 +8,7 @@ import { isManagedConnectorProvider } from "@app/lib/data_sources";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -109,7 +109,7 @@ export async function getDataSourceViewsUsageByCategory({
   });
 
   const agentConfigurationInclude = {
-    model: AgentConfiguration,
+    model: AgentConfigurationModel,
     as: "agent_configuration",
     attributes: [],
     required: true,
@@ -225,7 +225,7 @@ export async function getDataSourceViewsUsageByCategory({
           required: true,
           include: [
             {
-              model: AgentConfiguration,
+              model: AgentConfigurationModel,
               as: "agent_configuration",
               attributes: [],
               required: true,
@@ -361,7 +361,7 @@ export async function getDataSourcesUsageByCategory({
           required: true,
           include: [
             {
-              model: AgentConfiguration,
+              model: AgentConfigurationModel,
               as: "agent_configuration",
               attributes: [],
               required: true,
@@ -418,7 +418,7 @@ export async function getDataSourcesUsageByCategory({
           required: true,
           include: [
             {
-              model: AgentConfiguration,
+              model: AgentConfigurationModel,
               as: "agent_configuration",
               attributes: [],
               required: true,
@@ -530,7 +530,7 @@ export async function getDataSourceUsage({
           required: true,
           include: [
             {
-              model: AgentConfiguration,
+              model: AgentConfigurationModel,
               as: "agent_configuration",
               attributes: [],
               required: true,
@@ -577,7 +577,7 @@ export async function getDataSourceUsage({
           required: true,
           include: [
             {
-              model: AgentConfiguration,
+              model: AgentConfigurationModel,
               as: "agent_configuration",
               attributes: [],
               required: true,
@@ -675,7 +675,7 @@ export async function getDataSourceViewUsage({
           required: true,
           include: [
             {
-              model: AgentConfiguration,
+              model: AgentConfigurationModel,
               as: "agent_configuration",
               attributes: [],
               required: true,
@@ -722,7 +722,7 @@ export async function getDataSourceViewUsage({
           required: true,
           include: [
             {
-              model: AgentConfiguration,
+              model: AgentConfigurationModel,
               as: "agent_configuration",
               attributes: [],
               required: true,

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -5,9 +5,9 @@ import { Op, Sequelize } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { isManagedConnectorProvider } from "@app/lib/data_sources";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -119,7 +119,7 @@ export async function getDataSourceViewsUsageByCategory({
   };
 
   const res = (await Promise.all([
-    AgentDataSourceConfiguration.findAll({
+    AgentDataSourceConfigurationModel.findAll({
       raw: true,
       group: ["dataSourceView.id"],
       where: {
@@ -165,7 +165,7 @@ export async function getDataSourceViewsUsageByCategory({
           ],
         },
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           attributes: [],
           required: true,
@@ -173,7 +173,7 @@ export async function getDataSourceViewsUsageByCategory({
         },
       ],
     }),
-    AgentTablesQueryConfigurationTable.findAll({
+    AgentTablesQueryConfigurationTableModel.findAll({
       raw: true,
       group: ["dataSourceView.id"],
       where: {
@@ -219,7 +219,7 @@ export async function getDataSourceViewsUsageByCategory({
           ],
         },
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           attributes: [],
           required: true,
@@ -317,7 +317,7 @@ export async function getDataSourcesUsageByCategory({
   }
 
   const res = (await Promise.all([
-    AgentDataSourceConfiguration.findAll({
+    AgentDataSourceConfigurationModel.findAll({
       raw: true,
       group: ["dataSource.id"],
       where: {
@@ -355,7 +355,7 @@ export async function getDataSourcesUsageByCategory({
           },
         },
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           attributes: [],
           required: true,
@@ -374,7 +374,7 @@ export async function getDataSourcesUsageByCategory({
         },
       ],
     }),
-    AgentTablesQueryConfigurationTable.findAll({
+    AgentTablesQueryConfigurationTableModel.findAll({
       raw: true,
       group: ["dataSource.id"],
       where: {
@@ -412,7 +412,7 @@ export async function getDataSourcesUsageByCategory({
           },
         },
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           attributes: [],
           required: true,
@@ -496,7 +496,7 @@ export async function getDataSourceUsage({
   }
 
   const res = (await Promise.all([
-    AgentDataSourceConfiguration.findOne({
+    AgentDataSourceConfigurationModel.findOne({
       raw: true,
       attributes: [
         [
@@ -524,7 +524,7 @@ export async function getDataSourceUsage({
       },
       include: [
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           attributes: [],
           required: true,
@@ -543,7 +543,7 @@ export async function getDataSourceUsage({
         },
       ],
     }),
-    AgentTablesQueryConfigurationTable.findOne({
+    AgentTablesQueryConfigurationTableModel.findOne({
       raw: true,
       attributes: [
         [
@@ -571,7 +571,7 @@ export async function getDataSourceUsage({
       },
       include: [
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           attributes: [],
           required: true,
@@ -641,7 +641,7 @@ export async function getDataSourceViewUsage({
   }
 
   const res = (await Promise.all([
-    AgentDataSourceConfiguration.findOne({
+    AgentDataSourceConfigurationModel.findOne({
       raw: true,
       attributes: [
         [
@@ -669,7 +669,7 @@ export async function getDataSourceViewUsage({
       },
       include: [
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           attributes: [],
           required: true,
@@ -688,7 +688,7 @@ export async function getDataSourceViewUsage({
         },
       ],
     }),
-    AgentTablesQueryConfigurationTable.findOne({
+    AgentTablesQueryConfigurationTableModel.findOne({
       raw: true,
       attributes: [
         [
@@ -716,7 +716,7 @@ export async function getDataSourceViewUsage({
       },
       include: [
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           attributes: [],
           required: true,

--- a/front/lib/api/agent_triggers.ts
+++ b/front/lib/api/agent_triggers.ts
@@ -1,7 +1,7 @@
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { WebhookSourcesViewModel } from "@app/lib/models/agent/triggers/webhook_sources_view";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -55,7 +55,7 @@ async function getAccessibleAgentsInfoBySId({
         ],
       };
 
-  const accessibleAgents = await AgentConfiguration.findAll({
+  const accessibleAgents = await AgentConfigurationModel.findAll({
     attributes: ["id", "sId", "name"],
     where: agentWhereClause,
   });

--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -15,7 +15,7 @@ import {
 import { getShouldTrackTokenUsageCostsESFilter } from "@app/lib/api/programmatic_usage_tracking";
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -437,7 +437,7 @@ export async function handleProgrammaticCostRequest(
         const agentNames: Record<string, string> = {};
         if (groupBy === "agent") {
           const agentIds = availableGroupBuckets.map((b) => b.key);
-          const agents = await AgentConfiguration.findAll({
+          const agents = await AgentConfigurationModel.findAll({
             where: {
               sId: agentIds,
             },

--- a/front/lib/api/assistant/configuration/actions.ts
+++ b/front/lib/api/assistant/configuration/actions.ts
@@ -10,13 +10,13 @@ import type {
   TableDataSourceConfiguration,
 } from "@app/lib/api/assistant/configuration/types";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
-  AgentChildAgentConfiguration,
-  AgentMCPServerConfiguration,
+  AgentChildAgentConfigurationModel,
+  AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { AgentReasoningConfiguration } from "@app/lib/models/agent/actions/reasoning";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
@@ -54,7 +54,7 @@ export async function createAgentActionConfiguration(
       server: { name: serverName, description: serverDescription },
     } = mcpServerView.toJSON();
 
-    const mcpConfig = await AgentMCPServerConfiguration.create(
+    const mcpConfig = await AgentMCPServerConfigurationModel.create(
       {
         sId: generateRandomModelSId(),
         agentConfigurationId: agentConfiguration.id,
@@ -145,9 +145,9 @@ async function createAgentDataSourcesConfiguration(
     mcpServerConfiguration,
   }: {
     dataSourceConfigurations: DataSourceConfiguration[];
-    mcpServerConfiguration: AgentMCPServerConfiguration | null;
+    mcpServerConfiguration: AgentMCPServerConfigurationModel | null;
   }
-): Promise<AgentDataSourceConfiguration[]> {
+): Promise<AgentDataSourceConfigurationModel[]> {
   const owner = auth.getNonNullableWorkspace();
 
   // Although we have the capability to support multiple workspaces,
@@ -210,9 +210,12 @@ async function createAgentDataSourcesConfiguration(
     })
   );
 
-  return AgentDataSourceConfiguration.bulkCreate(agentDataSourceConfigBlobs, {
-    transaction: t,
-  });
+  return AgentDataSourceConfigurationModel.bulkCreate(
+    agentDataSourceConfigBlobs,
+    {
+      transaction: t,
+    }
+  );
 }
 
 async function createTableDataSourceConfiguration(
@@ -223,7 +226,7 @@ async function createTableDataSourceConfiguration(
     mcpConfig,
   }: {
     tableConfigurations: TableDataSourceConfiguration[];
-    mcpConfig: AgentMCPServerConfiguration;
+    mcpConfig: AgentMCPServerConfigurationModel;
   }
 ) {
   const owner = auth.getNonNullableWorkspace();
@@ -267,7 +270,7 @@ async function createTableDataSourceConfiguration(
     })
   );
 
-  return AgentTablesQueryConfigurationTable.bulkCreate(tableConfigBlobs, {
+  return AgentTablesQueryConfigurationTableModel.bulkCreate(tableConfigBlobs, {
     transaction: t,
   });
 }
@@ -280,10 +283,10 @@ async function createChildAgentConfiguration(
     mcpConfig,
   }: {
     childAgentId: string;
-    mcpConfig: AgentMCPServerConfiguration;
+    mcpConfig: AgentMCPServerConfigurationModel;
   }
 ) {
-  return AgentChildAgentConfiguration.create(
+  return AgentChildAgentConfigurationModel.create(
     {
       agentConfigurationId: childAgentId,
       mcpServerConfigurationId: mcpConfig.id,
@@ -302,11 +305,11 @@ async function createReasoningConfiguration(
     agentConfiguration,
   }: {
     reasoningModel: ReasoningModelConfigurationType;
-    mcpConfig: AgentMCPServerConfiguration;
+    mcpConfig: AgentMCPServerConfigurationModel;
     agentConfiguration: LightAgentConfigurationType;
   }
 ) {
-  return AgentReasoningConfiguration.create(
+  return AgentReasoningConfigurationModel.create(
     {
       sId: generateRandomModelSId(),
       mcpServerConfigurationId: mcpConfig.id,

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -25,16 +25,16 @@ import config from "@app/lib/api/config";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import type { DustError } from "@app/lib/error";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
-  AgentChildAgentConfiguration,
-  AgentMCPServerConfiguration,
+  AgentChildAgentConfigurationModel,
+  AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { AgentReasoningConfiguration } from "@app/lib/models/agent/actions/reasoning";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import {
   AgentConfiguration,
-  AgentUserRelation,
+  AgentUserRelationModel,
 } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
@@ -430,7 +430,7 @@ export async function createAgentConfiguration(
             transaction: t,
             limit: 1,
           }),
-          AgentUserRelation.findOne({
+          AgentUserRelationModel.findOne({
             where: {
               workspaceId: owner.id,
               agentConfiguration: agentConfigurationId,
@@ -1117,7 +1117,7 @@ export async function unsafeHardDeleteAgentConfiguration(
 
   await withTransaction(async (t) => {
     // Clean up MCP server configurations and their children first
-    const mcpConfigs = await AgentMCPServerConfiguration.findAll({
+    const mcpConfigs = await AgentMCPServerConfigurationModel.findAll({
       where: {
         agentConfigurationId: agentConfiguration.id,
         workspaceId,
@@ -1128,7 +1128,7 @@ export async function unsafeHardDeleteAgentConfiguration(
     if (mcpConfigs.length) {
       const mcpIds = mcpConfigs.map((c) => c.id);
 
-      await AgentDataSourceConfiguration.destroy({
+      await AgentDataSourceConfigurationModel.destroy({
         where: {
           workspaceId,
           mcpServerConfigurationId: { [Op.in]: mcpIds },
@@ -1136,7 +1136,7 @@ export async function unsafeHardDeleteAgentConfiguration(
         transaction: t,
       });
 
-      await AgentTablesQueryConfigurationTable.destroy({
+      await AgentTablesQueryConfigurationTableModel.destroy({
         where: {
           workspaceId,
           mcpServerConfigurationId: { [Op.in]: mcpIds },
@@ -1144,7 +1144,7 @@ export async function unsafeHardDeleteAgentConfiguration(
         transaction: t,
       });
 
-      await AgentReasoningConfiguration.destroy({
+      await AgentReasoningConfigurationModel.destroy({
         where: {
           workspaceId,
           mcpServerConfigurationId: { [Op.in]: mcpIds },
@@ -1152,7 +1152,7 @@ export async function unsafeHardDeleteAgentConfiguration(
         transaction: t,
       });
 
-      await AgentChildAgentConfiguration.destroy({
+      await AgentChildAgentConfigurationModel.destroy({
         where: {
           workspaceId,
           mcpServerConfigurationId: { [Op.in]: mcpIds },
@@ -1160,7 +1160,7 @@ export async function unsafeHardDeleteAgentConfiguration(
         transaction: t,
       });
 
-      await AgentMCPServerConfiguration.destroy({
+      await AgentMCPServerConfigurationModel.destroy({
         where: {
           workspaceId,
           id: { [Op.in]: mcpIds },

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -3,7 +3,7 @@ import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
@@ -17,7 +17,7 @@ import type {
 } from "@app/types";
 
 function getModelForAgentConfiguration(
-  agent: AgentConfiguration
+  agent: AgentConfigurationModel
 ): AgentModelConfigurationType {
   const model: AgentModelConfigurationType = {
     providerId: agent.providerId,
@@ -76,7 +76,7 @@ export async function getAgentSIdFromName(
 ): Promise<string | null> {
   const owner = auth.getNonNullableWorkspace();
 
-  const agent = await AgentConfiguration.findOne({
+  const agent = await AgentConfigurationModel.findOne({
     attributes: ["sId"],
     where: {
       workspaceId: owner.id,
@@ -97,7 +97,7 @@ export async function getAgentSIdFromName(
  */
 export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
   auth: Authenticator,
-  agentConfigurations: AgentConfiguration[],
+  agentConfigurations: AgentConfigurationModel[],
   {
     variant,
     agentIdsForUserAsEditor,

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -10,7 +10,7 @@ import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  AgentConfiguration,
+  AgentConfigurationModel,
   AgentUserRelationModel,
 } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -131,7 +131,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     owner: WorkspaceType;
     sort?: SortStrategyType;
   }
-): Promise<AgentConfiguration[]> {
+): Promise<AgentConfigurationModel[]> {
   const sortStrategy = sort && sortStrategies[sort];
 
   const baseWhereConditions = {
@@ -152,13 +152,13 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
 
   switch (agentsGetView) {
     case "admin_internal":
-      return AgentConfiguration.findAll({
+      return AgentConfigurationModel.findAll({
         ...baseAgentsSequelizeQuery,
         where: baseWhereConditions,
       });
     case "current_user":
       const authorId = auth.getNonNullableUser().id;
-      const r = await AgentConfiguration.findAll({
+      const r = await AgentConfigurationModel.findAll({
         attributes: ["sId"],
         group: "sId",
         where: {
@@ -167,7 +167,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
         },
       });
 
-      return AgentConfiguration.findAll({
+      return AgentConfigurationModel.findAll({
         ...baseAgentsSequelizeQuery,
         where: {
           ...baseWhereConditions,
@@ -177,7 +177,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     case "archived":
       // Get the latest version of all archived agents.
       // For each sId, we want to fetch the one with the highest version, only if its status is "archived".
-      return AgentConfiguration.findAll({
+      return AgentConfigurationModel.findAll({
         attributes: [[Sequelize.fn("MAX", Sequelize.col("id")), "maxId"]],
         group: "sId",
         raw: true,
@@ -192,7 +192,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
           (id) => agentIdsForUserAsEditor.includes(id) || auth.isAdmin()
         );
 
-        return AgentConfiguration.findAll({
+        return AgentConfigurationModel.findAll({
           where: {
             id: {
               [Op.in]: filteredIds,
@@ -203,13 +203,13 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
       });
 
     case "all":
-      return AgentConfiguration.findAll({
+      return AgentConfigurationModel.findAll({
         ...baseAgentsSequelizeQuery,
         where: baseConditionsAndScopesIn(["workspace", "published", "visible"]),
       });
 
     case "published":
-      return AgentConfiguration.findAll({
+      return AgentConfigurationModel.findAll({
         ...baseAgentsSequelizeQuery,
         where: baseConditionsAndScopesIn(["published", "visible"]),
       });
@@ -217,7 +217,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     case "list":
     case "manage":
       const user = auth.user();
-      return AgentConfiguration.findAll({
+      return AgentConfigurationModel.findAll({
         ...baseAgentsSequelizeQuery,
         where: {
           ...baseWhereConditions,
@@ -250,7 +250,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
         return [];
       }
 
-      return AgentConfiguration.findAll({
+      return AgentConfigurationModel.findAll({
         ...baseAgentsSequelizeQuery,
         where: {
           ...baseWhereConditions,

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -11,7 +11,7 @@ import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_age
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentConfiguration,
-  AgentUserRelation,
+  AgentUserRelationModel,
 } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type {
@@ -237,7 +237,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
       if (!userId) {
         return [];
       }
-      const relations = await AgentUserRelation.findAll({
+      const relations = await AgentUserRelationModel.findAll({
         where: {
           workspaceId: owner.id,
           userId,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1253,7 +1253,7 @@ export async function softDeleteUserMessage(
     });
 
     if (relatedContentFragments.length > 0) {
-      await Message.update(
+      await MessageModel.update(
         {
           visibility: "deleted",
           contentFragmentId: col("contentFragmentId"),

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -29,10 +29,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { USER_MENTION_REGEX } from "@app/lib/mentions/format";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
-  Message,
-  UserMessage,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { triggerConversationUnreadNotifications } from "@app/lib/notifications/workflows/conversation-unread";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
@@ -222,7 +222,7 @@ export async function getConversationMessageType(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
-  const message = await Message.findOne({
+  const message = await MessageModel.findOne({
     where: {
       conversationId: conversation.id,
       sId: messageId,
@@ -251,7 +251,7 @@ export async function getMessageConversationId(
   auth: Authenticator,
   { messageId }: { messageId: number }
 ): Promise<{ conversationId: string | null; messageId: string | null }> {
-  const messageRow = await Message.findOne({
+  const messageRow = await MessageModel.findOne({
     attributes: ["sId"],
     where: {
       agentMessageId: messageId,
@@ -278,7 +278,7 @@ export async function getLastUserMessage(
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const message = await Message.findOne({
+  const message = await MessageModel.findOne({
     where: {
       workspaceId: owner.id,
       conversationId: conversation.id,
@@ -289,7 +289,7 @@ export async function getLastUserMessage(
     ],
     include: [
       {
-        model: UserMessage,
+        model: UserMessageModel,
         as: "userMessage",
         required: false,
       },
@@ -521,7 +521,7 @@ export async function postUserMessage(
     }
 
     let nextMessageRank =
-      ((await Message.max<number | null, Message>("rank", {
+      ((await MessageModel.max<number | null, MessageModel>("rank", {
         where: {
           conversationId: conversation.id,
         },
@@ -744,7 +744,7 @@ export async function editUserMessage(
       // connection pool, resulting in a deadlock.
       await getConversationRankVersionLock(auth, conversation, t);
 
-      const messageRow = await Message.findOne({
+      const messageRow = await MessageModel.findOne({
         where: {
           sId: message.sId,
           conversationId: conversation.id,
@@ -752,7 +752,7 @@ export async function editUserMessage(
         },
         include: [
           {
-            model: UserMessage,
+            model: UserMessageModel,
             as: "userMessage",
             required: true,
           },
@@ -766,7 +766,7 @@ export async function editUserMessage(
         );
       }
 
-      const newerMessage = await Message.findOne({
+      const newerMessage = await MessageModel.findOne({
         where: {
           workspaceId: owner.id,
           rank: messageRow.rank,
@@ -826,7 +826,7 @@ export async function editUserMessage(
         // Only create agent messages if there are no agent messages after the edited user message
         if (!hasAgentMessagesAfter) {
           const nextMessageRank =
-            ((await Message.max<number | null, Message>("rank", {
+            ((await MessageModel.max<number | null, MessageModel>("rank", {
               where: {
                 conversationId: conversation.id,
               },
@@ -968,7 +968,7 @@ export async function retryAgentMessage(
         );
       }
 
-      const messageRow = await Message.findOne({
+      const messageRow = await MessageModel.findOne({
         where: {
           workspaceId: auth.getNonNullableWorkspace().id,
           conversationId: conversation.id,
@@ -976,7 +976,7 @@ export async function retryAgentMessage(
         },
         include: [
           {
-            model: AgentMessage,
+            model: AgentMessageModel,
             as: "agentMessage",
             required: true,
           },
@@ -987,7 +987,7 @@ export async function retryAgentMessage(
       if (!messageRow || !messageRow.agentMessage || !messageRow.parentId) {
         return null;
       }
-      const newerMessage = await Message.findOne({
+      const newerMessage = await MessageModel.findOne({
         where: {
           workspaceId: auth.getNonNullableWorkspace().id,
           rank: messageRow.rank,
@@ -1171,13 +1171,13 @@ export async function postNewContentFragment(
     })();
 
     const nextMessageRank =
-      ((await Message.max<number | null, Message>("rank", {
+      ((await MessageModel.max<number | null, MessageModel>("rank", {
         where: {
           conversationId: conversation.id,
         },
         transaction: t,
       })) ?? -1) + 1;
-    const messageRow = await Message.create(
+    const messageRow = await MessageModel.create(
       {
         sId: messageId,
         rank: nextMessageRank,
@@ -1312,7 +1312,7 @@ export async function softDeleteAgentMessage(
   const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
 
-  const parentMessage = await Message.findOne({
+  const parentMessage = await MessageModel.findOne({
     where: {
       sId: message.parentMessageId,
       conversationId: conversation.id,
@@ -1320,7 +1320,7 @@ export async function softDeleteAgentMessage(
     },
     include: [
       {
-        model: UserMessage,
+        model: UserMessageModel,
         as: "userMessage",
         required: true,
       },

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -5,12 +5,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
-  AgentMessage,
   AgentMessageFeedbackModel,
-  Mention,
-  Message,
-  MessageReaction,
-  UserMessage,
+  AgentMessageModel,
+  MentionModel,
+  MessageModel,
+  MessageReactionModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
@@ -48,14 +48,14 @@ async function destroyActionsRelatedResources(
 }
 
 async function destroyMessageRelatedResources(messageIds: Array<ModelId>) {
-  await MessageReaction.destroy({
+  await MessageReactionModel.destroy({
     where: { messageId: messageIds },
   });
-  await Mention.destroy({
+  await MentionModel.destroy({
     where: { messageId: messageIds },
   });
   // TODO: We should also destroy the parent message
-  await Message.destroy({
+  await MessageModel.destroy({
     where: { id: messageIds },
   });
 }
@@ -151,7 +151,7 @@ export async function destroyConversation(
 
   const conversation = conversationRes.value;
 
-  const messages = await Message.findAll({
+  const messages = await MessageModel.findAll({
     attributes: [
       "id",
       "sId",
@@ -183,7 +183,7 @@ export async function destroyConversation(
 
     await destroyActionsRelatedResources(auth, agentMessageIds);
 
-    await UserMessage.destroy({
+    await UserMessageModel.destroy({
       where: { id: userMessageIds },
     });
     await AgentStepContentModel.destroy({
@@ -192,7 +192,7 @@ export async function destroyConversation(
     await AgentMessageFeedbackModel.destroy({
       where: { agentMessageId: agentMessageIds },
     });
-    await AgentMessage.destroy({
+    await AgentMessageModel.destroy({
       where: { id: agentMessageIds },
     });
 

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -2,11 +2,11 @@ import chunk from "lodash/chunk";
 
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPActionOutputItem } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
   AgentMessage,
-  AgentMessageFeedback,
+  AgentMessageFeedbackModel,
   Mention,
   Message,
   MessageReaction,
@@ -37,7 +37,7 @@ async function destroyActionsRelatedResources(
   );
 
   // Destroy MCP action output items.
-  await AgentMCPActionOutputItem.destroy({
+  await AgentMCPActionOutputItemModel.destroy({
     where: { agentMCPActionId: mcpActions.map((a) => a.id) },
   });
 
@@ -189,7 +189,7 @@ export async function destroyConversation(
     await AgentStepContentModel.destroy({
       where: { agentMessageId: agentMessageIds },
     });
-    await AgentMessageFeedback.destroy({
+    await AgentMessageFeedbackModel.destroy({
       where: { agentMessageId: agentMessageIds },
     });
     await AgentMessage.destroy({

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -3,9 +3,9 @@ import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
-  AgentMessage,
-  Message,
-  UserMessage,
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -35,7 +35,7 @@ export async function getConversation(
     return new Err(new ConversationError("conversation_not_found"));
   }
 
-  const messages = await Message.findAll({
+  const messages = await MessageModel.findAll({
     where: {
       conversationId: conversation.id,
       workspaceId: owner.id,
@@ -46,12 +46,12 @@ export async function getConversation(
     ],
     include: [
       {
-        model: UserMessage,
+        model: UserMessageModel,
         as: "userMessage",
         required: false,
       },
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: false,
         include: [

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -19,13 +19,13 @@ import {
   createUserMessage,
 } from "@app/lib/api/assistant/conversation/mentions";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationParticipantModel,
-  Mention,
-  Message,
-  UserMessage,
+  MentionModel,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import {
@@ -117,7 +117,7 @@ describe("createAgentMessages", () => {
     expect(result[0].skipToolsValidation).toBe(false);
 
     // Verify database records were created
-    const mentionInDb = await Mention.findOne({
+    const mentionInDb = await MentionModel.findOne({
       where: {
         messageId: messageRow.id,
         agentConfigurationId: agentConfig1.sId,
@@ -125,13 +125,13 @@ describe("createAgentMessages", () => {
     });
     expect(mentionInDb).not.toBeNull();
 
-    const agentMessageInDb = await AgentMessage.findByPk(
+    const agentMessageInDb = await AgentMessageModel.findByPk(
       result[0].agentMessageId
     );
     expect(agentMessageInDb).not.toBeNull();
     expect(agentMessageInDb?.status).toBe("created");
 
-    const messageInDb = await Message.findByPk(result[0].id);
+    const messageInDb = await MessageModel.findByPk(result[0].id);
     expect(messageInDb).not.toBeNull();
     expect(messageInDb?.rank).toBe(1);
     expect(messageInDb?.parentId).toBe(messageRow.id);
@@ -184,7 +184,7 @@ describe("createAgentMessages", () => {
     expect(result[1].configuration.sId).toBe(agentConfig2.sId);
 
     // Verify both mentions were created
-    const mentionsInDb = await Mention.findAll({
+    const mentionsInDb = await MentionModel.findAll({
       where: {
         messageId: messageRow.id,
       },
@@ -514,7 +514,7 @@ describe("createAgentMessages", () => {
     expect(space1ModelId).not.toBeNull();
     expect(space2ModelId).not.toBeNull();
 
-    await AgentConfiguration.update(
+    await AgentConfigurationModel.update(
       {
         requestedSpaceIds: [space1ModelId!, space2ModelId!],
       },
@@ -528,7 +528,7 @@ describe("createAgentMessages", () => {
     );
 
     // Fetch updated agent configuration
-    const updatedAgentConfig = await AgentConfiguration.findOne({
+    const updatedAgentConfig = await AgentConfigurationModel.findOne({
       where: {
         workspaceId: workspace.id,
         sId: agentConfig.sId,
@@ -655,7 +655,7 @@ describe("createAgentMessages", () => {
     expect(space1ModelId).not.toBeNull();
     expect(space2ModelId).not.toBeNull();
 
-    await AgentConfiguration.update(
+    await AgentConfigurationModel.update(
       {
         requestedSpaceIds: [space1ModelId!, space2ModelId!],
       },
@@ -785,7 +785,7 @@ describe("createAgentMessages", () => {
     expect(space1ModelId).not.toBeNull();
     expect(space2ModelId).not.toBeNull();
 
-    await AgentConfiguration.update(
+    await AgentConfigurationModel.update(
       {
         requestedSpaceIds: [space1ModelId!, space2ModelId!],
       },
@@ -929,7 +929,7 @@ describe("createUserMentions", () => {
     });
 
     // Verify user mention was stored in the database
-    const userMentionInDb = await Mention.findOne({
+    const userMentionInDb = await MentionModel.findOne({
       where: {
         messageId: userMessage.id,
         userId: mentionedUser.id,
@@ -983,7 +983,7 @@ describe("createUserMentions", () => {
     });
 
     // Verify both user mentions were stored
-    const allMentionsInDb = await Mention.findAll({
+    const allMentionsInDb = await MentionModel.findAll({
       where: {
         messageId: userMessage.id,
       },
@@ -1039,7 +1039,7 @@ describe("createUserMentions", () => {
     });
 
     // Verify no mentions were stored
-    const allMentionsInDb = await Mention.findAll({
+    const allMentionsInDb = await MentionModel.findAll({
       where: {
         messageId: userMessage.id,
       },
@@ -1086,7 +1086,7 @@ describe("createUserMentions", () => {
     });
 
     // Verify only user mention was stored, agent mention should be ignored
-    const allMentionsInDb = await Mention.findAll({
+    const allMentionsInDb = await MentionModel.findAll({
       where: {
         messageId: userMessage.id,
       },
@@ -1165,13 +1165,13 @@ describe("createUserMessage", () => {
     expect(userMessage.agenticMessageData).toBeUndefined();
 
     // Verify database records were created
-    const messageInDb = await Message.findByPk(userMessage.id);
+    const messageInDb = await MessageModel.findByPk(userMessage.id);
     expect(messageInDb).not.toBeNull();
     expect(messageInDb?.rank).toBe(rank);
     expect(messageInDb?.version).toBe(0);
     expect(messageInDb?.parentId).toBeNull();
 
-    const userMessageInDb = await UserMessage.findByPk(
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb).not.toBeNull();
@@ -1226,7 +1226,7 @@ describe("createUserMessage", () => {
 
     // Create an origin message first with rank 0
     const originMessage = await withTransaction(async (transaction) => {
-      const originAgentMessage = await AgentMessage.create(
+      const originAgentMessage = await AgentMessageModel.create(
         {
           workspaceId: workspace.id,
           skipToolsValidation: false,
@@ -1236,7 +1236,7 @@ describe("createUserMessage", () => {
         { transaction }
       );
 
-      return Message.create(
+      return MessageModel.create(
         {
           sId: generateRandomModelSId(),
           rank: 0,
@@ -1285,8 +1285,8 @@ describe("createUserMessage", () => {
     expect(userMessage.agenticMessageData).toEqual(agenticMessageData);
 
     // Verify database records
-    const messageInDb = await Message.findByPk(userMessage.id);
-    const userMessageInDb = await UserMessage.findByPk(
+    const messageInDb = await MessageModel.findByPk(userMessage.id);
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.agenticMessageType).toBe("agent_handover");
@@ -1336,8 +1336,8 @@ describe("createUserMessage", () => {
 
     // Verify database records - both fields should be null since origin message doesn't exist
     // The model validation requires agenticMessageType and agenticOriginMessageId to be set together
-    const messageInDb = await Message.findByPk(userMessage.id);
-    const userMessageInDb = await UserMessage.findByPk(
+    const messageInDb = await MessageModel.findByPk(userMessage.id);
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.agenticMessageType).toBeNull();
@@ -1396,12 +1396,12 @@ describe("createUserMessage", () => {
     expect(editedMessage.context).toEqual(originalMessage.context);
 
     // Verify database records
-    const messageInDb = await Message.findByPk(editedMessage.id);
+    const messageInDb = await MessageModel.findByPk(editedMessage.id);
     expect(messageInDb).not.toBeNull();
     expect(messageInDb?.version).toBe(originalMessage.version + 1);
     expect(messageInDb?.parentId).toBe(originalMessage.id);
 
-    const userMessageInDb = await UserMessage.findByPk(
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.content).toBe(editedContent);
@@ -1472,7 +1472,7 @@ describe("createUserMessage", () => {
 
     // Create origin message
     const originMessage = await withTransaction(async (transaction) => {
-      const originAgentMessage = await AgentMessage.create(
+      const originAgentMessage = await AgentMessageModel.create(
         {
           workspaceId: workspace.id,
           skipToolsValidation: false,
@@ -1482,7 +1482,7 @@ describe("createUserMessage", () => {
         { transaction }
       );
 
-      return Message.create(
+      return MessageModel.create(
         {
           sId: generateRandomModelSId(),
           rank: 0,
@@ -1546,8 +1546,8 @@ describe("createUserMessage", () => {
     expect(editedMessage.rank).toBe(originalMessage.rank);
 
     // Verify database records
-    const messageInDb = await Message.findByPk(editedMessage.id);
-    const userMessageInDb = await UserMessage.findByPk(
+    const messageInDb = await MessageModel.findByPk(editedMessage.id);
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.agenticMessageType).toBe("agent_handover");
@@ -1619,8 +1619,8 @@ describe("createUserMessage", () => {
     );
 
     // Verify database records
-    const messageInDb = await Message.findByPk(editedMessage.id);
-    const userMessageInDb = await UserMessage.findByPk(
+    const messageInDb = await MessageModel.findByPk(editedMessage.id);
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.userContextTimezone).toBe(originalContext.timezone);
@@ -1681,7 +1681,7 @@ describe("createUserMessage", () => {
     expect(firstEdit.rank).toBe(originalMessage.rank);
 
     // Verify parentId points to original message
-    const firstEditMessageInDb = await Message.findByPk(firstEdit.id);
+    const firstEditMessageInDb = await MessageModel.findByPk(firstEdit.id);
     expect(firstEditMessageInDb?.parentId).toBe(originalMessage.id);
 
     // Second edit
@@ -1702,7 +1702,7 @@ describe("createUserMessage", () => {
     expect(secondEdit.rank).toBe(originalMessage.rank);
 
     // Verify parentId points to first edit
-    const secondEditMessageInDb = await Message.findByPk(secondEdit.id);
+    const secondEditMessageInDb = await MessageModel.findByPk(secondEdit.id);
     expect(secondEditMessageInDb?.parentId).toBe(firstEdit.id);
 
     // Third edit
@@ -1723,7 +1723,7 @@ describe("createUserMessage", () => {
     expect(thirdEdit.rank).toBe(originalMessage.rank);
 
     // Verify parentId points to second edit
-    const thirdEditMessageInDb = await Message.findByPk(thirdEdit.id);
+    const thirdEditMessageInDb = await MessageModel.findByPk(thirdEdit.id);
     expect(thirdEditMessageInDb?.parentId).toBe(secondEdit.id);
   });
 
@@ -1778,8 +1778,8 @@ describe("createUserMessage", () => {
     expect(editedMessage.rank).toBe(originalMessage.rank);
 
     // Verify database records
-    const messageInDb = await Message.findByPk(editedMessage.id);
-    const userMessageInDb = await UserMessage.findByPk(
+    const messageInDb = await MessageModel.findByPk(editedMessage.id);
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.userId).toBeNull();
@@ -1836,8 +1836,8 @@ describe("createUserMessage", () => {
     expect(editedMessage.user?.username).toBe(userJson.username);
 
     // Verify database records
-    const messageInDb = await Message.findByPk(editedMessage.id);
-    const userMessageInDb = await UserMessage.findByPk(
+    const messageInDb = await MessageModel.findByPk(editedMessage.id);
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.userId).toBe(userJson.id);
@@ -1921,8 +1921,8 @@ describe("createUserMessage", () => {
     expect(userMessage.context).toEqual(context);
 
     // Verify database records
-    const messageInDb = await Message.findByPk(userMessage.id);
-    const userMessageInDb = await UserMessage.findByPk(
+    const messageInDb = await MessageModel.findByPk(userMessage.id);
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.userContextTimezone).toBe(context.timezone);
@@ -1972,8 +1972,8 @@ describe("createUserMessage", () => {
     expect(userMessage.context).toEqual(context);
 
     // Verify database records
-    const messageInDb = await Message.findByPk(userMessage.id);
-    const userMessageInDb = await UserMessage.findByPk(
+    const messageInDb = await MessageModel.findByPk(userMessage.id);
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.userContextFullName).toBeNull();
@@ -2066,8 +2066,8 @@ describe("createUserMessage", () => {
     expect(userMessage.user).toBeNull();
 
     // Verify database records
-    const messageInDb = await Message.findByPk(userMessage.id);
-    const userMessageInDb = await UserMessage.findByPk(
+    const messageInDb = await MessageModel.findByPk(userMessage.id);
+    const userMessageInDb = await UserMessageModel.findByPk(
       messageInDb!.userMessageId!
     );
     expect(userMessageInDb?.userId).toBeNull();

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -3,7 +3,7 @@ import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
-import { Message } from "@app/lib/models/agent/conversation";
+import { MessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { ConversationType, Result } from "@app/types";
@@ -28,7 +28,7 @@ async function findUserMessageForRetry(
   const workspaceId = auth.getNonNullableWorkspace().id;
 
   // Query 1: Get the message and its parentId.
-  const agentMessage = await Message.findOne({
+  const agentMessage = await MessageModel.findOne({
     where: {
       conversationId: conversation.id,
       sId: messageId,
@@ -42,7 +42,7 @@ async function findUserMessageForRetry(
   }
 
   // Query 2: Get the parent message's sId (which is the user message).
-  const parentMessage = await Message.findOne({
+  const parentMessage = await MessageModel.findOne({
     where: {
       id: agentMessage.parentId,
       conversationId: conversation.id,

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -11,7 +11,10 @@ import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import { Message, UserMessage } from "@app/lib/models/agent/conversation";
+import {
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -31,7 +34,7 @@ async function getUserMessageIdFromMessageId(
   userMessageUserId: number;
 }> {
   // Query 1: Get the message and its parentId.
-  const agentMessage = await Message.findOne({
+  const agentMessage = await MessageModel.findOne({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       sId: messageId,
@@ -46,7 +49,7 @@ async function getUserMessageIdFromMessageId(
   );
 
   // Query 2: Get the parent message's sId (which is the user message).
-  const parentMessage = await Message.findOne({
+  const parentMessage = await MessageModel.findOne({
     where: {
       id: agentMessage.parentId,
       workspaceId: auth.getNonNullableWorkspace().id,
@@ -54,7 +57,7 @@ async function getUserMessageIdFromMessageId(
     attributes: ["sId", "version"],
     include: [
       {
-        model: UserMessage,
+        model: UserMessageModel,
         as: "userMessage",
         required: true,
         attributes: ["userId"],

--- a/front/lib/api/assistant/get_favorite_states.ts
+++ b/front/lib/api/assistant/get_favorite_states.ts
@@ -1,7 +1,7 @@
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
-import { AgentUserRelation } from "@app/lib/models/agent/agent";
+import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
 
 export async function getFavoriteStates(
   auth: Authenticator,
@@ -17,7 +17,7 @@ export async function getFavoriteStates(
     return new Map();
   }
 
-  const relations = await AgentUserRelation.findAll({
+  const relations = await AgentUserRelationModel.findAll({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       agentConfiguration: { [Op.in]: configurationIds },

--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -8,7 +8,7 @@ import {
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { AgentConfigurationType } from "@app/types";
 import {
@@ -36,7 +36,7 @@ export function _getClaude3HaikuGlobalAgent({
   webSearchBrowseMCPServerView,
   interactiveContentMCPServerView,
 }: {
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -92,7 +92,7 @@ export function _getClaude3OpusGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -151,7 +151,7 @@ export function _getClaude3GlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -210,7 +210,7 @@ export function _getClaude4SonnetGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -269,7 +269,7 @@ export function _getClaude3_7GlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -328,7 +328,7 @@ export function _getClaude4_5SonnetGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -388,7 +388,7 @@ export function _getClaude4_5HaikuGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {

--- a/front/lib/api/assistant/global_agents/configurations/deepseek.ts
+++ b/front/lib/api/assistant/global_agents/configurations/deepseek.ts
@@ -1,7 +1,7 @@
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { AgentConfigurationType } from "@app/types";
 import {
   FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG,
@@ -13,7 +13,7 @@ export function _getDeepSeekR1GlobalAgent({
   settings,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "disabled_by_admin";
   if (!auth.isUpgraded()) {

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -17,7 +17,7 @@ import {
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,
@@ -430,7 +430,7 @@ export function _getDeepDiveGlobalAgent(
     toolsetsMCPServerView,
     slideshowMCPServerView,
   }: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
     dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
@@ -624,7 +624,7 @@ export function _getDustTaskGlobalAgent(
     dataSourcesFileSystemMCPServerView,
     dataWarehousesMCPServerView,
   }: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
     dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
@@ -736,7 +736,7 @@ export function _getDustTaskGlobalAgent(
 
 export function _getPlanningAgent(
   auth: Authenticator,
-  { settings }: { settings: GlobalAgentSettings | null }
+  { settings }: { settings: GlobalAgentSettingsModel | null }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
 
@@ -798,7 +798,7 @@ export function _getPlanningAgent(
 
 export function _getBrowserSummaryAgent(
   auth: Authenticator,
-  { settings }: { settings: GlobalAgentSettings | null }
+  { settings }: { settings: GlobalAgentSettingsModel | null }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -24,7 +24,7 @@ import {
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { timeAgoFrom } from "@app/lib/utils";
@@ -322,7 +322,7 @@ function _getDustLikeGlobalAgent(
     memories,
     availableToolsets,
   }: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     agentRouterMCPServerView: MCPServerViewResource | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
@@ -565,7 +565,7 @@ function _getDustLikeGlobalAgent(
 export function _getDustGlobalAgent(
   auth: Authenticator,
   args: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     agentRouterMCPServerView: MCPServerViewResource | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
@@ -589,7 +589,7 @@ export function _getDustGlobalAgent(
 export function _getDustEdgeGlobalAgent(
   auth: Authenticator,
   args: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     agentRouterMCPServerView: MCPServerViewResource | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
@@ -614,7 +614,7 @@ export function _getDustEdgeGlobalAgent(
 export function _getDustQuickGlobalAgent(
   auth: Authenticator,
   args: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     agentRouterMCPServerView: MCPServerViewResource | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;

--- a/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
@@ -1,14 +1,14 @@
 import memoizer from "lru-memoizer";
 
 import type { Authenticator } from "@app/lib/auth";
-import { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 
 export const isDeepDiveDisabledByAdmin = memoizer.sync({
   load: async (auth: Authenticator): Promise<boolean> => {
     // We cannot call getGlobalAgents here because it will cause a dependency cycle.
     // Can be cached if too many calls are made.
-    const settings = await GlobalAgentSettings.findOne({
+    const settings = await GlobalAgentSettingsModel.findOne({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         agentId: GLOBAL_AGENTS_SID.DEEP_DIVE,

--- a/front/lib/api/assistant/global_agents/configurations/google.ts
+++ b/front/lib/api/assistant/global_agents/configurations/google.ts
@@ -8,7 +8,7 @@ import {
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { AgentConfigurationType } from "@app/types";
 import {
@@ -24,7 +24,7 @@ export function _getGeminiProGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {

--- a/front/lib/api/assistant/global_agents/configurations/mistral.ts
+++ b/front/lib/api/assistant/global_agents/configurations/mistral.ts
@@ -8,7 +8,7 @@ import {
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { AgentConfigurationType } from "@app/types";
 import {
@@ -34,7 +34,7 @@ export function _getMistralLargeGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -92,7 +92,7 @@ export function _getMistralMediumGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -148,7 +148,7 @@ export function _getMistralSmallGlobalAgent({
   webSearchBrowseMCPServerView,
   interactiveContentMCPServerView,
 }: {
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -8,7 +8,7 @@ import {
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationStatus,
@@ -40,7 +40,7 @@ export function _getGPT35TurboGlobalAgent({
   webSearchBrowseMCPServerView,
   interactiveContentMCPServerView,
 }: {
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -94,7 +94,7 @@ export function _getGPT4GlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -155,7 +155,7 @@ export function _getGPT5GlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -226,7 +226,7 @@ export function _getGPT5ThinkingGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -291,7 +291,7 @@ export function _getGPT5MiniGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -355,7 +355,7 @@ export function _getGPT5NanoGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -420,7 +420,7 @@ export function _getO3MiniGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -482,7 +482,7 @@ export function _getO1GlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -537,7 +537,7 @@ export function _getO1MiniGlobalAgent({
   settings,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -583,7 +583,7 @@ export function _getO1HighReasoningGlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
@@ -641,7 +641,7 @@ export function _getO3GlobalAgent({
   interactiveContentMCPServerView,
 }: {
   auth: Authenticator;
-  settings: GlobalAgentSettings | null;
+  settings: GlobalAgentSettingsModel | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {

--- a/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
+++ b/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
@@ -4,7 +4,7 @@ import { BREVITY_PROMPT } from "@app/lib/api/assistant/global_agents/guidelines"
 import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
-import type { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,
@@ -30,7 +30,7 @@ function _getManagedDataSourceAgent(
     preFetchedDataSources,
     searchMCPServerView,
   }: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     connectorProvider: ConnectorProvider;
     agentId: GLOBAL_AGENTS_SID;
     name: string;
@@ -155,7 +155,7 @@ export function _getGoogleDriveGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView,
   }: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     searchMCPServerView: MCPServerViewResource | null;
   }
@@ -185,7 +185,7 @@ export function _getSlackGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView,
   }: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     searchMCPServerView: MCPServerViewResource | null;
   }
@@ -215,7 +215,7 @@ export function _getGithubGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView,
   }: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     searchMCPServerView: MCPServerViewResource | null;
   }
@@ -245,7 +245,7 @@ export function _getNotionGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView,
   }: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     searchMCPServerView: MCPServerViewResource | null;
   }
@@ -275,7 +275,7 @@ export function _getIntercomGlobalAgent(
     preFetchedDataSources,
     searchMCPServerView,
   }: {
-    settings: GlobalAgentSettings | null;
+    settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     searchMCPServerView: MCPServerViewResource | null;
   }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -55,7 +55,7 @@ import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_ag
 import { getDataSourcesAndWorkspaceIdForGlobalAgents } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { GlobalAgentSettings } from "@app/lib/models/agent/agent";
+import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -95,7 +95,7 @@ function getGlobalAgent({
   sId: string | number;
   preFetchedDataSources: PrefetchedDataSourcesType | null;
   helperPromptInstance: HelperAssistantPrompt;
-  globalAgentSettings: GlobalAgentSettings[];
+  globalAgentSettings: GlobalAgentSettingsModel[];
   agentRouterMCPServerView: MCPServerViewResource | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   searchMCPServerView: MCPServerViewResource | null;
@@ -494,7 +494,7 @@ export async function getGlobalAgents(
     variant === "full"
       ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
       : null,
-    GlobalAgentSettings.findAll({
+    GlobalAgentSettingsModel.findAll({
       where: { workspaceId: owner.id },
     }),
     HelperAssistantPrompt.getInstance(),
@@ -706,14 +706,14 @@ export async function upsertGlobalAgentSettings(
     throw new Error("Global Agent not found: invalid agentId.");
   }
 
-  const settings = await GlobalAgentSettings.findOne({
+  const settings = await GlobalAgentSettingsModel.findOne({
     where: { workspaceId: owner.id, agentId },
   });
 
   if (settings) {
     await settings.update({ status });
   } else {
-    await GlobalAgentSettings.create({
+    await GlobalAgentSettingsModel.create({
       workspaceId: owner.id,
       agentId,
       status,

--- a/front/lib/api/assistant/mcp_configurations.ts
+++ b/front/lib/api/assistant/mcp_configurations.ts
@@ -1,6 +1,6 @@
 import { Op } from "sequelize";
 
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 
 export type AgentMcpConfigurationSummary = {
@@ -14,7 +14,7 @@ export async function listAgentMcpConfigurationsForAgent(params: {
 }): Promise<AgentMcpConfigurationSummary[]> {
   const { workspaceId, agentConfigurationSId } = params;
 
-  const mcpConfigurations = await AgentMCPServerConfiguration.findAll({
+  const mcpConfigurations = await AgentMCPServerConfigurationModel.findAll({
     where: {
       workspaceId,
     },

--- a/front/lib/api/assistant/mcp_configurations.ts
+++ b/front/lib/api/assistant/mcp_configurations.ts
@@ -1,7 +1,7 @@
 import { Op } from "sequelize";
 
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 
 export type AgentMcpConfigurationSummary = {
   sId: string;
@@ -21,7 +21,7 @@ export async function listAgentMcpConfigurationsForAgent(params: {
     attributes: ["sId", "name"],
     include: [
       {
-        model: AgentConfiguration,
+        model: AgentConfigurationModel,
         where: {
           sId: agentConfigurationSId,
           status: {

--- a/front/lib/api/assistant/messages.test.ts
+++ b/front/lib/api/assistant/messages.test.ts
@@ -3,9 +3,9 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  AgentMessage,
-  Message,
-  UserMessage,
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -45,19 +45,19 @@ describe("batchRenderMessages", () => {
       expect(conversationResource).not.toBeNull();
 
       // Get all messages from the conversation
-      const allMessages = await Message.findAll({
+      const allMessages = await MessageModel.findAll({
         where: {
           conversationId: conversation.id,
           workspaceId: workspace.id,
         },
         include: [
           {
-            model: UserMessage,
+            model: UserMessageModel,
             as: "userMessage",
             required: false,
           },
           {
-            model: AgentMessage,
+            model: AgentMessageModel,
             as: "agentMessage",
             required: false,
           },
@@ -122,19 +122,19 @@ describe("batchRenderMessages", () => {
       expect(conversationResource).not.toBeNull();
 
       // Get all messages from the conversation
-      const allMessages = await Message.findAll({
+      const allMessages = await MessageModel.findAll({
         where: {
           conversationId: conversation.id,
           workspaceId: workspace.id,
         },
         include: [
           {
-            model: UserMessage,
+            model: UserMessageModel,
             as: "userMessage",
             required: false,
           },
           {
-            model: AgentMessage,
+            model: AgentMessageModel,
             as: "agentMessage",
             required: false,
           },
@@ -192,19 +192,19 @@ describe("batchRenderMessages", () => {
       expect(conversationResource).not.toBeNull();
 
       // Get all messages from the conversation
-      const allMessages = await Message.findAll({
+      const allMessages = await MessageModel.findAll({
         where: {
           conversationId: conversation.id,
           workspaceId: workspace.id,
         },
         include: [
           {
-            model: UserMessage,
+            model: UserMessageModel,
             as: "userMessage",
             required: false,
           },
           {
-            model: AgentMessage,
+            model: AgentMessageModel,
             as: "agentMessage",
             required: false,
           },

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -9,10 +9,10 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  AgentMessage,
-  Mention,
-  Message,
-  UserMessage,
+  AgentMessageModel,
+  MentionModel,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
@@ -142,13 +142,13 @@ function interleaveConditionalNewlines(parts: string[]): string[] {
 
 async function batchRenderUserMessages(
   auth: Authenticator,
-  messages: Message[]
+  messages: MessageModel[]
 ): Promise<UserMessageType[]> {
   const userMessages = messages.filter(
     (m) => m.userMessage !== null && m.userMessage !== undefined
   );
 
-  const mentionRows = await Mention.findAll({
+  const mentionRows = await MentionModel.findAll({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       messageId: userMessages.map((m) => m.id),
@@ -256,7 +256,7 @@ async function batchRenderUserMessages(
 
 async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   auth: Authenticator,
-  messages: Message[],
+  messages: MessageModel[],
   viewType: V
 ): Promise<
   Result<
@@ -458,7 +458,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
           },
           "Couldn't find parent message for agent message in the messages map, can happen if you are only rendering a subset of the messages. Falling back to fetch the message from the database."
         );
-        parentMessage = await Message.findOne({
+        parentMessage = await MessageModel.findOne({
           where: {
             id: message.parentId,
             workspaceId: auth.getNonNullableWorkspace().id,
@@ -466,7 +466,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
           },
           include: [
             {
-              model: UserMessage,
+              model: UserMessageModel,
               as: "userMessage",
               required: true,
             },
@@ -478,7 +478,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       const userMessage = parentMessage.userMessage;
       assert(!!userMessage, "Parent message must be a userMessage.");
 
-      let parentAgentMessage: Message | null = null;
+      let parentAgentMessage: MessageModel | null = null;
 
       // TODO(2025-11-24 PPUL): Remove this block once data has been backfilled
       if (
@@ -551,7 +551,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
 async function batchRenderContentFragment(
   auth: Authenticator,
   conversationId: string,
-  messages: Message[]
+  messages: MessageModel[]
 ): Promise<ContentFragmentType[]> {
   const messagesWithContentFragment = messages.filter(
     (m) => !!m.contentFragment
@@ -563,7 +563,7 @@ async function batchRenderContentFragment(
   }
 
   return Promise.all(
-    messagesWithContentFragment.map(async (message: Message) => {
+    messagesWithContentFragment.map(async (message: MessageModel) => {
       const contentFragment = ContentFragmentResource.fromMessage(message);
       const render = await contentFragment.renderFromMessage({
         auth,
@@ -581,7 +581,7 @@ type RenderMessageVariant = "legacy-light" | "full" | "light";
 export async function batchRenderMessages<V extends RenderMessageVariant>(
   auth: Authenticator,
   conversation: ConversationResource,
-  messages: Message[],
+  messages: MessageModel[],
   viewType: V
 ): Promise<
   Result<
@@ -732,7 +732,7 @@ export async function fetchMessageInConversation(
   messageId: string,
   version?: number
 ) {
-  return Message.findOne({
+  return MessageModel.findOne({
     where: {
       conversationId: conversation.id,
       sId: messageId,
@@ -741,12 +741,12 @@ export async function fetchMessageInConversation(
     },
     include: [
       {
-        model: UserMessage,
+        model: UserMessageModel,
         as: "userMessage",
         required: false,
       },
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: false,
       },

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -3,9 +3,9 @@ import { Op } from "sequelize";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationParticipantModel,
-  Message,
+  MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type {
@@ -72,7 +72,7 @@ export async function fetchConversationParticipants(
   }
 
   // We fetch agent participants from the messages table
-  const messages = await Message.findAll({
+  const messages = await MessageModel.findAll({
     where: {
       conversationId: conversation.id,
       workspaceId: owner.id,
@@ -80,7 +80,7 @@ export async function fetchConversationParticipants(
     attributes: [],
     include: [
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: true,
         attributes: ["agentConfigurationId"],

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -1,5 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
-import { Message, MessageReaction } from "@app/lib/models/agent/conversation";
+import {
+  MessageModel,
+  MessageReactionModel,
+} from "@app/lib/models/agent/conversation";
 import type {
   ConversationError,
   ConversationMessageReactions,
@@ -22,7 +25,7 @@ export async function getMessageReactions(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
-  const messages = await Message.findAll({
+  const messages = await MessageModel.findAll({
     where: {
       workspaceId: owner.id,
       conversationId: conversation.id,
@@ -30,7 +33,7 @@ export async function getMessageReactions(
     attributes: ["sId"],
     include: [
       {
-        model: MessageReaction,
+        model: MessageReactionModel,
         as: "reactions",
         required: false,
       },
@@ -47,10 +50,10 @@ export async function getMessageReactions(
 }
 
 function _renderMessageReactions(
-  reactions: MessageReaction[]
+  reactions: MessageReactionModel[]
 ): MessageReactionType[] {
   return reactions.reduce<MessageReactionType[]>(
-    (acc: MessageReactionType[], r: MessageReaction) => {
+    (acc: MessageReactionType[], r: MessageReactionModel) => {
       const reaction = acc.find((r2) => r2.emoji === r.reaction);
       if (reaction) {
         reaction.users.push({
@@ -101,7 +104,7 @@ export async function createMessageReaction(
 ): Promise<boolean | null> {
   const owner = auth.getNonNullableWorkspace();
 
-  const message = await Message.findOne({
+  const message = await MessageModel.findOne({
     where: {
       sId: messageId,
       conversationId: conversation.id,
@@ -113,7 +116,7 @@ export async function createMessageReaction(
     return null;
   }
 
-  const newReaction = await MessageReaction.create({
+  const newReaction = await MessageReactionModel.create({
     messageId: message.id,
     userId: user ? user.id : null,
     userContextUsername: context.username,
@@ -152,7 +155,7 @@ export async function deleteMessageReaction(
     throw new Error("Unexpected `auth` without `workspace`.");
   }
 
-  const message = await Message.findOne({
+  const message = await MessageModel.findOne({
     where: {
       sId: messageId,
       conversationId: conversation.id,
@@ -164,7 +167,7 @@ export async function deleteMessageReaction(
     return null;
   }
 
-  const deletedReaction = await MessageReaction.destroy({
+  const deletedReaction = await MessageReactionModel.destroy({
     where: {
       messageId: message.id,
       userId: user ? user.id : null,

--- a/front/lib/api/assistant/recent_authors.ts
+++ b/front/lib/api/assistant/recent_authors.ts
@@ -2,7 +2,7 @@ import { Sequelize } from "sequelize";
 
 import { runOnRedis } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   AgentRecentAuthors,
@@ -31,7 +31,7 @@ async function fetchRecentAuthorIdsWithVersion(
   auth: Authenticator,
   { agentId }: { agentId: string }
 ) {
-  return AgentConfiguration.findAll({
+  return AgentConfigurationModel.findAll({
     attributes: [
       "authorId",
       [Sequelize.fn("MAX", Sequelize.col("version")), "version"],

--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -2,7 +2,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type {
   BuilderSuggestionInputType,
   ModelConversationTypeMultiActions,
@@ -75,7 +75,7 @@ async function filterSuggestedNames(
   }
   // Filter out suggested names that are already in use in the workspace.
   const existingNames = (
-    await AgentConfiguration.findAll({
+    await AgentConfigurationModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         status: "active",

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -1,6 +1,6 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentUserRelation } from "@app/lib/models/agent/agent";
+import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
@@ -36,7 +36,7 @@ export async function setAgentUserFavorite({
     return new Err(new Error("Agent is not active"));
   }
 
-  await AgentUserRelation.upsert({
+  await AgentUserRelationModel.upsert({
     userId: user.id,
     workspaceId: workspace.id,
     agentConfiguration: agentConfiguration.sId,

--- a/front/lib/api/datasets.ts
+++ b/front/lib/api/datasets.ts
@@ -1,7 +1,7 @@
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import type { AppResource } from "@app/lib/resources/app_resource";
-import { Dataset } from "@app/lib/resources/storage/models/apps";
+import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import logger from "@app/logger/logger";
 import type { AppType } from "@app/types";
 import type { DatasetSchema, DatasetType } from "@app/types";
@@ -16,7 +16,7 @@ export async function getDatasets(
     return [];
   }
 
-  const datasets = await Dataset.findAll({
+  const datasets = await DatasetModel.findAll({
     where: {
       workspaceId: owner.id,
       appId: app.id,
@@ -43,7 +43,7 @@ export async function getDatasetSchema(
     return null;
   }
 
-  const dataset = await Dataset.findOne({
+  const dataset = await DatasetModel.findOne({
     where: {
       workspaceId: owner.id,
       appId: app.id,
@@ -70,7 +70,7 @@ export async function getDatasetHash(
     return null;
   }
 
-  const dataset = await Dataset.findOne({
+  const dataset = await DatasetModel.findOne({
     where: {
       workspaceId: owner.id,
       appId: app.id,

--- a/front/lib/api/dust_app_secrets.ts
+++ b/front/lib/api/dust_app_secrets.ts
@@ -1,5 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import type { DustAppSecretType } from "@app/types";
 import { decrypt, redactString } from "@app/types";
 
@@ -12,7 +12,7 @@ export async function getDustAppSecrets(
     return [];
   }
 
-  const secrets = await DustAppSecret.findAll({
+  const secrets = await DustAppSecretModel.findAll({
     where: {
       workspaceId: owner.id,
     },
@@ -31,13 +31,13 @@ export async function getDustAppSecrets(
 export async function getDustAppSecret(
   auth: Authenticator,
   name: string
-): Promise<DustAppSecret | null> {
+): Promise<DustAppSecretModel | null> {
   const owner = auth.workspace();
   if (!owner) {
     return null;
   }
 
-  const secret = await DustAppSecret.findOne({
+  const secret = await DustAppSecretModel.findOne({
     where: {
       name: name,
       workspaceId: owner.id,

--- a/front/lib/api/files/client_executable.test.ts
+++ b/front/lib/api/files/client_executable.test.ts
@@ -12,10 +12,10 @@ import {
   isCreateFileActionForFileId,
 } from "@app/lib/api/files/client_executable";
 import type { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentMCPActionOutputItem } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 
 const mockAgentMCPActionOutputItemFindAll = vi
-  .spyOn(AgentMCPActionOutputItem, "findAll")
+  .spyOn(AgentMCPActionOutputItemModel, "findAll")
   .mockImplementation(() => Promise.resolve([]));
 
 const createEditAction = (

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -15,7 +15,10 @@ import {
   AgentMCPActionModel,
   AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { AgentMessage, Message } from "@app/lib/models/agent/conversation";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
@@ -731,12 +734,12 @@ export async function revertClientExecutableFileChanges(
     const conversationActions = await AgentMCPActionModel.findAll({
       include: [
         {
-          model: AgentMessage,
+          model: AgentMessageModel,
           as: "agentMessage",
           required: true,
           include: [
             {
-              model: Message,
+              model: MessageModel,
               as: "message",
               required: true,
               where: {

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -13,7 +13,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
-  AgentMCPActionOutputItem,
+  AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentMessage, Message } from "@app/lib/models/agent/conversation";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -440,8 +440,8 @@ function isRenameFileActionType(
 }
 
 function isCreateFileActionOutputType(
-  output: AgentMCPActionOutputItem
-): output is AgentMCPActionOutputItem & {
+  output: AgentMCPActionOutputItemModel
+): output is AgentMCPActionOutputItemModel & {
   content: { resource: { fileId: string } };
 } {
   if (typeof output.content !== "object" || output.content === null) {
@@ -471,7 +471,7 @@ export async function isCreateFileActionForFileId({
   fileId: string;
 }) {
   if (isCreateFileActionType(action)) {
-    const actionOutputs = await AgentMCPActionOutputItem.findAll({
+    const actionOutputs = await AgentMCPActionOutputItemModel.findAll({
       where: {
         agentMCPActionId: action.id,
         workspaceId: workspace.id,

--- a/front/lib/api/mcp/error.ts
+++ b/front/lib/api/mcp/error.ts
@@ -3,7 +3,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { MCPErrorEvent, MCPSuccessEvent } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
-import { AgentMCPActionOutputItem } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
@@ -28,7 +28,7 @@ export async function handleMCPActionError({
   status,
   executionDurationMs,
 }: HandleErrorParams): Promise<MCPErrorEvent | MCPSuccessEvent> {
-  await AgentMCPActionOutputItem.bulkCreate(
+  await AgentMCPActionOutputItemModel.bulkCreate(
     errorContent.map((item) => ({
       workspaceId: action.workspaceId,
       agentMCPActionId: action.id,

--- a/front/lib/api/poke/plugins/global/create_workspace.ts
+++ b/front/lib/api/poke/plugins/global/create_workspace.ts
@@ -3,7 +3,7 @@ import { createPlugin } from "@app/lib/api/poke/types";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
-import { PlanModel } from "@app/lib/models/planModel";
+import { PlanModel } from "@app/lib/models/plan";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { getRegionDisplay } from "@app/lib/poke/regions";
 import { isEmailValid } from "@app/lib/utils";

--- a/front/lib/api/poke/plugins/global/create_workspace.ts
+++ b/front/lib/api/poke/plugins/global/create_workspace.ts
@@ -3,7 +3,7 @@ import { createPlugin } from "@app/lib/api/poke/types";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
-import { Plan } from "@app/lib/models/plan";
+import { PlanModel } from "@app/lib/models/planModel";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { getRegionDisplay } from "@app/lib/poke/regions";
 import { isEmailValid } from "@app/lib/utils";
@@ -52,7 +52,7 @@ export const createWorkspacePlugin = createPlugin({
   },
   populateAsyncArgs: async () => {
     // Fetch all plans from the database
-    const plans = await Plan.findAll({ order: [["name", "ASC"]] });
+    const plans = await PlanModel.findAll({ order: [["name", "ASC"]] });
 
     // Create enum values with "None" as the first option
     const planValues = [

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -1,5 +1,5 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { FeatureFlag } from "@app/lib/models/feature_flag";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { Ok } from "@app/types";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {
@@ -30,7 +30,7 @@ export const toggleFeatureFlagPlugin = createPlugin({
   },
   populateAsyncArgs: async (auth) => {
     const workspace = auth.getNonNullableWorkspace();
-    const enabledFlags = await FeatureFlag.findAll({
+    const enabledFlags = await FeatureFlagModel.findAll({
       where: {
         workspaceId: workspace.id,
       },
@@ -60,7 +60,7 @@ export const toggleFeatureFlagPlugin = createPlugin({
   },
   execute: async (auth, _, args) => {
     const workspace = auth.getNonNullableWorkspace();
-    const existingFlags = await FeatureFlag.findAll({
+    const existingFlags = await FeatureFlagModel.findAll({
       where: {
         workspaceId: workspace.id,
       },
@@ -76,13 +76,13 @@ export const toggleFeatureFlagPlugin = createPlugin({
       .filter((flag) => !featureFlags.includes(flag.name))
       .map((flag) => flag.name);
 
-    await FeatureFlag.bulkCreate(
+    await FeatureFlagModel.bulkCreate(
       toAdd.map((feature) => ({
         workspaceId: workspace.id,
         name: feature as WhitelistableFeature,
       }))
     );
-    await FeatureFlag.destroy({
+    await FeatureFlagModel.destroy({
       where: {
         workspaceId: workspace.id,
         name: toRemove,

--- a/front/lib/api/viz/files.ts
+++ b/front/lib/api/viz/files.ts
@@ -1,8 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
 import {
   ConversationModel,
-  Message,
-  UserMessage,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
@@ -40,7 +40,7 @@ async function isAncestorConversation(
   const workspaceId = auth.getNonNullableWorkspace().id;
 
   // Get the first user message from conversation B.
-  const firstUserMessage = await Message.findOne({
+  const firstUserMessage = await MessageModel.findOne({
     where: {
       conversationId: conversationB.id,
       workspaceId,
@@ -51,7 +51,7 @@ async function isAncestorConversation(
     ],
     include: [
       {
-        model: UserMessage,
+        model: UserMessageModel,
         as: "userMessage",
         required: true,
       },
@@ -67,7 +67,7 @@ async function isAncestorConversation(
   }
 
   // Find the origin message and its conversation.
-  const originMessage = await Message.findOne({
+  const originMessage = await MessageModel.findOne({
     where: {
       workspaceId,
       sId: originMessageId,

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -3,7 +3,7 @@ import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { getUsageToReportForSubscriptionItem } from "@app/lib/plans/usage";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -3,7 +3,7 @@ import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { getUsageToReportForSubscriptionItem } from "@app/lib/plans/usage";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
@@ -334,7 +334,7 @@ export async function unsafeGetWorkspacesByModelId(
 export async function areAllSubscriptionsCanceled(
   workspace: LightWorkspaceType
 ): Promise<boolean> {
-  const subscriptions = await Subscription.findAll({
+  const subscriptions = await SubscriptionModel.findAll({
     where: {
       workspaceId: workspace.id,
       stripeSubscriptionId: {
@@ -497,12 +497,12 @@ export async function whitelistWorkspaceToBusinessPlan(
 export async function checkSeatCountForWorkspace(
   workspace: LightWorkspaceType
 ): Promise<Result<string, Error>> {
-  const subscription = await Subscription.findOne({
+  const subscription = await SubscriptionModel.findOne({
     where: {
       workspaceId: workspace.id,
       status: "active",
     },
-    include: [Plan],
+    include: [PlanModel],
   });
   if (!subscription) {
     return new Err(new Error("Workspace has no active subscription."));

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -12,7 +12,7 @@ import config from "@app/lib/api/config";
 import type { WorkOSJwtPayload } from "@app/lib/api/workos";
 import { getWorkOSSession } from "@app/lib/api/workos/user";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { FeatureFlag } from "@app/lib/models/feature_flag";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { KeyAuthType } from "@app/lib/resources/key_resource";
@@ -1179,7 +1179,7 @@ export const getFeatureFlags = memoizer.sync({
     if (ACTIVATE_ALL_FEATURES_DEV && isDevelopment()) {
       return [...WHITELISTABLE_FEATURES];
     } else {
-      const res = await FeatureFlag.findAll({
+      const res = await FeatureFlagModel.findAll({
         where: { workspaceId: workspace.id },
       });
       return res.map((flag) => flag.name);

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -3,13 +3,13 @@ import type { Authenticator } from "@app/lib/auth";
 import type { ExternalUser, SessionWithUser } from "@app/lib/iam/provider";
 import {
   AgentConfiguration,
-  AgentUserRelation,
+  AgentUserRelationModel,
 } from "@app/lib/models/agent/agent";
 import {
   ConversationParticipantModel,
   UserMessage,
 } from "@app/lib/models/agent/conversation";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
@@ -279,7 +279,7 @@ export async function mergeUserIdentities({
   await ContentFragmentModel.update(userIdValues, userIdOptions);
   // Migrate authorship of files from the secondary user to the primary user.
   await FileModel.update(userIdValues, userIdOptions);
-  await DustAppSecret.update(userIdValues, userIdOptions);
+  await DustAppSecretModel.update(userIdValues, userIdOptions);
   // Migrate authorship of agent memories from the secondary user to the primary user.
   await AgentMemoryModel.update(userIdValues, userIdOptions);
 
@@ -302,14 +302,14 @@ export async function mergeUserIdentities({
   await GroupMembershipModel.update(userIdValues, userIdOptions);
 
   // Delete all agent-user relations for the secondary user that already have a relation.
-  const agentConfigurations = await AgentUserRelation.findAll({
+  const agentConfigurations = await AgentUserRelationModel.findAll({
     where: {
       userId: primaryUser.id,
       workspaceId: workspaceId,
     },
     attributes: ["agentConfiguration"],
   });
-  await AgentUserRelation.destroy({
+  await AgentUserRelationModel.destroy({
     where: {
       userId: secondaryUser.id,
       agentConfiguration: agentConfigurations.map((p) => p.agentConfiguration),
@@ -317,7 +317,7 @@ export async function mergeUserIdentities({
     },
   });
   // Migrate agent-user relations from the secondary user to the primary user.
-  await AgentUserRelation.update(userIdValues, userIdOptions);
+  await AgentUserRelationModel.update(userIdValues, userIdOptions);
 
   // Migrate authorship of keys from the secondary user to the primary user.
   await KeyModel.update(userIdValues, userIdOptions);

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -2,12 +2,12 @@ import { revokeAndTrackMembership } from "@app/lib/api/membership";
 import type { Authenticator } from "@app/lib/auth";
 import type { ExternalUser, SessionWithUser } from "@app/lib/iam/provider";
 import {
-  AgentConfiguration,
+  AgentConfigurationModel,
   AgentUserRelationModel,
 } from "@app/lib/models/agent/agent";
 import {
   ConversationParticipantModel,
-  UserMessage,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -234,7 +234,7 @@ export async function mergeUserIdentities({
   }
 
   // Migrate authorship of agent configurations from the secondary user to the primary user.
-  await AgentConfiguration.update(
+  await AgentConfigurationModel.update(
     {
       authorId: primaryUser.id,
     },
@@ -274,7 +274,7 @@ export async function mergeUserIdentities({
   // Replace all conversation participants for the secondary user with the primary user.
   await ConversationParticipantModel.update(userIdValues, userIdOptions);
   // Migrate authorship of user messages from the secondary user to the primary user.
-  await UserMessage.update(userIdValues, userIdOptions);
+  await UserMessageModel.update(userIdValues, userIdOptions);
   // Migrate authorship of content fragments from the secondary user to the primary user.
   await ContentFragmentModel.update(userIdValues, userIdOptions);
   // Migrate authorship of files from the secondary user to the primary user.

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -1,6 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { Plan } from "@app/lib/models/plan";
+import { PlanModel } from "@app/lib/models/planModel";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -40,7 +40,7 @@ export async function createWorkspaceInternal({
         `Invalid plan code: ${planCode}. Only free plans are supported.`
       );
     }
-    const plan = await Plan.findOne({
+    const plan = await PlanModel.findOne({
       where: {
         code: planCode,
       },

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -1,6 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { PlanModel } from "@app/lib/models/planModel";
+import { PlanModel } from "@app/lib/models/plan";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";

--- a/front/lib/models/agent/actions/data_sources.ts
+++ b/front/lib/models/agent/actions/data_sources.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
@@ -10,7 +10,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 /**
  * Configuration of Data Sources used for Retrieval, Process and MCP server actions.
  */
-export class AgentDataSourceConfiguration extends WorkspaceAwareModel<AgentDataSourceConfiguration> {
+export class AgentDataSourceConfigurationModel extends WorkspaceAwareModel<AgentDataSourceConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -27,13 +27,13 @@ export class AgentDataSourceConfiguration extends WorkspaceAwareModel<AgentDataS
   // AgentDataSourceConfiguration can be used by both the retrieval
   // and the MCP actions' configurations.
   declare mcpServerConfigurationId: ForeignKey<
-    AgentMCPServerConfiguration["id"]
+    AgentMCPServerConfigurationModel["id"]
   > | null;
 
   declare dataSource: NonAttribute<DataSourceModel>;
   declare dataSourceView: NonAttribute<DataSourceViewModel>;
 }
-AgentDataSourceConfiguration.init(
+AgentDataSourceConfigurationModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -96,7 +96,7 @@ AgentDataSourceConfiguration.init(
     ],
     sequelize: frontSequelize,
     hooks: {
-      beforeValidate: (dsConfig: AgentDataSourceConfiguration) => {
+      beforeValidate: (dsConfig: AgentDataSourceConfigurationModel) => {
         // Checking tags.
         if ((dsConfig.tagsIn === null) !== (dsConfig.tagsNotIn === null)) {
           throw new Error("Tags must be both set or both null");
@@ -124,32 +124,32 @@ AgentDataSourceConfiguration.init(
 );
 
 // MCP server config <> Data source config
-AgentMCPServerConfiguration.hasMany(AgentDataSourceConfiguration, {
+AgentMCPServerConfigurationModel.hasMany(AgentDataSourceConfigurationModel, {
   foreignKey: { name: "mcpServerConfigurationId", allowNull: true },
   onDelete: "RESTRICT",
 });
-AgentDataSourceConfiguration.belongsTo(AgentMCPServerConfiguration, {
+AgentDataSourceConfigurationModel.belongsTo(AgentMCPServerConfigurationModel, {
   foreignKey: { name: "mcpServerConfigurationId", allowNull: true },
 });
 
 // Data source config <> Data source
-DataSourceModel.hasMany(AgentDataSourceConfiguration, {
+DataSourceModel.hasMany(AgentDataSourceConfigurationModel, {
   as: "dataSource",
   foreignKey: { name: "dataSourceId", allowNull: false },
   onDelete: "RESTRICT",
 });
-AgentDataSourceConfiguration.belongsTo(DataSourceModel, {
+AgentDataSourceConfigurationModel.belongsTo(DataSourceModel, {
   as: "dataSource",
   foreignKey: { name: "dataSourceId", allowNull: false },
 });
 
 // Data source config <> Data source view
-DataSourceViewModel.hasMany(AgentDataSourceConfiguration, {
+DataSourceViewModel.hasMany(AgentDataSourceConfigurationModel, {
   as: "dataSourceView",
   foreignKey: { allowNull: true },
   onDelete: "RESTRICT",
 });
-AgentDataSourceConfiguration.belongsTo(DataSourceViewModel, {
+AgentDataSourceConfigurationModel.belongsTo(DataSourceViewModel, {
   as: "dataSourceView",
   foreignKey: { allowNull: false },
 });

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -29,7 +29,7 @@ export type AdditionalConfigurationType = Record<
   AdditionalConfigurationValueType
 >;
 
-export class AgentMCPServerConfiguration extends WorkspaceAwareModel<AgentMCPServerConfiguration> {
+export class AgentMCPServerConfigurationModel extends WorkspaceAwareModel<AgentMCPServerConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -61,7 +61,7 @@ export class AgentMCPServerConfiguration extends WorkspaceAwareModel<AgentMCPSer
   declare singleToolDescriptionOverride: string | null;
 }
 
-AgentMCPServerConfiguration.init(
+AgentMCPServerConfigurationModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -182,21 +182,21 @@ AgentMCPServerConfiguration.init(
   }
 );
 
-AgentConfiguration.hasMany(AgentMCPServerConfiguration, {
+AgentConfiguration.hasMany(AgentMCPServerConfigurationModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   as: "mcpServerConfigurations",
   onDelete: "RESTRICT",
 });
-AgentMCPServerConfiguration.belongsTo(AgentConfiguration, {
+AgentMCPServerConfigurationModel.belongsTo(AgentConfiguration, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });
 
-MCPServerViewModel.hasMany(AgentMCPServerConfiguration, {
+MCPServerViewModel.hasMany(AgentMCPServerConfigurationModel, {
   foreignKey: { name: "mcpServerViewId", allowNull: false },
   onDelete: "RESTRICT",
 });
-AgentMCPServerConfiguration.belongsTo(MCPServerViewModel, {
+AgentMCPServerConfigurationModel.belongsTo(MCPServerViewModel, {
   foreignKey: { name: "mcpServerViewId", allowNull: false },
   as: "mcpServerView",
 });
@@ -219,7 +219,7 @@ export class AgentMCPActionModel extends WorkspaceAwareModel<AgentMCPActionModel
 
   declare executionDurationMs: number | null;
 
-  declare outputItems: NonAttribute<AgentMCPActionOutputItem[]>;
+  declare outputItems: NonAttribute<AgentMCPActionOutputItemModel[]>;
 
   declare agentMessage?: NonAttribute<AgentMessage>;
 }
@@ -323,7 +323,7 @@ AgentStepContentModel.hasMany(AgentMCPActionModel, {
   as: "agentMCPActions",
 });
 
-export class AgentMCPActionOutputItem extends WorkspaceAwareModel<AgentMCPActionOutputItem> {
+export class AgentMCPActionOutputItemModel extends WorkspaceAwareModel<AgentMCPActionOutputItemModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -334,7 +334,7 @@ export class AgentMCPActionOutputItem extends WorkspaceAwareModel<AgentMCPAction
   declare file: NonAttribute<FileModel>;
 }
 
-AgentMCPActionOutputItem.init(
+AgentMCPActionOutputItemModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -390,17 +390,17 @@ AgentMCPActionOutputItem.init(
   }
 );
 
-AgentMCPActionModel.hasMany(AgentMCPActionOutputItem, {
+AgentMCPActionModel.hasMany(AgentMCPActionOutputItemModel, {
   foreignKey: { name: "agentMCPActionId", allowNull: false },
   as: "outputItems",
   onDelete: "CASCADE",
 });
 
-AgentMCPActionOutputItem.belongsTo(AgentMCPActionModel, {
+AgentMCPActionOutputItemModel.belongsTo(AgentMCPActionModel, {
   foreignKey: { name: "agentMCPActionId", allowNull: false },
 });
 
-AgentMCPActionOutputItem.belongsTo(FileModel, {
+AgentMCPActionOutputItemModel.belongsTo(FileModel, {
   foreignKey: { name: "fileId", allowNull: true },
   onDelete: "SET NULL",
 });
@@ -410,17 +410,17 @@ AgentMCPActionOutputItem.belongsTo(FileModel, {
  * TODO(mcp): move this model in a file dedicated to the configuration blocks, add Resources for
  *  all of them (should be done after cleaning up all the actions).
  */
-export class AgentChildAgentConfiguration extends WorkspaceAwareModel<AgentChildAgentConfiguration> {
+export class AgentChildAgentConfigurationModel extends WorkspaceAwareModel<AgentChildAgentConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare agentConfigurationId: string;
 
   declare mcpServerConfigurationId: ForeignKey<
-    AgentMCPServerConfiguration["id"]
+    AgentMCPServerConfigurationModel["id"]
   >;
 }
-AgentChildAgentConfiguration.init(
+AgentChildAgentConfigurationModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -453,10 +453,10 @@ AgentChildAgentConfiguration.init(
 );
 
 // MCP server configuration <> Child agent configuration
-AgentMCPServerConfiguration.hasMany(AgentChildAgentConfiguration, {
+AgentMCPServerConfigurationModel.hasMany(AgentChildAgentConfigurationModel, {
   foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });
-AgentChildAgentConfiguration.belongsTo(AgentMCPServerConfiguration, {
+AgentChildAgentConfigurationModel.belongsTo(AgentMCPServerConfigurationModel, {
   foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
 });

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -7,9 +7,9 @@ import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
-import { AgentMessage } from "@app/lib/models/agent/conversation";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -33,7 +33,7 @@ export class AgentMCPServerConfigurationModel extends WorkspaceAwareModel<AgentM
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  declare agentConfigurationId: ForeignKey<AgentConfigurationModel["id"]>;
 
   declare sId: string;
 
@@ -182,12 +182,12 @@ AgentMCPServerConfigurationModel.init(
   }
 );
 
-AgentConfiguration.hasMany(AgentMCPServerConfigurationModel, {
+AgentConfigurationModel.hasMany(AgentMCPServerConfigurationModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   as: "mcpServerConfigurations",
   onDelete: "RESTRICT",
 });
-AgentMCPServerConfigurationModel.belongsTo(AgentConfiguration, {
+AgentMCPServerConfigurationModel.belongsTo(AgentConfigurationModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });
@@ -207,7 +207,7 @@ export class AgentMCPActionModel extends WorkspaceAwareModel<AgentMCPActionModel
 
   declare mcpServerConfigurationId: string;
   declare version: number;
-  declare agentMessageId: ForeignKey<AgentMessage["id"]>;
+  declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
   declare stepContentId: ForeignKey<AgentStepContentModel["id"]>;
 
   declare status: ToolExecutionStatus;
@@ -221,7 +221,7 @@ export class AgentMCPActionModel extends WorkspaceAwareModel<AgentMCPActionModel
 
   declare outputItems: NonAttribute<AgentMCPActionOutputItemModel[]>;
 
-  declare agentMessage?: NonAttribute<AgentMessage>;
+  declare agentMessage?: NonAttribute<AgentMessageModel>;
 }
 
 AgentMCPActionModel.init(
@@ -303,12 +303,12 @@ AgentMCPActionModel.init(
   }
 );
 
-AgentMCPActionModel.belongsTo(AgentMessage, {
+AgentMCPActionModel.belongsTo(AgentMessageModel, {
   foreignKey: { name: "agentMessageId", allowNull: false },
   as: "agentMessage",
 });
 
-AgentMessage.hasMany(AgentMCPActionModel, {
+AgentMessageModel.hasMany(AgentMCPActionModel, {
   foreignKey: { name: "agentMessageId", allowNull: false },
 });
 

--- a/front/lib/models/agent/actions/mcp_server_connection.ts
+++ b/front/lib/models/agent/actions/mcp_server_connection.ts
@@ -7,7 +7,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { assertNever } from "@app/types";
 
-export class MCPServerConnection extends WorkspaceAwareModel<MCPServerConnection> {
+export class MCPServerConnectionModel extends WorkspaceAwareModel<MCPServerConnectionModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -25,7 +25,7 @@ export class MCPServerConnection extends WorkspaceAwareModel<MCPServerConnection
   declare user: NonAttribute<UserModel>;
 }
 
-MCPServerConnection.init(
+MCPServerConnectionModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -95,7 +95,7 @@ MCPServerConnection.init(
       },
     ],
     hooks: {
-      beforeValidate: (config: MCPServerConnection) => {
+      beforeValidate: (config: MCPServerConnectionModel) => {
         if (config.serverType) {
           switch (config.serverType) {
             case "internal":
@@ -131,19 +131,19 @@ MCPServerConnection.init(
   }
 );
 
-RemoteMCPServerModel.hasMany(MCPServerConnection, {
+RemoteMCPServerModel.hasMany(MCPServerConnectionModel, {
   foreignKey: { name: "remoteMCPServerId", allowNull: true },
   onDelete: "RESTRICT",
 });
-MCPServerConnection.belongsTo(RemoteMCPServerModel, {
+MCPServerConnectionModel.belongsTo(RemoteMCPServerModel, {
   foreignKey: { name: "remoteMCPServerId", allowNull: true },
 });
 
-UserModel.hasMany(MCPServerConnection, {
+UserModel.hasMany(MCPServerConnectionModel, {
   foreignKey: { name: "userId", allowNull: false },
   onDelete: "RESTRICT",
 });
-MCPServerConnection.belongsTo(UserModel, {
+MCPServerConnectionModel.belongsTo(UserModel, {
   as: "user",
   foreignKey: { name: "userId", allowNull: false },
 });

--- a/front/lib/models/agent/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/agent/actions/mcp_server_view_helper.ts
@@ -3,12 +3,12 @@ import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
-  AgentChildAgentConfiguration,
-  AgentMCPServerConfiguration,
+  AgentChildAgentConfigurationModel,
+  AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import type { ModelId } from "@app/types";
 
 export const destroyMCPServerViewDependencies = async (
@@ -23,7 +23,7 @@ export const destroyMCPServerViewDependencies = async (
 ) => {
   // Delete all dependencies.
   const agentConfigurationIds = (
-    await AgentMCPServerConfiguration.findAll({
+    await AgentMCPServerConfigurationModel.findAll({
       attributes: ["id"],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -31,9 +31,9 @@ export const destroyMCPServerViewDependencies = async (
       },
       transaction,
     })
-  ).map((view: AgentMCPServerConfiguration) => view.id);
+  ).map((view: AgentMCPServerConfigurationModel) => view.id);
 
-  await AgentDataSourceConfiguration.destroy({
+  await AgentDataSourceConfigurationModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       mcpServerConfigurationId: {
@@ -43,7 +43,7 @@ export const destroyMCPServerViewDependencies = async (
     transaction,
   });
 
-  await AgentTablesQueryConfigurationTable.destroy({
+  await AgentTablesQueryConfigurationTableModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       mcpServerConfigurationId: {
@@ -53,7 +53,7 @@ export const destroyMCPServerViewDependencies = async (
     transaction,
   });
 
-  await AgentChildAgentConfiguration.destroy({
+  await AgentChildAgentConfigurationModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       mcpServerConfigurationId: {
@@ -63,7 +63,7 @@ export const destroyMCPServerViewDependencies = async (
     transaction,
   });
 
-  await AgentMCPServerConfiguration.destroy({
+  await AgentMCPServerConfigurationModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       mcpServerViewId: mcpServerViewId,

--- a/front/lib/models/agent/actions/reasoning.ts
+++ b/front/lib/models/agent/actions/reasoning.ts
@@ -1,13 +1,13 @@
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ModelIdType, ModelProviderIdType } from "@app/types";
 import type { AgentReasoningEffort } from "@app/types";
 
-export class AgentReasoningConfiguration extends WorkspaceAwareModel<AgentReasoningConfiguration> {
+export class AgentReasoningConfigurationModel extends WorkspaceAwareModel<AgentReasoningConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -17,13 +17,13 @@ export class AgentReasoningConfiguration extends WorkspaceAwareModel<AgentReason
   declare reasoningEffort: AgentReasoningEffort | null;
 
   declare mcpServerConfigurationId: ForeignKey<
-    AgentMCPServerConfiguration["id"]
+    AgentMCPServerConfigurationModel["id"]
   >;
 
   declare sId: string;
 }
 
-AgentReasoningConfiguration.init(
+AgentReasoningConfigurationModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -73,11 +73,11 @@ AgentReasoningConfiguration.init(
   }
 );
 
-AgentMCPServerConfiguration.hasMany(AgentReasoningConfiguration, {
+AgentMCPServerConfigurationModel.hasMany(AgentReasoningConfigurationModel, {
   foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });
-AgentReasoningConfiguration.belongsTo(AgentMCPServerConfiguration, {
+AgentReasoningConfigurationModel.belongsTo(AgentMCPServerConfigurationModel, {
   foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });

--- a/front/lib/models/agent/actions/tables_query.ts
+++ b/front/lib/models/agent/actions/tables_query.ts
@@ -1,13 +1,13 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 
-export class AgentTablesQueryConfigurationTable extends WorkspaceAwareModel<AgentTablesQueryConfigurationTable> {
+export class AgentTablesQueryConfigurationTableModel extends WorkspaceAwareModel<AgentTablesQueryConfigurationTableModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -16,14 +16,14 @@ export class AgentTablesQueryConfigurationTable extends WorkspaceAwareModel<Agen
   declare dataSourceId: ForeignKey<DataSourceModel["id"]> | null;
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
   declare mcpServerConfigurationId: ForeignKey<
-    AgentMCPServerConfiguration["id"]
+    AgentMCPServerConfigurationModel["id"]
   >;
 
   declare dataSource: NonAttribute<DataSourceModel>;
   declare dataSourceView: NonAttribute<DataSourceViewModel>;
 }
 
-AgentTablesQueryConfigurationTable.init(
+AgentTablesQueryConfigurationTableModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -68,31 +68,31 @@ AgentTablesQueryConfigurationTable.init(
 );
 
 // MCP server config <> Table config
-AgentMCPServerConfiguration.hasMany(AgentTablesQueryConfigurationTable, {
+AgentMCPServerConfigurationModel.hasMany(AgentTablesQueryConfigurationTableModel, {
   foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });
-AgentTablesQueryConfigurationTable.belongsTo(AgentMCPServerConfiguration, {
+AgentTablesQueryConfigurationTableModel.belongsTo(AgentMCPServerConfigurationModel, {
   foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });
 
 // Config <> Data source.
-DataSourceModel.hasMany(AgentTablesQueryConfigurationTable, {
+DataSourceModel.hasMany(AgentTablesQueryConfigurationTableModel, {
   foreignKey: { allowNull: false, name: "dataSourceId" },
   onDelete: "RESTRICT",
 });
-AgentTablesQueryConfigurationTable.belongsTo(DataSourceModel, {
+AgentTablesQueryConfigurationTableModel.belongsTo(DataSourceModel, {
   as: "dataSource",
   foreignKey: { allowNull: false, name: "dataSourceId" },
 });
 
 // Config <> Data source view.
-DataSourceViewModel.hasMany(AgentTablesQueryConfigurationTable, {
+DataSourceViewModel.hasMany(AgentTablesQueryConfigurationTableModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-AgentTablesQueryConfigurationTable.belongsTo(DataSourceViewModel, {
+AgentTablesQueryConfigurationTableModel.belongsTo(DataSourceViewModel, {
   as: "dataSourceView",
   foreignKey: { allowNull: false },
 });

--- a/front/lib/models/agent/actions/tables_query.ts
+++ b/front/lib/models/agent/actions/tables_query.ts
@@ -68,14 +68,20 @@ AgentTablesQueryConfigurationTableModel.init(
 );
 
 // MCP server config <> Table config
-AgentMCPServerConfigurationModel.hasMany(AgentTablesQueryConfigurationTableModel, {
-  foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
-  onDelete: "RESTRICT",
-});
-AgentTablesQueryConfigurationTableModel.belongsTo(AgentMCPServerConfigurationModel, {
-  foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
-  onDelete: "RESTRICT",
-});
+AgentMCPServerConfigurationModel.hasMany(
+  AgentTablesQueryConfigurationTableModel,
+  {
+    foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
+    onDelete: "RESTRICT",
+  }
+);
+AgentTablesQueryConfigurationTableModel.belongsTo(
+  AgentMCPServerConfigurationModel,
+  {
+    foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
+    onDelete: "RESTRICT",
+  }
+);
 
 // Config <> Data source.
 DataSourceModel.hasMany(AgentTablesQueryConfigurationTableModel, {

--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -18,7 +18,7 @@ import type {
 /**
  * Agent configuration
  */
-export class AgentConfiguration extends WorkspaceAwareModel<AgentConfiguration> {
+export class AgentConfigurationModel extends WorkspaceAwareModel<AgentConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -51,10 +51,12 @@ export class AgentConfiguration extends WorkspaceAwareModel<AgentConfiguration> 
 
   declare author: NonAttribute<UserModel>;
 
-  declare mcpServerConfigurations: NonAttribute<AgentMCPServerConfigurationModel[]>;
+  declare mcpServerConfigurations: NonAttribute<
+    AgentMCPServerConfigurationModel[]
+  >;
 }
 
-AgentConfiguration.init(
+AgentConfigurationModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -184,11 +186,11 @@ AgentConfiguration.init(
 );
 
 // Agent config <> Author
-UserModel.hasMany(AgentConfiguration, {
+UserModel.hasMany(AgentConfigurationModel, {
   foreignKey: { name: "authorId", allowNull: false },
   onDelete: "RESTRICT",
 });
-AgentConfiguration.belongsTo(UserModel, {
+AgentConfigurationModel.belongsTo(UserModel, {
   foreignKey: { name: "authorId", allowNull: false },
 });
 
@@ -234,12 +236,12 @@ GlobalAgentSettingsModel.init(
     ],
   }
 );
-TemplateModel.hasOne(AgentConfiguration, {
+TemplateModel.hasOne(AgentConfigurationModel, {
   foreignKey: { name: "templateId", allowNull: true },
   onDelete: "SET NULL",
 });
 
-AgentConfiguration.belongsTo(TemplateModel, {
+AgentConfigurationModel.belongsTo(TemplateModel, {
   foreignKey: { name: "templateId", allowNull: true },
 });
 

--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import type { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -51,7 +51,7 @@ export class AgentConfiguration extends WorkspaceAwareModel<AgentConfiguration> 
 
   declare author: NonAttribute<UserModel>;
 
-  declare mcpServerConfigurations: NonAttribute<AgentMCPServerConfiguration[]>;
+  declare mcpServerConfigurations: NonAttribute<AgentMCPServerConfigurationModel[]>;
 }
 
 AgentConfiguration.init(
@@ -195,7 +195,7 @@ AgentConfiguration.belongsTo(UserModel, {
 /**
  * Global Agent settings
  */
-export class GlobalAgentSettings extends WorkspaceAwareModel<GlobalAgentSettings> {
+export class GlobalAgentSettingsModel extends WorkspaceAwareModel<GlobalAgentSettingsModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -203,7 +203,7 @@ export class GlobalAgentSettings extends WorkspaceAwareModel<GlobalAgentSettings
 
   declare status: GlobalAgentStatus;
 }
-GlobalAgentSettings.init(
+GlobalAgentSettingsModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -243,7 +243,7 @@ AgentConfiguration.belongsTo(TemplateModel, {
   foreignKey: { name: "templateId", allowNull: true },
 });
 
-export class AgentUserRelation extends WorkspaceAwareModel<AgentUserRelation> {
+export class AgentUserRelationModel extends WorkspaceAwareModel<AgentUserRelationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -254,7 +254,7 @@ export class AgentUserRelation extends WorkspaceAwareModel<AgentUserRelation> {
   declare userId: ForeignKey<UserModel["id"]>;
 }
 
-AgentUserRelation.init(
+AgentUserRelationModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -291,10 +291,10 @@ AgentUserRelation.init(
   }
 );
 
-UserModel.hasMany(AgentUserRelation, {
+UserModel.hasMany(AgentUserRelationModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-AgentUserRelation.belongsTo(UserModel, {
+AgentUserRelationModel.belongsTo(UserModel, {
   foreignKey: { allowNull: false },
 });

--- a/front/lib/models/agent/agent_skill.ts
+++ b/front/lib/models/agent/agent_skill.ts
@@ -46,7 +46,7 @@ AgentSkillModel.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
-    AgentConfigurationModelId: {
+    agentConfigurationId: {
       type: DataTypes.BIGINT,
       allowNull: false,
     },
@@ -54,7 +54,7 @@ AgentSkillModel.init(
   {
     modelName: "agent_skills",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["workspaceId", "AgentConfigurationModelId"] }],
+    indexes: [{ fields: ["workspaceId", "agentConfigurationId"] }],
     validate: {
       eitherGlobalOrCustomSkill() {
         const hasCustomSkill = this.customSkillId !== null;
@@ -83,11 +83,11 @@ SkillConfigurationModel.hasMany(AgentSkillModel, {
 
 // Association with AgentConfigurationModel
 AgentSkillModel.belongsTo(AgentConfigurationModel, {
-  foreignKey: { name: "AgentConfigurationModelId", allowNull: false },
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });
 AgentConfigurationModel.hasMany(AgentSkillModel, {
-  foreignKey: { name: "AgentConfigurationModelId", allowNull: false },
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
   as: "skillAgentLinks",
 });
 
@@ -95,12 +95,12 @@ AgentConfigurationModel.hasMany(AgentSkillModel, {
 SkillConfigurationModel.belongsToMany(AgentConfigurationModel, {
   through: AgentSkillModel,
   foreignKey: "customSkillId",
-  otherKey: "AgentConfigurationModelId",
+  otherKey: "agentConfigurationId",
   as: "AgentConfigurationModels",
 });
 AgentConfigurationModel.belongsToMany(SkillConfigurationModel, {
   through: AgentSkillModel,
-  foreignKey: "AgentConfigurationModelId",
+  foreignKey: "agentConfigurationId",
   otherKey: "customSkillId",
   as: "skills",
 });

--- a/front/lib/models/agent/agent_skill.ts
+++ b/front/lib/models/agent/agent_skill.ts
@@ -19,8 +19,8 @@ export class AgentSkillModel extends WorkspaceAwareModel<AgentSkillModel> {
   declare customSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
   declare globalSkillId: string | null;
 
-  declare AgentConfigurationModel: NonAttribute<AgentConfigurationModel>;
-  declare AgentConfigurationModelId: ForeignKey<AgentConfigurationModel["id"]>;
+  declare agentConfiguration: NonAttribute<AgentConfigurationModel>;
+  declare agentConfigurationId: ForeignKey<AgentConfigurationModel["id"]>;
 
   declare getCustomSkill: BelongsToGetAssociationMixin<SkillConfigurationModel>;
   declare getAgentConfigurationModel: BelongsToGetAssociationMixin<AgentConfigurationModel>;

--- a/front/lib/models/agent/agent_skill.ts
+++ b/front/lib/models/agent/agent_skill.ts
@@ -6,7 +6,7 @@ import type {
 } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -19,11 +19,11 @@ export class AgentSkillModel extends WorkspaceAwareModel<AgentSkillModel> {
   declare customSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
   declare globalSkillId: string | null;
 
-  declare agentConfiguration: NonAttribute<AgentConfiguration>;
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  declare AgentConfigurationModel: NonAttribute<AgentConfigurationModel>;
+  declare AgentConfigurationModelId: ForeignKey<AgentConfigurationModel["id"]>;
 
   declare getCustomSkill: BelongsToGetAssociationMixin<SkillConfigurationModel>;
-  declare getAgentConfiguration: BelongsToGetAssociationMixin<AgentConfiguration>;
+  declare getAgentConfigurationModel: BelongsToGetAssociationMixin<AgentConfigurationModel>;
 }
 
 AgentSkillModel.init(
@@ -46,7 +46,7 @@ AgentSkillModel.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
-    agentConfigurationId: {
+    AgentConfigurationModelId: {
       type: DataTypes.BIGINT,
       allowNull: false,
     },
@@ -54,7 +54,7 @@ AgentSkillModel.init(
   {
     modelName: "agent_skills",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["workspaceId", "agentConfigurationId"] }],
+    indexes: [{ fields: ["workspaceId", "AgentConfigurationModelId"] }],
     validate: {
       eitherGlobalOrCustomSkill() {
         const hasCustomSkill = this.customSkillId !== null;
@@ -81,26 +81,26 @@ SkillConfigurationModel.hasMany(AgentSkillModel, {
   onDelete: "RESTRICT",
 });
 
-// Association with AgentConfiguration
-AgentSkillModel.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
+// Association with AgentConfigurationModel
+AgentSkillModel.belongsTo(AgentConfigurationModel, {
+  foreignKey: { name: "AgentConfigurationModelId", allowNull: false },
   onDelete: "RESTRICT",
 });
-AgentConfiguration.hasMany(AgentSkillModel, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
+AgentConfigurationModel.hasMany(AgentSkillModel, {
+  foreignKey: { name: "AgentConfigurationModelId", allowNull: false },
   as: "skillAgentLinks",
 });
 
 // Many-to-Many associations
-SkillConfigurationModel.belongsToMany(AgentConfiguration, {
+SkillConfigurationModel.belongsToMany(AgentConfigurationModel, {
   through: AgentSkillModel,
   foreignKey: "customSkillId",
-  otherKey: "agentConfigurationId",
-  as: "agentConfigurations",
+  otherKey: "AgentConfigurationModelId",
+  as: "AgentConfigurationModels",
 });
-AgentConfiguration.belongsToMany(SkillConfigurationModel, {
+AgentConfigurationModel.belongsToMany(SkillConfigurationModel, {
   through: AgentSkillModel,
-  foreignKey: "agentConfigurationId",
+  foreignKey: "AgentConfigurationModelId",
   otherKey: "customSkillId",
   as: "skills",
 });

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -2,7 +2,7 @@ import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import type { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentMessage } from "@app/lib/models/agent/conversation";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
@@ -11,14 +11,14 @@ export class AgentStepContentModel extends WorkspaceAwareModel<AgentStepContentM
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare agentMessageId: ForeignKey<AgentMessage["id"]>;
+  declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
   declare step: number;
   declare index: number;
   declare version: number;
   declare type: AgentContentItemType["type"];
   declare value: AgentContentItemType;
 
-  declare agentMessage?: NonAttribute<AgentMessage>;
+  declare agentMessage?: NonAttribute<AgentMessageModel>;
   declare agentMCPActions?: NonAttribute<AgentMCPActionModel[]>;
 }
 
@@ -93,7 +93,7 @@ AgentStepContentModel.init(
   }
 );
 
-AgentStepContentModel.belongsTo(AgentMessage, {
+AgentStepContentModel.belongsTo(AgentMessageModel, {
   as: "agentMessage",
   foreignKey: {
     name: "agentMessageId",
@@ -102,7 +102,7 @@ AgentStepContentModel.belongsTo(AgentMessage, {
   onDelete: "RESTRICT",
 });
 
-AgentMessage.hasMany(AgentStepContentModel, {
+AgentMessageModel.hasMany(AgentStepContentModel, {
   as: "agentStepContents",
   foreignKey: {
     name: "agentMessageId",

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -355,7 +355,7 @@ export class AgentMessage extends WorkspaceAwareModel<AgentMessage> {
 
   declare agentStepContents?: NonAttribute<AgentStepContentModel[]>;
   declare message?: NonAttribute<Message>;
-  declare feedbacks?: NonAttribute<AgentMessageFeedback[]>;
+  declare feedbacks?: NonAttribute<AgentMessageFeedbackModel[]>;
 
   declare modelInteractionDurationMs: number | null;
   declare completedAt: Date | null;
@@ -451,7 +451,7 @@ AgentMessage.init(
   }
 );
 
-export class AgentMessageFeedback extends WorkspaceAwareModel<AgentMessageFeedback> {
+export class AgentMessageFeedbackModel extends WorkspaceAwareModel<AgentMessageFeedbackModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -469,7 +469,7 @@ export class AgentMessageFeedback extends WorkspaceAwareModel<AgentMessageFeedba
   declare user: NonAttribute<UserModel>;
 }
 
-AgentMessageFeedback.init(
+AgentMessageFeedbackModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -531,17 +531,17 @@ AgentMessageFeedback.init(
   }
 );
 
-AgentMessage.hasMany(AgentMessageFeedback, {
+AgentMessage.hasMany(AgentMessageFeedbackModel, {
   as: "feedbacks",
   onDelete: "RESTRICT",
 });
-UserModel.hasMany(AgentMessageFeedback, {
+UserModel.hasMany(AgentMessageFeedbackModel, {
   onDelete: "SET NULL",
 });
-AgentMessageFeedback.belongsTo(UserModel, {
+AgentMessageFeedbackModel.belongsTo(UserModel, {
   as: "user",
 });
-AgentMessageFeedback.belongsTo(AgentMessage, {
+AgentMessageFeedbackModel.belongsTo(AgentMessage, {
   as: "agentMessage",
 });
 

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -198,7 +198,7 @@ ConversationParticipantModel.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: false },
 });
 
-export class UserMessage extends WorkspaceAwareModel<UserMessage> {
+export class UserMessageModel extends WorkspaceAwareModel<UserMessageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -227,7 +227,7 @@ export class UserMessage extends WorkspaceAwareModel<UserMessage> {
   declare user?: NonAttribute<UserModel>;
 }
 
-UserMessage.init(
+UserMessageModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -329,14 +329,14 @@ UserMessage.init(
   }
 );
 
-UserModel.hasMany(UserMessage, {
+UserModel.hasMany(UserMessageModel, {
   foreignKey: { name: "userId", allowNull: true }, // null = message is not associated with a user
 });
-UserMessage.belongsTo(UserModel, {
+UserMessageModel.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: true },
 });
 
-export class AgentMessage extends WorkspaceAwareModel<AgentMessage> {
+export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runIds: string[] | null;
@@ -354,14 +354,14 @@ export class AgentMessage extends WorkspaceAwareModel<AgentMessage> {
   declare agentConfigurationVersion: number;
 
   declare agentStepContents?: NonAttribute<AgentStepContentModel[]>;
-  declare message?: NonAttribute<Message>;
+  declare message?: NonAttribute<MessageModel>;
   declare feedbacks?: NonAttribute<AgentMessageFeedbackModel[]>;
 
   declare modelInteractionDurationMs: number | null;
   declare completedAt: Date | null;
 }
 
-AgentMessage.init(
+AgentMessageModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -457,7 +457,7 @@ export class AgentMessageFeedbackModel extends WorkspaceAwareModel<AgentMessageF
 
   declare agentConfigurationId: string;
   declare agentConfigurationVersion: number;
-  declare agentMessageId: ForeignKey<AgentMessage["id"]>;
+  declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
   declare userId: ForeignKey<UserModel["id"]>;
   declare isConversationShared: boolean;
   declare dismissed: boolean;
@@ -465,7 +465,7 @@ export class AgentMessageFeedbackModel extends WorkspaceAwareModel<AgentMessageF
   declare thumbDirection: AgentMessageFeedbackDirection;
   declare content: string | null;
 
-  declare agentMessage: NonAttribute<AgentMessage>;
+  declare agentMessage: NonAttribute<AgentMessageModel>;
   declare user: NonAttribute<UserModel>;
 }
 
@@ -531,7 +531,7 @@ AgentMessageFeedbackModel.init(
   }
 );
 
-AgentMessage.hasMany(AgentMessageFeedbackModel, {
+AgentMessageModel.hasMany(AgentMessageFeedbackModel, {
   as: "feedbacks",
   onDelete: "RESTRICT",
 });
@@ -541,11 +541,11 @@ UserModel.hasMany(AgentMessageFeedbackModel, {
 AgentMessageFeedbackModel.belongsTo(UserModel, {
   as: "user",
 });
-AgentMessageFeedbackModel.belongsTo(AgentMessage, {
+AgentMessageFeedbackModel.belongsTo(AgentMessageModel, {
   as: "agentMessage",
 });
 
-export class Message extends WorkspaceAwareModel<Message> {
+export class MessageModel extends WorkspaceAwareModel<MessageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -557,20 +557,20 @@ export class Message extends WorkspaceAwareModel<Message> {
 
   declare conversationId: ForeignKey<ConversationModel["id"]>;
 
-  declare parentId: ForeignKey<Message["id"]> | null;
-  declare userMessageId: ForeignKey<UserMessage["id"]> | null;
-  declare agentMessageId: ForeignKey<AgentMessage["id"]> | null;
+  declare parentId: ForeignKey<MessageModel["id"]> | null;
+  declare userMessageId: ForeignKey<UserMessageModel["id"]> | null;
+  declare agentMessageId: ForeignKey<AgentMessageModel["id"]> | null;
   declare contentFragmentId: ForeignKey<ContentFragmentModel["id"]> | null;
 
-  declare userMessage?: NonAttribute<UserMessage>;
-  declare agentMessage?: NonAttribute<AgentMessage>;
+  declare userMessage?: NonAttribute<UserMessageModel>;
+  declare agentMessage?: NonAttribute<AgentMessageModel>;
   declare contentFragment?: NonAttribute<ContentFragmentModel>;
-  declare reactions?: NonAttribute<MessageReaction[]>;
+  declare reactions?: NonAttribute<MessageReactionModel[]>;
 
   declare conversation?: NonAttribute<ConversationModel>;
 }
 
-Message.init(
+MessageModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -664,49 +664,49 @@ Message.init(
   }
 );
 
-ConversationModel.hasMany(Message, {
+ConversationModel.hasMany(MessageModel, {
   foreignKey: { name: "conversationId", allowNull: false },
   onDelete: "RESTRICT",
 });
-Message.belongsTo(ConversationModel, {
+MessageModel.belongsTo(ConversationModel, {
   as: "conversation",
   foreignKey: { name: "conversationId", allowNull: false },
 });
 
-UserMessage.hasOne(Message, {
+UserMessageModel.hasOne(MessageModel, {
   as: "message",
   foreignKey: { name: "userMessageId", allowNull: true },
 });
-Message.belongsTo(UserMessage, {
+MessageModel.belongsTo(UserMessageModel, {
   as: "userMessage",
   foreignKey: { name: "userMessageId", allowNull: true },
 });
 
-AgentMessage.hasOne(Message, {
+AgentMessageModel.hasOne(MessageModel, {
   as: "message",
   foreignKey: { name: "agentMessageId", allowNull: true },
 });
-Message.belongsTo(AgentMessage, {
+MessageModel.belongsTo(AgentMessageModel, {
   as: "agentMessage",
   foreignKey: { name: "agentMessageId", allowNull: true },
 });
 
-Message.belongsTo(Message, {
+MessageModel.belongsTo(MessageModel, {
   foreignKey: { name: "parentId", allowNull: true },
 });
-ContentFragmentModel.hasOne(Message, {
+ContentFragmentModel.hasOne(MessageModel, {
   as: "message",
   foreignKey: { name: "contentFragmentId", allowNull: true },
 });
-Message.belongsTo(ContentFragmentModel, {
+MessageModel.belongsTo(ContentFragmentModel, {
   as: "contentFragment",
   foreignKey: { name: "contentFragmentId", allowNull: true },
 });
-export class MessageReaction extends WorkspaceAwareModel<MessageReaction> {
+export class MessageReactionModel extends WorkspaceAwareModel<MessageReactionModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare messageId: ForeignKey<Message["id"]>;
+  declare messageId: ForeignKey<MessageModel["id"]>;
 
   // User is nullable so that we can store reactions from a Slackbot message
   declare userId: ForeignKey<UserModel["id"]> | null;
@@ -716,7 +716,7 @@ export class MessageReaction extends WorkspaceAwareModel<MessageReaction> {
   declare reaction: string;
 }
 
-MessageReaction.init(
+MessageReactionModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -759,36 +759,36 @@ MessageReaction.init(
   }
 );
 
-Message.hasMany(MessageReaction, {
+MessageModel.hasMany(MessageReactionModel, {
   as: "reactions",
   foreignKey: { name: "messageId", allowNull: false },
   onDelete: "RESTRICT",
 });
-MessageReaction.belongsTo(Message, {
+MessageReactionModel.belongsTo(MessageModel, {
   foreignKey: { name: "messageId", allowNull: false },
 });
-UserModel.hasMany(MessageReaction, {
+UserModel.hasMany(MessageReactionModel, {
   foreignKey: { name: "userId", allowNull: true }, // null = mention is from a user using a Slackbot
 });
-MessageReaction.belongsTo(UserModel, {
+MessageReactionModel.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: true }, // null = mention is not a user using a Slackbot
 });
 
-export class Mention extends WorkspaceAwareModel<Mention> {
+export class MentionModel extends WorkspaceAwareModel<MentionModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare messageId: ForeignKey<Message["id"]>;
+  declare messageId: ForeignKey<MessageModel["id"]>;
 
   // a Mention is either an agent mention xor a user mention
   declare agentConfigurationId: string | null; // Not a relation as global agents are not in the DB
   declare userId: ForeignKey<UserModel["id"]> | null;
   declare user: NonAttribute<UserModel> | null;
 
-  declare message: NonAttribute<Message>;
+  declare message: NonAttribute<MessageModel>;
 }
 
-Mention.init(
+MentionModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -847,13 +847,13 @@ Mention.init(
   }
 );
 
-Message.hasMany(Mention, {
+MessageModel.hasMany(MentionModel, {
   foreignKey: { name: "messageId", allowNull: false },
   onDelete: "RESTRICT",
 });
-Mention.belongsTo(Message, {
+MentionModel.belongsTo(MessageModel, {
   foreignKey: { name: "messageId", allowNull: false },
 });
-Mention.belongsTo(UserModel, {
+MentionModel.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: true },
 });

--- a/front/lib/models/agent/group_agent.ts
+++ b/front/lib/models/agent/group_agent.ts
@@ -5,7 +5,7 @@ import type {
 } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -16,11 +16,11 @@ export class GroupAgentModel extends WorkspaceAwareModel<GroupAgentModel> {
   declare updatedAt: CreationOptional<Date>;
 
   declare groupId: ForeignKey<GroupModel["id"]>;
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  declare agentConfigurationId: ForeignKey<AgentConfigurationModel["id"]>;
   // workspaceId is inherited from WorkspaceAwareModel
 
   declare getGroup: BelongsToGetAssociationMixin<GroupModel>;
-  declare getAgentConfiguration: BelongsToGetAssociationMixin<AgentConfiguration>;
+  declare getAgentConfiguration: BelongsToGetAssociationMixin<AgentConfigurationModel>;
   // getWorkspace is inherited
 }
 
@@ -79,24 +79,24 @@ GroupModel.hasMany(GroupAgentModel, {
 });
 
 // Association with AgentConfiguration
-GroupAgentModel.belongsTo(AgentConfiguration, {
+GroupAgentModel.belongsTo(AgentConfigurationModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   targetKey: "id",
 });
-AgentConfiguration.hasMany(GroupAgentModel, {
+AgentConfigurationModel.hasMany(GroupAgentModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   sourceKey: "id",
   as: "agentGroupLinks",
 });
 
 // Many-to-Many between Group and AgentConfiguration (ensure FKs match)
-GroupModel.belongsToMany(AgentConfiguration, {
+GroupModel.belongsToMany(AgentConfigurationModel, {
   through: GroupAgentModel,
   foreignKey: "groupId",
   otherKey: "agentConfigurationId",
   as: "agentConfigurations",
 });
-AgentConfiguration.belongsToMany(GroupModel, {
+AgentConfigurationModel.belongsToMany(GroupModel, {
   through: GroupAgentModel,
   foreignKey: "agentConfigurationId",
   otherKey: "groupId",

--- a/front/lib/models/agent/tag_agent.ts
+++ b/front/lib/models/agent/tag_agent.ts
@@ -6,7 +6,7 @@ import type {
 } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TagModel } from "@app/lib/models/tags";
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { GroupModel } from "@app/lib/resources/storage/models/groups";
@@ -20,12 +20,12 @@ export class TagAgentModel extends WorkspaceAwareModel<TagAgentModel> {
   declare tag: NonAttribute<TagModel>;
   declare tagId: ForeignKey<TagModel["id"]>;
 
-  declare agentConfiguration: NonAttribute<AgentConfiguration>;
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  declare agentConfiguration: NonAttribute<AgentConfigurationModel>;
+  declare agentConfigurationId: ForeignKey<AgentConfigurationModel["id"]>;
   // workspaceId is inherited from WorkspaceAwareModel
 
   declare getGroup: BelongsToGetAssociationMixin<GroupModel>;
-  declare getAgentConfiguration: BelongsToGetAssociationMixin<AgentConfiguration>;
+  declare getAgentConfiguration: BelongsToGetAssociationMixin<AgentConfigurationModel>;
 }
 
 TagAgentModel.init(
@@ -84,12 +84,12 @@ TagModel.hasMany(TagAgentModel, {
 });
 
 // Association with AgentConfiguration
-TagAgentModel.belongsTo(AgentConfiguration, {
+TagAgentModel.belongsTo(AgentConfigurationModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   targetKey: "id",
   onDelete: "RESTRICT",
 });
-AgentConfiguration.hasMany(TagAgentModel, {
+AgentConfigurationModel.hasMany(TagAgentModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   sourceKey: "id",
   as: "agentTagLinks",
@@ -97,14 +97,14 @@ AgentConfiguration.hasMany(TagAgentModel, {
 });
 
 // Many-to-Many between Tags and AgentConfiguration (ensure FKs match)
-TagModel.belongsToMany(AgentConfiguration, {
+TagModel.belongsToMany(AgentConfigurationModel, {
   through: TagAgentModel,
   foreignKey: "tagId",
   otherKey: "agentConfigurationId",
   as: "agentConfigurations",
   onDelete: "RESTRICT",
 });
-AgentConfiguration.belongsToMany(TagModel, {
+AgentConfigurationModel.belongsToMany(TagModel, {
   through: TagAgentModel,
   foreignKey: "agentConfigurationId",
   otherKey: "tagId",

--- a/front/lib/models/agent/triggers/triggers.ts
+++ b/front/lib/models/agent/triggers/triggers.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { AgentConfiguration } from "@app/lib/models/agent/agent";
+import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { WebhookSourcesViewModel } from "@app/lib/models/agent/triggers/webhook_sources_view";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -36,7 +36,7 @@ export class TriggerModel extends WorkspaceAwareModel<TriggerModel> {
    * We use the sId, because it's static between an agent versions,
    * whereas the id is dynamic and changes with each new agent version.
    */
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["sId"]>;
+  declare agentConfigurationId: ForeignKey<AgentConfigurationModel["sId"]>;
   declare editor: ForeignKey<UserModel["id"]>;
 }
 

--- a/front/lib/models/dust_app_secret.ts
+++ b/front/lib/models/dust_app_secret.ts
@@ -5,7 +5,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 
-export class DustAppSecret extends WorkspaceAwareModel<DustAppSecret> {
+export class DustAppSecretModel extends WorkspaceAwareModel<DustAppSecretModel> {
   declare createdAt: CreationOptional<Date>;
 
   declare name: string;
@@ -15,7 +15,7 @@ export class DustAppSecret extends WorkspaceAwareModel<DustAppSecret> {
 
   declare user: NonAttribute<UserModel>;
 }
-DustAppSecret.init(
+DustAppSecretModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -38,8 +38,8 @@ DustAppSecret.init(
   }
 );
 // We don't want to delete keys when a user gets deleted.
-UserModel.hasMany(DustAppSecret, {
+UserModel.hasMany(DustAppSecretModel, {
   foreignKey: { allowNull: true },
   onDelete: "SET NULL",
 });
-DustAppSecret.belongsTo(UserModel);
+DustAppSecretModel.belongsTo(UserModel);

--- a/front/lib/models/feature_flag.ts
+++ b/front/lib/models/feature_flag.ts
@@ -5,14 +5,14 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { WhitelistableFeature } from "@app/types";
 
-export class FeatureFlag extends WorkspaceAwareModel<FeatureFlag> {
+export class FeatureFlagModel extends WorkspaceAwareModel<FeatureFlagModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare name: WhitelistableFeature;
 }
 
-FeatureFlag.init(
+FeatureFlagModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -176,8 +176,8 @@ export class SubscriptionModel extends WorkspaceAwareModel<SubscriptionModel> {
   declare startDate: Date;
   declare endDate: Date | null;
 
-  declare planId: ForeignKey<PlanModel["id"]>;
-  declare plan: NonAttribute<PlanModel>;
+  declare planId: ForeignKey<Plan["id"]>;
+  declare plan: NonAttribute<Plan>;
 
   declare stripeSubscriptionId: string | null;
 
@@ -272,10 +272,10 @@ SubscriptionModel.addHook(
 );
 
 // Plan <> Subscription relationship: attribute "planId" in Subscription
-PlanModel.hasMany(SubscriptionModel, {
+Plan.hasMany(SubscriptionModel, {
   foreignKey: { name: "planId", allowNull: false },
   onDelete: "RESTRICT",
 });
-SubscriptionModel.belongsTo(PlanModel, {
+SubscriptionModel.belongsTo(Plan, {
   foreignKey: { name: "planId", allowNull: false },
 });

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -176,8 +176,8 @@ export class SubscriptionModel extends WorkspaceAwareModel<SubscriptionModel> {
   declare startDate: Date;
   declare endDate: Date | null;
 
-  declare planId: ForeignKey<Plan["id"]>;
-  declare plan: NonAttribute<Plan>;
+  declare planId: ForeignKey<PlanModel["id"]>;
+  declare plan: NonAttribute<PlanModel>;
 
   declare stripeSubscriptionId: string | null;
 
@@ -272,10 +272,10 @@ SubscriptionModel.addHook(
 );
 
 // Plan <> Subscription relationship: attribute "planId" in Subscription
-Plan.hasMany(SubscriptionModel, {
+PlanModel.hasMany(SubscriptionModel, {
   foreignKey: { name: "planId", allowNull: false },
   onDelete: "RESTRICT",
 });
-SubscriptionModel.belongsTo(Plan, {
+SubscriptionModel.belongsTo(PlanModel, {
   foreignKey: { name: "planId", allowNull: false },
 });

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -248,7 +248,10 @@ Subscription.init(
 Subscription.addHook(
   "beforeCreate",
   "enforce_single_active_subscription",
-  async (subscription: Subscription, options: { transaction: Transaction }) => {
+  async (
+    subscription: Subscription,
+    options: { transaction: Transaction }
+  ) => {
     if (subscription.status === "active") {
       // Check if there's already an active subscription for the same workspace
       const existingActiveSubscription = await Subscription.findOne({

--- a/front/lib/models/planModel.ts
+++ b/front/lib/models/planModel.ts
@@ -15,7 +15,7 @@ import type {
 } from "@app/types";
 import { SUBSCRIPTION_STATUSES } from "@app/types";
 
-export class Plan extends BaseModel<Plan> {
+export class PlanModel extends BaseModel<PlanModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -45,7 +45,7 @@ export class Plan extends BaseModel<Plan> {
   declare maxDataSourcesDocumentsCount: number;
   declare maxDataSourcesDocumentsSizeMb: number;
 }
-Plan.init(
+PlanModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -164,7 +164,7 @@ Plan.init(
   }
 );
 
-export class Subscription extends WorkspaceAwareModel<Subscription> {
+export class SubscriptionModel extends WorkspaceAwareModel<SubscriptionModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -176,8 +176,8 @@ export class Subscription extends WorkspaceAwareModel<Subscription> {
   declare startDate: Date;
   declare endDate: Date | null;
 
-  declare planId: ForeignKey<Plan["id"]>;
-  declare plan: NonAttribute<Plan>;
+  declare planId: ForeignKey<PlanModel["id"]>;
+  declare plan: NonAttribute<PlanModel>;
 
   declare stripeSubscriptionId: string | null;
 
@@ -185,7 +185,7 @@ export class Subscription extends WorkspaceAwareModel<Subscription> {
   // for analytics and business operations.
   declare requestCancelAt: Date | null;
 }
-Subscription.init(
+SubscriptionModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -245,16 +245,16 @@ Subscription.init(
   }
 );
 // Define a hook to ensure there's only one active subscription for each workspace
-Subscription.addHook(
+SubscriptionModel.addHook(
   "beforeCreate",
   "enforce_single_active_subscription",
   async (
-    subscription: Subscription,
+    subscription: SubscriptionModel,
     options: { transaction: Transaction }
   ) => {
     if (subscription.status === "active") {
       // Check if there's already an active subscription for the same workspace
-      const existingActiveSubscription = await Subscription.findOne({
+      const existingActiveSubscription = await SubscriptionModel.findOne({
         where: {
           workspaceId: subscription.workspaceId,
           status: "active",
@@ -272,10 +272,10 @@ Subscription.addHook(
 );
 
 // Plan <> Subscription relationship: attribute "planId" in Subscription
-Plan.hasMany(Subscription, {
+PlanModel.hasMany(SubscriptionModel, {
   foreignKey: { name: "planId", allowNull: false },
   onDelete: "RESTRICT",
 });
-Subscription.belongsTo(Plan, {
+SubscriptionModel.belongsTo(PlanModel, {
   foreignKey: { name: "planId", allowNull: false },
 });

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -1,6 +1,6 @@
 import type { Attributes } from "sequelize";
 
-import { PlanModel } from "@app/lib/models/planModel";
+import { PlanModel } from "@app/lib/models/plan";
 import {
   FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -1,6 +1,6 @@
 import type { Attributes } from "sequelize";
 
-import { Plan } from "@app/lib/models/plan";
+import { PlanModel } from "@app/lib/models/planModel";
 import {
   FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
@@ -8,7 +8,7 @@ import {
 } from "@app/lib/plans/plan_codes";
 
 export type PlanAttributes = Omit<
-  Attributes<Plan>,
+  Attributes<PlanModel>,
   "id" | "createdAt" | "updatedAt"
 >;
 
@@ -115,13 +115,13 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
  */
 export const upsertFreePlans = async () => {
   for (const planData of FREE_PLANS_DATA) {
-    const plan = await Plan.findOne({
+    const plan = await PlanModel.findOne({
       where: {
         code: planData.code,
       },
     });
     if (plan === null) {
-      await Plan.create(planData);
+      await PlanModel.create(planData);
       console.log(`Free plan ${planData.code} created.`);
     } else {
       await plan.update(planData);

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -1,6 +1,6 @@
 import type { Attributes } from "sequelize";
 
-import { Plan } from "@app/lib/models/plan";
+import { PlanModel } from "@app/lib/models/planModel";
 import {
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
@@ -8,7 +8,7 @@ import {
 import { isDevelopment, isTest } from "@app/types";
 
 export type PlanAttributes = Omit<
-  Attributes<Plan>,
+  Attributes<PlanModel>,
   "id" | "createdAt" | "updatedAt"
 >;
 
@@ -87,13 +87,13 @@ if (isDevelopment() || isTest()) {
  */
 export const upsertProPlans = async () => {
   for (const planData of PRO_PLANS_DATA) {
-    const plan = await Plan.findOne({
+    const plan = await PlanModel.findOne({
       where: {
         code: planData.code,
       },
     });
     if (plan === null) {
-      await Plan.create(planData);
+      await PlanModel.create(planData);
       // console.log(`Pro plan ${planData.code} created.`);
     } else {
       await plan.update(planData);

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -1,6 +1,6 @@
 import type { Attributes } from "sequelize";
 
-import { PlanModel } from "@app/lib/models/planModel";
+import { PlanModel } from "@app/lib/models/plan";
 import {
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -1,4 +1,4 @@
-import type { SubscriptionModel } from "@app/lib/models/planModel";
+import type { SubscriptionModel } from "@app/lib/models/plan";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import type { PlanType, SubscriptionType } from "@app/types";
 

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -1,4 +1,4 @@
-import type { Subscription } from "@app/lib/models/plan";
+import type { SubscriptionModel } from "@app/lib/models/planModel";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import type { PlanType, SubscriptionType } from "@app/types";
 
@@ -60,7 +60,7 @@ export function renderSubscriptionFromModels({
   activeSubscription,
 }: {
   plan: PlanAttributes;
-  activeSubscription: Subscription | null;
+  activeSubscription: SubscriptionModel | null;
 }): SubscriptionType {
   return {
     status: activeSubscription?.status ?? "active",

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { Stripe } from "stripe";
 
 import config from "@app/lib/api/config";
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import {
@@ -171,7 +171,7 @@ export const createProPlanCheckoutSession = async ({
 }): Promise<string | null> => {
   const stripe = getStripeClient();
 
-  const plan = await Plan.findOne({ where: { code: planCode } });
+  const plan = await PlanModel.findOne({ where: { code: planCode } });
   if (!plan) {
     throw new Error(
       `Cannot create checkout session for plan ${planCode}: plan not found.`
@@ -203,9 +203,9 @@ export const createProPlanCheckoutSession = async ({
   // subscription before.
   // User under the grandfathered free plan are not allowed to have a trial.
   let trialAllowed = true;
-  const existingSubscription = await Subscription.findOne({
+  const existingSubscription = await SubscriptionModel.findOne({
     where: { workspaceId: owner.id },
-    include: [Plan],
+    include: [PlanModel],
   });
   if (existingSubscription && !isOldFreePlan(existingSubscription.plan.code)) {
     trialAllowed = false;

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { Stripe } from "stripe";
 
 import config from "@app/lib/api/config";
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import {

--- a/front/lib/plans/trial.ts
+++ b/front/lib/plans/trial.ts
@@ -1,4 +1,4 @@
-import type { Plan, Subscription } from "@app/lib/models/plan";
+import type { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import type { SubscriptionType } from "@app/types";
 
@@ -10,7 +10,7 @@ const TRIAL_LIMITS: Partial<PlanAttributes> = {
   maxImagesPerWeek: 50,
 };
 
-export function getTrialVersionForPlan(plan: Plan): PlanAttributes {
+export function getTrialVersionForPlan(plan: PlanModel): PlanAttributes {
   return {
     ...plan.get(),
     ...TRIAL_LIMITS,
@@ -18,7 +18,7 @@ export function getTrialVersionForPlan(plan: Plan): PlanAttributes {
 }
 
 export function isTrial(
-  subscription: SubscriptionType | Subscription
+  subscription: SubscriptionType | SubscriptionModel
 ): boolean {
   return subscription.trialing === true;
 }

--- a/front/lib/plans/trial.ts
+++ b/front/lib/plans/trial.ts
@@ -1,4 +1,4 @@
-import type { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import type { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import type { SubscriptionType } from "@app/types";
 

--- a/front/lib/poke/conversation.ts
+++ b/front/lib/poke/conversation.ts
@@ -1,7 +1,7 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMessage } from "@app/lib/models/agent/conversation";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { getDustProdAction } from "@app/lib/registry";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type {
@@ -38,7 +38,7 @@ export async function getPokeConversation(
       for (const m of messages) {
         if (m.type === "agent_message") {
           const runIds = (
-            await AgentMessage.findOne({
+            await AgentMessageModel.findOne({
               where: {
                 id: m.agentMessageId,
                 workspaceId: owner.id,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -25,7 +25,7 @@ import { getAgentConfigurationsWithVersion } from "@app/lib/api/assistant/config
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
-  AgentMCPActionOutputItem,
+  AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
 import {
   AgentMessage,
@@ -551,7 +551,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     const outputItemsByActionId = _.groupBy(
-      await AgentMCPActionOutputItem.findAll({
+      await AgentMCPActionOutputItemModel.findAll({
         where: {
           workspaceId,
           agentMCPActionId: {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -28,9 +28,9 @@ import {
   AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
 import {
-  AgentMessage,
-  Message,
-  UserMessage,
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -212,12 +212,12 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     const blockedActions = await AgentMCPActionModel.findAll({
       include: [
         {
-          model: AgentMessage,
+          model: AgentMessageModel,
           as: "agentMessage",
           required: true,
           include: [
             {
-              model: Message,
+              model: MessageModel,
               as: "message",
               required: true,
               where: {
@@ -240,7 +240,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       blockedActions.map((a) => a.agentMessage!.message!.parentId)
     );
 
-    const parentUserMessages = await Message.findAll({
+    const parentUserMessages = await MessageModel.findAll({
       where: {
         workspaceId: owner.id,
         conversationId: conversation.id,
@@ -248,7 +248,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       },
       include: [
         {
-          model: UserMessage,
+          model: UserMessageModel,
           as: "userMessage",
           required: true,
           include: [

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -14,7 +14,7 @@ import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import {
   AgentMessage,
   AgentMessage as AgentMessageModel,
-  AgentMessageFeedback,
+  AgentMessageFeedbackModel,
   ConversationModel,
   Message,
 } from "@app/lib/models/agent/conversation";
@@ -41,18 +41,19 @@ import { Err, GLOBAL_AGENTS_SID, Ok } from "@app/types";
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface AgentMessageFeedbackResource
-  extends ReadonlyAttributesType<AgentMessageFeedback> {}
+  extends ReadonlyAttributesType<AgentMessageFeedbackModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedback> {
-  static model: ModelStatic<AgentMessageFeedback> = AgentMessageFeedback;
+export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedbackModel> {
+  static model: ModelStatic<AgentMessageFeedbackModel> =
+    AgentMessageFeedbackModel;
 
   readonly message?: Attributes<Message>;
   readonly user?: Attributes<UserModel>;
   readonly conversationId?: string;
 
   constructor(
-    model: ModelStatic<AgentMessageFeedback>,
-    blob: Attributes<AgentMessageFeedback>,
+    model: ModelStatic<AgentMessageFeedbackModel>,
+    blob: Attributes<AgentMessageFeedbackModel>,
     {
       message,
       user,
@@ -63,7 +64,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       conversationId?: string;
     } = {}
   ) {
-    super(AgentMessageFeedback, blob);
+    super(AgentMessageFeedbackModel, blob);
 
     this.message = message;
     this.user = user;
@@ -91,7 +92,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   }
 
   static async makeNew(
-    blob: CreationAttributes<AgentMessageFeedback>,
+    blob: CreationAttributes<AgentMessageFeedbackModel>,
     {
       message,
       user,
@@ -102,12 +103,12 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       conversationId?: string;
     } = {}
   ): Promise<AgentMessageFeedbackResource> {
-    const agentMessageFeedback = await AgentMessageFeedback.create({
+    const agentMessageFeedback = await AgentMessageFeedbackModel.create({
       ...blob,
     });
 
     return new AgentMessageFeedbackResource(
-      AgentMessageFeedback,
+      AgentMessageFeedbackModel,
       agentMessageFeedback.get(),
       { message, user, conversationId }
     );
@@ -129,7 +130,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   async updateFields(
     blob: Partial<
       Pick<
-        AgentMessageFeedback,
+        AgentMessageFeedbackModel,
         "content" | "thumbDirection" | "isConversationShared"
       >
     >
@@ -164,7 +165,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       return null;
     }
 
-    const where: WhereOptions<AgentMessageFeedback> = {
+    const where: WhereOptions<AgentMessageFeedbackModel> = {
       id: resourceId,
       workspaceId: auth.getNonNullableWorkspace().id,
     };
@@ -173,14 +174,14 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       where.agentConfigurationId = agentConfigurationId;
     }
 
-    const feedback = await AgentMessageFeedback.findOne({ where });
+    const feedback = await AgentMessageFeedbackModel.findOne({ where });
 
     if (!feedback) {
       return null;
     }
 
     return new AgentMessageFeedbackResource(
-      AgentMessageFeedback,
+      AgentMessageFeedbackModel,
       feedback.get()
     );
   }
@@ -196,7 +197,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     paginationParams: PaginationParams;
     filter?: "active" | "all";
   }) {
-    const where: WhereOptions<AgentMessageFeedback> = {
+    const where: WhereOptions<AgentMessageFeedbackModel> = {
       // Safety check: global models share ids across workspaces and some have had feedbacks.
       workspaceId: workspace.id,
       agentConfigurationId: agentConfiguration.sId,
@@ -213,7 +214,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       };
     }
 
-    const agentMessageFeedback = await AgentMessageFeedback.findAll({
+    const agentMessageFeedback = await AgentMessageFeedbackModel.findAll({
       where,
       include: [
         {
@@ -254,7 +255,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
 
     return agentMessageFeedback.map((feedback) => {
       return new AgentMessageFeedbackResource(
-        AgentMessageFeedback,
+        AgentMessageFeedbackModel,
         feedback.get(),
         {
           message: feedback.agentMessage?.message,
@@ -276,7 +277,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     workspace: WorkspaceType;
     transaction?: Transaction;
   }) {
-    const agentMessageFeedback = await AgentMessageFeedback.findAll({
+    const agentMessageFeedback = await AgentMessageFeedbackModel.findAll({
       where: {
         // IMPORTANT: Necessary for global models who share ids across workspaces.
         workspaceId: workspace.id,
@@ -319,7 +320,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       .filter((feedback) => Boolean(feedback.user))
       .map((feedback) => {
         return new AgentMessageFeedbackResource(
-          AgentMessageFeedback,
+          AgentMessageFeedbackModel,
           feedback.get(),
           {
             user: feedback.user,
@@ -339,7 +340,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       dateMinusXDays.setDate(dateMinusXDays.getDate() - daysOld);
     }
     const workspace = auth.getNonNullableWorkspace();
-    const feedbackCount = await AgentMessageFeedback.findAndCountAll({
+    const feedbackCount = await AgentMessageFeedbackModel.findAndCountAll({
       attributes: ["agentConfigurationId", "thumbDirection"],
       where: {
         workspaceId: workspace.id,
@@ -393,7 +394,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
         (
           message
         ): message is Message & {
-          agentMessage: { feedbacks: AgentMessageFeedback[] };
+          agentMessage: { feedbacks: AgentMessageFeedbackModel[] };
         } =>
           !!message.agentMessage?.feedbacks &&
           message.agentMessage.feedbacks.length > 0
@@ -401,7 +402,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       .map((message) => {
         const feedback = message.agentMessage?.feedbacks?.[0];
         return new AgentMessageFeedbackResource(
-          AgentMessageFeedback,
+          AgentMessageFeedbackModel,
           feedback.get(),
           {
             message,
@@ -469,7 +470,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       return new Err(new Error("Agent message not found"));
     }
 
-    const agentMessageFeedback = await AgentMessageFeedback.findOne({
+    const agentMessageFeedback = await AgentMessageFeedbackModel.findOne({
       where: {
         userId: user.id,
         agentMessageId: message.agentMessage.id,
@@ -478,7 +479,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     });
     const agentMessageFeedbackResource = agentMessageFeedback
       ? new AgentMessageFeedbackResource(
-          AgentMessageFeedback,
+          AgentMessageFeedbackModel,
           agentMessageFeedback.get()
         )
       : null;
@@ -548,7 +549,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   ): Promise<AgentMessageFeedbackResource[]> {
     const workspace = auth.getNonNullableWorkspace();
 
-    const feedbacks = await AgentMessageFeedback.findAll({
+    const feedbacks = await AgentMessageFeedbackModel.findAll({
       where: {
         agentMessageId,
         workspaceId: workspace.id,

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -14,7 +14,6 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
   AgentMessageFeedbackModel,
   AgentMessageModel,
-  AgentMessageModel as AgentMessageModel,
   ConversationModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -10,13 +10,13 @@ import { Op } from "sequelize";
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
-  AgentMessage,
-  AgentMessage as AgentMessageModel,
   AgentMessageFeedbackModel,
+  AgentMessageModel,
+  AgentMessageModel as AgentMessageModel,
   ConversationModel,
-  Message,
+  MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { UserModel } from "@app/lib/resources/storage/models/user";
@@ -47,7 +47,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   static model: ModelStatic<AgentMessageFeedbackModel> =
     AgentMessageFeedbackModel;
 
-  readonly message?: Attributes<Message>;
+  readonly message?: Attributes<MessageModel>;
   readonly user?: Attributes<UserModel>;
   readonly conversationId?: string;
 
@@ -59,7 +59,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       user,
       conversationId,
     }: {
-      message?: Attributes<Message>;
+      message?: Attributes<MessageModel>;
       user?: Attributes<UserModel>;
       conversationId?: string;
     } = {}
@@ -98,7 +98,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       user,
       conversationId,
     }: {
-      message?: Attributes<Message>;
+      message?: Attributes<MessageModel>;
       user?: Attributes<UserModel>;
       conversationId?: string;
     } = {}
@@ -223,7 +223,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
           as: "agentMessage",
           include: [
             {
-              model: Message,
+              model: MessageModel,
               as: "message",
               attributes: ["id", "sId"],
               include: [
@@ -293,7 +293,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
           as: "agentMessage",
           include: [
             {
-              model: Message,
+              model: MessageModel,
               as: "message",
               attributes: ["id", "sId"],
               include: [
@@ -363,7 +363,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
   ) {
     const user = auth.getNonNullableUser();
 
-    const feedbackForMessages = await Message.findAll({
+    const feedbackForMessages = await MessageModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         conversationId: conversation.id,
@@ -374,7 +374,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       attributes: ["id", "sId", "agentMessageId"],
       include: [
         {
-          model: AgentMessage,
+          model: AgentMessageModel,
           as: "agentMessage",
           attributes: ["id"],
           include: [
@@ -393,7 +393,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       .filter(
         (
           message
-        ): message is Message & {
+        ): message is MessageModel & {
           agentMessage: { feedbacks: AgentMessageFeedbackModel[] };
         } =>
           !!message.agentMessage?.feedbacks &&
@@ -440,7 +440,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       Error
     >
   > {
-    const message = await Message.findOne({
+    const message = await MessageModel.findOne({
       attributes: ["id", "sId"],
       where: {
         sId: messageId,
@@ -449,7 +449,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       },
       include: [
         {
-          model: AgentMessage,
+          model: AgentMessageModel,
           as: "agentMessage",
           attributes: [
             "id",
@@ -510,7 +510,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
       });
     }
 
-    const agentConfiguration = await AgentConfiguration.findOne({
+    const agentConfiguration = await AgentConfigurationModel.findOne({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         sId: message.agentMessage.agentConfigurationId,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -15,9 +15,9 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
-  Message,
+  MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -60,7 +60,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
   ): Promise<ModelId[]> {
     const uniqueAgentMessageIds = [...new Set(agentMessageIds)];
 
-    const agentMessages = await AgentMessage.findAll({
+    const agentMessages = await AgentMessageModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         id: { [Op.in]: uniqueAgentMessageIds },
@@ -236,7 +236,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
 
     const includeClause: IncludeOptions[] = [
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: true,
         where: {
@@ -244,7 +244,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         },
         include: [
           {
-            model: Message,
+            model: MessageModel,
             as: "message",
             required: true,
             include: [

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -5,7 +5,7 @@ import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { DatasetResource } from "@app/lib/resources/dataset_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { RunResource } from "@app/lib/resources/run_resource";
@@ -118,7 +118,7 @@ export class AppResource extends ResourceWithSpace<AppModel> {
       },
     });
 
-    const agentConfigurations = await AgentConfiguration.findAll({
+    const agentConfigurations = await AgentConfigurationModel.findAll({
       where: {
         workspaceId: owner.id,
         status: "active",

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -4,13 +4,13 @@ import type { Attributes, CreationAttributes, ModelStatic } from "sequelize";
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import { DatasetResource } from "@app/lib/resources/dataset_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { RunResource } from "@app/lib/resources/run_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { AppModel, Clone } from "@app/lib/resources/storage/models/apps";
+import { AppModel, CloneModel } from "@app/lib/resources/storage/models/apps";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
@@ -111,7 +111,7 @@ export class AppResource extends ResourceWithSpace<AppModel> {
   async getUsagesByAgents(auth: Authenticator) {
     const owner = auth.getNonNullableWorkspace();
 
-    const mcpConfigurations = await AgentMCPServerConfiguration.findAll({
+    const mcpConfigurations = await AgentMCPServerConfigurationModel.findAll({
       where: {
         appId: this.sId,
         workspaceId: owner.id,
@@ -199,7 +199,7 @@ export class AppResource extends ResourceWithSpace<AppModel> {
     }
 
     // Create clone relationship.
-    await Clone.create({
+    await CloneModel.create({
       fromId: this.id,
       toId: newApp.id,
       workspaceId: newApp.workspaceId,
@@ -255,7 +255,7 @@ export class AppResource extends ResourceWithSpace<AppModel> {
     const deletedCount = await withTransaction(async (t) => {
       await RunResource.deleteAllByAppId(this.id, t);
 
-      await Clone.destroy({
+      await CloneModel.destroy({
         where: {
           [Op.or]: [{ fromId: this.id }, { toId: this.id }],
         },

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -21,7 +21,7 @@ import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { Message } from "@app/lib/models/agent/conversation";
+import { MessageModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -151,7 +151,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
   }
 
   static fromMessage(
-    message: Message & { contentFragment?: ContentFragmentModel }
+    message: MessageModel & { contentFragment?: ContentFragmentModel }
   ) {
     if (!message.contentFragment) {
       throw new Error(
@@ -188,7 +188,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
   }
 
   static async fromMessageId(auth: Authenticator, id: ModelId) {
-    const message = await Message.findOne({
+    const message = await MessageModel.findOne({
       where: {
         id,
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -280,7 +280,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
   }: {
     auth: Authenticator;
     conversationId: string;
-    message: Message;
+    message: MessageModel;
   }): Promise<ContentFragmentType> {
     const owner = auth.workspace();
     if (!owner) {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -10,7 +10,7 @@ import {
 
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import { Authenticator } from "@app/lib/auth";
-import { Message } from "@app/lib/models/agent/conversation";
+import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -1863,7 +1863,7 @@ describe("Space Handling", () => {
       assert(conversationResource, "Conversation resource not found");
 
       // Get all messages to find a user message
-      const messages = await Message.findAll({
+      const messages = await MessageModel.findAll({
         where: {
           conversationId: conversationResource.id,
           workspaceId: auth.getNonNullableWorkspace().id,
@@ -1902,7 +1902,7 @@ describe("Space Handling", () => {
       assert(conversationResource, "Conversation resource not found");
 
       // Get all messages to find an agent message
-      const messages = await Message.findAll({
+      const messages = await MessageModel.findAll({
         where: {
           conversationId: conversationResource.id,
           workspaceId: auth.getNonNullableWorkspace().id,
@@ -1969,7 +1969,7 @@ describe("Space Handling", () => {
       assert(conversationResource, "Conversation resource not found");
 
       // Get a message from the other conversation
-      const otherMessages = await Message.findAll({
+      const otherMessages = await MessageModel.findAll({
         where: {
           conversationId: (await ConversationResource.fetchById(
             auth,
@@ -2001,7 +2001,7 @@ describe("Space Handling", () => {
       assert(conversationResource, "Conversation resource not found");
 
       // Get all messages
-      const messages = await Message.findAll({
+      const messages = await MessageModel.findAll({
         where: {
           conversationId: conversationResource.id,
           workspaceId: auth.getNonNullableWorkspace().id,
@@ -2046,7 +2046,7 @@ describe("Space Handling", () => {
       assert(conversationResource, "Conversation resource not found");
 
       // Get the first message
-      const messages = await Message.findAll({
+      const messages = await MessageModel.findAll({
         where: {
           conversationId: conversationResource.id,
           workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -9,8 +9,8 @@ import { Op } from "sequelize";
 
 import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
@@ -438,14 +438,14 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<Result<number, Error>> {
-    await AgentDataSourceConfiguration.destroy({
+    await AgentDataSourceConfigurationModel.destroy({
       where: {
         dataSourceId: this.id,
       },
       transaction,
     });
 
-    await AgentTablesQueryConfigurationTable.destroy({
+    await AgentTablesQueryConfigurationTableModel.destroy({
       where: {
         dataSourceId: this.id,
       },

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -16,9 +16,9 @@ import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { isFolder, isWebsite } from "@app/lib/data_sources";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
@@ -725,7 +725,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     const agentDataSourceConfigurations =
-      await AgentDataSourceConfiguration.findAll({
+      await AgentDataSourceConfigurationModel.findAll({
         where: {
           dataSourceViewId: this.id,
           workspaceId,
@@ -733,7 +733,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       });
 
     const agentTablesQueryConfigurations =
-      await AgentTablesQueryConfigurationTable.findAll({
+      await AgentTablesQueryConfigurationTableModel.findAll({
         where: {
           dataSourceViewId: this.id,
           workspaceId,
@@ -746,7 +746,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       )
     );
 
-    await AgentDataSourceConfiguration.destroy({
+    await AgentDataSourceConfigurationModel.destroy({
       where: {
         dataSourceViewId: this.id,
         workspaceId,
@@ -754,7 +754,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       transaction,
     });
 
-    await AgentTablesQueryConfigurationTable.destroy({
+    await AgentTablesQueryConfigurationTableModel.destroy({
       where: {
         dataSourceViewId: this.id,
         workspaceId,
@@ -764,7 +764,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
 
     // Delete associated MCP server configurations.
     if (mcpServerConfigurationIds.length > 0) {
-      await AgentMCPServerConfiguration.destroy({
+      await AgentMCPServerConfigurationModel.destroy({
         where: {
           id: {
             [Op.in]: mcpServerConfigurationIds,

--- a/front/lib/resources/dataset_resource.ts
+++ b/front/lib/resources/dataset_resource.ts
@@ -8,7 +8,7 @@ import type {
 import type { Authenticator } from "@app/lib/auth";
 import type { AppResource } from "@app/lib/resources/app_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { Dataset } from "@app/lib/resources/storage/models/apps";
+import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { DatasetType, Result } from "@app/types";
 import { Ok } from "@app/types";
@@ -16,25 +16,28 @@ import { Ok } from "@app/types";
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
-export interface DatasetResource extends ReadonlyAttributesType<Dataset> {}
+export interface DatasetResource extends ReadonlyAttributesType<DatasetModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class DatasetResource extends BaseResource<Dataset> {
-  static model: ModelStatic<Dataset> = Dataset;
+export class DatasetResource extends BaseResource<DatasetModel> {
+  static model: ModelStatic<DatasetModel> = DatasetModel;
 
-  constructor(model: ModelStatic<Dataset>, blob: Attributes<Dataset>) {
-    super(Dataset, blob);
+  constructor(
+    model: ModelStatic<DatasetModel>,
+    blob: Attributes<DatasetModel>
+  ) {
+    super(DatasetModel, blob);
   }
 
   static async makeNew(
-    blob: Omit<CreationAttributes<Dataset>, "appId">,
+    blob: Omit<CreationAttributes<DatasetModel>, "appId">,
     app: AppResource
   ) {
-    const dataset = await Dataset.create({
+    const dataset = await DatasetModel.create({
       ...blob,
       appId: app.id,
     });
 
-    return new this(Dataset, dataset.get());
+    return new this(DatasetModel, dataset.get());
   }
 
   // Deletion.
@@ -43,7 +46,7 @@ export class DatasetResource extends BaseResource<Dataset> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
-    await Dataset.destroy({
+    await DatasetModel.destroy({
       where: {
         id: this.id,
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -58,7 +61,7 @@ export class DatasetResource extends BaseResource<Dataset> {
     app: AppResource,
     t?: Transaction
   ): Promise<Result<undefined, Error>> {
-    await Dataset.destroy({
+    await DatasetModel.destroy({
       where: {
         appId: app.id,
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -69,14 +72,14 @@ export class DatasetResource extends BaseResource<Dataset> {
   }
 
   static async listForApp(auth: Authenticator, app: AppResource) {
-    const datasets = await Dataset.findAll({
+    const datasets = await DatasetModel.findAll({
       where: {
         appId: app.id,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
 
-    return datasets.map((dataset) => new this(Dataset, dataset.get()));
+    return datasets.map((dataset) => new this(DatasetModel, dataset.get()));
   }
 
   // Serialization.

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -15,7 +15,7 @@ import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import type { AgentConfiguration } from "@app/lib/models/agent/agent";
+import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import type { SkillConfigurationModel } from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
@@ -82,7 +82,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    */
   static async makeNewAgentEditorsGroup(
     auth: Authenticator,
-    agent: AgentConfiguration,
+    agent: AgentConfigurationModel,
     { transaction }: { transaction?: Transaction } = {}
   ) {
     const user = auth.getNonNullableUser();
@@ -767,7 +767,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     isDeletionFlow = false,
   }: {
     auth: Authenticator;
-    agentConfiguration: AgentConfiguration | AgentConfigurationType;
+    agentConfiguration: AgentConfigurationModel | AgentConfigurationType;
     isDeletionFlow?: boolean;
   }): Promise<GroupResource | null> {
     const workspace = auth.getNonNullableWorkspace();
@@ -1597,7 +1597,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     transaction,
   }: {
     auth: Authenticator;
-    agentConfiguration: AgentConfiguration;
+    agentConfiguration: AgentConfigurationModel;
     transaction?: Transaction;
   }): Promise<Result<void, Error>> {
     assert(

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -27,7 +27,7 @@ import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { InternalMCPServerCredentialModel } from "@app/lib/models/agent/actions/internal_mcp_server_credentials";
-import { MCPServerConnection } from "@app/lib/models/agent/actions/mcp_server_connection";
+import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { destroyMCPServerViewDependencies } from "@app/lib/models/agent/actions/mcp_server_view_helper";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
@@ -255,7 +255,7 @@ export class InternalMCPServerInMemoryResource {
       hardDelete: true,
     });
 
-    await MCPServerConnection.destroy({
+    await MCPServerConnectionModel.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         internalMCPServerId: this.id,

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -34,7 +34,8 @@ export interface MCPServerConnectionResource
   extends ReadonlyAttributesType<MCPServerConnectionModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class MCPServerConnectionResource extends BaseResource<MCPServerConnectionModel> {
-  static model: ModelStatic<MCPServerConnectionModel> = MCPServerConnectionModel;
+  static model: ModelStatic<MCPServerConnectionModel> =
+    MCPServerConnectionModel;
 
   readonly user: Attributes<UserModel>;
 

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -13,7 +13,7 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import { MCPServerConnection } from "@app/lib/models/agent/actions/mcp_server_connection";
+import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -31,19 +31,19 @@ import {
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
 export interface MCPServerConnectionResource
-  extends ReadonlyAttributesType<MCPServerConnection> {}
+  extends ReadonlyAttributesType<MCPServerConnectionModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class MCPServerConnectionResource extends BaseResource<MCPServerConnection> {
-  static model: ModelStatic<MCPServerConnection> = MCPServerConnection;
+export class MCPServerConnectionResource extends BaseResource<MCPServerConnectionModel> {
+  static model: ModelStatic<MCPServerConnectionModel> = MCPServerConnectionModel;
 
   readonly user: Attributes<UserModel>;
 
   constructor(
-    model: ModelStatic<MCPServerConnection>,
-    blob: Attributes<MCPServerConnection>,
+    model: ModelStatic<MCPServerConnectionModel>,
+    blob: Attributes<MCPServerConnectionModel>,
     { user }: { user: Attributes<UserModel> }
   ) {
-    super(MCPServerConnection, blob);
+    super(MCPServerConnectionModel, blob);
 
     this.user = user;
   }
@@ -51,7 +51,7 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
   static async makeNew(
     auth: Authenticator,
     blob: Omit<
-      CreationAttributes<MCPServerConnection>,
+      CreationAttributes<MCPServerConnectionModel>,
       "userId" | "workspaceId"
     >
   ) {
@@ -63,12 +63,12 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
     }
 
     const user = auth.getNonNullableUser();
-    const server = await MCPServerConnection.create({
+    const server = await MCPServerConnectionModel.create({
       ...blob,
       workspaceId: auth.getNonNullableWorkspace().id,
       userId: user.id,
     });
-    return new this(MCPServerConnection, server.get(), {
+    return new this(MCPServerConnectionModel, server.get(), {
       user,
     });
   }
@@ -77,13 +77,13 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
 
   private static async baseFetch(
     auth: Authenticator,
-    { where, limit, order }: ResourceFindOptions<MCPServerConnection> = {}
+    { where, limit, order }: ResourceFindOptions<MCPServerConnectionModel> = {}
   ) {
     const connections = await this.model.findAll({
       where: {
         ...where,
         workspaceId: auth.getNonNullableWorkspace().id,
-      } as WhereOptions<MCPServerConnection>,
+      } as WhereOptions<MCPServerConnectionModel>,
       limit,
       order,
       include: [

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -16,7 +16,7 @@ import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { MCPToolType, RemoteMCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import { MCPServerConnection } from "@app/lib/models/agent/actions/mcp_server_connection";
+import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { destroyMCPServerViewDependencies } from "@app/lib/models/agent/actions/mcp_server_view_helper";
 import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
@@ -208,7 +208,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       },
     });
 
-    await MCPServerConnection.destroy({
+    await MCPServerConnectionModel.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         remoteMCPServerId: this.id,

--- a/front/lib/resources/storage/models/apps.ts
+++ b/front/lib/resources/storage/models/apps.ts
@@ -92,14 +92,14 @@ AppModel.belongsTo(SpaceModel, {
   foreignKey: { allowNull: false, name: "vaultId" },
 });
 
-export class Provider extends WorkspaceAwareModel<Provider> {
+export class ProviderModel extends WorkspaceAwareModel<ProviderModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare providerId: string;
   declare config: string;
 }
-Provider.init(
+ProviderModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -127,7 +127,7 @@ Provider.init(
   }
 );
 
-export class Dataset extends WorkspaceAwareModel<Dataset> {
+export class DatasetModel extends WorkspaceAwareModel<DatasetModel> {
   declare id: CreationOptional<number>;
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -138,7 +138,7 @@ export class Dataset extends WorkspaceAwareModel<Dataset> {
 
   declare appId: ForeignKey<AppModel["id"]>;
 }
-Dataset.init(
+DatasetModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -169,20 +169,20 @@ Dataset.init(
   }
 );
 
-AppModel.hasMany(Dataset, {
+AppModel.hasMany(DatasetModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-Dataset.belongsTo(AppModel);
+DatasetModel.belongsTo(AppModel);
 
-export class Clone extends WorkspaceAwareModel<Clone> {
+export class CloneModel extends WorkspaceAwareModel<CloneModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare fromId: ForeignKey<AppModel["id"]>;
   declare toId: ForeignKey<AppModel["id"]>;
 }
-Clone.init(
+CloneModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -201,11 +201,11 @@ Clone.init(
     indexes: [{ fields: ["workspaceId"], concurrently: true }],
   }
 );
-Clone.belongsTo(AppModel, {
+CloneModel.belongsTo(AppModel, {
   foreignKey: { name: "fromId", allowNull: false },
   onDelete: "RESTRICT",
 });
-Clone.belongsTo(AppModel, {
+CloneModel.belongsTo(AppModel, {
   foreignKey: { name: "toId", allowNull: false },
   onDelete: "RESTRICT",
 });

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -14,7 +14,9 @@ export class LabsTranscriptsConfigurationModel extends WorkspaceAwareModel<LabsT
 
   declare connectionId: string | null;
   declare provider: LabsTranscriptsProviderType;
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["sId"]> | null;
+  declare agentConfigurationId: ForeignKey<
+    AgentConfiguration["sId"]
+  > | null;
   declare isActive: boolean;
 
   declare isDefaultWorkspaceConfiguration: boolean; // For default provider

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { AgentConfiguration } from "@app/lib/models/agent/agent";
+import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -15,7 +15,7 @@ export class LabsTranscriptsConfigurationModel extends WorkspaceAwareModel<LabsT
   declare connectionId: string | null;
   declare provider: LabsTranscriptsProviderType;
   declare agentConfigurationId: ForeignKey<
-    AgentConfiguration["sId"]
+    AgentConfigurationModel["sId"]
   > | null;
   declare isActive: boolean;
 

--- a/front/lib/resources/storage/models/workspace.ts
+++ b/front/lib/resources/storage/models/workspace.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { Subscription } from "@app/lib/models/plan";
+import type { SubscriptionModel } from "@app/lib/models/planModel";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type {
@@ -24,7 +24,7 @@ export class WorkspaceModel extends BaseModel<WorkspaceModel> {
   declare segmentation: WorkspaceSegmentationType;
   declare ssoEnforced?: boolean;
   declare workOSOrganizationId: string | null;
-  declare subscriptions: NonAttribute<Subscription[]>;
+  declare subscriptions: NonAttribute<SubscriptionModel[]>;
   declare whiteListedProviders: ModelProviderIdType[] | null;
   declare defaultEmbeddingProvider: EmbeddingProviderIdType | null;
   declare metadata: Record<string, string | number | boolean | object> | null;

--- a/front/lib/resources/storage/models/workspace.ts
+++ b/front/lib/resources/storage/models/workspace.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { SubscriptionModel } from "@app/lib/models/planModel";
+import type { SubscriptionModel } from "@app/lib/models/plan";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -7,7 +7,7 @@ import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import {
@@ -66,24 +66,32 @@ const FREE_NO_PLAN_SUBSCRIPTION_ID = -1;
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SubscriptionResource
-  extends ReadonlyAttributesType<Subscription> {}
+  extends ReadonlyAttributesType<SubscriptionModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class SubscriptionResource extends BaseResource<Subscription> {
-  static model: ModelStaticWorkspaceAware<Subscription> = Subscription;
+export class SubscriptionResource extends BaseResource<SubscriptionModel> {
+  static model: ModelStaticWorkspaceAware<SubscriptionModel> =
+    SubscriptionModel;
   private readonly plan: PlanType;
 
   constructor(
-    model: ModelStaticWorkspaceAware<Subscription>,
-    blob: Attributes<Subscription>,
+    model: ModelStaticWorkspaceAware<SubscriptionModel>,
+    blob: Attributes<SubscriptionModel>,
     plan: PlanType
   ) {
-    super(Subscription, blob);
+    super(SubscriptionModel, blob);
     this.plan = plan;
   }
 
-  static async makeNew(blob: CreationAttributes<Subscription>, plan: PlanType) {
-    const subscription = await Subscription.create({ ...blob });
-    return new SubscriptionResource(Subscription, subscription.get(), plan);
+  static async makeNew(
+    blob: CreationAttributes<SubscriptionModel>,
+    plan: PlanType
+  ) {
+    const subscription = await SubscriptionModel.create({ ...blob });
+    return new SubscriptionResource(
+      SubscriptionModel,
+      subscription.get(),
+      plan
+    );
   }
 
   static async fetchActiveByWorkspace(
@@ -124,7 +132,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
         dangerouslyBypassWorkspaceIsolationSecurity: true,
         include: [
           {
-            model: Plan,
+            model: PlanModel,
             as: "plan",
             required: true,
           },
@@ -162,7 +170,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
         }
       }
       subscriptionResourceByWorkspaceSid[sId] = new SubscriptionResource(
-        Subscription,
+        SubscriptionModel,
         activeSubscription?.get() ||
           this.createFreeNoPlanSubscription(workspace),
         renderPlanFromModel({ plan })
@@ -177,15 +185,15 @@ export class SubscriptionResource extends BaseResource<Subscription> {
   ): Promise<SubscriptionResource[]> {
     const owner = auth.getNonNullableWorkspace();
 
-    const subscriptions = await Subscription.findAll({
+    const subscriptions = await SubscriptionModel.findAll({
       where: { workspaceId: owner.id },
-      include: [Plan],
+      include: [PlanModel],
     });
 
     return subscriptions.map(
       (s) =>
         new SubscriptionResource(
-          Subscription,
+          SubscriptionModel,
           s.get(),
           renderPlanFromModel({ plan: s.plan })
         )
@@ -197,7 +205,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
   ): Promise<SubscriptionResource | null> {
     const res = await this.model.findOne({
       where: { stripeSubscriptionId },
-      include: [Plan],
+      include: [PlanModel],
 
       // WORKSPACE_ISOLATION_BYPASS: Used to check if a subscription is not attached to a workspace
       dangerouslyBypassWorkspaceIsolationSecurity: true,
@@ -208,7 +216,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     }
 
     return new SubscriptionResource(
-      Subscription,
+      SubscriptionModel,
       res.get(),
       renderPlanFromModel({ plan: res.plan })
     );
@@ -217,7 +225,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
   static async internalFetchWorkspacesWithFreeEndedSubscriptions(): Promise<{
     workspaces: LightWorkspaceType[];
   }> {
-    const freeEndedSubscriptions = await Subscription.findAll({
+    const freeEndedSubscriptions = await SubscriptionModel.findAll({
       where: {
         status: "active",
         stripeSubscriptionId: null,
@@ -252,7 +260,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
       dangerouslyBypassWorkspaceIsolationSecurity: true,
       include: [
         {
-          model: Plan,
+          model: PlanModel,
           as: "plan",
           where: {
             code: {
@@ -290,7 +298,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     await this.endActiveSubscription(workspace);
 
     return new SubscriptionResource(
-      Subscription,
+      SubscriptionModel,
       this.createFreeNoPlanSubscription(workspace),
       renderPlanFromModel({ plan: FREE_NO_PLAN_DATA })
     );
@@ -320,7 +328,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     const now = new Date();
 
     // Find active subscription
-    const activeSubscription = await Subscription.findOne({
+    const activeSubscription = await SubscriptionModel.findOne({
       where: { workspaceId: workspace.id, status: "active" },
     });
 
@@ -357,7 +365,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
         );
       }
 
-      return Subscription.create(
+      return SubscriptionModel.create(
         {
           sId: generateRandomModelSId(),
           workspaceId: workspace.id,
@@ -386,7 +394,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     }
 
     return new SubscriptionResource(
-      Subscription,
+      SubscriptionModel,
       newSubscription.get(),
       renderPlanFromModel({ plan: newPlan })
     );
@@ -437,7 +445,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     if (activeSubscription && activeSubscription.plan.code === newPlan.code) {
       // If you are already on this free plan and you want to change the end date, we let you do it.
       if (isFreePlan(newPlan.code) && activeSubscription.endDate !== endDate) {
-        await Subscription.update(
+        await SubscriptionModel.update(
           { endDate },
           {
             where: { sId: activeSubscription.sId },
@@ -479,7 +487,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
         );
       }
 
-      await Subscription.update(
+      await SubscriptionModel.update(
         { planId: newPlan.id },
         {
           where: {
@@ -536,7 +544,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
       return new Err(stripeResult.error);
     }
 
-    await Subscription.update(
+    await SubscriptionModel.update(
       { planId: businessPlan.id },
       {
         where: {
@@ -554,7 +562,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
   ) {
     const { id: stripeSubscriptionId } = eventStripeSubscription;
 
-    const subscription = await Subscription.findOne({
+    const subscription = await SubscriptionModel.findOne({
       where: { stripeSubscriptionId },
       include: [WorkspaceModel],
     });
@@ -747,7 +755,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
 
   private static createFreeNoPlanSubscription(
     workspace: LightWorkspaceType
-  ): Attributes<Subscription> {
+  ): Attributes<SubscriptionModel> {
     const now = new Date();
     return {
       id: FREE_NO_PLAN_SUBSCRIPTION_ID,
@@ -793,8 +801,8 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     return workspace;
   }
 
-  private static async findPlanOrThrow(planCode: string): Promise<Plan> {
-    const newPlan = await Plan.findOne({
+  private static async findPlanOrThrow(planCode: string): Promise<PlanModel> {
+    const newPlan = await PlanModel.findOne({
       where: { code: planCode },
     });
     if (!newPlan) {
@@ -811,11 +819,11 @@ export class SubscriptionResource extends BaseResource<Subscription> {
    */
   static async endActiveSubscription(
     workspace: LightWorkspaceType
-  ): Promise<Subscription | null> {
+  ): Promise<SubscriptionModel | null> {
     const now = new Date();
 
     // Find active subscription
-    const activeSubscription = await Subscription.findOne({
+    const activeSubscription = await SubscriptionModel.findOne({
       where: { workspaceId: workspace.id, status: "active" },
     });
 

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -7,7 +7,7 @@ import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import {

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TriggerSubscriberModel } from "@app/lib/models/agent/triggers/trigger_subscriber";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import * as temporalClient from "@app/temporal/triggers/schedule/client";
@@ -747,7 +747,7 @@ describe("TriggerResource", () => {
 
       // Mock AgentConfiguration.findAll to return different statuses
       const mockAgentConfigFindAll = vi
-        .spyOn(AgentConfiguration, "findAll")
+        .spyOn(AgentConfigurationModel, "findAll")
         .mockResolvedValue([
           {
             sId: activeAgentConfig.sId,

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -10,7 +10,7 @@ import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TriggerSubscriberModel } from "@app/lib/models/agent/triggers/trigger_subscriber";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { WebhookRequestModel } from "@app/lib/models/agent/triggers/webhook_request";
@@ -416,7 +416,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     }
 
     // Query latest versions of all agent configurations at once
-    const agentConfigs = await AgentConfiguration.findAll({
+    const agentConfigs = await AgentConfigurationModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         sId: agentConfigurationIds,
@@ -424,7 +424,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     });
 
     // Get only the latest version of each agent config (by latest createdAt)
-    const latestAgentConfigs = new Map<string, AgentConfiguration>();
+    const latestAgentConfigs = new Map<string, AgentConfigurationModel>();
     for (const config of agentConfigs) {
       const existing = latestAgentConfigs.get(config.sId);
       if (

--- a/front/lib/utils/apps.ts
+++ b/front/lib/utils/apps.ts
@@ -12,7 +12,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { BaseDustProdActionRegistry } from "@app/lib/registry";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { Dataset } from "@app/lib/resources/storage/models/apps";
+import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { CoreAPIError, Result } from "@app/types";
@@ -105,7 +105,7 @@ async function updateDatasets(
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
     // Getting all existing datasets for this app
-    const existingDatasets = await Dataset.findAll({
+    const existingDatasets = await DatasetModel.findAll({
       where: {
         workspaceId: owner.id,
         appId: app.id,
@@ -140,7 +140,7 @@ async function updateDatasets(
             });
           }
         } else {
-          await Dataset.create({
+          await DatasetModel.create({
             name: datasetToImport.name,
             description: datasetToImport.description,
             appId: app.id,

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -5,11 +5,11 @@ import { Op, QueryTypes, Sequelize } from "sequelize";
 import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
   ConversationModel,
-  Message,
-  UserMessage,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -344,7 +344,7 @@ export async function getUserUsageData(
 
   const allUserMessages = await getFrontReplicaDbConnection().transaction(
     async (t) => {
-      return Message.findAll({
+      return MessageModel.findAll({
         attributes: [
           "userMessage.userId",
           [
@@ -390,7 +390,7 @@ export async function getUserUsageData(
         },
         include: [
           {
-            model: UserMessage,
+            model: UserMessageModel,
             as: "userMessage",
             required: true,
             attributes: [],
@@ -553,7 +553,7 @@ export async function getBuildersUsageData(
   const wId = workspace.id;
   const agentConfigurations = await getFrontReplicaDbConnection().transaction(
     async (t) => {
-      return AgentConfiguration.findAll({
+      return AgentConfigurationModel.findAll({
         attributes: [
           [
             Sequelize.fn("COUNT", Sequelize.col("agent_configuration.sId")),
@@ -825,7 +825,7 @@ export async function checkWorkspaceActivity(auth: Authenticator) {
   const hasDataSource =
     (await DataSourceResource.listByWorkspace(auth, { limit: 1 })).length > 0;
 
-  const hasCreatedAssistant = await AgentConfiguration.findOne({
+  const hasCreatedAssistant = await AgentConfigurationModel.findOne({
     where: { workspaceId: auth.getNonNullableWorkspace().id },
   });
 

--- a/front/migrations/20230413_objects_workspaces.ts
+++ b/front/migrations/20230413_objects_workspaces.ts
@@ -3,8 +3,8 @@
 import { personalWorkspace } from "@app/lib/auth";
 import {
   AppModel,
-  Dataset,
-  Provider,
+  DatasetModel,
+  ProviderModel,
 } from "@app/lib/resources/storage/models/apps";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
@@ -12,7 +12,13 @@ import { RunModel } from "@app/lib/resources/storage/models/runs";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 
 async function addWorkspaceToObject(
-  object: AppModel | Dataset | Provider | KeyModel | DataSourceModel | RunModel
+  object:
+    | AppModel
+    | DatasetModel
+    | ProviderModel
+    | KeyModel
+    | DataSourceModel
+    | RunModel
 ) {
   if (object.workspaceId) {
     // @ts-expect-error old migration code kept for reference
@@ -48,8 +54,8 @@ async function addWorkspaceToObject(
 async function updateObjects(
   objects:
     | AppModel[]
-    | Dataset[]
-    | Provider[]
+    | DatasetModel[]
+    | ProviderModel[]
     | KeyModel[]
     | DataSourceModel[]
     | RunModel[]
@@ -76,12 +82,12 @@ async function updateApps() {
 }
 
 async function updateDatasets() {
-  const datasets = await Dataset.findAll();
+  const datasets = await DatasetModel.findAll();
   await updateObjects(datasets);
 }
 
 async function updateProviders() {
-  const providers = await Provider.findAll();
+  const providers = await ProviderModel.findAll();
   await updateObjects(providers);
 }
 

--- a/front/migrations/20231107_subscriptions_duplicated.ts
+++ b/front/migrations/20231107_subscriptions_duplicated.ts
@@ -1,4 +1,4 @@
-import { SubscriptionModel } from "@app/lib/models/planModel";
+import { SubscriptionModel } from "@app/lib/models/plan";
 
 const { LIVE = false, WORKSPACE_IDS = "" } = process.env;
 

--- a/front/migrations/20231107_subscriptions_duplicated.ts
+++ b/front/migrations/20231107_subscriptions_duplicated.ts
@@ -1,4 +1,4 @@
-import { Subscription } from "@app/lib/models/plan";
+import { SubscriptionModel } from "@app/lib/models/planModel";
 
 const { LIVE = false, WORKSPACE_IDS = "" } = process.env;
 
@@ -26,7 +26,7 @@ const getValidSubscriptionStartDateForWorkspace = async (
   workspaceId: number
 ) => {
   console.log(`Fixing subscription start date for workspace ${workspaceId}`);
-  const subscriptions = await Subscription.findAll({
+  const subscriptions = await SubscriptionModel.findAll({
     where: {
       workspaceId: workspaceId,
       planId: 5,
@@ -53,7 +53,7 @@ const deletedDuplicatedEndedSubscriptionsForWorkspace = async (
   workspaceId: number
 ) => {
   console.log(`Cleaning duplicated ended subscriptions for ${workspaceId}`);
-  const subscriptions = await Subscription.findAll({
+  const subscriptions = await SubscriptionModel.findAll({
     where: {
       workspaceId: workspaceId,
       status: "ended",

--- a/front/migrations/20231204_author_backfill.ts
+++ b/front/migrations/20231204_author_backfill.ts
@@ -1,11 +1,11 @@
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 
 async function main() {
   console.log("Starting author backfill");
   const workspaceIds = (
-    await AgentConfiguration.findAll({
+    await AgentConfigurationModel.findAll({
       attributes: ["workspaceId"],
       group: ["workspaceId"],
     })
@@ -51,7 +51,7 @@ async function backfillAuthor(workspaceId: number) {
   }
 
   // update all agent configurations with null author of this workspace
-  const agentConfigurations = await AgentConfiguration.update(
+  const agentConfigurations = await AgentConfigurationModel.update(
     {
       authorId: author.id,
     },

--- a/front/migrations/20231219_imageUrl_backfill.ts
+++ b/front/migrations/20231219_imageUrl_backfill.ts
@@ -1,4 +1,4 @@
-import { UserMessage } from "@app/lib/models/agent/conversation";
+import { UserMessageModel } from "@app/lib/models/agent/conversation";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -51,7 +51,7 @@ async function backfillImageUrl(workspaceId: number) {
   // for each user, find the last usermessage
   // and set the user's imageUrl to the usermessage's userContextProfilePictureUrl
   for (const user of users) {
-    const userMessage = await UserMessage.findOne({
+    const userMessage = await UserMessageModel.findOne({
       where: {
         userId: user.id,
       },

--- a/front/migrations/20240130_migrate_assistants_models.ts
+++ b/front/migrations/20240130_migrate_assistants_models.ts
@@ -1,4 +1,4 @@
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { GPT_4_TURBO_MODEL_ID } from "@app/types";
 import { Err } from "@app/types";
@@ -27,7 +27,7 @@ async function updateWorkspaceAssistants(wId: string) {
     throw new Error(`Workspace ${wId} not found`);
   }
 
-  const agentConfigurations = await AgentConfiguration.findAll({
+  const agentConfigurations = await AgentConfigurationModel.findAll({
     where: { workspaceId: w.id },
   });
 

--- a/front/migrations/20240325_content_fragments_sourceurl_migration.ts
+++ b/front/migrations/20240325_content_fragments_sourceurl_migration.ts
@@ -1,6 +1,6 @@
 import { Op } from "sequelize";
 
-import { Message } from "@app/lib/models/agent/conversation";
+import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 
@@ -13,7 +13,7 @@ async function main() {
 
   let messages = [];
   do {
-    messages = await Message.findAll({
+    messages = await MessageModel.findAll({
       where: {
         contentFragmentId: {
           [Op.not]: null,

--- a/front/migrations/20240422_pro_plan_max_message.ts
+++ b/front/migrations/20240422_pro_plan_max_message.ts
@@ -1,4 +1,4 @@
-import { PlanModel } from "@app/lib/models/planModel";
+import { PlanModel } from "@app/lib/models/plan";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 

--- a/front/migrations/20240422_pro_plan_max_message.ts
+++ b/front/migrations/20240422_pro_plan_max_message.ts
@@ -1,10 +1,10 @@
-import { Plan } from "@app/lib/models/plan";
+import { PlanModel } from "@app/lib/models/planModel";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
 const updateProMaxMessagesLimit = async (execute: boolean) => {
   if (execute) {
-    const res = await Plan.update(
+    const res = await PlanModel.update(
       {
         maxMessages: 100,
         maxMessagesTimeframe: "day",

--- a/front/migrations/20240513_backfill_customerio_membership_timestamps.ts
+++ b/front/migrations/20240513_backfill_customerio_membership_timestamps.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash";
 
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import {
   FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,

--- a/front/migrations/20240513_backfill_customerio_membership_timestamps.ts
+++ b/front/migrations/20240513_backfill_customerio_membership_timestamps.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash";
 
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import {
   FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
@@ -15,7 +15,7 @@ import { makeScript } from "@app/scripts/helpers";
 import { removeNulls } from "@app/types";
 
 const backfillCustomerIo = async (execute: boolean) => {
-  const allActiveSubscriptions = await Subscription.findAll({
+  const allActiveSubscriptions = await SubscriptionModel.findAll({
     where: {
       status: "active",
     },
@@ -23,7 +23,7 @@ const backfillCustomerIo = async (execute: boolean) => {
   const planIds = removeNulls(allActiveSubscriptions.map((s) => s.planId));
   const planById = _.keyBy(
     planIds.length
-      ? await Plan.findAll({
+      ? await PlanModel.findAll({
           where: {
             id: planIds,
           },

--- a/front/migrations/20240515_scrub_workspaces.ts
+++ b/front/migrations/20240515_scrub_workspaces.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
-import { SubscriptionModel } from "@app/lib/models/planModel";
+import { SubscriptionModel } from "@app/lib/models/plan";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";

--- a/front/migrations/20240515_scrub_workspaces.ts
+++ b/front/migrations/20240515_scrub_workspaces.ts
@@ -2,14 +2,14 @@ import _ from "lodash";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
-import { Subscription } from "@app/lib/models/plan";
+import { SubscriptionModel } from "@app/lib/models/planModel";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { launchImmediateWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 
 const scrubWorkspaces = async (execute: boolean) => {
-  const endedSubs = await Subscription.findAll({
+  const endedSubs = await SubscriptionModel.findAll({
     where: {
       // end date at least 14 days ago
       endDate: {
@@ -25,7 +25,7 @@ const scrubWorkspaces = async (execute: boolean) => {
   });
 
   const allSubsByWorkspaceId = _.groupBy(
-    await Subscription.findAll({
+    await SubscriptionModel.findAll({
       where: {
         workspaceId: workspaces.map((w) => w.id),
       },

--- a/front/migrations/20240611_agent_config_template_id_backfill.ts
+++ b/front/migrations/20240611_agent_config_template_id_backfill.ts
@@ -1,6 +1,6 @@
 import { QueryTypes } from "sequelize";
 
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
 import { makeScript } from "@app/scripts/helpers";
@@ -8,7 +8,7 @@ import { makeScript } from "@app/scripts/helpers";
 // Backfilling AgentConfiguration.templateId by computing a similarity score between
 // the instructions of the AgentConfiguration and the presetInstructions of the templates.
 makeScript({}, async ({ execute }) => {
-  const acs = await AgentConfiguration.findAll({
+  const acs = await AgentConfigurationModel.findAll({
     where: {
       templateId: null,
     },

--- a/front/migrations/20240731_backfill_views_in_agent_data_source_configurations.ts
+++ b/front/migrations/20240731_backfill_views_in_agent_data_source_configurations.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 
 import { Authenticator } from "@app/lib/auth";
 import { isManaged } from "@app/lib/data_sources";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -40,7 +40,7 @@ async function backfillViewsInAgentDataSourceConfigurationForWorkspace(
   // Count agent data source configurations that uses those data sources.
 
   const agentDataSourceConfigurationsCount =
-    await AgentDataSourceConfiguration.count({
+    await AgentDataSourceConfigurationModel.count({
       where: {
         dataSourceId: managedDataSources.map((ds) => ds.id),
       },
@@ -63,7 +63,7 @@ async function backfillViewsInAgentDataSourceConfigurationForWorkspace(
       `Data source view not found for data source ${ds.id}.`
     );
 
-    await AgentDataSourceConfiguration.update(
+    await AgentDataSourceConfigurationModel.update(
       { dataSourceViewId: dataSourceView.id },
       {
         where: {

--- a/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240902_backfill_views_in_agent_table_query_configurations.ts
@@ -3,7 +3,7 @@ import type { GroupedCountResultItem } from "sequelize";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -37,7 +37,7 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
 
   // Count agent tables query configurations that uses those data sources and have no dataSourceViewId.
   const agentTablesQueryConfigurationsCount: GroupedCountResultItem[] =
-    await AgentTablesQueryConfigurationTable.count({
+    await AgentTablesQueryConfigurationTableModel.count({
       // @ts-expect-error `dataSourceViewId` is not nullable.
       where: {
         dataSourceId: dataSources.map((ds) => ds.id),
@@ -64,7 +64,7 @@ async function backfillViewsInAgentTableQueryConfigurationForWorkspace(
       `Data source view not found for data source ${ds.id}.`
     );
 
-    await AgentTablesQueryConfigurationTable.update(
+    await AgentTablesQueryConfigurationTableModel.update(
       { dataSourceViewId: dataSourceView.id },
       {
         where: {

--- a/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
@@ -3,7 +3,7 @@ import type { GroupedCountResultItem } from "sequelize";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -37,7 +37,7 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
 
   // Count agent tables query configurations that uses those data sources and have no dataSourceIdNew.
   const agentTablesQueryConfigurationsCount: GroupedCountResultItem[] =
-    await AgentTablesQueryConfigurationTable.count({
+    await AgentTablesQueryConfigurationTableModel.count({
       where: {
         dataSourceId: dataSources.map((ds) => ds.sId),
         // @ts-expect-error `dataSourceIdNew` has been removed.
@@ -66,7 +66,7 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
       `Error while fetching data source view for data source ${ds.id} // Found ${dataSourceViewsForDataSource.length} data source views.`
     );
 
-    const [, affectedRows] = await AgentTablesQueryConfigurationTable.update(
+    const [, affectedRows] = await AgentTablesQueryConfigurationTableModel.update(
       {
         // @ts-expect-error `dataSourceIdNew` has been removed.
         dataSourceIdNew: ds.id,
@@ -95,7 +95,7 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
           // Expected dataSourceViewId to be ${dataSourceViewsForDataSource[0].id} but got ${r.dataSourceViewId}.`
         );
 
-        await AgentTablesQueryConfigurationTable.update(
+        await AgentTablesQueryConfigurationTableModel.update(
           {
             dataSourceViewId: dataSourceViewsForDataSource[0].id,
           },

--- a/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
+++ b/front/migrations/20240916_backfill_ds_in_agent_table_query_configurations.ts
@@ -11,6 +11,7 @@ import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types";
+
 async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
   workspace: LightWorkspaceType,
   logger: Logger,
@@ -66,24 +67,25 @@ async function backfillDataSourceIdInAgentTableQueryConfigurationForWorkspace(
       `Error while fetching data source view for data source ${ds.id} // Found ${dataSourceViewsForDataSource.length} data source views.`
     );
 
-    const [, affectedRows] = await AgentTablesQueryConfigurationTableModel.update(
-      {
-        // @ts-expect-error `dataSourceIdNew` has been removed.
-        dataSourceIdNew: ds.id,
-      },
-      {
-        where: {
-          // /!\ `dataSourceId` is the data source's name, not the id.
-          dataSourceId: ds.sId,
-          dataSourceIdNew: {
-            [Op.is]: null,
-          },
-          // Given that the name isn't unique we need to precise the workspace.
-          dataSourceWorkspaceId: workspace.sId,
+    const [, affectedRows] =
+      await AgentTablesQueryConfigurationTableModel.update(
+        {
+          // @ts-expect-error `dataSourceIdNew` has been removed.
+          dataSourceIdNew: ds.id,
         },
-        returning: true,
-      }
-    );
+        {
+          where: {
+            // /!\ `dataSourceId` is the data source's name, not the id.
+            dataSourceId: ds.sId,
+            dataSourceIdNew: {
+              [Op.is]: null,
+            },
+            // Given that the name isn't unique we need to precise the workspace.
+            dataSourceWorkspaceId: workspace.sId,
+          },
+          returning: true,
+        }
+      );
 
     if (affectedRows && affectedRows.length > 0) {
       const [r] = affectedRows;

--- a/front/migrations/20240927_backfill_conversations_groupIds.ts
+++ b/front/migrations/20240927_backfill_conversations_groupIds.ts
@@ -2,11 +2,11 @@ import _ from "lodash";
 import { Sequelize } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
-  Message,
+  MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { Logger } from "@app/logger/logger";
@@ -28,7 +28,7 @@ makeScript({}, async ({ execute }, logger) => {
 });
 
 async function getDistinctWorkspaceIds(): Promise<number[]> {
-  const workspaceIds = await AgentConfiguration.findAll({
+  const workspaceIds = await AgentConfigurationModel.findAll({
     attributes: [
       [Sequelize.fn("DISTINCT", Sequelize.col("workspaceId")), "workspaceId"],
     ],
@@ -88,13 +88,13 @@ async function updateConversation(
   // we get all messages without checking rank, because we only use them to get
   // the agentConfigurationIds. At the time of writing (pre-spaces release), we
   // don't need to consider message version at all for the backfill.
-  const messages = await Message.findAll({
+  const messages = await MessageModel.findAll({
     where: {
       conversationId: conversation.id,
     },
     include: [
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: true,
         attributes: ["agentConfigurationId"],
@@ -113,7 +113,7 @@ async function updateConversation(
 
   const groupIds = _.uniq(
     (
-      await AgentConfiguration.findAll({
+      await AgentConfigurationModel.findAll({
         where: { sId: agentConfigurationIds },
       })
     )

--- a/front/migrations/20241011_backfill_favorites.ts
+++ b/front/migrations/20241011_backfill_favorites.ts
@@ -1,14 +1,14 @@
 import _ from "lodash";
 import { Op } from "sequelize";
 
-import { AgentUserRelation } from "@app/lib/models/agent/agent";
+import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
 import { makeScript } from "@app/scripts/helpers";
 
 makeScript({}, async ({ execute }, logger) => {
   // table is ~234K rows at the time of writing
   let lastSeenId = 0;
   do {
-    const relations = await AgentUserRelation.findAll({
+    const relations = await AgentUserRelationModel.findAll({
       where: {
         id: {
           [Op.gt]: lastSeenId,
@@ -35,7 +35,10 @@ makeScript({}, async ({ execute }, logger) => {
   } while (lastSeenId !== -1);
 });
 
-async function updateRelation(relation: AgentUserRelation, execute: boolean) {
+async function updateRelation(
+  relation: AgentUserRelationModel,
+  execute: boolean
+) {
   if (execute) {
     // ~233K rows 'in-list' at the time of writing
     // @ts-expect-error column removed in a later migration

--- a/front/migrations/20241211_parents_front_migrator.ts
+++ b/front/migrations/20241211_parents_front_migrator.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import type { Logger } from "pino";
 import { Op } from "sequelize";
 
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -120,7 +120,7 @@ async function migrateAgentDataSourceConfigurations({
 }) {
   let lastSeenId = 0;
   for (;;) {
-    const configurations = await AgentDataSourceConfiguration.findAll({
+    const configurations = await AgentDataSourceConfigurationModel.findAll({
       limit: BATCH_SIZE,
       where: { id: { [Op.gt]: lastSeenId } },
       order: [["id", "ASC"]],

--- a/front/migrations/20250123_backfill_workspace_id_conversation_related_models.ts
+++ b/front/migrations/20250123_backfill_workspace_id_conversation_related_models.ts
@@ -2,13 +2,13 @@ import _ from "lodash";
 import { Op } from "sequelize";
 
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
   ConversationParticipantModel,
-  Mention,
-  Message,
-  MessageReaction,
-  UserMessage,
+  MentionModel,
+  MessageModel,
+  MessageReactionModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import type { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -34,7 +34,7 @@ const TABLES: TableConfig[] = [
     ],
   },
   {
-    model: Message,
+    model: MessageModel,
     include: (workspaceId: number) => [
       {
         as: "conversation",
@@ -45,11 +45,11 @@ const TABLES: TableConfig[] = [
     ],
   },
   {
-    model: UserMessage,
+    model: UserMessageModel,
     include: (workspaceId: number) => [
       {
         as: "message",
-        model: Message,
+        model: MessageModel,
         required: true,
         include: [
           {
@@ -63,11 +63,11 @@ const TABLES: TableConfig[] = [
     ],
   },
   {
-    model: AgentMessage,
+    model: AgentMessageModel,
     include: (workspaceId: number) => [
       {
         as: "message",
-        model: Message,
+        model: MessageModel,
         required: true,
         include: [
           {
@@ -85,7 +85,7 @@ const TABLES: TableConfig[] = [
     include: (workspaceId: number) => [
       {
         as: "message",
-        model: Message,
+        model: MessageModel,
         required: true,
         include: [
           {
@@ -99,10 +99,10 @@ const TABLES: TableConfig[] = [
     ],
   },
   {
-    model: MessageReaction,
+    model: MessageReactionModel,
     include: (workspaceId: number) => [
       {
-        model: Message,
+        model: MessageModel,
         required: true,
         include: [
           {
@@ -116,10 +116,10 @@ const TABLES: TableConfig[] = [
     ],
   },
   {
-    model: Mention,
+    model: MentionModel,
     include: (workspaceId: number) => [
       {
-        model: Message,
+        model: MessageModel,
         required: true,
         include: [
           {

--- a/front/migrations/20250128_backfill_avatars.ts
+++ b/front/migrations/20250128_backfill_avatars.ts
@@ -2,7 +2,7 @@ import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
@@ -31,7 +31,7 @@ async function backfillAvatars(
   const baseUrl = `https://storage.googleapis.com/${bucket.name}/`;
 
   // Get all agent with legacy avatars
-  const agentConfigurations = await AgentConfiguration.findAll({
+  const agentConfigurations = await AgentConfigurationModel.findAll({
     where: {
       workspaceId: workspace.id,
       pictureUrl: {

--- a/front/migrations/20250220_workspace_check_seat_count.ts
+++ b/front/migrations/20250220_workspace_check_seat_count.ts
@@ -1,5 +1,5 @@
 import { checkSeatCountForWorkspace } from "@app/lib/api/workspace";
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import {
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,

--- a/front/migrations/20250220_workspace_check_seat_count.ts
+++ b/front/migrations/20250220_workspace_check_seat_count.ts
@@ -1,5 +1,5 @@
 import { checkSeatCountForWorkspace } from "@app/lib/api/workspace";
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import {
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
@@ -14,12 +14,12 @@ async function checkWorkspaceSeatCount(
   logger: Logger,
   execute: boolean
 ) {
-  const subscription = await Subscription.findOne({
+  const subscription = await SubscriptionModel.findOne({
     where: {
       workspaceId: workspace.id,
       status: "active",
     },
-    include: [Plan],
+    include: [PlanModel],
   });
   const localLogger = logger.child({
     workspaceId: workspace.sId,

--- a/front/migrations/20250408_missing_conversation_participants.ts
+++ b/front/migrations/20250408_missing_conversation_participants.ts
@@ -4,8 +4,8 @@ import { Op, UniqueConstraintError } from "sequelize";
 import {
   ConversationModel,
   ConversationParticipantModel,
-  Message,
-  UserMessage,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -80,7 +80,7 @@ async function processConversation(
   execute: boolean
 ) {
   // Getting all the user messages in the conversation.
-  const messages = await Message.findAll({
+  const messages = await MessageModel.findAll({
     where: {
       conversationId: conversation.id,
       userMessageId: {
@@ -89,7 +89,7 @@ async function processConversation(
     },
     include: [
       {
-        model: UserMessage,
+        model: UserMessageModel,
         as: "userMessage",
         attributes: ["userId", "createdAt"],
         order: [["createdAt", "DESC"]],

--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -4,7 +4,7 @@ import type { Logger } from "pino";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -20,7 +20,7 @@ import { AGENT_GROUP_PREFIX } from "@app/types";
 
 async function backfillAgentEditorsGroup(
   auth: Authenticator,
-  agentConfigs: AgentConfiguration[],
+  agentConfigs: AgentConfigurationModel[],
   workspace: LightWorkspaceType,
   execute: boolean,
   logger: Logger
@@ -145,7 +145,7 @@ const migrateWorkspaceEditorsGroups = async (
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   const agents = await (async () => {
     try {
-      return await AgentConfiguration.findAll({
+      return await AgentConfigurationModel.findAll({
         where: {
           workspaceId: workspace.id,
           status: {

--- a/front/migrations/20250429_update_agent_scopes.ts
+++ b/front/migrations/20250429_update_agent_scopes.ts
@@ -2,7 +2,7 @@ import type { Logger } from "pino";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -18,7 +18,7 @@ const migrateWorkspace = async (
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   logger.info({ workspace: workspace.sId }, "Migrating agents");
-  const agents = await AgentConfiguration.findAll({
+  const agents = await AgentConfigurationModel.findAll({
     where: {
       workspaceId: workspace.id,
       scope: ["workspace", "published", "private"],

--- a/front/migrations/20250503_backfill_agent_mcp_server_internal_id.ts
+++ b/front/migrations/20250503_backfill_agent_mcp_server_internal_id.ts
@@ -1,13 +1,13 @@
 import type { NonAttribute } from "sequelize";
 
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
 async function main({ execute }: { execute: boolean }) {
   // Fetch all AgentMCPServerConfiguration records
-  const configurations = await AgentMCPServerConfiguration.findAll({
+  const configurations = await AgentMCPServerConfigurationModel.findAll({
     include: [
       {
         model: MCPServerViewModel,

--- a/front/migrations/20250505_delete_group_draft_agents.ts
+++ b/front/migrations/20250505_delete_group_draft_agents.ts
@@ -1,5 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -12,7 +12,7 @@ makeScript({}, async ({ execute }, logger) => {
     attributes: ["groupId"],
     include: [
       {
-        model: AgentConfiguration,
+        model: AgentConfigurationModel,
         where: {
           status: "draft",
         },

--- a/front/migrations/20250526_migrate_extract_to_mcp.ts
+++ b/front/migrations/20250526_migrate_extract_to_mcp.ts
@@ -2,8 +2,8 @@ import fs from "fs";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -120,7 +120,7 @@ async function migrateWorkspaceExtractActions(
     processConfigs,
     async (processConfig) => {
       if (execute) {
-        const mcpConfig = await AgentMCPServerConfiguration.create({
+        const mcpConfig = await AgentMCPServerConfigurationModel.create({
           sId: generateRandomModelSId(),
           // @ts-ignore
           agentConfigurationId: processConfig.agentConfigurationId,
@@ -156,7 +156,7 @@ async function migrateWorkspaceExtractActions(
         });
 
         // Move the datasources to the new MCP server configuration.
-        const datasources = await AgentDataSourceConfiguration.findAll({
+        const datasources = await AgentDataSourceConfigurationModel.findAll({
           where: {
             workspaceId: auth.getNonNullableWorkspace().id,
             // @ts-ignore

--- a/front/migrations/20250526_migrate_extract_to_mcp.ts
+++ b/front/migrations/20250526_migrate_extract_to_mcp.ts
@@ -5,7 +5,7 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
@@ -25,7 +25,7 @@ async function findWorkspacesWithProcessConfigurations(): Promise<ModelId[]> {
     include: [
       {
         attributes: [],
-        model: AgentConfiguration,
+        model: AgentConfigurationModel,
         required: true,
         where: {
           status: "active",
@@ -72,7 +72,7 @@ async function migrateWorkspaceExtractActions(
     include: [
       {
         attributes: [],
-        model: AgentConfiguration,
+        model: AgentConfigurationModel,
         required: true,
         where: {
           status: "active",

--- a/front/migrations/20250626_move_process_actions_to_mcp.ts
+++ b/front/migrations/20250626_move_process_actions_to_mcp.ts
@@ -16,8 +16,8 @@ import {
   AgentMCPActionOutputItemModel,
   AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
-import { AgentMessage } from "@app/lib/models/agent/conversation";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
@@ -49,7 +49,7 @@ function getTimeFrameUnit(processAction: AgentProcessAction): TimeFrame | null {
 function agentProcessActionToAgentMCPAction(
   // @ts-ignore
   processAction: AgentProcessAction,
-  agentConfiguration: AgentConfiguration | null,
+  agentConfiguration: AgentConfigurationModel | null,
   mcpServerViewForExtractId: ModelId,
   logger: Logger
 ): {
@@ -209,10 +209,10 @@ function createResultOutputItem(
 
 async function migrateSingleProcessAction(
   auth: Authenticator,
-  agentMessage: AgentMessage,
+  agentMessage: AgentMessageModel,
   // @ts-ignore
   processAction: AgentProcessAction,
-  agentConfiguration: AgentConfiguration | null,
+  agentConfiguration: AgentConfigurationModel | null,
   logger: Logger,
   {
     execute,
@@ -297,7 +297,7 @@ async function migrateWorkspaceProcessActions(
     logger.info(`Found ${processActions.length} process actions`);
 
     // Step 2: Find the corresponding AgentMessages.
-    const agentMessages = await AgentMessage.findAll({
+    const agentMessages = await AgentMessageModel.findAll({
       where: {
         id: {
           // @ts-ignore
@@ -312,7 +312,7 @@ async function migrateWorkspaceProcessActions(
       ...new Set(agentMessages.map((message) => message.agentConfigurationId)),
     ];
 
-    const agentConfigurations = await AgentConfiguration.findAll({
+    const agentConfigurations = await AgentConfigurationModel.findAll({
       where: {
         sId: {
           [Op.in]: agentConfigurationSIds,

--- a/front/migrations/20250626_move_process_actions_to_mcp.ts
+++ b/front/migrations/20250626_move_process_actions_to_mcp.ts
@@ -13,8 +13,8 @@ import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
-  AgentMCPActionOutputItem,
-  AgentMCPServerConfiguration,
+  AgentMCPActionOutputItemModel,
+  AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import { AgentMessage } from "@app/lib/models/agent/conversation";
@@ -136,7 +136,7 @@ function createQueryOutputItem(
   // @ts-ignore
   processAction: AgentProcessAction,
   mcpActionId: ModelId
-): CreationAttributes<AgentMCPActionOutputItem> {
+): CreationAttributes<AgentMCPActionOutputItemModel> {
   const timeFrame = getTimeFrameUnit(processAction);
   const timeFrameAsString = timeFrame
     ? "the last " +
@@ -170,7 +170,7 @@ function createResultOutputItem(
   processAction: AgentProcessAction,
   mcpActionId: ModelId,
   auth: Authenticator
-): CreationAttributes<AgentMCPActionOutputItem> | null {
+): CreationAttributes<AgentMCPActionOutputItemModel> | null {
   if (!processAction.outputs || !processAction.jsonFileId) {
     return null;
   }
@@ -243,7 +243,7 @@ async function migrateSingleProcessAction(
     const mcpActionCreated = await AgentMCPActionModel.create(mcpAction.action);
 
     // Step 3: Create the MCP action output items.
-    const outputItems: CreationAttributes<AgentMCPActionOutputItem>[] = [];
+    const outputItems: CreationAttributes<AgentMCPActionOutputItemModel>[] = [];
 
     // Create the query resource.
     outputItems.push(createQueryOutputItem(processAction, mcpActionCreated.id));
@@ -258,7 +258,7 @@ async function migrateSingleProcessAction(
       outputItems.push(resultItem);
     }
 
-    await AgentMCPActionOutputItem.bulkCreate(outputItems);
+    await AgentMCPActionOutputItemModel.bulkCreate(outputItems);
   }
 }
 
@@ -321,7 +321,7 @@ async function migrateWorkspaceProcessActions(
       },
       include: [
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "mcpServerConfigurations",
         },
       ],

--- a/front/migrations/20250704_update_reasoning_effort_values.ts
+++ b/front/migrations/20250704_update_reasoning_effort_values.ts
@@ -2,7 +2,7 @@ import { Op } from "sequelize";
 
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
-import { AgentReasoningConfiguration } from "@app/lib/models/agent/actions/reasoning";
+import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type Logger from "@app/logger/logger";
@@ -109,7 +109,7 @@ async function updateReasoningEffortForWorkspace(
   }
 
   // Update agent reasoning configurations with "low"
-  const reasoningConfigsWithLow = await AgentReasoningConfiguration.findAll({
+  const reasoningConfigsWithLow = await AgentReasoningConfigurationModel.findAll({
     where: {
       workspaceId,
       reasoningEffort: "low",

--- a/front/migrations/20250704_update_reasoning_effort_values.ts
+++ b/front/migrations/20250704_update_reasoning_effort_values.ts
@@ -3,7 +3,7 @@ import { Op } from "sequelize";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type Logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
@@ -33,7 +33,7 @@ async function updateReasoningEffortForWorkspace(
   const workspaceId = auth.getNonNullableWorkspace().id;
 
   // Update agent configurations with "low" reasoning effort
-  const agentConfigsWithLow = await AgentConfiguration.findAll({
+  const agentConfigsWithLow = await AgentConfigurationModel.findAll({
     where: {
       workspaceId,
       reasoningEffort: "low",
@@ -63,7 +63,7 @@ async function updateReasoningEffortForWorkspace(
   }
 
   // Update agent configurations with null/undefined reasoning effort
-  const agentConfigsWithNull = await AgentConfiguration.findAll({
+  const agentConfigsWithNull = await AgentConfigurationModel.findAll({
     where: {
       workspaceId,
       reasoningEffort: {
@@ -109,12 +109,13 @@ async function updateReasoningEffortForWorkspace(
   }
 
   // Update agent reasoning configurations with "low"
-  const reasoningConfigsWithLow = await AgentReasoningConfigurationModel.findAll({
-    where: {
-      workspaceId,
-      reasoningEffort: "low",
-    },
-  });
+  const reasoningConfigsWithLow =
+    await AgentReasoningConfigurationModel.findAll({
+      where: {
+        workspaceId,
+        reasoningEffort: "low",
+      },
+    });
 
   workspaceLogger.info(
     `Found ${reasoningConfigsWithLow.length} agent reasoning configurations with reasoning effort "low"`

--- a/front/migrations/20250720_update_agent_max_steps_to_128.ts
+++ b/front/migrations/20250720_update_agent_max_steps_to_128.ts
@@ -1,12 +1,12 @@
 import { Op } from "sequelize";
 
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types";
 
 const updateAllAgentMaxSteps = async (execute: boolean) => {
-  const agentConfigurations = await AgentConfiguration.findAll({
+  const agentConfigurations = await AgentConfigurationModel.findAll({
     where: {
       maxStepsPerRun: { [Op.lt]: MAX_STEPS_USE_PER_RUN_LIMIT },
       status: "active",

--- a/front/migrations/20250725_backfill_agent_configurations.ts
+++ b/front/migrations/20250725_backfill_agent_configurations.ts
@@ -6,7 +6,7 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/age
 import { getAgentConfigurationRequirementsFromActions } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Logger } from "@app/logger/logger";
@@ -21,7 +21,7 @@ interface AgentUpdateStats {
 
 async function updateAgentConfigurationGroupIds(
   auth: Authenticator,
-  agent: AgentConfiguration,
+  agent: AgentConfigurationModel,
   execute: boolean,
   logger: Logger
 ): Promise<{ updated: boolean; error?: string }> {
@@ -80,7 +80,7 @@ async function updateAgentConfigurationGroupIds(
     );
 
     if (execute) {
-      await AgentConfiguration.update(
+      await AgentConfigurationModel.update(
         {
           requestedSpaceIds: newRequirements.requestedSpaceIds,
         },
@@ -119,7 +119,7 @@ async function updateAgentsForWorkspace(
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   // Find all active agent configurations that have MCP actions with dust apps
-  const agentsWithDustApps = await AgentConfiguration.findAll({
+  const agentsWithDustApps = await AgentConfigurationModel.findAll({
     where: {
       workspaceId,
       status: "active",

--- a/front/migrations/20250725_backfill_agent_configurations.ts
+++ b/front/migrations/20250725_backfill_agent_configurations.ts
@@ -5,7 +5,7 @@ import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guard
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationRequirementsFromActions } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -124,7 +124,7 @@ async function updateAgentsForWorkspace(
       workspaceId,
       status: "active",
       id: {
-        [Op.in]: await AgentMCPServerConfiguration.findAll({
+        [Op.in]: await AgentMCPServerConfigurationModel.findAll({
           where: {
             workspaceId,
             appId: { [Op.not]: null },
@@ -184,7 +184,7 @@ async function updateAgentsForWorkspace(
 
 async function getWorkspacesWithDustApps(): Promise<number[]> {
   // Find all workspaces that have agents with dust app configurations
-  const workspaceIds = await AgentMCPServerConfiguration.findAll({
+  const workspaceIds = await AgentMCPServerConfigurationModel.findAll({
     where: {
       appId: { [Op.not]: null },
     },

--- a/front/migrations/20250904_migrate_agents_using_slack_channels.ts
+++ b/front/migrations/20250904_migrate_agents_using_slack_channels.ts
@@ -5,7 +5,7 @@ import config from "@app/lib/api/config";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { makeScript } from "@app/scripts/helpers";
 import { OAuthAPI } from "@app/types";
 
@@ -164,7 +164,7 @@ makeScript(
     logger.info(`Generated instruction text: ${instructionText}`);
 
     // Get the agent configuration with workspace context
-    const agentConfig = await AgentConfiguration.findOne({
+    const agentConfig = await AgentConfigurationModel.findOne({
       where: {
         id: mcpServerConfig.agentConfigurationId,
         workspaceId: mcpServerConfig.workspaceId,

--- a/front/migrations/20250904_migrate_agents_using_slack_channels.ts
+++ b/front/migrations/20250904_migrate_agents_using_slack_channels.ts
@@ -2,8 +2,8 @@ import { WebClient } from "@slack/web-api";
 import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
 
 import config from "@app/lib/api/config";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
-import { MCPServerConnection } from "@app/lib/models/agent/actions/mcp_server_connection";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import { makeScript } from "@app/scripts/helpers";
@@ -58,7 +58,7 @@ makeScript(
     );
 
     // Get the agent MCP server configuration
-    const mcpServerConfig = await AgentMCPServerConfiguration.findByPk(
+    const mcpServerConfig = await AgentMCPServerConfigurationModel.findByPk(
       agentMcpServerConfigurationId
     );
     if (!mcpServerConfig) {
@@ -95,7 +95,7 @@ makeScript(
     }
 
     // Get the MCP server connection
-    const mcpServerConnection = await MCPServerConnection.findOne({
+    const mcpServerConnection = await MCPServerConnectionModel.findOne({
       where: {
         internalMCPServerId: mcpServerView.internalMCPServerId,
         connectionType: "workspace",

--- a/front/migrations/20250928_check_templates_id_match.ts
+++ b/front/migrations/20250928_check_templates_id_match.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { Op } from "sequelize";
 
 import { config } from "@app/lib/api/regions/config";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
 import { TemplateResource } from "@app/lib/resources/template_resource";
@@ -148,7 +148,7 @@ async function fixTemplateMismatch(
         );
         assert(templateCopy.id === remoteTemplate.id);
 
-        const [affectedCount] = await AgentConfiguration.update(
+        const [affectedCount] = await AgentConfigurationModel.update(
           {
             templateId: templateCopy.id,
           },
@@ -175,7 +175,7 @@ async function fixTemplateMismatch(
       "Successfully fixed template ID mismatch"
     );
   } else {
-    const affectedAgentConfigurations = await AgentConfiguration.findAll({
+    const affectedAgentConfigurations = await AgentConfigurationModel.findAll({
       where: { templateId: localTemplate.id },
     });
     logger.info(

--- a/front/migrations/20251011_replace_viz_by_frame.ts
+++ b/front/migrations/20251011_replace_viz_by_frame.ts
@@ -7,7 +7,7 @@ import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/cons
 import { createAgentActionConfiguration } from "@app/lib/api/assistant/configuration/actions";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
@@ -25,7 +25,7 @@ async function updateLegacyVizByFrame(
 ) {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-  const agentWithVisualization = await AgentConfiguration.findAll({
+  const agentWithVisualization = await AgentConfigurationModel.findAll({
     where: {
       // @ts-expect-error visualizationEnabled is not exposed in the types.
       visualizationEnabled: true,
@@ -141,7 +141,7 @@ async function updateLegacyVizByFrame(
 
   // Finally, disable visualization on all agents that had it enabled.
   if (execute) {
-    await AgentConfiguration.update(
+    await AgentConfigurationModel.update(
       // @ts-expect-error visualizationEnabled is not exposed in the types.
       { visualizationEnabled: false },
       {

--- a/front/migrations/20251015_backfill_misconfigured_data_sources.ts
+++ b/front/migrations/20251015_backfill_misconfigured_data_sources.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import * as fs from "fs";
 import { Op } from "sequelize";
 
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
 
@@ -13,7 +13,7 @@ makeScript({}, async ({ execute }, logger) => {
 
   logger.info("Starting migration of AgentDataSourceConfiguration parentsIn");
 
-  const dataSourceConfigurations = await AgentDataSourceConfiguration.findAll({
+  const dataSourceConfigurations = await AgentDataSourceConfigurationModel.findAll({
     where: {
       parentsIn: [],
       parentsNotIn: {

--- a/front/migrations/20251015_backfill_misconfigured_data_sources.ts
+++ b/front/migrations/20251015_backfill_misconfigured_data_sources.ts
@@ -13,14 +13,15 @@ makeScript({}, async ({ execute }, logger) => {
 
   logger.info("Starting migration of AgentDataSourceConfiguration parentsIn");
 
-  const dataSourceConfigurations = await AgentDataSourceConfigurationModel.findAll({
-    where: {
-      parentsIn: [],
-      parentsNotIn: {
-        [Op.and]: [{ [Op.not]: null }, { [Op.ne]: [] }],
+  const dataSourceConfigurations =
+    await AgentDataSourceConfigurationModel.findAll({
+      where: {
+        parentsIn: [],
+        parentsNotIn: {
+          [Op.and]: [{ [Op.not]: null }, { [Op.ne]: [] }],
+        },
       },
-    },
-  });
+    });
 
   logger.info(
     `Found ${dataSourceConfigurations.length} configurations to process`

--- a/front/migrations/20251016_gate_workspaces_in_legacy_dust_apps.ts
+++ b/front/migrations/20251016_gate_workspaces_in_legacy_dust_apps.ts
@@ -1,6 +1,6 @@
 import { Op } from "sequelize";
 
-import { FeatureFlag } from "@app/lib/models/feature_flag";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { makeScript } from "@app/scripts/helpers";
@@ -32,7 +32,7 @@ makeScript({}, async ({ execute }, logger) => {
     return;
   }
 
-  const existingFlags = await FeatureFlag.findAll({
+  const existingFlags = await FeatureFlagModel.findAll({
     attributes: ["workspaceId"],
     where: {
       name: FEATURE_FLAG_NAME,
@@ -85,7 +85,7 @@ makeScript({}, async ({ execute }, logger) => {
 
   for (const workspace of targetWorkspaces) {
     if (execute) {
-      await FeatureFlag.create({
+      await FeatureFlagModel.create({
         workspaceId: workspace.id,
         name: FEATURE_FLAG_NAME,
       });

--- a/front/migrations/20251017_backfill_agent_requested_space_ids.ts
+++ b/front/migrations/20251017_backfill_agent_requested_space_ids.ts
@@ -4,7 +4,7 @@ import { Op } from "sequelize";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationRequirementsFromActions } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Logger } from "@app/logger/logger";
@@ -19,7 +19,7 @@ interface AgentUpdateStats {
 
 async function updateAgentRequestedSpaceIds(
   auth: Authenticator,
-  agent: AgentConfiguration,
+  agent: AgentConfigurationModel,
   execute: boolean,
   logger: Logger
 ): Promise<{ updated: boolean; error?: string }> {
@@ -74,7 +74,7 @@ async function updateAgentRequestedSpaceIds(
   );
 
   if (execute) {
-    await AgentConfiguration.update(
+    await AgentConfigurationModel.update(
       {
         requestedSpaceIds: requirements.requestedSpaceIds,
       },
@@ -114,7 +114,7 @@ async function updateAgentsForWorkspace(
   });
 
   // Find all agent configurations (active and archived, but not draft) with empty requestedSpaceIds
-  const agents = await AgentConfiguration.findAll({
+  const agents = await AgentConfigurationModel.findAll({
     where: {
       workspaceId: workspace.id,
       status: {

--- a/front/migrations/20251017_backfill_conversation_requested_space_ids.ts
+++ b/front/migrations/20251017_backfill_conversation_requested_space_ids.ts
@@ -2,11 +2,11 @@ import * as _ from "lodash";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
-  Message,
+  MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -38,7 +38,7 @@ async function updateConversationRequestedSpaceIds(
   }
 
   // Find all agent messages in this conversation to determine which agents are involved
-  const messages = await Message.findAll({
+  const messages = await MessageModel.findAll({
     where: {
       workspaceId: workspace.id,
       conversationId: conversation.id,
@@ -46,7 +46,7 @@ async function updateConversationRequestedSpaceIds(
     },
     include: [
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: true,
         attributes: ["agentConfigurationId", "agentConfigurationVersion"],
@@ -70,7 +70,7 @@ async function updateConversationRequestedSpaceIds(
   }
 
   // Get the agent configurations involved in this conversation (matching sId and version pairs)
-  const agentConfigurations = await AgentConfiguration.findAll({
+  const agentConfigurations = await AgentConfigurationModel.findAll({
     where: {
       workspaceId: workspace.id,
       [Op.or]: agentConfigPairs.map((pair) => ({

--- a/front/migrations/20251024_mark_blocked_auth_agent_messages_failed.ts.ts
+++ b/front/migrations/20251024_mark_blocked_auth_agent_messages_failed.ts.ts
@@ -1,7 +1,7 @@
 import { Op } from "sequelize";
 
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentMessage } from "@app/lib/models/agent/conversation";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import type Logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { markAgentMessageAsFailed } from "@app/temporal/agent_loop/activities/common";
@@ -44,7 +44,7 @@ async function processBlockedAuthAgentMessages(
     ];
 
     // Find agent messages with status "created"
-    const agentMessages = await AgentMessage.findAll({
+    const agentMessages = await AgentMessageModel.findAll({
       where: {
         id: { [Op.in]: agentMessageIds },
         status: "created",

--- a/front/migrations/20251103_backfill_agent_analytics.ts
+++ b/front/migrations/20251103_backfill_agent_analytics.ts
@@ -3,11 +3,11 @@ import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
 import {
-  AgentMessage,
+  AgentMessageModel,
   AgentMessageFeedbackModel,
   ConversationModel,
-  Message,
-  UserMessage,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -40,7 +40,7 @@ async function backfillAgentAnalytics(
   );
 
   // First, count total messages to process
-  const totalCount = await Message.count({
+  const totalCount = await MessageModel.count({
     where: {
       workspaceId: workspace.id,
       agentMessageId: {
@@ -89,7 +89,7 @@ async function backfillAgentAnalytics(
       "Processing batch"
     );
 
-    const agentMessagesBatch = await Message.findAll({
+    const agentMessagesBatch = await MessageModel.findAll({
       where: {
         workspaceId: workspace.id,
         agentMessageId: {
@@ -101,7 +101,7 @@ async function backfillAgentAnalytics(
       },
       include: [
         {
-          model: AgentMessage,
+          model: AgentMessageModel,
           as: "agentMessage",
           required: true,
           include: [
@@ -154,14 +154,14 @@ async function backfillAgentAnalytics(
               return;
             }
 
-            const userMessageRow = await Message.findOne({
+            const userMessageRow = await MessageModel.findOne({
               where: {
                 id: agentMessageRow.parentId,
                 workspaceId: workspace.id,
               },
               include: [
                 {
-                  model: UserMessage,
+                  model: UserMessageModel,
                   as: "userMessage",
                   required: true,
                   include: [

--- a/front/migrations/20251103_backfill_agent_analytics.ts
+++ b/front/migrations/20251103_backfill_agent_analytics.ts
@@ -4,7 +4,7 @@ import { Op } from "sequelize";
 import { Authenticator } from "@app/lib/auth";
 import {
   AgentMessage,
-  AgentMessageFeedback,
+  AgentMessageFeedbackModel,
   ConversationModel,
   Message,
   UserMessage,
@@ -106,7 +106,7 @@ async function backfillAgentAnalytics(
           required: true,
           include: [
             {
-              model: AgentMessageFeedback,
+              model: AgentMessageFeedbackModel,
               as: "feedbacks",
               required: false,
               include: [

--- a/front/migrations/20251116_backfill_context_origin_analytics.ts
+++ b/front/migrations/20251116_backfill_context_origin_analytics.ts
@@ -2,10 +2,10 @@ import { subDays } from "date-fns";
 import { Op } from "sequelize";
 
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
-  Message,
-  UserMessage,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ANALYTICS_ALIAS_NAME, getClient } from "@app/lib/api/elasticsearch";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -43,7 +43,7 @@ async function backfillContextOriginForWorkspace(
     },
   };
 
-  const totalAgentMessages = await Message.count({
+  const totalAgentMessages = await MessageModel.count({
     where: baseWhere,
   });
 
@@ -81,12 +81,12 @@ async function backfillContextOriginForWorkspace(
       };
     }
 
-    const agentMessagesBatch = await Message.findAll({
+    const agentMessagesBatch = await MessageModel.findAll({
       where,
       attributes: ["id", "sId", "version", "parentId"],
       include: [
         {
-          model: AgentMessage,
+          model: AgentMessageModel,
           as: "agentMessage",
           required: true,
         },
@@ -124,7 +124,7 @@ async function backfillContextOriginForWorkspace(
       continue;
     }
 
-    const parentMessages = await Message.findAll({
+    const parentMessages = await MessageModel.findAll({
       where: {
         id: parentIds,
         workspaceId: workspace.id,
@@ -132,7 +132,7 @@ async function backfillContextOriginForWorkspace(
       attributes: ["id"],
       include: [
         {
-          model: UserMessage,
+          model: UserMessageModel,
           as: "userMessage",
           required: true,
           attributes: ["userContextOrigin"],

--- a/front/migrations/20251117_backfill_missing_agent_editor_groups.ts
+++ b/front/migrations/20251117_backfill_missing_agent_editor_groups.ts
@@ -3,7 +3,7 @@ import type { Logger } from "pino";
 import { Op } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -15,8 +15,8 @@ import type { LightWorkspaceType } from "@app/types";
 
 async function backfillMissingEditorGroupForAgent(
   auth: Authenticator,
-  agentConfigs: AgentConfiguration[],
-  currentConfig: AgentConfiguration,
+  agentConfigs: AgentConfigurationModel[],
+  currentConfig: AgentConfigurationModel,
   workspace: LightWorkspaceType,
   execute: boolean,
   logger: Logger
@@ -152,7 +152,7 @@ const migrateWorkspaceMissingEditorGroups = async (
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   // First, find active agent configurations that currently have no editor group associated.
-  const activeAgents = await AgentConfiguration.findAll({
+  const activeAgents = await AgentConfigurationModel.findAll({
     where: {
       workspaceId: workspace.id,
       status: "active",
@@ -183,7 +183,7 @@ const migrateWorkspaceMissingEditorGroups = async (
 
   // For those agents, load all non-draft versions so we can reuse an existing
   // editor group if one is already associated with any version.
-  const agents = await AgentConfiguration.findAll({
+  const agents = await AgentConfigurationModel.findAll({
     where: {
       workspaceId: workspace.id,
       status: {

--- a/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
+++ b/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
@@ -7,9 +7,9 @@ import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_a
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
-  Message,
+  MessageModel,
 } from "@app/lib/models/agent/conversation";
 import type { Logger } from "@app/logger/logger";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -48,7 +48,7 @@ async function backfillMcpServerConfigurationSidForWorkspace(
     },
   };
 
-  const totalAgentMessages = await Message.count({
+  const totalAgentMessages = await MessageModel.count({
     where: baseWhere,
   });
 
@@ -86,12 +86,12 @@ async function backfillMcpServerConfigurationSidForWorkspace(
       };
     }
 
-    const agentMessagesBatch = await Message.findAll({
+    const agentMessagesBatch = await MessageModel.findAll({
       where,
       attributes: ["id", "sId", "version"],
       include: [
         {
-          model: AgentMessage,
+          model: AgentMessageModel,
           as: "agentMessage",
           required: true,
         },

--- a/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
+++ b/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
@@ -5,7 +5,7 @@ import { ANALYTICS_ALIAS_NAME, getClient } from "@app/lib/api/elasticsearch";
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
 import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import {
   AgentMessage,
   ConversationModel,
@@ -136,7 +136,7 @@ async function backfillMcpServerConfigurationSidForWorkspace(
       new Set(actions.map((a) => a.mcpServerConfigurationId))
     );
 
-    const serverConfigs = await AgentMCPServerConfiguration.findAll({
+    const serverConfigs = await AgentMCPServerConfigurationModel.findAll({
       where: {
         workspaceId: workspace.id,
         id: uniqueConfigIds,

--- a/front/migrations/20251125_backfill_agentic_origin_fields.ts
+++ b/front/migrations/20251125_backfill_agentic_origin_fields.ts
@@ -1,6 +1,9 @@
 import { Op } from "sequelize";
 
-import { Message, UserMessage } from "@app/lib/models/agent/conversation";
+import {
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { UserMessageOrigin } from "@app/types";
@@ -8,11 +11,11 @@ import { UserMessageOrigin } from "@app/types";
 const BATCH_SIZE = 1000;
 
 export async function getRootContextOrigin(
-  userMessage: UserMessage
+  userMessage: UserMessageModel
 ): Promise<UserMessageOrigin | null> {
   const originAgentMessageId = userMessage.userContextOriginMessageId;
   if (originAgentMessageId) {
-    const originAgentMessageRow = await Message.findOne({
+    const originAgentMessageRow = await MessageModel.findOne({
       where: {
         sId: originAgentMessageId,
         workspaceId: userMessage.workspaceId,
@@ -20,14 +23,14 @@ export async function getRootContextOrigin(
       attributes: ["parentId"],
     });
     if (originAgentMessageRow?.parentId) {
-      const parentMessage = await Message.findOne({
+      const parentMessage = await MessageModel.findOne({
         where: {
           id: originAgentMessageRow.parentId,
           workspaceId: userMessage.workspaceId,
         },
         include: [
           {
-            model: UserMessage,
+            model: UserMessageModel,
             as: "userMessage",
             required: true,
           },
@@ -61,7 +64,7 @@ async function updateAgenticFields(
   let hasMore = true;
 
   // Get total count for progress tracking
-  const totalCount = await UserMessage.count({
+  const totalCount = await UserMessageModel.count({
     where: {
       userContextOrigin: {
         [Op.in]: ["run_agent", "agent_handover"],
@@ -81,7 +84,7 @@ async function updateAgenticFields(
 
     try {
       // Get batch of messages to update - need full objects to resolve root origin
-      const batchMessages = await UserMessage.findAll({
+      const batchMessages = await UserMessageModel.findAll({
         where: {
           userContextOrigin: {
             [Op.in]: ["run_agent", "agent_handover"],

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -85,7 +85,9 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const planModels = await Plan.findAll({ order: [["createdAt", "ASC"]] });
+      const planModels = await Plan.findAll({
+        order: [["createdAt", "ASC"]],
+      });
       const plans: PlanType[] = planModels.map((plan) =>
         renderPlanFromModel({ plan })
       );

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { Plan } from "@app/lib/models/plan";
+import { PlanModel } from "@app/lib/models/planModel";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { apiError } from "@app/logger/withlogging";
 import { config as documentBodyParserConfig } from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]";
@@ -85,7 +85,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const planModels = await Plan.findAll({
+      const planModels = await PlanModel.findAll({
         order: [["createdAt", "ASC"]],
       });
       const plans: PlanType[] = planModels.map((plan) =>
@@ -124,7 +124,7 @@ async function handler(
         });
       }
 
-      await Plan.upsert({
+      await PlanModel.upsert({
         code: body.code,
         name: body.name,
         isSlackbotAllowed: body.limits.assistant.isSlackBotAllowed,

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -6,7 +6,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { PlanModel } from "@app/lib/models/planModel";
+import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { apiError } from "@app/logger/withlogging";
 import { config as documentBodyParserConfig } from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]";

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { FeatureFlag } from "@app/lib/models/feature_flag";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { apiError } from "@app/logger/withlogging";
 import type { WhitelistableFeature, WithAPIErrorResponse } from "@app/types";
 import { isWhitelistableFeature } from "@app/types";
@@ -57,7 +57,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const flags = await FeatureFlag.findAll({
+      const flags = await FeatureFlagModel.findAll({
         where: {
           workspaceId: owner.id,
         },

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -6,7 +6,7 @@ import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import {
   isEntreprisePlanPrefix,
@@ -234,13 +234,13 @@ async function handler(
         limit,
         include: [
           {
-            model: Subscription,
+            model: SubscriptionModel,
             as: "subscriptions",
             where: { status: "active" },
             required: false,
             include: [
               {
-                model: Plan,
+                model: PlanModel,
                 as: "plan",
               },
             ],

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -6,7 +6,7 @@ import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import {
   isEntreprisePlanPrefix,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -24,7 +24,7 @@ import {
   invoiceEnterprisePAYGCredits,
   isPAYGEnabled,
 } from "@app/lib/credits/payg";
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import {
   assertStripeSubscriptionIsValid,
   createCustomerPortalSession,
@@ -181,7 +181,7 @@ async function handler(
               // the warnings and create an alert if this log appears in all regions
               return res.status(200).json({ success: true });
             }
-            const plan = await Plan.findOne({
+            const plan = await PlanModel.findOne({
               where: { code: planCode },
             });
             if (!plan) {
@@ -191,11 +191,11 @@ async function handler(
             }
 
             await withTransaction(async (t) => {
-              const activeSubscription = await Subscription.findOne({
+              const activeSubscription = await SubscriptionModel.findOne({
                 where: { workspaceId: workspace.id, status: "active" },
                 include: [
                   {
-                    model: Plan,
+                    model: PlanModel,
                     as: "plan",
                   },
                 ],
@@ -255,7 +255,7 @@ async function handler(
               const stripeSubscription =
                 await stripe.subscriptions.retrieve(stripeSubscriptionId);
 
-              await Subscription.create(
+              await SubscriptionModel.create(
                 {
                   sId: generateRandomModelSId(),
                   workspaceId: workspace.id,
@@ -326,7 +326,7 @@ async function handler(
             );
           }
           // Setting subscription payment status to succeeded
-          const subscription = await Subscription.findOne({
+          const subscription = await SubscriptionModel.findOne({
             where: { stripeSubscriptionId: invoice.subscription },
             include: [WorkspaceModel],
           });
@@ -416,7 +416,7 @@ async function handler(
           }
 
           // Logging that we have a failed payment
-          subscription = await Subscription.findOne({
+          subscription = await SubscriptionModel.findOne({
             where: { stripeSubscriptionId: invoice.subscription },
             include: [WorkspaceModel],
           });
@@ -572,7 +572,7 @@ async function handler(
             );
           }
 
-          const subscription = await Subscription.findOne({
+          const subscription = await SubscriptionModel.findOne({
             where: { stripeSubscriptionId: stripeSubscription.id },
             include: [WorkspaceModel],
           });
@@ -623,7 +623,7 @@ async function handler(
 
           // Billing cycle changed
           if ("current_period_start" in previousAttributes) {
-            const subscription = await Subscription.findOne({
+            const subscription = await SubscriptionModel.findOne({
               where: { stripeSubscriptionId: stripeSubscription.id },
               include: [WorkspaceModel],
             });
@@ -722,7 +722,7 @@ async function handler(
               stripeSubscription.cancel_at
             ) {
               const endDate = new Date(stripeSubscription.cancel_at * 1000);
-              const subscription = await Subscription.findOne({
+              const subscription = await SubscriptionModel.findOne({
                 where: { stripeSubscriptionId: stripeSubscription.id },
                 include: [WorkspaceModel],
               });
@@ -759,7 +759,7 @@ async function handler(
               : null;
 
             // get subscription
-            const subscription = await Subscription.findOne({
+            const subscription = await SubscriptionModel.findOne({
               where: { stripeSubscriptionId: stripeSubscription.id },
               include: [WorkspaceModel],
             });
@@ -849,7 +849,7 @@ async function handler(
               }
             }
           } else if (stripeSubscription.status === "active") {
-            const subscription = await Subscription.findOne({
+            const subscription = await SubscriptionModel.findOne({
               where: { stripeSubscriptionId: stripeSubscription.id },
             });
             if (!subscription) {
@@ -913,7 +913,7 @@ async function handler(
             });
           }
 
-          const matchingSubscription = await Subscription.findOne({
+          const matchingSubscription = await SubscriptionModel.findOne({
             where: { stripeSubscriptionId: stripeSubscription.id },
             include: [WorkspaceModel],
           });
@@ -998,7 +998,7 @@ async function handler(
           );
           stripeSubscription = event.data.object as Stripe.Subscription;
 
-          const trialingSubscription = await Subscription.findOne({
+          const trialingSubscription = await SubscriptionModel.findOne({
             where: { stripeSubscriptionId: stripeSubscription.id },
             include: [WorkspaceModel],
           });

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -24,7 +24,7 @@ import {
   invoiceEnterprisePAYGCredits,
   isPAYGEnabled,
 } from "@app/lib/credits/payg";
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import {
   assertStripeSubscriptionIsValid,
   createCustomerPortalSession,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -13,7 +13,7 @@ import { AppResource } from "@app/lib/resources/app_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { Provider } from "@app/lib/resources/storage/models/apps";
+import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -214,7 +214,7 @@ async function handler(
   const keyWorkspaceId = keyAuth.getNonNullableWorkspace().id;
   const [app, providers, secrets] = await Promise.all([
     AppResource.fetchById(auth, req.query.aId as string),
-    Provider.findAll({
+    ProviderModel.findAll({
       where: {
         workspaceId: keyWorkspaceId,
       },

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -9,7 +9,7 @@ import {
 import { getAgentRecentAuthors } from "@app/lib/api/assistant/recent_authors";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { apiError } from "@app/logger/withlogging";
 import { createOrUpgradeAgentConfiguration } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { AgentConfigurationType, WithAPIErrorResponse } from "@app/types";
@@ -83,7 +83,7 @@ async function handler(
         });
       }
 
-      const agentConfiguration = await AgentConfiguration.findOne({
+      const agentConfiguration = await AgentConfigurationModel.findOne({
         where: {
           sId: req.query.aId as string,
           workspaceId: auth.workspace()?.id,

--- a/front/pages/api/w/[wId]/dust_app_secrets/index.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/index.ts
@@ -6,7 +6,7 @@ import {
   getDustAppSecrets,
 } from "@app/lib/api/dust_app_secrets";
 import type { Authenticator } from "@app/lib/auth";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -104,7 +104,7 @@ async function handler(
           hash: encryptedValue,
         });
       } else {
-        postSecret = await DustAppSecret.create({
+        postSecret = await DustAppSecretModel.create({
           userId: user.id,
           workspaceId: owner.id,
           name: sanitizedSecretName,

--- a/front/pages/api/w/[wId]/providers/[pId]/index.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/index.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { Provider } from "@app/lib/resources/storage/models/apps";
+import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { apiError } from "@app/logger/withlogging";
 import type { ProviderType, WithAPIErrorResponse } from "@app/types";
 
@@ -37,7 +37,7 @@ async function handler(
   }
 
   let [provider] = await Promise.all([
-    Provider.findOne({
+    ProviderModel.findOne({
       where: {
         workspaceId: owner.id,
         providerId: req.query.pId,
@@ -68,7 +68,7 @@ async function handler(
       }
 
       if (!provider) {
-        provider = await Provider.create({
+        provider = await ProviderModel.create({
           providerId: req.query.pId,
           config: req.body.config,
           workspaceId: owner.id,
@@ -105,7 +105,7 @@ async function handler(
         });
       }
 
-      await Provider.destroy({
+      await ProviderModel.destroy({
         where: {
           workspaceId: owner.id,
           providerId: req.query.pId,

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { Provider } from "@app/lib/resources/storage/models/apps";
+import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import {
@@ -35,7 +35,7 @@ async function handler(
   const owner = auth.getNonNullableWorkspace();
 
   const [provider] = await Promise.all([
-    Provider.findOne({
+    ProviderModel.findOne({
       where: {
         workspaceId: owner.id,
         providerId: req.query.pId,

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { Provider } from "@app/lib/resources/storage/models/apps";
+import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { apiError } from "@app/logger/withlogging";
 import type { ProviderType, WithAPIErrorResponse } from "@app/types";
 import { redactString } from "@app/types";
@@ -40,7 +40,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const providers = await Provider.findAll({
+      const providers = await ProviderModel.findAll({
         where: {
           workspaceId: owner.id,
         },

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
@@ -10,7 +10,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { checkDatasetData } from "@app/lib/datasets";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { Dataset } from "@app/lib/resources/storage/models/apps";
+import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { DatasetType, WithAPIErrorResponse } from "@app/types";
@@ -70,7 +70,7 @@ async function handler(
   }
 
   const [dataset] = await Promise.all([
-    Dataset.findOne({
+    DatasetModel.findOne({
       where: {
         workspaceId: owner.id,
         appId: app.id,
@@ -231,7 +231,7 @@ async function handler(
           },
         });
       }
-      await Dataset.destroy({
+      await DatasetModel.destroy({
         where: {
           workspaceId: owner.id,
           appId: app.id,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
@@ -11,7 +11,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { checkDatasetData } from "@app/lib/datasets";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { Dataset } from "@app/lib/resources/storage/models/apps";
+import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { DatasetType, WithAPIErrorResponse } from "@app/types";
@@ -111,7 +111,7 @@ async function handler(
       }
 
       // Check that dataset does not already exist.
-      const existing = await Dataset.findAll({
+      const existing = await DatasetModel.findAll({
         where: {
           workspaceId: owner.id,
           appId: app.id,
@@ -199,7 +199,7 @@ async function handler(
         ? bodyValidation.right.dataset.description
         : null;
 
-      await Dataset.create({
+      await DatasetModel.create({
         name: bodyValidation.right.dataset.name,
         description,
         appId: app.id,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -9,7 +9,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { Provider } from "@app/lib/resources/storage/models/apps";
+import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { dumpSpecification } from "@app/lib/specification";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -74,7 +74,7 @@ async function handler(
   switch (req.method) {
     case "POST":
       const [providers, secrets] = await Promise.all([
-        Provider.findAll({
+        ProviderModel.findAll({
           where: {
             workspaceId: owner.id,
           },

--- a/front/pages/api/w/[wId]/tags/index.ts
+++ b/front/pages/api/w/[wId]/tags/index.ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -85,7 +85,7 @@ async function handler(
       });
 
       if (agentIds) {
-        const agentsToTag = await AgentConfiguration.findAll({
+        const agentsToTag = await AgentConfigurationModel.findAll({
           where: {
             sId: agentIds,
             workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -49,7 +49,7 @@ import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import type { ActionRegistry } from "@app/lib/registry";
 import { getDustProdActionRegistry } from "@app/lib/registry";

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -49,7 +49,7 @@ import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import type { ActionRegistry } from "@app/lib/registry";
 import { getDustProdActionRegistry } from "@app/lib/registry";
@@ -86,12 +86,12 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const subscriptionModels = await Subscription.findAll({
+  const subscriptionModels = await SubscriptionModel.findAll({
     where: { workspaceId: owner.id },
   });
 
   const plans = keyBy(
-    await Plan.findAll({
+    await PlanModel.findAll({
       where: {
         id: subscriptionModels.map((s) => s.planId),
       },

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -26,7 +26,7 @@ import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
-import { SubscriptionModel } from "@app/lib/models/planModel";
+import { SubscriptionModel } from "@app/lib/models/plan";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -8,23 +8,23 @@ import { hardDeleteSpace } from "@app/lib/api/spaces";
 import { deleteWorksOSOrganizationWithWorkspace } from "@app/lib/api/workos/organization";
 import { areAllSubscriptionsCanceled } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
-  AgentChildAgentConfiguration,
-  AgentMCPServerConfiguration,
+  AgentChildAgentConfigurationModel,
+  AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { AgentReasoningConfiguration } from "@app/lib/models/agent/actions/reasoning";
+import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import {
   AgentConfiguration,
-  AgentUserRelation,
-  GlobalAgentSettings,
+  AgentUserRelationModel,
+  GlobalAgentSettingsModel,
 } from "@app/lib/models/agent/agent";
 import { AgentDataRetentionModel } from "@app/lib/models/agent/agent_data_retention";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
-import { DustAppSecret } from "@app/lib/models/dust_app_secret";
-import { FeatureFlag } from "@app/lib/models/feature_flag";
+import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { Subscription } from "@app/lib/models/plan";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
@@ -46,7 +46,7 @@ import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_r
 import { RunResource } from "@app/lib/resources/run_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
-import { Provider } from "@app/lib/resources/storage/models/apps";
+import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import {
@@ -211,34 +211,27 @@ export async function deleteAgentsActivity({
     },
   });
 
-  await GlobalAgentSettings.destroy({
+  await GlobalAgentSettingsModel.destroy({
     where: {
       workspaceId: workspace.id,
     },
   });
   for (const agent of agents) {
-    const mcpServerConfigurations = await AgentMCPServerConfiguration.findAll({
-      where: {
-        agentConfigurationId: agent.id,
-        workspaceId: workspace.id,
-      },
-    });
-    await AgentDataSourceConfiguration.destroy({
+    const mcpServerConfigurations =
+      await AgentMCPServerConfigurationModel.findAll({
+        where: {
+          agentConfigurationId: agent.id,
+          workspaceId: workspace.id,
+        },
+      });
+    await AgentDataSourceConfigurationModel.destroy({
       where: {
         mcpServerConfigurationId: {
           [Op.in]: mcpServerConfigurations.map((r) => r.id),
         },
       },
     });
-    await AgentTablesQueryConfigurationTable.destroy({
-      where: {
-        mcpServerConfigurationId: {
-          [Op.in]: mcpServerConfigurations.map((r) => r.id),
-        },
-      },
-    });
-
-    await AgentReasoningConfiguration.destroy({
+    await AgentTablesQueryConfigurationTableModel.destroy({
       where: {
         mcpServerConfigurationId: {
           [Op.in]: mcpServerConfigurations.map((r) => r.id),
@@ -246,7 +239,15 @@ export async function deleteAgentsActivity({
       },
     });
 
-    await AgentChildAgentConfiguration.destroy({
+    await AgentReasoningConfigurationModel.destroy({
+      where: {
+        mcpServerConfigurationId: {
+          [Op.in]: mcpServerConfigurations.map((r) => r.id),
+        },
+      },
+    });
+
+    await AgentChildAgentConfigurationModel.destroy({
       where: {
         mcpServerConfigurationId: {
           [Op.in]: mcpServerConfigurations.map((r) => `${r.id}`),
@@ -254,14 +255,14 @@ export async function deleteAgentsActivity({
         workspaceId: workspace.id,
       },
     });
-    await AgentMCPServerConfiguration.destroy({
+    await AgentMCPServerConfigurationModel.destroy({
       where: {
         agentConfigurationId: agent.id,
         workspaceId: workspace.id,
       },
     });
 
-    await AgentUserRelation.destroy({
+    await AgentUserRelationModel.destroy({
       where: {
         agentConfiguration: agent.sId,
       },
@@ -316,7 +317,7 @@ export async function deleteAppsActivity({
 
   await KeyResource.deleteAllForWorkspace(auth);
 
-  await Provider.destroy({
+  await ProviderModel.destroy({
     where: {
       workspaceId: workspace.id,
     },
@@ -613,16 +614,16 @@ export async function deleteWorkspaceActivity({
   await WorkspaceHasDomainModel.destroy({
     where: { workspaceId: workspace.id },
   });
-  await AgentUserRelation.destroy({
+  await AgentUserRelationModel.destroy({
     where: { workspaceId: workspace.id },
   });
   await ExtensionConfigurationResource.deleteForWorkspace(auth, {});
-  await DustAppSecret.destroy({
+  await DustAppSecretModel.destroy({
     where: {
       workspaceId: workspace.id,
     },
   });
-  await FeatureFlag.destroy({
+  await FeatureFlagModel.destroy({
     where: {
       workspaceId: workspace.id,
     },

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -17,7 +17,7 @@ import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import {
-  AgentConfiguration,
+  AgentConfigurationModel,
   AgentUserRelationModel,
   GlobalAgentSettingsModel,
 } from "@app/lib/models/agent/agent";
@@ -26,7 +26,7 @@ import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
-import { Subscription } from "@app/lib/models/plan";
+import { SubscriptionModel } from "@app/lib/models/planModel";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";
@@ -205,7 +205,7 @@ export async function deleteAgentsActivity({
     throw new Error("Could not find the workspace.");
   }
 
-  const agents = await AgentConfiguration.findAll({
+  const agents = await AgentConfigurationModel.findAll({
     where: {
       workspaceId: workspace.id,
     },
@@ -596,7 +596,7 @@ export async function deleteWorkspaceActivity({
   }
   const workspace = auth.getNonNullableWorkspace();
 
-  await Subscription.destroy({
+  await SubscriptionModel.destroy({
     where: {
       workspaceId: workspace.id,
     },

--- a/front/scripts/add_agent_favorites.ts
+++ b/front/scripts/add_agent_favorites.ts
@@ -1,4 +1,4 @@
-import { AgentUserRelation } from "@app/lib/models/agent/agent";
+import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -43,7 +43,7 @@ makeScript(
         continue;
       }
 
-      const agentRelation = await AgentUserRelation.findOne({
+      const agentRelation = await AgentUserRelationModel.findOne({
         where: {
           workspaceId: workspace.id,
           agentConfiguration: agentConfigurationSID,
@@ -72,7 +72,7 @@ makeScript(
     for (const membership of memberships) {
       for (const agentConfigurationSID of agents) {
         // Check if relation already exists
-        const [, created] = await AgentUserRelation.findOrCreate({
+        const [, created] = await AgentUserRelationModel.findOrCreate({
           where: {
             workspaceId: workspace.id,
             userId: membership.userId,

--- a/front/scripts/dev/create_test_workspaces.ts
+++ b/front/scripts/dev/create_test_workspaces.ts
@@ -1,6 +1,6 @@
 import { createAndLogMembership } from "@app/lib/api/signup";
 import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
-import { PlanModel } from "@app/lib/models/planModel";
+import { PlanModel } from "@app/lib/models/plan";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";

--- a/front/scripts/dev/create_test_workspaces.ts
+++ b/front/scripts/dev/create_test_workspaces.ts
@@ -1,6 +1,6 @@
 import { createAndLogMembership } from "@app/lib/api/signup";
 import { createWorkspaceInternal } from "@app/lib/iam/workspaces";
-import { Plan } from "@app/lib/models/plan";
+import { PlanModel } from "@app/lib/models/planModel";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -16,7 +16,7 @@ async function createTestWorkspaces(
     throw new Error("This script can only be run in development.");
   }
 
-  const plans = await Plan.findAll();
+  const plans = await PlanModel.findAll();
 
   if (plans.length === 0) {
     throw new Error(

--- a/front/scripts/remove_draft_agent_configurations.ts
+++ b/front/scripts/remove_draft_agent_configurations.ts
@@ -5,9 +5,9 @@ import {
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
-import { Mention } from "@app/lib/models/agent/conversation";
+import { MentionModel } from "@app/lib/models/agent/conversation";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -25,7 +25,7 @@ import type { LightWorkspaceType } from "@app/types";
  */
 async function deleteDraftAgentConfigurationAndRelatedResources(
   workspace: LightWorkspaceType,
-  agent: AgentConfiguration,
+  agent: AgentConfigurationModel,
   logger: Logger,
   execute: boolean
 ): Promise<boolean> {
@@ -35,7 +35,7 @@ async function deleteDraftAgentConfigurationAndRelatedResources(
   }
 
   // Only deletes draft agent configuration without mentions.
-  const hasAtLeastOneMention = await Mention.findOne({
+  const hasAtLeastOneMention = await MentionModel.findOne({
     where: {
       workspaceId: workspace.id,
       agentConfigurationId: agent.sId,
@@ -96,7 +96,7 @@ async function deleteDraftAgentConfigurationAndRelatedResources(
   });
 
   // Finally delete the agent configuration.
-  await AgentConfiguration.destroy({
+  await AgentConfigurationModel.destroy({
     where: {
       id: agent.id,
     },
@@ -112,7 +112,7 @@ async function removeDraftAgentConfigurationsForWorkspace(
 ) {
   let nbAgentsDeleted = 0;
 
-  const draftAgents = await AgentConfiguration.findAll({
+  const draftAgents = await AgentConfigurationModel.findAll({
     where: {
       workspaceId: workspace.id,
       status: "draft",

--- a/front/scripts/remove_draft_agent_configurations.ts
+++ b/front/scripts/remove_draft_agent_configurations.ts
@@ -1,10 +1,10 @@
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import {
-  AgentChildAgentConfiguration,
-  AgentMCPServerConfiguration,
+  AgentChildAgentConfigurationModel,
+  AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
-import { AgentReasoningConfiguration } from "@app/lib/models/agent/actions/reasoning";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { Mention } from "@app/lib/models/agent/conversation";
@@ -52,31 +52,32 @@ async function deleteDraftAgentConfigurationAndRelatedResources(
     return true;
   }
 
-  const mcpServerConfigurations = await AgentMCPServerConfiguration.findAll({
-    where: {
-      agentConfigurationId: agent.id,
-    },
-  });
+  const mcpServerConfigurations =
+    await AgentMCPServerConfigurationModel.findAll({
+      where: {
+        agentConfigurationId: agent.id,
+      },
+    });
 
-  await AgentDataSourceConfiguration.destroy({
-    where: {
-      mcpServerConfigurationId: mcpServerConfigurations.map((r) => r.id),
-    },
-  });
-
-  await AgentTablesQueryConfigurationTable.destroy({
+  await AgentDataSourceConfigurationModel.destroy({
     where: {
       mcpServerConfigurationId: mcpServerConfigurations.map((r) => r.id),
     },
   });
 
-  await AgentReasoningConfiguration.destroy({
+  await AgentTablesQueryConfigurationTableModel.destroy({
     where: {
       mcpServerConfigurationId: mcpServerConfigurations.map((r) => r.id),
     },
   });
 
-  await AgentChildAgentConfiguration.destroy({
+  await AgentReasoningConfigurationModel.destroy({
+    where: {
+      mcpServerConfigurationId: mcpServerConfigurations.map((r) => r.id),
+    },
+  });
+
+  await AgentChildAgentConfigurationModel.destroy({
     where: {
       mcpServerConfigurationId: mcpServerConfigurations.map((r) => r.id),
     },

--- a/front/scripts/remove_reasoning_tool.ts
+++ b/front/scripts/remove_reasoning_tool.ts
@@ -1,6 +1,6 @@
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 
@@ -11,7 +11,7 @@ import { makeScript } from "@app/scripts/helpers";
 async function deleteReasoningConfigurationAndRelatedResources(
   reasoningConfig: AgentReasoningConfigurationModel & {
     agent_mcp_server_configuration: AgentMCPServerConfigurationModel & {
-      agent_configuration: AgentConfiguration;
+      agent_configuration: AgentConfigurationModel;
     };
   },
   logger: Logger,
@@ -86,29 +86,30 @@ makeScript({}, async ({ execute }, logger) => {
 
   // Get all reasoning configurations with agent information
 
-  const reasoningConfigurations = await AgentReasoningConfigurationModel.findAll({
-    attributes: ["id", "sId", "mcpServerConfigurationId"],
-    include: [
-      {
-        model: AgentMCPServerConfigurationModel,
-        required: true,
-        include: [
-          {
-            model: AgentConfiguration,
-            required: true,
-            attributes: [
-              "id",
-              "sId",
-              "name",
-              "modelId",
-              "providerId",
-              "status",
-            ],
-          },
-        ],
-      },
-    ],
-  });
+  const reasoningConfigurations =
+    await AgentReasoningConfigurationModel.findAll({
+      attributes: ["id", "sId", "mcpServerConfigurationId"],
+      include: [
+        {
+          model: AgentMCPServerConfigurationModel,
+          required: true,
+          include: [
+            {
+              model: AgentConfigurationModel,
+              required: true,
+              attributes: [
+                "id",
+                "sId",
+                "name",
+                "modelId",
+                "providerId",
+                "status",
+              ],
+            },
+          ],
+        },
+      ],
+    });
 
   if (reasoningConfigurations.length === 0) {
     logger.info("No reasoning configurations found");
@@ -140,7 +141,7 @@ makeScript({}, async ({ execute }, logger) => {
     const success = await deleteReasoningConfigurationAndRelatedResources(
       reasoningConfig as AgentReasoningConfigurationModel & {
         agent_mcp_server_configuration: AgentMCPServerConfigurationModel & {
-          agent_configuration: AgentConfiguration;
+          agent_configuration: AgentConfigurationModel;
         };
       },
       logger,

--- a/front/scripts/remove_reasoning_tool.ts
+++ b/front/scripts/remove_reasoning_tool.ts
@@ -1,5 +1,5 @@
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
-import { AgentReasoningConfiguration } from "@app/lib/models/agent/actions/reasoning";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentReasoningConfigurationModel } from "@app/lib/models/agent/actions/reasoning";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
@@ -9,8 +9,8 @@ import { makeScript } from "@app/scripts/helpers";
  * This script performs cascading deletions in the correct order to avoid foreign key constraints.
  */
 async function deleteReasoningConfigurationAndRelatedResources(
-  reasoningConfig: AgentReasoningConfiguration & {
-    agent_mcp_server_configuration: AgentMCPServerConfiguration & {
+  reasoningConfig: AgentReasoningConfigurationModel & {
+    agent_mcp_server_configuration: AgentMCPServerConfigurationModel & {
       agent_configuration: AgentConfiguration;
     };
   },
@@ -43,14 +43,14 @@ async function deleteReasoningConfigurationAndRelatedResources(
   try {
     // Delete in the correct order to avoid foreign key constraint violations
     // 1. Delete agent_reasoning_configurations
-    await AgentReasoningConfiguration.destroy({
+    await AgentReasoningConfigurationModel.destroy({
       where: {
         mcpServerConfigurationId,
       },
     });
 
     // 2. Finally delete agent_mcp_server_configurations
-    await AgentMCPServerConfiguration.destroy({
+    await AgentMCPServerConfigurationModel.destroy({
       where: {
         id: mcpServerConfigurationId,
       },
@@ -86,11 +86,11 @@ makeScript({}, async ({ execute }, logger) => {
 
   // Get all reasoning configurations with agent information
 
-  const reasoningConfigurations = await AgentReasoningConfiguration.findAll({
+  const reasoningConfigurations = await AgentReasoningConfigurationModel.findAll({
     attributes: ["id", "sId", "mcpServerConfigurationId"],
     include: [
       {
-        model: AgentMCPServerConfiguration,
+        model: AgentMCPServerConfigurationModel,
         required: true,
         include: [
           {
@@ -138,8 +138,8 @@ makeScript({}, async ({ execute }, logger) => {
   // Process each reasoning configuration
   for (const reasoningConfig of reasoningConfigurations) {
     const success = await deleteReasoningConfigurationAndRelatedResources(
-      reasoningConfig as AgentReasoningConfiguration & {
-        agent_mcp_server_configuration: AgentMCPServerConfiguration & {
+      reasoningConfig as AgentReasoningConfigurationModel & {
+        agent_mcp_server_configuration: AgentMCPServerConfigurationModel & {
           agent_configuration: AgentConfiguration;
         };
       },

--- a/front/scripts/table_get_agent_usage.ts
+++ b/front/scripts/table_get_agent_usage.ts
@@ -6,7 +6,7 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
@@ -74,7 +74,7 @@ makeScript(
           required: true,
           include: [
             {
-              model: AgentConfiguration,
+              model: AgentConfigurationModel,
               as: "agent_configuration",
               required: true,
               where: {
@@ -144,7 +144,7 @@ makeScript(
           required: true,
           include: [
             {
-              model: AgentConfiguration,
+              model: AgentConfigurationModel,
               as: "agent_configuration",
               required: true,
               where: {

--- a/front/scripts/table_get_agent_usage.ts
+++ b/front/scripts/table_get_agent_usage.ts
@@ -3,9 +3,9 @@ import { Op } from "sequelize";
 import { getAgentsEditors } from "@app/lib/api/assistant/editors";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/agent/actions/data_sources";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
-import { AgentTablesQueryConfigurationTable } from "@app/lib/models/agent/actions/tables_query";
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import { AgentConfiguration } from "@app/lib/models/agent/agent";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -59,7 +59,7 @@ makeScript(
     // console.log(tableRes.value.table.parents);
 
     // Find all data source search
-    const dsConfigs = await AgentDataSourceConfiguration.findAll({
+    const dsConfigs = await AgentDataSourceConfigurationModel.findAll({
       where: {
         dataSourceId: dataSource.id,
         workspaceId: owner.id,
@@ -69,7 +69,7 @@ makeScript(
       },
       include: [
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           required: true,
           include: [
@@ -131,7 +131,7 @@ makeScript(
     });
 
     // Find all table query tool
-    const tableConfigs = await AgentTablesQueryConfigurationTable.findAll({
+    const tableConfigs = await AgentTablesQueryConfigurationTableModel.findAll({
       where: {
         dataSourceId: dataSource.id,
         workspaceId: owner.id,
@@ -139,7 +139,7 @@ makeScript(
       },
       include: [
         {
-          model: AgentMCPServerConfiguration,
+          model: AgentMCPServerConfigurationModel,
           as: "agent_mcp_server_configuration",
           required: true,
           include: [

--- a/front/scripts/toggle_feature_flags.ts
+++ b/front/scripts/toggle_feature_flags.ts
@@ -1,4 +1,4 @@
-import { FeatureFlag } from "@app/lib/models/feature_flag";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
 import type { WhitelistableFeature } from "@app/types";
@@ -11,7 +11,7 @@ async function enableFeatureFlag(
 ) {
   const { id: workspaceId, name } = workspace;
 
-  const existingFlag = await FeatureFlag.findOne({
+  const existingFlag = await FeatureFlagModel.findOne({
     where: {
       workspaceId,
       name: featureFlag,
@@ -25,7 +25,7 @@ async function enableFeatureFlag(
   }
 
   if (execute) {
-    await FeatureFlag.create({
+    await FeatureFlagModel.create({
       workspaceId,
       name: featureFlag satisfies WhitelistableFeature,
     });
@@ -46,7 +46,7 @@ async function disableFeatureFlag(
   const { id: workspaceId, name } = workspace;
 
   if (execute) {
-    const existingFlag = await FeatureFlag.findOne({
+    const existingFlag = await FeatureFlagModel.findOne({
       where: {
         workspaceId,
         name: featureFlag,

--- a/front/scripts/update_agent_models.ts
+++ b/front/scripts/update_agent_models.ts
@@ -1,6 +1,6 @@
 import { Op } from "sequelize";
 
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { makeScript } from "@app/scripts/helpers";
 import type { ModelId, SupportedModel } from "@app/types";
@@ -27,7 +27,7 @@ async function findMatchingWorkspaces(
     };
   }
 
-  const agentConfigurations = await AgentConfiguration.findAll({
+  const agentConfigurations = await AgentConfigurationModel.findAll({
     where: whereClause,
     attributes: ["workspaceId"],
     raw: true,
@@ -56,7 +56,7 @@ async function updateWorkspaceAssistants(
     };
   }
 
-  const agentConfigurations = await AgentConfiguration.findAll({
+  const agentConfigurations = await AgentConfigurationModel.findAll({
     where: whereClause,
   });
 

--- a/front/scripts/update_agent_requested_group_and_space_ids.ts
+++ b/front/scripts/update_agent_requested_group_and_space_ids.ts
@@ -4,7 +4,7 @@ import type { WhereOptions } from "sequelize";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationRequirementsFromActions } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { Logger } from "@app/logger/logger";
@@ -38,7 +38,7 @@ async function updateAgentRequestedSpaceIds(
   );
 
   // Build where clause
-  const whereClause: WhereOptions<AgentConfiguration> = {
+  const whereClause: WhereOptions<AgentConfigurationModel> = {
     workspaceId: workspace.id,
   };
 
@@ -52,7 +52,7 @@ async function updateAgentRequestedSpaceIds(
 
   // Fetch all agent configurations that match the criteria
   // Note: We filter out global agents as they may reference cross-workspace resources
-  const agentConfigurations = await AgentConfiguration.findAll({
+  const agentConfigurations = await AgentConfigurationModel.findAll({
     where: {
       ...whereClause,
       scope: ["workspace", "published", "hidden", "visible"],
@@ -142,7 +142,7 @@ async function updateAgentRequestedSpaceIds(
     );
 
     if (execute) {
-      await AgentConfiguration.update(
+      await AgentConfigurationModel.update(
         {
           requestedSpaceIds: newSpaceIds,
         },

--- a/front/scripts/update_conversation_requested_group_and_spaces_ids.ts
+++ b/front/scripts/update_conversation_requested_group_and_spaces_ids.ts
@@ -5,11 +5,11 @@ import { Op } from "sequelize";
 
 import { enrichAgentConfigurations } from "@app/lib/api/assistant/configuration/helpers";
 import { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/agent/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
-  Message,
+  MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -102,7 +102,7 @@ async function updateConversationRequestedSpaceIds(
 
     for (const conversation of conversations) {
       // Get all agent messages in this conversation with their versions
-      const messages = await Message.findAll({
+      const messages = await MessageModel.findAll({
         where: {
           conversationId: conversation.id,
           workspaceId: workspace.id,
@@ -110,7 +110,7 @@ async function updateConversationRequestedSpaceIds(
         attributes: [],
         include: [
           {
-            model: AgentMessage,
+            model: AgentMessageModel,
             as: "agentMessage",
             required: true,
             attributes: ["agentConfigurationId", "agentConfigurationVersion"],
@@ -147,7 +147,7 @@ async function updateConversationRequestedSpaceIds(
 
       // Get the exact agent versions that were used in the conversation
       // Fetch directly from DB to get specific versions (not just latest)
-      const agentConfigs = await AgentConfiguration.findAll({
+      const agentConfigs = await AgentConfigurationModel.findAll({
         where: {
           workspaceId: workspace.id,
           [Op.or]: Array.from(agentVersionPairs.values()).map((v) => ({

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -10,7 +10,7 @@ import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types"
 import { TERMINAL_AGENT_MESSAGE_EVENT_TYPES } from "@app/lib/api/assistant/streaming/types";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { Authenticator as AuthenticatorClass } from "@app/lib/auth";
-import type { AgentMessage } from "@app/lib/models/agent/conversation";
+import type { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
@@ -22,7 +22,7 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";
 
 export async function markAgentMessageAsFailed(
-  agentMessageRow: AgentMessage,
+  agentMessageRow: AgentMessageModel,
   error: ToolErrorEvent["error"]
 ): Promise<void> {
   await agentMessageRow.update({
@@ -45,7 +45,7 @@ async function processEventForDatabase(
     modelInteractionDurationMs,
   }: {
     event: AgentMessageEvents;
-    agentMessageRow: AgentMessage;
+    agentMessageRow: AgentMessageModel;
     step: number;
     conversation: ConversationWithoutContentType;
     modelInteractionDurationMs?: number;
@@ -180,7 +180,7 @@ export async function updateResourceAndPublishEvent(
     modelInteractionDurationMs,
   }: {
     event: AgentMessageEvents;
-    agentMessageRow: AgentMessage;
+    agentMessageRow: AgentMessageModel;
     conversation: ConversationWithoutContentType;
     step: number;
     modelInteractionDurationMs?: number;

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -1,6 +1,6 @@
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
-import { AgentMessage } from "@app/lib/models/agent/conversation";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { assertNever } from "@app/types";
 
@@ -21,7 +21,7 @@ export async function publishDeferredEventsActivity(
     const { event, context } = deferredEvent;
     const isLastEvent = index === deferredEvents.length - 1;
 
-    const agentMessageRow = await AgentMessage.findByPk(
+    const agentMessageRow = await AgentMessageModel.findByPk(
       context.agentMessageRowId
     );
     if (!agentMessageRow) {

--- a/front/temporal/agent_loop/activities/usage_tracking.ts
+++ b/front/temporal/agent_loop/activities/usage_tracking.ts
@@ -5,9 +5,9 @@ import {
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import {
-  AgentMessage,
-  Message,
-  UserMessage,
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import type { AgentMessageStatus } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -27,14 +27,14 @@ export async function trackProgrammaticUsageActivity(
   const { agentMessageId, userMessageId } = agentLoopArgs;
 
   // Query the Message/AgentMessage/Conversation rows.
-  const agentMessageRow = await Message.findOne({
+  const agentMessageRow = await MessageModel.findOne({
     where: {
       sId: agentMessageId,
       workspaceId: workspace.id,
     },
     include: [
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: true,
       },
@@ -44,14 +44,14 @@ export async function trackProgrammaticUsageActivity(
   const agentMessage = agentMessageRow?.agentMessage;
 
   // Query the UserMessage row to get user.
-  const userMessageRow = await Message.findOne({
+  const userMessageRow = await MessageModel.findOne({
     where: {
       sId: userMessageId,
       workspaceId: workspace.id,
     },
     include: [
       {
-        model: UserMessage,
+        model: UserMessageModel,
         as: "userMessage",
         required: true,
       },

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -11,7 +11,7 @@ import type { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
 import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMessage } from "@app/lib/models/agent/conversation";
+import type { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import type {
@@ -123,7 +123,7 @@ async function createActionForTool(
     actionConfiguration: MCPToolConfigurationType;
     agentConfiguration: AgentConfigurationType;
     agentMessage: AgentMessageType;
-    agentMessageRow: AgentMessage;
+    agentMessageRow: AgentMessageModel;
     conversation: ConversationWithoutContentType;
     stepContentId: ModelId;
     stepContext: StepContext;

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -2,7 +2,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import type { AgentMessageContentParser } from "@app/lib/api/assistant/agent_message_content_parser";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMessage } from "@app/lib/models/agent/conversation";
+import type { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import type {
   AgentConfigurationType,
   AgentMessageType,
@@ -44,7 +44,7 @@ export type GetOutputRequestParams = {
   specifications: AgentActionSpecification[];
   flushParserTokens: () => Promise<void>;
   contentParser: AgentMessageContentParser;
-  agentMessageRow: AgentMessage;
+  agentMessageRow: AgentMessageModel;
   step: number;
   agentConfiguration: AgentConfigurationType;
   agentMessage: AgentMessageType;
@@ -65,7 +65,7 @@ export type GetOutputRequestParams = {
       modelInteractionDurationMs,
     }: {
       event: AgentMessageEvents;
-      agentMessageRow: AgentMessage;
+      agentMessageRow: AgentMessageModel;
       conversation: ConversationWithoutContentType;
       step: number;
       modelInteractionDurationMs?: number;

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -7,10 +7,10 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMessageFeedbackModel } from "@app/lib/models/agent/conversation";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
-  Message,
-  UserMessage,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
@@ -43,7 +43,7 @@ export async function storeAgentAnalyticsActivity(
   const { agentMessageId, userMessageId } = agentLoopArgs;
 
   // Query the Message/AgentMessage/Conversation rows.
-  const agentMessageRow = await Message.findOne({
+  const agentMessageRow = await MessageModel.findOne({
     where: {
       sId: agentMessageId,
       workspaceId: workspace.id,
@@ -55,7 +55,7 @@ export async function storeAgentAnalyticsActivity(
         required: true,
       },
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: true,
       },
@@ -74,14 +74,14 @@ export async function storeAgentAnalyticsActivity(
   }
 
   // Query the UserMessage row to get user.
-  const userMessageRow = await Message.findOne({
+  const userMessageRow = await MessageModel.findOne({
     where: {
       sId: userMessageId,
       workspaceId: workspace.id,
     },
     include: [
       {
-        model: UserMessage,
+        model: UserMessageModel,
         as: "userMessage",
         required: true,
         include: [
@@ -120,8 +120,8 @@ export async function storeAgentAnalyticsActivity(
 export async function storeAgentAnalytics(
   auth: Authenticator,
   params: {
-    agentMessageRow: Message;
-    agentAgentMessageRow: AgentMessage;
+    agentMessageRow: MessageModel;
+    agentAgentMessageRow: AgentMessageModel;
     userModel: UserModel | null;
     conversationRow: ConversationModel;
     contextOrigin: UserMessageOrigin | null;
@@ -188,7 +188,7 @@ export async function storeAgentAnalytics(
  */
 async function collectTokenUsage(
   auth: Authenticator,
-  agentMessage: AgentMessage
+  agentMessage: AgentMessageModel
 ): Promise<AgentMessageAnalyticsTokens> {
   if (!agentMessage.runIds || agentMessage.runIds.length === 0) {
     return {
@@ -332,14 +332,14 @@ export async function storeAgentMessageFeedbackActivity(
 
   const workspace = auth.getNonNullableWorkspace();
 
-  const agentMessageRow = await Message.findOne({
+  const agentMessageRow = await MessageModel.findOne({
     where: {
       sId: message.agentMessageId,
       workspaceId: workspace.id,
     },
     include: [
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: true,
       },

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -4,8 +4,8 @@ import { updateAnalyticsFeedback } from "@app/lib/analytics/feedback";
 import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
-import type { AgentMessageFeedback } from "@app/lib/models/agent/conversation";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import type { AgentMessageFeedbackModel } from "@app/lib/models/agent/conversation";
 import {
   AgentMessage,
   ConversationModel,
@@ -242,7 +242,7 @@ async function collectToolUsageFromMessage(
     new Set(actionResources.map((a) => a.mcpServerConfigurationId))
   );
 
-  const serverConfigs = await AgentMCPServerConfiguration.findAll({
+  const serverConfigs = await AgentMCPServerConfigurationModel.findAll({
     where: {
       workspaceId,
       id: uniqueConfigIds,
@@ -306,7 +306,9 @@ async function storeToElasticsearch(
 }
 
 function getAgentMessageFeedbackAnalytics(
-  agentMessageFeedbacks: AgentMessageFeedbackResource[] | AgentMessageFeedback[]
+  agentMessageFeedbacks:
+    | AgentMessageFeedbackResource[]
+    | AgentMessageFeedbackModel[]
 ): AgentMessageAnalyticsFeedback[] {
   return agentMessageFeedbacks.map((agentMessageFeedback) => ({
     feedback_id: agentMessageFeedback.id,

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -1,4 +1,4 @@
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { reportUsageForSubscriptionItems } from "@app/lib/plans/usage";

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -1,4 +1,4 @@
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { reportUsageForSubscriptionItems } from "@app/lib/plans/usage";
@@ -20,12 +20,12 @@ export async function recordUsageActivity(workspaceId: string) {
     return;
   }
 
-  const subscription = await Subscription.findOne({
+  const subscription = await SubscriptionModel.findOne({
     where: {
       workspaceId: workspace.id,
       status: "active",
     },
-    include: [Plan],
+    include: [PlanModel],
   });
 
   if (!subscription) {

--- a/front/tests/utils/AgentMCPServerConfigurationFactory.ts
+++ b/front/tests/utils/AgentMCPServerConfigurationFactory.ts
@@ -1,6 +1,6 @@
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPServerConfiguration } from "@app/lib/models/agent/actions/mcp";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -10,7 +10,7 @@ export class AgentMCPServerConfigurationFactory {
   static async create(
     auth: Authenticator,
     space: SpaceResource
-  ): Promise<AgentMCPServerConfiguration> {
+  ): Promise<AgentMCPServerConfigurationModel> {
     const owner = auth.getNonNullableWorkspace();
 
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
@@ -23,7 +23,7 @@ export class AgentMCPServerConfigurationFactory {
       space
     );
 
-    return AgentMCPServerConfiguration.create({
+    return AgentMCPServerConfigurationModel.create({
       sId: generateRandomModelSId(),
       agentConfigurationId: agent.id,
       workspaceId: owner.id,

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -3,10 +3,10 @@ import type { Transaction } from "sequelize";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  AgentMessage,
+  AgentMessageModel,
   ConversationModel,
-  Message,
-  UserMessage,
+  MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
@@ -108,8 +108,8 @@ export class ConversationFactory {
     origin?: UserMessageOrigin;
     agenticMessageType?: "run_agent" | "agent_handover";
     agenticOriginMessageId?: string;
-  }): Promise<{ messageRow: Message; userMessage: UserMessageType }> {
-    const userMessageRow = await UserMessage.create({
+  }): Promise<{ messageRow: MessageModel; userMessage: UserMessageType }> {
+    const userMessageRow = await UserMessageModel.create({
       userId: auth.getNonNullableUser().id,
       workspaceId: workspace.id,
       content,
@@ -122,7 +122,7 @@ export class ConversationFactory {
       clientSideMCPServerIds: [],
     });
 
-    const messageRow = await Message.create({
+    const messageRow = await MessageModel.create({
       sId: generateRandomModelSId(),
       rank: 0,
       conversationId: conversation.id,
@@ -180,8 +180,8 @@ export class ConversationFactory {
     rank: number;
     content: string;
     origin?: UserMessageOrigin;
-  }): Promise<Message> {
-    const userMessageRow = await UserMessage.create({
+  }): Promise<MessageModel> {
+    const userMessageRow = await UserMessageModel.create({
       userId: auth.user()?.id,
       workspaceId: workspace.id,
       content,
@@ -194,7 +194,7 @@ export class ConversationFactory {
       clientSideMCPServerIds: [],
     });
 
-    return Message.create({
+    return MessageModel.create({
       sId: generateRandomModelSId(),
       rank,
       conversationId,
@@ -217,8 +217,8 @@ export class ConversationFactory {
     conversationId: ModelId;
     rank: number;
     agentConfigurationId: string;
-  }): Promise<Message> {
-    const agentMessageRow = await AgentMessage.create({
+  }): Promise<MessageModel> {
+    const agentMessageRow = await AgentMessageModel.create({
       status: "created",
       agentConfigurationId,
       agentConfigurationVersion: 0,
@@ -226,7 +226,7 @@ export class ConversationFactory {
       skipToolsValidation: false,
     });
 
-    return Message.create({
+    return MessageModel.create({
       sId: generateRandomModelSId(),
       rank,
       conversationId,
@@ -258,7 +258,7 @@ export class ConversationFactory {
     title: string;
     contentType?: SupportedContentFragmentType;
     fileName?: string;
-  }): Promise<Message> {
+  }): Promise<MessageModel> {
     let finalFileId = fileId;
     if (!finalFileId) {
       // Default to text/plain for file creation if contentType is not a valid file content type
@@ -294,7 +294,7 @@ export class ConversationFactory {
       textBytes: null,
     });
 
-    return Message.create({
+    return MessageModel.create({
       sId: generateRandomModelSId(),
       rank,
       conversationId,
@@ -319,8 +319,8 @@ const createUserMessage = async ({
   createdAt: Date;
   rank: number;
   t?: Transaction;
-}): Promise<Message> => {
-  return Message.create(
+}): Promise<MessageModel> => {
+  return MessageModel.create(
     {
       createdAt,
       updatedAt: createdAt,
@@ -329,7 +329,7 @@ const createUserMessage = async ({
       conversationId: conversationModelId,
       parentId: null,
       userMessageId: (
-        await UserMessage.create(
+        await UserMessageModel.create(
           {
             createdAt,
             updatedAt: createdAt,
@@ -372,7 +372,7 @@ const createMessageAndAgentMessage = async ({
   parentId?: ModelId | null;
   t?: Transaction;
 }) => {
-  const agentMessageRow = await AgentMessage.create(
+  const agentMessageRow = await AgentMessageModel.create(
     {
       createdAt,
       updatedAt: createdAt,
@@ -384,7 +384,7 @@ const createMessageAndAgentMessage = async ({
     },
     { transaction: t }
   );
-  const messageRow = await Message.create(
+  const messageRow = await MessageModel.create(
     {
       createdAt,
       updatedAt: createdAt,

--- a/front/tests/utils/FeatureFlagFactory.ts
+++ b/front/tests/utils/FeatureFlagFactory.ts
@@ -1,4 +1,4 @@
-import { FeatureFlag } from "@app/lib/models/feature_flag";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import type { WhitelistableFeature, WorkspaceType } from "@app/types";
 
 export class FeatureFlagFactory {
@@ -6,7 +6,7 @@ export class FeatureFlagFactory {
     featureName: WhitelistableFeature,
     workspace: WorkspaceType
   ) {
-    return FeatureFlag.create({
+    return FeatureFlagModel.create({
       name: featureName,
       workspaceId: workspace.id,
     });

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { expect } from "vitest";
 
-import { Plan, Subscription } from "@app/lib/models/plan";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { upsertProPlans } from "@app/lib/plans/pro_plans";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -19,12 +19,12 @@ export class WorkspaceFactory {
       workOSOrganizationId: faker.string.alpha(10),
     });
 
-    const newPlan = await Plan.findOne({
+    const newPlan = await PlanModel.findOne({
       where: { code: PRO_PLAN_SEAT_29_CODE },
     });
     const now = new Date();
 
-    await Subscription.create({
+    await SubscriptionModel.create({
       sId: generateRandomModelSId(),
       workspaceId: workspace.id,
       planId: newPlan?.id,

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { expect } from "vitest";
 
-import { PlanModel, SubscriptionModel } from "@app/lib/models/planModel";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { upsertProPlans } from "@app/lib/plans/pro_plans";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -5,7 +5,10 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
-import { AgentMessage, Message } from "@app/lib/models/agent/conversation";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
 import type { Result } from "@app/types";
 import { Err, isGlobalAgentId, Ok } from "@app/types";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
@@ -40,7 +43,7 @@ export type AgentMessageRef = {
 export type AgentLoopExecutionData = {
   agentConfiguration: AgentConfigurationType;
   agentMessage: AgentMessageType;
-  agentMessageRow: AgentMessage;
+  agentMessageRow: AgentMessageModel;
   conversation: ConversationType;
   userMessage: UserMessageType;
 };
@@ -108,7 +111,7 @@ export async function getAgentLoopData(
   }
 
   // Get the AgentMessage database row by querying through Message model.
-  const agentMessageRow = await Message.findOne({
+  const agentMessageRow = await MessageModel.findOne({
     where: {
       // Leveraging the index on workspaceId, conversationId, sId.
       conversationId: conversation.id,
@@ -119,7 +122,7 @@ export async function getAgentLoopData(
     },
     include: [
       {
-        model: AgentMessage,
+        model: AgentMessageModel,
         as: "agentMessage",
         required: true,
       },


### PR DESCRIPTION
## Description

- Following up on [this thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1765270517063989).
- Some of the older Sequelize models in the codebase don't have the `Model` suffix.
- This PR adds it when missing.
- No database change. We don't use `Model.name` for FKs.

## Tests

- Tested locally and on front-edge.
- Checked that `create-db-migration` does not show any diff.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
