### PR TITLE
feat(audit): add author for membership resources

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -74,6 +74,7 @@ export const applyGroupRoles = createPlugin({
           user,
           workspace,
           newRole: expectedRole,
+          author: auth.user()?.toJSON() ?? "no-author",
         });
 
         if (updateResult.isErr()) {

--- a/front/lib/api/poke/plugins/workspaces/reset_provisioned_members_not_in_directory.ts
+++ b/front/lib/api/poke/plugins/workspaces/reset_provisioned_members_not_in_directory.ts
@@ -174,6 +174,7 @@ export const resetProvisionedMembersNotInDirectoryPlugin = createPlugin({
           user,
           workspace,
           newOrigin: "invited",
+          author: auth.user()?.toJSON() ?? "no-author",
         });
 
         return {

--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -61,10 +61,13 @@ export async function createAndLogMembership({
 // `membershipInvite` flow: we know we can add the user to the associated `workspaceId` as all the
 // checks (decoding the JWT) have been run before. Simply create the membership if it does not
 // already exist and mark the invitation as consumed.
-export async function handleMembershipInvite(
-  user: UserResource,
-  membershipInvite: MembershipInvitationResource
-): Promise<
+export async function handleMembershipInvite({
+  user,
+  membershipInvite,
+}: {
+  user: UserResource;
+  membershipInvite: MembershipInvitationResource;
+}): Promise<
   Result<
     {
       flow: "joined";
@@ -121,6 +124,7 @@ export async function handleMembershipInvite(
       workspace: lightWorkspace,
       newRole: membershipInvite.initialRole,
       allowTerminated: true,
+      author: "no-author",
     });
 
     if (updateRes.isErr()) {

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -27,6 +27,7 @@ import type {
   ModelId,
   RequireAtLeastOne,
   Result,
+  UserType,
 } from "@app/types";
 import { assertNever, Err, normalizeError, Ok } from "@app/types";
 
@@ -666,6 +667,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     allowTerminated = false,
     allowLastAdminRemoval = false,
     transaction,
+    author,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
@@ -674,6 +676,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     allowTerminated?: boolean;
     allowLastAdminRemoval?: boolean;
     transaction?: Transaction;
+    author: UserType | "no-author";
   }): Promise<
     Result<
       { previousRole: MembershipRoleType; newRole: MembershipRoleType },
@@ -758,7 +761,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
     auditLog(
       {
-        author: "no-author",
+        author,
         userId: user.id,
         workspaceId: workspace.id,
         previousRole,
@@ -833,11 +836,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     workspace,
     newOrigin,
     transaction,
+    author,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
     newOrigin: MembershipOriginType;
     transaction?: Transaction;
+    author: UserType | "no-author";
   }): Promise<{
     previousOrigin: MembershipOriginType;
     newOrigin: MembershipOriginType;
@@ -848,7 +853,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
     auditLog(
       {
-        author: "no-author",
+        author,
         userId: user.id,
         workspaceId: workspace.id,
         previousOrigin,

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -131,7 +131,11 @@ async function handler(
 
     const finalMembershipInvite = membershipInvite ?? pendingInvitations?.[0];
     const loginFctn = finalMembershipInvite
-      ? async () => handleMembershipInvite(user, finalMembershipInvite)
+      ? async () =>
+          handleMembershipInvite({
+            user,
+            membershipInvite: finalMembershipInvite,
+          })
       : async () =>
           handleRegularSignupFlow(
             session,

--- a/front/pages/api/poke/workspaces/[wId]/roles.ts
+++ b/front/pages/api/poke/workspaces/[wId]/roles.ts
@@ -75,6 +75,7 @@ async function handler(
         newRole: role,
         // We allow to re-activate a terminated membership when updating the role here.
         allowTerminated: true,
+        author: auth.user()?.toJSON() ?? "no-author",
       });
 
       if (updateRes.isErr()) {

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -195,6 +195,7 @@ async function handler(
           // We allow to re-activate a terminated membership when updating the role here.
           allowTerminated: true,
           allowLastAdminRemoval,
+          author: auth.user()?.toJSON() ?? "no-author",
         });
 
         if (updateRes.isErr()) {


### PR DESCRIPTION
## Description

Audit Logs must (at least should heavily) have a clear author, [see](https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=144022758&issue=dust-tt%7Ctasks%7C5511)


Let's add it to the audit log, this is split in 3 phases:
1. add a nullable `author`
2. fill the easy `author` from the `auth` 
3. fill the less easy `author` from the `auth` <= this PR

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
