### PR TITLE
Add ability to delete Notion page

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -378,6 +378,7 @@ export const INTERNAL_MCP_SERVERS = {
       add_page_content: "low",
       create_comment: "low",
       delete_block: "low",
+      delete_page: "low",
       update_row_database: "low",
       update_schema_database: "low",
     },

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -813,11 +813,9 @@ function createServer(
 
   server.tool(
     "delete_block",
-    "Archive (delete) a block, page, or database in Notion by setting it to archived: true. In the Notion UI, this moves the block to the 'trash,' where it can be restored if needed.",
+    "Archive (delete) block content in a page. In the Notion UI, this moves the block to the 'trash,' where it can be restored if needed.",
     {
-      blockId: z
-        .string()
-        .describe("The ID of the block, page, or database to delete."),
+      blockId: z.string().describe("The ID of the block"),
     },
     withToolLogging(
       auth,
@@ -829,6 +827,27 @@ function createServer(
         return withNotionClient(
           (notion) =>
             notion.blocks.update({ block_id: blockId, archived: true }),
+          authInfo
+        );
+      }
+    )
+  );
+
+  server.tool(
+    "delete_page",
+    "Archive (delete) a page or database row. In the Notion UI, this moves the block to the 'trash,' where it can be restored if needed.",
+    {
+      pageId: z.string().describe("The ID of the page"),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: NOTION_TOOL_NAME,
+        agentLoopContext,
+      },
+      async ({ pageId }, { authInfo }) => {
+        return withNotionClient(
+          (notion) => notion.pages.update({ page_id: pageId, in_trash: true }),
           authInfo
         );
       }


### PR DESCRIPTION
## Description

* This is broken currently as you cannot use the delete_block tool to delete child pages or database rows

## Tests

* Validated locally

## Risk

* Low

## Deploy Plan

* Deploy front