### PR TITLE
[skills] Add a 'similar skills' endpoint and section in UI

### DIFF
--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -1,0 +1,69 @@
+import {
+  Avatar,
+  ContentMessage,
+  InformationCircleIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
+
+import { SKILL_ICON } from "@app/lib/skill";
+import type { SkillConfigurationWithAuthorType } from "@app/types/skill_configuration";
+
+type SimilarSkillsDisplayProps = {
+  similarSkills: SkillConfigurationWithAuthorType[];
+  isLoading: boolean;
+};
+
+export function SimilarSkillsDisplay({
+  similarSkills,
+  isLoading,
+}: SimilarSkillsDisplayProps) {
+  if (similarSkills.length === 0 && !isLoading) {
+    return null;
+  }
+
+  if (similarSkills.length === 0 && isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+        <Spinner size="xs" />
+        <span>Checking for similar skills...</span>
+      </div>
+    );
+  }
+
+  return (
+    <ContentMessage
+      variant="outline"
+      size="md"
+      title="Similar skills found"
+      icon={InformationCircleIcon}
+    >
+      <div className="mt-2 space-y-3">
+        {similarSkills.map((skill) => (
+          <div key={skill.sId} className="flex items-start gap-2">
+            <Avatar
+              name={skill.name}
+              visual={<SKILL_ICON className="text-element-700" />}
+              size="xs"
+            />
+            <div className="flex flex-col">
+              <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                {skill.name}
+              </span>
+              {skill.description && (
+                <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  {skill.description}
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+        {isLoading && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+            <Spinner size="xs" />
+            <span>Checking for similar skills...</span>
+          </div>
+        )}
+      </div>
+    </ContentMessage>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderDescriptionSection.tsx
@@ -1,10 +1,87 @@
 import { TextArea } from "@dust-tt/sparkle";
+import type { ChangeEvent } from "react";
+import { useCallback, useState } from "react";
 
 import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
+import { SimilarSkillsDisplay } from "@app/components/skill_builder/SimilarSkillsDisplay";
+import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import { useDebounceWithAbort } from "@app/hooks/useDebounce";
+import {
+  useSimilarSkills,
+  useSkillConfigurations,
+} from "@app/lib/swr/skill_configurations";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { SkillConfigurationWithAuthorType } from "@app/types/skill_configuration";
 
 const DESCRIPTION_FIELD_NAME = "description";
+const DEBOUNCE_DELAY_MS = 250;
+const MIN_DESCRIPTION_LENGTH = 10;
 
 export function SkillBuilderDescriptionSection() {
+  const { owner } = useSkillBuilderContext();
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+  const isSimilarSkillsEnabled = hasFeature("skills_similar_display");
+
+  const { getSimilarSkills } = useSimilarSkills({ owner });
+  const { skillConfigurations } = useSkillConfigurations({
+    workspaceId: owner.sId,
+    disabled: !isSimilarSkillsEnabled,
+  });
+
+  const [similarSkills, setSimilarSkills] = useState<
+    SkillConfigurationWithAuthorType[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchSimilarSkills = useCallback(
+    async (description: string, signal: AbortSignal) => {
+      if (!isSimilarSkillsEnabled) {
+        return;
+      }
+
+      if (description.length < MIN_DESCRIPTION_LENGTH) {
+        setSimilarSkills([]);
+        setIsLoading(false);
+        return;
+      }
+
+      const result = await getSimilarSkills(description, signal);
+
+      // Only update state if the request was not aborted
+      if (!signal.aborted) {
+        setIsLoading(false);
+        if (result.isOk()) {
+          const similarSkillIds = result.value;
+          const matchedSkills = skillConfigurations.filter((skill) =>
+            similarSkillIds.includes(skill.sId)
+          );
+          setSimilarSkills(matchedSkills);
+        }
+      }
+    },
+    [getSimilarSkills, isSimilarSkillsEnabled, skillConfigurations]
+  );
+
+  const triggerSimilarSkillsFetch = useDebounceWithAbort(fetchSimilarSkills, {
+    delayMs: DEBOUNCE_DELAY_MS,
+  });
+
+  const handleDescriptionChange = useCallback(
+    (
+      e: ChangeEvent<HTMLTextAreaElement>,
+      formOnChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
+    ) => {
+      formOnChange(e);
+      if (isSimilarSkillsEnabled) {
+        const value = e.target.value;
+        // Set loading immediately when description is long enough
+        setIsLoading(value.length >= MIN_DESCRIPTION_LENGTH);
+        triggerSimilarSkillsFetch(value);
+      }
+    },
+    [triggerSimilarSkillsFetch, isSimilarSkillsEnabled]
+  );
+
   return (
     <BaseFormFieldSection
       title="What will this skill be used for?"
@@ -12,15 +89,23 @@ export function SkillBuilderDescriptionSection() {
       triggerValidationOnChange={false}
     >
       {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
-        <TextArea
-          ref={registerRef}
-          placeholder="When should this skill be used? What will this skill be good for?"
-          className="min-h-24"
-          onChange={onChange}
-          error={hasError ? errorMessage : undefined}
-          showErrorLabel={hasError}
-          {...registerProps}
-        />
+        <div className="space-y-3">
+          <TextArea
+            ref={registerRef}
+            placeholder="When should this skill be used? What will this skill be good for?"
+            className="min-h-24"
+            onChange={(e) => handleDescriptionChange(e, onChange)}
+            error={hasError ? errorMessage : undefined}
+            showErrorLabel={hasError}
+            {...registerProps}
+          />
+          {isSimilarSkillsEnabled && (
+            <SimilarSkillsDisplay
+              similarSkills={similarSkills}
+              isLoading={isLoading}
+            />
+          )}
+        </div>
       )}
     </BaseFormFieldSection>
   );

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -25,7 +25,8 @@ export interface LLMTraceContext {
     | "trigger_webhook_filter_generator"
     | "voice_agent_finder"
     | "workspace_tags_suggestion"
-    | "agent_observability_summary";
+    | "agent_observability_summary"
+    | "skills_similarity_checker";
 
   /** Context-specific identifier (e.g., agentConfigId, conversationId, etc.) */
   contextId?: string;

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -1,0 +1,184 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
+
+// Safeguards to avoid sending a huge number of skills to the LLM
+const MAX_SKILLS_SENT_TO_LLM = 100;
+const MAX_DESCRIPTION_LENGTH = 500;
+
+const SET_SIMILAR_SKILLS_FUNCTION_NAME = "set_similar_skills";
+
+const specifications: AgentActionSpecification[] = [
+  {
+    name: SET_SIMILAR_SKILLS_FUNCTION_NAME,
+    description: "Set the similar skill ids",
+    inputSchema: {
+      type: "object",
+      properties: {
+        similar_skills_array: {
+          type: "array",
+          description: "An array of similar skill ids.",
+          items: {
+            type: "string",
+          },
+        },
+      },
+      required: ["similar_skills_array"],
+    },
+  },
+];
+
+const PROMPT = `# Role
+The user is creating a new skill to be added to thei agents.
+You must find if there is existing similar skills in the user's workspace to avoid duplicates.
+
+# Instuctions
+
+Given the natural description of the new skill, return a list of similar skill IDs already present in the user's workspace.
+Use the set_similar_skills function to return the similar skill IDs as an array of integers.
+
+Critically, only return skills that are truly similar to the new skill description.
+If there is n o similar skill, return an empty array, THIS IS TOTALLY OK.
+
+Skills are consider similar if they do similar actions over the same platforms or services.
+
+# Example
+## Example 1:
+Input: "This skills handle creation of support ticket on github"
+Existing skill:
+---
+Skill ID abc12:
+"Open support cards on github.com"
+---
+Skill ID xxx15:
+"Read and edit Jira tickets"
+---
+Skill ID 20aaa:
+"Create issues on GitHub repositories"
+---
+Skill ID 25iju:
+"Manage customer support emails"
+ 
+Output: 
+set_similar_skills({
+  "similar_skills_array": [abc12, 20aaa]
+})
+
+## Example 2:
+Input: "This allow the creation of vizualition similar to power point slides which can be shared with team members"
+Skill ID abc12:
+"Open support cards on github.com"
+---
+Skill ID xxx15:
+"Read and edit Jira tickets"
+---
+Skill ID 20aaa:
+"Create issues on GitHub repositories"
+---
+Skill ID 25iju:
+"Manage customer support emails"
+
+Output: 
+set_similar_skills({
+  "similar_skills_array": []
+})
+`;
+
+function truncateDescription(description: string): string {
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    return description.slice(0, MAX_DESCRIPTION_LENGTH);
+  }
+  return description;
+}
+
+export async function getSimilarSkills(
+  auth: Authenticator,
+  inputs: { naturalDescription: string }
+): Promise<Result<{ similar_skills: string[] }, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const model = getSmallWhitelistedModel(owner);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model to generate cron rule")
+    );
+  }
+
+  // Retrieve existing skills
+  const skills: SkillConfigurationResource[] =
+    await SkillConfigurationResource.fetchAllAvailableSkills(
+      auth,
+      MAX_SKILLS_SENT_TO_LLM
+    );
+  if (skills.length === MAX_SKILLS_SENT_TO_LLM) {
+    logger.warn(
+      { workspaceId: owner.sId },
+      "The number of skills fetched reached the limit. Some skills might not be considered in the similarity check."
+    );
+  }
+
+  const existingSkills = skills
+    .map(
+      (s) => `Skill ID ${s.sId}:
+"${truncateDescription(s.description)}"`
+    )
+    .join("\n---\n");
+  const inputText = `Input description:"${inputs.naturalDescription}"
+Existing skills:
+${existingSkills}
+`;
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      modelId: model.modelId,
+      providerId: model.providerId,
+      temperature: 0.7,
+      useCache: false,
+    },
+    {
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: inputText }],
+            name: "",
+          },
+        ],
+      },
+      prompt: PROMPT,
+      specifications,
+    },
+    {
+      context: {
+        operationType: "skills_similarity_checker",
+        userId: auth.user()?.sId,
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  let similar_skills: string[] | null = null;
+
+  if (res.value.actions) {
+    for (const action of res.value.actions) {
+      if (action.name === SET_SIMILAR_SKILLS_FUNCTION_NAME) {
+        similar_skills = action.arguments.similar_skills_array;
+      }
+    }
+  }
+
+  if (!similar_skills) {
+    return new Err(new Error("No similar skills generated"));
+  }
+
+  return new Ok({ similar_skills: similar_skills });
+}

--- a/front/lib/resources/skill_configuration_resource.ts
+++ b/front/lib/resources/skill_configuration_resource.ts
@@ -236,6 +236,18 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
     return resources[0];
   }
 
