### PR TITLE
[Programmatic Usage] Improve credits usage page UI

### DIFF
--- a/front/components/workspace/CreditsList.tsx
+++ b/front/components/workspace/CreditsList.tsx
@@ -36,7 +36,7 @@ const TYPE_SORT_ORDER: Record<CreditType, number> = {
 
 // Display labels for credit types
 const TYPE_LABELS: Record<CreditType, string> = {
-  free: "Included",
+  free: "Free",
   committed: "Committed",
   payg: "Pay-as-you-go",
 };

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -506,9 +506,7 @@ export function BaseProgrammaticCostChart({
           )}
         </div>
       }
-      description={
-        groupBy ? "Filter by clicking on legend items." : undefined
-      }
+      description={groupBy ? "Filter by clicking on legend items." : undefined}
       isLoading={isProgrammaticCostLoading}
       errorMessage={
         isProgrammaticCostError

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -483,7 +483,7 @@ export function BaseProgrammaticCostChart({
     <ChartContainer
       title={
         <div className="flex items-center gap-2">
-          <span>Usage Graph</span>
+          <span>Usage cost graph</span>
           <Button
             icon={ChevronLeftIcon}
             size="xs"
@@ -506,7 +506,9 @@ export function BaseProgrammaticCostChart({
           )}
         </div>
       }
-      description="Total cost accumulated. Filter by clicking on legend items."
+      description={
+        groupBy ? "Filter by clicking on legend items." : undefined
+      }
       isLoading={isProgrammaticCostLoading}
       errorMessage={
         isProgrammaticCostError

--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -529,7 +529,7 @@ export async function handleProgrammaticCostRequest(
         // Add "total" to available groups
         availableGroups.push({
           groupKey: "total",
-          groupLabel: "Cumulative Cost",
+          groupLabel: "Total cost consumed",
         });
       }
 

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -247,9 +247,7 @@ function UsageSection({
     <div className="flex flex-col gap-6">
       {/* Usage Header */}
       <div className="flex items-center justify-between">
-        <Page.Vertical gap="xs">
-          <Page.H variant="h5">Available credits</Page.H>
-        </Page.Vertical>
+        <Page.H variant="h5">Available credits</Page.H>
         {billingCycle && (
           <Page.P variant="secondary">
             {formatDateShort(billingCycle.cycleStart)} →{" "}
@@ -278,7 +276,7 @@ function UsageSection({
           title="Free credits"
           consumed={creditsByType.free.consumed}
           total={creditsByType.free.total}
-          renewalDate={formatRenewalDate(creditsByType.free.expirationDate)}
+          renewalDate={formatRenewalDate(billingCycle?.cycleEnd.getTime() ?? null)}
         />
         <CreditCategoryBar
           title="Purchased credits"

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -276,7 +276,9 @@ function UsageSection({
           title="Free credits"
           consumed={creditsByType.free.consumed}
           total={creditsByType.free.total}
-          renewalDate={formatRenewalDate(billingCycle?.cycleEnd.getTime() ?? null)}
+          renewalDate={formatRenewalDate(
+            billingCycle?.cycleEnd.getTime() ?? null
+          )}
         />
         <CreditCategoryBar
           title="Purchased credits"


### PR DESCRIPTION
## Description

UI improvements to the credits usage page:
- Fix vertical alignment between "Available credits" header and date range
- Show filtering hint only when group by is enabled (not in Global mode)
- Rename chart title to "Usage cost graph"
- Rename legend label to "Total cost consumed" in global mode
- Use billing cycle end date for free credits renewal instead of earliest expiration date
- Rename credit type label from "Included" to "Free"

## Risks

Blast radius: Credits usage page display only
Risk: low

## Deploy Plan

- deploy front