### PR TITLE
feat(skills): give enable skill tool to agents

### DIFF
--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -182,19 +182,12 @@ export async function getJITServers(
           "MCP server view not found for skill_management. Ensure auto tools are created."
         );
       } else if (!agentMcpServerViewIds.includes(skillManagementView.sId)) {
-        const skillManagementViewJSON = skillManagementView.toJSON();
         const skillManagementServer: ServerSideMCPServerConfigurationType = {
           id: -1,
           sId: generateRandomModelSId(),
           type: "mcp_server_configuration",
-          name:
-            skillManagementViewJSON.name ??
-            skillManagementViewJSON.server.name ??
-            SKILL_MANAGEMENT_SERVER_NAME,
-          description:
-            skillManagementViewJSON.description ??
-            skillManagementViewJSON.server.description ??
-            "Enable skills for the conversation.",
+          name: SKILL_MANAGEMENT_SERVER_NAME,
+          description: "Enable skills for the conversation.",
           dataSources: null,
           tables: null,
           childAgentId: null,
@@ -203,7 +196,7 @@ export async function getJITServers(
           jsonSchema: null,
           secretName: null,
           additionalConfiguration: {},
-          mcpServerViewId: skillManagementViewJSON.sId,
+          mcpServerViewId: skillManagementView.sId,
           dustAppConfiguration: null,
           internalMCPServerId: skillManagementView.mcpServerId,
         };

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -27,13 +27,13 @@ import {
 import { isMultiSheetSpreadsheetContentType } from "@app/lib/api/assistant/conversation/content_types";
 import { isSearchableFolder } from "@app/lib/api/assistant/jit_utils";
 import config from "@app/lib/api/config";
-import { getFeatureFlags } from "@app/lib/auth";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { SkillConfigurationResource } from "@app/lib/resources/skill_configuration_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -42,7 +42,6 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types";
 import { CoreAPI } from "@app/types";
-import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 
 export async function getJITServers(
   auth: Authenticator,

--- a/front/lib/resources/skill_configuration_resource.ts
+++ b/front/lib/resources/skill_configuration_resource.ts
@@ -190,6 +190,20 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
     return customSkills.map((skill) => new this(this.model, skill.get()));
   }
 
+  static async countByAgentConfigurationId(
+    auth: Authenticator,
+    agentConfigurationId: ModelId
+  ): Promise<number> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    return AgentSkillModel.count({
+      where: {
+        agentConfigurationId,
+        workspaceId: workspace.id,
+      },
+    });
+  }
+
   static modelIdToSId({
     id,
     workspaceId,

--- a/front/lib/resources/skill_configuration_resource.ts
+++ b/front/lib/resources/skill_configuration_resource.ts
@@ -190,20 +190,6 @@ export class SkillConfigurationResource extends BaseResource<SkillConfigurationM
     return customSkills.map((skill) => new this(this.model, skill.get()));
   }
 
-  static async countByAgentConfigurationId(
-    auth: Authenticator,
-    agentConfigurationId: ModelId
-  ): Promise<number> {
-    const workspace = auth.getNonNullableWorkspace();
-
-    return AgentSkillModel.count({
-      where: {
-        agentConfigurationId,
-        workspaceId: workspace.id,
-      },
-    });
-  }
-
   static modelIdToSId({
     id,
     workspaceId,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR allows us to expose the skill_management MCP Server to agents that have at least 1 skill configured.

This works by fetching the count of skills on a given agent configuration.
Note: we don't have a AgentConfigurationResource now, fetching the raw model for now as I believe this query should 99% live in this resource.

Closes https://github.com/dust-tt/tasks/issues/5406

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Unused

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low - Unused

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front