### PR TITLE
[Programmatic Usage] Count Zendesk as human usage

### DIFF
--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -44,7 +44,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   triggered: "user",
   web: "user",
   zapier: "programmatic",
-  zendesk: "programmatic",
+  zendesk: "user",
   onboarding_conversation: "user",
 };
 


### PR DESCRIPTION
Description
-----
Count Zendesk as human usage. It was a mistake to count it as programmatic usage. Related thread: https://dust4ai.slack.com/archives/C05BUSJQP5W/p1765271759019739?thread_ts=1765230139.687879&cid=C05BUSJQP5W

Risks
-----
Low.

Deploy
-----
pmrr
front
