### PR TITLE
Fix user mention markdown for agents, alt in email, logo size

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
@@ -289,8 +289,8 @@ async function createServer(
             {
               type: "text",
               text: serializeMention({
-                name: mention.label,
-                sId: mention.id,
+                id: mention.id,
+                label: mention.label,
                 type: "user",
               }),
             },

--- a/front/lib/notifications/email-templates/_layout.tsx
+++ b/front/lib/notifications/email-templates/_layout.tsx
@@ -29,10 +29,9 @@ export const EmailLayout = ({
             target="_new"
           >
             <img
-              alt="Dust Logo"
               style={{ margin: "0 auto", border: "0px" }}
-              width={192}
-              height={48}
+              width={168}
+              height={42}
               src="https://dust.tt/static/landing/logos/dust/Dust_Logo.png"
             />
           </a>

--- a/front/lib/notifications/workflows/conversation-added-as-participant.ts
+++ b/front/lib/notifications/workflows/conversation-added-as-participant.ts
@@ -163,7 +163,7 @@ export const conversationAddedAsParticipantWorkflow = workflow(
           },
         });
         return {
-          subject: `[Dust] You have been added to a conversation`,
+          subject: `[Dust] You were mentioned in a conversation`,
           body,
         };
       },


### PR DESCRIPTION
## Description

Various tweaks requested over time:
- Remove logo alt in email (it shows in the mac notifications)
- Reduce logo size in email
- Changed email subject
- Updated Sender (direcly in novu) team@dust.tt (Dust Team) => no-reply@dust.help (Dust Notications)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
