### PR TITLE
Check origin by api usage type

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -408,7 +408,7 @@ export function validateUserMessageContext(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "The origin is not allowed for API key usage.",
+            message: "This origin is not allowed when using a custom API key. See documentation to fix to an allowed origin.",
           },
         });
       }
@@ -419,7 +419,7 @@ export function validateUserMessageContext(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "The origin is not allowed for OAuth usage.",
+            message: "This origin is not allowed when using OAuth for authentication. See documentation to fix to an allowed origin.",
           },
         });
       }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -408,7 +408,8 @@ export function validateUserMessageContext(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "This origin is not allowed when using a custom API key. See documentation to fix to an allowed origin.",
+            message:
+              "This origin is not allowed when using a custom API key. See documentation to fix to an allowed origin.",
           },
         });
       }
@@ -419,7 +420,8 @@ export function validateUserMessageContext(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "This origin is not allowed when using OAuth for authentication. See documentation to fix to an allowed origin.",
+            message:
+              "This origin is not allowed when using OAuth for authentication. See documentation to fix to an allowed origin.",
           },
         });
       }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -67,6 +67,7 @@ import type {
   ModelId,
   Result,
   UserMessageContext,
+  UserMessageOrigin,
   UserMessageType,
 } from "@app/types";
 import {
@@ -83,6 +84,28 @@ import {
   removeNulls,
 } from "@app/types";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
+
+const ALLOWED_API_KEY_ORIGINS: UserMessageOrigin[] = [
+  "api",
+  "excel",
+  "github-copilot-chat", // TODO: find out how it's used
+  "gsheet",
+  "make",
+  "n8n",
+  "powerpoint",
+  "zapier",
+  "zendesk",
+];
+
+const ALLOWED_OAUTH_ORIGINS: UserMessageOrigin[] = [
+  "api",
+  "cli",
+  "cli_programmatic",
+  "extension",
+  "github-copilot-chat", // TODO: find out how it's used
+  "raycast",
+  "teams",
+];
 
 /**
  * Conversation Creation, update and deletion
@@ -373,6 +396,45 @@ export function getRelatedContentFragments(
   return relatedContentFragments;
 }
 
+export function validateUserMessageContext(
+  auth: Authenticator,
+  context: UserMessageContext
+): Result<void, APIErrorWithStatusCode> {
+  const authMethod = auth.authMethod();
+  switch (authMethod) {
+    case "api_key":
+      if (!ALLOWED_API_KEY_ORIGINS.includes(context.origin)) {
+        return new Err({
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The origin is not allowed for API key usage.",
+          },
+        });
+      }
+      break;
+    case "oauth":
+      if (!ALLOWED_OAUTH_ORIGINS.includes(context.origin)) {
+        return new Err({
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The origin is not allowed for OAuth usage.",
+          },
+        });
+      }
+      break;
+    case "session":
+    case "internal":
+    case "system_api_key":
+      break;
+    default:
+      assertNever(authMethod);
+  }
+
+  return new Ok(undefined);
+}
+
 // This method is in charge of creating a new user message in database, running the necessary agents
 // in response and updating accordingly the conversation. AgentMentions must point to valid agent
 // configurations from the same workspace or whose scope is global.
@@ -402,6 +464,14 @@ export async function postUserMessage(
     APIErrorWithStatusCode
   >
 > {
+  const validateUserMessageContextRes = validateUserMessageContext(
+    auth,
+    context
+  );
+  if (validateUserMessageContextRes.isErr()) {
+    return validateUserMessageContextRes;
+  }
+
   const user = auth.user();
   const owner = auth.workspace();
   const subscription = auth.subscription();

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -33,6 +33,7 @@ function createMockAuthenticator(): Authenticator {
     role: "none",
     groups: [],
     subscription: null,
+    authMethod: "internal",
   });
 }
 

--- a/front/lib/api/user.test.ts
+++ b/front/lib/api/user.test.ts
@@ -32,6 +32,7 @@ describe("getUserForWorkspace", () => {
       groups: [],
       workspace: null,
       subscription: null,
+      authMethod: "internal",
     });
 
     const result = await getUserForWorkspace(auth, { userId: user2.sId });
@@ -56,6 +57,7 @@ describe("getUserForWorkspace", () => {
       role: "none",
       groups: [],
       subscription: null,
+      authMethod: "internal",
     });
 
     // User1 tries to get info about user2, but user1 is not in the workspace.
@@ -81,6 +83,7 @@ describe("getUserForWorkspace", () => {
       role: "user",
       groups: [],
       subscription: null,
+      authMethod: "internal",
     });
 
     // User1 can get info about user2 because they're in the same workspace.
@@ -105,6 +108,7 @@ describe("getUserForWorkspace", () => {
       role: "user",
       groups: [],
       subscription: null,
+      authMethod: "internal",
     });
 
     // User1 gets their own info.
@@ -131,6 +135,7 @@ describe("getUserForWorkspace", () => {
       role: "user",
       groups: [],
       subscription: null,
+      authMethod: "internal",
     });
 
     // User1 tries to get user2's info, but user2 is not in workspace1.
@@ -154,6 +159,7 @@ describe("getUserForWorkspace", () => {
       role: "user",
       groups: [],
       subscription: null,
+      authMethod: "internal",
     });
 
     // Try to get a non-existent user.
@@ -184,6 +190,7 @@ describe("getUserForWorkspace", () => {
       role: "admin",
       groups: [],
       subscription: null,
+      authMethod: "internal",
     });
 
     // Revoke user2's membership.
@@ -195,6 +202,7 @@ describe("getUserForWorkspace", () => {
       role: "user",
       groups: [],
       subscription: null,
+      authMethod: "internal",
     });
 
     // User1 cannot see user2 because user2 no longer has an active membership.
@@ -220,6 +228,7 @@ describe("getUserForWorkspace", () => {
       role: "user",
       groups: [],
       subscription: null,
+      authMethod: "internal",
     });
 
     // User1 tries to access user2 from workspace1 context, but user2 is only in workspace2.
@@ -247,6 +256,7 @@ describe("getUserForWorkspace", () => {
       role: "user",
       groups: [],
       subscription: null,
+      authMethod: "internal",
     });
 
     // User1 can access user2 in workspace1 context.

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -68,7 +68,7 @@ export const isOAuthToken = (token: string): boolean => {
 };
 
 export interface AuthenticatorType {
-  authMethod?: AuthMethodType;
+  authMethod: AuthMethodType;
   workspaceId: string;
   userId: string | null;
   role: RoleType;
@@ -91,7 +91,7 @@ export class Authenticator {
   _user: UserResource | null;
   _groups: GroupResource[];
   _workspace: WorkspaceResource | null;
-  _authMethod?: AuthMethodType;
+  _authMethod: AuthMethodType;
 
   // Should only be called from the static methods below.
   constructor({
@@ -107,7 +107,7 @@ export class Authenticator {
     user?: UserResource | null;
     role: RoleType;
     groups: GroupResource[];
-    authMethod?: AuthMethodType;
+    authMethod: AuthMethodType;
     subscription?: SubscriptionResource | null;
     key?: KeyAuthType;
   }) {
@@ -697,7 +697,7 @@ export class Authenticator {
     return !!this._key;
   }
 
-  authMethod(): AuthMethodType | undefined {
+  authMethod(): AuthMethodType {
     return this._authMethod;
   }
 

--- a/front/migrations/20251210_backfill_user_context_origin.sql
+++ b/front/migrations/20251210_backfill_user_context_origin.sql
@@ -1,3 +1,37 @@
+COPY (
+    SELECT "id", "userContextOrigin"
+    FROM user_messages
+    WHERE
+        "userContextOrigin" NOT IN (
+            'api',
+            'cli',
+            'cli_programmatic',
+            'email',
+            'excel',
+            'extension',
+            'github-copilot-chat',
+            'gsheet',
+            'make',
+            'n8n',
+            'powerpoint',
+            'raycast',
+            'slack',
+            'slack_workflow',
+            'teams',
+            'transcript',
+            'triggered_programmatic',
+            'triggered',
+            'web',
+            'zapier',
+            'zendesk',
+            'onboarding_conversation',
+            'run_agent',
+            'agent_handover'
+        )
+) TO STDOUT
+WITH
+    CSV DELIMITER ',' HEADER;
+
 UPDATE user_messages
 SET
     "userContextOrigin" = 'api'

--- a/front/migrations/20251210_backfill_user_context_origin.sql
+++ b/front/migrations/20251210_backfill_user_context_origin.sql
@@ -1,0 +1,30 @@
+UPDATE user_messages
+SET
+    "userContextOrigin" = 'api'
+WHERE
+    "userContextOrigin" NOT IN (
+        'api',
+        'cli',
+        'cli_programmatic',
+        'email',
+        'excel',
+        'extension',
+        'github-copilot-chat',
+        'gsheet',
+        'make',
+        'n8n',
+        'powerpoint',
+        'raycast',
+        'slack',
+        'slack_workflow',
+        'teams',
+        'transcript',
+        'triggered_programmatic',
+        'triggered',
+        'web',
+        'zapier',
+        'zendesk',
+        'onboarding_conversation',
+        'run_agent',
+        'agent_handover'
+    );

--- a/front/migrations/db/migration_447.sql
+++ b/front/migrations/db/migration_447.sql
@@ -1,0 +1,3 @@
+-- Migration created on Dec 06, 2025
+ALTER TABLE "public"."user_messages"
+DROP COLUMN "userContextOriginMessageId";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -121,7 +121,7 @@ async function handler(
         context?.origin &&
         req.body.context.origin !== context.origin
       ) {
-        logger.info(
+        logger.warn(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
             authMethod: auth.authMethod(),

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -18,6 +18,7 @@ import {
 } from "@app/lib/api/programmatic_usage_tracking";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { UserMessageContext, WithAPIErrorResponse } from "@app/types";
 import { isEmptyString } from "@app/types";
@@ -114,6 +115,22 @@ async function handler(
         skipToolsValidation,
         agenticMessageData,
       } = r.data;
+
+      if (
+        req.body.context?.origin &&
+        context?.origin &&
+        req.body.context.origin !== context.origin
+      ) {
+        logger.info(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            authMethod: auth.authMethod(),
+            originProvided: req.body.context.origin,
+            originUsed: context.origin,
+          },
+          "Invalid origin used, fallbacking to default value"
+        );
+      }
 
       const origin = context.origin ?? "api";
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -149,7 +149,7 @@ async function handler(
         message?.context?.origin &&
         req.body.message.context.origin !== message.context.origin
       ) {
-        logger.info(
+        logger.warn(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
             authMethod: auth.authMethod(),

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -28,6 +28,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
   AgenticMessageData,
@@ -142,6 +143,22 @@ async function handler(
         skipToolsValidation,
         blocking,
       } = r.data;
+
+      if (
+        req.body.message?.context?.origin &&
+        message?.context?.origin &&
+        req.body.message.context.origin !== message.context.origin
+      ) {
+        logger.info(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            authMethod: auth.authMethod(),
+            originProvided: req.body.message.context.origin,
+            originUsed: message.context.origin,
+          },
+          "Invalid origin used, fallbacking to default value"
+        );
+      }
 
       const origin = message?.context.origin ?? "api";
 

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -120,7 +120,8 @@
  *           example: "https://example.com/profiles/johndoe123.jpg"
  *         origin:
  *           type: string
- *           description: Origin of the context (contact us to add more at support@dust.tt)
+ *           description: Origin of the context (contact us to add more at support@dust.tt). Some values are protected - if you get a invalid_request_error, consider using "api" instead.
+ *           default: "api"
  *           enum:
  *             - api
  *             - cli

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -123,15 +123,21 @@
  *           description: Origin of the context (contact us to add more at support@dust.tt)
  *           enum:
  *             - api
- *             - slack
- *             - gsheet
- *             - zapier
- *             - make
- *             - zendesk
- *             - raycast
- *             - github-copilot-chat
- *             - extension
+ *             - cli
+ *             - cli_programmatic
  *             - email
+ *             - excel
+ *             - extension
+ *             - github-copilot-chat
+ *             - gsheet
+ *             - make
+ *             - n8n
+ *             - powerpoint
+ *             - raycast
+ *             - slack
+ *             - teams
+ *             - zapier
+ *             - zendesk
  *         agenticMessageData:
  *           type: object
  *           properties:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -4969,7 +4969,8 @@
           },
           "origin": {
             "type": "string",
-            "description": "Origin of the context (contact us to add more at support@dust.tt)",
+            "description": "Origin of the context (contact us to add more at support@dust.tt). Some values are protected - if you get a invalid_request_error, consider using \"api\" instead.",
+            "default": "api",
             "enum": [
               "api",
               "cli",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -4972,15 +4972,21 @@
             "description": "Origin of the context (contact us to add more at support@dust.tt)",
             "enum": [
               "api",
-              "slack",
-              "gsheet",
-              "zapier",
-              "make",
-              "zendesk",
-              "raycast",
-              "github-copilot-chat",
+              "cli",
+              "cli_programmatic",
+              "email",
+              "excel",
               "extension",
-              "email"
+              "github-copilot-chat",
+              "gsheet",
+              "make",
+              "n8n",
+              "powerpoint",
+              "raycast",
+              "slack",
+              "teams",
+              "zapier",
+              "zendesk"
             ]
           },
           "agenticMessageData": {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -297,30 +297,32 @@ export function isSupportedAudioContentType(
   return supportedAudioContentTypes.includes(contentType as AudioContentType);
 }
 
-const UserMessageOriginSchema = FlexibleEnumSchema<
-  | "api"
-  | "cli"
-  | "cli_programmatic"
-  | "email"
-  | "excel"
-  | "extension"
-  | "github-copilot-chat"
-  | "gsheet"
-  | "make"
-  | "n8n"
-  | "powerpoint"
-  | "raycast"
-  | "slack"
-  | "slack_workflow"
-  | "teams"
-  | "transcript"
-  | "triggered_programmatic"
-  | "triggered"
-  | "web"
-  | "zapier"
-  | "zendesk"
-  | "onboarding_conversation"
->()
+const UserMessageOriginSchema = z
+  .enum([
+    "api",
+    "cli",
+    "cli_programmatic",
+    "email",
+    "excel",
+    "extension",
+    "github-copilot-chat",
+    "gsheet",
+    "make",
+    "n8n",
+    "powerpoint",
+    "raycast",
+    "slack",
+    "slack_workflow",
+    "teams",
+    "transcript",
+    "triggered_programmatic",
+    "triggered",
+    "web",
+    "zapier",
+    "zendesk",
+    "onboarding_conversation",
+  ])
+  .catch("api")
   .or(z.null())
   .or(z.undefined());
 


### PR DESCRIPTION
fixes: 

[#5306](https://github.com/dust-tt/tasks/issues/5306)

## Description

This adds enforcement on the origin, based on api
- Only allows values expected in type. Fallback on "api" if it's not known
- Add list of allowed origin for api-key and oauth based authentication. 
- ~~"is programmatic" is now only based on origin, not auth type. We can have programmatic usage based on oauth or api-key, this should not be related to auth.~~

Except zendesk (that will be handled in https://github.com/dust-tt/tasks/issues/5524 ), all origins allowed for api-key are programmatic usage . This ensure we can't spoof non-programmatic with api-key.
It's still possible to create non-programmatic usage using oauth token, but given the additional complexity to create an oauth based, this is imo ok. This will anyway require explicit user login and fall in fair usage.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

This may block some users using not-allowed origins (people sending "web" as origin with api-key), identify usage before merging.

## Deploy Plan

deploy front
run sql backfill 
run 20251116_backfill_context_origin_analytics.ts yo update index
