### PR TITLE
feat: allow one liner CSV for google and microsoft

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file/handle_file_export.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/handle_file_export.ts
@@ -124,6 +124,7 @@ export async function handleFileExport(
       connectorId,
       parents,
       tags: file.labels,
+      allowEmptySchema: true, // CSV files can be empty or with just one line, so we allow empty schemas
     });
   } else if (file.mimeType === "text/markdown") {
     const textContent = handleTextFile(res.data, maxDocumentLen);

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -270,6 +270,7 @@ export async function syncOneFile({
       connectorId,
       parents,
       tags: columns,
+      allowEmptySchema: true, // CSV files can be empty or with just one line, so we allow empty schemas
     });
 
     if (result.isErr()) {

--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -80,6 +80,7 @@ export async function handleCsvFile({
   connectorId,
   parents,
   tags,
+  allowEmptySchema,
 }: {
   data: ArrayBuffer;
   tableId: string;
@@ -91,6 +92,7 @@ export async function handleCsvFile({
   connectorId: ModelId;
   parents: string[];
   tags: string[];
+  allowEmptySchema: boolean;
 }): Promise<Result<null, Error>> {
   if (data.byteLength > 4 * maxDocumentLen) {
     localLogger.info({}, "File too big to be chunked. Skipping");
@@ -120,6 +122,7 @@ export async function handleCsvFile({
         title: fileName,
         mimeType: "text/csv",
         tags,
+        allowEmptySchema,
       })
     );
   } catch (err) {

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -842,7 +842,8 @@ export async function upsertTable({
       return new Err({
         name: "dust_error",
         code: "invalid_csv_content",
-        message: "Invalid CSV content, skipping",
+        message:
+          "Cannot determine schema of CSV, and it's required. It can mean the CSV has only 1 row. Skipping",
       });
     }
   }


### PR DESCRIPTION
## Description

I hope this is the last. 

We still have some CSV issues (new ones after each PR at least). 
It seems we do a check on a schema in core, and allow the connector to know what to do with it. I think allowing one liner CSV is ok for microsoft and google connectors

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
