### PR TITLE
[front] ppul(fix): Enforce userContextOrigin

### DIFF
--- a/front/lib/api/assistant/conversation/getRelatedContentFragments.test.ts
+++ b/front/lib/api/assistant/conversation/getRelatedContentFragments.test.ts
@@ -62,6 +62,7 @@ function createMockUserMessage(rank: number): UserMessageType {
       fullName: null,
       email: null,
       profilePictureUrl: null,
+      origin: "api",
     },
   };
 }

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -83,6 +83,7 @@ describe("renderAllMessages", () => {
               fullName: null,
               email: null,
               profilePictureUrl: null,
+              origin: "web",
             },
           } satisfies UserMessageType,
         ];

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -74,24 +74,8 @@ function getRedisKey(workspace: LightWorkspaceType): string {
 
 export function isProgrammaticUsage(
   auth: Authenticator,
-  { userMessageOrigin }: { userMessageOrigin?: UserMessageOrigin | null } = {}
+  { userMessageOrigin }: { userMessageOrigin: UserMessageOrigin }
 ): boolean {
-  // TODO(2025-12-01 PPUL): Remove once PPUL is out.
-  if (auth.isKey() && !auth.isSystemKey()) {
-    return true;
-  }
-
-  // Track for API keys, listed programmatic origins or unspecified user message origins.
-  // This must be in sync with the getShouldTrackTokenUsageCostsESFilter function.
-  // TODO(PPUL): enforce passing non-null userMessageOrigin.
-  if (!userMessageOrigin) {
-    logger.warn(
-      { workspaceId: auth.getNonNullableWorkspace().sId },
-      "No user message origin provided, assuming non-programmatic usage for now"
-    );
-    return false;
-  }
-
   if (
     auth.authMethod() === "api_key" ||
     USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic"
@@ -290,7 +274,7 @@ export async function trackProgrammaticCost(
   {
     dustRunIds,
     userMessageOrigin,
-  }: { dustRunIds: string[]; userMessageOrigin?: UserMessageOrigin | null }
+  }: { dustRunIds: string[]; userMessageOrigin: UserMessageOrigin }
 ) {
   if (!isProgrammaticUsage(auth, { userMessageOrigin })) {
     return;

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -213,7 +213,7 @@ export class UserMessage extends WorkspaceAwareModel<UserMessage> {
   declare userContextFullName: string | null;
   declare userContextEmail: string | null;
   declare userContextProfilePictureUrl: string | null;
-  declare userContextOrigin: UserMessageOrigin | null;
+  declare userContextOrigin: UserMessageOrigin;
   // TODO(2025-11-24 PPUL): Remove this once data has been backfilled
   declare userContextOriginMessageId: string | null;
 
@@ -276,7 +276,7 @@ UserMessage.init(
     },
     userContextOrigin: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: false,
     },
     // TODO: Remove this once backfilled
     userContextOriginMessageId: {

--- a/front/migrations/20251125_backfill_agentic_origin_fields.ts
+++ b/front/migrations/20251125_backfill_agentic_origin_fields.ts
@@ -113,7 +113,7 @@ async function updateAgenticFields(
         if (execute) {
           await userMessage.update(
             {
-              userContextOrigin: rootContextOrigin,
+              userContextOrigin: rootContextOrigin ?? "api",
               agenticOriginMessageId: userMessage.userContextOriginMessageId,
               agenticMessageType: originalUserContextOrigin as
                 | "run_agent"

--- a/front/migrations/db/migration_431.sql
+++ b/front/migrations/db/migration_431.sql
@@ -1,13 +1,17 @@
-update user_messages
-set
-    "origin" = 'triggered'
-from user_messages
-where
-    "userContextOrigin" is null
-    and content not like 'Transcript%'
-update user_messages
-set
-    "origin" = 'transcript'
-where
-    "userContextOrigin" is null
-    and content like 'Transcript%'
+UPDATE user_messages
+SET
+    "userContextOrigin" = 'triggered'
+WHERE
+    "userContextOrigin" IS NULL
+    AND content NOT LIKE 'Transcript%';
+
+UPDATE user_messages
+SET
+    "userContextOrigin" = 'transcript'
+WHERE
+    "userContextOrigin" IS NULL
+    AND content LIKE 'Transcript%';
+
+ALTER TABLE "user_messages"
+ALTER COLUMN "userContextOrigin"
+SET NOT NULL;

--- a/front/migrations/db/migration_431.sql
+++ b/front/migrations/db/migration_431.sql
@@ -1,0 +1,13 @@
+update user_messages
+set
+    "origin" = 'triggered'
+from user_messages
+where
+    "userContextOrigin" is null
+    and content not like 'Transcript%'
+update user_messages
+set
+    "origin" = 'transcript'
+where
+    "userContextOrigin" is null
+    and content like 'Transcript%'

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -106,8 +106,19 @@ async function handler(
         });
       }
 
+      const {
+        content,
+        context,
+        mentions,
+        blocking,
+        skipToolsValidation,
+        agenticMessageData,
+      } = r.data;
+
+      const origin = context.origin ?? "api";
+
       const hasReachedLimits = isProgrammaticUsage(auth, {
-        userMessageOrigin: r.data.context.origin,
+        userMessageOrigin: origin,
       })
         ? await hasReachedProgrammaticUsageLimits(auth)
         : false;
@@ -122,15 +133,6 @@ async function handler(
           },
         });
       }
-
-      const {
-        content,
-        context,
-        mentions,
-        blocking,
-        skipToolsValidation,
-        agenticMessageData,
-      } = r.data;
 
       if (isEmptyString(context.username)) {
         return apiError(req, res, {
@@ -206,7 +208,7 @@ async function handler(
         clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
         email: context.email?.toLowerCase() ?? null,
         fullName: context.fullName ?? null,
-        origin: context.origin ?? "api",
+        origin,
         originMessageId: context.originMessageId ?? null,
         profilePictureUrl: context.profilePictureUrl ?? null,
         timezone: context.timezone,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -144,23 +144,25 @@ async function handler(
         blocking,
       } = r.data;
 
-      const hasReachedLimits =
-        isProgrammaticUsage(auth, {
-          userMessageOrigin: message?.context.origin,
-        }) && (await hasReachedProgrammaticUsageLimits(auth));
-      if (hasReachedLimits) {
-        return apiError(req, res, {
-          status_code: 429,
-          api_error: {
-            type: "rate_limit_error",
-            message:
-              "Monthly API usage limit exceeded. Please upgrade your plan or wait until your " +
-              "limit resets next billing period.",
-          },
-        });
-      }
+      const origin = message?.context.origin ?? "api";
 
       if (message) {
+        const hasReachedLimits =
+          isProgrammaticUsage(auth, {
+            userMessageOrigin: origin,
+          }) && (await hasReachedProgrammaticUsageLimits(auth));
+        if (hasReachedLimits) {
+          return apiError(req, res, {
+            status_code: 429,
+            api_error: {
+              type: "rate_limit_error",
+              message:
+                "Monthly API usage limit exceeded. Please upgrade your plan or wait until your " +
+                "limit resets next billing period.",
+            },
+          });
+        }
+
         if (isUserMessageContextOverflowing(message.context)) {
           return apiError(req, res, {
             status_code: 400,
@@ -379,7 +381,7 @@ async function handler(
           clientSideMCPServerIds: message.context.clientSideMCPServerIds ?? [],
           email: message.context.email?.toLowerCase() ?? null,
           fullName: message.context.fullName ?? null,
-          origin: message.context.origin ?? "api",
+          origin,
           profilePictureUrl: message.context.profilePictureUrl ?? null,
           timezone: message.context.timezone,
           username: message.context.username,

--- a/front/temporal/agent_loop/activities/usage_tracking.ts
+++ b/front/temporal/agent_loop/activities/usage_tracking.ts
@@ -73,7 +73,7 @@ export async function trackProgrammaticUsageActivity(
   ) {
     await trackProgrammaticCost(auth, {
       dustRunIds: agentMessage.runIds,
-      userMessageOrigin: userMessage.userContextOrigin ?? null,
+      userMessageOrigin: userMessage.userContextOrigin,
     });
   }
 }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -103,7 +103,7 @@ export type UserMessageContext = {
   fullName: string | null;
   email: string | null;
   profilePictureUrl: string | null;
-  origin?: UserMessageOrigin | null;
+  origin: UserMessageOrigin;
   originMessageId?: string | null;
   lastTriggerRunAt?: number | null;
   clientSideMCPServerIds?: string[];


### PR DESCRIPTION
fixes: [#5227](https://github.com/dust-tt/tasks/issues/5227)

## Description

This enforce passing a userContextOrigin for all user messages. No changes in the public API here, if no origin is passed we fallback to "api".

We only had a few entries in db where origin was not set : transcript ( which now have "transcript" origin) and triggered (during a few weeks, no origin was passed, should be "triggered" ). Using simple sql backfill to fix before adding constraint in db.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

run the migration
deploy front

