### PR TITLE
feat(skills): enable skill tool

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -41,6 +41,8 @@ export const GET_MENTION_MARKDOWN_TOOL_NAME = "get_mention_markdown";
 export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
   "__dust_conversation_history";
 
+export const DEFAULT_ENABLE_SKILL_TOOL_NAME = "enable_skill";
+
 export const DEFAULT_MCP_ACTION_NAME = "mcp";
 export const DEFAULT_MCP_ACTION_VERSION = "1.0.0";
 export const DEFAULT_MCP_ACTION_DESCRIPTION =

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -59,6 +59,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "data_warehouses", id: 1012 },
       { name: "toolsets", id: 1013 },
       { name: "common_utilities", id: 1017 },
+      { name: "skill_management", id: 1019 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -31,7 +31,6 @@ import type {
   WhitelistableFeature,
 } from "@app/types";
 import { Err, Ok } from "@app/types";
-import { SKILL_ICON } from "@app/lib/skill";
 
 export const ADVANCED_SEARCH_SWITCH = "advanced_search";
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -31,6 +31,7 @@ import type {
   WhitelistableFeature,
 } from "@app/types";
 import { Err, Ok } from "@app/types";
+import { SKILL_ICON } from "@app/lib/skill";
 
 export const ADVANCED_SEARCH_SWITCH = "advanced_search";
 
@@ -58,6 +59,7 @@ export const SEARCH_SERVER_NAME = "search";
 export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2"; // Do not change the name until we fixed the extension
 export const DATA_WAREHOUSE_SERVER_NAME = "data_warehouses";
 export const AGENT_MEMORY_SERVER_NAME = "agent_memory";
+export const SKILL_MANAGEMENT_SERVER_NAME = "skill_management";
 
 // IDs of internal MCP servers that are no longer present.
 // We need to keep them to avoid breaking previous output that might reference sId that mapped to these servers.
@@ -122,6 +124,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "zendesk",
   SEARCH_SERVER_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
+  SKILL_MANAGEMENT_SERVER_NAME,
 ] as const;
 
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
@@ -1675,6 +1678,28 @@ export const INTERNAL_MCP_SERVERS = {
         "- Use LLM-friendly timeline format for conversation data\n" +
         "- Include full context (metadata, custom fields) in responses",
       developerSecretSelection: "required",
+    },
+  },
+  [SKILL_MANAGEMENT_SERVER_NAME]: {
+    id: 1019,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("skills");
+    },
+    tools_stakes: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: SKILL_MANAGEMENT_SERVER_NAME,
+      version: "1.0.0",
+      description: "",
+      // TODO(skill): Add proper skill icon here once in ActionsIcons
+      icon: "ActionLightbulbIcon",
+      authorization: null,
+      documentationUrl: null,
+      instructions: null,
     },
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -47,6 +47,7 @@ import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
 import { default as salesloftServer } from "@app/lib/actions/mcp_internal_actions/servers/salesloft";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
