### PR TITLE
Attachement Viewer supports mardown + Google Drive file exported as markdown

### DIFF
--- a/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
@@ -7,6 +7,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Markdown,
   Spinner,
 } from "@dust-tt/sparkle";
 import React, { useEffect, useMemo, useState } from "react";
@@ -49,6 +50,7 @@ export const AttachmentViewer = ({
   const [text, setText] = useState<string | undefined>();
 
   const isAudio = isAudioContentType(attachmentCitation);
+  const isMarkdown = attachmentCitation.contentType === "text/markdown";
 
   // For input bar attachments, try to get the local file blob for reading content directly.
   // For fragments/mcp, we always fetch from server.
@@ -179,6 +181,9 @@ export const AttachmentViewer = ({
                 className={"mr-2 align-middle"}
               />
             )}
+            <span className="mr-2 inline-flex align-middle">
+              {attachmentCitation.visual}
+            </span>
             {attachmentCitation.title}
           </DialogTitle>
         </DialogHeader>
@@ -189,10 +194,11 @@ export const AttachmentViewer = ({
             </div>
           )}
           {!isLoading && audioPlayer}
-          {!isLoading && (
-            <pre className="m-0 max-h-[60vh] whitespace-pre-wrap break-words">
-              {text}
-            </pre>
+          {!isLoading && isMarkdown && text && (
+            <Markdown content={text} isStreaming={false} isLastMessage />
+          )}
+          {!isLoading && !isMarkdown && !isAudio && (
+            <pre className="m-0 whitespace-pre-wrap break-words">{text}</pre>
           )}
         </DialogContainer>
         <DialogFooter

--- a/front/lib/providers/google_drive/search.ts
+++ b/front/lib/providers/google_drive/search.ts
@@ -1,3 +1,5 @@
+import TurndownService from "turndown";
+
 import {
   getGoogleDriveClient,
   MAX_FILE_SIZE,
@@ -10,6 +12,26 @@ import type {
   ToolSearchRawResult,
 } from "@app/lib/search/tools/types";
 import type { ContentNodeType } from "@app/types/core/content_node";
+
+const turndownService = new TurndownService({
+  headingStyle: "atx",
+  codeBlockStyle: "fenced",
+  bulletListMarker: "-",
+});
+
+turndownService.remove(["style", "script", "meta", "link", "head"]);
+
+// Remove images with base64 data URIs (they're huge and not useful in text form).
+turndownService.addRule("removeBase64Images", {
+  filter: (node) => {
+    if (node.nodeName !== "IMG") {
+      return false;
+    }
+    const src = node.getAttribute("src") ?? "";
+    return src.startsWith("data:");
+  },
+  replacement: () => "",
+});
 
 export async function search({
   accessToken,
@@ -75,20 +97,23 @@ export async function download({
   }
 
   let content: string;
+  let contentType: "text/markdown" | "text/csv" | "text/plain";
 
   // Export Google native files or download regular files.
   if (
     file.mimeType === "application/vnd.google-apps.document" ||
     file.mimeType === "application/vnd.google-apps.presentation"
   ) {
+    // Export as HTML and convert to markdown to preserve formatting (headings, lists, etc).
     const exportRes = await drive.files.export({
       fileId: externalId,
-      mimeType: "text/plain",
+      mimeType: "text/html",
     });
     if (typeof exportRes.data !== "string") {
       throw new Error("Failed to export file content.");
     }
-    content = exportRes.data;
+    content = turndownService.turndown(exportRes.data);
+    contentType = "text/markdown";
   } else if (file.mimeType === "application/vnd.google-apps.spreadsheet") {
     // Export Google Sheets as CSV.
     const exportRes = await drive.files.export({
@@ -99,6 +124,7 @@ export async function download({
       throw new Error("Failed to export spreadsheet content.");
     }
     content = exportRes.data;
+    contentType = "text/csv";
   } else if (SUPPORTED_MIMETYPES.includes(file.mimeType)) {
     const downloadRes = await drive.files.get({
       fileId: externalId,
@@ -108,6 +134,7 @@ export async function download({
       throw new Error("Failed to download file content.");
     }
     content = downloadRes.data;
+    contentType = "text/plain";
   } else {
     throw new Error(`Unsupported file type: ${file.mimeType}`);
   }
@@ -115,6 +142,6 @@ export async function download({
   return {
     content,
     fileName: file.name,
-    mimeType: file.mimeType,
+    contentType,
   };
 }

--- a/front/lib/search/tools/search.ts
+++ b/front/lib/search/tools/search.ts
@@ -185,9 +185,16 @@ export async function downloadAndUploadToolFile({
     );
   }
 
+  const contentTypeToExtension: Record<string, string> = {
+    "text/markdown": "md",
+    "text/csv": "csv",
+    "text/plain": "txt",
+  };
+  const extension = contentTypeToExtension[downloadResult.contentType] ?? "txt";
+
   const file = await FileResource.makeNew({
-    contentType: "text/plain",
-    fileName: `${downloadResult.fileName}.txt`,
+    contentType: downloadResult.contentType,
+    fileName: `${downloadResult.fileName}.${extension}`,
     fileSize: Buffer.byteLength(downloadResult.content, "utf8"),
     userId: user.id,
     workspaceId: owner.id,

--- a/front/lib/search/tools/types.ts
+++ b/front/lib/search/tools/types.ts
@@ -32,7 +32,7 @@ export type ToolDownloadParams = {
 export type ToolDownloadResult = {
   content: string;
   fileName: string;
-  mimeType: string;
+  contentType: "text/markdown" | "text/csv" | "text/plain";
 };
 
 export type SearchableTool = {


### PR DESCRIPTION
## Description

- Google drive file exported as mardown. 
- Dialog shows markdown if markdown. 


Before: 
<kbd>
<img width="848" height="697" alt="Screenshot 2025-12-10 at 10 38 08" src="https://github.com/user-attachments/assets/2d622258-0c2c-4dfd-aa4a-2098b3bf75da" />
</kbd>

After: 
<kbd>
<img width="850" height="668" alt="Screenshot 2025-12-10 at 10 38 22" src="https://github.com/user-attachments/assets/378a1ce4-0004-4254-b208-6c64facb5513" />
</kbd>

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 