### PR TITLE
Add new advanced search capability and handle pagination for list_issue in github mcp.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -157,6 +157,7 @@ export const INTERNAL_MCP_SERVERS = {
       list_organization_projects: "never_ask",
       list_issues: "never_ask",
       list_pull_requests: "never_ask",
+      search_advanced: "never_ask",
       get_issue: "never_ask",
     },
     tools_retry_policies: undefined,


### PR DESCRIPTION
## Description

- Add pagination support for "list_issues".
- Add new tool for advanced search (much much more efficient for a lot of use cases in my testing). See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front