### PR TITLE
chore(local-setup): add DUST_MANAGED prefix to api key not set env error message

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -33,7 +33,9 @@ export class AnthropicLLM extends LLM {
     super(auth, overwriteLLMParameters(llmParameters));
     const { ANTHROPIC_API_KEY } = dustManagedCredentials();
     if (!ANTHROPIC_API_KEY) {
-      throw new Error("ANTHROPIC_API_KEY environment variable is required");
+      throw new Error(
+        "DUST_MANAGED_ANTHROPIC_API_KEY environment variable is required"
+      );
     }
 
     this.client = new Anthropic({

--- a/front/lib/api/llm/clients/fireworks/index.ts
+++ b/front/lib/api/llm/clients/fireworks/index.ts
@@ -34,7 +34,9 @@ export class FireworksLLM extends LLM {
 
     const { FIREWORKS_API_KEY } = dustManagedCredentials();
     if (!FIREWORKS_API_KEY) {
-      throw new Error("FIREWORKS_API_KEY environment variable is required");
+      throw new Error(
+        "DUST_MANAGED_FIREWORKS_API_KEY environment variable is required"
+      );
     }
     this.client = new OpenAI({
       apiKey: FIREWORKS_API_KEY,

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -37,7 +37,7 @@ export class GoogleLLM extends LLM {
     const { GOOGLE_AI_STUDIO_API_KEY } = dustManagedCredentials();
     if (!GOOGLE_AI_STUDIO_API_KEY) {
       throw new Error(
-        "GOOGLE_AI_STUDIO_API_KEY environment variable is required"
+        "DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY environment variable is required"
       );
     }
 

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -42,7 +42,9 @@ export class MistralLLM extends LLM {
     });
     const { MISTRAL_API_KEY } = dustManagedCredentials();
     if (!MISTRAL_API_KEY) {
-      throw new Error("MISTRAL_API_KEY environment variable is required");
+      throw new Error(
+        "DUST_MANAGED_MISTRAL_API_KEY environment variable is required"
+      );
     }
     this.client = new Mistral({
       apiKey: MISTRAL_API_KEY,

--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -43,7 +43,9 @@ export class OpenAIResponsesLLM extends LLM {
 
     const { OPENAI_API_KEY, OPENAI_BASE_URL } = dustManagedCredentials();
     if (!OPENAI_API_KEY) {
-      throw new Error("OPENAI_API_KEY environment variable is required");
+      throw new Error(
+        "DUST_MANAGED_OPENAI_API_KEY environment variable is required"
+      );
     }
 
     this.client = new OpenAI({

--- a/front/lib/api/llm/clients/xai/index.ts
+++ b/front/lib/api/llm/clients/xai/index.ts
@@ -32,7 +32,9 @@ export class XaiLLM extends LLM {
 
     const { XAI_API_KEY } = dustManagedCredentials();
     if (!XAI_API_KEY) {
-      throw new Error("XAI_API_KEY environment variable is required");
+      throw new Error(
+        "DUST_MANAGED_XAI_API_KEY environment variable is required"
+      );
     }
     this.client = new OpenAI({
       apiKey: XAI_API_KEY,


### PR DESCRIPTION


## Description

Indicate the right env to be set

Before :
`[provider]_API_KEY environment variable is required`
After :
`DUST_MANAGED_[provider]_API_KEY environment variable is required`

## Tests

None

## Risk

None

## Deploy Plan

None
