### PR TITLE
Fix: do not hide onboarding messages from state (only from UI).

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -21,7 +21,6 @@ import type {
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
 import {
-  isHiddenMessage,
   isMessageTemporayState,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
@@ -70,8 +69,7 @@ export const AgentInputBar = ({
       (m) =>
         isUserMessage(m) &&
         m.user?.id === context.user.id &&
-        m.visibility !== "deleted" &&
-        !isHiddenMessage(m)
+        m.visibility !== "deleted"
     );
 
   const draftAgent = context.agentBuilderContext?.draftAgent;

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -14,6 +14,7 @@ import {
   getMessageDate,
   getMessageSId,
   isHandoverUserMessage,
+  isHiddenMessage,
   isMessageTemporayState,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
@@ -145,7 +146,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             "max-w-4xl"
           )}
         >
-          {isUserMessage(data) && (
+          {isUserMessage(data) && !isHiddenMessage(data) && (
             <UserMessage
               citations={citations}
               conversationId={context.conversationId}


### PR DESCRIPTION
## Description

Do not exclude onboarding messages from the conversation state as auto-prefixing relies on it.

## Tests

Local before/after

## Risk

Low

## Deploy Plan

Deploy front