### PR TITLE
Fix: correct error when the MCP server is missing admin connexion.

### DIFF
--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -86,3 +86,32 @@ export class MCPServerPersonalAuthenticationRequiredError extends Error {
     );
   }
 }
+
+const MCPServerRequiresAdminAuthenticationErrorName =
+  "MCPServerRequiresAdminAuthenticationError";
+
+export class MCPServerRequiresAdminAuthenticationError extends Error {
+  mcpServerId: string;
+  provider: OAuthProvider;
+  scope?: string;
+
+  constructor(mcpServerId: string, provider: OAuthProvider, scope?: string) {
+    super(
+      `MCP server ${mcpServerId} requires your admin(s) to setup the connection for your workspace on Dust.`
+    );
+    this.name = MCPServerRequiresAdminAuthenticationErrorName;
+    this.mcpServerId = mcpServerId;
+    this.provider = provider;
+    this.scope = scope;
+  }
+
+  static is(
+    error: unknown
+  ): error is MCPServerRequiresAdminAuthenticationError {
+    return (
+      error instanceof Error &&
+      error.name === MCPServerRequiresAdminAuthenticationErrorName &&
+      "mcpServerId" in error
+    );
+  }
+}

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -18,6 +18,7 @@ import {
 import {
   getConnectionForMCPServer,
   MCPServerPersonalAuthenticationRequiredError,
+  MCPServerRequiresAdminAuthenticationError,
 } from "@app/lib/actions/mcp_authentication";
 import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
 import {
@@ -252,6 +253,24 @@ export const connectToMCPServer = async (
                   "Internal server requires workspace authentication but no connection found"
                 );
                 if (params.oAuthUseCase === "personal_actions") {
+                  // Check if admin connection exists for the server.
+                  const adminConnection = await getConnectionForMCPServer(
+                    auth,
+                    {
+                      mcpServerId: params.mcpServerId,
+                      connectionType: "workspace",
+                    }
+                  );
+                  // If no admin connection exists, return an error to display a message to the user saying that the server requires the admin to setup the connection.
+                  if (!adminConnection) {
+                    return new Err(
+                      new MCPServerRequiresAdminAuthenticationError(
+                        params.mcpServerId,
+                        metadata.authorization.provider,
+                        metadata.authorization.scope
+                      )
+                    );
+                  }
                   return new Err(
                     new MCPServerPersonalAuthenticationRequiredError(
                       params.mcpServerId,
@@ -259,8 +278,17 @@ export const connectToMCPServer = async (
                       metadata.authorization.scope
                     )
                   );
+                } else if (params.oAuthUseCase === "platform_actions") {
+                  // For platform actions, we return an error to display a message to the user saying that the server requires the admin to setup the connection.
+                  return new Err(
+                    new MCPServerRequiresAdminAuthenticationError(
+                      params.mcpServerId,
+                      metadata.authorization.provider,
+                      metadata.authorization.scope
+                    )
+                  );
                 } else {
-                  // TODO(mcp): We return an result to display a message to the user saying that the server requires the admin to setup the connection.
+                  assertNever(params.oAuthUseCase);
                 }
               }
             }


### PR DESCRIPTION
## Description

Fix a 500 when the user was sent to connect a tool but the admin connexion is not available by sending a specific error that the model can interpret.

## Tests

<img width="909" height="739" alt="image" src="https://github.com/user-attachments/assets/ebe9b41c-81de-49e9-ba99-cf381211a954" />

## Risk

Low

## Deploy Plan

Deploy front
