### PR TITLE
Create per-project launch.json that work with dust.code-workspace

### DIFF
--- a/connectors/.vscode/launch.json
+++ b/connectors/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node-terminal",
+      "name": "Debug connectors server",
+      "request": "launch",
+      "command": "npx tsx ./src/start.ts -p 3002",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env.local"
+    }
+  ]
+}

--- a/core/.vscode/launch.json
+++ b/core/.vscode/launch.json
@@ -20,6 +20,23 @@
         }
       },
       "args": []
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug sqlite worker",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=sqlite-worker",
+          "--manifest-path=${workspaceFolder}/Cargo.toml"
+        ],
+        "filter": {
+          "name": "sqlite-worker",
+          "kind": "bin"
+        }
+      },
+      "args": []
     }
   ]
 }

--- a/core/.vscode/launch.json
+++ b/core/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug core-api",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=core-api",
+          "--manifest-path=${workspaceFolder}/Cargo.toml"
+        ],
+        "filter": {
+          "name": "core-api",
+          "kind": "bin"
+        }
+      },
+      "args": []
+    }
+  ]
+}

--- a/front/.vscode/launch.json
+++ b/front/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node-terminal",
+      "name": "Debug front server",
+      "request": "launch",
+      "command": "npm run dev",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env.local"
+    },
+    {
+      "type": "node-terminal",
+      "name": "Debug front worker",
+      "request": "launch",
+      "command": "npm run start:worker",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env.local"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

The existing .vscode/launch.json doesn't play well with dust.code-workspace, which treats each folder as a separate project. Plus it's cleaner not to have everything in one file.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

None.