### PR TITLE
fix: parse CSV of single line ones

### DIFF
--- a/.run/Template Vitest.run.xml
+++ b/.run/Template Vitest.run.xml
@@ -1,6 +1,5 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="true" type="JavaScriptTestRunnerVitest">
-    <config value="$PROJECT_DIR$/front/vite.config.mjs" />
     <node-interpreter value="project" />
     <envs>
       <env name="VITEST_DEBUG" value="1" />

--- a/connectors/src/types/shared/utils/structured_data.test.ts
+++ b/connectors/src/types/shared/utils/structured_data.test.ts
@@ -8,6 +8,17 @@ import { decodeBuffer } from "@connectors/connectors/shared/file";
 import { parseAndStringifyCsv } from "./structured_data";
 
 describe("parseAndStringifyCsv", () => {
+  it("should parse and stringify a single line CSV", async () => {
+    const result = await parseAndStringifyCsv(
+      '"Last name"\t"First name"\t"Email"\t"Program session"\t"Path session"\t"Course"\t"Score"\t"Progress"\t"Start"\t"End"\t"Total time spent"'
+    );
+
+    expect(result).toBe(
+      `Last name,First name,Email,Program session,Path session,Course,Score,Progress,Start,End,Total time spent
+`
+    );
+  });
+
   it("should parse and stringify a comma-separated CSV", async () => {
     const csv = `name,age,city
 Alice,30,Paris

--- a/connectors/src/types/shared/utils/structured_data.ts
+++ b/connectors/src/types/shared/utils/structured_data.ts
@@ -4,12 +4,21 @@ import { stringify } from "csv-stringify";
 export class InvalidStructuredDataHeaderError extends Error {}
 class ParsingCsvError extends Error {}
 
-async function guessDelimiter(csv: string): Promise<string | undefined> {
-  // Detect the delimiter: try to parse the first 2 lines with different delimiters,
-  // keep the one that works for both lines and has the most columns.
+const _POSSIBLE_DELIMITERS = [",", ";", "\t"];
+
+/**
+ * Detect the delimiter: try to parse the first 2 lines with different delimiters,
+ * keep the one that works for both lines and has the most columns.
+ */
+async function guessDelimiter(
+  csv: string
+): Promise<{ delimiter: string | undefined; oneLineCsv: boolean }> {
   let delimiter: string | undefined = undefined;
   let delimiterColsCount = 0;
-  for (const d of [",", ";", "\t"]) {
+  let oneLineCsv = false;
+
+  // Try to parse first 8 lines with each delimiter
+  for (const d of _POSSIBLE_DELIMITERS) {
     const records: unknown[][] = [];
     try {
       // We parse at most 8 lines with skipEmptyLines with the goal of getting 2 valid ones,
@@ -32,34 +41,50 @@ async function guessDelimiter(csv: string): Promise<string | undefined> {
     }
 
     const [firstRecord, secondRecord] = records;
-    // Check for more than one line to ensure sufficient data for accurate delimiter detection.
-    if (!firstRecord || !secondRecord) {
-      continue;
+
+    // If we have 2 records with matching column counts
+    if (
+      firstRecord &&
+      secondRecord &&
+      firstRecord.length === secondRecord.length &&
+      firstRecord.length > delimiterColsCount
+    ) {
+      delimiterColsCount = firstRecord.length;
+      delimiter = d;
     }
 
-    if (!!firstRecord.length && firstRecord.length === secondRecord.length) {
-      if (firstRecord.length > delimiterColsCount) {
-        delimiterColsCount = firstRecord.length;
+    // If only 1 record exists, use statistical analysis as fallback
+    if (firstRecord && !secondRecord && !delimiter) {
+      // Count occurrences in the first line
+      const firstLine = csv.split("\n")[0] || "";
+      const count = (firstLine.match(new RegExp(`\\${d}`, "g")) || []).length;
+      if (count > 0 && count > delimiterColsCount) {
+        delimiterColsCount = count;
         delimiter = d;
+        oneLineCsv = true;
       }
     }
   }
 
-  return delimiter;
+  return { delimiter, oneLineCsv };
 }
 
 // This function is used by connectors to turn a , ; \t separated file into a comma-separated file.
 // It also will raise if the file can't be parsed.
 export async function parseAndStringifyCsv(tableCsv: string): Promise<string> {
-  const delimiter = await guessDelimiter(tableCsv);
+  const guessedDelimiter = await guessDelimiter(tableCsv);
   const records: unknown[] = [];
+
+  if (!guessedDelimiter.delimiter) {
+    throw new ParsingCsvError("Unable to detect CSV delimiter");
+  }
 
   try {
     const parser = parse(tableCsv, {
       bom: true, // Remove BOM if present, useful for UTF-8/16 files.
-      delimiter,
+      delimiter: guessedDelimiter.delimiter,
       skipEmptyLines: true,
-      columns: (c) => c,
+      columns: !guessedDelimiter.oneLineCsv,
     });
 
     for await (const record of parser) {
@@ -74,12 +99,16 @@ export async function parseAndStringifyCsv(tableCsv: string): Promise<string> {
   }
 
   return new Promise((resolve, reject) => {
-    stringify(records, { header: true }, (err, output) => {
-      if (err) {
-        reject(new ParsingCsvError("Unable to stringify parsed CSV data"));
-      } else {
-        resolve(output);
+    stringify(
+      records,
+      { header: !guessedDelimiter.oneLineCsv, delimiter: "," },
+      (err, output) => {
+        if (err) {
+          reject(new ParsingCsvError("Unable to stringify parsed CSV data"));
+        } else {
+          resolve(output);
+        }
       }
-    });
+    );
   });
 }

--- a/connectors/vite.config.mjs
+++ b/connectors/vite.config.mjs
@@ -4,6 +4,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [],
   test: {
+    testTimeout: (function getTestTimeout() {
+      const isDebug =
+        process.env.VITEST_DEBUG === "1" ||
+        process.execArgv?.some((a) => a.includes("--inspect")) === true;
+      return isDebug ? Infinity : 5_000;
+    })(),
     globals: true,
     setupFiles: "./vite.setup.ts",
     globalSetup: "./vite.globalSetup.ts",


### PR DESCRIPTION
## Description

Another fix in the CSV world. This time, we had a bug in the guessDelimiter function with one line CSV. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
