### PR TITLE
Allow custom Authorization headers for MCP server

### DIFF
--- a/front/components/actions/mcp/InternalMCPBearerTokenForm.tsx
+++ b/front/components/actions/mcp/InternalMCPBearerTokenForm.tsx
@@ -34,7 +34,9 @@ export function InternalMCPBearerTokenForm() {
         }
       />
       <CollapsibleComponent
-        triggerChildren={<div className="heading-lg">Headers</div>}
+        triggerChildren={
+          <div className="heading-lg">Headers ({fields.length})</div>
+        }
         contentChildren={
           <div className="space-y-2">
             <McpServerHeaders

--- a/front/components/actions/mcp/MCPServerDetailsInfo.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsInfo.tsx
@@ -44,25 +44,18 @@ export function MCPServerDetailsInfo({
       )}
       <Separator />
       <MCPServerViewForm mcpServerView={mcpServerView} />
+      <Separator />
       {mcpServerView.server.authorization && (
-        <>
-          <Separator />
-          <MCPServerSettings mcpServerView={mcpServerView} owner={owner} />
-        </>
+        <MCPServerSettings mcpServerView={mcpServerView} owner={owner} />
       )}
       {isRemoteMCPServerType(mcpServerView.server) ? (
         <RemoteMCPForm mcpServer={mcpServerView.server} owner={owner} />
       ) : requiresBearerToken ? (
-        <>
-          <Separator />
-          <InternalMCPBearerTokenForm />
-        </>
+        <InternalMCPBearerTokenForm />
       ) : null}
-
-      <Separator className="mb-4 mt-4" />
-      <div className="heading-lg">Available Tools</div>
-
-      <ToolsList owner={owner} mcpServerView={mcpServerView} />
+      <div className="mt-2">
+        <ToolsList owner={owner} mcpServerView={mcpServerView} />
+      </div>
     </div>
   );
 }

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -136,18 +136,6 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
         </div>
       </div>
 
-      <CollapsibleComponent
-        triggerChildren={<div className="heading-lg">Networking & Headers</div>}
-        contentChildren={
-          <div className="space-y-2">
-            <McpServerHeaders
-              headers={headerFields.map(({ key, value }) => ({ key, value }))}
-              onHeadersChange={(rows) => replace(rows)}
-            />
-          </div>
-        }
-      />
-
       {!mcpServer.authorization && (
         <CollapsibleComponent
           triggerChildren={<div className="heading-lg">Advanced Settings</div>}
@@ -168,6 +156,22 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
           }
         />
       )}
+
+      <CollapsibleComponent
+        triggerChildren={
+          <div className="heading-lg">
+            Networking & Headers ({headerFields.length})
+          </div>
+        }
+        contentChildren={
+          <div className="space-y-2">
+            <McpServerHeaders
+              headers={headerFields.map(({ key, value }) => ({ key, value }))}
+              onHeadersChange={(rows) => replace(rows)}
+            />
+          </div>
+        }
+      />
     </div>
   );
 }

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Card,
   Checkbox,
+  CollapsibleComponent,
   ContentMessage,
   DropdownMenu,
   DropdownMenuContent,
@@ -9,7 +10,7 @@ import {
   DropdownMenuTrigger,
   InformationCircleIcon,
 } from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 import type { MCPServerFormValues } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
@@ -37,171 +38,190 @@ interface ToolItemProps {
   defaultPermission: MCPToolStakeLevelType;
 }
 
