### PR TITLE
[front] - feat(skills): edit

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -95,7 +95,6 @@ export default function SkillBuilder({
     const result = await submitSkillBuilderForm({
       formData: data,
       owner,
-      user,
       skillConfigurationId: !isCreatingNew
         ? skillConfiguration?.sId
         : undefined,

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -47,7 +47,7 @@ export default function SkillBuilder({
   const [isSaving, setIsSaving] = useState(false);
 
   const { actions, isActionsLoading } = useSkillConfigurationTools(
-    owner.sId,
+    owner,
     skillConfiguration?.sId ?? null
   );
 

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -32,7 +32,6 @@ import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
-<<<<<<< HEAD
 import { useSkillConfigurationTools } from "@app/lib/swr/actions";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
 import { emptyArray } from "@app/lib/swr/swr";
@@ -44,13 +43,6 @@ function processActionsFromStorage(actions: BuilderAction[]): BuilderAction[] {
 
 interface SkillBuilderProps {
   skillConfiguration?: SkillConfigurationType;
-=======
-import { useSkillEditors } from "@app/lib/swr/skill_editors";
-import type { SkillConfiguration } from "@app/types/skill_configuration";
-
-interface SkillBuilderProps {
-  skillConfiguration?: SkillConfiguration;
->>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   duplicateSkillId?: string | null;
 }
 
@@ -63,26 +55,20 @@ export default function SkillBuilder({
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
 
-<<<<<<< HEAD
   const { actions, isActionsLoading } = useSkillConfigurationTools(
     owner.sId,
     skillConfiguration?.sId ?? null
   );
 
-=======
->>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   const { editors } = useSkillEditors({
     owner,
     skillConfigurationId: skillConfiguration?.sId ?? null,
   });
 
-<<<<<<< HEAD
   const processedActions = useMemo(() => {
     return processActionsFromStorage(actions ?? emptyArray());
   }, [actions]);
 
-=======
->>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   const defaultValues = useMemo(() => {
     if (duplicateSkillId && skillConfiguration) {
       return transformDuplicateSkillToFormData(skillConfiguration, user);
@@ -104,26 +90,19 @@ export default function SkillBuilder({
     },
   });
 
-<<<<<<< HEAD
   // Populate editors and tools reactively
-=======
->>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   useEffect(() => {
     const currentValues = form.getValues();
 
     form.reset({
       ...currentValues,
-<<<<<<< HEAD
       tools: processedActions,
-=======
->>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
       editors: duplicateSkillId
         ? [user]
         : skillConfiguration || editors.length > 0
           ? editors
           : [user],
     });
-<<<<<<< HEAD
   }, [
     isActionsLoading,
     processedActions,
@@ -133,9 +112,6 @@ export default function SkillBuilder({
     user,
     skillConfiguration,
   ]);
-=======
-  }, [editors, form, duplicateSkillId, user, skillConfiguration]);
->>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
 
   const isCreatingNew = duplicateSkillId || !skillConfiguration;
   const { isDirty } = form.formState;

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -32,6 +32,7 @@ import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
+<<<<<<< HEAD
 import { useSkillConfigurationTools } from "@app/lib/swr/actions";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
 import { emptyArray } from "@app/lib/swr/swr";
@@ -43,6 +44,13 @@ function processActionsFromStorage(actions: BuilderAction[]): BuilderAction[] {
 
 interface SkillBuilderProps {
   skillConfiguration?: SkillConfigurationType;
+=======
+import { useSkillEditors } from "@app/lib/swr/skill_editors";
+import type { SkillConfiguration } from "@app/types/skill_configuration";
+
+interface SkillBuilderProps {
+  skillConfiguration?: SkillConfiguration;
+>>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   duplicateSkillId?: string | null;
 }
 
@@ -55,20 +63,26 @@ export default function SkillBuilder({
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
 
+<<<<<<< HEAD
   const { actions, isActionsLoading } = useSkillConfigurationTools(
     owner.sId,
     skillConfiguration?.sId ?? null
   );
 
+=======
+>>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   const { editors } = useSkillEditors({
     owner,
     skillConfigurationId: skillConfiguration?.sId ?? null,
   });
 
+<<<<<<< HEAD
   const processedActions = useMemo(() => {
     return processActionsFromStorage(actions ?? emptyArray());
   }, [actions]);
 
+=======
+>>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   const defaultValues = useMemo(() => {
     if (duplicateSkillId && skillConfiguration) {
       return transformDuplicateSkillToFormData(skillConfiguration, user);
@@ -90,19 +104,26 @@ export default function SkillBuilder({
     },
   });
 
+<<<<<<< HEAD
   // Populate editors and tools reactively
+=======
+>>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   useEffect(() => {
     const currentValues = form.getValues();
 
     form.reset({
       ...currentValues,
+<<<<<<< HEAD
       tools: processedActions,
+=======
+>>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
       editors: duplicateSkillId
         ? [user]
         : skillConfiguration || editors.length > 0
           ? editors
           : [user],
     });
+<<<<<<< HEAD
   }, [
     isActionsLoading,
     processedActions,
@@ -112,6 +133,9 @@ export default function SkillBuilder({
     user,
     skillConfiguration,
   ]);
+=======
+  }, [editors, form, duplicateSkillId, user, skillConfiguration]);
+>>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
 
   const isCreatingNew = duplicateSkillId || !skillConfiguration;
   const { isDirty } = form.formState;

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -99,6 +99,7 @@ export default function SkillBuilder({
       skillConfigurationId: !isCreatingNew
         ? skillConfiguration?.sId
         : undefined,
+      currentEditors: editors,
     });
 
     if (result.isErr()) {

--- a/front/components/skill_builder/SkillBuilderContext.tsx
+++ b/front/components/skill_builder/SkillBuilderContext.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 
+import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
+import { MCPServerViewsProvider } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { UserType, WorkspaceType } from "@app/types";
 
 export type SkillBuilderContextType = {
@@ -24,7 +26,11 @@ export function SkillBuilderProvider({
 }: SkillBuilderProviderProps) {
   return (
     <SkillBuilderContext.Provider value={{ owner, user }}>
-      {children}
+      <SpacesProvider owner={owner}>
+        <MCPServerViewsProvider owner={owner}>
+          {children}
+        </MCPServerViewsProvider>
+      </SpacesProvider>
     </SkillBuilderContext.Provider>
   );
 }

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -12,7 +12,6 @@ export const skillBuilderFormSchema = z.object({
     .refine((value) => !/\s/.test(value), "Skill name cannot contain spaces"),
   description: z.string().min(1, "Skill description is required"),
   instructions: z.string().min(1, "Skill instructions are required"),
-  scope: z.enum(["private", "workspace"]),
   editors: z.array(editorUserSchema),
   tools: z.array(actionSchema),
 });

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -8,13 +8,11 @@ import { Err, normalizeError, Ok } from "@app/types";
 export async function submitSkillBuilderForm({
   formData,
   owner,
-  user,
   skillConfigurationId,
   currentEditors = [],
 }: {
   formData: SkillBuilderFormData;
   owner: WorkspaceType;
-  user: UserType;
   skillConfigurationId?: string;
   currentEditors?: UserType[];
 }): Promise<
@@ -66,14 +64,13 @@ export async function submitSkillBuilderForm({
 
     const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
     const currentEditorIds = new Set(currentEditors.map((e) => e.sId));
-    const creatorId = user.sId;
 
     const addEditorIds: string[] = [];
     const removeEditorIds: string[] = [];
 
-    // Add editors who are in desired but not in current (excluding creator who is added automatically)
+    // Add editors who are in desired but not in current
     for (const editor of formData.editors) {
-      if (editor.sId !== creatorId && !currentEditorIds.has(editor.sId)) {
+      if (!currentEditorIds.has(editor.sId)) {
         addEditorIds.push(editor.sId);
       }
     }

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -22,6 +22,7 @@ export async function submitSkillBuilderForm({
     Error
   >
 > {
+<<<<<<< HEAD
   try {
     const endpoint = skillConfigurationId
       ? `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfigurationId}`
@@ -61,6 +62,45 @@ export async function submitSkillBuilderForm({
       | PatchSkillConfigurationResponseBody = await response.json();
 
     const skillConfiguration = result.skillConfiguration;
+=======
+  const endpoint = skillConfigurationId
+    ? `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfigurationId}`
+    : `/api/w/${owner.sId}/assistant/skill_configurations`;
+
+  const method = skillConfigurationId ? "PATCH" : "POST";
+
+  const response = await clientFetch(endpoint, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: formData.name,
+      description: formData.description,
+      instructions: formData.instructions,
+      scope: formData.scope,
+      tools: formData.tools.map((tool) => ({
+        mcpServerViewId: tool.configuration.mcpServerViewId,
+      })),
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    return new Err(
+      new Error(
+        errorData.error?.message ??
+          (skillConfigurationId
+            ? "Failed to update skill"
+            : "Failed to create skill")
+      )
+    );
+  }
+
+  const result:
+    | PostSkillConfigurationResponseBody
+    | PatchSkillConfigurationResponseBody = await response.json();
+>>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
 
     const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
     const creatorId = user.sId;

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -22,7 +22,6 @@ export async function submitSkillBuilderForm({
     Error
   >
 > {
-<<<<<<< HEAD
   try {
     const endpoint = skillConfigurationId
       ? `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfigurationId}`
@@ -62,45 +61,6 @@ export async function submitSkillBuilderForm({
       | PatchSkillConfigurationResponseBody = await response.json();
 
     const skillConfiguration = result.skillConfiguration;
-=======
-  const endpoint = skillConfigurationId
-    ? `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfigurationId}`
-    : `/api/w/${owner.sId}/assistant/skill_configurations`;
-
-  const method = skillConfigurationId ? "PATCH" : "POST";
-
-  const response = await clientFetch(endpoint, {
-    method,
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      name: formData.name,
-      description: formData.description,
-      instructions: formData.instructions,
-      scope: formData.scope,
-      tools: formData.tools.map((tool) => ({
-        mcpServerViewId: tool.configuration.mcpServerViewId,
-      })),
-    }),
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json();
-    return new Err(
-      new Error(
-        errorData.error?.message ??
-          (skillConfigurationId
-            ? "Failed to update skill"
-            : "Failed to create skill")
-      )
-    );
-  }
-
-  const result:
-    | PostSkillConfigurationResponseBody
-    | PatchSkillConfigurationResponseBody = await response.json();
->>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
 
     const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
     const creatorId = user.sId;

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -1,6 +1,7 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { PostSkillConfigurationResponseBody } from "@app/pages/api/w/[wId]/assistant/skill_configurations";
+import type { PatchSkillConfigurationResponseBody } from "@app/pages/api/w/[wId]/assistant/skill_configurations/[sId]";
 import type { Result, UserType, WorkspaceType } from "@app/types";
 import { Err, Ok } from "@app/types";
 
@@ -8,17 +9,28 @@ export async function submitSkillBuilderForm({
   formData,
   owner,
   user,
+  skillConfigurationId,
 }: {
   formData: SkillBuilderFormData;
   owner: WorkspaceType;
   user: UserType;
+  skillConfigurationId?: string;
 }): Promise<
-  Result<PostSkillConfigurationResponseBody["skillConfiguration"], Error>
+  Result<
+    | PostSkillConfigurationResponseBody["skillConfiguration"]
+    | PatchSkillConfigurationResponseBody["skillConfiguration"],
+    Error
+  >
 > {
-  const response = await clientFetch(
-    `/api/w/${owner.sId}/assistant/skill_configurations`,
-    {
-      method: "POST",
+  try {
+    const endpoint = skillConfigurationId
+      ? `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfigurationId}`
+      : `/api/w/${owner.sId}/assistant/skill_configurations`;
+
+    const method = skillConfigurationId ? "PATCH" : "POST";
+
+    const response = await clientFetch(endpoint, {
+      method,
       headers: {
         "Content-Type": "application/json",
       },
@@ -26,56 +38,79 @@ export async function submitSkillBuilderForm({
         name: formData.name,
         description: formData.description,
         instructions: formData.instructions,
-        scope: formData.scope,
         tools: formData.tools.map((tool) => ({
           mcpServerViewId: tool.configuration.mcpServerViewId,
         })),
       }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      return new Err(
+        new Error(
+          errorData.error?.message ??
+            (skillConfigurationId
+              ? "Failed to update skill"
+              : "Failed to create skill")
+        )
+      );
     }
-  );
 
-  if (!response.ok) {
-    const errorData = await response.json();
-    return new Err(
-      new Error(errorData.error?.message ?? "Failed to create skill")
-    );
-  }
+    const result:
+      | PostSkillConfigurationResponseBody
+      | PatchSkillConfigurationResponseBody = await response.json();
 
-  const result: PostSkillConfigurationResponseBody = await response.json();
+    const skillConfiguration = result.skillConfiguration;
 
-  const skillConfiguration = result.skillConfiguration;
+    const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
+    const creatorId = user.sId;
 
-  const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
-  const creatorId = user.sId;
+    const addEditorIds: string[] = [];
+    const removeEditorIds: string[] = [];
 
-  const addEditorIds: string[] = [];
-  const removeEditorIds: string[] = [];
-
-  for (const editor of formData.editors) {
-    if (editor.sId !== creatorId) {
-      addEditorIds.push(editor.sId);
-    }
-  }
-
-  if (!desiredEditorIds.has(creatorId)) {
-    removeEditorIds.push(creatorId);
-  }
-
-  if (addEditorIds.length > 0 || removeEditorIds.length > 0) {
-    await clientFetch(
-      `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfiguration.sId}/editors`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          addEditorIds,
-          removeEditorIds,
-        }),
+    for (const editor of formData.editors) {
+      if (editor.sId !== creatorId) {
+        addEditorIds.push(editor.sId);
       }
+    }
+
+    if (!desiredEditorIds.has(creatorId)) {
+      removeEditorIds.push(creatorId);
+    }
+
+    if (addEditorIds.length > 0 || removeEditorIds.length > 0) {
+      const editorsResponse = await clientFetch(
+        `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfiguration.sId}/editors`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            addEditorIds,
+            removeEditorIds,
+          }),
+        }
+      );
+
+      if (!editorsResponse.ok) {
+        const errorData = await editorsResponse.json();
+        return new Err(
+          new Error(
+            errorData.error?.message ?? "Failed to update skill editors"
+          )
+        );
+      }
+    }
+
+    return new Ok(skillConfiguration);
+  } catch (error) {
+    return new Err(
+      new Error(
+        `Unexpected error ${skillConfigurationId ? "updating" : "creating"} skill: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      )
     );
   }
-
-  return new Ok(skillConfiguration);
 }

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -3,7 +3,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import type { PostSkillConfigurationResponseBody } from "@app/pages/api/w/[wId]/assistant/skill_configurations";
 import type { PatchSkillConfigurationResponseBody } from "@app/pages/api/w/[wId]/assistant/skill_configurations/[sId]";
 import type { Result, UserType, WorkspaceType } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 export async function submitSkillBuilderForm({
   formData,
@@ -112,11 +112,10 @@ export async function submitSkillBuilderForm({
 
     return new Ok(skillConfiguration);
   } catch (error) {
+    const normalizedError = normalizeError(error);
     return new Err(
       new Error(
-        `Unexpected error ${skillConfigurationId ? "updating" : "creating"} skill: ${
-          error instanceof Error ? error.message : "Unknown error"
-        }`
+        `Unexpected error ${skillConfigurationId ? "updating" : "creating"} skill: ${normalizedError.message}`
       )
     );
   }

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -15,7 +15,11 @@ export function transformSkillConfigurationToFormData(
     description: skillConfiguration.description,
     instructions: skillConfiguration.instructions,
     editors: [], // Will be populated reactively from useEditors hook
+<<<<<<< HEAD
     tools: [], // Will be populated reactively from MCP server views context
+=======
+    tools: skillConfiguration.tools || [],
+>>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   };
 }
 

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -1,21 +1,21 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import type { UserType } from "@app/types";
-import type { SkillConfiguration } from "@app/types/skill_configuration";
+import type { SkillConfigurationType } from "@app/types/skill_configuration";
 
 /**
  * Transforms a skill configuration (server-side) into skill builder form data (client-side).
- * Dynamic values (editors) are intentionally set to empty defaults
+ * Dynamic values (editors, tools) are intentionally set to empty defaults
  * as they will be populated reactively in the component.
  */
 export function transformSkillConfigurationToFormData(
-  skillConfiguration: SkillConfiguration
+  skillConfiguration: SkillConfigurationType
 ): SkillBuilderFormData {
   return {
     name: skillConfiguration.name,
     description: skillConfiguration.description,
     instructions: skillConfiguration.instructions,
-    scope: skillConfiguration.scope,
     editors: [], // Will be populated reactively from useEditors hook
+    tools: [], // Will be populated reactively from MCP server views context
   };
 }
 
@@ -31,18 +31,18 @@ export function getDefaultSkillFormData({
     name: "",
     description: "",
     instructions: "",
-    scope: "private",
     editors: [user],
+    tools: [],
   };
 }
 
 /**
  * Transforms a skill configuration for duplication into skill builder form data.
- * Similar to transformSkillConfigurationToFormData but adds "_Copy" suffix to name,
- * resets editors to current user, and defaults to private scope.
+ * Similar to transformSkillConfigurationToFormData but adds "_Copy" suffix to name
+ * and resets editors to current user.
  */
 export function transformDuplicateSkillToFormData(
-  skillConfiguration: SkillConfiguration,
+  skillConfiguration: SkillConfigurationType,
   user: UserType
 ): SkillBuilderFormData {
   const baseFormData =
@@ -51,7 +51,6 @@ export function transformDuplicateSkillToFormData(
   return {
     ...baseFormData,
     name: `${skillConfiguration.name}_Copy`,
-    scope: "private", // Default duplicated skills to private scope
     editors: [user], // Reset editors to current user for duplicated skill
   };
 }

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -35,22 +35,3 @@ export function getDefaultSkillFormData({
     tools: [],
   };
 }
-
-/**
- * Transforms a skill configuration for duplication into skill builder form data.
- * Similar to transformSkillConfigurationToFormData but adds "_Copy" suffix to name
- * and resets editors to current user.
- */
-export function transformDuplicateSkillToFormData(
-  skillConfiguration: SkillConfigurationType,
-  user: UserType
-): SkillBuilderFormData {
-  const baseFormData =
-    transformSkillConfigurationToFormData(skillConfiguration);
-
-  return {
-    ...baseFormData,
-    name: `${skillConfiguration.name}_Copy`,
-    editors: [user], // Reset editors to current user for duplicated skill
-  };
-}

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -1,0 +1,57 @@
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import type { UserType } from "@app/types";
+import type { SkillConfiguration } from "@app/types/skill_configuration";
+
+/**
+ * Transforms a skill configuration (server-side) into skill builder form data (client-side).
+ * Dynamic values (editors) are intentionally set to empty defaults
+ * as they will be populated reactively in the component.
+ */
+export function transformSkillConfigurationToFormData(
+  skillConfiguration: SkillConfiguration
+): SkillBuilderFormData {
+  return {
+    name: skillConfiguration.name,
+    description: skillConfiguration.description,
+    instructions: skillConfiguration.instructions,
+    scope: skillConfiguration.scope,
+    editors: [], // Will be populated reactively from useEditors hook
+  };
+}
+
+/**
+ * Returns default form data for creating a new skill.
+ */
+export function getDefaultSkillFormData({
+  user,
+}: {
+  user: UserType;
+}): SkillBuilderFormData {
+  return {
+    name: "",
+    description: "",
+    instructions: "",
+    scope: "private",
+    editors: [user],
+  };
+}
+
+/**
+ * Transforms a skill configuration for duplication into skill builder form data.
+ * Similar to transformSkillConfigurationToFormData but adds "_Copy" suffix to name,
+ * resets editors to current user, and defaults to private scope.
+ */
+export function transformDuplicateSkillToFormData(
+  skillConfiguration: SkillConfiguration,
+  user: UserType
+): SkillBuilderFormData {
+  const baseFormData =
+    transformSkillConfigurationToFormData(skillConfiguration);
+
+  return {
+    ...baseFormData,
+    name: `${skillConfiguration.name}_Copy`,
+    scope: "private", // Default duplicated skills to private scope
+    editors: [user], // Reset editors to current user for duplicated skill
+  };
+}

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -15,11 +15,7 @@ export function transformSkillConfigurationToFormData(
     description: skillConfiguration.description,
     instructions: skillConfiguration.instructions,
     editors: [], // Will be populated reactively from useEditors hook
-<<<<<<< HEAD
     tools: [], // Will be populated reactively from MCP server views context
-=======
-    tools: skillConfiguration.tools || [],
->>>>>>> c8ec270dd6 ([skill_builder] - feature: enhance SkillBuilder to support editing and duplicating skills)
   };
 }
 

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -14,7 +14,6 @@ import type {
 } from "@app/types/skill_configuration";
 
 type RowData = {
-  id: number;
   sId: string;
   name: string;
   description: string;

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -1,7 +1,6 @@
 import type { MenuItem } from "@dust-tt/sparkle";
 import { DataTable, TrashIcon } from "@dust-tt/sparkle";
 import type { CellContext } from "@tanstack/react-table";
-import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
@@ -106,10 +105,14 @@ const getTableColumns = () => {
 type SkillsTableProps = {
   skillConfigurations: SkillConfigurationWithAuthorType[];
   owner: LightWorkspaceType;
+  setSkillConfiguration: (skill: SkillConfigurationWithAuthorType) => void;
 };
 
-export function SkillsTable({ skillConfigurations, owner }: SkillsTableProps) {
-  const router = useRouter();
+export function SkillsTable({
+  skillConfigurations,
+  owner,
+  setSkillConfiguration,
+}: SkillsTableProps) {
   const { pagination, setPagination } = usePaginationFromUrl({});
   const [skillConfigurationToArchive, setSkillConfigurationToArchive] =
     useState<SkillConfigurationType | null>(null);
@@ -120,9 +123,7 @@ export function SkillsTable({ skillConfigurations, owner }: SkillsTableProps) {
         return {
           ...skillConfiguration,
           onClick: () => {
-            void router.push(
-              `/w/${owner.sId}/builder/skills/${skillConfiguration.sId}`
-            );
+            setSkillConfiguration(skillConfiguration);
           },
           menuItems: [
             {
@@ -138,7 +139,7 @@ export function SkillsTable({ skillConfigurations, owner }: SkillsTableProps) {
           ],
         };
       }),
-    [skillConfigurations, owner, router]
+    [skillConfigurations, setSkillConfiguration]
   );
 
   if (rows.length === 0) {

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -1,6 +1,7 @@
 import type { MenuItem } from "@dust-tt/sparkle";
 import { DataTable, TrashIcon } from "@dust-tt/sparkle";
 import type { CellContext } from "@tanstack/react-table";
+import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
@@ -13,6 +14,7 @@ import type {
 } from "@app/types/skill_configuration";
 
 type RowData = {
+  id: number;
   sId: string;
   name: string;
   description: string;
@@ -104,15 +106,11 @@ const getTableColumns = () => {
 
 type SkillsTableProps = {
   skillConfigurations: SkillConfigurationWithAuthorType[];
-  setSkillConfiguration: (skill: SkillConfigurationWithAuthorType) => void;
   owner: LightWorkspaceType;
 };
 
-export function SkillsTable({
-  owner,
-  skillConfigurations,
-  setSkillConfiguration,
-}: SkillsTableProps) {
+export function SkillsTable({ skillConfigurations, owner }: SkillsTableProps) {
+  const router = useRouter();
   const { pagination, setPagination } = usePaginationFromUrl({});
   const [skillConfigurationToArchive, setSkillConfigurationToArchive] =
     useState<SkillConfigurationType | null>(null);
@@ -123,7 +121,9 @@ export function SkillsTable({
         return {
           ...skillConfiguration,
           onClick: () => {
-            setSkillConfiguration(skillConfiguration);
+            void router.push(
+              `/w/${owner.sId}/builder/skills/${skillConfiguration.sId}`
+            );
           },
           menuItems: [
             {
@@ -139,7 +139,7 @@ export function SkillsTable({
           ],
         };
       }),
-    [skillConfigurations, setSkillConfiguration]
+    [skillConfigurations, owner, router]
   );
 
   if (rows.length === 0) {

--- a/front/lib/resources/skill_configuration_resource.ts
+++ b/front/lib/resources/skill_configuration_resource.ts
@@ -388,6 +388,7 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
     }));
     if (this.author) {
       return {
+        id: this.id,
         sId: this.sId,
         createdAt: this.createdAt,
         updatedAt: this.updatedAt,
@@ -413,6 +414,7 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
     }
 
     return {
+      id: this.id,
       sId: this.sId,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/front/lib/resources/skill_configuration_resource.ts
+++ b/front/lib/resources/skill_configuration_resource.ts
@@ -14,6 +14,7 @@ import {
   SkillMCPServerConfigurationModel,
 } from "@app/lib/models/skill";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {

--- a/front/lib/resources/skill_configuration_resource.ts
+++ b/front/lib/resources/skill_configuration_resource.ts
@@ -383,7 +383,6 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
     }
   }
 
-
   async updateSkill(
     auth: Authenticator,
     {

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -6,6 +6,7 @@ import type { AgentBuilderMCPConfigurationWithId } from "@app/components/agent_b
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetActionsResponseBody } from "@app/pages/api/w/[wId]/builder/assistants/[aId]/actions";
 import type { GetSkillActionsResponseBody } from "@app/pages/api/w/[wId]/builder/skills/[sId]/actions";
+import type { LightWorkspaceType } from "@app/types";
 
 export function useAgentConfigurationActions(
   ownerId: string,
@@ -40,13 +41,13 @@ export function useAgentConfigurationActions(
 }
 
 export function useSkillConfigurationTools(
-  ownerId: string,
+  owner: LightWorkspaceType,
   skillConfigurationId: string | null
 ) {
   const disabled = skillConfigurationId === null;
   const actionsFetcher: Fetcher<GetSkillActionsResponseBody> = fetcher;
   const { data, error } = useSWRWithDefaults(
-    `/api/w/${ownerId}/builder/skills/${skillConfigurationId}/actions`,
+    `/api/w/${owner.sId}/builder/skills/${skillConfigurationId}/actions`,
     actionsFetcher,
     {
       disabled,

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -5,6 +5,7 @@ import type { Fetcher } from "swr";
 import type { AgentBuilderMCPConfigurationWithId } from "@app/components/agent_builder/types";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetActionsResponseBody } from "@app/pages/api/w/[wId]/builder/assistants/[aId]/actions";
+import type { GetSkillActionsResponseBody } from "@app/pages/api/w/[wId]/builder/skills/[sId]/actions";
 
 export function useAgentConfigurationActions(
   ownerId: string,
@@ -14,6 +15,38 @@ export function useAgentConfigurationActions(
   const actionsFetcher: Fetcher<GetActionsResponseBody> = fetcher;
   const { data, error } = useSWRWithDefaults(
     `/api/w/${ownerId}/builder/assistants/${agentConfigurationId}/actions`,
+    actionsFetcher,
+    {
+      disabled,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
+
+  const actionsWithIds: AgentBuilderMCPConfigurationWithId[] = useMemo(
+    () =>
+      data?.actions.map((action) => ({
+        ...action,
+        id: uniqueId(),
+      })) ?? emptyArray(),
+    [data?.actions]
+  );
+
+  return {
+    actions: actionsWithIds,
+    isActionsLoading: !error && !data && !disabled,
+    error,
+  };
+}
+
+export function useSkillConfigurationTools(
+  ownerId: string,
+  skillConfigurationId: string | null
+) {
+  const disabled = skillConfigurationId === null;
+  const actionsFetcher: Fetcher<GetSkillActionsResponseBody> = fetcher;
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${ownerId}/builder/skills/${skillConfigurationId}/actions`,
     actionsFetcher,
     {
       disabled,

--- a/front/lib/swr/skill_editors.ts
+++ b/front/lib/swr/skill_editors.ts
@@ -79,7 +79,7 @@ export function useUpdateSkillEditors({
           body.removeEditorIds != null &&
           body.removeEditorIds.length > 0
         ) {
-          title = "Successfully update editors";
+          title = "Successfully updated editors";
           description = "Successfully added and removed editors";
         } else if (
           (body.addEditorIds == null || body.addEditorIds.length <= 0) &&

--- a/front/lib/swr/skill_editors.ts
+++ b/front/lib/swr/skill_editors.ts
@@ -1,0 +1,105 @@
+import { useCallback } from "react";
+import type { Fetcher } from "swr";
+
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  GetSkillEditorsResponseBody,
+  PatchSkillEditorsRequestBody,
+} from "@app/pages/api/w/[wId]/assistant/skill_configurations/[sId]/editors";
+import type { LightWorkspaceType } from "@app/types";
+import { pluralize } from "@app/types";
+
+export function useSkillEditors({
+  owner,
+  skillConfigurationId,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  skillConfigurationId: string | null;
+  disabled?: boolean;
+}) {
+  const editorsFetcher: Fetcher<GetSkillEditorsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    skillConfigurationId
+      ? `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfigurationId}/editors`
+      : null,
+
+    editorsFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    editors: data?.editors ?? emptyArray(),
+    isEditorsLoading: !error && !data && !disabled,
+    isEditorsError: !!error,
+    mutateEditors: mutate,
+  };
+}
+
+export function useUpdateSkillEditors({
+  owner,
+  skillConfigurationId,
+}: {
+  owner: LightWorkspaceType;
+  skillConfigurationId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateEditors } = useSkillEditors({
+    owner,
+    skillConfigurationId,
+    disabled: true,
+  });
+
+  const updateSkillEditors = useCallback(
+    async (body: PatchSkillEditorsRequestBody) => {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfigurationId}/editors`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (res.ok) {
+        void mutateEditors();
+
+        let title = "";
+        let description: string | undefined = undefined;
+        if (
+          body.addEditorIds != null &&
+          body.addEditorIds.length > 0 &&
+          body.removeEditorIds != null &&
+          body.removeEditorIds.length > 0
+        ) {
+          title = "Successfully update editors";
+          description = "Successfully added and removed editors";
+        } else if (
+          (body.addEditorIds == null || body.addEditorIds.length <= 0) &&
+          body.removeEditorIds != null &&
+          body.removeEditorIds.length > 0
+        ) {
+          title = `Successfully removed editor${pluralize(body.removeEditorIds.length)}`;
+        } else {
+          title = `Successfully added editor${pluralize(body.addEditorIds?.length ?? 0)}`;
+        }
+
+        sendNotification({
+          type: "success",
+          title,
+          description,
+        });
+      }
+    },
+    [owner, skillConfigurationId, mutateEditors, sendNotification]
+  );
+
+  return updateSkillEditors;
+}

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -419,7 +419,7 @@ export async function createOrUpgradeAgentConfiguration({
     assistant.skills,
     async (skill) => {
       // Validate the skill exists and belongs to this workspace
-      const skillResource = await SkillConfigurationResource.fetchById(
+      const skillResource = await SkillConfigurationResource.fetchBySId(
         auth,
         skill.sId
       );

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.test.ts
@@ -221,7 +221,7 @@ describe("PATCH /api/w/[wId]/assistant/skill_configurations/[sId]", () => {
     });
 
     // Create another skill with a different name
-    const otherSkill = await SkillConfigurationFactory.create(requestUserAuth, {
+    await SkillConfigurationFactory.create(requestUserAuth, {
       name: "Other Skill",
     });
 

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.test.ts
@@ -1,0 +1,396 @@
+import type { RequestMethod } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+
+import handler from "./index";
+
+async function setupTest(
+  options: {
+    skillOwnerRole?: "admin" | "builder" | "user";
+    requestUserRole?: "admin" | "builder" | "user";
+    method?: RequestMethod;
+  } = {}
+) {
+  const skillOwnerRole = options.skillOwnerRole ?? "admin";
+  const requestUserRole = options.requestUserRole ?? "admin";
+  const method = options.method ?? "GET";
+
+  // Create workspace, requesting user and auth based on requestUserRole
+  const {
+    req,
+    res,
+    workspace,
+    user: requestUser,
+  } = await createPrivateApiMockRequest({
+    role: requestUserRole,
+    method: method,
+  });
+  let requestUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    requestUser.sId,
+    workspace.sId
+  );
+
+  // Create skill owner (might be the same as requestUser or different)
+  let skillOwner: UserResource;
+  let skillOwnerAuth: Authenticator;
+  if (requestUserRole === skillOwnerRole) {
+    skillOwner = requestUser;
+    skillOwnerAuth = requestUserAuth;
+  } else {
+    skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: skillOwnerRole,
+    });
+    skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+  }
+
+  // Create skill owned by skillOwner
+  const skillModel = await SkillConfigurationFactory.create(skillOwnerAuth);
+  const skill = await SkillConfigurationResource.fetchByModelIdWithAuth(
+    skillOwnerAuth,
+    skillModel.id
+  );
+  if (!skill) {
+    throw new Error("Failed to create skill");
+  }
+
+  // Create editor group for the skill
+  await GroupResource.makeNewSkillEditorsGroup(skillOwnerAuth, skill);
+
+  // Regenerate auth to pick up the new group membership
+  skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    skillOwner.sId,
+    workspace.sId
+  );
+  requestUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    requestUser.sId,
+    workspace.sId
+  );
+
+  // Set up query parameters for the skill
+  req.query = { ...req.query, wId: workspace.sId, sId: skill.sId };
+
+  return {
+    req,
+    res,
+    workspace,
+    skillOwner,
+    skillOwnerAuth,
+    skill,
+    requestUser,
+    requestUserAuth,
+    requestUserRole,
+  };
+}
+
+describe("GET /api/w/[wId]/assistant/skill_configurations/[sId]", () => {
+  it("should return 200 and the skill configuration for admin", async () => {
+    const { req, res, skill } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty("skillConfiguration");
+    expect(data.skillConfiguration.sId).toBe(skill.sId);
+    expect(data.skillConfiguration.name).toBe("Test Skill");
+  });
+
+  it("should return 404 for non-existent skill", async () => {
+    const { req, res } = await setupTest();
+    req.query.sId = "non_existent_skill_sid";
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "skill_not_found",
+        message: "The skill you're trying to access was not found.",
+      },
+    });
+  });
+});
+
+describe("PATCH /api/w/[wId]/assistant/skill_configurations/[sId]", () => {
+  it("should successfully update skill by admin", async () => {
+    const { req, res, workspace } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    // Create an MCP server and view for tools
+    const server = await RemoteMCPServerFactory.create(workspace);
+    const globalSpace = await SpaceFactory.global(workspace);
+    const mcpServerView = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      globalSpace
+    );
+
+    req.body = {
+      name: "Updated Skill",
+      description: "Updated description",
+      instructions: "Updated instructions",
+      tools: [{ mcpServerViewId: mcpServerView.sId }],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.skillConfiguration.name).toBe("Updated Skill");
+    expect(data.skillConfiguration.description).toBe("Updated description");
+    expect(data.skillConfiguration.instructions).toBe("Updated instructions");
+    expect(data.skillConfiguration.tools).toHaveLength(1);
+    expect(data.skillConfiguration.tools[0].mcpServerViewId).toBe(
+      mcpServerView.sId
+    );
+    expect(data.skillConfiguration.version).toBe(2); // Version should increment
+  });
+
+  it("should successfully update skill by editor", async () => {
+    const { req, res, workspace } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "builder",
+      method: "PATCH",
+    });
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+    const globalSpace = await SpaceFactory.global(workspace);
+    const mcpServerView = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      globalSpace
+    );
+
+    req.body = {
+      name: "Updated by Editor",
+      description: "Updated description",
+      instructions: "Updated instructions",
+      tools: [{ mcpServerViewId: mcpServerView.sId }],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.skillConfiguration.name).toBe("Updated by Editor");
+  });
+
+  it("should return 403 for non-editor user", async () => {
+    const { req, res } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "user",
+      method: "PATCH",
+    });
+
+    req.body = {
+      name: "Unauthorized Update",
+      description: "Description",
+      instructions: "Instructions",
+      tools: [],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "app_auth_error",
+        message: "Only editors can modify this skill.",
+      },
+    });
+  });
+
+  it("should return 400 for duplicate skill name", async () => {
+    const { req, res, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    // Create another skill with a different name
+    const otherSkill = await SkillConfigurationFactory.create(requestUserAuth, {
+      name: "Other Skill",
+    });
+
+    // Try to update to the name of the other skill
+    req.body = {
+      name: "Other Skill",
+      description: "Description",
+      instructions: "Instructions",
+      tools: [],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: 'A skill with the name "Other Skill" already exists.',
+      },
+    });
+  });
+
+  it("should return 400 for invalid MCP server view ID", async () => {
+    const { req, res } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    req.body = {
+      name: "Updated Skill",
+      description: "Description",
+      instructions: "Instructions",
+      tools: [{ mcpServerViewId: "invalid_id" }],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    expect(res._getJSONData().error.message).toContain("Invalid MCP server");
+  });
+
+  it("should return 400 for invalid request body", async () => {
+    const { req, res } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    req.body = {
+      // Missing required fields
+      name: "Updated Skill",
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should rollback on error (transaction test)", async () => {
+    const { req, res, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    // Use a non-existent MCP server view ID to trigger an error after skill update
+    req.body = {
+      name: "Updated Skill Name",
+      description: "Updated description",
+      instructions: "Updated instructions",
+      tools: [{ mcpServerViewId: "mcp_srv_view_nonexistent" }],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(500);
+
+    // Verify skill was not updated (transaction rolled back)
+    const skillAfter = await SkillConfigurationResource.fetchByModelIdWithAuth(
+      requestUserAuth,
+      skill.id
+    );
+    expect(skillAfter?.name).toBe("Test Skill"); // Original name unchanged
+  });
+});
+
+describe("DELETE /api/w/[wId]/assistant/skill_configurations/[sId]", () => {
+  it("should successfully delete skill by admin", async () => {
+    const { req, res, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+      method: "DELETE",
+    });
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+
+    // Verify skill was deleted
+    const deletedSkill =
+      await SkillConfigurationResource.fetchByModelIdWithAuth(
+        requestUserAuth,
+        skill.id
+      );
+    expect(deletedSkill).toBeNull();
+  });
+
+  it("should successfully delete skill by editor", async () => {
+    const { req, res, skill, skillOwnerAuth } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "builder",
+      method: "DELETE",
+    });
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+
+    // Verify skill was deleted
+    const deletedSkill =
+      await SkillConfigurationResource.fetchByModelIdWithAuth(
+        skillOwnerAuth,
+        skill.id
+      );
+    expect(deletedSkill).toBeNull();
+  });
+
+  it("should return 403 for non-editor user", async () => {
+    const { req, res } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "user",
+      method: "DELETE",
+    });
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "app_auth_error",
+        message: "Only editors can delete this skill.",
+      },
+    });
+  });
+
+  it("should return 404 for non-existent skill", async () => {
+    const { req, res } = await setupTest({ method: "DELETE" });
+    req.query.sId = "non_existent_skill_sid";
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "skill_not_found",
+        message: "The skill you're trying to access was not found.",
+      },
+    });
+  });
+});
+
+describe("Method Support /api/w/[wId]/assistant/skill_configurations/[sId]", () => {
+  it("only supports GET, PATCH, and DELETE methods", async () => {
+    for (const method of ["POST", "PUT"] as const) {
+      const { req, res } = await setupTest({ method });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET, PATCH or DELETE is expected.",
+        },
+      });
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.test.ts
@@ -133,6 +133,9 @@ describe("PATCH /api/w/[wId]/assistant/skill_configurations/[sId]", () => {
       method: "PATCH",
     });
 
+    // Create system space (required for MCP server creation)
+    await SpaceFactory.system(workspace);
+
     // Create an MCP server and view for tools
     const server = await RemoteMCPServerFactory.create(workspace);
     const globalSpace = await SpaceFactory.global(workspace);
@@ -168,6 +171,9 @@ describe("PATCH /api/w/[wId]/assistant/skill_configurations/[sId]", () => {
       requestUserRole: "builder",
       method: "PATCH",
     });
+
+    // Create system space (required for MCP server creation)
+    await SpaceFactory.system(workspace);
 
     const server = await RemoteMCPServerFactory.create(workspace);
     const globalSpace = await SpaceFactory.global(workspace);

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
@@ -119,8 +119,7 @@ async function handler(
       const body: PatchSkillConfigurationRequestBody = bodyValidation.right;
 
       // Check if user can edit
-      const canEdit = await skillResource.canUserEdit(auth);
-      if (!canEdit && !auth.isAdmin()) {
+      if (!skillResource.canEdit && !auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -255,8 +254,7 @@ async function handler(
 
     case "DELETE": {
       // Check if user can edit
-      const canEdit = await skillResource.canUserEdit(auth);
-      if (!canEdit && !auth.isAdmin()) {
+      if (!skillResource.canEdit && !auth.isAdmin()) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
@@ -11,12 +11,12 @@ import {
   SkillConfigurationModel,
   SkillMCPServerConfigurationModel,
 } from "@app/lib/models/skill";
+import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import {
   getResourceIdFromSId,
   isResourceSId,
+  makeSId,
 } from "@app/lib/resources/string_ids";
-import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
-import { makeSId } from "@app/lib/resources/string_ids";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/skill_configuration";

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
@@ -235,6 +235,7 @@ async function handler(
 
       return res.status(200).json({
         skillConfiguration: {
+          id: updatedSkill.id,
           sId: makeSId("skill", {
             id: updatedSkill.id,
             workspaceId: updatedSkill.workspaceId,

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
@@ -1,0 +1,219 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import type { SkillConfiguration } from "@app/types/skill_configuration";
+
+export type GetSkillConfigurationResponseBody = {
+  skillConfiguration: SkillConfiguration;
+};
+
+export type PatchSkillConfigurationResponseBody = {
+  skillConfiguration: Omit<
+    SkillConfiguration,
+    | "author"
+    | "requestedSpaceIds"
+    | "workspaceId"
+    | "createdAt"
+    | "updatedAt"
+    | "authorId"
+  >;
+};
+
+export type DeleteSkillConfigurationResponseBody = {
+  success: boolean;
+};
+
+// Request body schema for PATCH
+const PatchSkillConfigurationRequestBodySchema = t.type({
+  name: t.string,
+  description: t.string,
+  instructions: t.string,
+  scope: t.union([t.literal("private"), t.literal("workspace")]),
+});
+
+type PatchSkillConfigurationRequestBody = t.TypeOf<
+  typeof PatchSkillConfigurationRequestBodySchema
+>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      | GetSkillConfigurationResponseBody
+      | PatchSkillConfigurationResponseBody
+      | DeleteSkillConfigurationResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (!featureFlags.includes("skills")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Skill builder is not enabled for this workspace.",
+      },
+    });
+  }
+
+  const sId = req.query.sId as string;
+  const skillResource = await SkillConfigurationResource.fetchBySIdWithAuth(
+    auth,
+    sId
+  );
+
+  if (!skillResource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "The skill you're trying to access was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const skillConfiguration = skillResource.toJSON();
+      return res.status(200).json({ skillConfiguration });
+    }
+
+    case "PATCH": {
+      const bodyValidation = PatchSkillConfigurationRequestBodySchema.decode(
+        req.body
+      );
+
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const body: PatchSkillConfigurationRequestBody = bodyValidation.right;
+
+      // Check if user can edit
+      const canEdit = await skillResource.canUserEdit(auth);
+      if (!canEdit && !auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message: "Only editors can modify this skill.",
+          },
+        });
+      }
+
+      // Check for existing active skill with the same name (excluding current skill)
+      const existingSkill = await SkillConfigurationModel.findOne({
+        where: {
+          workspaceId: owner.id,
+          name: body.name,
+          status: "active",
+        },
+      });
+
+      if (existingSkill && existingSkill.id !== skillResource.id) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `A skill with the name "${body.name}" already exists.`,
+          },
+        });
+      }
+
+      const updateResult = await skillResource.updateSkill(auth, {
+        name: body.name,
+        description: body.description,
+        instructions: body.instructions,
+        scope: body.scope,
+      });
+
+      if (updateResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Error updating skill: ${updateResult.error.message}`,
+          },
+        });
+      }
+
+      const updatedSkill = updateResult.value;
+
+      return res.status(200).json({
+        skillConfiguration: {
+          id: updatedSkill.id,
+          sId: makeSId("skill", {
+            id: updatedSkill.id,
+            workspaceId: updatedSkill.workspaceId,
+          }),
+          name: updatedSkill.name,
+          description: updatedSkill.description,
+          instructions: updatedSkill.instructions,
+          status: updatedSkill.status,
+          scope: updatedSkill.scope,
+          version: updatedSkill.version,
+        },
+      });
+    }
+
+    case "DELETE": {
+      // Check if user can edit
+      const canEdit = await skillResource.canUserEdit(auth);
+      if (!canEdit && !auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message: "Only editors can delete this skill.",
+          },
+        });
+      }
+
+      const deleteResult = await skillResource.delete(auth);
+      if (deleteResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Error deleting skill: ${deleteResult.error.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET, PATCH or DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
@@ -82,7 +82,17 @@ async function handler(
     });
   }
 
-  const sId = req.query.sId as string;
+  if (typeof req.query.sId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid skill ID.",
+      },
+    });
+  }
+
+  const sId = req.query.sId;
   const skillResource = await SkillConfigurationResource.fetchBySId(auth, sId);
 
   if (!skillResource) {

--- a/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
@@ -1,0 +1,139 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
+import { getAccessibleSourcesAndAppsForActions } from "@app/lib/agent_builder/server_side_props_helpers";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+function nameToStorageFormat(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+}
+
+export type GetSkillActionsResponseBody = {
+  actions: AgentBuilderMCPConfiguration[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetSkillActionsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (!featureFlags.includes("skills")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Skill builder is not enabled for this workspace.",
+      },
+    });
+  }
+
+  const { sId } = req.query;
+  if (typeof sId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid skill ID.",
+      },
+    });
+  }
+
+  try {
+    const skillResource = await SkillConfigurationResource.fetchBySId(
+      auth,
+      sId
+    );
+
+    if (!skillResource) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "Skill configuration not found.",
+        },
+      });
+    }
+
+    if (!skillResource.canEdit && !auth.isAdmin()) {
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only editors can view skill actions.",
+        },
+      });
+    }
+
+    const { mcpServerViews } =
+      await getAccessibleSourcesAndAppsForActions(auth);
+    const mcpServerViewsJSON = mcpServerViews.map((v) => v.toJSON());
+
+    // Build actions from skill's MCP server configurations
+    const actions: AgentBuilderMCPConfiguration[] = [];
+    for (const mcpConfig of skillResource.mcpServerConfigurations) {
+      const mcpServerView = mcpServerViewsJSON.find(
+        (view) => view.id === mcpConfig.mcpServerViewId
+      );
+      if (!mcpServerView) {
+        continue;
+      }
+
+      // Generate name using same logic as agent builder
+      const rawName = mcpServerView.name ?? mcpServerView.server.name ?? "";
+      const sanitizedName = rawName ? nameToStorageFormat(rawName) : "";
+
+      actions.push({
+        type: "MCP",
+        name: sanitizedName,
+        description: mcpServerView.server.description,
+        configuration: {
+          mcpServerViewId: mcpServerView.sId,
+          dataSourceConfigurations: null,
+          tablesConfigurations: null,
+          childAgentId: null,
+          timeFrame: null,
+          additionalConfiguration: {},
+          dustAppConfiguration: null,
+          secretName: null,
+          jsonSchema: null,
+          reasoningModel: null,
+          _jsonSchemaString: null,
+        },
+      });
+    }
+
+    res.status(200).json({ actions });
+  } catch (error) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to fetch skill actions.",
+      },
+    });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
@@ -88,6 +88,7 @@ async function handler(
   // Build actions from skill's MCP server configurations
   const actions: AgentBuilderMCPConfiguration[] = [];
   for (const mcpConfig of skillResource.mcpServerConfigurations) {
+    /**/
     const mcpServerView = mcpServerViewsJSON.find(
       (view) => view.id === mcpConfig.mcpServerViewId
     );

--- a/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
@@ -130,7 +130,7 @@ async function handler(
       status_code: 500,
       api_error: {
         type: "internal_server_error",
-        message: "Failed to fetch skill actions.",
+        message: `Failed to fetch skill actions: ${error instanceof Error ? error.message : "Unknown error"}`,
       },
     });
   }

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -54,7 +54,7 @@ async function handler(
 
   const skillId = req.query.sId;
 
-  const skillConfiguration = await SkillConfigurationResource.fetchById(
+  const skillConfiguration = await SkillConfigurationResource.fetchBySId(
     auth,
     skillId
   );

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -9,11 +9,11 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
-import type { SkillConfiguration } from "@app/types/skill_configuration";
+import type { SkillConfigurationType } from "@app/types/skill_configuration";
 
 // Serialized version with Date objects converted to timestamps
 type SerializedSkillConfiguration = Omit<
-  SkillConfiguration,
+  SkillConfigurationType,
   "createdAt" | "updatedAt"
 > & {
   createdAt: number;
@@ -90,7 +90,7 @@ export default function EditSkill({
   }
 
   // Convert timestamps back to Date objects for SkillBuilder
-  const skillConfiguration: SkillConfiguration = {
+  const skillConfiguration: SkillConfigurationType = {
     ...serializedSkillConfiguration,
     createdAt: new Date(serializedSkillConfiguration.createdAt),
     updatedAt: new Date(serializedSkillConfiguration.updatedAt),

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -53,8 +53,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const canEdit = await skillResource.canUserEdit(auth);
-  if (!canEdit && !auth.isAdmin()) {
+  if (!skillResource.canEdit && !auth.isAdmin()) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -1,0 +1,90 @@
+import type { InferGetServerSidePropsType } from "next";
+import Head from "next/head";
+import React from "react";
+
+import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
+import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
+import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { getFeatureFlags } from "@app/lib/auth";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
+import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
+import type { SkillConfiguration } from "@app/types/skill_configuration";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  skillConfiguration: SkillConfiguration;
+  owner: WorkspaceType;
+  user: UserType;
+  subscription: SubscriptionType;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  const subscription = auth.subscription();
+
+  if (!owner || !auth.isUser() || !subscription || !context.params?.sId) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (!featureFlags.includes("skills")) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const skillResource = await SkillConfigurationResource.fetchBySIdWithAuth(
+    auth,
+    context.params.sId as string
+  );
+
+  if (!skillResource) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const canEdit = await skillResource.canUserEdit(auth);
+  if (!canEdit && !auth.isAdmin()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const user = auth.getNonNullableUser().toJSON();
+  const skillConfiguration = skillResource.toJSON();
+
+  return {
+    props: {
+      skillConfiguration,
+      owner,
+      subscription,
+      user,
+    },
+  };
+});
+
+export default function EditSkill({
+  skillConfiguration,
+  owner,
+  user,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  if (skillConfiguration.status === "archived") {
+    throw new Error("Cannot edit archived skill");
+  }
+
+  return (
+    <SkillBuilderProvider owner={owner} user={user}>
+      <>
+        <Head>
+          <title>{`Dust - ${skillConfiguration.name}`}</title>
+        </Head>
+        <SkillBuilder skillConfiguration={skillConfiguration} />
+      </>
+    </SkillBuilderProvider>
+  );
+}
+
+EditSkill.getLayout = (page: React.ReactElement) => {
+  return <AppRootLayout>{page}</AppRootLayout>;
+};

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -42,9 +42,15 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
+  if (typeof context.params?.sId !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
   const skillResource = await SkillConfigurationResource.fetchBySId(
     auth,
-    context.params.sId as string
+    context.params.sId
   );
 
   if (!skillResource) {

--- a/front/types/skill_configuration.ts
+++ b/front/types/skill_configuration.ts
@@ -4,6 +4,7 @@ import type { UserType } from "./user";
 export type SkillStatus = "active" | "archived";
 
 export type SkillConfigurationType = {
+  id: number;
   sId: string;
   createdAt: Date;
   updatedAt: Date;


### PR DESCRIPTION
## Description

This PR implements the ability to edit existing skills in the skill builder. Previously, skills could only be created. Now users with proper authorization (skill editors or admins) can modify skill configurations including name, description, instructions, and tools.

The main changes include:
- Added a new page at `/w/[wId]/builder/skills/[sId]` for editing existing skills
- Implemented `PATCH` and `DELETE` API endpoints for skill configurations at `/api/w/[wId]/assistant/skill_configurations/[sId]`
- Added a new endpoint to fetch skill actions at `/api/w/[wId]/builder/skills/[sId]/actions`
- Enhanced `SkillConfigurationResource` with an `updateSkill` method and a `canEdit` property that checks if the current user has permission to edit
- Refactored `SkillBuilder` component to support both creation and editing modes
- Added navigation lock to prevent accidental data loss when editing
- Moved provider wrappers (`SpacesProvider`, `MCPServerViewsProvider`) to `SkillBuilderContext` for better organization
- Added reactive population of editors and tools from the server when editing an existing skill
- Removed the `scope` field from the skill builder form schema

## Risk

Breaking changes to skill configuration types: added `id` field to `SkillConfigurationType` which is now required in API responses. This could impact any code that depends on the existing type structure.

## Tests

- [x] Locally
- [ ] front-edge

## Deploy 

- Deploy front
