### PR TITLE
Excessive line spacing when using line returns in input bar

### DIFF
--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -63,7 +63,7 @@ export function Markdown({
   textColor = "s-text-foreground dark:s-text-foreground-night",
   forcedTextSize,
   isLastMessage = false,
-  tightParagraphSpacing = false,
+  compactSpacing = false,
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
 }: {
@@ -71,18 +71,18 @@ export function Markdown({
   isStreaming?: boolean;
   textColor?: string;
   isLastMessage?: boolean;
-  tightParagraphSpacing?: boolean; // When true, removes vertical padding from paragraph blocks for tighter spacing
+  compactSpacing?: boolean; // When true, removes vertical padding from paragraph blocks for tighter spacing
   forcedTextSize?: string;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
 }) {
   const processedContent = useMemo(() => {
     let sanitized = sanitizeContent(content);
-    if (tightParagraphSpacing) {
+    if (compactSpacing) {
       sanitized = preserveLineBreaks(sanitized);
     }
     return preprocessDollarSigns(sanitized);
-  }, [content]);
+  }, [content, compactSpacing]);
 
   // Note on re-renderings. A lot of effort has been put into preventing rerendering across markdown
   // AST parsing rounds (happening at each token being streamed).
@@ -132,7 +132,7 @@ export function Markdown({
         <ParagraphBlock
           textColor={textColor}
           textSize={forcedTextSize ? forcedTextSize : sizes.p}
-          tightSpacing={tightParagraphSpacing}
+          compactSpacing={compactSpacing}
         >
           {children}
         </ParagraphBlock>
@@ -221,7 +221,7 @@ export function Markdown({
       code: CodeBlockWithExtendedSupport,
       ...additionalMarkdownComponents,
     };
-  }, [textColor, tightParagraphSpacing, additionalMarkdownComponents]);
+  }, [textColor, compactSpacing, additionalMarkdownComponents]);
 
   const markdownPlugins: PluggableList = useMemo(
     () => [

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -26,6 +26,7 @@ import {
 } from "@sparkle/components/markdown/TableBlock";
 import {
   preprocessDollarSigns,
+  preserveLineBreaks,
   sanitizeContent,
 } from "@sparkle/components/markdown/utils";
 import { cn } from "@sparkle/lib/utils";
@@ -62,6 +63,7 @@ export function Markdown({
   textColor = "s-text-foreground dark:s-text-foreground-night",
   forcedTextSize,
   isLastMessage = false,
+  tightParagraphSpacing = false,
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
 }: {
@@ -69,12 +71,16 @@ export function Markdown({
   isStreaming?: boolean;
   textColor?: string;
   isLastMessage?: boolean;
+  tightParagraphSpacing?: boolean; // When true, removes vertical padding from paragraph blocks for tighter spacing
   forcedTextSize?: string;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
 }) {
   const processedContent = useMemo(() => {
-    const sanitized = sanitizeContent(content);
+    let sanitized = sanitizeContent(content);
+    if (tightParagraphSpacing) {
+      sanitized = preserveLineBreaks(sanitized);
+    }
     return preprocessDollarSigns(sanitized);
   }, [content]);
 
@@ -126,6 +132,7 @@ export function Markdown({
         <ParagraphBlock
           textColor={textColor}
           textSize={forcedTextSize ? forcedTextSize : sizes.p}
+          tightSpacing={tightParagraphSpacing}
         >
           {children}
         </ParagraphBlock>
@@ -214,7 +221,7 @@ export function Markdown({
       code: CodeBlockWithExtendedSupport,
       ...additionalMarkdownComponents,
     };
-  }, [textColor, additionalMarkdownComponents]);
+  }, [textColor, tightParagraphSpacing, additionalMarkdownComponents]);
 
   const markdownPlugins: PluggableList = useMemo(
     () => [

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -6,12 +6,12 @@ import { cn } from "@sparkle/lib";
 export const paragraphBlockVariants = cva(
   [
     "s-whitespace-pre-wrap s-break-words s-font-normal first:s-pt-0 last:s-pb-0",
-    "s-py-0",
   ],
   {
     variants: {
-      variant: {
-        surface: ["s-py-1 @md:s-py-2 @md:s-leading-7"],
+      tightSpacing: {
+        true: ["s-py-0"],
+        false: ["s-py-1 @md:s-py-2 @md:s-leading-7"],
       },
     },
   }
@@ -21,18 +21,22 @@ interface ParagraphBlockProps {
   children: React.ReactNode;
   textColor: string;
   textSize: string;
-  variant?: "surface";
+  tightSpacing?: boolean;
 }
 
 export function ParagraphBlock({
   children,
   textColor,
   textSize,
-  variant = "surface",
+  tightSpacing = false,
 }: ParagraphBlockProps) {
   return (
     <div
-      className={cn(paragraphBlockVariants({ variant }), textSize, textColor)}
+      className={cn(
+        paragraphBlockVariants({ tightSpacing }),
+        textSize,
+        textColor
+      )}
     >
       {children}
     </div>

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -3,24 +3,37 @@ import React from "react";
 
 import { cn } from "@sparkle/lib";
 
-export const paragraphBlockVariants = cva([
-  "s-whitespace-pre-wrap s-break-words s-font-normal first:s-pt-0 last:s-pb-0",
-  "s-py-1 @md:s-py-2 @md:s-leading-7",
-]);
+export const paragraphBlockVariants = cva(
+  [
+    "s-whitespace-pre-wrap s-break-words s-font-normal first:s-pt-0 last:s-pb-0",
+    "s-py-0",
+  ],
+  {
+    variants: {
+      variant: {
+        surface: ["s-py-1 @md:s-py-2 @md:s-leading-7"],
+      },
+    },
+  }
+);
 
 interface ParagraphBlockProps {
   children: React.ReactNode;
   textColor: string;
   textSize: string;
+  variant?: "surface";
 }
 
 export function ParagraphBlock({
   children,
   textColor,
   textSize,
+  variant = "surface",
 }: ParagraphBlockProps) {
   return (
-    <div className={cn(paragraphBlockVariants(), textSize, textColor)}>
+    <div
+      className={cn(paragraphBlockVariants({ variant }), textSize, textColor)}
+    >
       {children}
     </div>
   );

--- a/sparkle/src/components/markdown/ParagraphBlock.tsx
+++ b/sparkle/src/components/markdown/ParagraphBlock.tsx
@@ -9,7 +9,7 @@ export const paragraphBlockVariants = cva(
   ],
   {
     variants: {
-      tightSpacing: {
+      compactSpacing: {
         true: ["s-py-0"],
         false: ["s-py-1 @md:s-py-2 @md:s-leading-7"],
       },
@@ -21,19 +21,19 @@ interface ParagraphBlockProps {
   children: React.ReactNode;
   textColor: string;
   textSize: string;
-  tightSpacing?: boolean;
+  compactSpacing?: boolean;
 }
 
 export function ParagraphBlock({
   children,
   textColor,
   textSize,
-  tightSpacing = false,
+  compactSpacing = false,
 }: ParagraphBlockProps) {
   return (
     <div
       className={cn(
-        paragraphBlockVariants({ tightSpacing }),
+        paragraphBlockVariants({ compactSpacing }),
         textSize,
         textColor
       )}

--- a/sparkle/src/components/markdown/utils.ts
+++ b/sparkle/src/components/markdown/utils.ts
@@ -41,6 +41,16 @@ export function detectLanguage(children: React.ReactNode) {
 }
 
 /**
+ * Converts consecutive newlines (\n\n) into hard breaks to preserve line spacing.
+ * Inserts an empty line with a non-breaking space to create visual spacing.
+ */
+export function preserveLineBreaks(content: string): string {
+  // Replace \n\n with \n&nbsp;\n\n to insert an empty line with content
+  // This creates visual spacing between paragraphs
+  return content.replace(/\n\n\n\n/g, "\n\n&nbsp;\n\n");
+}
+
+/**
  * Preprocesses content to escape dollar signs that are likely NOT inlione LaTeX math. This helps
  * prevent false positives when enabling single $ math rendering.
  *


### PR DESCRIPTION
## Description

When doing line returns in the input bar, there is much more space between the lines than expected.
This PR removes the padding of the lines, only in the input bar and user messages.
Another PR will follow with changes in front.

<img width="922" height="359" alt="Image" src="https://github.com/user-attachments/assets/98e97a85-39df-42a4-8152-ca6006e01657" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Publish Sparkle and bump the package in front
