### PR TITLE
feat(cli): move origin to be considered non programmatic

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/dust-cli",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
-        "@dust-tt/client": "^1.1.21",
+        "@dust-tt/client": "^1.1.22",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "clipboardy": "^4.0.0",
         "execa": "^9.6.0",
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.21.tgz",
-      "integrity": "sha512-QheWfFCEY0zqtIN4IEyUWPZiG7NJmINxzXSsvjh/1VhcxR2Ge5go2gZOGZwr/eMgpJ9wMC6gnPgqjfQQuhh42A==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.22.tgz",
+      "integrity": "sha512-HE/wntlVwQmoDEpVwZJFjSapxIhHDKHCu3EfzrwC2jqMiegvZcUPS1RZHpBTc1UXdKdqlOEARzm12vBL3L5YtA==",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   "author": "Dust",
   "license": "MIT",
   "dependencies": {
-    "@dust-tt/client": "^1.1.21",
+    "@dust-tt/client": "^1.1.22",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "clipboardy": "^4.0.0",
     "execa": "^9.6.0",

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -513,7 +513,7 @@ const CliChat: FC<CliChatProps> = ({
                 username: me.username,
                 fullName: me.fullName,
                 email: me.email,
-                origin: "api",
+                origin: "cli",
                 clientSideMCPServerIds: fileSystemServerId
                   ? [fileSystemServerId]
                   : null,
@@ -554,7 +554,7 @@ const CliChat: FC<CliChatProps> = ({
                 username: me.username,
                 fullName: me.fullName,
                 email: me.email,
-                origin: "api",
+                origin: "cli",
               },
             },
           });

--- a/cli/src/ui/commands/chat/nonInteractive.ts
+++ b/cli/src/ui/commands/chat/nonInteractive.ts
@@ -75,7 +75,7 @@ export async function sendNonInteractiveMessage(
             username: me.username,
             fullName: me.fullName,
             email: me.email,
-            origin: "api",
+            origin: "cli_programmatic",
           },
         },
       });
@@ -117,7 +117,7 @@ export async function sendNonInteractiveMessage(
             username: me.username,
             fullName: me.fullName,
             email: me.email,
-            origin: "api",
+            origin: "cli_programmatic",
           },
         },
         contentFragment: undefined,

--- a/cli/src/utils/mcpServer.ts
+++ b/cli/src/utils/mcpServer.ts
@@ -1,10 +1,6 @@
-import type {
-  Result} from "@dust-tt/client";
-import type {GetAgentConfigurationsResponseType} from "@dust-tt/client";
-import {
-  Err,
-  Ok
-} from "@dust-tt/client";
+import type { Result } from "@dust-tt/client";
+import type { GetAgentConfigurationsResponseType } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import type { Request, Response } from "express";
@@ -114,7 +110,7 @@ export async function startMcpServer(
                   fullName: user.fullName,
                   email: user.email,
                   profilePictureUrl: user.image,
-                  origin: "api",
+                  origin: "cli",
                 },
               },
               contentFragment: undefined,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Interactive messages are now considered in fair-use, non-interactive chats are still considered programmatic.

Closes https://github.com/dust-tt/dust/issues/18839

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front