### PR TITLE
[Front] Update fair usage modal content

### DIFF
--- a/front/components/FairUsageModal.tsx
+++ b/front/components/FairUsageModal.tsx
@@ -16,20 +16,24 @@ interface FairUsageModalProps {
 
 const FAIR_USE_CONTENT = `
 # Fair use principles
-**Dust Pro** is designed company setting and team use
-of AI. It is not designed as a model wrapper for programmatic usage.
 
-**Dust Enterprise** provides programmatic usage (though
-API), with custom prices.
-___
-# What is "unfair" usage?
-Is considered *"Unfair"* usage:
-- Sharing single seat between multiple people.
-- Using Dust programmatically at a large scale on a Pro plan.
+Fair usage applies to messages typed and sent by human users, without using programmatic methods (scripts, API calls, etc.).
 ___
 # "Fair use" limitations
-- For **Pro plans**, a limit at 100 messages / seat / day (Enough to cover any fair usage) is in place and apply to programmatic (API) use as well.
-- For **Business plans**, a limit at 150 messages / seat / day (Enough to cover any fair usage) is in place and apply to programmatic (API) use as well.
+- For **Pro plans**, a limit at 100 messages / seat / day (Enough to cover any fair usage) is applied.
+- For **Enterprise plans**, a limit at 200 messages / seat / day (Enough to cover any fair usage) is applied.
+___
+# What is "unfair" usage?
+The following usage is considered *"Unfair"*:
+- sharing a single seat between multiple people;
+- sending messages programmatically using a regular user seat.
+___
+# Can messages be sent programmatically with Dust?
+Yes. Such messages are not covered by fair use limits, and are billed separately.
+
+Check out [Programmatic usage](https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e) documentation for more information
+
+
 `;
 
 export function FairUsageModal({ isOpened, onClose }: FairUsageModalProps) {

--- a/front/components/FairUsageModal.tsx
+++ b/front/components/FairUsageModal.tsx
@@ -19,21 +19,19 @@ const FAIR_USE_CONTENT = `
 
 "Fair use" applies to messages typed and sent by human users, without using programmatic methods (scripts, API calls, etc.).
 ___
+## **"Fair use" limitations**
 
-# "Fair use" limitations
 - For **Pro plans**, a limit at 100 messages / seat / day (Enough to cover any fair usage) is applied.
 - For **Enterprise plans**, a limit at 200 messages / seat / day (Enough to cover any fair usage) is applied.
 ___
+## **What is "unfair" usage?**
 
-What is "unfair" usage?
-===
 The following usage is considered *"Unfair"*:
 - sharing a single seat between multiple people;
 - sending messages programmatically using a regular user seat.
 ___
+## **Can messages be sent programmatically with Dust?**
 
-Can messages be sent programmatically with Dust?
-===
 Yes. Such messages are not covered by fair use limits, and are billed separately.
 
 Check out [Programmatic usage](https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e) documentation for more information

--- a/front/components/FairUsageModal.tsx
+++ b/front/components/FairUsageModal.tsx
@@ -17,18 +17,23 @@ interface FairUsageModalProps {
 const FAIR_USE_CONTENT = `
 # Fair use principles
 
-Fair usage applies to messages typed and sent by human users, without using programmatic methods (scripts, API calls, etc.).
+"Fair use" applies to messages typed and sent by human users, without using programmatic methods (scripts, API calls, etc.).
 ___
+
 # "Fair use" limitations
 - For **Pro plans**, a limit at 100 messages / seat / day (Enough to cover any fair usage) is applied.
 - For **Enterprise plans**, a limit at 200 messages / seat / day (Enough to cover any fair usage) is applied.
 ___
-# What is "unfair" usage?
+
+What is "unfair" usage?
+===
 The following usage is considered *"Unfair"*:
 - sharing a single seat between multiple people;
 - sending messages programmatically using a regular user seat.
 ___
-# Can messages be sent programmatically with Dust?
+
+Can messages be sent programmatically with Dust?
+===
 Yes. Such messages are not covered by fair use limits, and are billed separately.
 
 Check out [Programmatic usage](https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e) documentation for more information

--- a/front/components/FairUsageModal.tsx
+++ b/front/components/FairUsageModal.tsx
@@ -15,7 +15,7 @@ interface FairUsageModalProps {
 }
 
 const FAIR_USE_CONTENT = `
-# Fair use principles for user seats
+# **Fair use principles for user seats**
 
 Each user seat at Dust is tied to a specific human user, and is destined to be used by that person only, for the purposes of typing and sending messages manually (as opposed to using programmatic methods such as scripts, API calls, etc. which is covered separately).
 
@@ -29,6 +29,7 @@ ___
 # **Can messages be sent programmatically with Dust?**
 
 Yes, and this usage is encouraged. However, such messages are not covered by individual user seats and fair use limits, and are billed separately. 
+
 Dust plans already include monthly credits for programmatic usage, and more credits can be purchased if needed, see [Programmatic usage at Dust](https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e).
 
 `;

--- a/front/components/FairUsageModal.tsx
+++ b/front/components/FairUsageModal.tsx
@@ -15,27 +15,21 @@ interface FairUsageModalProps {
 }
 
 const FAIR_USE_CONTENT = `
-# Fair use principles
+# Fair use principles for user seats
 
-"Fair use" applies to messages typed and sent by human users, without using programmatic methods (scripts, API calls, etc.).
+Each user seat at Dust is tied to a specific human user, and is destined to be used by that person only, for the purposes of typing and sending messages manually (as opposed to using programmatic methods such as scripts, API calls, etc. which is covered separately).
+
+"Fair use" limits apply to each user seat, as follows:
+- For **Pro plans**, a limit at 100 messages / seat / day is applied.
+- For **Enterprise plans**, a limit at 200 messages / seat / day is applied.
+
+These limits should be understood as a way to prevent abuse, not as an allowed quota of messages. In particular, it is considered unfair to share a single seat between multiple people.
+
 ___
-## **"Fair use" limitations**
+# **Can messages be sent programmatically with Dust?**
 
-- For **Pro plans**, a limit at 100 messages / seat / day (Enough to cover any fair usage) is applied.
-- For **Enterprise plans**, a limit at 200 messages / seat / day (Enough to cover any fair usage) is applied.
-___
-## **What is "unfair" usage?**
-
-The following usage is considered *"Unfair"*:
-- sharing a single seat between multiple people;
-- sending messages programmatically using a regular user seat.
-___
-## **Can messages be sent programmatically with Dust?**
-
-Yes. Such messages are not covered by fair use limits, and are billed separately.
-
-Check out [Programmatic usage](https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e) documentation for more information
-
+Yes, and this usage is encouraged. However, such messages are not covered by individual user seats and fair use limits, and are billed separately. 
+Dust plans already include monthly credits for programmatic usage, and more credits can be purchased if needed, see [Programmatic usage at Dust](https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e).
 
 `;
 

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Hoverable,
+  LinkWrapper,
   PriceTable,
   RocketIcon,
   Tabs,
@@ -172,6 +173,22 @@ export function ProPriceTable({
           >
             Fair use limits apply*
           </Hoverable>
+          )
+        </>
+      ),
+      variant: "check",
+      display: ["landing", "subscribe"],
+    },
+    {
+      label: (
+        <>
+          Free credits for programmatic usage (API, GSheet, Zapier) (
+          <LinkWrapper
+            href="https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e#2b728599d941808b8f8dfa8dbe7e466f"
+            target="_blank"
+          >
+            Learn more
+          </LinkWrapper>
           )
         </>
       ),

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -171,7 +171,7 @@ export function ProPriceTable({
             className="cursor-pointer text-gray-400 underline hover:text-gray-500"
             onClick={() => setIsFairUseModalOpened(true)}
           >
-            Fair use limits apply*
+            Fair use limits apply
           </Hoverable>
           )
         </>
@@ -182,13 +182,14 @@ export function ProPriceTable({
     {
       label: (
         <>
-          Free credits for programmatic usage (API, GSheet, Zapier) (
-          <LinkWrapper
+          Free credits for programmatic usage (API, GSheet, Zapier,...) (
+          <Hoverable
+            className="cursor-pointer text-gray-400 underline hover:text-gray-500"
             href="https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e#2b728599d941808b8f8dfa8dbe7e466f"
             target="_blank"
           >
             Learn more
-          </LinkWrapper>
+          </Hoverable>
           )
         </>
       ),
@@ -196,7 +197,7 @@ export function ProPriceTable({
       display: ["landing", "subscribe"],
     },
     {
-      label: "Fixed price on programmatic usage (API, GSheet, Zapier)",
+      label: "Fixed price on additional programmatic usage",
       variant: "dash",
       display: ["landing", "subscribe"],
     },

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Hoverable,
-  LinkWrapper,
   PriceTable,
   RocketIcon,
   Tabs,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5288

Updates the fair usage modal to:
- Clarify that fair usage applies to human-sent messages, not programmatic ones
- Reorder sections for better clarity (fair use limitations before unfair usage examples)
- Add Enterprise plan limits (200 msg/seat/day)
- Explain that programmatic messages are billed separately with link to documentation

Add a line for free credits in the pricing table
## Risks

Blast radius: Fair usage modal display only
Risk: none

## Deploy Plan

- deploy front