### PR TITLE
[SKILLS] Open sheet details (empty)

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -318,7 +318,7 @@ const getTableColumns = ({
 type AssistantsTableProps = {
   owner: WorkspaceType;
   agents: LightAgentConfigurationType[];
-  setShowDetails: (agent: LightAgentConfigurationType) => void;
+  setDetailedAgentId: (sId: string) => void;
   handleToggleAgentStatus: (
     agent: LightAgentConfigurationType
   ) => Promise<void>;
@@ -333,7 +333,7 @@ type AssistantsTableProps = {
 export function AssistantsTable({
   owner,
   agents,
-  setShowDetails,
+  setDetailedAgentId,
   handleToggleAgentStatus,
   showDisabledFreeWorkspacePopup,
   setShowDisabledFreeWorkspacePopup,
@@ -407,7 +407,7 @@ export function AssistantsTable({
                 );
               }
             } else {
-              setShowDetails(agentConfiguration);
+              setDetailedAgentId(agentConfiguration.sId);
             }
           },
           menuItems:
@@ -448,7 +448,7 @@ export function AssistantsTable({
                     icon: EyeIcon,
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
-                      setShowDetails(agentConfiguration);
+                      setDetailedAgentId(agentConfiguration.sId);
                     },
                     kind: "item" as const,
                   },
@@ -490,7 +490,7 @@ export function AssistantsTable({
     [
       agents,
       owner,
-      setShowDetails,
+      setDetailedAgentId,
       setShowDisabledFreeWorkspacePopup,
       showDisabledFreeWorkspacePopup,
       selection,

--- a/front/components/skills/SkillDetails.tsx
+++ b/front/components/skills/SkillDetails.tsx
@@ -35,7 +35,7 @@ export const SCOPE_INFO: Record<
 } as const;
 
 type SkillDetailsProps = {
-  skillConfiguration: SkillConfigurationWithAuthorType | null;
+  skillConfiguration: SkillConfigurationWithAuthorType;
   onClose: () => void;
 };
 
@@ -57,9 +57,7 @@ export function SkillDetails({
           <SheetTitle />
         </VisuallyHidden>
         <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
-          {skillConfiguration && (
-            <DescriptionSection skillConfiguration={skillConfiguration} />
-          )}
+          <DescriptionSection skillConfiguration={skillConfiguration} />
         </SheetHeader>
       </SheetContent>
     </Sheet>

--- a/front/components/skills/SkillDetails.tsx
+++ b/front/components/skills/SkillDetails.tsx
@@ -44,7 +44,14 @@ export function SkillDetails({
   onClose,
 }: SkillDetailsProps) {
   return (
-    <Sheet open={!!skillConfiguration} onOpenChange={onClose}>
+    <Sheet
+      open={!!skillConfiguration}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
       <SheetContent size="lg">
         <VisuallyHidden>
           <SheetTitle />

--- a/front/components/skills/SkillDetails.tsx
+++ b/front/components/skills/SkillDetails.tsx
@@ -1,0 +1,86 @@
+import {
+  Avatar,
+  Chip,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@dust-tt/sparkle";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+
+import { SKILL_ICON } from "@app/lib/skill";
+import type {
+  SkillConfigurationWithAuthorType,
+  SkillScope,
+} from "@app/types/skill_configuration";
+
+export const SCOPE_INFO: Record<
+  SkillScope,
+  {
+    shortLabel: string;
+    label: string;
+    color: "green" | "primary";
+  }
+> = {
+  workspace: {
+    shortLabel: "Published",
+    label: "Published",
+    color: "green",
+  },
+  private: {
+    shortLabel: "Not published",
+    label: "Not published",
+    color: "primary",
+  },
+} as const;
+
+type SkillDetailsProps = {
+  skillConfiguration: SkillConfigurationWithAuthorType | null;
+  onClose: () => void;
+};
+
+export function SkillDetails({
+  skillConfiguration,
+  onClose,
+}: SkillDetailsProps) {
+  return (
+    <Sheet open={!!skillConfiguration} onOpenChange={onClose}>
+      <SheetContent size="lg">
+        <VisuallyHidden>
+          <SheetTitle />
+        </VisuallyHidden>
+        <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
+          {skillConfiguration && (
+            <DescriptionSection skillConfiguration={skillConfiguration} />
+          )}
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+type DescriptionSectionProps = {
+  skillConfiguration: SkillConfigurationWithAuthorType;
+};
+
+const DescriptionSection = ({
+  skillConfiguration,
+}: DescriptionSectionProps) => (
+  <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-3 sm:flex-row">
+      <Avatar name="Agent avatar" visual={<SKILL_ICON />} size="lg" />
+      <div className="flex grow flex-col gap-1">
+        <div className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">
+          {skillConfiguration.name}
+        </div>
+        {skillConfiguration.status === "active" && (
+          <div>
+            <Chip color={SCOPE_INFO[skillConfiguration.scope].color}>
+              {SCOPE_INFO[skillConfiguration.scope].label}
+            </Chip>
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+);

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -87,12 +87,12 @@ const getTableColumns = () => {
 
 type SkillsTableProps = {
   skillsConfigurations: SkillConfigurationWithAuthorType[];
-  setShowDetails: (skill: SkillConfigurationWithAuthorType) => void;
+  setSkillConfiguration: (skill: SkillConfigurationWithAuthorType) => void;
 };
 
 export function SkillsTable({
   skillsConfigurations,
-  setShowDetails,
+  setSkillConfiguration,
 }: SkillsTableProps) {
   const { pagination, setPagination } = usePaginationFromUrl({});
 
@@ -102,11 +102,11 @@ export function SkillsTable({
         return {
           ...skillConfiguration,
           onClick: () => {
-            setShowDetails(skillConfiguration);
+            setSkillConfiguration(skillConfiguration);
           },
         };
       }),
-    [skillsConfigurations, setShowDetails]
+    [skillsConfigurations, setSkillConfiguration]
   );
 
   if (rows.length === 0) {

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -87,9 +87,13 @@ const getTableColumns = () => {
 
 type SkillsTableProps = {
   skillsConfigurations: SkillConfigurationWithAuthorType[];
+  setShowDetails: (skill: SkillConfigurationWithAuthorType) => void;
 };
 
-export function SkillsTable({ skillsConfigurations }: SkillsTableProps) {
+export function SkillsTable({
+  skillsConfigurations,
+  setShowDetails,
+}: SkillsTableProps) {
   const { pagination, setPagination } = usePaginationFromUrl({});
 
   const rows: RowData[] = useMemo(
@@ -97,10 +101,12 @@ export function SkillsTable({ skillsConfigurations }: SkillsTableProps) {
       skillsConfigurations.map((skillConfiguration) => {
         return {
           ...skillConfiguration,
-          onClick: () => {},
+          onClick: () => {
+            setShowDetails(skillConfiguration);
+          },
         };
       }),
-    [skillsConfigurations]
+    [skillsConfigurations, setShowDetails]
   );
 
   if (rows.length === 0) {

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -86,19 +86,19 @@ const getTableColumns = () => {
 };
 
 type SkillsTableProps = {
-  skillsConfigurations: SkillConfigurationWithAuthorType[];
+  skillConfigurations: SkillConfigurationWithAuthorType[];
   setSkillConfiguration: (skill: SkillConfigurationWithAuthorType) => void;
 };
 
 export function SkillsTable({
-  skillsConfigurations,
+  skillConfigurations,
   setSkillConfiguration,
 }: SkillsTableProps) {
   const { pagination, setPagination } = usePaginationFromUrl({});
 
   const rows: RowData[] = useMemo(
     () =>
-      skillsConfigurations.map((skillConfiguration) => {
+      skillConfigurations.map((skillConfiguration) => {
         return {
           ...skillConfiguration,
           onClick: () => {
@@ -106,7 +106,7 @@ export function SkillsTable({
           },
         };
       }),
-    [skillsConfigurations, setSkillConfiguration]
+    [skillConfigurations, setSkillConfiguration]
   );
 
   if (rows.length === 0) {

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -308,7 +308,6 @@ export default function WorkspaceAssistants({
         <AgentDetails
           owner={owner}
           user={user}
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           agentId={detailedAgentId}
           onClose={() => setDetailedAgentId(null)}
         />

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -224,8 +224,7 @@ export default function WorkspaceAssistants({
     return { uniqueTags };
   }, [agentConfigurations]);
 
-  const [showDetails, setShowDetails] =
-    useState<LightAgentConfigurationType | null>(null);
+  const [detailedAgentId, setDetailedAgentId] = useState<string | null>(null);
 
   const handleToggleAgentStatus = async (
     agent: LightAgentConfigurationType
@@ -310,8 +309,8 @@ export default function WorkspaceAssistants({
           owner={owner}
           user={user}
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          agentId={showDetails?.sId || null}
-          onClose={() => setShowDetails(null)}
+          agentId={detailedAgentId}
+          onClose={() => setDetailedAgentId(null)}
         />
         <div className="flex w-full flex-col gap-8 pt-2 lg:pt-8">
           <Page.Header title="Manage Agents" icon={ContactsRobotIcon} />
@@ -414,7 +413,7 @@ export default function WorkspaceAssistants({
                   setSelection={setSelection}
                   owner={owner}
                   agents={agentsByTab[activeTab]}
-                  setShowDetails={setShowDetails}
+                  setDetailedAgentId={setDetailedAgentId}
                   handleToggleAgentStatus={handleToggleAgentStatus}
                   showDisabledFreeWorkspacePopup={
                     showDisabledFreeWorkspacePopup

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -63,10 +63,12 @@ export default function WorkspaceSkills({
 
   return (
     <>
-      <SkillDetails
-        skillConfiguration={showDetails}
-        onClose={() => setShowDetails(null)}
-      />
+      {!!showDetails && (
+        <SkillDetails
+          skillConfiguration={showDetails}
+          onClose={() => setShowDetails(null)}
+        />
+      )}
       <ConversationsNavigationProvider>
         <AppWideModeLayout
           subscription={subscription}

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -1,9 +1,11 @@
 import { Button, Page, PlusIcon } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import Head from "next/head";
+import { useState } from "react";
 
 import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import { SkillDetails } from "@app/components/skills/SkillDetails";
 import { SkillsTable } from "@app/components/skills/SkillsTable";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
@@ -14,6 +16,7 @@ import { useSkillConfigurations } from "@app/lib/swr/skill_configurations";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
 import { isBuilder } from "@app/types";
+import type { SkillConfigurationWithAuthorType } from "@app/types/skill_configuration";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -51,38 +54,50 @@ export default function WorkspaceSkills({
   owner,
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [showDetails, setShowDetails] =
+    useState<SkillConfigurationWithAuthorType | null>(null);
+
   const { skillConfigurations } = useSkillConfigurations({
     workspaceId: owner.sId,
   });
 
   return (
-    <ConversationsNavigationProvider>
-      <AppWideModeLayout
-        subscription={subscription}
-        owner={owner}
-        navChildren={<AgentSidebarMenu owner={owner} />}
-      >
-        <Head>
-          <title>Dust - Manage Skills</title>
-        </Head>
-        <div className="flex w-full flex-col gap-8 pt-2 lg:pt-8">
-          <Page.Header title="Manage Skills" icon={SKILL_ICON} />
-          <Page.Vertical gap="md" align="stretch">
-            <div className="flex justify-end">
-              <Button
-                label="Create skill"
-                href={getSkillBuilderRoute(owner.sId, "new")}
-                icon={PlusIcon}
-                tooltip="Create a new skill"
-              />
-            </div>
-            <div className="flex flex-col pt-3">
-              <SkillsTable skillsConfigurations={skillConfigurations} />
-            </div>
-          </Page.Vertical>
-        </div>
-      </AppWideModeLayout>
-    </ConversationsNavigationProvider>
+    <>
+      <SkillDetails
+        skillConfiguration={showDetails}
+        onClose={() => setShowDetails(null)}
+      />
+      <ConversationsNavigationProvider>
+        <AppWideModeLayout
+          subscription={subscription}
+          owner={owner}
+          navChildren={<AgentSidebarMenu owner={owner} />}
+        >
+          <Head>
+            <title>Dust - Manage Skills</title>
+          </Head>
+          <div className="flex w-full flex-col gap-8 pt-2 lg:pt-8">
+            <Page.Header title="Manage Skills" icon={SKILL_ICON} />
+            <Page.Vertical gap="md" align="stretch">
+              <div className="flex justify-end">
+                <Button
+                  label="Create skill"
+                  href={getSkillBuilderRoute(owner.sId, "new")}
+                  icon={PlusIcon}
+                  tooltip="Create a new skill"
+                />
+              </div>
+              <div className="flex flex-col pt-3">
+                <SkillsTable
+                  skillsConfigurations={skillConfigurations}
+                  setShowDetails={setShowDetails}
+                />
+              </div>
+            </Page.Vertical>
+          </div>
+        </AppWideModeLayout>
+      </ConversationsNavigationProvider>
+    </>
   );
 }
 

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -54,7 +54,7 @@ export default function WorkspaceSkills({
   owner,
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const [showDetails, setShowDetails] =
+  const [skillConfiguration, setSkillConfiguration] =
     useState<SkillConfigurationWithAuthorType | null>(null);
 
   const { skillConfigurations } = useSkillConfigurations({
@@ -63,10 +63,10 @@ export default function WorkspaceSkills({
 
   return (
     <>
-      {!!showDetails && (
+      {!!skillConfiguration && (
         <SkillDetails
-          skillConfiguration={showDetails}
-          onClose={() => setShowDetails(null)}
+          skillConfiguration={skillConfiguration}
+          onClose={() => setSkillConfiguration(null)}
         />
       )}
       <ConversationsNavigationProvider>
@@ -92,7 +92,7 @@ export default function WorkspaceSkills({
               <div className="flex flex-col pt-3">
                 <SkillsTable
                   skillsConfigurations={skillConfigurations}
-                  setShowDetails={setShowDetails}
+                  setSkillConfiguration={setSkillConfiguration}
                 />
               </div>
             </Page.Vertical>

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -91,7 +91,7 @@ export default function WorkspaceSkills({
               </div>
               <div className="flex flex-col pt-3">
                 <SkillsTable
-                  skillsConfigurations={skillConfigurations}
+                  skillConfigurations={skillConfigurations}
                   setSkillConfiguration={setSkillConfiguration}
                 />
               </div>


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/5503
As a user, on the manage skills page, when I click on a row (a skill), I see a sheet open with the skill name

<img width="1359" height="971" alt="image" src="https://github.com/user-attachments/assets/168887a8-2e1c-48c8-b06a-f9a3ecea6bad" />


## Tests

local

## Risk

no - ff

## Deploy Plan

front
