### PR TITLE
[sparkle] - chore(Chip): remove uppercase in `mini`

### DIFF
--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -215,11 +215,7 @@ const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
         )}
         {label && (
           <span
-            className={cn(
-              "s-grow s-truncate",
-              onClick && "s-cursor-pointer",
-              size === "mini" && "s-uppercase"
-            )}
+            className={cn("s-grow s-truncate", onClick && "s-cursor-pointer")}
           >
             {isBusy ? (
               <AnimatedText variant={color}>{label}</AnimatedText>


### PR DESCRIPTION
## Description

This PR removes conditional class assignments for 'mini' size to streamline component styling

