### PR TITLE
slack_bot: remove legacy migration code

### DIFF
--- a/connectors/admin/checks.sh
+++ b/connectors/admin/checks.sh
@@ -9,8 +9,8 @@ OUT_DIR="$ROOT_DIR/out"
 
 mkdir -p "$OUT_DIR"
 
-COMMANDS=("npx tsc --noEmit" "npm run lint" "npm run format")
-NAMES=("TypeScript (tsc --noEmit)" "Lint" "Format")
+COMMANDS=("npx tsgo --noEmit" "npm run lint" "npm run format")
+NAMES=("TypeScript (tsgo --noEmit)" "Lint" "Format")
 LOGS=("$OUT_DIR/tsc.log" "$OUT_DIR/lint.log" "$OUT_DIR/format.log")
 PIDS=()
 


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C050SM8NSPK/p1765289774164849
https://app.datadoghq.eu/logs?query=%22Auto-migration%20recap%20after%20Slack%20bot%20connector%20creation%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40configurationSource%2C%40channelsMigrated%2C%40channelsMigrationStatus%2C%40whitelistMigrationStatus&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1762702923795&to_ts=1765294923795&live=true

Removes code that was copying old slack connector bot info to new slack_bot connector. I suspect the positive logs we're seeing today are people disabling/re-enabling the bot in the admin. I think we're good nuking that code.

Possibly interesting commit to look at that introduced it: https://github.com/dust-tt/dust/commit/855dd00e2e21e790fa0d61a2f5eb861b6f698904

## Tests

None

## Risk

Low

## Deploy Plan

- deploy `connectors`