### PR TITLE
fix(webhooks): scrub webhooks on scrub spaces

### DIFF
--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -151,6 +151,13 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     });
   }
 
+  static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
+    const webhookSources = await this.listByWorkspace(auth);
+    for (const webhookSource of webhookSources) {
+      await webhookSource.delete(auth);
+    }
+  }
+
   async updateRemoteMetadata(
     updates: Partial<
       Pick<WebhookSourceModel, "remoteMetadata" | "oauthConnectionId">

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -59,6 +59,8 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -561,6 +563,18 @@ export async function deleteSpacesActivity({
       await mcpServerView.delete(auth, { hardDelete: false });
     }
 
+    // Delete all the webhook source views of the space.
+    const webhookSourceViews = await WebhookSourcesViewResource.listBySpace(
+      auth,
+      space,
+      {
+        includeDeleted: true,
+      }
+    );
+    for (const webhookSourceView of webhookSourceViews) {
+      await webhookSourceView.hardDelete(auth);
+    }
+
     await scrubSpaceActivity({
       spaceId: space.sId,
       workspaceId,
@@ -601,6 +615,7 @@ export async function deleteWorkspaceActivity({
       workspaceId: workspace.id,
     },
   });
+  await WebhookSourceResource.deleteAllForWorkspace(auth);
   await TriggerResource.deleteAllForWorkspace(auth);
   await FileResource.deleteAllForWorkspace(auth);
   await RunResource.deleteAllForWorkspace(auth);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

As told by henry here https://dust4ai.slack.com/archives/C050SM8NSPK/p1765294977553479
=> we're not scrubing the webhooks sources when we should

This PR solves it.

- Scrubs webhook source views on deleteSpacesActivity
- Scrubs webhook source views on space manual deletion
- Scrubs webhook sources on deleteWorkspaceActivity

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front