### PR TITLE
[SPARKLE] Quotes and codes design

### DIFF
--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -4,14 +4,19 @@ import React from "react";
 import { ContentBlockWrapper } from "@sparkle/components";
 
 export const blockquoteVariants = cva(
-  ["s-w-full s-text-base s-italic s-rounded-2xl s-py-3 s-pl-5 s-pr-12"],
+  [
+    "s-w-full s-text-base s-italic s-py-3 s-pl-3 s-pr-12",
+    "s-relative",
+    "before:s-content-[''] before:s-absolute before:s-left-0 before:s-top-3 before:s-bottom-3",
+    "before:s-w-1 before:s-bg-border-night dark:before:s-bg-border",
+    "before:s-rounded-full",
+  ],
   {
     variants: {
       variant: {
         surface: [
           "s-text-foreground dark:s-text-foreground-night",
-          "s-bg-muted-background dark:s-bg-muted-background-night",
-          "s-border border-border dark:border-border-night",
+          "s-bg-transparent",
         ],
       },
     },

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -8,19 +8,35 @@ const SyntaxHighlighter = React.lazy(
   () => import("react-syntax-highlighter/dist/esm/default-highlight")
 );
 
-export const codeBlockVariants = cva(
+export const codeInlineVariants = cva(
   [
     "s-mx-0.5 s-my-0.5 s-cursor-text s-rounded-md s-border s-px-1 s-py-0.5",
+    "s-border-border dark:s-border-border-night",
+    "s-text-[0.90em]",
+    "s-text-golden-600 dark:s-text-golden-600-night",
+  ],
+  {
+    variants: {
+      variant: {
+        surface: ["s-bg-muted/70 dark:s-bg-muted-night/70"],
+      },
+    },
+    defaultVariants: {
+      variant: "surface",
+    },
+  }
+);
+
+export const codeBlockVariants = cva(
+  [
+    "s-mx-0.5 s-my-0.5 s-cursor-text s-rounded-md s-border s-p-2",
     "s-border-border dark:s-border-border-night",
     "s-text-[0.90em]",
   ],
   {
     variants: {
       variant: {
-        surface: [
-          "s-bg-muted/70 dark:s-bg-muted-night/70",
-          "s-text-golden-600 dark:s-text-golden-600-night",
-        ],
+        surface: ["s-bg-muted/70 dark:s-bg-muted-night/70"],
       },
     },
     defaultVariants: {
@@ -153,7 +169,7 @@ export function CodeBlock({
     },
   };
 
-  return !inline && language ? (
+  return !inline ? (
     <Suspense fallback={<div />}>
       <div className="s-text-foreground dark:s-text-foreground-night">
         <SyntaxHighlighter
@@ -169,6 +185,6 @@ export function CodeBlock({
       </div>
     </Suspense>
   ) : (
-    <code className={codeBlockVariants({ variant })}>{children}</code>
+    <code className={codeInlineVariants({ variant })}>{children}</code>
   );
 }

--- a/sparkle/src/components/markdown/styles.ts
+++ b/sparkle/src/components/markdown/styles.ts
@@ -1,5 +1,8 @@
 import { blockquoteVariants } from "@sparkle/components/markdown/BlockquoteBlock";
-import { codeBlockVariants } from "@sparkle/components/markdown/CodeBlock";
+import {
+  codeBlockVariants,
+  codeInlineVariants,
+} from "@sparkle/components/markdown/CodeBlock";
 import {
   liBlockVariants,
   olBlockVariants,
@@ -12,7 +15,8 @@ import { preBlockVariants } from "@sparkle/components/markdown/PreBlock";
 // It is used in the InputBar component.
 export const markdownStyles = {
   blockquote: blockquoteVariants,
-  code: codeBlockVariants,
+  codeInline: codeInlineVariants,
+  codeBlock: codeBlockVariants,
   list: liBlockVariants,
   orderedList: olBlockVariants,
   paragraph: paragraphBlockVariants,


### PR DESCRIPTION
## Description

This PR harmonizes the way quote blocks and code blocks are displayed between the input bar and the messages content.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Publish Sparkle
