### PR TITLE
[Front] chore(slackstorm): add disclaimer for legacy apps with a goto link

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -313,6 +313,36 @@ function UpdateConnectionOAuthModal({
               title={`${connectorConfiguration.name} data & permissions`}
             />
           </div>
+
+          {isLegacySlackApp && (
+            <div className="mt-4">
+              <ContentMessage
+                size="md"
+                variant="warning"
+                title="Migration required"
+                icon={InformationCircleIcon}
+              >
+                You are using a legacy way to connect your Slack workspace to
+                Dust. Starting December 2025, all Slack connections require
+                customers to create their own Slack app. This change ensures
+                optimal performance and reliable real-time syncing.
+                <br />
+                <br />
+                Please follow the instructions of the section{" "}
+                <b>"Setting up the Connection"</b> in our{" "}
+                <Hoverable
+                  href="https://docs.dust.tt/docs/slack-connection#setting-up-the-connection"
+                  target="_blank"
+                  variant="highlight"
+                >
+                  official documentation
+                </Hoverable>{" "}
+                and enter your credentials below to{" "}
+                <b>complete the migration before March 3, 2026</b>.
+              </ContentMessage>
+            </div>
+          )}
+
           {isDataSourceOwner && (
             <div className="mb-4 mt-8 w-full rounded-lg bg-info-50 p-3">
               <div className="flex items-center gap-2 font-medium text-info-800">
@@ -389,9 +419,6 @@ function UpdateConnectionOAuthModal({
                   .
                 </div>
               )}
-              {
-                isLegacySlackApp && "" // TODO(slackstorm) fabien: add message about legacy slack app
-              }
             </ContentMessage>
           </div>
         )}
@@ -609,9 +636,18 @@ function DataSourceDeletionModal({
   );
 }
 
+type ModalType =
+  | "data_updated"
+  | "edition"
+  | "selection"
+  | "deletion"
+  | "private_integration"
+  | null;
+
 interface ConnectorPermissionsModalProps {
   connector: ConnectorType;
   dataSourceView: DataSourceViewType;
+  initialModalState?: ModalType;
   isAdmin: boolean;
   isOpen: boolean;
   onClose: (save: boolean) => void;
@@ -623,6 +659,7 @@ interface ConnectorPermissionsModalProps {
 export function ConnectorPermissionsModal({
   connector,
   dataSourceView,
+  initialModalState = "selection",
   isAdmin,
   isOpen,
   onClose,
@@ -710,14 +747,7 @@ export function ConnectorPermissionsModal({
     }
   }, [initialTreeSelectionModel, isOpen]);
 
-  const [modalToShow, setModalToShow] = useState<
-    | "data_updated"
-    | "edition"
-    | "selection"
-    | "deletion"
-    | "private_integration"
-    | null
-  >(null);
+  const [modalToShow, setModalToShow] = useState<ModalType>(null);
 
   const { activeSubscription } = useWorkspaceActiveSubscription({
     owner,
@@ -827,11 +857,11 @@ export function ConnectorPermissionsModal({
   useEffect(() => {
     if (isOpen) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setModalToShow("selection");
+      setModalToShow(initialModalState);
     } else {
       setModalToShow(null);
     }
-  }, [connector.type, isOpen]);
+  }, [connector.type, initialModalState, isOpen]);
 
   const connectorConfiguration = CONNECTOR_CONFIGURATIONS[connector.type];
   const connectorUIConfiguration = CONNECTOR_UI_CONFIGURATIONS[connector.type];

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -3,13 +3,12 @@ import type { ReactElement } from "react";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
 import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
-import { Authenticator, getSession } from "@app/lib/auth";
+import { getSession } from "@app/lib/auth";
 import {
   getUserFromSession,
   makeGetServerSidePropsRequirementsWrapper,
 } from "@app/lib/iam/session";
 import { getPersistedNavigationSelection } from "@app/lib/persisted_navigation_selection";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { extractUTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
@@ -75,21 +74,6 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
     const { goto, templateId } = context.query;
     if (goto === "template" && isString(templateId)) {
       url = url + `/builder/agents/create?templateId=${templateId}`;
-    }
-
-    // This allows linking to the Slack connection configuration modal.
-    if (goto === "configureSlack") {
-      const targetWorkspace = user.workspaces.find(
-        (w) => w.sId === url.replace("/w/", "")
-      );
-      if (targetWorkspace) {
-        const auth = await Authenticator.fromSuperUserSession(
-          session,
-          targetWorkspace.sId
-        );
-        const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-        url = `/w/${targetWorkspace.sId}/spaces/${systemSpace.sId}/categories/managed?configureConnection=slack`;
-      }
     }
 
     if (context.query.inviteToken) {

--- a/front/pages/w/[wId]/index.tsx
+++ b/front/pages/w/[wId]/index.tsx
@@ -1,4 +1,5 @@
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<object>(
@@ -6,6 +7,19 @@ export const getServerSideProps = withDefaultUserAuthRequirements<object>(
     if (!auth.workspace() || !auth.user()) {
       return {
         notFound: true,
+      };
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+
+    // Handle configureSlack redirect - redirect to system space managed page (admin only).
+    if (context.query.goto === "configureSlack" && auth.isAdmin()) {
+      const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+      return {
+        redirect: {
+          destination: `/w/${owner.sId}/spaces/${systemSpace.sId}/categories/managed?configureConnection=slack`,
+          permanent: false,
+        },
       };
     }
 


### PR DESCRIPTION
## Description

Add a disclaimer to slack edit permissions modal for users that are still using our `Slack Data Sync` app to encourage them to migrate to the self-created app flow.

Add a goto link with logic to open the correct modal to include it in communications email and facilitate the migration of customers with active slack connections

Note :
- if the user has no slack connection it will simply redirect them to the system space page
- if the user is not admin he will not be redirected

gotolink will be of format : `https://dust.tt/w/[wId]?goto=configureSlack`

## Tests


https://github.com/user-attachments/assets/02652b6b-763b-40ef-b1f9-80db30e2eb92


## Risk

Low

## Deploy Plan

Front