### PR TITLE
[front] add max width in action details card 

### DIFF
--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -85,7 +85,7 @@ export function AgentMessageActions({
       )}
     >
       {lastAction && lastAgentStateClassification === "acting" ? (
-        <Card variant="secondary" size="sm">
+        <Card variant="secondary" className="max-w-xl">
           <MCPActionDetails
             viewType="conversation"
             action={lastAction}


### PR DESCRIPTION
## Description
This PR is to add max width to action details card, closing https://github.com/dust-tt/tasks/issues/5479 

(before it was full width)
<img width="1926" height="836" alt="CleanShot 2025-12-09 at 10 42 34@2x" src="https://github.com/user-attachments/assets/4c83db92-6c7e-4e1d-b674-19265f732d6d" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
