### PR TITLE
fix(front): re-order mcp servers by id

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -51,14 +51,14 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "deep_dive", id: 29 },
       { name: "speech_generator", id: 34 },
       { name: "search", id: 1006 },
-      { name: "run_agent", id: 1008 },
-      { name: "common_utilities", id: 1017 },
       { name: "reasoning", id: 1007 },
+      { name: "run_agent", id: 1008 },
       { name: "query_tables_v2", id: 1009 },
       { name: "data_sources_file_system", id: 1010 },
       { name: "agent_management", id: 1011 },
       { name: "data_warehouses", id: 1012 },
       { name: "toolsets", id: 1013 },
+      { name: "common_utilities", id: 1017 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1293,6 +1293,33 @@ export const INTERNAL_MCP_SERVERS = {
       developerSecretSelection: "required",
     },
   },
+  zendesk: {
+    id: 42,
+    availability: "manual",
+    allowMultipleInstances: true,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: {
+      get_ticket: "never_ask",
+      search_tickets: "never_ask",
+      draft_reply: "low", // Low because it's a draft.
+    },
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "zendesk",
+      version: "1.0.0",
+      description:
+        "Access and manage support tickets, help center, and customer interactions.",
+      authorization: {
+        provider: "zendesk" as const,
+        supported_use_cases: ["platform_actions"] as const,
+      },
+      icon: "ZendeskLogo",
+      documentationUrl: null,
+      instructions: null,
+    },
+  },
   slab: {
     id: 43,
     availability: "manual",
@@ -1347,44 +1374,8 @@ export const INTERNAL_MCP_SERVERS = {
       instructions: null,
     },
   },
-  [SEARCH_SERVER_NAME]: {
-    id: 1006,
-    availability: "auto",
-    allowMultipleInstances: false,
-    isRestricted: undefined,
-    isPreview: false,
-    tools_stakes: undefined,
-    tools_retry_policies: { default: "retry_on_interrupt" },
-    timeoutMs: undefined,
-    serverInfo: {
-      name: SEARCH_SERVER_NAME,
-      version: "1.0.0",
-      description: "Search content to find the most relevant information.",
-      icon: "ActionMagnifyingGlassIcon",
-      authorization: null,
-      documentationUrl: null,
-      instructions: null,
-    },
-  },
-  run_agent: {
-    id: 1008,
-    availability: "auto",
-    allowMultipleInstances: true,
-    isRestricted: undefined,
-    isPreview: false,
-    tools_stakes: undefined,
-    tools_retry_policies: { default: "retry_on_interrupt" },
-    timeoutMs: DEFAULT_MCP_REQUEST_TIMEOUT_MS,
-    serverInfo: {
-      name: "run_agent",
-      version: "1.0.0",
-      description: "Run a child agent (agent as tool).",
-      icon: "ActionRobotIcon",
-      authorization: null,
-      documentationUrl: null,
-      instructions: null,
-    },
-  },
+
+  //
   primitive_types_debugger: {
     id: 1004,
     availability: "manual",
@@ -1407,42 +1398,20 @@ export const INTERNAL_MCP_SERVERS = {
       instructions: null,
     },
   },
-  common_utilities: {
-    id: 1017,
-    availability: "auto_hidden_builder",
+  [SEARCH_SERVER_NAME]: {
+    id: 1006,
+    availability: "auto",
     allowMultipleInstances: false,
-    isPreview: false,
     isRestricted: undefined,
-    tools_stakes: undefined,
-    tools_retry_policies: undefined,
-    timeoutMs: undefined,
-    serverInfo: {
-      name: "common_utilities",
-      version: "1.0.0",
-      description:
-        "Miscellaneous helper tools such as random numbers, time retrieval, and timers.",
-      icon: "ActionAtomIcon",
-      authorization: null,
-      documentationUrl: null,
-      instructions: null,
-    },
-  },
-  jit_testing: {
-    id: 1016,
-    availability: "manual",
-    allowMultipleInstances: false,
     isPreview: false,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("dev_mcp_actions");
-    },
     tools_stakes: undefined,
-    tools_retry_policies: undefined,
+    tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
-      name: "jit_testing",
+      name: SEARCH_SERVER_NAME,
       version: "1.0.0",
-      description: "Demo server to test if can be added to JIT.",
-      icon: "ActionEmotionLaughIcon",
+      description: "Search content to find the most relevant information.",
+      icon: "ActionMagnifyingGlassIcon",
       authorization: null,
       documentationUrl: null,
       instructions: null,
@@ -1463,6 +1432,25 @@ export const INTERNAL_MCP_SERVERS = {
       description:
         "Agent can decide to trigger a reasoning model for complex tasks.",
       icon: "ActionLightbulbIcon",
+      authorization: null,
+      documentationUrl: null,
+      instructions: null,
+    },
+  },
+  run_agent: {
+    id: 1008,
+    availability: "auto",
+    allowMultipleInstances: true,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    tools_retry_policies: { default: "retry_on_interrupt" },
+    timeoutMs: DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+    serverInfo: {
+      name: "run_agent",
+      version: "1.0.0",
+      description: "Run a child agent (agent as tool).",
+      icon: "ActionRobotIcon",
       authorization: null,
       documentationUrl: null,
       instructions: null,
@@ -1602,6 +1590,47 @@ export const INTERNAL_MCP_SERVERS = {
       developerSecretSelection: "required",
     },
   },
+  jit_testing: {
+    id: 1016,
+    availability: "manual",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("dev_mcp_actions");
+    },
+    tools_stakes: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "jit_testing",
+      version: "1.0.0",
+      description: "Demo server to test if can be added to JIT.",
+      icon: "ActionEmotionLaughIcon",
+      authorization: null,
+      documentationUrl: null,
+      instructions: null,
+    },
+  },
+  common_utilities: {
+    id: 1017,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: undefined,
+    tools_stakes: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "common_utilities",
+      version: "1.0.0",
+      description:
+        "Miscellaneous helper tools such as random numbers, time retrieval, and timers.",
+      icon: "ActionAtomIcon",
+      authorization: null,
+      documentationUrl: null,
+      instructions: null,
+    },
+  },
   front: {
     id: 1018,
     availability: "manual",
@@ -1648,33 +1677,6 @@ export const INTERNAL_MCP_SERVERS = {
         "- Use LLM-friendly timeline format for conversation data\n" +
         "- Include full context (metadata, custom fields) in responses",
       developerSecretSelection: "required",
-    },
-  },
-  zendesk: {
-    id: 42,
-    availability: "manual",
-    allowMultipleInstances: true,
-    isRestricted: undefined,
-    isPreview: false,
-    tools_stakes: {
-      get_ticket: "never_ask",
-      search_tickets: "never_ask",
-      draft_reply: "low", // Low because it's a draft.
-    },
-    tools_retry_policies: undefined,
-    timeoutMs: undefined,
-    serverInfo: {
-      name: "zendesk",
-      version: "1.0.0",
-      description:
-        "Access and manage support tickets, help center, and customer interactions.",
-      authorization: {
-        provider: "zendesk" as const,
-        supported_use_cases: ["platform_actions"] as const,
-      },
-      icon: "ZendeskLogo",
-      documentationUrl: null,
-      instructions: null,
     },
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1374,8 +1374,6 @@ export const INTERNAL_MCP_SERVERS = {
       instructions: null,
     },
   },
-
-  //
   primitive_types_debugger: {
     id: 1004,
     availability: "manual",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Currently really unclear from the code to know which IDs are available, this PR only reorders the internal servers by ID.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, just reodering the object

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front