### PR TITLE
Add open sourceUrl to attachment viewer

### DIFF
--- a/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
@@ -7,6 +7,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  ExternalLinkIcon,
   Spinner,
 } from "@dust-tt/sparkle";
 import React, { useEffect, useMemo, useState } from "react";
@@ -164,11 +165,28 @@ export const AttachmentViewer = ({
     }
   };
 
+  const sourceUrl = attachmentCitation.sourceUrl;
+  const onClickOpenSource = () => {
+    if (sourceUrl) {
+      window.open(sourceUrl, "_blank");
+    }
+  };
+
   return (
     <Dialog open={viewerOpen} onOpenChange={setViewerOpen}>
       <DialogContent size="xl" height="lg">
         <DialogHeader>
           <DialogTitle>
+            {sourceUrl && (
+              <Button
+                onClick={onClickOpenSource}
+                icon={ExternalLinkIcon}
+                size="mini"
+                tooltip="Open document source"
+                variant="ghost"
+                className={"mr-2 align-middle"}
+              />
+            )}
             {canDownload && (
               <Button
                 onClick={onClickDownload}


### PR DESCRIPTION
## Description

Add "Open source" button in attachment viewer dialog to open the original file in its source (e.g., Google Drive) when a sourceUrl is available.

Design is the most basic, to check with Ed first!

<img width="894" height="667" alt="Screenshot 2025-12-09 at 23 10 06" src="https://github.com/user-attachments/assets/fa305e88-a728-4f6f-9290-254e693bc822" />



## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 