### PR TITLE
feat: add author to auditLog

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -126,9 +126,11 @@
         "@types/event-source-polyfill": "^1.0.5",
         "@types/node": "^22.7.5",
         "@types/uuid": "^9.0.7",
-        "dts-cli": "^2.0.5",
+        "esbuild": "^0.24.0",
         "eslint-plugin-simple-import-sort": "^12.1.0",
+        "npm-watch": "^0.11.0",
         "tslib": "^2.6.2",
+        "tsx": "^4.19.1",
         "typescript": "^5.4.5"
       },
       "engines": {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1282,6 +1282,7 @@ export async function softDeleteUserMessage(
 
   auditLog(
     {
+      author: "no-author",
       workspaceId: owner.sId,
       userId: user.sId,
       conversationId: conversation.sId,
@@ -1353,6 +1354,7 @@ export async function softDeleteAgentMessage(
 
   auditLog(
     {
+      author: "no-author",
       workspaceId: owner.sId,
       userId: user.sId,
       conversationId: conversation.sId,

--- a/front/lib/api/poke/plugins/data_sources/bigquery_change_location.ts
+++ b/front/lib/api/poke/plugins/data_sources/bigquery_change_location.ts
@@ -189,6 +189,7 @@ export const bigqueryChangeLocationPlugin = createPlugin({
 
     auditLog(
       {
+        author: "no-author",
         connectorId: dataSource.connectorId,
         previousConnectionId: connector.connectionId,
         newConnectionId: newCredentialsId,

--- a/front/lib/api/poke/plugins/data_sources/operations.ts
+++ b/front/lib/api/poke/plugins/data_sources/operations.ts
@@ -68,6 +68,7 @@ export const connectorOperationsPlugin = createPlugin({
 
     auditLog(
       {
+        author: "no-author",
         connectorId,
         op,
         who: auth.user(),

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -758,6 +758,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
     auditLog(
       {
+        author: "no-author",
         userId: user.id,
         workspaceId: workspace.id,
         previousRole,
@@ -847,6 +848,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
     auditLog(
       {
+        author: "no-author",
         userId: user.id,
         workspaceId: workspace.id,
         previousOrigin,

--- a/front/logger/logger.ts
+++ b/front/logger/logger.ts
@@ -1,6 +1,8 @@
 import type { LoggerOptions } from "pino";
 import pino from "pino";
 
+import type { UserType } from "@app/types";
+
 const NODE_ENV = process.env.NODE_ENV;
 const LOG_LEVEL = process.env.LOG_LEVEL ?? "info";
 
@@ -52,7 +54,7 @@ export default logger;
 export type { Logger } from "pino";
 
 export function auditLog(
-  data: Record<string, unknown>,
+  data: { author: UserType | "no-author" } & Record<string, unknown>,
   message: string,
   auditLogger = logger
 ) {

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/token.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/token.ts
@@ -89,6 +89,7 @@ async function handler(
 
       auditLog(
         {
+          author: "no-author",
           connectorId: connector.id,
           who: auth.user(),
         },


### PR DESCRIPTION
## Description

Audit Logs must (at least should heavily) have a clear author, [see](https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=144022758&issue=dust-tt%7Ctasks%7C5511)

Let's add it to the audit log, this is split in 3 phases:
1. add a `author`<= this PR
2. fill the easy `author` from the `auth`
3. fill the less easy `author` from the `auth`

I used UserResource, as we can get those nice logs => https://app.datadoghq.eu/logs?query=%40audit%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZsCvEN0g_FJ8AAAABhBWnNDdkVWMUFBQXhVeUo1XzNUTjRRRDQAAAAkMTE5YjAyZjMtZTY2OC00M2MwLWI3NmItMWExNTQzMGUzZmMxAAAAAw&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1765196825202&to_ts=1765283225202&live=true

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