+  static async fetchAllAvailableSkills(
+    auth: Authenticator,
+    limit?: number
+  ): Promise<SkillConfigurationResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        status: "active",
+      },
+      ...(limit ? { limit } : {}),
+    });
+  }
+
   get sId(): string {
     return SkillConfigurationResource.modelIdToSId({
       id: this.id,

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -5,7 +5,7 @@ import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetSkillConfigurationsResponseBody } from "@app/pages/api/w/[wId]/skills";
 import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
 import type { LightWorkspaceType } from "@app/types";
-import { Err, normalizeError, Ok } from "@app/types";
+import { Ok } from "@app/types";
 
 export function useSkillConfigurations({
   workspaceId,
@@ -33,22 +33,18 @@ export function useSkillConfigurations({
 export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
   const getSimilarSkills = useCallback(
     async (naturalDescription: string, signal?: AbortSignal) => {
-      try {
-        const response: GetSimilarSkillsResponseBody = await fetcher(
-          `/api/w/${owner.sId}/skills/similar`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ naturalDescription }),
-            signal,
-          }
-        );
-        return new Ok(response.similar_skills);
-      } catch (e: unknown) {
-        return new Err(normalizeError(e));
-      }
+      const response: GetSimilarSkillsResponseBody = await fetcher(
+        `/api/w/${owner.sId}/skills/similar`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ naturalDescription }),
+          signal,
+        }
+      );
+      return new Ok(response.similar_skills);
     },
     [owner.sId]
   );

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -1,7 +1,11 @@
+import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetSkillConfigurationsResponseBody } from "@app/pages/api/w/[wId]/skills";
+import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
+import type { LightWorkspaceType } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 export function useSkillConfigurations({
   workspaceId,
@@ -24,4 +28,30 @@ export function useSkillConfigurations({
     isSkillConfigurationsError: !!error,
     isSkillConfigurationsLoading: isLoading,
   };
+}
+
+export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
+  const getSimilarSkills = useCallback(
+    async (naturalDescription: string, signal?: AbortSignal) => {
+      try {
+        const response: GetSimilarSkillsResponseBody = await fetcher(
+          `/api/w/${owner.sId}/skills/similar`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ naturalDescription }),
+            signal,
+          }
+        );
+        return new Ok(response.similar_skills);
+      } catch (e: unknown) {
+        return new Err(normalizeError(e));
+      }
+    },
+    [owner.sId]
+  );
+
+  return { getSimilarSkills };
 }

