### PR TITLE
[front] fix(skills): fix `fetchBySId` renaming and date typing

### DIFF
--- a/front/lib/resources/skill_configuration_resource.ts
+++ b/front/lib/resources/skill_configuration_resource.ts
@@ -120,15 +120,15 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
     return resources[0];
   }
 
-  static async fetchBySId(
+  static async fetchById(
     auth: Authenticator,
-    sId: string
+    skillId: string
   ): Promise<SkillConfigurationResource | null> {
-    if (!isResourceSId("skill", sId)) {
+    if (!isResourceSId("skill", skillId)) {
       return null;
     }
 
-    const resourceId = getResourceIdFromSId(sId);
+    const resourceId = getResourceIdFromSId(skillId);
     if (resourceId === null) {
       return null;
     }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -419,7 +419,7 @@ export async function createOrUpgradeAgentConfiguration({
     assistant.skills,
     async (skill) => {
       // Validate the skill exists and belongs to this workspace
-      const skillResource = await SkillConfigurationResource.fetchBySId(
+      const skillResource = await SkillConfigurationResource.fetchById(
         auth,
         skill.sId
       );

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
@@ -8,7 +8,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { isResourceSId, makeSId } from "@app/lib/resources/string_ids";
+import { isResourceSId } from "@app/lib/resources/string_ids";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/skill_configuration";
@@ -84,7 +84,7 @@ async function handler(
   }
 
   const sId = req.query.sId;
-  const skillResource = await SkillConfigurationResource.fetchBySId(auth, sId);
+  const skillResource = await SkillConfigurationResource.fetchById(auth, sId);
 
   if (!skillResource) {
     return apiError(req, res, {
@@ -197,19 +197,7 @@ async function handler(
 
         return res.status(200).json({
           skillConfiguration: {
-            id: result.updatedSkill.id,
-            sId: makeSId("skill", {
-              id: result.updatedSkill.id,
-              workspaceId: result.updatedSkill.workspaceId,
-            }),
-            name: result.updatedSkill.name,
-            description: result.updatedSkill.description,
-            instructions: result.updatedSkill.instructions,
-            status: result.updatedSkill.status,
-            version: result.updatedSkill.version,
-            createdAt: result.updatedSkill.createdAt,
-            updatedAt: result.updatedSkill.updatedAt,
-            requestedSpaceIds: result.updatedSkill.requestedSpaceIds,
+            ...result.updatedSkill.toJSON(),
             tools: result.createdTools,
           },
         });

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
@@ -12,7 +12,6 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { Err } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/skill_configuration";
 
 export type GetSkillConfigurationResponseBody = {
@@ -189,10 +188,8 @@ async function handler(
           );
 
           if (mcpServerViewIds.length !== mcpServerViews.length) {
-            return new Err(
-              new Error(
-                `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`
-              )
+            throw new Error(
+              `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`
             );
           }
 

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
@@ -6,11 +6,13 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { Err } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/skill_configuration";
 
 export type GetSkillConfigurationResponseBody = {
@@ -180,10 +182,24 @@ async function handler(
           const updatedSkill = updateResult.value;
 
           // Update tools
+          const mcpServerViewIds = body.tools.map((t) => t.mcpServerViewId);
+          const mcpServerViews = await MCPServerViewResource.fetchByIds(
+            auth,
+            mcpServerViewIds
+          );
+
+          if (mcpServerViewIds.length !== mcpServerViews.length) {
+            return new Err(
+              new Error(
+                `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`
+              )
+            );
+          }
+
           const toolsResult = await updatedSkill.updateTools(
             auth,
             {
-              mcpServerViewIds: body.tools.map((t) => t.mcpServerViewId),
+              mcpServerViews,
             },
             { transaction }
           );

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/[sId]/index.ts
@@ -12,6 +12,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { normalizeError } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/skill_configuration";
 
 export type GetSkillConfigurationResponseBody = {
@@ -219,7 +220,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Error updating skill: ${error instanceof Error ? error.message : "Unknown error"}`,
+            message: `Error updating skill: ${normalizeError(error).message}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
@@ -60,7 +60,7 @@ async function handler(
     });
   }
 
-  const skillResource = await SkillConfigurationResource.fetchBySId(auth, sId);
+  const skillResource = await SkillConfigurationResource.fetchById(auth, sId);
 
   if (!skillResource) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -54,7 +54,7 @@ async function handler(
 
   const skillId = req.query.sId;
 
-  const skillConfiguration = await SkillConfigurationResource.fetchBySId(
+  const skillConfiguration = await SkillConfigurationResource.fetchById(
     auth,
     skillId
   );

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -48,7 +48,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const skillResource = await SkillConfigurationResource.fetchBySId(
+  const skillResource = await SkillConfigurationResource.fetchById(
     auth,
     context.params.sId
   );
@@ -65,41 +65,24 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const user = auth.getNonNullableUser().toJSON();
-  const skillConfiguration = skillResource.toJSON();
-
-  // Serialize dates for Next.js
-  const serializedSkillConfiguration = {
-    ...skillConfiguration,
-    createdAt: skillConfiguration.createdAt.getTime(),
-    updatedAt: skillConfiguration.updatedAt.getTime(),
-  };
-
   return {
     props: {
-      skillConfiguration: serializedSkillConfiguration,
+      skillConfiguration: skillResource.toJSON(),
       owner,
       subscription,
-      user,
+      user: auth.getNonNullableUser().toJSON(),
     },
   };
 });
 
 export default function EditSkill({
-  skillConfiguration: serializedSkillConfiguration,
+  skillConfiguration,
   owner,
   user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  if (serializedSkillConfiguration.status === "archived") {
+  if (skillConfiguration.status === "archived") {
     throw new Error("Cannot edit archived skill");
   }
-
-  // Convert timestamps back to Date objects for SkillBuilder
-  const skillConfiguration: SkillConfigurationType = {
-    ...serializedSkillConfiguration,
-    createdAt: new Date(serializedSkillConfiguration.createdAt),
-    updatedAt: new Date(serializedSkillConfiguration.updatedAt),
-  };
 
   return (
     <SkillBuilderProvider owner={owner} user={user}>

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -11,17 +11,8 @@ import { SkillConfigurationResource } from "@app/lib/resources/skill_configurati
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/skill_configuration";
 
-// Serialized version with Date objects converted to timestamps
-type SerializedSkillConfiguration = Omit<
-  SkillConfigurationType,
-  "createdAt" | "updatedAt"
-> & {
-  createdAt: number;
-  updatedAt: number;
-};
-
 export const getServerSideProps = withDefaultUserAuthRequirements<{
-  skillConfiguration: SerializedSkillConfiguration;
+  skillConfiguration: SkillConfigurationType;
   owner: WorkspaceType;
   user: UserType;
   subscription: SubscriptionType;


### PR DESCRIPTION
## Description

- This PR fixes lint on main after 2 commits got crossed.
- The `fetchBySId` renaming into `fetchById` got lost, same for a conversion on dates/timestamp.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
