### PR TITLE
[front] enh: Use streaming to show results sequentially

### DIFF
--- a/front/lib/search/tools/search.ts
+++ b/front/lib/search/tools/search.ts
@@ -66,6 +66,101 @@ async function _getToolAndAccessTokenForView(
   };
 }
 
+async function searchServerView(
+  auth: Authenticator,
+  serverView: MCPServerViewResource,
+  query: string,
+  pageSize: number
+): Promise<ToolSearchResult[]> {
+  const result = await _getToolAndAccessTokenForView(auth, serverView);
+  if (!result) {
+    return [];
+  }
+
+  let rawResults: ToolSearchRawResult[] = [];
+  try {
+    rawResults = await result.tool.search({
+      accessToken: result.accessToken,
+      query,
+      pageSize,
+    });
+  } catch (error) {
+    const r = getInternalMCPServerNameAndWorkspaceId(serverView.mcpServerId);
+    logger.error(
+      {
+        error,
+        serverName: r.isOk() ? r.value.name : "unknown",
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Error searching for attachments"
+    );
+    return [];
+  }
+
+  const serverJson = serverView.toJSON();
+  return rawResults.map((rawResult) => ({
+    ...rawResult,
+    serverViewId: serverView.sId,
+    serverName: serverJson.server.name,
+    serverIcon: serverJson.server.icon,
+  }));
+}
+
+export async function* streamToolFiles({
+  auth,
+  query,
+  pageSize,
+}: {
+  auth: Authenticator;
+  query: string;
+  pageSize: number;
+}): AsyncGenerator<ToolSearchResult[], void, undefined> {
+  const spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
+  const serverViews = await MCPServerViewResource.listBySpaces(auth, spaces);
+
+  const searchableServerViews = serverViews.filter((view) => {
+    const r = getInternalMCPServerNameAndWorkspaceId(view.mcpServerId);
+    return r.isOk() && _isSearchableTool(r.value.name);
+  });
+
+  if (searchableServerViews.length === 0) {
+    return;
+  }
+
+  // Create promises for all searches with unique IDs to track them
+  interface PromiseWithId {
+    promise: Promise<ToolSearchResult[]>;
+    id: symbol;
+  }
+
+  const pending: PromiseWithId[] = searchableServerViews.map((serverView) => ({
+    promise: searchServerView(auth, serverView, query, pageSize),
+    id: Symbol(),
+  }));
+
+  // Yield results as each promise completes (not in order)
+  while (pending.length > 0) {
+    // Wrap each pending promise to include its ID when it resolves
+    const wrappedPromises = pending.map(({ promise, id }) =>
+      promise.then((results) => ({ results, id }))
+    );
+
+    // Wait for the first one to complete
+    const completed = await Promise.race(wrappedPromises);
+
+    // Remove the completed promise from pending
+    const index = pending.findIndex((p) => p.id === completed.id);
+    if (index !== -1) {
+      pending.splice(index, 1);
+    }
+
+    // Yield results if not empty
+    if (completed.results.length > 0) {
+      yield completed.results;
+    }
+  }
+}
+
 export async function searchToolFiles({
   auth,
   query,
@@ -89,42 +184,7 @@ export async function searchToolFiles({
 
   const results = await concurrentExecutor(
     searchableServerViews,
-    async (serverView) => {
-      const result = await _getToolAndAccessTokenForView(auth, serverView);
-      if (!result) {
-        return [];
-      }
-
-      let rawResults: ToolSearchRawResult[] = [];
-      try {
-        rawResults = await result.tool.search({
-          accessToken: result.accessToken,
-          query,
-          pageSize,
-        });
-      } catch (error) {
-        const r = getInternalMCPServerNameAndWorkspaceId(
-          serverView.mcpServerId
-        );
-        logger.error(
-          {
-            error,
-            serverName: r.isOk() ? r.value.name : "unknown",
-            workspaceId: auth.getNonNullableWorkspace().sId,
-          },
-          "Error searching for attachments"
-        );
-        return [];
-      }
-
-      const serverJson = serverView.toJSON();
-      return rawResults.map((rawResult) => ({
-        ...rawResult,
-        serverViewId: serverView.sId,
-        serverName: serverJson.server.name,
-        serverIcon: serverJson.server.icon,
-      }));
-    },
+    async (serverView) => searchServerView(auth, serverView, query, pageSize),
     { concurrency: 4 }
   );
 

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -48,7 +48,7 @@ export function useSearchToolFiles({
 
     setIsSearchLoading(true);
 
-    const url = `/api/w/${owner.sId}/search/tools?query=${encodeURIComponent(query)}&pageSize=${pageSize}&stream=true`;
+    const url = `/api/w/${owner.sId}/search/tools?query=${encodeURIComponent(query)}&pageSize=${pageSize}`;
     const eventSource = new EventSource(url);
     eventSourceRef.current = eventSource;
 

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -1,12 +1,14 @@
-import type { Fetcher } from "swr";
+import { useEffect, useRef, useState } from "react";
 
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray } from "@app/lib/swr/swr";
 import type { LightWorkspaceType } from "@app/types";
 
-interface ToolSearchResponse {
+interface ToolSearchStreamChunk {
   results: ToolSearchResult[];
   resultsCount: number;
+  done?: boolean;
+  totalCount?: number;
 }
 
 export function useSearchToolFiles({
@@ -20,26 +22,84 @@ export function useSearchToolFiles({
   pageSize?: number;
   disabled?: boolean;
 }) {
-  const searchFetcher: Fetcher<ToolSearchResponse> = fetcher;
-  const url =
-    query && query.length >= 3 && !disabled
-      ? `/api/w/${owner.sId}/search/tools?query=${encodeURIComponent(query)}&pageSize=${pageSize}`
-      : null;
+  const [searchResults, setSearchResults] = useState<ToolSearchResult[]>([]);
+  const [resultsCount, setResultsCount] = useState(0);
+  const [isSearchLoading, setIsSearchLoading] = useState(false);
+  const [isSearchError, setIsSearchError] = useState<Error | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
 
-  const { data, error, isLoading, isValidating } = useSWRWithDefaults(
-    url,
-    searchFetcher,
-    {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSearchResults([]);
+    setResultsCount(0);
+    setIsSearchError(null);
+
+    // Close any existing EventSource
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
     }
-  );
+
+    // Don't start a new search if disabled or query too short
+    if (disabled || !query || query.length < 3) {
+      setIsSearchLoading(false);
+      return;
+    }
+
+    setIsSearchLoading(true);
+
+    const url = `/api/w/${owner.sId}/search/tools?query=${encodeURIComponent(query)}&pageSize=${pageSize}&stream=true`;
+    const eventSource = new EventSource(url);
+    eventSourceRef.current = eventSource;
+
+    const accumulatedResults: ToolSearchResult[] = [];
+
+    eventSource.onopen = () => {
+      setIsSearchLoading(true);
+    };
+
+    eventSource.onmessage = (event) => {
+      try {
+        const chunk: ToolSearchStreamChunk = JSON.parse(event.data);
+
+        if (chunk.done) {
+          // Final message with totalCount
+          setResultsCount(chunk.totalCount ?? 0);
+          setIsSearchLoading(false);
+          eventSource.close();
+        } else {
+          // Accumulate results as they come in
+          accumulatedResults.push(...chunk.results);
+          setSearchResults([...accumulatedResults]);
+          setResultsCount(accumulatedResults.length);
+        }
+      } catch (error) {
+        setIsSearchError(
+          error instanceof Error ? error : new Error("Failed to parse stream")
+        );
+        setIsSearchLoading(false);
+        eventSource.close();
+      }
+    };
+
+    eventSource.onerror = () => {
+      setIsSearchError(new Error("Failed to fetch search results"));
+      setIsSearchLoading(false);
+      eventSource.close();
+    };
+
+    // Cleanup function
+    return () => {
+      eventSource.close();
+    };
+  }, [owner.sId, query, pageSize, disabled]);
 
   return {
-    searchResults: data?.results ?? emptyArray<ToolSearchResult>(),
-    resultsCount: data?.resultsCount ?? 0,
-    isSearchLoading: isLoading,
-    isSearchValidating: isValidating,
-    isSearchError: error,
+    searchResults:
+      searchResults.length > 0 ? searchResults : emptyArray<ToolSearchResult>(),
+    resultsCount,
+    isSearchLoading,
+    isSearchValidating: false, // No validation with streaming
+    isSearchError,
   };
 }

--- a/front/pages/api/w/[wId]/search/tools.ts
+++ b/front/pages/api/w/[wId]/search/tools.ts
@@ -28,7 +28,7 @@ async function handler(
     });
   }
 
-  const { query, pageSize: pageSizeParam, stream } = req.query;
+  const { query, pageSize: pageSizeParam } = req.query;
   if (typeof query !== "string" || query.length < 1) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/search/tools.ts
+++ b/front/pages/api/w/[wId]/search/tools.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { searchToolFiles, streamToolFiles } from "@app/lib/search/tools/search";
+import { streamToolFiles } from "@app/lib/search/tools/search";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -60,54 +60,43 @@ async function handler(
   }
 
   try {
-    // Handle streaming mode
-    if (stream === "true") {
-      res.writeHead(200, {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-      });
-      res.flushHeaders();
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    res.flushHeaders();
 
-      // Create an AbortController to handle client disconnection
-      const controller = new AbortController();
-      const { signal } = controller;
+    // Create an AbortController to handle client disconnection
+    const controller = new AbortController();
+    const { signal } = controller;
 
-      // Handle client disconnection
-      req.on("close", () => {
-        controller.abort();
-      });
+    // Handle client disconnection
+    req.on("close", () => {
+      controller.abort();
+    });
 
-      let totalCount = 0;
+    let totalCount = 0;
 
-      for await (const results of streamToolFiles({ auth, query, pageSize })) {
-        // If the client disconnected, stop streaming
-        if (signal.aborted) {
-          break;
-        }
-
-        totalCount += results.length;
-        res.write(
-          `data: ${JSON.stringify({ results, resultsCount: results.length })}\n\n`
-        );
-        // @ts-expect-error - We need it for streaming but it does not exist in the types.
-        res.flush();
+    for await (const results of streamToolFiles({ auth, query, pageSize })) {
+      // If the client disconnected, stop streaming
+      if (signal.aborted) {
+        break;
       }
 
-      res.write(`data: ${JSON.stringify({ done: true, totalCount })}\n\n`);
+      totalCount += results.length;
+      res.write(
+        `data: ${JSON.stringify({ results, resultsCount: results.length })}\n\n`
+      );
       // @ts-expect-error - We need it for streaming but it does not exist in the types.
       res.flush();
-      res.status(200).end();
-      return;
     }
 
-    // Non-streaming mode (existing behavior)
-    const results = await searchToolFiles({ auth, query, pageSize });
-
-    return res.status(200).json({
-      results,
-      resultsCount: results.length,
-    });
+    res.write(`data: ${JSON.stringify({ done: true, totalCount })}\n\n`);
+    // @ts-expect-error - We need it for streaming but it does not exist in the types.
+    res.flush();
+    res.status(200).end();
+    return;
   } catch (error) {
     logger.error(
       {

--- a/front/pages/api/w/[wId]/search/tools.ts
+++ b/front/pages/api/w/[wId]/search/tools.ts
@@ -2,10 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  searchToolFiles,
-  streamToolFiles,
-} from "@app/lib/search/tools/search";
+import { searchToolFiles, streamToolFiles } from "@app/lib/search/tools/search";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";


### PR DESCRIPTION
fixes: [#5530](https://github.com/dust-tt/tasks/issues/5530)

## Description

When searching in tools, search in all possible tools in parallel but send results as they arrive instead of waiting for all to finish. Use SSE in search/tools and handle search result events in hook. 

## Tests

Locally with microsoft+google search

## Risk

low, gated

## Deploy Plan

deploy front
