### PR TITLE
[Programmatic Usage] Fix total credits line dropping for future points

### DIFF
--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -393,7 +393,9 @@ export function BaseProgrammaticCostChart({
     });
   }
 
-  // Transform points into chart data using labels from availableGroups
+  // Transform points into chart data using labels from availableGroups.
+  // Track the last known cumulative cost for use in future points.
+  let lastKnownCumulativeCost = 0;
   const chartData = points.map((point) => {
     const dataPoint: ChartDataPoint = {
       timestamp: point.timestamp,
@@ -403,12 +405,18 @@ export function BaseProgrammaticCostChart({
     // This avoids showing a total credits line below cumulative cost when credits expire
     // (expired credits are no longer in totalInitialCreditsMicroUsd but their consumed
     // usage is still in cumulative cost).
+    // For future points (where cumulatedCostMicroUsd is undefined), use the last known
+    // cumulative cost so the total credits line stays level.
     const cumulativeCost = point.groups.reduce(
       (acc, g) => acc + (g.cumulatedCostMicroUsd ?? 0),
       0
     );
+    if (cumulativeCost > 0) {
+      lastKnownCumulativeCost = cumulativeCost;
+    }
     dataPoint.totalCreditsMicroUsd =
-      cumulativeCost + point.totalRemainingCreditsMicroUsd;
+      (cumulativeCost > 0 ? cumulativeCost : lastKnownCumulativeCost) +
+      point.totalRemainingCreditsMicroUsd;
 
     // Add each group's cumulative cost to the data point using labels from availableGroups
     // Keep undefined values as-is so Recharts doesn't render those points


### PR DESCRIPTION
## Description

For future points in the usage chart, `cumulatedCostMicroUsd` is undefined (since usage has not happened yet). This caused the total credits line to drop to just the remaining credits value instead of staying level.

This fix tracks the last known cumulative cost and uses it for future points, keeping the total credits line at a consistent level.

## Risks

Blast radius: Programmatic usage chart display
Risk: low

## Deploy Plan
- pmrr
- deploy front