### PR TITLE
[front] use button group and remove separator from action buttons

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -525,11 +525,6 @@ export function AgentMessage({
     );
   }
 
-  // Add separator if we have both feedback and copy buttons
-  if (shouldShowFeedback && shouldShowCopy) {
-    messageButtons.push(<Separator key="separator" orientation="vertical" />);
-  }
-
   // Add copy button or split button with dropdown (only when mentions_v2 is enabled)
   if (
     userMentionsEnabled &&

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -9,7 +9,6 @@ import {
   InteractiveImageGrid,
   Markdown,
   MoreIcon,
-  Separator,
   StopIcon,
   TrashIcon,
   useCopyToClipboard,

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonGroup,
   Checkbox,
   HandThumbDownIcon,
   HandThumbUpIcon,
@@ -133,33 +134,44 @@ export function FeedbackSelector({
     lastSelectedThumb,
   ]);
 
-  const ThumbButtons = (
-    <div className="flex items-center gap-0.5">
-      <Button
-        tooltip="I found this helpful"
-        variant={feedback?.thumb === "up" ? "primary" : "ghost-secondary"}
-        size="xs"
-        disabled={isSubmittingThumb}
-        onClick={handleThumbUp}
-        icon={HandThumbUpIcon}
-        className={feedback?.thumb === "up" ? "" : "text-muted-foreground"}
-      />
-      <Button
-        tooltip="Report an issue with this answer"
-        variant={feedback?.thumb === "down" ? "primary" : "ghost-secondary"}
-        size="xs"
-        disabled={isSubmittingThumb}
-        onClick={handleThumbDown}
-        icon={HandThumbDownIcon}
-        className={feedback?.thumb === "down" ? "" : "text-muted-foreground"}
-      />
-    </div>
-  );
-
   return (
     <div ref={containerRef} className="flex items-center">
       <PopoverRoot open={isPopoverOpen}>
-        <PopoverTrigger asChild>{ThumbButtons}</PopoverTrigger>
+        <PopoverTrigger asChild>
+          <ButtonGroup
+            variant="outline"
+            items={[
+              {
+                type: "button",
+                props: {
+                  tooltip: "I found this helpful",
+                  variant:
+                    feedback?.thumb === "up" ? "primary" : "ghost-secondary",
+                  size: "xs",
+                  disabled: isSubmittingThumb,
+                  onClick: handleThumbUp,
+                  icon: HandThumbUpIcon,
+                  className:
+                    feedback?.thumb === "up" ? "" : "text-muted-foreground",
+                },
+              },
+              {
+                type: "button",
+                props: {
+                  tooltip: "Report an issue with this answer",
+                  variant:
+                    feedback?.thumb === "down" ? "primary" : "ghost-secondary",
+                  size: "xs",
+                  disabled: isSubmittingThumb,
+                  onClick: handleThumbDown,
+                  icon: HandThumbDownIcon,
+                  className:
+                    feedback?.thumb === "down" ? "" : "text-muted-foreground",
+                },
+              },
+            ]}
+          />
+        </PopoverTrigger>
         <PopoverContent
           fullWidth={true}
           onInteractOutside={closePopover}

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -74,36 +74,33 @@ export function FeedbackSelector({
     feedback?.thumb,
   ]);
 
-  const selectThumb = useCallback(
-    async (thumb: ThumbReaction) => {
-      const shouldRemoveExistingFeedback = feedback?.thumb === thumb;
-      setIsPopoverOpen(!shouldRemoveExistingFeedback);
-      setLastSelectedThumb(shouldRemoveExistingFeedback ? null : thumb);
-      setIsConversationShared(thumb === "down");
+  const selectThumb = async (thumb: ThumbReaction) => {
+    const shouldRemoveExistingFeedback = feedback?.thumb === thumb;
+    setIsPopoverOpen(!shouldRemoveExistingFeedback);
+    setLastSelectedThumb(shouldRemoveExistingFeedback ? null : thumb);
+    setIsConversationShared(thumb === "down");
 
-      // We enforce written feedback for thumbs down.
-      // -> Not saving the reaction until then.
-      if (thumb === "down" && !shouldRemoveExistingFeedback) {
-        return;
-      }
+    // We enforce written feedback for thumbs down.
+    // -> Not saving the reaction until then.
+    if (thumb === "down" && !shouldRemoveExistingFeedback) {
+      return;
+    }
 
-      await onSubmitThumb({
-        feedbackContent: localFeedbackContent,
-        thumb,
-        shouldRemoveExistingFeedback,
-        isConversationShared: false,
-      });
-    },
-    [feedback?.thumb, localFeedbackContent, onSubmitThumb]
-  );
+    await onSubmitThumb({
+      feedbackContent: localFeedbackContent,
+      thumb,
+      shouldRemoveExistingFeedback,
+      isConversationShared: false,
+    });
+  };
 
-  const handleThumbUp = useCallback(async () => {
+  const handleThumbUp = async () => {
     await selectThumb("up");
-  }, [selectThumb]);
+  };
 
-  const handleThumbDown = useCallback(async () => {
+  const handleThumbDown = async () => {
     await selectThumb("down");
-  }, [selectThumb]);
+  };
 
   const handleTextAreaChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -112,11 +109,11 @@ export function FeedbackSelector({
     []
   );
 
-  const closePopover = useCallback(() => {
+  const closePopover = () => {
     setIsPopoverOpen(false);
-  }, []);
+  };
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmit = async () => {
     setIsPopoverOpen(false);
     if (lastSelectedThumb) {
       await onSubmitThumb({
@@ -127,12 +124,7 @@ export function FeedbackSelector({
       });
       setLocalFeedbackContent(null);
     }
-  }, [
-    onSubmitThumb,
-    localFeedbackContent,
-    isConversationShared,
-    lastSelectedThumb,
-  ]);
+  };
 
   return (
     <div ref={containerRef} className="flex items-center">


### PR DESCRIPTION
## Description
closing https://github.com/dust-tt/tasks/issues/5478 

before:
<img width="656" height="462" alt="CleanShot 2025-12-09 at 10 52 37@2x" src="https://github.com/user-attachments/assets/9f141ca5-dc13-417b-95b2-bb6018521cfb" />


after:
<img width="632" height="410" alt="CleanShot 2025-12-09 at 10 52 15@2x" src="https://github.com/user-attachments/assets/b1122fa7-8553-4c66-b442-5845c9e04f58" />




<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
