### PR TITLE
re-add canva mcp

### DIFF
--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -242,8 +242,6 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
     },
   },
   */
-  /*
-  //Removed temporaly see https://dust4ai.slack.com/archives/C05BUSJQP5W/p1762164149080909?thread_ts=1762159475.187129&cid=C05BUSJQP5W
   {
     id: 10006,
     name: "Canva",
@@ -277,7 +275,6 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
       create_design_from_candidate: "low",
     },
   },
-  **/
 ];
 
 export const isDefaultRemoteMcpServerURL = (url: string | undefined) => {


### PR DESCRIPTION
## Description

re-add canva MCP after whitelisting process

## Tests

- locally for front
- on prod to verify whitelisting

## Risk

low

## Deploy Plan

front only
