### PR TITLE
[PPUL] Exclude zendesk origin from programmatic usage tracking

### DIFF
--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -78,6 +78,13 @@ export function isProgrammaticUsage(
   auth: Authenticator,
   { userMessageOrigin }: { userMessageOrigin: UserMessageOrigin }
 ): boolean {
+  // TODO(PPUL): this is a temporary fix to allow zendesk to not be tracked as
+  // programmatic usage, despite it relying on a custom API key. This should be
+  // removed once we have a proper solution for zendesk.
+  if (userMessageOrigin === "zendesk") {
+    return false;
+  }
+
   if (
     auth.authMethod() === "api_key" ||
     USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic"


### PR DESCRIPTION
## Description

Context: [slack thread](https://dust4ai.slack.com/archives/C05BUSJQP5W/p1765296965427829?thread_ts=1765230139.687879&cid=C05BUSJQP5W)

Temporary fix to exclude "zendesk" origin from being tracked as programmatic usage, despite it relying on a custom API key.

We should remove this once https://github.com/dust-tt/tasks/issues/5524 is tackled
## Risks

Blast radius: programmatic usage tracking for zendesk conversations
Risk: low

## Deploy Plan
- pmrr
- deploy front