--- a/front/pages/api/w/[wId]/skills/similar.test.ts
+++ b/front/pages/api/w/[wId]/skills/similar.test.ts
@@ -1,0 +1,134 @@
+import type { RequestMethod } from "node-mocks-http";
+import { describe, expect, it, vi } from "vitest";
+
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types";
+
+import handler from "./similar";
+
+vi.mock("@app/lib/api/assistant/call_llm", () => ({
+  runMultiActionsAgent: vi.fn(),
+}));
+
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+
+async function setupTest(
+  role: "builder" | "user" | "admin" = "builder",
+  method: RequestMethod = "POST",
+  withFeatureFlags = true
+) {
+  const { req, res, workspace } = await createPrivateApiMockRequest({
+    role,
+    method,
+  });
+
+  req.query.wId = workspace.sId;
+
+  if (withFeatureFlags) {
+    await FeatureFlagFactory.basic("skills", workspace);
+    await FeatureFlagFactory.basic("skills_similar_display", workspace);
+  }
+
+  return { req, res, workspace };
+}
+
+describe("POST /api/w/[wId]/skills/similar", () => {
+  it("returns 405 for non-POST methods", async () => {
+    for (const method of ["GET", "PUT", "DELETE", "PATCH"] as const) {
+      const { req, res } = await setupTest("builder", method);
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+    }
+  });
+
+  it("returns 403 when user is not a builder", async () => {
+    const { req, res } = await setupTest("user", "POST");
+
+    req.body = { naturalDescription: "test description" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "app_auth_error",
+        message: "User is not a builder.",
+      },
+    });
+  });
+
+  it("returns similar skills when runMultiActionsAgent succeeds", async () => {
+    const { req, res } = await setupTest("builder", "POST");
+
+    req.body = { naturalDescription: "Create GitHub issues for support" };
+
+    vi.mocked(runMultiActionsAgent).mockResolvedValue(
+      new Ok({
+        actions: [
+          {
+            name: "set_similar_skills",
+            arguments: { similar_skills_array: ["abc12", "20zer", "35xyz"] },
+          },
+        ],
+        generation: "",
+      })
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      similar_skills: ["abc12", "20zer", "35xyz"],
+    });
+  });
+
+  it("returns empty similar skills when runMultiActionsAgent succeeds with empty array", async () => {
+    const { req, res } = await setupTest("builder", "POST");
+
+    req.body = { naturalDescription: "Create GitHub issues for support" };
+
+    vi.mocked(runMultiActionsAgent).mockResolvedValue(
+      new Ok({
+        actions: [
+          {
+            name: "set_similar_skills",
+            arguments: { similar_skills_array: [] },
+          },
+        ],
+        generation: "",
+      })
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      similar_skills: [],
+    });
+  });
+
+  it("returns 400 when naturalDescription is missing", async () => {
+    const { req, res } = await setupTest("builder", "POST");
+
+    req.body = {};
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "naturalDescription is required and must be a string.",
+      },
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/skills/similar.ts
+++ b/front/pages/api/w/[wId]/skills/similar.ts
@@ -1,0 +1,95 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { getSimilarSkills } from "@app/lib/api/skills/existing_skill_checker";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isBuilder } from "@app/types";
+
+export type GetSimilarSkillsResponseBody = {
+  similar_skills: string[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetSimilarSkillsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+  console.log("BODY");
+  console.log(req.body);
+
+  if (!isBuilder(owner)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "User is not a builder.",
+      },
+    });
+  }
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (!featureFlags.includes("skills")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Skills are not enabled for this workspace.",
+      },
+    });
+  }
+
+  if (!featureFlags.includes("skills_similar_display")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Similar skills display is not enabled for this workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const { naturalDescription } = req.body;
+
+      if (!naturalDescription || typeof naturalDescription !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "naturalDescription is required and must be a string.",
+          },
+        });
+      }
+
+      const result = await getSimilarSkills(auth, { naturalDescription });
+
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      return res.status(200).json(result.value);
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -229,6 +229,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Access to Skills, which are packaged sets of instructions and tools",
     stage: "dust_only",
   },
