### PR TITLE
enh(gh): retry small file upload

### DIFF
--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -253,6 +253,7 @@ export class GCSRepositoryManager {
             return;
           } catch (error) {
             lastError = error;
+            // If we're not on the last attempt, back off before retrying.
             if (attempt < SMALL_FILE_UPLOAD_MAX_RETRIES - 1) {
               const delay =
                 SMALL_FILE_UPLOAD_BASE_DELAY_MS * Math.pow(2, attempt);


### PR DESCRIPTION
## Description

For the Github code connectors, we want to retry the GCS upload of small files up to 3 times.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
