### PR TITLE
enh(superuser): send onboarding chat from quick dev tools

### DIFF
--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -45,3 +45,31 @@ export async function forceUserRole(
     return new Err("Error updating role");
   }
 }
+
+export async function sendOnboardingConversation(
+  owner: LightWorkspaceType,
+  featureFlags: WhitelistableFeature[]
+): Promise<
+  { isOk: true; conversationSId: string } | { isOk: false; error: string }
+> {
+  if (!showDebugTools(featureFlags)) {
+    return { isOk: false, error: "Not allowed" };
+  }
+
+  const response = await clientFetch(
+    `/api/w/${owner.sId}/assistant/conversations/send-onboarding`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  if (response.ok) {
+    const data = await response.json();
+    return { isOk: true, conversationSId: data.conversationSId };
+  } else {
+    return { isOk: false, error: "Error sending onboarding conversation" };
+  }
+}

--- a/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
@@ -1,0 +1,65 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { createOnboardingConversationIfNeeded } from "@app/lib/api/assistant/onboarding";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type PostSendOnboardingResponseBody = {
+  conversationSId: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PostSendOnboardingResponseBody | void>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only superusers can send onboarding conversations.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST":
+      const result = await createOnboardingConversationIfNeeded(auth, {
+        force: true,
+      });
+
+      if (result.isErr()) {
+        return apiError(req, res, result.error);
+      }
+
+      const conversationSId = result.value;
+      if (!conversationSId) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to create onboarding conversation.",
+          },
+        });
+      }
+
+      res.status(200).json({ conversationSId });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Allows to quickly obtain an onboarding conversation from the profile dev tools without having to go to poké and use the plugin

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