-function ToolItem({
-  tool,
-  mayUpdate,
-  availableStakeLevels,
-  metadata,
-  defaultPermission,
-}: ToolItemProps) {
-  const { control } = useFormContext<MCPServerFormValues>();
-  const { field } = useController({
-    control,
-    name: `toolSettings.${tool.name}`,
-    defaultValue: {
-      enabled: metadata?.enabled ?? true,
-      permission: metadata?.permission ?? defaultPermission,
-    },
-  });
-
-  const toolPermission = field.value.permission;
-  const toolEnabled = field.value.enabled;
-
-  const handleToggle = () => {
-    field.onChange({
-      ...field.value,
-      enabled: !toolEnabled,
+const ToolItem = memo(
+  ({
+    tool,
+    mayUpdate,
+    availableStakeLevels,
+    metadata,
+    defaultPermission,
+  }: ToolItemProps) => {
+    const { control } = useFormContext<MCPServerFormValues>();
+    const { field } = useController({
+      control,
+      name: `toolSettings.${tool.name}`,
+      defaultValue: {
+        enabled: metadata?.enabled ?? true,
+        permission: metadata?.permission ?? defaultPermission,
+      },
     });
-  };
 
-  const handlePermissionChange = (permission: MCPToolStakeLevelType) => {
-    field.onChange({
-      ...field.value,
-      permission,
-    });
-  };
+    const toolPermission = field.value.permission;
+    const toolEnabled = field.value.enabled;
 
-  const toolPermissionLabel: Record<MCPToolStakeLevelType, string> = {
-    high: "High (update data or send information)",
-    low: "Low (retrieve data or generate content)",
-    never_ask: "Never ask (automatic execution)",
-  };
+    const handleToggle = () => {
+      field.onChange({
+        ...field.value,
+        enabled: !toolEnabled,
+      });
+    };
 
-  return (
-    <div
-      className={`flex flex-col gap-1 pb-2 ${!toolEnabled ? "opacity-50" : ""}`}
-    >
-      <div className="flex items-center gap-2">
-        {mayUpdate && <Checkbox checked={toolEnabled} onClick={handleToggle} />}
-        <h4 className="heading-base flex-grow text-foreground dark:text-foreground-night">
-          {asDisplayName(tool.name)}
-        </h4>
-      </div>
-      {tool.description && (
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {tool.description}
-        </p>
-      )}
-      {toolEnabled && (
-        <Card variant="primary" className="flex-col">
-          <div className="heading-sm text-muted-foreground dark:text-muted-foreground-night">
-            Tool stake setting
-          </div>
-          <div className="flex justify-end">
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                asChild
-                disabled={!mayUpdate || !toolEnabled}
-              >
-                <Button
-                  variant="outline"
-                  label={toolPermissionLabel[toolPermission]}
-                  isSelect
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                {availableStakeLevels.map((permission) => (
-                  <DropdownMenuItem
-                    key={permission}
-                    onClick={() => handlePermissionChange(permission)}
-                    label={toolPermissionLabel[permission]}
-                    disabled={!toolEnabled}
+    const handlePermissionChange = (permission: MCPToolStakeLevelType) => {
+      field.onChange({
+        ...field.value,
+        permission,
+      });
+    };
+
+    const toolPermissionLabel: Record<MCPToolStakeLevelType, string> = {
+      high: "High (update data or send information)",
+      low: "Low (retrieve data or generate content)",
+      never_ask: "Never ask (automatic execution)",
+    };
+
+    return (
+      <div
+        className={`flex flex-col gap-1 pb-2 ${!toolEnabled ? "opacity-50" : ""}`}
+      >
+        <div className="flex items-center gap-2">
+          {mayUpdate && (
+            <Checkbox checked={toolEnabled} onClick={handleToggle} />
+          )}
+          <h4 className="heading-base flex-grow text-foreground dark:text-foreground-night">
+            {asDisplayName(tool.name)}
+          </h4>
+        </div>
+        {tool.description && (
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {tool.description}
+          </p>
+        )}
+        {toolEnabled && (
+          <Card variant="primary" className="flex-col">
+            <div className="heading-sm text-muted-foreground dark:text-muted-foreground-night">
+              Tool stake setting
+            </div>
+            <div className="flex justify-end">
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  asChild
+                  disabled={!mayUpdate || !toolEnabled}
+                >
+                  <Button
+                    variant="outline"
+                    label={toolPermissionLabel[toolPermission]}
+                    isSelect
                   />
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </Card>
-      )}
-    </div>
-  );
-}
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  {availableStakeLevels.map((permission) => (
+                    <DropdownMenuItem
+                      key={permission}
+                      onClick={() => handlePermissionChange(permission)}
+                      label={toolPermissionLabel[permission]}
+                      disabled={!toolEnabled}
+                    />
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </Card>
+        )}
+      </div>
+    );
+  }
+);
 
 // We disable buttons for agent builder view because it would feel like
 // you can configure per agent
-export function ToolsList({
-  owner,
-  mcpServerView,
-  disableUpdates,
-}: ToolsListProps) {
-  const mayUpdate = useMemo(
-    () => (disableUpdates ? false : isAdmin(owner)),
-    [owner, disableUpdates]
-  );
-  const tools = useMemo(
-    () => mcpServerView.server.tools,
-    [mcpServerView.server.tools]
-  );
+export const ToolsList = memo(
+  ({ owner, mcpServerView, disableUpdates }: ToolsListProps) => {
+    const mayUpdate = useMemo(
+      () => (disableUpdates ? false : isAdmin(owner)),
+      [owner, disableUpdates]
+    );
+    const tools = useMemo(
+      () => mcpServerView.server.tools,
+      [mcpServerView.server.tools]
+    );
 
-  const getAvailableStakeLevels = (): MCPToolStakeLevelType[] => {
-    return [...MCP_TOOL_STAKE_LEVELS];
-  };
+    const getAvailableStakeLevels = (): MCPToolStakeLevelType[] => {
+      return [...MCP_TOOL_STAKE_LEVELS];
+    };
 
-  return (
-    <>
-      {tools && tools.length > 0 && (
-        <ContentMessage
-          className="mb-4 w-full"
-          variant="blue"
-          size="lg"
-          icon={InformationCircleIcon}
-          title="User Approval Settings"
-        >
-          <ul>
-            <li>
-              <b>High stake</b> tools need explicit user approval.
-            </li>
-            <li>
-              Users can disable confirmations for <b>low stake</b> tools.
-            </li>
-            <li>
-              <b>Never ask</b> tools run automatically.
-            </li>
-          </ul>
-        </ContentMessage>
-      )}
-      <div>
-        {tools && tools.length > 0 ? (
-          <div className="flex flex-col gap-4">
-            {tools.map(
-              (tool: { name: string; description: string }, index: number) => {
-                const availableStakeLevels = getAvailableStakeLevels();
-                const metadata = mcpServerView.toolsMetadata?.find(
-                  (m) => m.toolName === tool.name
-                );
+    return (
+      <>
+        {tools && tools.length > 0 && (
+          <CollapsibleComponent
+            rootProps={{ defaultOpen: tools.length <= 5 }}
+            triggerChildren={
+              <div className="heading-lg">Available Tools ({tools.length})</div>
+            }
+            contentChildren={
+              <>
+                <ContentMessage
+                  className="mb-4 w-full"
+                  variant="blue"
+                  size="lg"
+                  icon={InformationCircleIcon}
+                  title="User Approval Settings"
+                >
+                  <ul>
+                    <li>
+                      <b>High stake</b> tools need explicit user approval.
+                    </li>
+                    <li>
+                      Users can disable confirmations for <b>low stake</b>{" "}
+                      tools.
+                    </li>
+                    <li>
+                      <b>Never ask</b> tools run automatically.
+                    </li>
+                  </ul>
+                </ContentMessage>
 
-                const defaultPermission = getDefaultInternalToolStakeLevel(
-                  mcpServerView.server,
-                  tool.name
-                );
+                <div>
+                  {tools && tools.length > 0 ? (
+                    <div className="flex flex-col gap-4">
+                      {tools.map(
+                        (
+                          tool: { name: string; description: string },
+                          index: number
+                        ) => {
+                          const availableStakeLevels =
+                            getAvailableStakeLevels();
+                          const metadata = mcpServerView.toolsMetadata?.find(
+                            (m) => m.toolName === tool.name
+                          );
 
-                return (
-                  <ToolItem
-                    key={index}
-                    tool={tool}
-                    mayUpdate={mayUpdate}
-                    availableStakeLevels={availableStakeLevels}
-                    metadata={metadata}
-                    defaultPermission={defaultPermission}
-                  />
-                );
-              }
-            )}
-          </div>
-        ) : (
-          <p className="text-sm text-faint">No tools available</p>
+                          const defaultPermission =
+                            getDefaultInternalToolStakeLevel(
+                              mcpServerView.server,
+                              tool.name
+                            );
+
+                          return (
+                            <ToolItem
+                              key={index}
+                              tool={tool}
+                              mayUpdate={mayUpdate}
+                              availableStakeLevels={availableStakeLevels}
+                              metadata={metadata}
+                              defaultPermission={defaultPermission}
+                            />
+                          );
+                        }
+                      )}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-faint">No tools available</p>
+                  )}
+                </div>
+              </>
+            }
+          />
         )}
-      </div>
-    </>
-  );
-}
+      </>
+    );
+  }
+);

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -270,9 +270,7 @@ async function handleRemotePatch(
   } else if ("sharedSecret" in body || "customHeaders" in body) {
     const sanitizedRecord =
       body.customHeaders !== undefined
-        ? headersArrayToRecord(body.customHeaders, {
-            stripAuthorization: true,
-          })
+        ? headersArrayToRecord(body.customHeaders)
         : undefined;
     const update = await server.updateMetadata(auth, {
       sharedSecret: body.sharedSecret,
@@ -326,9 +324,7 @@ async function handleInternalPatch(
   if ("sharedSecret" in body || "customHeaders" in body) {
     const sanitizedRecord =
       body.customHeaders !== undefined
-        ? headersArrayToRecord(body.customHeaders, {
-            stripAuthorization: true,
-          })
+        ? headersArrayToRecord(body.customHeaders)
         : undefined;
     const recordOrNull =
       sanitizedRecord !== undefined

--- a/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -60,9 +60,7 @@ async function handler(
 
       const { url, customHeaders } = r.right;
 
-      const headers = headersArrayToRecord(customHeaders, {
-        stripAuthorization: false,
-      });
+      const headers = headersArrayToRecord(customHeaders);
 
       const r2 = await connectToMCPServer(auth, {
         params: {

--- a/front/pages/api/w/[wId]/mcp/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/index.test.ts
@@ -275,7 +275,7 @@ describe("POST /api/w/[wId]/mcp/", () => {
       sharedSecret: "test-secret-123",
       customHeaders: [
         { key: "X-Custom-Header", value: "custom-value" },
-        { key: "Authorization", value: "Bearer should-be-stripped" },
+        { key: "Authorization", value: "Bearer should-be-kept" },
       ],
     };
 
@@ -306,9 +306,9 @@ describe("POST /api/w/[wId]/mcp/", () => {
     expect(credential).toBeDefined();
     expect(credential?.sharedSecret).toBe("test-secret-123");
     expect(credential?.customHeaders).toEqual({
+      Authorization: "Bearer should-be-kept",
       "X-Custom-Header": "custom-value",
     });
-    expect(credential?.customHeaders).not.toHaveProperty("Authorization");
   });
 });
 

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -172,10 +172,7 @@ async function handler(
 
         // Merge custom headers (if any) with Authorization when probing the server.
         // Note: Authorization from OAuth/sharedSecret takes precedence over custom headers.
-        const sanitizedCustomHeaders = headersArrayToRecord(
-          body.customHeaders,
-          { stripAuthorization: false }
-        );
+        const sanitizedCustomHeaders = headersArrayToRecord(body.customHeaders);
 
         const headers = bearerToken
           ? {
@@ -218,12 +215,9 @@ async function handler(
               ? metadata.icon
               : DEFAULT_MCP_SERVER_ICON),
           version: metadata.version,
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          sharedSecret: sharedSecret || null,
-          // Persist only user-provided custom headers (exclude Authorization)
-          customHeaders: headersArrayToRecord(body.customHeaders, {
-            stripAuthorization: true,
-          }),
+          sharedSecret: sharedSecret ?? null,
+          // Persist only user-provided custom headers
+          customHeaders: headersArrayToRecord(body.customHeaders),
           authorization,
           oAuthUseCase: body.useCase ?? null,
         });
@@ -354,9 +348,7 @@ async function handler(
           requiresBearerTokenConfiguration(newInternalMCPServer.toJSON()) &&
           (body.sharedSecret !== undefined || body.customHeaders !== undefined)
         ) {
-          const sanitizedRecord = headersArrayToRecord(body.customHeaders, {
-            stripAuthorization: true,
-          });
+          const sanitizedRecord = headersArrayToRecord(body.customHeaders);
           const customHeaders =
             Object.keys(sanitizedRecord).length > 0 ? sanitizedRecord : null;
 

--- a/front/types/shared/utils/http_headers.ts
+++ b/front/types/shared/utils/http_headers.ts
@@ -16,18 +16,14 @@ export function sanitizeHeadersArray(rows: HeaderRow[]): HeaderRow[] {
 }
 
 export function headersArrayToRecord(
-  rows: HeaderRow[] | null | undefined,
-  opts?: { stripAuthorization?: boolean }
+  rows: HeaderRow[] | null | undefined
 ): Record<string, string> {
   if (!rows) {
     return Object.fromEntries([]);
   }
 
   const sanitized = sanitizeHeadersArray(rows);
-  let entries = sanitized.map(({ key, value }) => [key, value]);
+  const entries = sanitized.map(({ key, value }) => [key, value]);
 
-  if (opts?.stripAuthorization) {
-    entries = entries.filter(([k]) => k.toLowerCase() !== "authorization");
-  }
   return Object.fromEntries(entries);
 }


### PR DESCRIPTION
## Description

Allow custom Authorization header for customers who need it.
(also, improved a bit the form to avoid super big dom for servers with like.. 100+ tools)

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front