### PR TITLE
enh(snowflake-driver-core): increase session timeout to 60s

### DIFF
--- a/core/src/databases/remote_databases/snowflake/api/client.rs
+++ b/core/src/databases/remote_databases/snowflake/api/client.rs
@@ -42,7 +42,7 @@ impl SnowflakeClient {
         let mut builder = ClientBuilder::new()
             .gzip(true)
             .use_rustls_tls()
-            .timeout(std::time::Duration::from_secs(60));
+            .timeout(std::time::Duration::from_secs(90));
 
         // Only enable verbose connection logging in debug mode
         if tracing::enabled!(tracing::Level::DEBUG) {
@@ -66,7 +66,7 @@ impl SnowflakeClient {
             .gzip(true)
             .use_rustls_tls()
             .proxy(proxy)
-            .timeout(std::time::Duration::from_secs(60));
+            .timeout(std::time::Duration::from_secs(90));
 
         // Only enable verbose connection logging in debug mode
         if tracing::enabled!(tracing::Level::DEBUG) {

--- a/core/src/databases/remote_databases/snowflake/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake/snowflake.rs
@@ -253,7 +253,7 @@ impl SnowflakeRemoteDatabase {
                 role: Some(role),
                 database: None,
                 schema: None,
-                timeout: Some(std::time::Duration::from_secs(30)),
+                timeout: Some(std::time::Duration::from_secs(60)),
             },
         )
         .map_err(|e| {


### PR DESCRIPTION
## Description

Increase the snowflake session timeout to 60s in `core`.
As a result, HTTP timeout is being increased to 90s (safety margin)

This is a middle ground to support use cases that require longer-running queries, without adding risk of agents burning through too much snowflake compute.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