+  skills_similar_display: {
+    description:
+      "Display similar skills when creating a new skill to avoid duplicates",
+    stage: "dust_only",
+  },
   universal_search: {
     description:
       "WIP - Search from Input bar search in Knowledge and MCP tools. ",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -682,6 +682,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "self_created_slack_app_connector_rollout"
   | "show_debug_tools"
   | "skills"
+  | "skills_similar_display"
   | "slab_mcp"
   | "slack_bot_mcp"
   | "slack_enhanced_default_agent"


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/5412

 - Add an enpoint accessible to builder to get skills similar to their description
 - the function takes all the skills (limited to 100) and includ their description (limited to 500 chars) in the user prompt to detect some similarities
 - The UI does this call with 250 ms debounce and display similar skills
 - All this is gated behind the feature flag "skills_similar_display"

NOTE: The UI is clearly vibecoded and just here as a proof of concept, not the definitive thing. To be improved when there is an actual design for it.

## Tests

### manual test

<img width="2164" height="1082" alt="image" src="https://github.com/user-attachments/assets/adb8774b-f90b-4fa2-b8df-8103ef2a649e" />

<img width="2068" height="968" alt="image" src="https://github.com/user-attachments/assets/d5e4654b-962f-4f29-ba64-83753f3a3cf3" />

### Unit tests for the endpoint

✅ 

## Risk

low, there is a feature flag

## Deploy Plan

deploy front