+import { default as skillManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/skill_management";
 import { default as slabServer } from "@app/lib/actions/mcp_internal_actions/servers/slab";
 import { default as slackBotServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_bot";
 import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_personal";
@@ -59,7 +60,6 @@ import { default as valtownServer } from "@app/lib/actions/mcp_internal_actions/
 import { default as vantaServer } from "@app/lib/actions/mcp_internal_actions/servers/vanta";
 import { default as webtoolsServer } from "@app/lib/actions/mcp_internal_actions/servers/webtools";
 import { default as zendeskServer } from "@app/lib/actions/mcp_internal_actions/servers/zendesk";
-import { default as skillManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/skill_management";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -59,6 +59,7 @@ import { default as valtownServer } from "@app/lib/actions/mcp_internal_actions/
 import { default as vantaServer } from "@app/lib/actions/mcp_internal_actions/servers/vanta";
 import { default as webtoolsServer } from "@app/lib/actions/mcp_internal_actions/servers/webtools";
 import { default as zendeskServer } from "@app/lib/actions/mcp_internal_actions/servers/zendesk";
+import { default as skillManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/skill_management";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
@@ -214,6 +215,8 @@ export async function getInternalMCPServer(
       return frontServer(auth, agentLoopContext);
     case "zendesk":
       return zendeskServer(auth, agentLoopContext);
+    case "skill_management":
+      return skillManagementServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -24,7 +24,7 @@ function createServer(
     {
       skillId: z
         .string()
-        .describe("The sId of the skill to enable for the conversation"),
+        .describe("The id of the skill to enable for the conversation"),
     },
     withToolLogging(
       auth,

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -51,7 +51,7 @@ function createServer(
           );
         }
 
-        // TODO(skill): Create a AgentMessageSkillResource to encapsulate this logic
+        // TODO(skill): Use SkillConfigurationResource to encapsulate this logic
         await AgentMessageSkillModel.create({
           workspaceId: workspace.id,
           agentConfigurationId: agentConfiguration.id,

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -1,12 +1,16 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
 import { DEFAULT_ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
-
-import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import { AgentMessageSkillModel } from "@app/lib/models/skill/agent_message_skill";
+import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
+import { Err, Ok } from "@app/types";
 
 function createServer(
   auth: Authenticator,
@@ -16,17 +20,56 @@ function createServer(
 
   server.tool(
     DEFAULT_ENABLE_SKILL_TOOL_NAME,
-    "List all files attached to the conversation.",
-    {},
+    "Enable a skill for the current conversation. The skill will be available for subsequent messages in this conversation.",
+    {
+      skillId: z
+        .string()
+        .describe("The sId of the skill to enable for the conversation"),
+    },
     withToolLogging(
       auth,
       {
         toolNameForMonitoring: DEFAULT_ENABLE_SKILL_TOOL_NAME,
         agentLoopContext,
       },
-      async () => {
-        // Implementation will be added later.
-        throw new Error("Not implemented");
+      async ({ skillId }) => {
+        if (!agentLoopContext?.runContext) {
+          return new Err(new MCPError("No conversation context available"));
+        }
+
+        const workspace = auth.getNonNullableWorkspace();
+
+        const { conversation, agentConfiguration, agentMessage } =
+          agentLoopContext.runContext;
+
+        const skill = await SkillConfigurationResource.fetchById(auth, skillId);
+        if (!skill) {
+          return new Err(
+            new MCPError(`Skill "${skillId}" not found`, {
+              tracked: false,
+            })
+          );
+        }
+
+        // TODO(skill): Create a AgentMessageSkillResource to encapsulate this logic
+        await AgentMessageSkillModel.create({
+          workspaceId: workspace.id,
+          agentConfigurationId: agentConfiguration.id,
+          isActive: true,
+          customSkillId: skill.id,
+          globalSkillId: null,
+          agentMessageId: agentMessage.id,
+          conversationId: conversation.id,
+          source: "agent_enabled",
+          addedByUserId: null,
+        });
+
+        return new Ok([
+          {
+            type: "text",
+            text: `Skill "${skill.name}" has been enabled for this conversation.`,
+          },
+        ]);
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -1,0 +1,37 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { DEFAULT_ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+
+import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer(SKILL_MANAGEMENT_SERVER_NAME);
+
+  server.tool(
+    DEFAULT_ENABLE_SKILL_TOOL_NAME,
+    "List all files attached to the conversation.",
+    {},
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: DEFAULT_ENABLE_SKILL_TOOL_NAME,
+        agentLoopContext,
+      },
+      async () => {
+        // Implementation will be added later.
+        throw new Error("Not implemented");
+      }
+    )
+  );
+
+  return server;
+}
+
+export default createServer;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR adds a skill_management server with, for now, a single enable_skill tool.

This allows an agent to create an entry in the agent_message_skill table, to allow it to use the skill itself.

Contributes to https://github.com/dust-tt/tasks/issues/5406

Note: 
- AgentMessageSkill Resource to be implemented in subsequent PR.
- Need to add an ActionSkillIcon in figma / sparkle / etc - TBD with design

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front