### PR TITLE
[connectors] chore: add Model suffix to Sequelize models

### DIFF
--- a/connectors/migrations/20230505_add_notion_connector_state.ts
+++ b/connectors/migrations/20230505_add_notion_connector_state.ts
@@ -1,4 +1,4 @@
-import { NotionConnectorState } from "@connectors/lib/models/notion";
+import { NotionConnectorStateModel } from "@connectors/lib/models/notion";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 async function main() {
@@ -20,14 +20,14 @@ async function main() {
     }
 
     if (connector.type === "notion") {
-      const notionState = await NotionConnectorState.findOne({
+      const notionState = await NotionConnectorStateModel.findOne({
         where: { connectorId: connector.id },
       });
       if (!notionState) {
         console.log(
           `Creating NotionConnectorState for connector ${connector.id}...`
         );
-        await NotionConnectorState.create({
+        await NotionConnectorStateModel.create({
           connectorId: connector.id,
           notionWorkspaceId: "",
         });

--- a/connectors/migrations/20230725_slack_channel_permissions.ts
+++ b/connectors/migrations/20230725_slack_channel_permissions.ts
@@ -1,6 +1,6 @@
 import { getJoinedChannels } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 async function main() {
@@ -12,7 +12,7 @@ async function main() {
 
   for (const c of slackConnectors) {
     const channelsInDb = (
-      await SlackChannel.findAll({
+      await SlackChannelModel.findAll({
         where: {
           connectorId: c.id,
         },
@@ -20,7 +20,7 @@ async function main() {
     ).reduce(
       (acc, c) => Object.assign(acc, { [c.slackChannelId]: c }),
       {} as {
-        [key: string]: SlackChannel;
+        [key: string]: SlackChannelModel;
       }
     );
 
@@ -35,7 +35,7 @@ async function main() {
       (id) => !channelIdsInSlackSet.has(id)
     );
     console.log("Deleting channels", { channelIdsToDelete, connectorId: c.id });
-    await SlackChannel.destroy({
+    await SlackChannelModel.destroy({
       where: {
         connectorId: c.id,
         slackChannelId: channelIdsToDelete,
@@ -61,7 +61,7 @@ async function main() {
           slackChannelName: channel.name,
         });
       } else {
-        await SlackChannel.create({
+        await SlackChannelModel.create({
           connectorId: c.id,
           slackChannelId: channel.id,
           slackChannelName: channel.name,

--- a/connectors/migrations/20230906_2_slack_fill_parents_field.ts
+++ b/connectors/migrations/20230906_2_slack_fill_parents_field.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { Op } from "sequelize";
 
 import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
-import { SlackMessages } from "@connectors/lib/models/slack";
+import { SlackMessagesModel } from "@connectors/lib/models/slack";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 async function main() {
@@ -57,7 +57,7 @@ async function main() {
 async function updateParentsFieldForConnector(connector: ConnectorModel) {
   // get all distinct documentIds and their channel ids from slack messages in
   // this connector
-  const documentIdsAndChannels = await SlackMessages.findAll({
+  const documentIdsAndChannels = await SlackMessagesModel.findAll({
     where: {
       connectorId: connector.id,
     },

--- a/connectors/migrations/20230906_3_github_fill_parents_field.ts
+++ b/connectors/migrations/20230906_3_github_fill_parents_field.ts
@@ -6,7 +6,7 @@ import {
   getIssueInternalId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
-import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
+import { GithubDiscussionModel, GithubIssueModel } from "@connectors/lib/models/github";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 async function main() {
@@ -64,7 +64,7 @@ async function updateDiscussionsParentsFieldForConnector(
 ) {
   // get all distinct documentIds and their channel ids from slack messages in
   // this connector
-  const documentData = await GithubDiscussion.findAll({
+  const documentData = await GithubDiscussionModel.findAll({
     where: {
       connectorId: connector.id,
     },
@@ -98,7 +98,7 @@ async function updateDiscussionsParentsFieldForConnector(
 
 async function updateIssuesParentsFieldForConnector(connector: ConnectorModel) {
   // get all distinct issues  and their repo ids fro
-  const documentData = await GithubIssue.findAll({
+  const documentData = await GithubIssueModel.findAll({
     where: {
       connectorId: connector.id,
     },

--- a/connectors/migrations/20230906_3_github_fill_parents_field.ts
+++ b/connectors/migrations/20230906_3_github_fill_parents_field.ts
@@ -6,7 +6,10 @@ import {
   getIssueInternalId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
-import { GithubDiscussionModel, GithubIssueModel } from "@connectors/lib/models/github";
+import {
+  GithubDiscussionModel,
+  GithubIssueModel,
+} from "@connectors/lib/models/github";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 async function main() {

--- a/connectors/migrations/20230906_notion_fill_parents_field.ts
+++ b/connectors/migrations/20230906_notion_fill_parents_field.ts
@@ -2,7 +2,10 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { Op } from "sequelize";
 
 import { updateAllParentsFields } from "@connectors/connectors/notion/lib/parents";
-import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
+import {
+  NotionDatabaseModel,
+  NotionPageModel,
+} from "@connectors/lib/models/notion";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 async function main() {

--- a/connectors/migrations/20230906_notion_fill_parents_field.ts
+++ b/connectors/migrations/20230906_notion_fill_parents_field.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { Op } from "sequelize";
 
 import { updateAllParentsFields } from "@connectors/connectors/notion/lib/parents";
-import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
+import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 async function main() {
@@ -55,12 +55,12 @@ async function main() {
 
 async function updateParentsFieldForConnector(connector: ConnectorModel) {
   // get all pages and databases for this connector
-  const pages = await NotionPage.findAll({
+  const pages = await NotionPageModel.findAll({
     where: {
       connectorId: connector.id,
     },
   });
-  const databases = await NotionDatabase.findAll({
+  const databases = await NotionDatabaseModel.findAll({
     where: {
       connectorId: connector.id,
     },

--- a/connectors/migrations/20231109_2_create_gdrive_config.ts
+++ b/connectors/migrations/20231109_2_create_gdrive_config.ts
@@ -1,4 +1,4 @@
-import { GoogleDriveConfig } from "@connectors/lib/models/google_drive";
+import { GoogleDriveConfigModel } from "@connectors/lib/models/google_drive";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 async function main() {
@@ -9,7 +9,7 @@ async function main() {
   });
 
   for (const connector of gDriveConnectors) {
-    const config = await GoogleDriveConfig.create({
+    const config = await GoogleDriveConfigModel.create({
       connectorId: connector.id,
       pdfEnabled: false,
       csvEnabled: false,

--- a/connectors/migrations/20231109_incident_gdrive_non_deleted_files.ts
+++ b/connectors/migrations/20231109_incident_gdrive_non_deleted_files.ts
@@ -2,7 +2,7 @@ import { Sequelize } from "sequelize";
 
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { deleteDataSourceDocument } from "@connectors/lib/data_sources";
-import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 // To be run from connectors with `CORE_DATABASE_URI` and `FRONT_DATABASE_URI` set.
@@ -25,7 +25,7 @@ async function main() {
   console.log(`Processing ${gDriveConnectors.length} google drive connectors`);
 
   for (const c of gDriveConnectors) {
-    const files = await GoogleDriveFiles.findAll({
+    const files = await GoogleDriveFilesModel.findAll({
       where: {
         connectorId: c.id,
       },

--- a/connectors/migrations/20231214_find_non_shared_drives.ts
+++ b/connectors/migrations/20231214_find_non_shared_drives.ts
@@ -4,7 +4,7 @@ import {
   getAuthObject,
   getDriveClient,
 } from "@connectors/connectors/google_drive/temporal/utils";
-import { GoogleDriveFolders } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFoldersModel } from "@connectors/lib/models/google_drive";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 async function main() {
@@ -43,7 +43,7 @@ async function main() {
           }
           const rootId = myDriveRes.data.id;
 
-          const selectedFolders = await GoogleDriveFolders.findAll({
+          const selectedFolders = await GoogleDriveFoldersModel.findAll({
             where: {
               connectorId: c.id,
             },

--- a/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
+++ b/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
@@ -3,7 +3,10 @@ import {
   getIssueInternalId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
-import { GithubDiscussionModel, GithubIssueModel } from "@connectors/lib/models/github";
+import {
+  GithubDiscussionModel,
+  GithubIssueModel,
+} from "@connectors/lib/models/github";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 const { LIVE = null } = process.env;

--- a/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
+++ b/connectors/migrations/20240102_github_add_issues_discussions_parents.ts
@@ -3,7 +3,7 @@ import {
   getIssueInternalId,
 } from "@connectors/connectors/github/lib/utils";
 import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
-import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
+import { GithubDiscussionModel, GithubIssueModel } from "@connectors/lib/models/github";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 const { LIVE = null } = process.env;
@@ -24,7 +24,7 @@ async function main() {
 const CHUNK_SIZE = 32;
 
 async function updateParents(connector: ConnectorModel) {
-  const discussions = await GithubDiscussion.findAll({
+  const discussions = await GithubDiscussionModel.findAll({
     where: {
       connectorId: connector.id,
     },
@@ -58,7 +58,7 @@ async function updateParents(connector: ConnectorModel) {
     );
   }
 
-  const issues = await GithubIssue.findAll({
+  const issues = await GithubIssueModel.findAll({
     where: {
       connectorId: connector.id,
     },

--- a/connectors/migrations/20240312_resync_ghcode.ts
+++ b/connectors/migrations/20240312_resync_ghcode.ts
@@ -1,5 +1,5 @@
 import { launchGithubFullSyncWorkflow } from "@connectors/connectors/github/temporal/client";
-import { GithubConnectorState } from "@connectors/lib/models/github";
+import { GithubConnectorStateModel } from "@connectors/lib/models/github";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 const { LIVE } = process.env;
@@ -9,7 +9,7 @@ async function main() {
   const connectors = await ConnectorModel.findAll({
     include: [
       {
-        model: GithubConnectorState,
+        model: GithubConnectorStateModel,
         where: {
           codeSyncEnabled: true,
         },

--- a/connectors/migrations/20240529_clean_gdrive_folders.ts
+++ b/connectors/migrations/20240529_clean_gdrive_folders.ts
@@ -54,7 +54,9 @@ async function main() {
         `Connector not found, deleting folder (live: ${LIVE})`
       );
       if (LIVE) {
-        await GoogleDriveFoldersModel.destroy({ where: { connectorId, folderId } });
+        await GoogleDriveFoldersModel.destroy({
+          where: { connectorId, folderId },
+        });
       }
       continue;
     }
@@ -93,7 +95,9 @@ async function main() {
         `Folder not found on google, deleting folder (live: ${LIVE})`
       );
       if (LIVE) {
-        await GoogleDriveFoldersModel.destroy({ where: { connectorId, folderId } });
+        await GoogleDriveFoldersModel.destroy({
+          where: { connectorId, folderId },
+        });
       }
       continue;
     }

--- a/connectors/migrations/20240529_clean_gdrive_folders.ts
+++ b/connectors/migrations/20240529_clean_gdrive_folders.ts
@@ -7,8 +7,8 @@ import {
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
-  GoogleDriveFiles,
-  GoogleDriveFolders,
+  GoogleDriveFilesModel,
+  GoogleDriveFoldersModel,
 } from "@connectors/lib/models/google_drive";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -36,7 +36,7 @@ async function main() {
   // Map the results to GoogleDriveFolders instances
   const unusedFolders = results.map((result) =>
     // @ts-expect-error typescript cannot correctly infer result's type
-    GoogleDriveFolders.build(result, { isNewRecord: false })
+    GoogleDriveFoldersModel.build(result, { isNewRecord: false })
   );
 
   logger.info(`Found ${unusedFolders.length} unused folders`);
@@ -54,7 +54,7 @@ async function main() {
         `Connector not found, deleting folder (live: ${LIVE})`
       );
       if (LIVE) {
-        await GoogleDriveFolders.destroy({ where: { connectorId, folderId } });
+        await GoogleDriveFoldersModel.destroy({ where: { connectorId, folderId } });
       }
       continue;
     }
@@ -69,7 +69,7 @@ async function main() {
             `Auth revoked, deleting folder (live: ${LIVE})`
           );
           if (LIVE) {
-            await GoogleDriveFolders.destroy({
+            await GoogleDriveFoldersModel.destroy({
               where: { connectorId, folderId },
             });
           }
@@ -93,7 +93,7 @@ async function main() {
         `Folder not found on google, deleting folder (live: ${LIVE})`
       );
       if (LIVE) {
-        await GoogleDriveFolders.destroy({ where: { connectorId, folderId } });
+        await GoogleDriveFoldersModel.destroy({ where: { connectorId, folderId } });
       }
       continue;
     }
@@ -103,7 +103,7 @@ async function main() {
       `Folder found on google, backfilling google_drive_files (live: ${LIVE})`
     );
     if (LIVE) {
-      await GoogleDriveFiles.create({
+      await GoogleDriveFilesModel.create({
         connectorId,
         driveFileId: folderId,
         name: file.name,

--- a/connectors/migrations/20240717_gdrive_csv_deletion.ts
+++ b/connectors/migrations/20240717_gdrive_csv_deletion.ts
@@ -1,10 +1,10 @@
 import { deleteFile } from "@connectors/connectors/google_drive/temporal/activities/common/utils";
-import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 
 // Deleting all existing Google Drive CSV files
 export async function main(): Promise<void> {
   try {
-    const csvGoogleFiles = await GoogleDriveFiles.findAll({
+    const csvGoogleFiles = await GoogleDriveFilesModel.findAll({
       where: {
         mimeType: "text/csv",
       },

--- a/connectors/migrations/20240802_table_parents.ts
+++ b/connectors/migrations/20240802_table_parents.ts
@@ -11,11 +11,11 @@ import {
   updateDataSourceTableParents,
 } from "@connectors/lib/data_sources";
 import {
-  GoogleDriveFiles,
-  GoogleDriveSheet,
+  GoogleDriveFilesModel,
+  GoogleDriveSheetModel,
 } from "@connectors/lib/models/google_drive";
 import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
-import { NotionDatabase } from "@connectors/lib/models/notion";
+import { NotionDatabaseModel } from "@connectors/lib/models/notion";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types";
@@ -62,7 +62,7 @@ export async function googleTables(
 ): Promise<void> {
   logger.info(`Processing Google Drive connector ${connector.id}`);
   const memo = uuidv4();
-  const csvGoogleSheets = await GoogleDriveSheet.findAll({
+  const csvGoogleSheets = await GoogleDriveSheetModel.findAll({
     where: { connectorId: connector.id },
   });
 
@@ -84,7 +84,7 @@ export async function googleTables(
     });
   }
 
-  const csvFiles = await GoogleDriveFiles.findAll({
+  const csvFiles = await GoogleDriveFilesModel.findAll({
     where: {
       mimeType: "text/csv",
       connectorId: connector.id,
@@ -154,7 +154,7 @@ export async function notionTables(
   logger: Logger
 ): Promise<void> {
   logger.info(`Processing Notion connector ${connector.id}`);
-  const notionDatabases = await NotionDatabase.findAll({
+  const notionDatabases = await NotionDatabaseModel.findAll({
     where: {
       connectorId: connector.id,
       structuredDataUpsertedTs: {

--- a/connectors/migrations/20241030_fix_notion_parents.ts
+++ b/connectors/migrations/20241030_fix_notion_parents.ts
@@ -8,31 +8,31 @@ import {
   updateDataSourceDocumentParents,
   updateDataSourceTableParents,
 } from "@connectors/lib/data_sources";
-import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
+import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
 async function findAllDescendants(
-  nodes: (NotionPage | NotionDatabase)[],
+  nodes: (NotionPageModel | NotionDatabaseModel)[],
   connectorId: ModelId
-): Promise<(NotionPage | NotionDatabase)[]> {
-  const getNodeId = (node: NotionPage | NotionDatabase) =>
+): Promise<(NotionPageModel | NotionDatabaseModel)[]> {
+  const getNodeId = (node: NotionPageModel | NotionDatabaseModel) =>
     "notionPageId" in node ? node.notionPageId : node.notionDatabaseId;
 
-  const descendants: (NotionPage | NotionDatabase)[] = [];
+  const descendants: (NotionPageModel | NotionDatabaseModel)[] = [];
   const seen = new Set<string>();
 
   const nodeIds = nodes.map(getNodeId);
   while (nodeIds.length > 0) {
     const parentIds = nodeIds.splice(0, nodeIds.length);
 
-    const childPages = await NotionPage.findAll({
+    const childPages = await NotionPageModel.findAll({
       where: {
         connectorId,
         parentId: parentIds,
       },
     });
-    const childDatabases = await NotionDatabase.findAll({
+    const childDatabases = await NotionDatabaseModel.findAll({
       where: {
         connectorId,
         parentId: parentIds,
@@ -62,9 +62,9 @@ async function updateParentsFieldForConnector(
   let databasesIdCursor = 0;
 
   const pageSize = 512;
-  let nodes: (NotionPage | NotionDatabase)[] = [];
+  let nodes: (NotionPageModel | NotionDatabaseModel)[] = [];
   for (;;) {
-    const pages = await NotionPage.findAll({
+    const pages = await NotionPageModel.findAll({
       where: {
         connectorId: connector.id,
         id: {
@@ -75,7 +75,7 @@ async function updateParentsFieldForConnector(
       limit: pageSize,
       order: [["id", "ASC"]],
     });
-    const databases = await NotionDatabase.findAll({
+    const databases = await NotionDatabaseModel.findAll({
       where: {
         connectorId: connector.id,
         id: {
@@ -89,7 +89,7 @@ async function updateParentsFieldForConnector(
 
     nodes = [...pages, ...databases];
 
-    const descendants: (NotionPage | NotionDatabase)[] =
+    const descendants: (NotionPageModel | NotionDatabaseModel)[] =
       await findAllDescendants(nodes, connector.id);
 
     if (pages.length > 0) {

--- a/connectors/migrations/20241030_fix_notion_parents.ts
+++ b/connectors/migrations/20241030_fix_notion_parents.ts
@@ -8,7 +8,10 @@ import {
   updateDataSourceDocumentParents,
   updateDataSourceTableParents,
 } from "@connectors/lib/data_sources";
-import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
+import {
+  NotionDatabaseModel,
+  NotionPageModel,
+} from "@connectors/lib/models/notion";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 

--- a/connectors/migrations/20241211_fix_gdrive_parents.ts
+++ b/connectors/migrations/20241211_fix_gdrive_parents.ts
@@ -10,8 +10,8 @@ import {
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
 import {
-  GoogleDriveFiles,
-  GoogleDriveSheet,
+  GoogleDriveFilesModel,
+  GoogleDriveSheetModel,
 } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
@@ -54,7 +54,7 @@ async function migrate({
   const parentsMap: Record<string, string | null> = {};
   let nextId: number | undefined = 0;
   do {
-    const googleDriveFiles: GoogleDriveFiles[] = await GoogleDriveFiles.findAll(
+    const googleDriveFiles: GoogleDriveFilesModel[] = await GoogleDriveFilesModel.findAll(
       {
         where: {
           connectorId: connector.id,
@@ -74,7 +74,7 @@ async function migrate({
 
   nextId = 0;
   do {
-    const googleDriveFiles: GoogleDriveFiles[] = await GoogleDriveFiles.findAll(
+    const googleDriveFiles: GoogleDriveFilesModel[] = await GoogleDriveFilesModel.findAll(
       {
         where: {
           connectorId: connector.id,
@@ -163,8 +163,8 @@ async function migrate({
 
   nextId = 0;
   do {
-    const googleDriveSheets: GoogleDriveSheet[] =
-      await GoogleDriveSheet.findAll({
+    const googleDriveSheets: GoogleDriveSheetModel[] =
+      await GoogleDriveSheetModel.findAll({
         where: {
           connectorId: connector.id,
           id: {

--- a/connectors/migrations/20241211_fix_gdrive_parents.ts
+++ b/connectors/migrations/20241211_fix_gdrive_parents.ts
@@ -54,16 +54,15 @@ async function migrate({
   const parentsMap: Record<string, string | null> = {};
   let nextId: number | undefined = 0;
   do {
-    const googleDriveFiles: GoogleDriveFilesModel[] = await GoogleDriveFilesModel.findAll(
-      {
+    const googleDriveFiles: GoogleDriveFilesModel[] =
+      await GoogleDriveFilesModel.findAll({
         where: {
           connectorId: connector.id,
           id: {
             [Op.gt]: nextId,
           },
         },
-      }
-    );
+      });
 
     googleDriveFiles.forEach((file) => {
       parentsMap[file.driveFileId] = file.parentId;
@@ -74,8 +73,8 @@ async function migrate({
 
   nextId = 0;
   do {
-    const googleDriveFiles: GoogleDriveFilesModel[] = await GoogleDriveFilesModel.findAll(
-      {
+    const googleDriveFiles: GoogleDriveFilesModel[] =
+      await GoogleDriveFilesModel.findAll({
         where: {
           connectorId: connector.id,
           id: {
@@ -87,8 +86,7 @@ async function migrate({
         },
         order: [["id", "ASC"]],
         limit: QUERY_BATCH_SIZE,
-      }
-    );
+      });
 
     await concurrentExecutor(
       googleDriveFiles,

--- a/connectors/migrations/20241216_backfill_confluence_folders.ts
+++ b/connectors/migrations/20241216_backfill_confluence_folders.ts
@@ -4,7 +4,7 @@ import { makeSpaceInternalId } from "@connectors/connectors/confluence/lib/inter
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { ConfluenceSpace } from "@connectors/lib/models/confluence";
+import { ConfluenceSpaceModel } from "@connectors/lib/models/confluence";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 const FOLDER_CONCURRENCY = 10;
@@ -13,7 +13,7 @@ makeScript({}, async ({ execute }, logger) => {
   const connectors = await ConnectorResource.listByType("confluence", {});
 
   for (const connector of connectors) {
-    const confluenceSpaces = await ConfluenceSpace.findAll({
+    const confluenceSpaces = await ConfluenceSpaceModel.findAll({
       attributes: ["spaceId", "name"],
       where: { connectorId: connector.id },
     });

--- a/connectors/migrations/20241218_backfill_slack_folders.ts
+++ b/connectors/migrations/20241218_backfill_slack_folders.ts
@@ -4,7 +4,7 @@ import { slackChannelInternalIdFromSlackChannelId } from "@connectors/connectors
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 const FOLDER_CONCURRENCY = 16;
@@ -16,7 +16,7 @@ makeScript({}, async ({ execute }, logger) => {
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     const connectorId = connector.id;
 
-    const channels = await SlackChannel.findAll({
+    const channels = await SlackChannelModel.findAll({
       where: {
         connectorId: connectorId,
       },

--- a/connectors/migrations/20241218_backfill_webcrawler_folders.ts
+++ b/connectors/migrations/20241218_backfill_webcrawler_folders.ts
@@ -5,7 +5,7 @@ import { makeScript } from "scripts/helpers";
 
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { WebCrawlerFolder } from "@connectors/lib/models/webcrawler";
+import { WebCrawlerFolderModel } from "@connectors/lib/models/webcrawler";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { concurrentExecutor } from "@connectors/types";
 
@@ -46,7 +46,7 @@ makeScript(
         },
         "Starting connector backfill"
       );
-      const folders = await WebCrawlerFolder.findAll({
+      const folders = await WebCrawlerFolderModel.findAll({
         where: {
           connectorId,
         },
@@ -54,7 +54,7 @@ makeScript(
 
       const foldersByUrl = _.keyBy(folders, "url");
 
-      const getParents = (folder: WebCrawlerFolder): string[] => {
+      const getParents = (folder: WebCrawlerFolderModel): string[] => {
         assert(
           folder.parentUrl === null || foldersByUrl[folder.parentUrl],
           "Parent folder not found"

--- a/connectors/migrations/20241219_backfill_github_folders.ts
+++ b/connectors/migrations/20241219_backfill_github_folders.ts
@@ -11,9 +11,9 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import {
-  GithubCodeDirectory,
-  GithubCodeRepository,
-  GithubConnectorState,
+  GithubCodeDirectoryModel,
+  GithubCodeRepositoryModel,
+  GithubConnectorStateModel,
 } from "@connectors/lib/models/github";
 import type Logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -28,7 +28,7 @@ async function upsertFoldersForConnector(
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const connectorId = connector.id;
 
-  const repositories = await GithubCodeRepository.findAll({
+  const repositories = await GithubCodeRepositoryModel.findAll({
     where: { connectorId },
   });
 
@@ -87,7 +87,7 @@ async function upsertFoldersForConnector(
       logger.info(`Would upsert discussions folder ${discussionsInternalId}`);
     }
 
-    const connectorState = await GithubConnectorState.findOne({
+    const connectorState = await GithubConnectorStateModel.findOne({
       where: { connectorId },
     });
     if (connectorState?.codeSyncEnabled) {
@@ -107,7 +107,7 @@ async function upsertFoldersForConnector(
         logger.info(`Would upsert code root folder ${codeRootInternalId}`);
       }
 
-      const directories = await GithubCodeDirectory.findAll({
+      const directories = await GithubCodeDirectoryModel.findAll({
         where: { connectorId },
       });
 

--- a/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
+++ b/connectors/migrations/20250116_gdrive_spreadsheet_folders_backfill.ts
@@ -5,7 +5,7 @@ import { getLocalParents } from "@connectors/connectors/google_drive/lib";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
@@ -26,7 +26,7 @@ async function upsertFoldersForConnector(
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const spreadsheetMimeType = "application/vnd.google-apps.spreadsheet";
   // The 5 connectors with the most spreadsheets: 35k, 20k, 13k, 8k, 7k -> no need for batching
-  const spreadsheets = await GoogleDriveFiles.findAll({
+  const spreadsheets = await GoogleDriveFilesModel.findAll({
     where: {
       connectorId: connector.id,
       mimeType: spreadsheetMimeType,

--- a/connectors/migrations/20250122_gdrive_clean_parents.ts
+++ b/connectors/migrations/20250122_gdrive_clean_parents.ts
@@ -11,9 +11,9 @@ import {
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
 import {
-  GoogleDriveFiles,
-  GoogleDriveFolders,
-  GoogleDriveSheet,
+  GoogleDriveFilesModel,
+  GoogleDriveFoldersModel,
+  GoogleDriveSheetModel,
 } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
@@ -33,13 +33,13 @@ async function migrateConnector(
   const logger = parentLogger.child({ connectorId: connector.id });
   logger.info("Starting migration");
 
-  const files = await GoogleDriveFiles.findAll({
+  const files = await GoogleDriveFilesModel.findAll({
     where: {
       connectorId: connector.id,
     },
   });
 
-  const roots = await GoogleDriveFolders.findAll({
+  const roots = await GoogleDriveFoldersModel.findAll({
     where: {
       connectorId: connector.id,
     },
@@ -79,7 +79,7 @@ async function migrateConnector(
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   logger.info({ totalProcessed }, "Files: total processed");
-  const sheets = await GoogleDriveSheet.findAll({
+  const sheets = await GoogleDriveSheetModel.findAll({
     where: {
       connectorId: connector.id,
     },
@@ -116,7 +116,7 @@ async function processFilesBatch({
 }: {
   connector: ConnectorResource;
   dataSourceConfig: DataSourceConfig;
-  files: GoogleDriveFiles[];
+  files: GoogleDriveFilesModel[];
   execute: boolean;
   startTimeTs: number;
   driveRoots: string[];
@@ -185,7 +185,7 @@ async function processSheetsBatch({
 }: {
   connector: ConnectorResource;
   dataSourceConfig: DataSourceConfig;
-  sheets: GoogleDriveSheet[];
+  sheets: GoogleDriveSheetModel[];
   execute: boolean;
   startTimeTs: number;
   driveRoots: string[];

--- a/connectors/migrations/20250127_backfill_webcrawler_folder_titles.ts
+++ b/connectors/migrations/20250127_backfill_webcrawler_folder_titles.ts
@@ -6,7 +6,7 @@ import { makeScript } from "scripts/helpers";
 import { getDisplayNameForFolder } from "@connectors/connectors/webcrawler/lib/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { WebCrawlerFolder } from "@connectors/lib/models/webcrawler";
+import { WebCrawlerFolderModel } from "@connectors/lib/models/webcrawler";
 import type Logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { concurrentExecutor, INTERNAL_MIME_TYPES } from "@connectors/types";
@@ -22,13 +22,13 @@ async function migrateConnector(
 
   logger.info("MIGRATE");
 
-  const folders = await WebCrawlerFolder.findAll({
+  const folders = await WebCrawlerFolderModel.findAll({
     where: { connectorId },
   });
 
   const foldersByUrl = _.keyBy(folders, "url");
 
-  const getParents = (folder: WebCrawlerFolder): string[] => {
+  const getParents = (folder: WebCrawlerFolderModel): string[] => {
     assert(
       folder.parentUrl === null || foldersByUrl[folder.parentUrl],
       "Parent folder not found"

--- a/connectors/migrations/20250128_backfill_provider_visibility.ts
+++ b/connectors/migrations/20250128_backfill_provider_visibility.ts
@@ -8,7 +8,7 @@ import {
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
@@ -22,7 +22,7 @@ makeScript({}, async ({ execute }, logger) => {
     const dataSourceConfig = dataSourceConfigFromConnector(connector);
     const connectorId = connector.id;
 
-    const channels = await SlackChannel.findAll({
+    const channels = await SlackChannelModel.findAll({
       where: {
         connectorId: connectorId,
         permission: { [Op.or]: ["read", "read_write"] },

--- a/connectors/migrations/20250205_reupsert_confluence_space.ts
+++ b/connectors/migrations/20250205_reupsert_confluence_space.ts
@@ -5,7 +5,7 @@ import { getConfluenceClient } from "@connectors/connectors/confluence/lib/utils
 import { fetchConfluenceConfigurationActivity } from "@connectors/connectors/confluence/temporal/activities";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { ConfluenceSpace } from "@connectors/lib/models/confluence";
+import { ConfluenceSpaceModel } from "@connectors/lib/models/confluence";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
@@ -42,14 +42,14 @@ makeScript(
         mimeType: INTERNAL_MIME_TYPES.CONFLUENCE.SPACE,
         sourceUrl: `${baseUrl}/wiki${space._links.webui}`,
       });
-      const spaceInDb = await ConfluenceSpace.findOne({
+      const spaceInDb = await ConfluenceSpaceModel.findOne({
         where: {
           connectorId,
           spaceId,
         },
       });
       if (!spaceInDb) {
-        await ConfluenceSpace.create({
+        await ConfluenceSpaceModel.create({
           connectorId,
           name: space.name,
           spaceId: spaceId,

--- a/connectors/migrations/20250304_add_notion_workspace_id_to_connector_state.ts
+++ b/connectors/migrations/20250304_add_notion_workspace_id_to_connector_state.ts
@@ -2,7 +2,7 @@ import type { Logger } from "pino";
 import { makeScript } from "scripts/helpers";
 
 import { workspaceIdFromConnectionId } from "@connectors/connectors/notion";
-import { NotionConnectorState } from "@connectors/lib/models/notion";
+import { NotionConnectorStateModel } from "@connectors/lib/models/notion";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { concurrentExecutor } from "@connectors/types";
 
@@ -11,7 +11,7 @@ async function updateConnector(
   logger: Logger,
   execute: boolean
 ) {
-  const notionState = await NotionConnectorState.findOne({
+  const notionState = await NotionConnectorStateModel.findOne({
     where: { connectorId: connector.id },
   });
   if (!notionState) {
@@ -56,7 +56,7 @@ async function updateConnector(
     return;
   }
 
-  await NotionConnectorState.update(
+  await NotionConnectorStateModel.update(
     {
       notionWorkspaceId: workspaceIdRes.value,
     },

--- a/connectors/migrations/20250429_autojoin_slack_channels.ts
+++ b/connectors/migrations/20250429_autojoin_slack_channels.ts
@@ -6,7 +6,7 @@ import {
   joinChannel,
 } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
 import type Logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
@@ -34,7 +34,7 @@ async function setupSlackChannel({
   }
 
   // Find existing channel in DB
-  const existingChannel = await SlackChannel.findOne({
+  const existingChannel = await SlackChannelModel.findOne({
     where: {
       connectorId: connector.id,
       slackChannelId: channel.id,
@@ -49,7 +49,7 @@ async function setupSlackChannel({
     });
     logger.info(`Updated configuration for channel #${channel.name}`);
   } else {
-    await SlackChannel.create({
+    await SlackChannelModel.create({
       connectorId: connector.id,
       slackChannelId: channel.id,
       slackChannelName: channel.name,

--- a/connectors/migrations/20250806_backfill_confluence_parent_type.ts
+++ b/connectors/migrations/20250806_backfill_confluence_parent_type.ts
@@ -2,7 +2,7 @@ import type { Logger } from "pino";
 import { makeScript } from "scripts/helpers";
 import { Op } from "sequelize";
 
-import { ConfluencePage } from "@connectors/lib/models/confluence";
+import { ConfluencePageModel } from "@connectors/lib/models/confluence";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types/shared/model_id";
 import { concurrentExecutor } from "@connectors/types/shared/utils/async_utils";
@@ -20,7 +20,7 @@ async function backfillConfluenceParentTypeForConnector(
     const pagesWithParentButWithoutParentType: {
       pageId: string;
       id: ModelId;
-    }[] = await ConfluencePage.findAll({
+    }[] = await ConfluencePageModel.findAll({
       where: {
         connectorId: connector.id,
         parentType: {
@@ -53,7 +53,7 @@ async function backfillConfluenceParentTypeForConnector(
       ]?.id;
 
     if (execute) {
-      await ConfluencePage.update(
+      await ConfluencePageModel.update(
         {
           parentType: "page",
         },

--- a/connectors/scripts/migrate_slack_channels.ts
+++ b/connectors/scripts/migrate_slack_channels.ts
@@ -22,7 +22,7 @@
  */
 import type { CreationAttributes } from "sequelize";
 
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 import { makeScript } from "./helpers";
@@ -110,12 +110,12 @@ makeScript(
         continue;
       }
       const [legacyChannels, existingChannels] = await Promise.all([
-        SlackChannel.findAll({
+        SlackChannelModel.findAll({
           where: {
             connectorId: legacyConnector.id,
           },
         }),
-        SlackChannel.findAll({
+        SlackChannelModel.findAll({
           where: {
             connectorId: connector.id,
           },
@@ -162,7 +162,7 @@ makeScript(
         `🔧 Preparing ${channelsToMigrate.length} channels for migration...`
       );
       const creationRecords = channelsToMigrate.map(
-        (channel): CreationAttributes<SlackChannel> => ({
+        (channel): CreationAttributes<SlackChannelModel> => ({
           connectorId: connector.id, // Update to slack_bot connector ID
           createdAt: channel.createdAt, // Keep the original createdAt field
           updatedAt: channel.updatedAt, // Keep the original updatedAt field
@@ -192,7 +192,7 @@ makeScript(
 
         try {
           const createdChannels =
-            await SlackChannel.bulkCreate(creationRecords);
+            await SlackChannelModel.bulkCreate(creationRecords);
           logger.info(
             `✅ Successfully migrated ${createdChannels.length} channels for workspace ${workspaceId}`
           );

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -2,19 +2,19 @@ import type { Sequelize } from "sequelize";
 
 import { BigQueryConfigurationModel } from "@connectors/lib/models/bigquery";
 import {
-  ConfluenceConfiguration,
-  ConfluenceFolder,
-  ConfluencePage,
-  ConfluenceSpace,
+  ConfluenceConfigurationModel,
+  ConfluenceFolderModel,
+  ConfluencePageModel,
+  ConfluenceSpaceModel,
 } from "@connectors/lib/models/confluence";
 import { DiscordConfigurationModel } from "@connectors/lib/models/discord";
 import {
-  GithubCodeDirectory,
-  GithubCodeFile,
-  GithubCodeRepository,
-  GithubConnectorState,
-  GithubDiscussion,
-  GithubIssue,
+  GithubCodeDirectoryModel,
+  GithubCodeFileModel,
+  GithubCodeRepositoryModel,
+  GithubConnectorStateModel,
+  GithubDiscussionModel,
+  GithubIssueModel,
 } from "@connectors/lib/models/github";
 import {
   GongConfigurationModel,
@@ -22,11 +22,11 @@ import {
   GongUserModel,
 } from "@connectors/lib/models/gong";
 import {
-  GoogleDriveConfig,
-  GoogleDriveFiles,
-  GoogleDriveFolders,
-  GoogleDriveSheet,
-  GoogleDriveSyncToken,
+  GoogleDriveConfigModel,
+  GoogleDriveFilesModel,
+  GoogleDriveFoldersModel,
+  GoogleDriveSheetModel,
+  GoogleDriveSyncTokenModel,
 } from "@connectors/lib/models/google_drive";
 import {
   IntercomArticleModel,
@@ -43,15 +43,15 @@ import {
 } from "@connectors/lib/models/microsoft";
 import {
   MicrosoftBotConfigurationModel,
-  MicrosoftBotMessage,
+  MicrosoftBotMessageModel,
 } from "@connectors/lib/models/microsoft_bot";
 import {
-  NotionConnectorBlockCacheEntry,
-  NotionConnectorPageCacheEntry,
-  NotionConnectorResourcesToCheckCacheEntry,
-  NotionConnectorState,
-  NotionDatabase,
-  NotionPage,
+  NotionConnectorBlockCacheEntryModel,
+  NotionConnectorPageCacheEntryModel,
+  NotionConnectorResourcesToCheckCacheEntryModel,
+  NotionConnectorStateModel,
+  NotionDatabaseModel,
+  NotionPageModel,
 } from "@connectors/lib/models/notion";
 import {
   RemoteDatabaseModel,
@@ -64,17 +64,17 @@ import {
 } from "@connectors/lib/models/salesforce";
 import {
   SlackBotWhitelistModel,
-  SlackChannel,
-  SlackChatBotMessage,
+  SlackChannelModel,
+  SlackChatBotMessageModel,
   SlackConfigurationModel,
-  SlackMessages,
+  SlackMessagesModel,
 } from "@connectors/lib/models/slack";
 import { SnowflakeConfigurationModel } from "@connectors/lib/models/snowflake";
 import {
-  WebCrawlerConfigurationHeader,
+  WebCrawlerConfigurationHeaderModel,
   WebCrawlerConfigurationModel,
-  WebCrawlerFolder,
-  WebCrawlerPage,
+  WebCrawlerFolderModel,
+  WebCrawlerPageModel,
 } from "@connectors/lib/models/webcrawler";
 import {
   ZendeskArticleModel,
@@ -95,38 +95,38 @@ async function main(): Promise<void> {
     logger: logger,
   });
   await ConnectorModel.sync({ alter: true });
-  await ConfluenceConfiguration.sync({ alter: true });
-  await ConfluenceFolder.sync({ alter: true });
-  await ConfluencePage.sync({ alter: true });
-  await ConfluenceSpace.sync({ alter: true });
+  await ConfluenceConfigurationModel.sync({ alter: true });
+  await ConfluenceFolderModel.sync({ alter: true });
+  await ConfluencePageModel.sync({ alter: true });
+  await ConfluenceSpaceModel.sync({ alter: true });
   await DiscordConfigurationModel.sync({ alter: true });
   await SlackConfigurationModel.sync({ alter: true });
-  await SlackMessages.sync({ alter: true });
-  await SlackChannel.sync({ alter: true });
-  await SlackChatBotMessage.sync({ alter: true });
+  await SlackMessagesModel.sync({ alter: true });
+  await SlackChannelModel.sync({ alter: true });
+  await SlackChatBotMessageModel.sync({ alter: true });
   await SlackBotWhitelistModel.sync({ alter: true });
-  await NotionPage.sync({ alter: true });
-  await NotionDatabase.sync({ alter: true });
-  await NotionConnectorState.sync({ alter: true });
-  await GithubConnectorState.sync({ alter: true });
-  await GithubIssue.sync({ alter: true });
-  await GithubDiscussion.sync({ alter: true });
-  await GithubCodeRepository.sync({ alter: true });
-  await GithubCodeFile.sync({ alter: true });
-  await GithubCodeDirectory.sync({ alter: true });
-  await GoogleDriveFolders.sync({ alter: true });
-  await GoogleDriveFiles.sync({ alter: true });
-  await GoogleDriveSheet.sync({ alter: true });
-  await GoogleDriveSyncToken.sync({ alter: true });
+  await NotionPageModel.sync({ alter: true });
+  await NotionDatabaseModel.sync({ alter: true });
+  await NotionConnectorStateModel.sync({ alter: true });
+  await GithubConnectorStateModel.sync({ alter: true });
+  await GithubIssueModel.sync({ alter: true });
+  await GithubDiscussionModel.sync({ alter: true });
+  await GithubCodeRepositoryModel.sync({ alter: true });
+  await GithubCodeFileModel.sync({ alter: true });
+  await GithubCodeDirectoryModel.sync({ alter: true });
+  await GoogleDriveFoldersModel.sync({ alter: true });
+  await GoogleDriveFilesModel.sync({ alter: true });
+  await GoogleDriveSheetModel.sync({ alter: true });
+  await GoogleDriveSyncTokenModel.sync({ alter: true });
   await MicrosoftConfigurationModel.sync({ alter: true });
   await MicrosoftRootModel.sync({ alter: true });
   await MicrosoftNodeModel.sync({ alter: true });
   await MicrosoftBotConfigurationModel.sync({ alter: true });
-  await MicrosoftBotMessage.sync({ alter: true });
-  await NotionConnectorBlockCacheEntry.sync({ alter: true });
-  await NotionConnectorPageCacheEntry.sync({ alter: true });
-  await NotionConnectorResourcesToCheckCacheEntry.sync({ alter: true });
-  await GoogleDriveConfig.sync({ alter: true });
+  await MicrosoftBotMessageModel.sync({ alter: true });
+  await NotionConnectorBlockCacheEntryModel.sync({ alter: true });
+  await NotionConnectorPageCacheEntryModel.sync({ alter: true });
+  await NotionConnectorResourcesToCheckCacheEntryModel.sync({ alter: true });
+  await GoogleDriveConfigModel.sync({ alter: true });
   await IntercomWorkspaceModel.sync({ alter: true });
   await IntercomHelpCenterModel.sync({ alter: true });
   await IntercomCollectionModel.sync({ alter: true });
@@ -134,9 +134,9 @@ async function main(): Promise<void> {
   await IntercomTeamModel.sync({ alter: true });
   await IntercomConversationModel.sync({ alter: true });
   await WebCrawlerConfigurationModel.sync({ alter: true });
-  await WebCrawlerFolder.sync({ alter: true });
-  await WebCrawlerPage.sync({ alter: true });
-  await WebCrawlerConfigurationHeader.sync({ alter: true });
+  await WebCrawlerFolderModel.sync({ alter: true });
+  await WebCrawlerPageModel.sync({ alter: true });
+  await WebCrawlerConfigurationHeaderModel.sync({ alter: true });
   await SnowflakeConfigurationModel.sync({ alter: true });
   await BigQueryConfigurationModel.sync({ alter: true });
   await RemoteDatabaseModel.sync({ alter: true });

--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -1,7 +1,10 @@
 import { isConnectorProvider } from "@dust-tt/client";
 import type { Request, Response } from "express";
 
-import { GithubDiscussionModel, GithubIssueModel } from "@connectors/lib/models/github";
+import {
+  GithubDiscussionModel,
+  GithubIssueModel,
+} from "@connectors/lib/models/github";
 import { NotionPageModel } from "@connectors/lib/models/notion";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";

--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -1,8 +1,8 @@
 import { isConnectorProvider } from "@dust-tt/client";
 import type { Request, Response } from "express";
 
-import { GithubDiscussion, GithubIssue } from "@connectors/lib/models/github";
-import { NotionPage } from "@connectors/lib/models/notion";
+import { GithubDiscussionModel, GithubIssueModel } from "@connectors/lib/models/github";
+import { NotionPageModel } from "@connectors/lib/models/notion";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ConnectorType } from "@connectors/types";
@@ -41,12 +41,12 @@ const _getConnector = async (
     switch (connector.type) {
       case "github": {
         const [issues, discussions] = await Promise.all([
-          GithubIssue.count({
+          GithubIssueModel.count({
             where: {
               connectorId: connector.id,
             },
           }),
-          GithubDiscussion.count({
+          GithubDiscussionModel.count({
             where: {
               connectorId: connector.id,
             },
@@ -56,7 +56,7 @@ const _getConnector = async (
         break;
       }
       case "notion": {
-        const c = await NotionPage.count({
+        const c = await NotionPageModel.count({
           where: {
             connectorId: connector.id,
           },

--- a/connectors/src/api/get_notion_workspace_id.ts
+++ b/connectors/src/api/get_notion_workspace_id.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 
-import { NotionConnectorState } from "@connectors/lib/models/notion";
+import { NotionConnectorStateModel } from "@connectors/lib/models/notion";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
@@ -24,7 +24,7 @@ const _getNotionWorkspaceIdHandler = async (
   const { connector_id } = req.params;
 
   try {
-    const connectorState = await NotionConnectorState.findOne({
+    const connectorState = await NotionConnectorStateModel.findOne({
       where: {
         connectorId: connector_id,
       },

--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -10,7 +10,7 @@ import { getChannelById } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { slackChannelIdFromInternalId } from "@connectors/connectors/slack/lib/utils";
 import { launchJoinChannelWorkflow } from "@connectors/connectors/slack/temporal/client";
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
 import { normalizeError } from "@connectors/types";
@@ -64,7 +64,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
   const slackChannelIds = slackChannelInternalIds.map((s) =>
     slackChannelIdFromInternalId(s)
   );
-  const slackChannels = await SlackChannel.findAll({
+  const slackChannels = await SlackChannelModel.findAll({
     where: {
       slackChannelId: slackChannelIds,
       connectorId,
@@ -103,7 +103,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
                 `Unexpected error: Unable to find Slack channel ${slackChannelId}.`
               );
             }
-            return await SlackChannel.create(
+            return await SlackChannelModel.create(
               {
                 connectorId: parseInt(connectorId),
                 slackChannelId,
@@ -126,7 +126,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
       );
       slackChannelIds.push(...createdChannels.map((c) => c.slackChannelId));
     }
-    await SlackChannel.update(
+    await SlackChannelModel.update(
       { agentConfigurationId: null },
       {
         where: {
@@ -138,7 +138,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
     );
     await Promise.all(
       slackChannelIds.map((slackChannelId) =>
-        SlackChannel.update(
+        SlackChannelModel.update(
           {
             agentConfigurationId,
             autoRespondWithoutMention: autoRespondWithoutMention ?? false,
@@ -227,7 +227,7 @@ const _getSlackChannelsLinkedWithAgentHandler = async (
     });
   }
 
-  const slackChannels = await SlackChannel.findAll({
+  const slackChannels = await SlackChannelModel.findAll({
     where: {
       connectorId,
       agentConfigurationId: {

--- a/connectors/src/api/sync_webhook_router_config.ts
+++ b/connectors/src/api/sync_webhook_router_config.ts
@@ -4,7 +4,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 
 import { connectorsConfig } from "@connectors/connectors/shared/config";
-import { NotionConnectorState } from "@connectors/lib/models/notion";
+import { NotionConnectorStateModel } from "@connectors/lib/models/notion";
 import { WebhookRouterConfigService } from "@connectors/lib/webhook_router_config";
 import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
@@ -63,7 +63,7 @@ const _syncWebhookRouterEntryHandler = async (
 
   if (provider === "notion") {
     // Find all connectors for this Notion workspace in this region
-    const notionConnectorStates = await NotionConnectorState.findAll({
+    const notionConnectorStates = await NotionConnectorStateModel.findAll({
       where: { notionWorkspaceId: providerWorkspaceId },
     });
 

--- a/connectors/src/api/webhooks/teams/bot.ts
+++ b/connectors/src/api/webhooks/teams/bot.ts
@@ -25,7 +25,7 @@ import { annotateCitations } from "@connectors/lib/bot/citations";
 import { makeConversationUrl } from "@connectors/lib/bot/conversation_utils";
 import type { MentionMatch } from "@connectors/lib/bot/mentions";
 import { processMessageForMention } from "@connectors/lib/bot/mentions";
-import { MicrosoftBotMessage } from "@connectors/lib/models/microsoft_bot";
+import { MicrosoftBotMessageModel } from "@connectors/lib/models/microsoft_bot";
 import { getActionName } from "@connectors/lib/tools_utils";
 import type { Logger } from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -71,7 +71,7 @@ export async function botAnswerMessage(
   const { email, displayName, userAadObjectId } = validatedUser;
 
   // Check for existing Dust conversation for this Teams conversation
-  const allMicrosoftBotMessages = await MicrosoftBotMessage.findAll({
+  const allMicrosoftBotMessages = await MicrosoftBotMessageModel.findAll({
     where: {
       connectorId: connector.id,
       conversationId: conversationId,
@@ -253,7 +253,7 @@ export async function botAnswerMessage(
     }
   }
 
-  const m = await MicrosoftBotMessage.create({
+  const m = await MicrosoftBotMessageModel.create({
     connectorId: connector.id,
     userAadObjectId: userAadObjectId,
     email: email,
@@ -458,7 +458,7 @@ async function streamAgentResponse({
       }
       case "tool_approve_execution": {
         // Find the MicrosoftBotMessage to get the microsoftBotMessageId
-        const microsoftBotMessage = await MicrosoftBotMessage.findOne({
+        const microsoftBotMessage = await MicrosoftBotMessageModel.findOne({
           where: {
             connectorId: connector.id,
             dustConversationId: conversation.sId,
@@ -578,7 +578,7 @@ async function makeContentFragments(
   context: TurnContext,
   dustAPI: DustAPI,
   connector: ConnectorResource,
-  lastMicrosoftBotMessage: MicrosoftBotMessage | null,
+  lastMicrosoftBotMessage: MicrosoftBotMessageModel | null,
   localLogger: Logger
 ): Promise<Result<PublicPostContentFragmentRequestBody[] | undefined, Error>> {
   // Get Microsoft Graph client only for file downloads
@@ -750,7 +750,7 @@ export async function sendFeedback({
   }
 
   // Find the MicrosoftBotMessage to get the Dust conversation ID
-  const microsoftBotMessage = await MicrosoftBotMessage.findOne({
+  const microsoftBotMessage = await MicrosoftBotMessageModel.findOne({
     where: {
       connectorId: connector.id,
       conversationId: conversationId,
@@ -838,7 +838,7 @@ export async function botValidateToolExecution({
   const { email } = validatedUser;
 
   // Find the MicrosoftBotMessage
-  const microsoftBotMessage = await MicrosoftBotMessage.findOne({
+  const microsoftBotMessage = await MicrosoftBotMessageModel.findOne({
     where: { id: microsoftBotMessageId },
   });
 

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -22,8 +22,8 @@ import {
   launchGithubReposSyncWorkflow,
 } from "@connectors/connectors/github/temporal/client";
 import {
-  GithubCodeRepository,
-  GithubConnectorState,
+  GithubCodeRepositoryModel,
+  GithubConnectorStateModel,
 } from "@connectors/lib/models/github";
 import mainLogger from "@connectors/logger/logger";
 import { withLogging } from "@connectors/logger/withlogging";
@@ -102,7 +102,7 @@ const _webhookGithubAPIHandler = async (
 
   const installationId = payload.installation.id.toString();
 
-  const githubConnectorStates = await GithubConnectorState.findAll({
+  const githubConnectorStates = await GithubConnectorStateModel.findAll({
     where: {
       installationId,
     },
@@ -425,7 +425,7 @@ async function syncCode(
 
   await Promise.all(
     connectors.map(async (c) => {
-      const githubCodeRepository = await GithubCodeRepository.findOne({
+      const githubCodeRepository = await GithubCodeRepositoryModel.findOne({
         where: {
           connectorId: c.id,
           repoId: repoId.toString(),

--- a/connectors/src/api/webhooks/webhook_notion.ts
+++ b/connectors/src/api/webhooks/webhook_notion.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 
 import type { NotionWebhookEvent } from "@connectors/connectors/notion/lib/webhooks";
 import { processNotionWebhookEvent } from "@connectors/connectors/notion/lib/webhooks";
-import { NotionConnectorState } from "@connectors/lib/models/notion";
+import { NotionConnectorStateModel } from "@connectors/lib/models/notion";
 import mainLogger from "@connectors/logger/logger";
 import { withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -72,7 +72,7 @@ const _webhookNotionAPIHandler = async (
   }
 
   // Find the connector state from the Notion workspace ID
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: { notionWorkspaceId },
   });
 

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -32,7 +32,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
 import mainLogger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -177,7 +177,7 @@ const _webhookSlackAPIHandler = async (
             // Get valid slack configurations for this channel once
             const validConfigurations = await Promise.all(
               slackConfigurations.map(async (c) => {
-                const slackChannel = await SlackChannel.findOne({
+                const slackChannel = await SlackChannelModel.findOne({
                   where: {
                     connectorId: c.connectorId,
                     slackChannelId: channel,

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -30,8 +30,8 @@ import {
 } from "@connectors/connectors/interface";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
-  ConfluenceConfiguration,
-  ConfluenceSpace,
+  ConfluenceConfigurationModel,
+  ConfluenceSpaceModel,
 } from "@connectors/lib/models/confluence";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -116,7 +116,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
     }
 
     if (connectionId) {
-      const currentCloudInformation = await ConfluenceConfiguration.findOne({
+      const currentCloudInformation = await ConfluenceConfigurationModel.findOne({
         attributes: ["cloudId"],
         where: {
           connectorId: this.connectorId,
@@ -209,7 +209,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
         );
       }
 
-      const connectorState = await ConfluenceConfiguration.findOne({
+      const connectorState = await ConfluenceConfigurationModel.findOne({
         where: {
           connectorId: connector.id,
         },
@@ -231,7 +231,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
   }: {
     fromTs: number | null;
   }): Promise<Result<string, Error>> {
-    const spaces = await ConfluenceSpace.findAll({
+    const spaces = await ConfluenceSpaceModel.findAll({
       attributes: ["spaceId"],
       where: {
         connectorId: this.connectorId,
@@ -263,7 +263,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    const confluenceConfig = await ConfluenceConfiguration.findOne({
+    const confluenceConfig = await ConfluenceConfigurationModel.findOne({
       where: {
         connectorId: this.connectorId,
       },
@@ -356,7 +356,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
     for (const [internalId, permission] of Object.entries(permissions)) {
       const confluenceId = getConfluenceIdFromInternalId(internalId);
       if (permission === "none") {
-        await ConfluenceSpace.destroy({
+        await ConfluenceSpaceModel.destroy({
           where: {
             connectorId: this.connectorId,
             spaceId: confluenceId,
@@ -367,7 +367,7 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
       } else if (permission === "read") {
         const confluenceSpace = spaces.find((s) => s.id === confluenceId);
 
-        await ConfluenceSpace.upsert({
+        await ConfluenceSpaceModel.upsert({
           connectorId: this.connectorId,
           name: confluenceSpace?.name ?? confluenceId,
           spaceId: confluenceId,

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -116,12 +116,13 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
     }
 
     if (connectionId) {
-      const currentCloudInformation = await ConfluenceConfigurationModel.findOne({
-        attributes: ["cloudId"],
-        where: {
-          connectorId: this.connectorId,
-        },
-      });
+      const currentCloudInformation =
+        await ConfluenceConfigurationModel.findOne({
+          attributes: ["cloudId"],
+          where: {
+            connectorId: this.connectorId,
+          },
+        });
 
       const confluenceAccessTokenRes =
         await getConfluenceAccessToken(connectionId);

--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -20,8 +20,8 @@ import {
   confluenceUpsertPageWithFullParentsWorkflow,
 } from "@connectors/connectors/confluence/temporal/workflows";
 import {
-  ConfluencePage,
-  ConfluenceSpace,
+  ConfluencePageModel,
+  ConfluenceSpaceModel,
 } from "@connectors/lib/models/confluence";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import { default as topLogger } from "@connectors/logger/logger";
@@ -117,7 +117,7 @@ export const confluence = async ({
       const pageId = args.pageId;
       const skipReason = args.skipReason || "Blacklisted.";
 
-      const page = await ConfluencePage.findOne({
+      const page = await ConfluencePageModel.findOne({
         where: {
           connectorId,
           pageId: pageId.toString(),
@@ -194,7 +194,7 @@ export const confluence = async ({
     case "update-parents": {
       // Not passing a spaceId means that all spaces have to be checked out here.
       if (!args.spaceId) {
-        const spaces = await ConfluenceSpace.findAll({
+        const spaces = await ConfluenceSpaceModel.findAll({
           attributes: ["spaceId"],
           where: { connectorId: args.connectorId },
         });
@@ -258,7 +258,7 @@ export const confluence = async ({
         pageId
       );
 
-      const confluencePage = await ConfluencePage.findOne({
+      const confluencePage = await ConfluencePageModel.findOne({
         where: {
           connectorId,
           pageId,
@@ -358,7 +358,7 @@ export const confluence = async ({
       }
 
       // Get space information from database
-      const dbSpace = await ConfluenceSpace.findOne({
+      const dbSpace = await ConfluenceSpaceModel.findOne({
         where: {
           connectorId,
           spaceId: matchingSpace.id,
@@ -366,7 +366,7 @@ export const confluence = async ({
       });
 
       // Count pages in this space
-      const pageCount = await ConfluencePage.count({
+      const pageCount = await ConfluencePageModel.count({
         where: {
           connectorId,
           spaceId: matchingSpace.id,

--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -10,7 +10,7 @@ import {
   ConfluenceClient,
 } from "@connectors/connectors/confluence/lib/confluence_client";
 import { apiConfig } from "@connectors/lib/api/config";
-import { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
+import { ConfluenceConfigurationModel } from "@connectors/lib/models/confluence";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
@@ -59,7 +59,7 @@ export async function getConfluenceUserAccountId(accessToken: string) {
 }
 
 async function fetchConfluenceConfiguration(connectorId: ModelId) {
-  const confluenceConfig = await ConfluenceConfiguration.findOne({
+  const confluenceConfig = await ConfluenceConfigurationModel.findOne({
     where: {
       connectorId: connectorId,
     },
@@ -70,7 +70,7 @@ async function fetchConfluenceConfiguration(connectorId: ModelId) {
 
 export async function listConfluenceSpaces(
   connector: ConnectorResource,
-  confluenceConfig?: ConfluenceConfiguration
+  confluenceConfig?: ConfluenceConfigurationModel
 ): Promise<Result<ConfluenceSpaceType[], Error>> {
   const { id: connectorId, connectionId } = connector;
 

--- a/connectors/src/connectors/confluence/lib/content/folders.ts
+++ b/connectors/src/connectors/confluence/lib/content/folders.ts
@@ -18,7 +18,7 @@ import {
   deleteDataSourceFolder,
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
-import { ConfluenceFolder } from "@connectors/lib/models/confluence";
+import { ConfluenceFolderModel } from "@connectors/lib/models/confluence";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
@@ -35,7 +35,7 @@ async function markFolderHasVisited({
   spaceId: string;
   visitedAtMs: number;
 }) {
-  await ConfluenceFolder.update(
+  await ConfluenceFolderModel.update(
     {
       lastVisitedAt: new Date(visitedAtMs),
     },
@@ -77,7 +77,7 @@ export async function confluenceCheckAndUpsertSingleFolder({
   };
   const localLogger = logger.child(loggerArgs);
 
-  const folderAlreadyInDb = await ConfluenceFolder.findOne({
+  const folderAlreadyInDb = await ConfluenceFolderModel.findOne({
     attributes: ["parentId", "skipReason", "version"],
     where: {
       connectorId,
@@ -173,7 +173,7 @@ export async function confluenceCheckAndUpsertSingleFolder({
   });
 
   localLogger.info("Upserting Confluence folder in DB.");
-  await ConfluenceFolder.upsert({
+  await ConfluenceFolderModel.upsert({
     connectorId,
     externalUrl: folder._links.tinyui,
     folderId,
@@ -216,7 +216,7 @@ async function deleteFolder(
   });
 
   localLogger.info("Deleting Confluence folder from database.");
-  await ConfluenceFolder.destroy({
+  await ConfluenceFolderModel.destroy({
     where: {
       connectorId,
       folderId,
@@ -237,7 +237,7 @@ export async function confluenceRemoveUnvisitedFolders({
 }) {
   const { id: connectorId } = connector;
 
-  const unvisitedFolders = await ConfluenceFolder.findAll({
+  const unvisitedFolders = await ConfluenceFolderModel.findAll({
     attributes: ["folderId"],
     where: {
       connectorId,
@@ -264,7 +264,7 @@ export async function confluenceRemoveAllFoldersInSpace({
 }) {
   const { id: connectorId } = connector;
 
-  const allFolders = await ConfluenceFolder.findAll({
+  const allFolders = await ConfluenceFolderModel.findAll({
     attributes: ["folderId"],
     where: {
       connectorId,

--- a/connectors/src/connectors/confluence/lib/content/pages.ts
+++ b/connectors/src/connectors/confluence/lib/content/pages.ts
@@ -28,8 +28,8 @@ import {
   renderMarkdownSection,
   upsertDataSourceDocument,
 } from "@connectors/lib/data_sources";
-import type { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
-import { ConfluencePage } from "@connectors/lib/models/confluence";
+import type { ConfluenceConfigurationModel } from "@connectors/lib/models/confluence";
+import { ConfluencePageModel } from "@connectors/lib/models/confluence";
 import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -49,7 +49,7 @@ async function markPageHasVisited({
   spaceId: string;
   visitedAtMs: number;
 }) {
-  await ConfluencePage.update(
+  await ConfluencePageModel.update(
     {
       lastVisitedAt: new Date(visitedAtMs),
     },
@@ -71,7 +71,7 @@ interface ConfluenceUpsertPageInput {
   page: NonNullable<Awaited<ReturnType<ConfluenceClient["getPageById"]>>>;
   spaceName: string;
   parents: [string, string, ...string[]];
-  confluenceConfig: ConfluenceConfiguration;
+  confluenceConfig: ConfluenceConfigurationModel;
   syncType?: UpsertDataSourceDocumentParams["upsertContext"]["sync_type"];
   dataSourceConfig: DataSourceConfig;
   loggerArgs: Record<string, string | number>;
@@ -160,7 +160,7 @@ export async function upsertConfluencePageInDb(
   page: ConfluencePageWithBodyType,
   visitedAtMs: number
 ) {
-  await ConfluencePage.upsert({
+  await ConfluencePageModel.upsert({
     connectorId,
     externalUrl: page._links.tinyui,
     lastVisitedAt: new Date(visitedAtMs),
@@ -205,7 +205,7 @@ export async function confluenceCheckAndUpsertSinglePage({
   };
   const localLogger = logger.child(loggerArgs);
 
-  const pageAlreadyInDb = await ConfluencePage.findOne({
+  const pageAlreadyInDb = await ConfluencePageModel.findOne({
     attributes: ["parentId", "skipReason", "version"],
     where: {
       connectorId,
@@ -325,7 +325,7 @@ async function deletePage(
   });
 
   localLogger.info("Deleting Confluence page from database.");
-  await ConfluencePage.destroy({
+  await ConfluencePageModel.destroy({
     where: {
       connectorId,
       pageId,
@@ -346,7 +346,7 @@ export async function confluenceRemoveUnvisitedPages({
 }) {
   const { id: connectorId } = connector;
 
-  const unvisitedPages = await ConfluencePage.findAll({
+  const unvisitedPages = await ConfluencePageModel.findAll({
     attributes: ["pageId"],
     where: {
       connectorId,
@@ -380,7 +380,7 @@ export async function confluenceRemoveAllPagesInSpace({
     spaceId,
   });
 
-  const allPages = await ConfluencePage.findAll({
+  const allPages = await ConfluencePageModel.findAll({
     attributes: ["pageId"],
     where: {
       connectorId,

--- a/connectors/src/connectors/confluence/lib/hierarchy.ts
+++ b/connectors/src/connectors/confluence/lib/hierarchy.ts
@@ -3,8 +3,8 @@ import {
   makeSpaceInternalId,
 } from "@connectors/connectors/confluence/lib/internal_ids";
 import {
-  ConfluenceFolder,
-  ConfluencePage,
+  ConfluenceFolderModel,
+  ConfluencePageModel,
 } from "@connectors/lib/models/confluence";
 import type { ModelId } from "@connectors/types";
 
@@ -30,7 +30,7 @@ export async function getSpaceHierarchy(
   // By fetching all content within a space, we reconstruct parent-child
   // relationships in-app, minimizing database interactions.
   // If needed we could move the same approach as Notion and cache the results in Redis.
-  const allPages = await ConfluencePage.findAll({
+  const allPages = await ConfluencePageModel.findAll({
     attributes: ["pageId", "parentId", "parentType"],
     where: {
       connectorId,
@@ -38,7 +38,7 @@ export async function getSpaceHierarchy(
     },
   });
 
-  const allFolders = await ConfluenceFolder.findAll({
+  const allFolders = await ConfluenceFolderModel.findAll({
     attributes: ["folderId", "parentId", "parentType"],
     where: {
       connectorId,

--- a/connectors/src/connectors/confluence/lib/permissions.ts
+++ b/connectors/src/connectors/confluence/lib/permissions.ts
@@ -11,10 +11,10 @@ import {
   makePageInternalId,
   makeSpaceInternalId,
 } from "@connectors/connectors/confluence/lib/internal_ids";
-import type { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
+import type { ConfluenceConfigurationModel } from "@connectors/lib/models/confluence";
 import {
-  ConfluencePage,
-  ConfluenceSpace,
+  ConfluencePageModel,
+  ConfluenceSpaceModel,
 } from "@connectors/lib/models/confluence";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ConnectorPermission, ContentNode } from "@connectors/types";
@@ -23,7 +23,7 @@ import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 function isConfluenceSpaceModel(
   confluenceSpace: unknown
-): confluenceSpace is ConfluenceSpace {
+): confluenceSpace is ConfluenceSpaceModel {
   return (
     typeof confluenceSpace === "object" &&
     confluenceSpace !== null &&
@@ -33,7 +33,7 @@ function isConfluenceSpaceModel(
 }
 
 export function createContentNodeFromSpace(
-  space: ConfluenceSpace | ConfluenceSpaceType,
+  space: ConfluenceSpaceModel | ConfluenceSpaceType,
   baseUrl: string,
   permission: ConnectorPermission,
   { isExpandable }: { isExpandable: boolean }
@@ -59,7 +59,7 @@ export function createContentNodeFromSpace(
 export function createContentNodeFromPage(
   parent: { id: string; type: "page" | "space" },
   baseUrl: string,
-  page: ConfluencePage,
+  page: ConfluencePageModel,
   isExpandable = false
 ): ContentNode {
   return {
@@ -82,7 +82,7 @@ export async function checkPageHasChildren(
   connectorId: ModelId,
   pageId: string
 ) {
-  const childrenPage = await ConfluencePage.findOne({
+  const childrenPage = await ConfluencePageModel.findOne({
     attributes: ["id"],
     where: {
       connectorId,
@@ -95,12 +95,12 @@ export async function checkPageHasChildren(
 
 async function getSynchronizedSpaces(
   connectorId: ModelId,
-  confluenceConfig: ConfluenceConfiguration,
+  confluenceConfig: ConfluenceConfigurationModel,
   parentInternalId: string
 ): Promise<Result<ContentNode[], Error>> {
   const confluenceId = getConfluenceIdFromInternalId(parentInternalId);
 
-  const parentSpace = await ConfluenceSpace.findOne({
+  const parentSpace = await ConfluenceSpaceModel.findOne({
     attributes: ["id", "spaceId"],
     where: {
       connectorId,
@@ -112,7 +112,7 @@ async function getSynchronizedSpaces(
     return new Err(new Error(`Confluence space not found.`));
   }
 
-  const pagesWithinSpace = await ConfluencePage.findAll({
+  const pagesWithinSpace = await ConfluencePageModel.findAll({
     attributes: ["id", "pageId", "title", "externalUrl"],
     where: {
       connectorId,
@@ -142,12 +142,12 @@ async function getSynchronizedSpaces(
 
 async function getSynchronizedChildrenPages(
   connectorId: ModelId,
-  confluenceConfig: ConfluenceConfiguration,
+  confluenceConfig: ConfluenceConfigurationModel,
   parentInternalId: string
 ): Promise<Result<ContentNode[], Error>> {
   const confluenceId = getConfluenceIdFromInternalId(parentInternalId);
 
-  const parentPage = await ConfluencePage.findOne({
+  const parentPage = await ConfluencePageModel.findOne({
     attributes: ["id", "pageId"],
     where: {
       connectorId,
@@ -159,7 +159,7 @@ async function getSynchronizedChildrenPages(
     return new Err(new Error(`Confluence page not found.`));
   }
 
-  const pagesWithinSpace = await ConfluencePage.findAll({
+  const pagesWithinSpace = await ConfluencePageModel.findAll({
     attributes: ["id", "pageId", "title", "externalUrl"],
     where: {
       connectorId,
@@ -186,7 +186,7 @@ async function getSynchronizedChildrenPages(
 
 export async function retrieveHierarchyForParent(
   connector: ConnectorResource,
-  confluenceConfig: ConfluenceConfiguration,
+  confluenceConfig: ConfluenceConfigurationModel,
   parentInternalId: string | null
 ) {
   const { id: connectorId } = connector;
@@ -221,7 +221,7 @@ export async function retrieveHierarchyForParent(
     }
   }
 
-  const syncedSpaces = await ConfluenceSpace.findAll({
+  const syncedSpaces = await ConfluenceSpaceModel.findAll({
     where: {
       connectorId,
     },
@@ -240,11 +240,11 @@ export async function retrieveHierarchyForParent(
 
 export async function retrieveAvailableSpaces(
   connector: ConnectorResource,
-  confluenceConfig: ConfluenceConfiguration
+  confluenceConfig: ConfluenceConfigurationModel
 ): Promise<Result<ContentNode[], Error>> {
   const { id: connectorId } = connector;
 
-  const syncedSpaces = await ConfluenceSpace.findAll({
+  const syncedSpaces = await ConfluenceSpaceModel.findAll({
     where: {
       connectorId: connectorId,
     },

--- a/connectors/src/connectors/confluence/lib/utils.ts
+++ b/connectors/src/connectors/confluence/lib/utils.ts
@@ -1,5 +1,5 @@
 import { ConfluenceClient } from "@connectors/connectors/confluence/lib/confluence_client";
-import { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
+import { ConfluenceConfigurationModel } from "@connectors/lib/models/confluence";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -80,7 +80,7 @@ export async function getConfluenceConfig({
 }: {
   connectorId: ModelId;
 }) {
-  const confluenceConfig = await ConfluenceConfiguration.findOne({
+  const confluenceConfig = await ConfluenceConfigurationModel.findOne({
     where: {
       connectorId,
     },

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -43,10 +43,10 @@ import {
   isNotFoundError,
 } from "@connectors/lib/error";
 import {
-  ConfluenceConfiguration,
-  ConfluenceFolder,
-  ConfluencePage,
-  ConfluenceSpace,
+  ConfluenceConfigurationModel,
+  ConfluenceFolderModel,
+  ConfluencePageModel,
+  ConfluenceSpaceModel,
 } from "@connectors/lib/models/confluence";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
@@ -81,7 +81,7 @@ async function fetchConfluenceConnector(connectorId: ModelId) {
 }
 
 export async function getSpaceIdsToSyncActivity(connectorId: ModelId) {
-  const spaces = await ConfluenceSpace.findAll({
+  const spaces = await ConfluenceSpaceModel.findAll({
     attributes: ["spaceId"],
     where: {
       connectorId: connectorId,
@@ -134,7 +134,7 @@ export async function confluenceGetSpaceBlobActivity({
     connectorId,
   });
 
-  const spaceInDb = await ConfluenceSpace.findOne({
+  const spaceInDb = await ConfluenceSpaceModel.findOne({
     where: { connectorId, spaceId },
   });
 
@@ -195,7 +195,7 @@ export async function confluenceUpsertSpaceFolderActivity({
 
   const { id: spaceId, name: spaceName } = space;
 
-  const spaceInDb = await ConfluenceSpace.findOne({
+  const spaceInDb = await ConfluenceSpaceModel.findOne({
     where: { connectorId, spaceId },
   });
 
@@ -470,7 +470,7 @@ export async function confluenceUpdateContentParentIdsActivity(
 ) {
   const connector = await fetchConfluenceConnector(connectorId);
 
-  const pages = await ConfluencePage.findAll({
+  const pages = await ConfluencePageModel.findAll({
     attributes: ["id", "pageId", "parentId", "parentType", "spaceId"],
     where: {
       connectorId,
@@ -479,7 +479,7 @@ export async function confluenceUpdateContentParentIdsActivity(
     },
   });
 
-  const folders = await ConfluenceFolder.findAll({
+  const folders = await ConfluenceFolderModel.findAll({
     attributes: [
       "id",
       "folderId",
@@ -513,7 +513,7 @@ export async function confluenceUpdateContentParentIdsActivity(
   await concurrentExecutor(
     [...pages, ...folders],
     async (e) => {
-      const isPage = e instanceof ConfluencePage;
+      const isPage = e instanceof ConfluencePageModel;
 
       // Retrieve parents using the internal ID, which aligns with the permissions view rendering
       // and RAG requirements.
@@ -618,7 +618,7 @@ export async function fetchConfluenceSpaceIdsForConnectorActivity({
 }: {
   connectorId: ModelId;
 }) {
-  const spacesForConnector = await ConfluenceSpace.findAll({
+  const spacesForConnector = await ConfluenceSpaceModel.findAll({
     attributes: ["spaceId"],
     where: {
       connectorId,
@@ -667,7 +667,7 @@ export async function confluenceUpsertPageWithFullParentsActivity({
   const localLogger = logger.child(loggerArgs);
   const visitedAtMs = new Date().getTime();
 
-  const pageInDb = await ConfluencePage.findOne({
+  const pageInDb = await ConfluencePageModel.findOne({
     attributes: ["parentId", "skipReason"],
     where: { connectorId, pageId },
   });
@@ -753,7 +753,7 @@ interface ConfluenceUserAccountAndConnectorId {
 export async function fetchConfluenceUserAccountAndConnectorIdsActivity(): Promise<
   ConfluenceUserAccountAndConnectorId[]
 > {
-  return ConfluenceConfiguration.findAll({
+  return ConfluenceConfigurationModel.findAll({
     attributes: ["connectorId", "userAccountId"],
   });
 }
@@ -775,7 +775,7 @@ export async function confluenceGetReportPersonalActionActivity(
   }
 
   // We look for the oldest updated data.
-  const oldestPageSync = await ConfluencePage.findOne({
+  const oldestPageSync = await ConfluencePageModel.findOne({
     where: {
       connectorId,
     },

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -27,12 +27,12 @@ import {
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
 import {
-  GithubCodeDirectory,
-  GithubCodeFile,
-  GithubCodeRepository,
-  GithubConnectorState,
-  GithubDiscussion,
-  GithubIssue,
+  GithubCodeDirectoryModel,
+  GithubCodeFileModel,
+  GithubCodeRepositoryModel,
+  GithubConnectorStateModel,
+  GithubDiscussionModel,
+  GithubIssueModel,
 } from "@connectors/lib/models/github";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
@@ -98,7 +98,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     }
 
     if (connectionId) {
-      const connectorState = await GithubConnectorState.findOne({
+      const connectorState = await GithubConnectorStateModel.findOne({
         where: {
           connectorId: c.id,
         },
@@ -155,7 +155,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         return new Err(new Error("Connector not found"));
       }
 
-      const connectorState = await GithubConnectorState.findOne({
+      const connectorState = await GithubConnectorStateModel.findOne({
         where: {
           connectorId: connector.id,
         },
@@ -204,7 +204,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         return new Err(new Error("Connector not found"));
       }
 
-      const connectorState = await GithubConnectorState.findOne({
+      const connectorState = await GithubConnectorStateModel.findOne({
         where: {
           connectorId: connector.id,
         },
@@ -334,14 +334,14 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         case "REPO_FULL": {
           const [latestDiscussion, latestIssue, repoRes, codeRepo] =
             await Promise.all([
-              GithubDiscussion.findOne({
+              GithubDiscussionModel.findOne({
                 where: {
                   connectorId: c.id,
                   repoId: repoId.toString(),
                 },
                 order: [["updatedAt", "DESC"]],
               }),
-              GithubIssue.findOne({
+              GithubIssueModel.findOne({
                 where: {
                   connectorId: c.id,
                   repoId: repoId.toString(),
@@ -349,7 +349,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
                 order: [["updatedAt", "DESC"]],
               }),
               getRepo(c, repoId),
-              GithubCodeRepository.findOne({
+              GithubCodeRepositoryModel.findOne({
                 where: {
                   connectorId: c.id,
                   repoId: repoId.toString(),
@@ -417,13 +417,13 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         case "REPO_CODE":
         case "REPO_CODE_DIR": {
           const [files, directories] = await Promise.all([
-            GithubCodeFile.findAll({
+            GithubCodeFileModel.findAll({
               where: {
                 connectorId: c.id,
                 parentInternalId,
               },
             }),
-            GithubCodeDirectory.findAll({
+            GithubCodeDirectoryModel.findAll({
               where: {
                 connectorId: c.id,
                 parentInternalId,
@@ -513,7 +513,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
     switch (configKey) {
       case "codeSyncEnabled": {
-        const connectorState = await GithubConnectorState.findOne({
+        const connectorState = await GithubConnectorStateModel.findOne({
           where: {
             connectorId: connector.id,
           },
@@ -565,7 +565,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
     switch (configKey) {
       case "codeSyncEnabled": {
-        const connectorState = await GithubConnectorState.findOne({
+        const connectorState = await GithubConnectorStateModel.findOne({
           where: {
             connectorId: connector.id,
           },

--- a/connectors/src/connectors/github/lib/cli.ts
+++ b/connectors/src/connectors/github/lib/cli.ts
@@ -14,10 +14,10 @@ import {
   getRepoSyncWorkflowId,
 } from "@connectors/connectors/github/temporal/utils";
 import {
-  GithubCodeFile,
-  GithubCodeRepository,
-  GithubConnectorState,
-  GithubIssue,
+  GithubCodeFileModel,
+  GithubCodeRepositoryModel,
+  GithubConnectorStateModel,
+  GithubIssueModel,
 } from "@connectors/lib/models/github";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -161,7 +161,7 @@ export const github = async ({
 
       const enable = args.enable === "true";
 
-      const connectorState = await GithubConnectorState.findOne({
+      const connectorState = await GithubConnectorStateModel.findOne({
         where: {
           connectorId: connector.id,
         },
@@ -221,7 +221,7 @@ export const github = async ({
         throw new Error("Missing --skipReason argument");
       }
 
-      await GithubIssue.upsert({
+      await GithubIssueModel.upsert({
         repoId: args.repoId.toString(),
         issueNumber: parseInt(args.issueNumber, 10),
         connectorId: connector.id,
@@ -236,7 +236,7 @@ export const github = async ({
         throw new Error("Missing --repoId argument");
       }
 
-      const githubCodeRepository = await GithubCodeRepository.findOne({
+      const githubCodeRepository = await GithubCodeRepositoryModel.findOne({
         where: {
           connectorId: connector.id,
           repoId: args.repoId,
@@ -270,7 +270,7 @@ export const github = async ({
         throw new Error("Missing --skipReason argument");
       }
 
-      const githubCodeRepository = await GithubCodeRepository.findOne({
+      const githubCodeRepository = await GithubCodeRepositoryModel.findOne({
         where: {
           connectorId: connector.id,
           repoId: args.repoId,
@@ -298,7 +298,7 @@ export const github = async ({
         throw new Error("Missing --repoId argument");
       }
 
-      const githubCodeRepository = await GithubCodeRepository.findOne({
+      const githubCodeRepository = await GithubCodeRepositoryModel.findOne({
         where: {
           connectorId: connector.id,
           repoId: args.repoId,
@@ -320,7 +320,7 @@ export const github = async ({
     }
 
     case "list-skipped-repos": {
-      const skippedRepos = await GithubCodeRepository.findAll({
+      const skippedRepos = await GithubCodeRepositoryModel.findAll({
         where: {
           connectorId: connector.id,
           skipReason: {
@@ -350,7 +350,7 @@ export const github = async ({
         throw new Error("Missing --skipReason argument");
       }
 
-      const githubCodeRepository = await GithubCodeRepository.findOne({
+      const githubCodeRepository = await GithubCodeRepositoryModel.findOne({
         where: {
           connectorId: connector.id,
           repoId: args.repoId,
@@ -362,7 +362,7 @@ export const github = async ({
         );
       }
 
-      const githubCodeFile = await GithubCodeFile.findOne({
+      const githubCodeFile = await GithubCodeFileModel.findOne({
         where: {
           connectorId: connector.id,
           repoId: args.repoId,
@@ -395,7 +395,7 @@ export const github = async ({
         throw new Error("Missing --documentId argument");
       }
 
-      const githubCodeRepository = await GithubCodeRepository.findOne({
+      const githubCodeRepository = await GithubCodeRepositoryModel.findOne({
         where: {
           connectorId: connector.id,
           repoId: args.repoId,
@@ -407,7 +407,7 @@ export const github = async ({
         );
       }
 
-      const githubCodeFile = await GithubCodeFile.findOne({
+      const githubCodeFile = await GithubCodeFileModel.findOne({
         where: {
           connectorId: connector.id,
           repoId: args.repoId,
@@ -432,7 +432,7 @@ export const github = async ({
     }
 
     case "clear-installation-id": {
-      const connectorState = await GithubConnectorState.findOne({
+      const connectorState = await GithubConnectorStateModel.findOne({
         where: {
           connectorId: connector.id,
         },

--- a/connectors/src/connectors/github/lib/code/directory_operations.ts
+++ b/connectors/src/connectors/github/lib/code/directory_operations.ts
@@ -6,7 +6,7 @@ import {
   getDirectoryUrl,
 } from "@connectors/connectors/github/lib/utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { GithubCodeDirectory } from "@connectors/lib/models/github";
+import { GithubCodeDirectoryModel } from "@connectors/lib/models/github";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
@@ -87,7 +87,7 @@ export async function upsertCodeDirectory({
   });
 
   // Find or create directory in database.
-  let githubCodeDirectory = await GithubCodeDirectory.findOne({
+  let githubCodeDirectory = await GithubCodeDirectoryModel.findOne({
     where: {
       connectorId: connector.id,
       repoId: repoId.toString(),
@@ -96,7 +96,7 @@ export async function upsertCodeDirectory({
   });
 
   if (!githubCodeDirectory) {
-    githubCodeDirectory = await GithubCodeDirectory.create({
+    githubCodeDirectory = await GithubCodeDirectoryModel.create({
       codeUpdatedAt: codeSyncStartedAt,
       connectorId: connector.id,
       createdAt: codeSyncStartedAt,

--- a/connectors/src/connectors/github/lib/code/file_operations.ts
+++ b/connectors/src/connectors/github/lib/code/file_operations.ts
@@ -13,7 +13,7 @@ import {
   upsertDataSourceDocument,
 } from "@connectors/lib/data_sources";
 import { DataSourceQuotaExceededError } from "@connectors/lib/error";
-import { GithubCodeFile } from "@connectors/lib/models/github";
+import { GithubCodeFileModel } from "@connectors/lib/models/github";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
@@ -98,7 +98,7 @@ export async function upsertCodeFile({
   const sourceUrl = `${getRepoUrl(repoLogin, repoName)}/blob/${defaultBranch}/${relativePath}`;
 
   // Find file or create it with an empty contentHash.
-  const [githubCodeFile] = await GithubCodeFile.findOrCreate({
+  const [githubCodeFile] = await GithubCodeFileModel.findOrCreate({
     where: {
       connectorId: connector.id,
       repoId: repoId.toString(),

--- a/connectors/src/connectors/github/lib/code/garbage_collect.ts
+++ b/connectors/src/connectors/github/lib/code/garbage_collect.ts
@@ -6,8 +6,8 @@ import {
   deleteDataSourceFolder,
 } from "@connectors/lib/data_sources";
 import {
-  GithubCodeDirectory,
-  GithubCodeFile,
+  GithubCodeDirectoryModel,
+  GithubCodeFileModel,
 } from "@connectors/lib/models/github";
 import { heartbeat } from "@connectors/lib/temporal";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -23,7 +23,7 @@ export async function garbageCollectCodeSync(
   codeSyncStartedAt: Date,
   logger: Logger
 ) {
-  const filesToDelete = await GithubCodeFile.findAll({
+  const filesToDelete = await GithubCodeFileModel.findAll({
     where: {
       connectorId: connector.id,
       repoId: repoId.toString(),
@@ -58,7 +58,7 @@ export async function garbageCollectCodeSync(
     );
   }
 
-  const directoriesToDelete = await GithubCodeDirectory.findAll({
+  const directoriesToDelete = await GithubCodeDirectoryModel.findAll({
     where: {
       connectorId: connector.id,
       repoId: repoId.toString(),
@@ -87,7 +87,7 @@ export async function garbageCollectCodeSync(
       { concurrency: MAX_CONCURRENCY_DELETE }
     );
 
-    await GithubCodeDirectory.destroy({
+    await GithubCodeDirectoryModel.destroy({
       where: {
         connectorId: connector.id,
         repoId: repoId.toString(),

--- a/connectors/src/connectors/github/lib/hierarchy.ts
+++ b/connectors/src/connectors/github/lib/hierarchy.ts
@@ -3,7 +3,7 @@ import {
   getRepositoryInternalId,
   isGithubCodeDirId,
 } from "@connectors/connectors/github/lib/utils";
-import { GithubCodeDirectory } from "@connectors/lib/models/github";
+import { GithubCodeDirectoryModel } from "@connectors/lib/models/github";
 import type { ModelId } from "@connectors/types";
 
 export async function getGithubCodeDirectoryParentIds(
@@ -11,7 +11,7 @@ export async function getGithubCodeDirectoryParentIds(
   internalId: string,
   repoId: number
 ): Promise<string[]> {
-  const directory = await GithubCodeDirectory.findOne({
+  const directory = await GithubCodeDirectoryModel.findOne({
     where: {
       connectorId,
       internalId,

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -48,9 +48,9 @@ import {
 } from "@connectors/lib/data_sources";
 import { DataSourceQuotaExceededError } from "@connectors/lib/error";
 import {
-  GithubCodeRepository,
-  GithubDiscussion,
-  GithubIssue,
+  GithubCodeRepositoryModel,
+  GithubDiscussionModel,
+  GithubIssueModel,
 } from "@connectors/lib/models/github";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { getTemporalClient } from "@connectors/lib/temporal";
@@ -250,7 +250,7 @@ export async function githubUpsertIssueActivity(
     ...loggerArgs,
   });
   logger.info("Upserting GitHub issue.");
-  const existingIssue = await GithubIssue.findOne({
+  const existingIssue = await GithubIssueModel.findOne({
     where: {
       repoId: repoId.toString(),
       issueNumber,
@@ -336,7 +336,7 @@ export async function githubUpsertIssueActivity(
   }
 
   logger.info("Upserting GitHub issue in DB.");
-  await GithubIssue.upsert({
+  await GithubIssueModel.upsert({
     repoId: repoId.toString(),
     issueNumber,
     connectorId: connector.id,
@@ -563,7 +563,7 @@ export async function githubUpsertDiscussionActivity(
   }
 
   logger.info("Upserting GitHub discussion in DB.");
-  await GithubDiscussion.upsert({
+  await GithubDiscussionModel.upsert({
     repoId: repoId.toString(),
     discussionNumber: discussionNumber,
     connectorId: connector.id,
@@ -698,7 +698,7 @@ export async function githubRepoGarbageCollectActivity(
   }
   const logger = getActivityLogger(connector, { repoId });
 
-  const issuesInRepo = await GithubIssue.findAll({
+  const issuesInRepo = await GithubIssueModel.findAll({
     where: {
       repoId,
       connectorId: connector.id,
@@ -722,7 +722,7 @@ export async function githubRepoGarbageCollectActivity(
     );
   }
 
-  const discussionsInRepo = await GithubDiscussion.findAll({
+  const discussionsInRepo = await GithubDiscussionModel.findAll({
     where: {
       repoId,
       connectorId: connector.id,
@@ -772,7 +772,7 @@ export async function githubRepoGarbageCollectActivity(
   });
 
   // Finally delete the repository object if it exists.
-  await GithubCodeRepository.destroy({
+  await GithubCodeRepositoryModel.destroy({
     where: {
       connectorId: connector.id,
       repoId: repoId.toString(),
@@ -787,7 +787,7 @@ async function deleteIssue(
   issueNumber: number,
   logger: Logger
 ) {
-  const issueInDb = await GithubIssue.findOne({
+  const issueInDb = await GithubIssueModel.findOne({
     where: {
       repoId: repoId.toString(),
       issueNumber,
@@ -810,7 +810,7 @@ async function deleteIssue(
 
   if (issueInDb) {
     logger.info("Deleting GitHub issue from database.");
-    await GithubIssue.destroy({
+    await GithubIssueModel.destroy({
       where: {
         repoId: repoId.toString(),
         issueNumber,
@@ -827,7 +827,7 @@ async function deleteDiscussion(
   discussionNumber: number,
   logger: Logger
 ) {
-  const discussionInDb = await GithubDiscussion.findOne({
+  const discussionInDb = await GithubDiscussionModel.findOne({
     where: {
       repoId: repoId.toString(),
       discussionNumber,
@@ -854,7 +854,7 @@ async function deleteDiscussion(
   );
 
   logger.info({ documentId }, "Deleting GitHub discussion from database.");
-  await GithubDiscussion.destroy({
+  await GithubDiscussionModel.destroy({
     where: {
       repoId: repoId.toString(),
       discussionNumber: discussionNumber,

--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -29,8 +29,8 @@ import {
 } from "@connectors/lib/data_sources";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
-  GithubCodeRepository,
-  GithubConnectorState,
+  GithubCodeRepositoryModel,
+  GithubConnectorStateModel,
 } from "@connectors/lib/models/github";
 import { heartbeat } from "@connectors/lib/temporal";
 import { getActivityLogger } from "@connectors/logger/logger";
@@ -91,7 +91,7 @@ export async function githubExtractToGcsActivity({
     });
 
     // Finally delete the repository object if it exists.
-    await GithubCodeRepository.destroy({
+    await GithubCodeRepositoryModel.destroy({
       where: {
         connectorId: connector.id,
         repoId: repoId.toString(),
@@ -400,7 +400,7 @@ export async function githubCleanupCodeSyncActivity({
 
   // No need to delete the GCS repository, it will be deleted by the bucket lifecycle policy.
 
-  const githubCodeRepository = await GithubCodeRepository.findOne({
+  const githubCodeRepository = await GithubCodeRepositoryModel.findOne({
     where: {
       connectorId: connector.id,
       repoId: repoId.toString(),
@@ -445,7 +445,7 @@ export async function githubEnsureCodeSyncEnabledActivity({
     activityName: "githubEnsureCodeSyncEnabledActivity",
   });
 
-  const connectorState = await GithubConnectorState.findOne({
+  const connectorState = await GithubConnectorStateModel.findOne({
     where: {
       connectorId: connector.id,
     },
@@ -476,7 +476,7 @@ export async function githubEnsureCodeSyncEnabledActivity({
     });
 
     // Finally delete the repository object if it exists.
-    await GithubCodeRepository.destroy({
+    await GithubCodeRepositoryModel.destroy({
       where: {
         connectorId: connector.id,
         repoId: repoId.toString(),
@@ -486,7 +486,7 @@ export async function githubEnsureCodeSyncEnabledActivity({
     return false;
   }
 
-  let githubCodeRepository = await GithubCodeRepository.findOne({
+  let githubCodeRepository = await GithubCodeRepositoryModel.findOne({
     where: {
       connectorId: connector.id,
       repoId: repoId.toString(),
@@ -516,7 +516,7 @@ export async function githubEnsureCodeSyncEnabledActivity({
   });
 
   if (!githubCodeRepository) {
-    githubCodeRepository = await GithubCodeRepository.create({
+    githubCodeRepository = await GithubCodeRepositoryModel.create({
       connectorId: connector.id,
       repoId: repoId.toString(),
       repoLogin,

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -867,6 +867,7 @@ export function getSourceUrlForGoogleDriveSheet(
 ): string {
   const driveFileId =
     s instanceof GoogleDriveSheetModel ? s.driveFileId : s.spreadsheet.id;
-  const driveSheetId = s instanceof GoogleDriveSheetModel ? s.driveSheetId : s.id;
+  const driveSheetId =
+    s instanceof GoogleDriveSheetModel ? s.driveSheetId : s.id;
   return `https://docs.google.com/spreadsheets/d/${driveFileId}/edit#gid=${driveSheetId}`;
 }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -43,10 +43,10 @@ import {
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
-  GoogleDriveConfig,
-  GoogleDriveFiles,
-  GoogleDriveFolders,
-  GoogleDriveSheet,
+  GoogleDriveConfigModel,
+  GoogleDriveFilesModel,
+  GoogleDriveFoldersModel,
+  GoogleDriveSheetModel,
 } from "@connectors/lib/models/google_drive";
 import { syncSucceeded } from "@connectors/lib/sync_status";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
@@ -265,7 +265,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       if (filterPermission === "read") {
         if (parentDriveId === null) {
           // Return the list of folders explicitly selected by the user.
-          const folders = await GoogleDriveFolders.findAll({
+          const folders = await GoogleDriveFoldersModel.findAll({
             where: {
               connectorId: this.connectorId,
             },
@@ -286,7 +286,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
           return new Ok(nodes);
         } else {
           // Return the list of all folders and files synced in a parent folder.
-          const where: WhereOptions<InferAttributes<GoogleDriveFiles>> = {
+          const where: WhereOptions<InferAttributes<GoogleDriveFilesModel>> = {
             connectorId: this.connectorId,
             parentId: parentDriveId,
           };
@@ -298,12 +298,12 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
               "application/vnd.google-apps.spreadsheet",
             ];
           }
-          const folderOrFiles = await GoogleDriveFiles.findAll({
+          const folderOrFiles = await GoogleDriveFilesModel.findAll({
             where,
           });
-          let sheets: GoogleDriveSheet[] = [];
+          let sheets: GoogleDriveSheetModel[] = [];
           if (isTablesView) {
-            sheets = await GoogleDriveSheet.findAll({
+            sheets = await GoogleDriveSheetModel.findAll({
               where: {
                 connectorId: this.connectorId,
                 driveFileId: parentDriveId,
@@ -400,7 +400,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                   this.connectorId,
                   driveObject.id
                 ),
-                permission: (await GoogleDriveFolders.findOne({
+                permission: (await GoogleDriveFoldersModel.findOne({
                   where: {
                     connectorId: this.connectorId,
                     folderId: driveObject.id,
@@ -495,7 +495,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
                   driveObject.id
                 ),
                 lastUpdatedAt: driveObject.updatedAtMs || null,
-                permission: (await GoogleDriveFolders.findOne({
+                permission: (await GoogleDriveFoldersModel.findOne({
                   where: {
                     connectorId: this.connectorId,
                     folderId: driveObject.id,
@@ -554,7 +554,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       const id = getDriveFileId(internalId);
       if (permission === "none") {
         removedFolderIds.push(id);
-        await GoogleDriveFolders.destroy({
+        await GoogleDriveFoldersModel.destroy({
           where: {
             connectorId: this.connectorId,
             folderId: id,
@@ -562,7 +562,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         });
       } else if (permission === "read") {
         addedFolderIds.push(id);
-        await GoogleDriveFolders.upsert({
+        await GoogleDriveFoldersModel.upsert({
           connectorId: this.connectorId,
           folderId: id,
         });
@@ -613,7 +613,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         new Error(`Connector not found with id ${this.connectorId}`)
       );
     }
-    const config = await GoogleDriveConfig.findOne({
+    const config = await GoogleDriveConfigModel.findOne({
       where: { connectorId: this.connectorId },
     });
     if (!config) {
@@ -741,7 +741,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         new Error(`Connector not found with id ${this.connectorId}`)
       );
     }
-    const config = await GoogleDriveConfig.findOne({
+    const config = await GoogleDriveConfigModel.findOne({
       where: { connectorId: this.connectorId },
     });
     if (!config) {
@@ -812,7 +812,7 @@ async function getFoldersAsContentNodes({
   viewType,
 }: {
   authCredentials: OAuth2Client;
-  folders: GoogleDriveFolders[];
+  folders: GoogleDriveFoldersModel[];
   viewType: ContentNodesViewType;
 }) {
   return concurrentExecutor(
@@ -849,9 +849,9 @@ async function getFoldersAsContentNodes({
 }
 
 export function getSourceUrlForGoogleDriveFiles(
-  f: GoogleDriveFiles | GoogleDriveObjectType
+  f: GoogleDriveFilesModel | GoogleDriveObjectType
 ): string {
-  const driveFileId = f instanceof GoogleDriveFiles ? f.driveFileId : f.id;
+  const driveFileId = f instanceof GoogleDriveFilesModel ? f.driveFileId : f.id;
 
   if (isGoogleDriveSpreadSheetFile(f)) {
     return `https://docs.google.com/spreadsheets/d/${driveFileId}/edit`;
@@ -863,10 +863,10 @@ export function getSourceUrlForGoogleDriveFiles(
 }
 
 export function getSourceUrlForGoogleDriveSheet(
-  s: GoogleDriveSheet | Sheet
+  s: GoogleDriveSheetModel | Sheet
 ): string {
   const driveFileId =
-    s instanceof GoogleDriveSheet ? s.driveFileId : s.spreadsheet.id;
-  const driveSheetId = s instanceof GoogleDriveSheet ? s.driveSheetId : s.id;
+    s instanceof GoogleDriveSheetModel ? s.driveFileId : s.spreadsheet.id;
+  const driveSheetId = s instanceof GoogleDriveSheetModel ? s.driveSheetId : s.id;
   return `https://docs.google.com/spreadsheets/d/${driveFileId}/edit#gid=${driveSheetId}`;
 }

--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -27,9 +27,9 @@ import {
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { throwOnError } from "@connectors/lib/cli";
 import {
-  GoogleDriveConfig,
-  GoogleDriveFiles,
-  GoogleDriveFolders,
+  GoogleDriveConfigModel,
+  GoogleDriveFilesModel,
+  GoogleDriveFoldersModel,
 } from "@connectors/lib/models/google_drive";
 import { terminateWorkflow } from "@connectors/lib/temporal";
 import { default as topLogger } from "@connectors/logger/logger";
@@ -179,7 +179,7 @@ export const google_drive = async ({
 
       // Upsert parents if missing
       for (const parent of reversedParents) {
-        const file = await GoogleDriveFiles.findOne({
+        const file = await GoogleDriveFilesModel.findOne({
           where: {
             connectorId: connector.id,
             driveFileId: parent,
@@ -241,7 +241,7 @@ export const google_drive = async ({
         if (!connectorResource) {
           throw new Error("Connector not found");
         }
-        const existingFile = await GoogleDriveFiles.findOne({
+        const existingFile = await GoogleDriveFilesModel.findOne({
           where: {
             driveFileId: getDriveFileId(fileId),
             connectorId: connector.id,
@@ -275,7 +275,7 @@ export const google_drive = async ({
       if (!args.fileId) {
         throw new Error("Missing --fileId argument");
       }
-      const file = await GoogleDriveFiles.findOne({
+      const file = await GoogleDriveFilesModel.findOne({
         where: {
           connectorId: connector.id,
           dustFileId: args.fileId,
@@ -325,7 +325,7 @@ export const google_drive = async ({
         throw new Error("Missing --fileId argument");
       }
 
-      const existingFile = await GoogleDriveFiles.findOne({
+      const existingFile = await GoogleDriveFilesModel.findOne({
         where: {
           driveFileId: args.fileId,
           connectorId: connector.id,
@@ -336,7 +336,7 @@ export const google_drive = async ({
           skipReason: args.reason || "blacklisted",
         });
       } else {
-        await GoogleDriveFiles.create({
+        await GoogleDriveFilesModel.create({
           driveFileId: args.fileId,
           dustFileId: getInternalId(args.fileId),
           name: "unknown",
@@ -351,7 +351,7 @@ export const google_drive = async ({
 
     case "export-folder-structure": {
       const connector = await getConnector(args);
-      const config = await GoogleDriveConfig.findOne({
+      const config = await GoogleDriveConfigModel.findOne({
         where: {
           connectorId: connector.id,
         },
@@ -366,7 +366,7 @@ export const google_drive = async ({
       const drive = await getDriveClient(authCredentials);
 
       // Get all folders configured to sync
-      const foldersToSync = await GoogleDriveFolders.findAll({
+      const foldersToSync = await GoogleDriveFoldersModel.findAll({
         where: {
           connectorId: connector.id,
         },
@@ -411,7 +411,7 @@ export const google_drive = async ({
         });
 
         // Get lastSeenTs from database if it exists
-        const folderFile = await GoogleDriveFiles.findOne({
+        const folderFile = await GoogleDriveFilesModel.findOne({
           where: {
             connectorId: connector.id,
             driveFileId: folderId,

--- a/connectors/src/connectors/google_drive/lib/hierarchy.ts
+++ b/connectors/src/connectors/google_drive/lib/hierarchy.ts
@@ -2,7 +2,7 @@ import type { OAuth2Client } from "googleapis-common";
 import { Op } from "sequelize";
 
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
-import { GoogleDriveFolders } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFoldersModel } from "@connectors/lib/models/google_drive";
 import mainLogger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
 import type { GoogleDriveObjectType } from "@connectors/types";
@@ -54,7 +54,7 @@ async function getFileParents(
   }
 
   // Avoid inserting parents outside of what we sync by checking GoogleDriveFolder.
-  const syncedFolders = await GoogleDriveFolders.findAll({
+  const syncedFolders = await GoogleDriveFoldersModel.findAll({
     where: {
       connectorId: connectorId,
       folderId: {

--- a/connectors/src/connectors/google_drive/lib/permissions.ts
+++ b/connectors/src/connectors/google_drive/lib/permissions.ts
@@ -1,7 +1,7 @@
 import { isGoogleDriveFolder } from "@connectors/connectors/google_drive/temporal/mime_types";
-import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import type { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 
-export function getPermissionViewType(file: GoogleDriveFiles) {
+export function getPermissionViewType(file: GoogleDriveFilesModel) {
   if (isGoogleDriveFolder(file)) {
     return "folder";
   }

--- a/connectors/src/connectors/google_drive/temporal/activities/common/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/common/utils.ts
@@ -10,8 +10,8 @@ import {
   getMyDriveIdCached,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import {
-  GoogleDriveFiles,
-  GoogleDriveSyncToken,
+  GoogleDriveFilesModel,
+  GoogleDriveSyncTokenModel,
 } from "@connectors/lib/models/google_drive";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -21,7 +21,7 @@ export async function deleteOneFile(
   connectorId: ModelId,
   file: GoogleDriveObjectType
 ) {
-  const googleDriveFile = await GoogleDriveFiles.findOne({
+  const googleDriveFile = await GoogleDriveFilesModel.findOne({
     where: {
       connectorId: connectorId,
       driveFileId: file.id,
@@ -34,7 +34,7 @@ export async function deleteOneFile(
   await deleteFile(googleDriveFile);
 }
 
-export async function deleteFile(googleDriveFile: GoogleDriveFiles) {
+export async function deleteFile(googleDriveFile: GoogleDriveFilesModel) {
   const connectorId = googleDriveFile.connectorId;
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -100,7 +100,7 @@ export async function getSyncPageToken(
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);
   }
-  const last = await GoogleDriveSyncToken.findOne({
+  const last = await GoogleDriveSyncTokenModel.findOne({
     where: {
       connectorId: connectorId,
       driveId: driveId,

--- a/connectors/src/connectors/google_drive/temporal/activities/fix_parents_consistency_activity.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/fix_parents_consistency_activity.ts
@@ -1,7 +1,7 @@
 import { Op } from "sequelize";
 
 import { fixParentsConsistency } from "@connectors/connectors/google_drive/lib";
-import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
@@ -25,7 +25,7 @@ export async function fixParentsConsistencyActivity({
   const localLogger = getActivityLogger(connector);
 
   const limit = 1000;
-  const files = await GoogleDriveFiles.findAll({
+  const files = await GoogleDriveFilesModel.findAll({
     where: {
       connectorId: connector.id,
       id: { [Op.gt]: fromId },

--- a/connectors/src/connectors/google_drive/temporal/activities/garbage_collector.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/garbage_collector.ts
@@ -11,7 +11,7 @@ import {
 } from "@connectors/connectors/google_drive/temporal/activities/common/utils";
 import { getFoldersToSync } from "@connectors/connectors/google_drive/temporal/activities/get_folders_to_sync";
 import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
-import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
@@ -37,7 +37,7 @@ export async function garbageCollector(
 
   const ts = lastSeenTs || Date.now();
 
-  const files = await GoogleDriveFiles.findAll({
+  const files = await GoogleDriveFilesModel.findAll({
     where: {
       connectorId: connectorId,
       lastSeenTs: { [Op.or]: [{ [Op.lt]: new Date(lastSeenTs) }, null] },

--- a/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
@@ -2,7 +2,7 @@ import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/go
 import type { LightGoogleDrive } from "@connectors/connectors/google_drive/temporal/activities/common/types";
 import { getDrives } from "@connectors/connectors/google_drive/temporal/activities/common/utils";
 import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
-import { GoogleDriveFolders } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFoldersModel } from "@connectors/lib/models/google_drive";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
@@ -10,7 +10,7 @@ import type { ModelId } from "@connectors/types";
 export async function getDrivesToSync(
   connectorId: ModelId
 ): Promise<LightGoogleDrive[]> {
-  const selectedFolders = await GoogleDriveFolders.findAll({
+  const selectedFolders = await GoogleDriveFoldersModel.findAll({
     where: {
       connectorId: connectorId,
     },

--- a/connectors/src/connectors/google_drive/temporal/activities/get_folders_to_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/get_folders_to_sync.ts
@@ -1,8 +1,8 @@
-import { GoogleDriveFolders } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFoldersModel } from "@connectors/lib/models/google_drive";
 import type { ModelId } from "@connectors/types";
 
 export async function getFoldersToSync(connectorId: ModelId) {
-  const folders = await GoogleDriveFolders.findAll({
+  const folders = await GoogleDriveFoldersModel.findAll({
     where: {
       connectorId: connectorId,
     },

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -24,9 +24,9 @@ import {
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
-  GoogleDriveConfig,
-  GoogleDriveFiles,
-  GoogleDriveSyncToken,
+  GoogleDriveConfigModel,
+  GoogleDriveFilesModel,
+  GoogleDriveSyncTokenModel,
 } from "@connectors/lib/models/google_drive";
 import { heartbeat } from "@connectors/lib/temporal";
 import type { Logger } from "@connectors/logger/logger";
@@ -66,7 +66,7 @@ export async function incrementalSync(
         isSharedDrive
       );
     }
-    const config = await GoogleDriveConfig.findOne({
+    const config = await GoogleDriveConfigModel.findOne({
       where: {
         connectorId: connectorId,
       },
@@ -164,7 +164,7 @@ export async function incrementalSync(
       ) {
         // The current file is not in the list of selected folders.
         // If we have it locally, we need to garbage collect it.
-        const localFile = await GoogleDriveFiles.findOne({
+        const localFile = await GoogleDriveFilesModel.findOne({
           where: {
             connectorId: connectorId,
             driveFileId: change.file.id,
@@ -214,7 +214,7 @@ export async function incrementalSync(
           driveFile,
           startSyncTs
         );
-        const localFolder = await GoogleDriveFiles.findOne({
+        const localFolder = await GoogleDriveFilesModel.findOne({
           where: {
             connectorId: connectorId,
             driveFileId: change.file.id,
@@ -274,7 +274,7 @@ export async function incrementalSync(
       ? changesRes.data.nextPageToken
       : undefined;
     if (changesRes.data.newStartPageToken) {
-      await GoogleDriveSyncToken.upsert({
+      await GoogleDriveSyncTokenModel.upsert({
         connectorId: connectorId,
         driveId: driveId,
         syncToken: changesRes.data.newStartPageToken,
@@ -320,12 +320,12 @@ export async function incrementalSync(
 
 async function recurseUpdateParents(
   connector: ConnectorResource,
-  file: GoogleDriveFiles,
+  file: GoogleDriveFilesModel,
   parentIds: string[],
   logger: Logger
 ) {
   await heartbeat();
-  const children = await GoogleDriveFiles.findAll({
+  const children = await GoogleDriveFilesModel.findAll({
     where: {
       connectorId: connector.id,
       parentId: file.driveFileId,

--- a/connectors/src/connectors/google_drive/temporal/activities/mark_folder_as_visited.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/mark_folder_as_visited.ts
@@ -8,7 +8,7 @@ import {
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
@@ -61,7 +61,7 @@ export async function markFolderAsVisited(
     sourceUrl: getSourceUrlForGoogleDriveFiles(file),
   });
 
-  await GoogleDriveFiles.upsert({
+  await GoogleDriveFilesModel.upsert({
     connectorId: connectorId,
     dustFileId: getInternalId(driveFileId),
     driveFileId: file.id,

--- a/connectors/src/connectors/google_drive/temporal/activities/populate_sync_tokens.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/populate_sync_tokens.ts
@@ -3,7 +3,7 @@ import {
   getDrives,
   getSyncPageToken,
 } from "@connectors/connectors/google_drive/temporal/activities/common/utils";
-import { GoogleDriveSyncToken } from "@connectors/lib/models/google_drive";
+import { GoogleDriveSyncTokenModel } from "@connectors/lib/models/google_drive";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
@@ -19,7 +19,7 @@ export async function populateSyncTokens(connectorId: ModelId) {
       drive.id,
       drive.isSharedDrive
     );
-    await GoogleDriveSyncToken.upsert({
+    await GoogleDriveSyncTokenModel.upsert({
       connectorId: connectorId,
       driveId: drive.id,
       syncToken: lastSyncToken,
@@ -31,7 +31,7 @@ export async function populateSyncTokens(connectorId: ModelId) {
     GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID,
     false
   );
-  await GoogleDriveSyncToken.upsert({
+  await GoogleDriveSyncTokenModel.upsert({
     connectorId,
     driveId: GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID,
     syncToken: userLandSyncToken,

--- a/connectors/src/connectors/google_drive/temporal/activities/should_garbage_collect.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/should_garbage_collect.ts
@@ -1,6 +1,6 @@
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
-import { GoogleDriveFolders } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFoldersModel } from "@connectors/lib/models/google_drive";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
@@ -8,7 +8,7 @@ import type { ModelId } from "@connectors/types";
 // supposed to sync.
 // If we don't have access to one of them, we should garbage collect.
 export async function shouldGarbageCollect(connectorId: ModelId) {
-  const selectedFolder = await GoogleDriveFolders.findAll({
+  const selectedFolder = await GoogleDriveFoldersModel.findAll({
     where: {
       connectorId: connectorId,
     },

--- a/connectors/src/connectors/google_drive/temporal/activities/sync_files.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/sync_files.ts
@@ -14,8 +14,8 @@ import {
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
-  GoogleDriveConfig,
-  GoogleDriveFiles,
+  GoogleDriveConfigModel,
+  GoogleDriveFilesModel,
 } from "@connectors/lib/models/google_drive";
 import { heartbeat } from "@connectors/lib/temporal";
 import { getActivityLogger } from "@connectors/logger/logger";
@@ -38,7 +38,7 @@ export async function syncFiles(
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);
   }
-  const config = await GoogleDriveConfig.findOne({
+  const config = await GoogleDriveConfigModel.findOne({
     where: {
       connectorId: connectorId,
     },
@@ -87,7 +87,7 @@ export async function syncFiles(
   }
   if (nextPageToken === undefined) {
     // On the first page of a folder id, we can check if we already visited it
-    const visitedFolder = await GoogleDriveFiles.findOne({
+    const visitedFolder = await GoogleDriveFilesModel.findOne({
       where: {
         connectorId: connectorId,
         driveFileId: driveFolder.id,

--- a/connectors/src/connectors/google_drive/temporal/file/sync_one_file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/sync_one_file.ts
@@ -11,8 +11,8 @@ import {
   MAX_LARGE_DOCUMENT_TXT_LEN,
 } from "@connectors/lib/data_sources";
 import {
-  GoogleDriveConfig,
-  GoogleDriveFiles,
+  GoogleDriveConfigModel,
+  GoogleDriveFilesModel,
 } from "@connectors/lib/models/google_drive";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -44,14 +44,14 @@ export async function syncOneFile(
       if (!connector) {
         throw new Error(`Connector ${connectorId} not found`);
       }
-      const config = await GoogleDriveConfig.findOne({
+      const config = await GoogleDriveConfigModel.findOne({
         where: {
           connectorId,
         },
       });
 
       const documentId = getInternalId(file.id);
-      const fileInDb = await GoogleDriveFiles.findOne({
+      const fileInDb = await GoogleDriveFilesModel.findOne({
         where: { connectorId, driveFileId: file.id },
       });
 

--- a/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
@@ -10,7 +10,7 @@ import {
 } from "@connectors/connectors/google_drive/temporal/mime_types";
 import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
-import type { GoogleDriveConfig } from "@connectors/lib/models/google_drive";
+import type { GoogleDriveConfigModel } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
 import type {
   DataSourceConfig,
@@ -24,7 +24,7 @@ export async function syncOneFileTextDocument(
   oauth2client: OAuth2Client,
   file: GoogleDriveObjectType,
   localLogger: Logger,
-  config: GoogleDriveConfig | null,
+  config: GoogleDriveConfigModel | null,
   dataSourceConfig: DataSourceConfig,
   startSyncTs: number,
   isBatchSync: boolean,

--- a/connectors/src/connectors/google_drive/temporal/file/update_google_drive_files.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/update_google_drive_files.ts
@@ -1,6 +1,6 @@
 import type { CreationAttributes } from "sequelize";
 
-import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
 
 export async function updateGoogleDriveFiles(
@@ -10,7 +10,7 @@ export async function updateGoogleDriveFiles(
   skipReason: string | undefined,
   upsertTimestampMs: number | undefined
 ): Promise<void> {
-  const params: CreationAttributes<GoogleDriveFiles> = {
+  const params: CreationAttributes<GoogleDriveFilesModel> = {
     connectorId,
     dustFileId: documentId,
     driveFileId: file.id,
@@ -25,5 +25,5 @@ export async function updateGoogleDriveFiles(
     params.lastUpsertedTs = new Date(upsertTimestampMs);
   }
 
-  await GoogleDriveFiles.upsert(params);
+  await GoogleDriveFilesModel.upsert(params);
 }

--- a/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/google_drive/temporal/spreadsheets.ts
@@ -23,8 +23,8 @@ import {
   upsertDataSourceTableFromCsv,
 } from "@connectors/lib/data_sources";
 import { ProviderWorkflowError, TablesError } from "@connectors/lib/error";
-import type { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
-import { GoogleDriveSheet } from "@connectors/lib/models/google_drive";
+import type { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
+import { GoogleDriveSheetModel } from "@connectors/lib/models/google_drive";
 import type { Logger } from "@connectors/logger/logger";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -53,7 +53,7 @@ async function upsertSheetInDb(
   sheet: Sheet,
   upsertError: TablesError | null
 ) {
-  await GoogleDriveSheet.upsert({
+  await GoogleDriveSheetModel.upsert({
     connectorId: connector.id,
     driveFileId: sheet.spreadsheet.id,
     driveSheetId: sheet.id,
@@ -503,7 +503,7 @@ export async function syncSpreadSheet(
       );
 
       // List synced sheets.
-      const syncedSheets = await GoogleDriveSheet.findAll({
+      const syncedSheets = await GoogleDriveSheetModel.findAll({
         where: {
           connectorId: connector.id,
           driveFileId: file.id,
@@ -565,7 +565,7 @@ export async function syncSpreadSheet(
 
 async function deleteSheetForSpreadsheet(
   connector: ConnectorResource,
-  sheet: GoogleDriveSheet,
+  sheet: GoogleDriveSheetModel,
   spreadsheetFileId: string
 ) {
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
@@ -598,7 +598,7 @@ async function deleteSheetForSpreadsheet(
 
 async function deleteAllSheets(
   connector: ConnectorResource,
-  sheetsToDelete: GoogleDriveSheet[],
+  sheetsToDelete: GoogleDriveSheetModel[],
   spreadsheetFile: { driveFileId: string }
 ) {
   await concurrentExecutor(
@@ -613,9 +613,9 @@ async function deleteAllSheets(
 
 export async function deleteSpreadsheet(
   connector: ConnectorResource,
-  file: GoogleDriveFiles
+  file: GoogleDriveFilesModel
 ) {
-  const sheetsInSpreadsheet = await GoogleDriveSheet.findAll({
+  const sheetsInSpreadsheet = await GoogleDriveSheetModel.findAll({
     where: {
       driveFileId: file.driveFileId,
       connectorId: connector.id,

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -459,7 +459,9 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       pageNodes = pageNodes.filter((p) => p.expandable);
     }
 
-    const getDbNodes = async (db: NotionDatabaseModel): Promise<ContentNode> => {
+    const getDbNodes = async (
+      db: NotionDatabaseModel
+    ): Promise<ContentNode> => {
       return {
         internalId: nodeIdFromNotionId(db.notionDatabaseId),
         parentInternalId:

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -21,9 +21,9 @@ import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import {
-  NotionConnectorState,
-  NotionDatabase,
-  NotionPage,
+  NotionConnectorStateModel,
+  NotionDatabaseModel,
+  NotionPageModel,
 } from "@connectors/lib/models/notion";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -195,7 +195,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
         throw new Error("Error retrieving connection info to update connector");
       }
 
-      const connectorState = await NotionConnectorState.findOne({
+      const connectorState = await NotionConnectorStateModel.findOne({
         where: {
           connectorId: c.id,
         },
@@ -344,7 +344,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
 
-    const notionConnectorState = await NotionConnectorState.findOne({
+    const notionConnectorState = await NotionConnectorStateModel.findOne({
       where: {
         connectorId: this.connectorId,
       },
@@ -419,13 +419,13 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       (parentInternalId && notionIdFromNodeId(parentInternalId)) || "workspace";
 
     const [pages, dbs] = await Promise.all([
-      NotionPage.findAll({
+      NotionPageModel.findAll({
         where: {
           connectorId: this.connectorId,
           parentId: notionId,
         },
       }),
-      NotionDatabase.findAll({
+      NotionDatabaseModel.findAll({
         where: {
           connectorId: this.connectorId,
           parentId: notionId,
@@ -434,7 +434,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     ]);
 
     const hasChildrenByPageId = await hasChildren(pages, this.connectorId);
-    const getPageNode = async (page: NotionPage): Promise<ContentNode> => {
+    const getPageNode = async (page: NotionPageModel): Promise<ContentNode> => {
       const expandable = Boolean(hasChildrenByPageId[page.notionPageId]);
 
       return {
@@ -459,7 +459,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       pageNodes = pageNodes.filter((p) => p.expandable);
     }
 
-    const getDbNodes = async (db: NotionDatabase): Promise<ContentNode> => {
+    const getDbNodes = async (db: NotionDatabaseModel): Promise<ContentNode> => {
       return {
         internalId: nodeIdFromNotionId(db.notionDatabaseId),
         parentInternalId:
@@ -539,7 +539,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error(`Connector ${this.connectorId} not found`));
     }
 
-    const notionConnectorState = await NotionConnectorState.findOne({
+    const notionConnectorState = await NotionConnectorStateModel.findOne({
       where: { connectorId: connector.id },
     });
 
@@ -572,7 +572,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error(`Connector ${this.connectorId} not found`));
     }
 
-    const notionConnectorState = await NotionConnectorState.findOne({
+    const notionConnectorState = await NotionConnectorStateModel.findOne({
       where: { connectorId: connector.id },
     });
 

--- a/connectors/src/connectors/notion/lib/access_token.ts
+++ b/connectors/src/connectors/notion/lib/access_token.ts
@@ -1,5 +1,5 @@
 import { apiConfig } from "@connectors/lib/api/config";
-import { NotionConnectorState } from "@connectors/lib/models/notion";
+import { NotionConnectorStateModel } from "@connectors/lib/models/notion";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -14,7 +14,7 @@ export async function getNotionAccessToken(
   // Fetch connector and notion connector state concurrently
   const [connector, notionConnectorState] = await Promise.all([
     ConnectorResource.fetchById(connectorId),
-    NotionConnectorState.findOne({
+    NotionConnectorStateModel.findOne({
       where: { connectorId },
     }),
   ]);

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -20,7 +20,7 @@ import {
   upsertDatabaseWorkflow,
   upsertPageWorkflow,
 } from "@connectors/connectors/notion/temporal/workflows/admins";
-import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
+import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { default as topLogger } from "@connectors/logger/logger";
@@ -69,7 +69,7 @@ const getConnector = async (args: NotionCommandType["args"]) => {
 };
 
 async function listSkippedDatabaseIdsForConnectorId(connectorId: ModelId) {
-  const skippedDatabases = await NotionDatabase.findAll({
+  const skippedDatabases = await NotionDatabaseModel.findAll({
     where: {
       connectorId: connectorId,
       skipReason: {
@@ -121,7 +121,7 @@ export async function findNotionUrl({
 }): Promise<NotionFindUrlResponseType> {
   const pageOrDbId = pageOrDbIdFromUrl(url);
 
-  const page = await NotionPage.findOne({
+  const page = await NotionPageModel.findOne({
     where: {
       notionPageId: pageOrDbId,
       connectorId,
@@ -135,7 +135,7 @@ export async function findNotionUrl({
     logger.info({ pageOrDbId, url }, "findNotionUrl: Page not found");
   }
 
-  const db = await NotionDatabase.findOne({
+  const db = await NotionDatabaseModel.findOne({
     where: {
       notionDatabaseId: pageOrDbId,
       connectorId,
@@ -161,7 +161,7 @@ export async function deleteNotionUrl({
 }) {
   const pageOrDbId = pageOrDbIdFromUrl(url);
 
-  const page = await NotionPage.findOne({
+  const page = await NotionPageModel.findOne({
     where: {
       notionPageId: pageOrDbId,
       connectorId: connector.id,
@@ -186,7 +186,7 @@ export async function deleteNotionUrl({
     }
   }
 
-  const db = await NotionDatabase.findOne({
+  const db = await NotionDatabaseModel.findOne({
     where: {
       notionDatabaseId: pageOrDbId,
       connectorId: connector.id,
@@ -307,7 +307,7 @@ export const notion = async ({
       const pageId = parseNotionResourceId(args.pageId);
 
       const connectorId = connector.id;
-      const existingPage = await NotionPage.findOne({
+      const existingPage = await NotionPageModel.findOne({
         where: {
           notionPageId: pageId,
           connectorId: connector.id,
@@ -335,7 +335,7 @@ export const notion = async ({
           skipReason,
         });
       } else {
-        await NotionPage.create({
+        await NotionPageModel.create({
           notionPageId: pageId,
           skipReason,
           connectorId,
@@ -355,7 +355,7 @@ export const notion = async ({
 
       const connectorId = connector.id;
 
-      const existingDatabase = await NotionDatabase.findOne({
+      const existingDatabase = await NotionDatabaseModel.findOne({
         where: {
           notionDatabaseId: databaseId,
           connectorId,
@@ -400,7 +400,7 @@ export const notion = async ({
         `[Admin] Creating new skipped database ${databaseId} with reason ${skipReason}`
       );
 
-      await NotionDatabase.create({
+      await NotionDatabaseModel.create({
         notionDatabaseId: databaseId,
         skipReason,
         connectorId,

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -20,7 +20,10 @@ import {
   upsertDatabaseWorkflow,
   upsertPageWorkflow,
 } from "@connectors/connectors/notion/temporal/workflows/admins";
-import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
+import {
+  NotionDatabaseModel,
+  NotionPageModel,
+} from "@connectors/lib/models/notion";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { default as topLogger } from "@connectors/logger/logger";

--- a/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
+++ b/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
@@ -1,4 +1,4 @@
-import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
+import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 import type { DataSourceInfo } from "@connectors/types";
@@ -26,12 +26,12 @@ export async function upsertNotionPageInConnectorsDb({
   lastUpsertedTs?: number;
   skipReason?: string;
   lastCreatedOrMovedRunTs?: number;
-}): Promise<NotionPage> {
+}): Promise<NotionPageModel> {
   const connector = await ConnectorResource.findByDataSource(dataSourceInfo);
   if (!connector || connector.type !== "notion") {
     throw new Error("Could not find connector");
   }
-  const page = await NotionPage.findOne({
+  const page = await NotionPageModel.findOne({
     where: {
       notionPageId,
       connectorId: connector.id,
@@ -75,7 +75,7 @@ export async function upsertNotionPageInConnectorsDb({
   if (page) {
     return page.update(updateParams);
   } else {
-    return NotionPage.create({
+    return NotionPageModel.create({
       notionPageId,
       connectorId: connector.id,
       ...updateParams,
@@ -87,7 +87,7 @@ export async function getNotionPageFromConnectorsDb(
   connectorId: ModelId,
   notionPageId: string,
   lastSeenTs?: number
-): Promise<NotionPage | null> {
+): Promise<NotionPageModel | null> {
   const where: {
     notionPageId: string;
     connectorId: ModelId;
@@ -101,7 +101,7 @@ export async function getNotionPageFromConnectorsDb(
     where.lastSeenTs = new Date(lastSeenTs);
   }
 
-  return NotionPage.findOne({ where });
+  return NotionPageModel.findOne({ where });
 }
 
 // Note: this function does not let you "remove" a skipReason.
@@ -127,12 +127,12 @@ export async function upsertNotionDatabaseInConnectorsDb({
   skipReason?: string;
   lastCreatedOrMovedRunTs?: number;
   requestQueuingForUpsertToCore: boolean;
-}): Promise<NotionDatabase> {
+}): Promise<NotionDatabaseModel> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error("Could not find connector");
   }
-  const database = await NotionDatabase.findOne({
+  const database = await NotionDatabaseModel.findOne({
     where: {
       notionDatabaseId,
       connectorId: connector.id,
@@ -194,7 +194,7 @@ export async function upsertNotionDatabaseInConnectorsDb({
   if (database) {
     return database.update(updateParams);
   } else {
-    return NotionDatabase.create({
+    return NotionDatabaseModel.create({
       notionDatabaseId,
       connectorId: connector.id,
       firstSeenTs: new Date(runTimestamp),
@@ -207,7 +207,7 @@ export async function getNotionDatabaseFromConnectorsDb(
   connectorId: ModelId,
   notionDatabaseId: string,
   lastSeenTs?: number
-): Promise<NotionDatabase | null> {
+): Promise<NotionDatabaseModel | null> {
   const where: {
     notionDatabaseId: string;
     connectorId: ModelId;
@@ -221,7 +221,7 @@ export async function getNotionDatabaseFromConnectorsDb(
     where.lastSeenTs = new Date(lastSeenTs);
   }
 
-  return NotionDatabase.findOne({ where });
+  return NotionDatabaseModel.findOne({ where });
 }
 
 /**
@@ -232,8 +232,8 @@ export async function getNotionDatabaseFromConnectorsDb(
 export async function getPageChildrenOf(
   connectorId: ModelId,
   notionId: string
-): Promise<NotionPage[]> {
-  return NotionPage.findAll({
+): Promise<NotionPageModel[]> {
+  return NotionPageModel.findAll({
     where: {
       parentId: notionId,
       connectorId: connectorId,
@@ -249,8 +249,8 @@ export async function getPageChildrenOf(
 export async function getDatabaseChildrenOf(
   connectorId: ModelId,
   notionId: string
-): Promise<NotionDatabase[]> {
-  return NotionDatabase.findAll({
+): Promise<NotionDatabaseModel[]> {
+  return NotionDatabaseModel.findAll({
     where: {
       parentId: notionId,
       connectorId: connectorId,

--- a/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
+++ b/connectors/src/connectors/notion/lib/connectors_db_helpers.ts
@@ -1,4 +1,7 @@
-import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
+import {
+  NotionDatabaseModel,
+  NotionPageModel,
+} from "@connectors/lib/models/notion";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 import type { DataSourceInfo } from "@connectors/types";

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -10,7 +10,10 @@ import {
 } from "@connectors/connectors/notion/lib/connectors_db_helpers";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
-import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
+import {
+  NotionDatabaseModel,
+  NotionPageModel,
+} from "@connectors/lib/models/notion";
 import parentLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
@@ -301,14 +304,19 @@ async function getPagesAndDatabasesToUpdate(
   return pageAndDataBaseIdsToUpdate;
 }
 
-function notionPageOrDbId(pageOrDb: NotionPageModel | NotionDatabaseModel): string {
+function notionPageOrDbId(
+  pageOrDb: NotionPageModel | NotionDatabaseModel
+): string {
   return (
     (pageOrDb as NotionPageModel).notionPageId ||
     (pageOrDb as NotionDatabaseModel).notionDatabaseId
   );
 }
 
-export const hasChildren = async (pages: NotionPageModel[], connectorId: number) => {
+export const hasChildren = async (
+  pages: NotionPageModel[],
+  connectorId: number
+) => {
   const hasChildrenPage = (
     await NotionPageModel.findAll({
       attributes: [

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -10,7 +10,7 @@ import {
 } from "@connectors/connectors/notion/lib/connectors_db_helpers";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
-import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
+import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
 import parentLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
@@ -301,16 +301,16 @@ async function getPagesAndDatabasesToUpdate(
   return pageAndDataBaseIdsToUpdate;
 }
 
-function notionPageOrDbId(pageOrDb: NotionPage | NotionDatabase): string {
+function notionPageOrDbId(pageOrDb: NotionPageModel | NotionDatabaseModel): string {
   return (
-    (pageOrDb as NotionPage).notionPageId ||
-    (pageOrDb as NotionDatabase).notionDatabaseId
+    (pageOrDb as NotionPageModel).notionPageId ||
+    (pageOrDb as NotionDatabaseModel).notionDatabaseId
   );
 }
 
-export const hasChildren = async (pages: NotionPage[], connectorId: number) => {
+export const hasChildren = async (pages: NotionPageModel[], connectorId: number) => {
   const hasChildrenPage = (
-    await NotionPage.findAll({
+    await NotionPageModel.findAll({
       attributes: [
         "parentId",
         [Sequelize.fn("COUNT", Sequelize.col("*")), "count"],
@@ -327,7 +327,7 @@ export const hasChildren = async (pages: NotionPage[], connectorId: number) => {
   );
 
   const hasChildrenDb = (
-    await NotionDatabase.findAll({
+    await NotionDatabaseModel.findAll({
       attributes: [
         "parentId",
         [Sequelize.fn("COUNT", Sequelize.col("*")), "count"],
@@ -348,13 +348,13 @@ export const hasChildren = async (pages: NotionPage[], connectorId: number) => {
 
 export const getOrphanedCount = async (connectorId: number) => {
   const [orphanedPagesCount, orphanedDbsCount] = await Promise.all([
-    NotionPage.count({
+    NotionPageModel.count({
       where: {
         connectorId: connectorId,
         parentId: "unknown",
       },
     }),
-    NotionDatabase.count({
+    NotionDatabaseModel.count({
       where: {
         connectorId: connectorId,
         parentId: "unknown",

--- a/connectors/src/connectors/notion/lib/utils.ts
+++ b/connectors/src/connectors/notion/lib/utils.ts
@@ -5,7 +5,7 @@ import * as t from "io-ts";
 import type { Logger } from "pino";
 
 import { getParents } from "@connectors/connectors/notion/lib/parents";
-import { NotionDatabase, NotionPage } from "@connectors/lib/models/notion";
+import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
 
 // Define the type codec for the Notion OAuth response
 export const NotionOAuthResponse = t.type({
@@ -71,10 +71,10 @@ export async function buildNotionBreadcrumbs(
 
   const current =
     resourceType === "page"
-      ? await NotionPage.findOne({
+      ? await NotionPageModel.findOne({
           where: { notionPageId: pageOrDbId, connectorId },
         })
-      : await NotionDatabase.findOne({
+      : await NotionDatabaseModel.findOne({
           where: { notionDatabaseId: pageOrDbId, connectorId },
         });
 
@@ -87,7 +87,7 @@ export async function buildNotionBreadcrumbs(
   }
 
   for (const parentId of breadcrumbIds) {
-    const page = await NotionPage.findOne({
+    const page = await NotionPageModel.findOne({
       where: { notionPageId: parentId, connectorId },
     });
 
@@ -100,7 +100,7 @@ export async function buildNotionBreadcrumbs(
       continue;
     }
 
-    const db = await NotionDatabase.findOne({
+    const db = await NotionDatabaseModel.findOne({
       where: { notionDatabaseId: parentId, connectorId },
     });
 
@@ -122,10 +122,10 @@ export async function buildNotionBreadcrumbs(
   } else if (breadcrumbs.length > 1) {
     const firstParentId = breadcrumbIds[breadcrumbIds.length - 1];
     const firstParent =
-      (await NotionPage.findOne({
+      (await NotionPageModel.findOne({
         where: { notionPageId: firstParentId, connectorId },
       })) ||
-      (await NotionDatabase.findOne({
+      (await NotionDatabaseModel.findOne({
         where: { notionDatabaseId: firstParentId, connectorId },
       }));
 

--- a/connectors/src/connectors/notion/lib/utils.ts
+++ b/connectors/src/connectors/notion/lib/utils.ts
@@ -5,7 +5,10 @@ import * as t from "io-ts";
 import type { Logger } from "pino";
 
 import { getParents } from "@connectors/connectors/notion/lib/parents";
-import { NotionDatabaseModel, NotionPageModel } from "@connectors/lib/models/notion";
+import {
+  NotionDatabaseModel,
+  NotionPageModel,
+} from "@connectors/lib/models/notion";
 
 // Define the type codec for the Notion OAuth response
 export const NotionOAuthResponse = t.type({

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2225,7 +2225,10 @@ export async function renderAndUpsertPageFromCache({
     },
   });
 
-  const blocksByParentId: Record<string, NotionConnectorBlockCacheEntryModel[]> = {};
+  const blocksByParentId: Record<
+    string,
+    NotionConnectorBlockCacheEntryModel[]
+  > = {};
   for (const blockCacheEntry of blockCacheEntries) {
     blocksByParentId[blockCacheEntry.parentBlockId || "root"] = [
       ...(blocksByParentId[blockCacheEntry.parentBlockId || "root"] ?? []),

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -74,12 +74,12 @@ import {
   upsertDataSourceTableFromCsv,
 } from "@connectors/lib/data_sources";
 import {
-  NotionConnectorBlockCacheEntry,
-  NotionConnectorPageCacheEntry,
-  NotionConnectorResourcesToCheckCacheEntry,
-  NotionConnectorState,
-  NotionDatabase,
-  NotionPage,
+  NotionConnectorBlockCacheEntryModel,
+  NotionConnectorPageCacheEntryModel,
+  NotionConnectorResourcesToCheckCacheEntryModel,
+  NotionConnectorStateModel,
+  NotionDatabaseModel,
+  NotionPageModel,
 } from "@connectors/lib/models/notion";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
@@ -162,7 +162,7 @@ export async function fetchDatabaseChildPages({
     throw new Error("Could not find connector");
   }
 
-  const notionDbModel = await NotionDatabase.findOne({
+  const notionDbModel = await NotionDatabaseModel.findOne({
     where: {
       connectorId: connector.id,
       notionDatabaseId: databaseId,
@@ -248,7 +248,7 @@ export async function fetchDatabaseChildPages({
 
   // We exclude pages that we have already seen since their lastEditedTs we recieved from
   // getPagesEditedSince.
-  const existingPages = await NotionPage.findAll({
+  const existingPages = await NotionPageModel.findAll({
     where: {
       notionPageId: pages.map((p) => p.id),
       connectorId: connector.id,
@@ -322,7 +322,7 @@ export async function getPagesAndDatabasesToSync({
 
   const accessToken = await getNotionAccessToken(connector.id);
 
-  const skippedDatabases = await NotionDatabase.findAll({
+  const skippedDatabases = await NotionDatabaseModel.findAll({
     where: {
       connectorId: connector.id,
       skipReason: {
@@ -402,7 +402,7 @@ export async function getPagesAndDatabasesToSync({
 
   // We exclude pages that we have already seen since their lastEditedTs we received from
   // getPagesEditedSince.
-  const existingPages = await NotionPage.findAll({
+  const existingPages = await NotionPageModel.findAll({
     where: {
       notionPageId: pages.map((p) => p.id),
       connectorId: connector.id,
@@ -434,7 +434,7 @@ export async function getPagesAndDatabasesToSync({
   );
 
   // We do the same for databases.
-  const existingDatabases = await NotionDatabase.findAll({
+  const existingDatabases = await NotionDatabaseModel.findAll({
     where: {
       notionDatabaseId: dbs.map((d) => d.id),
       connectorId: connector.id,
@@ -532,7 +532,7 @@ export async function upsertDatabaseInConnectorsDb({
     }
   );
 
-  let parentType: NotionConnectorPageCacheEntry["parentType"] | undefined =
+  let parentType: NotionConnectorPageCacheEntryModel["parentType"] | undefined =
     parsedDb?.parentType;
   let parentId = parsedDb?.parentId;
 
@@ -623,7 +623,7 @@ export async function isFullSyncPendingOrOngoing({
     throw new Error("Could not find connector");
   }
 
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: {
       connectorId: connector.id,
     },
@@ -683,7 +683,7 @@ export async function garbageCollectorMarkAsSeenAndReturnNewEntities({
 
   const existingPageIds = new Set(
     (
-      await NotionPage.findAll({
+      await NotionPageModel.findAll({
         where: {
           notionPageId: pageIds,
           connectorId: connector.id,
@@ -706,7 +706,7 @@ export async function garbageCollectorMarkAsSeenAndReturnNewEntities({
 
   const existingDatabaseIds = new Set(
     (
-      await NotionDatabase.findAll({
+      await NotionDatabaseModel.findAll({
         where: {
           notionDatabaseId: databaseIds,
           connectorId: connector.id,
@@ -767,14 +767,14 @@ export async function deletePage({
     "deletePage: Deleted page"
   );
 
-  const notionPage = await NotionPage.findOne({
+  const notionPage = await NotionPageModel.findOne({
     where: {
       connectorId,
       notionPageId: pageId,
     },
   });
   if (notionPage?.parentType === "database" && notionPage.parentId) {
-    const parentDatabase = await NotionDatabase.findOne({
+    const parentDatabase = await NotionDatabaseModel.findOne({
       where: {
         connectorId,
         notionDatabaseId: notionPage.parentId,
@@ -837,7 +837,7 @@ export async function deleteDatabase({
     dataSourceConfig,
     `notion-database-${databaseId}`
   );
-  const notionDatabase = await NotionDatabase.findOne({
+  const notionDatabase = await NotionDatabaseModel.findOne({
     where: {
       connectorId,
       notionDatabaseId: databaseId,
@@ -847,7 +847,7 @@ export async function deleteDatabase({
     const tableId = `notion-${notionDatabase.notionDatabaseId}`;
     await deleteDataSourceTable({ dataSourceConfig, tableId });
   }
-  await NotionDatabase.destroy({
+  await NotionDatabaseModel.destroy({
     where: {
       connectorId,
       notionDatabaseId: databaseId,
@@ -879,7 +879,7 @@ export async function garbageCollectBatch({
     workspaceId: connector.workspaceId,
   });
 
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: {
       connectorId: connector.id,
     },
@@ -961,7 +961,7 @@ export async function garbageCollectBatch({
     if (resourceIsAccessible) {
       // Mark the resource as seen, so it is lower priority if we run into it again in a future GC run.
       if (x.type === "page") {
-        await NotionPage.update(
+        await NotionPageModel.update(
           {
             lastSeenTs: new Date(runTimestamp),
           },
@@ -974,7 +974,7 @@ export async function garbageCollectBatch({
         );
         stillAccessiblePagesCount++;
       } else if (x.type === "database") {
-        await NotionDatabase.update(
+        await NotionDatabaseModel.update(
           {
             lastSeenTs: new Date(runTimestamp),
           },
@@ -1032,7 +1032,7 @@ export async function completeGarbageCollectionRun(
     throw new Error("Could not find connector");
   }
 
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: {
       connectorId: connector.id,
     },
@@ -1191,7 +1191,7 @@ export async function deletePageOrDatabaseIfArchived({
   });
 
   if (objectType === "page") {
-    const notionPageModel = await NotionPage.findOne({
+    const notionPageModel = await NotionPageModel.findOne({
       where: {
         connectorId,
         notionPageId: objectId,
@@ -1203,7 +1203,7 @@ export async function deletePageOrDatabaseIfArchived({
     }
   }
   if (objectType === "database") {
-    const notionDatabaseModel = await NotionDatabase.findOne({
+    const notionDatabaseModel = await NotionDatabaseModel.findOne({
       where: {
         connectorId: connector.id,
         notionDatabaseId: objectId,
@@ -1274,7 +1274,7 @@ export async function createResourcesNotSeenInGarbageCollectionRunBatches({
   const databaseIdsSeenInRun = new Set(databaseIdsSeenInRunRaw);
 
   const pagesNotSeenInGarbageCollectionRun = (
-    await NotionPage.findAll({
+    await NotionPageModel.findAll({
       where: {
         connectorId,
         skipReason: {
@@ -1292,7 +1292,7 @@ export async function createResourcesNotSeenInGarbageCollectionRunBatches({
     }));
 
   const databasesNotSeenInGarbageCollectionRun = (
-    await NotionDatabase.findAll({
+    await NotionDatabaseModel.findAll({
       where: {
         connectorId,
         skipReason: {
@@ -1379,7 +1379,7 @@ export async function updateParentsFields({
   if (!connector) {
     throw new Error("Could not find connector");
   }
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: {
       connectorId: connector.id,
     },
@@ -1427,7 +1427,7 @@ export async function updateParentsFields({
   const notionPageIds =
     cursors?.pageCursor !== null
       ? (
-          await NotionPage.findAll({
+          await NotionPageModel.findAll({
             where: pageWhereClause,
             order: [["notionPageId", "ASC"]],
             limit: PARENTS_UPDATE_BATCH_SIZE,
@@ -1440,7 +1440,7 @@ export async function updateParentsFields({
   const notionDatabaseIds =
     cursors?.databaseCursor !== null
       ? (
-          await NotionDatabase.findAll({
+          await NotionDatabaseModel.findAll({
             where: databaseWhereClause,
             order: [["notionDatabaseId", "ASC"]],
             limit: PARENTS_UPDATE_BATCH_SIZE,
@@ -1494,7 +1494,7 @@ export async function drainDocumentUpsertQueue({
     throw new Error("Could not find connector");
   }
 
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: { connectorId: connector.id },
   });
   if (!notionConnectorState) {
@@ -1511,13 +1511,13 @@ export async function drainDocumentUpsertQueue({
     },
   };
 
-  const pageNeedingUpdating = await NotionPage.findOne({
+  const pageNeedingUpdating = await NotionPageModel.findOne({
     where: whereClause,
     attributes: ["id"],
   });
 
   if (!pageNeedingUpdating) {
-    const dbNeedingUpdating = await NotionDatabase.findOne({
+    const dbNeedingUpdating = await NotionDatabaseModel.findOne({
       where: whereClause,
       attributes: ["id"],
     });
@@ -1565,7 +1565,7 @@ export async function markParentsAsUpdated({
   if (!connector) {
     throw new Error("Could not find connector");
   }
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: {
       connectorId: connector.id,
     },
@@ -1597,8 +1597,8 @@ export async function getAllOrphanedResources({
 }> {
   const pages =
     cursor && !cursor.pageCursor
-      ? ([] as NotionPage[])
-      : await NotionPage.findAll({
+      ? ([] as NotionPageModel[])
+      : await NotionPageModel.findAll({
           where: {
             connectorId,
             parentType: "unknown",
@@ -1613,8 +1613,8 @@ export async function getAllOrphanedResources({
 
   const databases =
     cursor && !cursor.databaseCursor
-      ? ([] as NotionDatabase[])
-      : await NotionDatabase.findAll({
+      ? ([] as NotionDatabaseModel[])
+      : await NotionDatabaseModel.findAll({
           where: {
             connectorId,
             parentType: "unknown",
@@ -1700,7 +1700,7 @@ export async function cachePage({
   localLogger.info(
     "notionRetrievePageActivity: Checking if page is already in cache."
   );
-  const pageInCache = await NotionConnectorPageCacheEntry.findOne({
+  const pageInCache = await NotionConnectorPageCacheEntryModel.findOne({
     where: {
       notionPageId: pageId,
       connectorId: connector.id,
@@ -1738,7 +1738,7 @@ export async function cachePage({
 
   const parent = getPageOrBlockParent(notionPage);
 
-  await NotionConnectorPageCacheEntry.upsert({
+  await NotionConnectorPageCacheEntryModel.upsert({
     notionPageId: pageId,
     connectorId: connector.id,
     pageProperties: {},
@@ -1784,7 +1784,7 @@ export async function cacheBlockChildren({
     throw new Error("Could not find connector");
   }
 
-  const notionPageModel = await NotionPage.findOne({
+  const notionPageModel = await NotionPageModel.findOne({
     where: {
       connectorId: connector.id,
       notionPageId: pageId,
@@ -1864,7 +1864,7 @@ export async function cacheBlockChildren({
   if (blockId) {
     // remove blocks that are already in the cache, as Notion data structure can
     // have cycles and we don't want to loop forever.
-    const existingBlocks = await NotionConnectorBlockCacheEntry.findAll({
+    const existingBlocks = await NotionConnectorBlockCacheEntryModel.findAll({
       where: {
         notionPageId: pageId,
         notionBlockId: parsedBlocks.map((b) => b.id),
@@ -1905,7 +1905,7 @@ export async function cacheBlockChildren({
   await concurrentExecutor(
     parsedBlocks,
     async (block, idx) => {
-      await NotionConnectorBlockCacheEntry.upsert({
+      await NotionConnectorBlockCacheEntryModel.upsert({
         notionPageId: pageId,
         notionBlockId: block.id,
         blockType: block.type,
@@ -1951,7 +1951,7 @@ async function cacheDatabaseChildPages({
     dataSourceId: connector.dataSourceId,
   });
 
-  const notionDatabaseModel = await NotionDatabase.findOne({
+  const notionDatabaseModel = await NotionDatabaseModel.findOne({
     where: {
       connectorId: connector.id,
       notionDatabaseId: databaseId,
@@ -1967,7 +1967,7 @@ async function cacheDatabaseChildPages({
   }
 
   // exclude pages that are already in the cache
-  const existingPages = await NotionConnectorPageCacheEntry.findAll({
+  const existingPages = await NotionConnectorPageCacheEntryModel.findAll({
     where: {
       notionPageId: pages.map((p) => p.id),
       connectorId: connector.id,
@@ -1994,7 +1994,7 @@ async function cacheDatabaseChildPages({
   await concurrentExecutor(
     pages,
     async (page) =>
-      NotionConnectorPageCacheEntry.upsert({
+      NotionConnectorPageCacheEntryModel.upsert({
         notionPageId: page.id,
         connectorId: connector.id,
         pageProperties: {},
@@ -2022,7 +2022,7 @@ async function maybeAddParentToResourcesToCheck({
 }: {
   connectorId: ModelId;
   parentId: string;
-  parentType: NotionConnectorPageCacheEntry["parentType"];
+  parentType: NotionConnectorPageCacheEntryModel["parentType"];
   pageOrDbId: string;
   topLevelWorkflowId: string;
   loggerArgs: Record<string, string | number>;
@@ -2043,7 +2043,7 @@ async function maybeAddParentToResourcesToCheck({
 
     let notionId: string | null = null;
     if (parentType === "page") {
-      const existingParentPage = await NotionPage.findOne({
+      const existingParentPage = await NotionPageModel.findOne({
         where: {
           notionPageId: parentId,
           connectorId,
@@ -2056,7 +2056,7 @@ async function maybeAddParentToResourcesToCheck({
         notionId = parentId;
       }
     } else if (parentType === "database") {
-      const existingParentDatabase = await NotionDatabase.findOne({
+      const existingParentDatabase = await NotionDatabaseModel.findOne({
         where: {
           notionDatabaseId: parentId,
           connectorId,
@@ -2073,7 +2073,7 @@ async function maybeAddParentToResourcesToCheck({
     }
 
     if (notionId) {
-      await NotionConnectorResourcesToCheckCacheEntry.upsert({
+      await NotionConnectorResourcesToCheckCacheEntryModel.upsert({
         notionId,
         connectorId,
         resourceType: parentType,
@@ -2091,13 +2091,13 @@ export async function resolveResourceParent({
   loggerArgs,
 }: {
   parentId: string;
-  parentType: NotionConnectorPageCacheEntry["parentType"];
+  parentType: NotionConnectorPageCacheEntryModel["parentType"];
   pageOrDbId: string;
   accessToken: string;
   loggerArgs: Record<string, string | number>;
 }): Promise<{
   parentId: string;
-  parentType: NotionConnectorPageCacheEntry["parentType"];
+  parentType: NotionConnectorPageCacheEntryModel["parentType"];
 }> {
   const localLogger = logger.child({
     ...loggerArgs,
@@ -2203,7 +2203,7 @@ export async function renderAndUpsertPageFromCache({
   localLogger.info(
     "notionRenderAndUpsertPageFromCache: Retrieving page from cache."
   );
-  const pageCacheEntry = await NotionConnectorPageCacheEntry.findOne({
+  const pageCacheEntry = await NotionConnectorPageCacheEntryModel.findOne({
     where: {
       notionPageId: pageId,
       connectorId: connector.id,
@@ -2217,7 +2217,7 @@ export async function renderAndUpsertPageFromCache({
   localLogger.info(
     "notionRenderAndUpsertPageFromCache: Retrieving blocks from cache."
   );
-  const blockCacheEntries = await NotionConnectorBlockCacheEntry.findAll({
+  const blockCacheEntries = await NotionConnectorBlockCacheEntryModel.findAll({
     where: {
       notionPageId: pageId,
       connectorId: connector.id,
@@ -2225,7 +2225,7 @@ export async function renderAndUpsertPageFromCache({
     },
   });
 
-  const blocksByParentId: Record<string, NotionConnectorBlockCacheEntry[]> = {};
+  const blocksByParentId: Record<string, NotionConnectorBlockCacheEntryModel[]> = {};
   for (const blockCacheEntry of blockCacheEntries) {
     blocksByParentId[blockCacheEntry.parentBlockId || "root"] = [
       ...(blocksByParentId[blockCacheEntry.parentBlockId || "root"] ?? []),
@@ -2455,7 +2455,7 @@ export async function renderAndUpsertPageFromCache({
     localLogger.info(
       "notionRenderAndUpsertPageFromCache: Retrieving parent database from connectors DB."
     );
-    const parentDb = await NotionDatabase.findOne({
+    const parentDb = await NotionDatabaseModel.findOne({
       where: {
         connectorId: connector.id,
         notionDatabaseId: parentId,
@@ -2531,7 +2531,7 @@ export async function renderAndUpsertPageFromCache({
 
   const childDatabaseIdsInDb = new Set(
     (
-      await NotionConnectorResourcesToCheckCacheEntry.findAll({
+      await NotionConnectorResourcesToCheckCacheEntryModel.findAll({
         where: {
           notionId: childDatabaseIdsToCheck,
           resourceType: "database",
@@ -2544,7 +2544,7 @@ export async function renderAndUpsertPageFromCache({
   );
   const childPageIdsInDb = new Set(
     (
-      await NotionConnectorResourcesToCheckCacheEntry.findAll({
+      await NotionConnectorResourcesToCheckCacheEntryModel.findAll({
         where: {
           notionId: childPageIdsToCheck,
           resourceType: "page",
@@ -2565,7 +2565,7 @@ export async function renderAndUpsertPageFromCache({
 
   await Promise.all([
     ...databaseEntriesToCreate.map((id) =>
-      NotionConnectorResourcesToCheckCacheEntry.upsert({
+      NotionConnectorResourcesToCheckCacheEntryModel.upsert({
         notionId: id,
         resourceType: "database",
         connectorId: connector.id,
@@ -2573,7 +2573,7 @@ export async function renderAndUpsertPageFromCache({
       })
     ),
     ...pageEntriesToCreate.map((id) =>
-      NotionConnectorResourcesToCheckCacheEntry.upsert({
+      NotionConnectorResourcesToCheckCacheEntryModel.upsert({
         notionId: id,
         resourceType: "page",
         connectorId: connector.id,
@@ -2607,19 +2607,19 @@ export async function clearWorkflowCache({
     },
     "notionClearConnectorCacheActivity: Clearing cache."
   );
-  await NotionConnectorResourcesToCheckCacheEntry.destroy({
+  await NotionConnectorResourcesToCheckCacheEntryModel.destroy({
     where: {
       connectorId: connector.id,
       workflowId: topLevelWorkflowId,
     },
   });
-  await NotionConnectorPageCacheEntry.destroy({
+  await NotionConnectorPageCacheEntryModel.destroy({
     where: {
       connectorId: connector.id,
       workflowId: topLevelWorkflowId,
     },
   });
-  await NotionConnectorBlockCacheEntry.destroy({
+  await NotionConnectorBlockCacheEntryModel.destroy({
     where: {
       connectorId: connector.id,
       workflowId: topLevelWorkflowId,
@@ -2650,7 +2650,7 @@ export async function getDiscoveredResourcesFromCache({
   );
 
   const resourcesToCheck =
-    await NotionConnectorResourcesToCheckCacheEntry.findAll({
+    await NotionConnectorResourcesToCheckCacheEntryModel.findAll({
       where: {
         connectorId: connector.id,
         workflowId: topLevelWorkflowId,
@@ -2666,7 +2666,7 @@ export async function getDiscoveredResourcesFromCache({
 
   const pageIdsAlreadySeen = new Set(
     (
-      await NotionPage.findAll({
+      await NotionPageModel.findAll({
         where: {
           connectorId: connector.id,
           notionPageId: pageIdsToCheck,
@@ -2678,7 +2678,7 @@ export async function getDiscoveredResourcesFromCache({
 
   const databaseIdsAlreadySeen = new Set(
     (
-      await NotionDatabase.findAll({
+      await NotionDatabaseModel.findAll({
         where: {
           connectorId: connector.id,
           notionDatabaseId: databaseIdsToCheck,
@@ -2709,7 +2709,7 @@ export async function getDiscoveredResourcesFromCache({
   );
 
   // Since we're about to process these resources, clear them from the cache
-  await NotionConnectorResourcesToCheckCacheEntry.destroy({
+  await NotionConnectorResourcesToCheckCacheEntryModel.destroy({
     where: {
       connectorId: connector.id,
       workflowId: topLevelWorkflowId,
@@ -2738,7 +2738,7 @@ async function renderPageSection({
   localLogger,
 }: {
   dsConfig: DataSourceConfig;
-  blocksByParentId: Record<string, NotionConnectorBlockCacheEntry[]>;
+  blocksByParentId: Record<string, NotionConnectorBlockCacheEntryModel[]>;
   localLogger: Logger;
 }): Promise<CoreAPIDataSourceDocumentSection> {
   const renderedPageSection: CoreAPIDataSourceDocumentSection = {
@@ -2784,14 +2784,14 @@ async function renderPageSection({
 
   const adaptedBlocksByParentId: Record<
     string,
-    NotionConnectorBlockCacheEntry[]
+    NotionConnectorBlockCacheEntryModel[]
   > = {};
   let now = Date.now();
 
   for (const parentId of orderedParentIds) {
     const blocks = blocksByParentId[
       parentId
-    ] as NotionConnectorBlockCacheEntry[];
+    ] as NotionConnectorBlockCacheEntryModel[];
     blocks.sort((a, b) => a.indexInParent - b.indexInParent);
     const currentHeadings: {
       h1: string | null;
@@ -2852,7 +2852,7 @@ async function renderPageSection({
   const renderingStack = new Set<string>();
 
   const renderBlockSection = async (
-    b: NotionConnectorBlockCacheEntry,
+    b: NotionConnectorBlockCacheEntryModel,
     depth: number,
     indent = ""
   ): Promise<CoreAPIDataSourceDocumentSection> => {
@@ -2984,7 +2984,7 @@ export async function upsertDatabaseStructuredDataFromCache({
 
   localLogger.info("Start upserting Notion Database.");
 
-  const dbModel = await NotionDatabase.findOne({
+  const dbModel = await NotionDatabaseModel.findOne({
     where: {
       connectorId,
       notionDatabaseId: databaseId,
@@ -2996,7 +2996,7 @@ export async function upsertDatabaseStructuredDataFromCache({
     return;
   }
 
-  const pageCacheEntriesCount = await NotionConnectorPageCacheEntry.count({
+  const pageCacheEntriesCount = await NotionConnectorPageCacheEntryModel.count({
     where: {
       parentId: databaseId,
       connectorId,
@@ -3019,7 +3019,7 @@ export async function upsertDatabaseStructuredDataFromCache({
     const pageCacheEntries: {
       notionPageId: string;
       pagePropertiesText: string;
-    }[] = await NotionConnectorPageCacheEntry.findAll({
+    }[] = await NotionConnectorPageCacheEntryModel.findAll({
       attributes: ["notionPageId", "pagePropertiesText"],
       raw: true,
       where: {
@@ -3201,7 +3201,7 @@ export async function logMaxSearchPageIndexReached({
   localLogger.info("Max search page index reached.");
 }
 
-function getTableInfoFromDatabase(database: NotionDatabase): {
+function getTableInfoFromDatabase(database: NotionDatabaseModel): {
   databaseName: string;
   tableId: string;
   tableName: string;
@@ -3421,14 +3421,14 @@ export async function maybeUpdateOrphaneResourcesParents({
     };
 
     if (resource.type === "page") {
-      await NotionPage.update(updateParams, {
+      await NotionPageModel.update(updateParams, {
         where: {
           notionPageId: resource.notionId,
           connectorId,
         },
       });
     } else if (resource.type === "database") {
-      await NotionDatabase.update(updateParams, {
+      await NotionDatabaseModel.update(updateParams, {
         where: {
           notionDatabaseId: resource.notionId,
           connectorId,
@@ -3446,7 +3446,7 @@ export async function clearParentsLastUpdatedAt({
   connectorId: ModelId;
 }): Promise<void> {
   const connector = await ConnectorResource.fetchById(connectorId);
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: {
       connectorId,
     },
@@ -3483,7 +3483,7 @@ export async function getNextDatabaseToUpsert({
 
   // Look if we have notion DBs that were never upserted.
   // If so, return the oldest one.
-  let notionDatabases = await NotionDatabase.findAll({
+  let notionDatabases = await NotionDatabaseModel.findAll({
     where: {
       connectorId,
       lastUpsertedRunTs: {
@@ -3506,7 +3506,7 @@ export async function getNextDatabaseToUpsert({
 
   // Otherwise, look if we have notion DBs that were upserted more than DATABASE_PROCESSING_INTERVAL_MS ago.
   // If so, return the oldest one.
-  notionDatabases = await NotionDatabase.findAll({
+  notionDatabases = await NotionDatabaseModel.findAll({
     where: {
       connectorId,
       lastUpsertedRunTs: {
@@ -3551,7 +3551,7 @@ export async function markDatabasesAsUpserted({
   databaseIds: string[];
   runTimestamp: number;
 }): Promise<{ isNewDatabase: boolean; isMissing: boolean }> {
-  const db = await NotionDatabase.findOne({
+  const db = await NotionDatabaseModel.findOne({
     where: {
       connectorId,
       notionDatabaseId: {
@@ -3564,7 +3564,7 @@ export async function markDatabasesAsUpserted({
     return { isNewDatabase: false, isMissing: true };
   }
 
-  await NotionDatabase.update(
+  await NotionDatabaseModel.update(
     {
       lastUpsertedRunTs: new Date(runTimestamp),
     },
@@ -3787,7 +3787,7 @@ export async function checkResourceAndDiscoverRelated({
     );
 
     // Add to cache (will be batch deleted later)
-    await NotionConnectorResourcesToCheckCacheEntry.upsert({
+    await NotionConnectorResourcesToCheckCacheEntryModel.upsert({
       notionId: resourceId,
       resourceType,
       connectorId,
@@ -3858,7 +3858,7 @@ export async function getResourcesToDeleteFromCache({
   connectorId: ModelId;
   workflowId: string;
 }): Promise<{ pageIds: string[]; databaseIds: string[] }> {
-  const entries = await NotionConnectorResourcesToCheckCacheEntry.findAll({
+  const entries = await NotionConnectorResourcesToCheckCacheEntryModel.findAll({
     where: {
       connectorId,
       workflowId,
@@ -3917,7 +3917,7 @@ export async function batchDeleteResources({
       pageId,
       logger: localLogger,
     });
-    await NotionConnectorResourcesToCheckCacheEntry.destroy({
+    await NotionConnectorResourcesToCheckCacheEntryModel.destroy({
       where: {
         resourceType: "page",
         notionId: pageId,
@@ -3935,7 +3935,7 @@ export async function batchDeleteResources({
       databaseId,
       logger: localLogger,
     });
-    await NotionConnectorResourcesToCheckCacheEntry.destroy({
+    await NotionConnectorResourcesToCheckCacheEntryModel.destroy({
       where: {
         resourceType: "database",
         notionId: databaseId,

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -18,7 +18,7 @@ import { notionDeletionCrawlWorkflow } from "@connectors/connectors/notion/tempo
 import { notionGarbageCollectionWorkflow } from "@connectors/connectors/notion/temporal/workflows/garbage_collection";
 import { processDatabaseUpsertQueueWorkflow } from "@connectors/connectors/notion/temporal/workflows/upsert_database_queue";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { NotionConnectorState } from "@connectors/lib/models/notion";
+import { NotionConnectorStateModel } from "@connectors/lib/models/notion";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -78,7 +78,7 @@ export async function launchNotionSyncWorkflow(
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: {
       connectorId,
     },
@@ -180,7 +180,7 @@ export async function stopNotionSyncWorkflow(
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
   }
 
-  const notionConnectorState = await NotionConnectorState.findOne({
+  const notionConnectorState = await NotionConnectorStateModel.findOne({
     where: {
       connectorId,
     },

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -59,8 +59,8 @@ import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sour
 import { sectionFullText } from "@connectors/lib/data_sources";
 import { ProviderRateLimitError } from "@connectors/lib/error";
 import {
-  SlackChannel,
-  SlackChatBotMessage,
+  SlackChannelModel,
+  SlackChatBotMessageModel,
 } from "@connectors/lib/models/slack";
 import { createProxyAwareFetch } from "@connectors/lib/proxy";
 import { throttleWithRedis } from "@connectors/lib/throttle";
@@ -212,7 +212,7 @@ export async function botReplaceMention(
   const { slackConfig, connector } = connectorRes.value;
 
   try {
-    const slackChatBotMessage = await SlackChatBotMessage.findOne({
+    const slackChatBotMessage = await SlackChatBotMessageModel.findOne({
       where: { id: messageId },
     });
     if (!slackChatBotMessage) {
@@ -299,7 +299,7 @@ export async function botValidateToolExecution(
   const { connector, slackConfig } = connectorRes.value;
 
   try {
-    const slackChatBotMessage = await SlackChatBotMessage.findOne({
+    const slackChatBotMessage = await SlackChatBotMessageModel.findOne({
       where: { id: slackChatBotMessageId },
     });
     if (!slackChatBotMessage) {
@@ -583,9 +583,9 @@ async function answerMessage(
   connector: ConnectorResource,
   slackConfig: SlackConfigurationResource
 ): Promise<Result<AgentMessageSuccessEvent | undefined, Error>> {
-  let lastSlackChatBotMessage: SlackChatBotMessage | null = null;
+  let lastSlackChatBotMessage: SlackChatBotMessageModel | null = null;
   if (slackThreadTs) {
-    lastSlackChatBotMessage = await SlackChatBotMessage.findOne({
+    lastSlackChatBotMessage = await SlackChatBotMessageModel.findOne({
       where: {
         connectorId: connector.id,
         channelId: slackChannel,
@@ -710,7 +710,7 @@ async function answerMessage(
     throw new Error("Failed to get slack user id or bot id");
   }
 
-  const slackChatBotMessage = await SlackChatBotMessage.create({
+  const slackChatBotMessage = await SlackChatBotMessageModel.create({
     connectorId: connector.id,
     message: message,
     slackUserId: slackUserIdOrBotId,
@@ -879,7 +879,7 @@ async function answerMessage(
 
   if (!mention) {
     // If no mention is found, we look at channel-based routing rules.
-    const channel = await SlackChannel.findOne({
+    const channel = await SlackChannelModel.findOne({
       where: {
         connectorId: connector.id,
         slackChannelId: slackChannel,
@@ -1172,7 +1172,7 @@ async function makeContentFragments(
   const allContentFragments: PublicPostContentFragmentRequestBody[] = [];
   let allMessages: MessageElement[] = [];
 
-  const slackBotMessages = await SlackChatBotMessage.findAll({
+  const slackBotMessages = await SlackChatBotMessageModel.findAll({
     where: {
       connectorId: connector.id,
       channelId: channelId,

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -32,7 +32,7 @@ import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_c
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { annotateCitations } from "@connectors/lib/bot/citations";
 import { makeConversationUrl } from "@connectors/lib/bot/conversation_utils";
-import type { SlackChatBotMessage } from "@connectors/lib/models/slack";
+import type { SlackChatBotMessageModel } from "@connectors/lib/models/slack";
 import { throttleWithRedis } from "@connectors/lib/throttle";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -80,7 +80,7 @@ interface StreamConversationToSlackParams {
     slackUserId: string | null;
   };
   userMessage: UserMessageType;
-  slackChatBotMessage: SlackChatBotMessage;
+  slackChatBotMessage: SlackChatBotMessageModel;
   agentConfigurations: LightAgentConfigurationType[];
   feedbackVisibleToAuthorOnly: boolean;
 }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -32,7 +32,7 @@ import { slackChannelIdFromInternalId } from "@connectors/connectors/slack/lib/u
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client.js";
 import { apiConfig } from "@connectors/lib/api/config";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
 import { WebhookRouterConfigService } from "@connectors/lib/webhook_router_config";
 import logger from "@connectors/logger/logger";
@@ -387,7 +387,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     }
 
     const channels = (
-      await SlackChannel.findAll({
+      await SlackChannelModel.findAll({
         where: {
           connectorId: this.connectorId,
           slackChannelId: Object.keys(permissions).map((k) =>
@@ -398,7 +398,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     ).reduce(
       (acc, c) => Object.assign(acc, { [c.slackChannelId]: c }),
       {} as {
-        [key: string]: SlackChannel;
+        [key: string]: SlackChannelModel;
       }
     );
 
@@ -427,7 +427,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
               `Could not get the Slack channel name for #${slackChannelId}.`
             );
           }
-          const slackChannel = await SlackChannel.create({
+          const slackChannel = await SlackChannelModel.create({
             connectorId: this.connectorId,
             slackChannelId: slackChannelId,
             slackChannelName: channelInfo.name,
@@ -987,7 +987,7 @@ async function getFilteredChannels(
   }[] = [];
 
   if (filterPermission === "read") {
-    const localChannels = await SlackChannel.findAll({
+    const localChannels = await SlackChannelModel.findAll({
       where: {
         connectorId,
         permission: permissionToFilter,
@@ -1007,7 +1007,7 @@ async function getFilteredChannels(
 
     const [remoteChannels, localChannels] = await Promise.all([
       getAllChannels(slackClient, connectorId),
-      SlackChannel.findAll({
+      SlackChannelModel.findAll({
         where: {
           connectorId,
           // Here we do not filter out channels with skipReason because we need to know the ones that are skipped.
@@ -1016,11 +1016,11 @@ async function getFilteredChannels(
     ]);
 
     const localChannelsById = localChannels.reduce(
-      (acc: Record<string, SlackChannel>, ch: SlackChannel) => {
+      (acc: Record<string, SlackChannelModel>, ch: SlackChannelModel) => {
         acc[ch.slackChannelId] = ch;
         return acc;
       },
-      {} as Record<string, SlackChannel>
+      {} as Record<string, SlackChannelModel>
     );
 
     for (const remoteChannel of remoteChannels) {

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -13,7 +13,7 @@ import {
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ProviderWorkflowError } from "@connectors/lib/error";
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { SlackChannelModel } from "@connectors/lib/models/slack";
 import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -62,7 +62,7 @@ export async function updateSlackChannelInConnectorsDb({
     throw new Error(`Could not find connector ${connectorId}`);
   }
 
-  let channel = await SlackChannel.findOne({
+  let channel = await SlackChannelModel.findOne({
     where: {
       connectorId,
       slackChannelId,
@@ -71,7 +71,7 @@ export async function updateSlackChannelInConnectorsDb({
 
   if (!channel) {
     if (createIfNotExistsWithParams) {
-      channel = await SlackChannel.create({
+      channel = await SlackChannelModel.create({
         connectorId,
         slackChannelId,
         slackChannelName,
@@ -120,7 +120,7 @@ export async function updateSlackChannelInCoreDb(
     );
   }
 
-  const channelOnDb = await SlackChannel.findOne({
+  const channelOnDb = await SlackChannelModel.findOne({
     where: {
       connectorId: connector.id,
       slackChannelId: channelId,
@@ -511,7 +511,7 @@ export async function getChannelsToSync(
 ) {
   const [remoteChannels, localChannels] = await Promise.all([
     getJoinedChannels(slackClient, connectorId),
-    SlackChannel.findAll({
+    SlackChannelModel.findAll({
       where: {
         connectorId,
         permission: {

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -22,7 +22,10 @@ import {
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { throwOnError } from "@connectors/lib/cli";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { SlackChannelModel, SlackMessagesModel } from "@connectors/lib/models/slack";
+import {
+  SlackChannelModel,
+  SlackMessagesModel,
+} from "@connectors/lib/models/slack";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -22,7 +22,7 @@ import {
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { throwOnError } from "@connectors/lib/cli";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { SlackChannel, SlackMessages } from "@connectors/lib/models/slack";
+import { SlackChannelModel, SlackMessagesModel } from "@connectors/lib/models/slack";
 import { default as topLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
@@ -43,7 +43,7 @@ export async function maybeLaunchSlackSyncWorkflowForChannelId(
   connectorId: number,
   slackChannelId: string
 ) {
-  const channelId = await SlackChannel.findOne({
+  const channelId = await SlackChannelModel.findOne({
     attributes: ["id"],
     where: {
       connectorId,
@@ -144,7 +144,7 @@ export const slack = async ({
         throw new Error(`Could not find connector for workspace ${args.wId}`);
       }
 
-      const thread = await SlackMessages.findOne({
+      const thread = await SlackMessagesModel.findOne({
         where: {
           connectorId: connector.id,
           channelId: args.channelId,
@@ -192,7 +192,7 @@ export const slack = async ({
         throw new Error(`Could not find connector for workspace ${args.wId}`);
       }
 
-      const existingMessage = await SlackMessages.findOne({
+      const existingMessage = await SlackMessagesModel.findOne({
         where: {
           connectorId: connector.id,
           channelId: args.channelId,
@@ -574,7 +574,7 @@ export const slack = async ({
         );
       }
 
-      const channel = await SlackChannel.findOne({
+      const channel = await SlackChannelModel.findOne({
         where: {
           connectorId: connector.id,
           slackChannelId: args.channelId,
@@ -649,7 +649,7 @@ export const slack = async ({
         channel.permission !== "read" &&
         channel.permission !== "read_write"
       ) {
-        const existing = await SlackChannel.findOne({
+        const existing = await SlackChannelModel.findOne({
           where: {
             connectorId: connector.id,
             slackChannelId: args.channelId,
@@ -693,7 +693,7 @@ export const slack = async ({
         throw new Error(`Could not find connector for workspace ${args.wId}`);
       }
 
-      const channel = await SlackChannel.findOne({
+      const channel = await SlackChannelModel.findOne({
         where: {
           connectorId: connector.id,
           slackChannelId: args.channelId,
@@ -745,7 +745,7 @@ export const slack = async ({
         throw new Error(`Could not find connector for workspace ${args.wId}`);
       }
 
-      const channel = await SlackChannel.findOne({
+      const channel = await SlackChannelModel.findOne({
         where: {
           connectorId: connector.id,
           slackChannelId: args.channelId,

--- a/connectors/src/connectors/slack/lib/errors.ts
+++ b/connectors/src/connectors/slack/lib/errors.ts
@@ -8,7 +8,7 @@ import type {
 import { ErrorCode } from "@slack/web-api";
 import type { Attributes } from "sequelize";
 
-import type { SlackChatBotMessage } from "@connectors/lib/models/slack";
+import type { SlackChatBotMessageModel } from "@connectors/lib/models/slack";
 
 function isCodedError(error: unknown): error is CodedError {
   return error != null && typeof error === "object" && "code" in error;
@@ -19,7 +19,7 @@ export class SlackExternalUserError extends Error {}
 export class SlackMessageError extends Error {
   constructor(
     message: string,
-    public slackChatBotMessage: Attributes<SlackChatBotMessage>,
+    public slackChatBotMessage: Attributes<SlackChatBotMessageModel>,
     public mainMessage: ChatPostMessageResponse
   ) {
     super(message);

--- a/connectors/src/connectors/slack/lib/utils.ts
+++ b/connectors/src/connectors/slack/lib/utils.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 
-import type { SlackChannel } from "@connectors/lib/models/slack";
+import type { SlackChannelModel } from "@connectors/lib/models/slack";
 import type { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 
 export function getWeekStart(date: Date): Date {
@@ -117,7 +117,7 @@ export function slackNonThreadedMessagesInternalIdFromSlackNonThreadedMessagesId
 export function getSlackChannelSourceUrl(
   slackChannelId: string,
   slackConfig: SlackConfigurationResource
-): `https://app.slack.com/client/${SlackConfigurationResource["slackTeamId"]}/${SlackChannel["slackChannelId"]}` {
+): `https://app.slack.com/client/${SlackConfigurationResource["slackTeamId"]}/${SlackChannelModel["slackChannelId"]}` {
   return `https://app.slack.com/client/${slackConfig.slackTeamId}/${slackChannelId}`;
 }
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -57,7 +57,10 @@ import {
   ExternalOAuthTokenError,
   ProviderWorkflowError,
 } from "@connectors/lib/error";
-import { SlackChannelModel, SlackMessagesModel } from "@connectors/lib/models/slack";
+import {
+  SlackChannelModel,
+  SlackMessagesModel,
+} from "@connectors/lib/models/slack";
 import {
   reportInitialSyncProgress,
   syncSucceeded,

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -3,7 +3,7 @@ import { Err, Ok, removeNulls } from "@dust-tt/client";
 import { getChannelsToSync } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { SlackMessages } from "@connectors/lib/models/slack";
+import { SlackMessagesModel } from "@connectors/lib/models/slack";
 import { getTemporalClient } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -110,7 +110,7 @@ export async function launchSlackSyncOneThreadWorkflow(
     return new Ok(undefined);
   }
 
-  const thread = await SlackMessages.findOne({
+  const thread = await SlackMessagesModel.findOne({
     where: {
       connectorId: connectorId,
       channelId: channelId,
@@ -186,7 +186,7 @@ export async function launchSlackSyncOneMessageWorkflow(
     return new Ok(undefined);
   }
 
-  const thread = await SlackMessages.findOne({
+  const thread = await SlackMessagesModel.findOne({
     where: {
       connectorId: connectorId,
       channelId: channelId,

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -28,7 +28,7 @@ import {
 import { launchSlackMigrateChannelsFromLegacyBotToNewBotWorkflow } from "@connectors/connectors/slack/temporal/client";
 import {
   SlackBotWhitelistModel,
-  SlackChannel,
+  SlackChannelModel,
 } from "@connectors/lib/models/slack";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -130,7 +130,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
       );
 
       if (legacyConnector) {
-        const slackBotChannelsCount = await SlackChannel.count({
+        const slackBotChannelsCount = await SlackChannelModel.count({
           where: {
             connectorId: connector.id,
           },
@@ -140,7 +140,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
         ) {
           // Migrate channels from legacy slack connector to keep default bot per Slack channel
           // functionality
-          const slackChannels = await SlackChannel.findAll({
+          const slackChannels = await SlackChannelModel.findAll({
             where: {
               connectorId: legacyConnector.id,
               // Only migrate channels with agent configuration
@@ -150,7 +150,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
 
           if (slackChannels.length > 0) {
             const creationRecords = slackChannels.map(
-              (channel): CreationAttributes<SlackChannel> => ({
+              (channel): CreationAttributes<SlackChannelModel> => ({
                 connectorId: connector.id, // Update to slack_bot connector ID
                 createdAt: channel.createdAt, // Keep the original createdAt field
                 updatedAt: channel.updatedAt, // Keep the original updatedAt field
@@ -162,7 +162,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
                 agentConfigurationId: channel.agentConfigurationId,
               })
             );
-            await SlackChannel.bulkCreate(creationRecords, { transaction });
+            await SlackChannelModel.bulkCreate(creationRecords, { transaction });
 
             channelsMigrated = slackChannels.length;
             channelsMigrationStatus = "success";
@@ -627,7 +627,7 @@ async function getFilteredChannels(
 
   const [remoteChannels, localChannels] = await Promise.all([
     getJoinedChannels(slackClient, connectorId),
-    SlackChannel.findAll({
+    SlackChannelModel.findAll({
       where: {
         connectorId,
         // Here we do not filter out channels with skipReason because we need to know the ones that
@@ -637,11 +637,11 @@ async function getFilteredChannels(
   ]);
 
   const localChannelsById = localChannels.reduce(
-    (acc: Record<string, SlackChannel>, ch: SlackChannel) => {
+    (acc: Record<string, SlackChannelModel>, ch: SlackChannelModel) => {
       acc[ch.slackChannelId] = ch;
       return acc;
     },
-    {} as Record<string, SlackChannel>
+    {} as Record<string, SlackChannelModel>
   );
 
   for (const remoteChannel of remoteChannels) {

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -162,7 +162,9 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
                 agentConfigurationId: channel.agentConfigurationId,
               })
             );
-            await SlackChannelModel.bulkCreate(creationRecords, { transaction });
+            await SlackChannelModel.bulkCreate(creationRecords, {
+              transaction,
+            });
 
             channelsMigrated = slackChannels.length;
             channelsMigrationStatus = "success";

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -19,8 +19,8 @@ import {
 } from "@connectors/connectors/webcrawler/lib/utils";
 import { getFirecrawl } from "@connectors/lib/firecrawl";
 import {
-  WebCrawlerFolder,
-  WebCrawlerPage,
+  WebCrawlerFolderModel,
+  WebCrawlerPageModel,
 } from "@connectors/lib/models/webcrawler";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -209,7 +209,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     }
     let parentUrl: string | null = null;
     if (parentInternalId) {
-      const parent = await WebCrawlerFolder.findOne({
+      const parent = await WebCrawlerFolderModel.findOne({
         where: {
           connectorId: connector.id,
           webcrawlerConfigurationId: webCrawlerConfig.id,
@@ -229,7 +229,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       parentUrl = parent.url;
     }
 
-    const pages = await WebCrawlerPage.findAll({
+    const pages = await WebCrawlerPageModel.findAll({
       where: {
         connectorId: connector.id,
         webcrawlerConfigurationId: webCrawlerConfig.id,
@@ -237,7 +237,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       },
     });
 
-    const folders = await WebCrawlerFolder.findAll({
+    const folders = await WebCrawlerFolderModel.findAll({
       where: {
         connectorId: connector.id,
         webcrawlerConfigurationId: webCrawlerConfig.id,

--- a/connectors/src/connectors/webcrawler/lib/utils.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.ts
@@ -5,8 +5,8 @@ import { NonRetryableError } from "crawlee";
 import dns from "dns";
 
 import type {
-  WebCrawlerFolder,
-  WebCrawlerPage,
+  WebCrawlerFolderModel,
+  WebCrawlerPageModel,
 } from "@connectors/lib/models/webcrawler";
 import { createProxyAwareFetch } from "@connectors/lib/proxy";
 import type { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
@@ -123,7 +123,7 @@ export function normalizeFolderUrl(url: string) {
   return result;
 }
 
-export function getDisplayNameForPage(page: WebCrawlerPage): string {
+export function getDisplayNameForPage(page: WebCrawlerPageModel): string {
   const parsed = new URL(page.url);
   let result = "";
   const fragments = parsed.pathname.split("/").filter((x) => x);
@@ -142,7 +142,7 @@ export function getDisplayNameForPage(page: WebCrawlerPage): string {
   return result;
 }
 
-export function getDisplayNameForFolder(folder: WebCrawlerFolder): string {
+export function getDisplayNameForFolder(folder: WebCrawlerFolderModel): string {
   return (
     new URL(folder.url).pathname
       .split("/")

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -33,8 +33,8 @@ import {
 } from "@connectors/lib/data_sources";
 import { getFirecrawl } from "@connectors/lib/firecrawl";
 import {
-  WebCrawlerFolder,
-  WebCrawlerPage,
+  WebCrawlerFolderModel,
+  WebCrawlerPageModel,
 } from "@connectors/lib/models/webcrawler";
 import {
   reportInitialSyncProgress,
@@ -375,9 +375,9 @@ export async function webCrawlerGarbageCollector(
     throw new Error(`Webcrawler configuration not found for connector.`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  let pagesToDelete: WebCrawlerPage[] = [];
+  let pagesToDelete: WebCrawlerPageModel[] = [];
   do {
-    pagesToDelete = await WebCrawlerPage.findAll({
+    pagesToDelete = await WebCrawlerPageModel.findAll({
       where: {
         connectorId,
         webcrawlerConfigurationId: webCrawlerConfig.id,
@@ -398,9 +398,9 @@ export async function webCrawlerGarbageCollector(
     }
   } while (pagesToDelete.length > 0);
 
-  let foldersToDelete: WebCrawlerFolder[] = [];
+  let foldersToDelete: WebCrawlerFolderModel[] = [];
   do {
-    foldersToDelete = await WebCrawlerFolder.findAll({
+    foldersToDelete = await WebCrawlerFolderModel.findAll({
       where: {
         connectorId,
         webcrawlerConfigurationId: webCrawlerConfig.id,
@@ -565,7 +565,7 @@ export async function firecrawlCrawlPage(
     const logicalParent = isTopFolder(sourceUrl)
       ? null
       : getFolderForUrl(folder);
-    const [webCrawlerFolder] = await WebCrawlerFolder.upsert({
+    const [webCrawlerFolder] = await WebCrawlerFolderModel.upsert({
       url: folder,
       parentUrl: logicalParent,
       connectorId: connector.id,
@@ -597,7 +597,7 @@ export async function firecrawlCrawlPage(
     ressourceType: "document",
   });
 
-  await WebCrawlerPage.upsert({
+  await WebCrawlerPageModel.upsert({
     url: sourceUrl,
     parentUrl: isTopFolder(sourceUrl) ? null : getFolderForUrl(sourceUrl),
     connectorId: connector.id,
@@ -697,7 +697,7 @@ export async function firecrawlCrawlPage(
   if (!connector?.firstSuccessfulSyncTime) {
     // If this is the first sync we report the progress. This is a bit racy but that's not a big
     // problem as this is simple reporting of initial progress.
-    const pagesCount = await WebCrawlerPage.count({
+    const pagesCount = await WebCrawlerPageModel.count({
       where: {
         connectorId,
         webcrawlerConfigurationId: webCrawlerConfig.id,

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -4,7 +4,7 @@ import { DataTypes } from "sequelize";
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
-export class ConfluenceConfiguration extends ConnectorBaseModel<ConfluenceConfiguration> {
+export class ConfluenceConfigurationModel extends ConnectorBaseModel<ConfluenceConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -12,7 +12,7 @@ export class ConfluenceConfiguration extends ConnectorBaseModel<ConfluenceConfig
   declare url: string;
   declare userAccountId: string;
 }
-ConfluenceConfiguration.init(
+ConfluenceConfigurationModel.init(
   {
     cloudId: {
       type: DataTypes.STRING,
@@ -49,7 +49,7 @@ ConfluenceConfiguration.init(
 );
 
 // ConfluenceSpace stores the global spaces selected by the user to sync.
-export class ConfluenceSpace extends ConnectorBaseModel<ConfluenceSpace> {
+export class ConfluenceSpaceModel extends ConnectorBaseModel<ConfluenceSpaceModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare deletedAt: Date | null;
@@ -58,7 +58,7 @@ export class ConfluenceSpace extends ConnectorBaseModel<ConfluenceSpace> {
   declare spaceId: string;
   declare urlSuffix?: string;
 }
-ConfluenceSpace.init(
+ConfluenceSpaceModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -95,7 +95,7 @@ ConfluenceSpace.init(
 );
 
 // ConfluencePages stores the pages.
-export class ConfluencePage extends ConnectorBaseModel<ConfluencePage> {
+export class ConfluencePageModel extends ConnectorBaseModel<ConfluencePageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastVisitedAt: CreationOptional<Date>;
@@ -109,7 +109,7 @@ export class ConfluencePage extends ConnectorBaseModel<ConfluencePage> {
   declare title: string;
   declare version: number;
 }
-ConfluencePage.init(
+ConfluencePageModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -172,7 +172,7 @@ ConfluencePage.init(
   }
 );
 
-export class ConfluenceFolder extends ConnectorBaseModel<ConfluenceFolder> {
+export class ConfluenceFolderModel extends ConnectorBaseModel<ConfluenceFolderModel> {
   declare createdAt: CreationOptional<Date>;
   declare lastVisitedAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -187,7 +187,7 @@ export class ConfluenceFolder extends ConnectorBaseModel<ConfluenceFolder> {
   declare version: number;
 }
 
-ConfluenceFolder.init(
+ConfluenceFolderModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -4,7 +4,7 @@ import { DataTypes } from "sequelize";
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
-export class GithubConnectorState extends ConnectorBaseModel<GithubConnectorState> {
+export class GithubConnectorStateModel extends ConnectorBaseModel<GithubConnectorStateModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -12,7 +12,7 @@ export class GithubConnectorState extends ConnectorBaseModel<GithubConnectorStat
   declare webhooksEnabledAt?: Date | null;
   declare codeSyncEnabled: boolean;
 }
-GithubConnectorState.init(
+GithubConnectorStateModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -49,7 +49,7 @@ GithubConnectorState.init(
   }
 );
 
-export class GithubIssue extends ConnectorBaseModel<GithubIssue> {
+export class GithubIssueModel extends ConnectorBaseModel<GithubIssueModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -58,7 +58,7 @@ export class GithubIssue extends ConnectorBaseModel<GithubIssue> {
   declare repoId: string;
   declare issueNumber: number;
 }
-GithubIssue.init(
+GithubIssueModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -94,14 +94,14 @@ GithubIssue.init(
   }
 );
 
-export class GithubDiscussion extends ConnectorBaseModel<GithubDiscussion> {
+export class GithubDiscussionModel extends ConnectorBaseModel<GithubDiscussionModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare repoId: string;
   declare discussionNumber: number;
 }
-GithubDiscussion.init(
+GithubDiscussionModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -133,7 +133,7 @@ GithubDiscussion.init(
   }
 );
 
-export class GithubCodeRepository extends ConnectorBaseModel<GithubCodeRepository> {
+export class GithubCodeRepositoryModel extends ConnectorBaseModel<GithubCodeRepositoryModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastSeenAt: CreationOptional<Date>;
@@ -148,7 +148,7 @@ export class GithubCodeRepository extends ConnectorBaseModel<GithubCodeRepositor
 
   declare sourceUrl: string;
 }
-GithubCodeRepository.init(
+GithubCodeRepositoryModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -203,7 +203,7 @@ GithubCodeRepository.init(
   }
 );
 
-export class GithubCodeFile extends ConnectorBaseModel<GithubCodeFile> {
+export class GithubCodeFileModel extends ConnectorBaseModel<GithubCodeFileModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastSeenAt: CreationOptional<Date>;
@@ -219,7 +219,7 @@ export class GithubCodeFile extends ConnectorBaseModel<GithubCodeFile> {
 
   declare skipReason: string | null;
 }
-GithubCodeFile.init(
+GithubCodeFileModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -280,7 +280,7 @@ GithubCodeFile.init(
   }
 );
 
-export class GithubCodeDirectory extends ConnectorBaseModel<GithubCodeDirectory> {
+export class GithubCodeDirectoryModel extends ConnectorBaseModel<GithubCodeDirectoryModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastSeenAt: CreationOptional<Date>;
@@ -293,7 +293,7 @@ export class GithubCodeDirectory extends ConnectorBaseModel<GithubCodeDirectory>
   declare dirName: string;
   declare sourceUrl: string;
 }
-GithubCodeDirectory.init(
+GithubCodeDirectoryModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -6,7 +6,7 @@ import { connectorsSequelize } from "@connectors/resources/storage";
 import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 
-export class GoogleDriveConfig extends ConnectorBaseModel<GoogleDriveConfig> {
+export class GoogleDriveConfigModel extends ConnectorBaseModel<GoogleDriveConfigModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
@@ -14,7 +14,7 @@ export class GoogleDriveConfig extends ConnectorBaseModel<GoogleDriveConfig> {
   declare csvEnabled: boolean;
   declare largeFilesEnabled: boolean;
 }
-GoogleDriveConfig.init(
+GoogleDriveConfigModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -51,13 +51,13 @@ GoogleDriveConfig.init(
 );
 
 // GoogleDriveFolders stores the folders selected by the user to sync.
-export class GoogleDriveFolders extends ConnectorBaseModel<GoogleDriveFolders> {
+export class GoogleDriveFoldersModel extends ConnectorBaseModel<GoogleDriveFoldersModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
   declare folderId: string;
 }
-GoogleDriveFolders.init(
+GoogleDriveFoldersModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -82,7 +82,7 @@ GoogleDriveFolders.init(
 );
 
 // GoogleDriveFiles stores files and folders synced from Google Drive.
-export class GoogleDriveFiles extends ConnectorBaseModel<GoogleDriveFiles> {
+export class GoogleDriveFilesModel extends ConnectorBaseModel<GoogleDriveFilesModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare lastSeenTs: Date | null;
@@ -95,7 +95,7 @@ export class GoogleDriveFiles extends ConnectorBaseModel<GoogleDriveFiles> {
   declare mimeType: string;
   declare parentId: string | null;
 }
-GoogleDriveFiles.init(
+GoogleDriveFilesModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -152,7 +152,7 @@ GoogleDriveFiles.init(
   }
 );
 
-export class GoogleDriveSheet extends ConnectorBaseModel<GoogleDriveSheet> {
+export class GoogleDriveSheetModel extends ConnectorBaseModel<GoogleDriveSheetModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
@@ -161,7 +161,7 @@ export class GoogleDriveSheet extends ConnectorBaseModel<GoogleDriveSheet> {
   declare name: string;
   declare notUpsertedReason: TablesErrorType | null;
 }
-GoogleDriveSheet.init(
+GoogleDriveSheetModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -201,7 +201,7 @@ GoogleDriveSheet.init(
 
 // Sync Token are the equivalent of a timestamp for syncing the delta
 // between the last sync and the current sync.
-export class GoogleDriveSyncToken extends ConnectorBaseModel<GoogleDriveSyncToken> {
+export class GoogleDriveSyncTokenModel extends ConnectorBaseModel<GoogleDriveSyncTokenModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   // The driveId is the Google Drive Id of the user's drive.
@@ -212,7 +212,7 @@ export class GoogleDriveSyncToken extends ConnectorBaseModel<GoogleDriveSyncToke
   declare syncToken: string;
   declare connectorId: ForeignKey<ConnectorModel["id"]>;
 }
-GoogleDriveSyncToken.init(
+GoogleDriveSyncTokenModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,

--- a/connectors/src/lib/models/microsoft_bot.ts
+++ b/connectors/src/lib/models/microsoft_bot.ts
@@ -43,7 +43,7 @@ MicrosoftBotConfigurationModel.init(
   }
 );
 
-export class MicrosoftBotMessage extends ConnectorBaseModel<MicrosoftBotMessage> {
+export class MicrosoftBotMessageModel extends ConnectorBaseModel<MicrosoftBotMessageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -57,7 +57,7 @@ export class MicrosoftBotMessage extends ConnectorBaseModel<MicrosoftBotMessage>
   declare dustAgentMessageId?: string;
 }
 
-MicrosoftBotMessage.init(
+MicrosoftBotMessageModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -5,7 +5,7 @@ import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { NotionBlockType, PageObjectProperties } from "@connectors/types";
 
-export class NotionConnectorState extends ConnectorBaseModel<NotionConnectorState> {
+export class NotionConnectorStateModel extends ConnectorBaseModel<NotionConnectorStateModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -17,7 +17,7 @@ export class NotionConnectorState extends ConnectorBaseModel<NotionConnectorStat
   declare notionWorkspaceId: string;
   declare privateIntegrationCredentialId?: string | null;
 }
-NotionConnectorState.init(
+NotionConnectorStateModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -58,7 +58,7 @@ NotionConnectorState.init(
   }
 );
 
-export class NotionPage extends ConnectorBaseModel<NotionPage> {
+export class NotionPageModel extends ConnectorBaseModel<NotionPageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -75,7 +75,7 @@ export class NotionPage extends ConnectorBaseModel<NotionPage> {
   declare titleSearchVector: unknown;
   declare notionUrl?: string | null;
 }
-NotionPage.init(
+NotionPageModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -146,7 +146,7 @@ NotionPage.init(
   }
 );
 
-export class NotionDatabase extends ConnectorBaseModel<NotionDatabase> {
+export class NotionDatabaseModel extends ConnectorBaseModel<NotionDatabaseModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -174,7 +174,7 @@ export class NotionDatabase extends ConnectorBaseModel<NotionDatabase> {
   declare structuredDataUpsertedTs: CreationOptional<Date | null>;
 }
 
-NotionDatabase.init(
+NotionDatabaseModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -269,7 +269,7 @@ NotionDatabase.init(
 // This is because it's a cache table that generates a lot of writes and we don't want to fill up the WAL.
 // It's also a cache table, so we don't care if we lose data.
 // This table is not replicated to the read replica, and all data is lost on a failover.
-export class NotionConnectorPageCacheEntry extends ConnectorBaseModel<NotionConnectorPageCacheEntry> {
+export class NotionConnectorPageCacheEntryModel extends ConnectorBaseModel<NotionConnectorPageCacheEntryModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -286,7 +286,7 @@ export class NotionConnectorPageCacheEntry extends ConnectorBaseModel<NotionConn
 
   declare workflowId: string;
 }
-NotionConnectorPageCacheEntry.init(
+NotionConnectorPageCacheEntryModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -364,7 +364,7 @@ NotionConnectorPageCacheEntry.init(
 // This is because it's a cache table that generates a lot of writes and we don't want to fill up the WAL.
 // It's also a cache table, so we don't care if we lose data.
 // This table is not replicated to the read replica, and all data is lost on a failover.
-export class NotionConnectorBlockCacheEntry extends ConnectorBaseModel<NotionConnectorBlockCacheEntry> {
+export class NotionConnectorBlockCacheEntryModel extends ConnectorBaseModel<NotionConnectorBlockCacheEntryModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -380,7 +380,7 @@ export class NotionConnectorBlockCacheEntry extends ConnectorBaseModel<NotionCon
 
   declare workflowId: string;
 }
-NotionConnectorBlockCacheEntry.init(
+NotionConnectorBlockCacheEntryModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -448,7 +448,7 @@ NotionConnectorBlockCacheEntry.init(
 // This is because it's a cache table that generates a lot of writes and we don't want to fill up the WAL.
 // It's also a cache table, so we don't care if we lose data.
 // This table is not replicated to the read replica, and all data is lost on a failover.
-export class NotionConnectorResourcesToCheckCacheEntry extends ConnectorBaseModel<NotionConnectorResourcesToCheckCacheEntry> {
+export class NotionConnectorResourcesToCheckCacheEntryModel extends ConnectorBaseModel<NotionConnectorResourcesToCheckCacheEntryModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -457,7 +457,7 @@ export class NotionConnectorResourcesToCheckCacheEntry extends ConnectorBaseMode
 
   declare workflowId: string;
 }
-NotionConnectorResourcesToCheckCacheEntry.init(
+NotionConnectorResourcesToCheckCacheEntryModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -83,7 +83,7 @@ SlackConfigurationModel.init(
   }
 );
 
-export class SlackMessages extends ConnectorBaseModel<SlackMessages> {
+export class SlackMessagesModel extends ConnectorBaseModel<SlackMessagesModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare channelId: string;
@@ -91,7 +91,7 @@ export class SlackMessages extends ConnectorBaseModel<SlackMessages> {
   declare documentId: string;
   declare skipReason?: string;
 }
-SlackMessages.init(
+SlackMessagesModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -129,7 +129,7 @@ SlackMessages.init(
   }
 );
 
-export class SlackChannel extends ConnectorBaseModel<SlackChannel> {
+export class SlackChannelModel extends ConnectorBaseModel<SlackChannelModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
@@ -144,7 +144,7 @@ export class SlackChannel extends ConnectorBaseModel<SlackChannel> {
   declare agentConfigurationId: CreationOptional<string | null>;
   declare autoRespondWithoutMention: CreationOptional<boolean>;
 }
-SlackChannel.init(
+SlackChannelModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -197,7 +197,7 @@ SlackChannel.init(
   }
 );
 
-export class SlackChatBotMessage extends ConnectorBaseModel<SlackChatBotMessage> {
+export class SlackChatBotMessageModel extends ConnectorBaseModel<SlackChatBotMessageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare channelId: string;
@@ -215,7 +215,7 @@ export class SlackChatBotMessage extends ConnectorBaseModel<SlackChatBotMessage>
   declare conversationId: string | null; // conversationId is set only for V2 conversations
   declare userType: "bot" | "user";
 }
-SlackChatBotMessage.init(
+SlackChatBotMessageModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -81,7 +81,7 @@ WebCrawlerConfigurationModel.init(
   }
 );
 
-export class WebCrawlerConfigurationHeader extends ConnectorBaseModel<WebCrawlerConfigurationHeader> {
+export class WebCrawlerConfigurationHeaderModel extends ConnectorBaseModel<WebCrawlerConfigurationHeaderModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare key: string;
@@ -91,7 +91,7 @@ export class WebCrawlerConfigurationHeader extends ConnectorBaseModel<WebCrawler
   >;
 }
 
-WebCrawlerConfigurationHeader.init(
+WebCrawlerConfigurationHeaderModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -125,9 +125,9 @@ WebCrawlerConfigurationHeader.init(
   }
 );
 
-WebCrawlerConfigurationModel.hasMany(WebCrawlerConfigurationHeader);
+WebCrawlerConfigurationModel.hasMany(WebCrawlerConfigurationHeaderModel);
 
-export class WebCrawlerFolder extends ConnectorBaseModel<WebCrawlerFolder> {
+export class WebCrawlerFolderModel extends ConnectorBaseModel<WebCrawlerFolderModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare parentUrl: string | null;
@@ -141,7 +141,7 @@ export class WebCrawlerFolder extends ConnectorBaseModel<WebCrawlerFolder> {
   >;
 }
 
-WebCrawlerFolder.init(
+WebCrawlerFolderModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -186,9 +186,9 @@ WebCrawlerFolder.init(
     modelName: "webcrawler_folders",
   }
 );
-WebCrawlerConfigurationModel.hasMany(WebCrawlerFolder);
+WebCrawlerConfigurationModel.hasMany(WebCrawlerFolderModel);
 
-export class WebCrawlerPage extends ConnectorBaseModel<WebCrawlerPage> {
+export class WebCrawlerPageModel extends ConnectorBaseModel<WebCrawlerPageModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare title: string | null;
@@ -202,7 +202,7 @@ export class WebCrawlerPage extends ConnectorBaseModel<WebCrawlerPage> {
   >;
 }
 
-WebCrawlerPage.init(
+WebCrawlerPageModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -255,4 +255,4 @@ WebCrawlerPage.init(
     modelName: "webcrawler_pages",
   }
 );
-WebCrawlerConfigurationModel.hasMany(WebCrawlerPage);
+WebCrawlerConfigurationModel.hasMany(WebCrawlerPageModel);

--- a/connectors/src/resources/connector/confluence.ts
+++ b/connectors/src/resources/connector/confluence.ts
@@ -1,10 +1,10 @@
 import type { Transaction } from "sequelize";
 
 import {
-  ConfluenceConfiguration,
-  ConfluenceFolder,
-  ConfluencePage,
-  ConfluenceSpace,
+  ConfluenceConfigurationModel,
+  ConfluenceFolderModel,
+  ConfluencePageModel,
+  ConfluenceSpaceModel,
 } from "@connectors/lib/models/confluence";
 import type {
   ConnectorProviderConfigurationType,
@@ -20,10 +20,10 @@ export class ConfluenceConnectorStrategy
 {
   async makeNew(
     connectorId: ModelId,
-    blob: WithCreationAttributes<ConfluenceConfiguration>,
+    blob: WithCreationAttributes<ConfluenceConfigurationModel>,
     transaction: Transaction
   ): Promise<ConnectorProviderModelResourceMapping["confluence"] | null> {
-    await ConfluenceConfiguration.create(
+    await ConfluenceConfigurationModel.create(
       {
         ...blob,
         connectorId,
@@ -38,25 +38,25 @@ export class ConfluenceConnectorStrategy
     connector: ConnectorResource,
     transaction: Transaction
   ): Promise<void> {
-    await ConfluenceConfiguration.destroy({
+    await ConfluenceConfigurationModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await ConfluenceSpace.destroy({
+    await ConfluenceSpaceModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await ConfluenceFolder.destroy({
+    await ConfluenceFolderModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await ConfluencePage.destroy({
+    await ConfluencePageModel.destroy({
       where: {
         connectorId: connector.id,
       },

--- a/connectors/src/resources/connector/github.ts
+++ b/connectors/src/resources/connector/github.ts
@@ -1,12 +1,12 @@
 import type { Transaction } from "sequelize";
 
 import {
-  GithubCodeDirectory,
-  GithubCodeFile,
-  GithubCodeRepository,
-  GithubConnectorState,
-  GithubDiscussion,
-  GithubIssue,
+  GithubCodeDirectoryModel,
+  GithubCodeFileModel,
+  GithubCodeRepositoryModel,
+  GithubConnectorStateModel,
+  GithubDiscussionModel,
+  GithubIssueModel,
 } from "@connectors/lib/models/github";
 import type {
   ConnectorProviderConfigurationType,
@@ -22,10 +22,10 @@ export class GithubConnectorStrategy
 {
   async makeNew(
     connectorId: ModelId,
-    blob: WithCreationAttributes<GithubConnectorState>,
+    blob: WithCreationAttributes<GithubConnectorStateModel>,
     transaction: Transaction
   ): Promise<ConnectorProviderModelResourceMapping["github"] | null> {
-    await GithubConnectorState.create(
+    await GithubConnectorStateModel.create(
       {
         ...blob,
         connectorId,
@@ -36,37 +36,37 @@ export class GithubConnectorStrategy
   }
 
   async delete(connector: ConnectorResource, transaction: Transaction) {
-    await GithubIssue.destroy({
+    await GithubIssueModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await GithubDiscussion.destroy({
+    await GithubDiscussionModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await GithubCodeRepository.destroy({
+    await GithubCodeRepositoryModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await GithubCodeFile.destroy({
+    await GithubCodeFileModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await GithubCodeDirectory.destroy({
+    await GithubCodeDirectoryModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await GithubConnectorState.destroy({
+    await GithubConnectorStateModel.destroy({
       where: {
         connectorId: connector.id,
       },

--- a/connectors/src/resources/connector/google_drive.ts
+++ b/connectors/src/resources/connector/google_drive.ts
@@ -1,11 +1,11 @@
 import type { Transaction } from "sequelize";
 
 import {
-  GoogleDriveConfig,
-  GoogleDriveFiles,
-  GoogleDriveFolders,
-  GoogleDriveSheet,
-  GoogleDriveSyncToken,
+  GoogleDriveConfigModel,
+  GoogleDriveFilesModel,
+  GoogleDriveFoldersModel,
+  GoogleDriveSheetModel,
+  GoogleDriveSyncTokenModel,
 } from "@connectors/lib/models/google_drive";
 import type {
   ConnectorProviderConfigurationType,
@@ -21,10 +21,10 @@ export class GoogleDriveConnectorStrategy
 {
   async makeNew(
     connectorId: ModelId,
-    blob: WithCreationAttributes<GoogleDriveConfig>,
+    blob: WithCreationAttributes<GoogleDriveConfigModel>,
     transaction: Transaction
   ): Promise<ConnectorProviderModelResourceMapping["google_drive"] | null> {
-    await GoogleDriveConfig.create(
+    await GoogleDriveConfigModel.create(
       {
         ...blob,
         connectorId,
@@ -38,32 +38,32 @@ export class GoogleDriveConnectorStrategy
     connector: ConnectorResource,
     transaction: Transaction
   ): Promise<void> {
-    await GoogleDriveFolders.destroy({
+    await GoogleDriveFoldersModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await GoogleDriveFiles.destroy({
+    await GoogleDriveFilesModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await GoogleDriveSheet.destroy({
+    await GoogleDriveSheetModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
 
-    await GoogleDriveSyncToken.destroy({
+    await GoogleDriveSyncTokenModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await GoogleDriveConfig.destroy({
+    await GoogleDriveConfigModel.destroy({
       where: {
         connectorId: connector.id,
       },

--- a/connectors/src/resources/connector/notion.ts
+++ b/connectors/src/resources/connector/notion.ts
@@ -1,12 +1,12 @@
 import type { Transaction } from "sequelize";
 
 import {
-  NotionConnectorBlockCacheEntry,
-  NotionConnectorPageCacheEntry,
-  NotionConnectorResourcesToCheckCacheEntry,
-  NotionConnectorState,
-  NotionDatabase,
-  NotionPage,
+  NotionConnectorBlockCacheEntryModel,
+  NotionConnectorPageCacheEntryModel,
+  NotionConnectorResourcesToCheckCacheEntryModel,
+  NotionConnectorStateModel,
+  NotionDatabaseModel,
+  NotionPageModel,
 } from "@connectors/lib/models/notion";
 import type {
   ConnectorProviderConfigurationType,
@@ -22,10 +22,10 @@ export class NotionConnectorStrategy
 {
   async makeNew(
     connectorId: ModelId,
-    blob: WithCreationAttributes<NotionConnectorState>,
+    blob: WithCreationAttributes<NotionConnectorStateModel>,
     transaction: Transaction
   ): Promise<ConnectorProviderModelResourceMapping["notion"] | null> {
-    await NotionConnectorState.create(
+    await NotionConnectorStateModel.create(
       {
         ...blob,
         connectorId,
@@ -39,37 +39,37 @@ export class NotionConnectorStrategy
     connector: ConnectorResource,
     transaction: Transaction
   ): Promise<void> {
-    await NotionPage.destroy({
+    await NotionPageModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await NotionDatabase.destroy({
+    await NotionDatabaseModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await NotionConnectorState.destroy({
+    await NotionConnectorStateModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await NotionConnectorBlockCacheEntry.destroy({
+    await NotionConnectorBlockCacheEntryModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await NotionConnectorPageCacheEntry.destroy({
+    await NotionConnectorPageCacheEntryModel.destroy({
       where: {
         connectorId: connector.id,
       },
       transaction,
     });
-    await NotionConnectorResourcesToCheckCacheEntry.destroy({
+    await NotionConnectorResourcesToCheckCacheEntryModel.destroy({
       where: {
         connectorId: connector.id,
       },

--- a/connectors/src/resources/connector/strategy.ts
+++ b/connectors/src/resources/connector/strategy.ts
@@ -3,15 +3,15 @@ import { assertNever } from "@dust-tt/client";
 import type { CreationAttributes, Model, Transaction } from "sequelize";
 
 import type { BigQueryConfigurationModel } from "@connectors/lib/models/bigquery";
-import type { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
+import type { ConfluenceConfigurationModel } from "@connectors/lib/models/confluence";
 import type { DiscordConfigurationModel } from "@connectors/lib/models/discord";
-import type { GithubConnectorState } from "@connectors/lib/models/github";
+import type { GithubConnectorStateModel } from "@connectors/lib/models/github";
 import type { GongConfigurationModel } from "@connectors/lib/models/gong";
-import type { GoogleDriveConfig } from "@connectors/lib/models/google_drive";
+import type { GoogleDriveConfigModel } from "@connectors/lib/models/google_drive";
 import type { IntercomWorkspaceModel } from "@connectors/lib/models/intercom";
 import type { MicrosoftConfigurationModel } from "@connectors/lib/models/microsoft";
 import type { MicrosoftBotConfigurationModel } from "@connectors/lib/models/microsoft_bot";
-import type { NotionConnectorState } from "@connectors/lib/models/notion";
+import type { NotionConnectorStateModel } from "@connectors/lib/models/notion";
 import type { SalesforceConfigurationModel } from "@connectors/lib/models/salesforce";
 import type { SlackConfigurationModel } from "@connectors/lib/models/slack";
 import type { SnowflakeConfigurationModel } from "@connectors/lib/models/snowflake";
@@ -47,14 +47,14 @@ export type WithCreationAttributes<T extends Model> = CreationAttributes<T>;
 // ConfigurationResource.
 
 export interface ConnectorProviderModelM {
-  confluence: ConfluenceConfiguration;
+  confluence: ConfluenceConfigurationModel;
   discord_bot: DiscordConfigurationModel;
-  github: GithubConnectorState;
-  google_drive: GoogleDriveConfig;
+  github: GithubConnectorStateModel;
+  google_drive: GoogleDriveConfigModel;
   intercom: IntercomWorkspaceModel;
   microsoft: MicrosoftConfigurationModel;
   microsoft_bot: MicrosoftBotConfigurationModel;
-  notion: NotionConnectorState;
+  notion: NotionConnectorStateModel;
   slack: SlackConfigurationModel;
   slack_bot: SlackConfigurationModel;
   webcrawler: WebCrawlerConfigurationModel;

--- a/connectors/src/resources/microsoft_bot_resources.ts
+++ b/connectors/src/resources/microsoft_bot_resources.ts
@@ -4,7 +4,7 @@ import type { Attributes, ModelStatic, Transaction } from "sequelize";
 
 import {
   MicrosoftBotConfigurationModel,
-  MicrosoftBotMessage,
+  MicrosoftBotMessageModel,
 } from "@connectors/lib/models/microsoft_bot";
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { WithCreationAttributes } from "@connectors/resources/connector/strategy";
@@ -93,7 +93,7 @@ export class MicrosoftBotConfigurationResource extends BaseResource<MicrosoftBot
   }
 
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
-    await MicrosoftBotMessage.destroy({
+    await MicrosoftBotMessageModel.destroy({
       where: {
         connectorId: this.connectorId,
       },

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -4,10 +4,10 @@ import type { Attributes, ModelStatic, Transaction } from "sequelize";
 
 import {
   SlackBotWhitelistModel,
-  SlackChannel,
-  SlackChatBotMessage,
+  SlackChannelModel,
+  SlackChatBotMessageModel,
   SlackConfigurationModel,
-  SlackMessages,
+  SlackMessagesModel,
 } from "@connectors/lib/models/slack";
 import logger from "@connectors/logger/logger";
 import { BaseResource } from "@connectors/resources/base_resource";
@@ -127,8 +127,8 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
   static async findChannelWithAutoRespond(
     connectorId: ModelId,
     slackChannelId: string
-  ): Promise<SlackChannel | null> {
-    return SlackChannel.findOne({
+  ): Promise<SlackChannelModel | null> {
+    return SlackChannelModel.findOne({
       where: {
         connectorId,
         slackChannelId,
@@ -331,21 +331,21 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
 
   async delete(transaction: Transaction): Promise<Result<undefined, Error>> {
     try {
-      await SlackChannel.destroy({
+      await SlackChannelModel.destroy({
         where: {
           connectorId: this.connectorId,
         },
         transaction,
       });
 
-      await SlackMessages.destroy({
+      await SlackMessagesModel.destroy({
         where: {
           connectorId: this.connectorId,
         },
         transaction,
       });
 
-      await SlackChatBotMessage.destroy({
+      await SlackChatBotMessageModel.destroy({
         where: {
           connectorId: this.connectorId,
         },

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -94,11 +94,12 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
       {} as Record<ModelId, WebCrawlerConfigurationResource>
     );
 
-    const configurationHeaders = await WebCrawlerConfigurationHeaderModel.findAll({
-      where: {
-        webcrawlerConfigurationId: blobs.map((b) => b.id),
-      },
-    });
+    const configurationHeaders =
+      await WebCrawlerConfigurationHeaderModel.findAll({
+        where: {
+          webcrawlerConfigurationId: blobs.map((b) => b.id),
+        },
+      });
 
     const configIdToConnectorId = blobs.reduce(
       (acc, blob) => {

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -10,10 +10,10 @@ import type {
 import { literal, Op } from "sequelize";
 
 import {
-  WebCrawlerConfigurationHeader,
+  WebCrawlerConfigurationHeaderModel,
   WebCrawlerConfigurationModel,
-  WebCrawlerFolder,
-  WebCrawlerPage,
+  WebCrawlerFolderModel,
+  WebCrawlerPageModel,
 } from "@connectors/lib/models/webcrawler";
 import { BaseResource } from "@connectors/resources/base_resource";
 import type {} from "@connectors/resources/connector/strategy";
@@ -52,7 +52,7 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
 
   async postFetchHook() {
     (
-      await WebCrawlerConfigurationHeader.findAll({
+      await WebCrawlerConfigurationHeaderModel.findAll({
         where: {
           webcrawlerConfigurationId: this.id,
         },
@@ -94,7 +94,7 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
       {} as Record<ModelId, WebCrawlerConfigurationResource>
     );
 
-    const configurationHeaders = await WebCrawlerConfigurationHeader.findAll({
+    const configurationHeaders = await WebCrawlerConfigurationHeaderModel.findAll({
       where: {
         webcrawlerConfigurationId: blobs.map((b) => b.id),
       },
@@ -134,7 +134,7 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
       { transaction }
     );
 
-    await WebCrawlerConfigurationHeader.bulkCreate(
+    await WebCrawlerConfigurationHeaderModel.bulkCreate(
       Object.entries(blob.headers).map(([key, value]) => {
         return {
           connectorId: blob.connectorId,
@@ -216,14 +216,14 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
     await withTransaction(async (transaction) => {
       const headersList = Object.entries(headers);
       // delete all headers before inserting new ones
-      await WebCrawlerConfigurationHeader.destroy({
+      await WebCrawlerConfigurationHeaderModel.destroy({
         where: {
           webcrawlerConfigurationId: this.id,
         },
         transaction,
       });
       // now insert new headers
-      await WebCrawlerConfigurationHeader.bulkCreate(
+      await WebCrawlerConfigurationHeaderModel.bulkCreate(
         headersList.map(([key, value]) => {
           return {
             connectorId: this.connectorId,
@@ -278,19 +278,19 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
   }
 
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
-    await WebCrawlerPage.destroy({
+    await WebCrawlerPageModel.destroy({
       where: {
         connectorId: this.connectorId,
       },
       transaction,
     });
-    await WebCrawlerFolder.destroy({
+    await WebCrawlerFolderModel.destroy({
       where: {
         connectorId: this.connectorId,
       },
       transaction,
     });
-    await WebCrawlerConfigurationHeader.destroy({
+    await WebCrawlerConfigurationHeaderModel.destroy({
       where: {
         webcrawlerConfigurationId: this.id,
       },


### PR DESCRIPTION
## Description

- Same as https://github.com/dust-tt/dust/pull/18843 but for connectors.
- Some Sequelize models have the suffix `Model` in their name, some older ones don't.
- This PR adds it when missing.

## Tests

- Tested locally but hard to be exhaustive.
- No risk of non deterministic errors since we can't rely on a Sequelize model in workflow code.

## Risk

- Lower than front given the lower data model complexity.

## Deploy Plan

- Deploy connectors.
