### PR TITLE
[front] - chore(MemberDetails): user info

### DIFF
--- a/front/components/assistant/details/MemberDetails.tsx
+++ b/front/components/assistant/details/MemberDetails.tsx
@@ -70,7 +70,6 @@ export function MemberDetails({ userId, onClose, owner }: MemberDetailsProps) {
                   </div>
                 )}
               </div>
-              {}
               {isUserDetailsError ? (
                 <ContentMessage title="Not Available" icon={LockIcon} size="md">
                   This user is not available.

--- a/front/components/assistant/details/MemberDetails.tsx
+++ b/front/components/assistant/details/MemberDetails.tsx
@@ -1,7 +1,7 @@
 import {
   Avatar,
+  Chip,
   ContentMessage,
-  InformationCircleIcon,
   LockIcon,
   Sheet,
   SheetContainer,
@@ -29,37 +29,6 @@ export function MemberDetails({ userId, onClose, owner }: MemberDetailsProps) {
       userId: userId,
     });
 
-  const DescriptionSection = () => (
-    <div className="flex flex-col gap-5">
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <Avatar
-          name="User avatar"
-          visual={userDetails?.image ?? undefined}
-          size="lg"
-          isRounded
-        />
-        <div className="flex grow flex-col gap-1">
-          <div className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">{`${userDetails?.fullName ?? ""}`}</div>
-        </div>
-      </div>
-      {userDetails?.revoked && (
-        <>
-          <ContentMessage
-            title="This user has been revoked."
-            variant="warning"
-            icon={InformationCircleIcon}
-            size="sm"
-          >
-            This user is no longer active in this workspace.
-            <br />
-          </ContentMessage>
-
-          <div className="flex justify-center"></div>
-        </>
-      )}
-    </div>
-  );
-
   return (
     <Sheet open={!!userId} onOpenChange={onClose}>
       <SheetContent size="lg">
@@ -73,10 +42,35 @@ export function MemberDetails({ userId, onClose, owner }: MemberDetailsProps) {
         ) : (
           <>
             <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
-              {/* eslint-disable-next-line react-hooks/static-components */}
-              <DescriptionSection />
+              <SheetTitle>Profile</SheetTitle>
             </SheetHeader>
             <SheetContainer className="pb-4">
+              <div className="flex w-full items-center">
+                {userDetails && (
+                  <div className="flex w-full flex-col items-center gap-4">
+                    <div className="relative flex flex-col items-center pb-5 sm:pb-3">
+                      <Avatar
+                        name={userDetails.fullName ?? "User avatar"}
+                        visual={userDetails.image ?? undefined}
+                        size="xl"
+                        isRounded
+                      />
+                      <Chip
+                        size="mini"
+                        color={userDetails.revoked ? "rose" : "success"}
+                        label={userDetails.revoked ? "Revoked" : "Active"}
+                        className="absolute -bottom-0 shadow-sm"
+                      />
+                    </div>
+                    <div className="flex grow flex-col gap-1 text-center sm:text-left">
+                      <div className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">
+                        {userDetails.fullName}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+              {}
               {isUserDetailsError ? (
                 <ContentMessage title="Not Available" icon={LockIcon} size="md">
                   This user is not available.

--- a/front/components/assistant/details/tabs/UserInfoTab.tsx
+++ b/front/components/assistant/details/tabs/UserInfoTab.tsx
@@ -48,7 +48,7 @@ const InfoField = ({ label, value, className }: InfoFieldProps) => (
     <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
       {label}
     </div>
-    <div className="mt-1 text-sm text-foreground dark:text-foreground-night">
+    <div className="mt-1 text-sm italic text-foreground dark:text-foreground-night">
       {value ?? (
         <span className="text-muted-foreground dark:text-muted-foreground-night">
           —
@@ -92,14 +92,14 @@ export function UserInfoTab({ userDetails, owner: _owner }: UserInfoTabProps) {
   return (
     <div className="flex flex-col gap-5">
       <Page.SectionHeader
-        title="User information"
+        title="Information"
         description="Details about this workspace member."
       />
 
       <div className="flex flex-col gap-4">
         <SectionCard
           title="Profile"
-          description="Identity and contact details that are visible to the workspace."
+          description="Identity and contact details."
         >
           <div className="grid gap-3 sm:grid-cols-2">
             <InfoField

--- a/front/components/assistant/details/tabs/UserInfoTab.tsx
+++ b/front/components/assistant/details/tabs/UserInfoTab.tsx
@@ -1,64 +1,147 @@
-import { Page } from "@dust-tt/sparkle";
+import { Card, Chip, cn, Page } from "@dust-tt/sparkle";
+import type { ComponentProps, ReactNode } from "react";
 
+import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { GetMemberResponseBody } from "@app/pages/api/w/[wId]/members/[uId]";
-import type { WorkspaceType } from "@app/types";
+import type { RoleType, WorkspaceType } from "@app/types";
 
 interface UserInfoTabProps {
   userDetails: GetMemberResponseBody["member"] | undefined;
   owner: WorkspaceType;
 }
 
+type SectionCardProps = {
+  title: string;
+  description?: string;
+  children: ReactNode;
+};
+
+type InfoFieldProps = {
+  label: string;
+  value?: ReactNode;
+  className?: string;
+};
+
+const SectionCard = ({ title, description, children }: SectionCardProps) => (
+  <Card variant="secondary" size="lg" className="flex flex-col gap-4">
+    <div className="flex flex-col gap-1">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+        {title}
+      </div>
+      {description && (
+        <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {description}
+        </div>
+      )}
+    </div>
+    {children}
+  </Card>
+);
+
+const InfoField = ({ label, value, className }: InfoFieldProps) => (
+  <div
+    className={cn(
+      "rounded-2xl bg-muted-background p-3 text-sm text-foreground dark:bg-muted-background-night dark:text-foreground-night",
+      className
+    )}
+  >
+    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+      {label}
+    </div>
+    <div className="mt-1 text-sm text-foreground dark:text-foreground-night">
+      {value ?? (
+        <span className="text-muted-foreground dark:text-muted-foreground-night">
+          —
+        </span>
+      )}
+    </div>
+  </div>
+);
+
+const formatTextValue = (value?: string | null) =>
+  value && value.trim().length > 0 ? value : undefined;
+
+type ChipColor = ComponentProps<typeof Chip>["color"];
+
+const capitalize = (value: string): string =>
+  value.charAt(0).toUpperCase() + value.slice(1);
+
+const getRoleChipProps = (
+  role: RoleType
+): { label: string; color: ChipColor } => {
+  if (role === "none") {
+    return {
+      label: "No access",
+      color: "primary",
+    };
+  }
+
+  return {
+    label: capitalize(displayRole(role)),
+    color: ROLES_DATA[role].color,
+  };
+};
+
 export function UserInfoTab({ userDetails, owner: _owner }: UserInfoTabProps) {
   if (!userDetails) {
     return null;
   }
 
+  const roleChip = getRoleChipProps(userDetails.role);
+
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-5">
       <Page.SectionHeader
         title="User information"
         description="Details about this workspace member."
       />
 
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-col gap-1">
-          <div className="text-xs font-medium text-muted-foreground">
-            Username
+      <div className="flex flex-col gap-4">
+        <SectionCard
+          title="Profile"
+          description="Identity and contact details that are visible to the workspace."
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <InfoField
+              label="Username"
+              value={formatTextValue(userDetails.username)}
+            />
+            <InfoField
+              label="Email"
+              value={formatTextValue(userDetails.email)}
+            />
+            <InfoField
+              label="Full name"
+              className="col-span-2"
+              value={formatTextValue(userDetails.fullName)}
+            />
           </div>
-          <div className="text-sm text-foreground dark:text-foreground-night">
-            {userDetails.username}
-          </div>
-        </div>
+        </SectionCard>
 
-        <div className="flex flex-col gap-1">
-          <div className="text-xs font-medium text-muted-foreground">Email</div>
-          <div className="text-sm text-foreground dark:text-foreground-night">
-            {userDetails.email}
-          </div>
-        </div>
+        <SectionCard
+          title="Workspace access"
+          description="How this member can use Dust."
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <InfoField
+              label="Role"
+              value={
+                <Chip size="xs" color={roleChip.color} label={roleChip.label} />
+              }
+            />
 
-        <div className="flex flex-col gap-1">
-          <div className="text-xs font-medium text-muted-foreground">Name</div>
-          <div className="text-sm text-foreground dark:text-foreground-night">
-            {userDetails.fullName}
+            <InfoField
+              label="Status"
+              value={
+                <Chip
+                  size="xs"
+                  color={userDetails.revoked ? "rose" : "success"}
+                  label={userDetails.revoked ? "Revoked" : "Active"}
+                />
+              }
+            />
           </div>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <div className="text-xs font-medium text-muted-foreground">Role</div>
-          <div className="text-sm text-foreground dark:text-foreground-night">
-            {userDetails.role}
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <div className="text-xs font-medium text-muted-foreground">
-            Status
-          </div>
-          <div className="text-sm text-foreground dark:text-foreground-night">
-            {userDetails.revoked ? "Revoked" : "Active"}
-          </div>
-        </div>
+        </SectionCard>
       </div>
     </div>
   );

--- a/front/lib/mentions/ui/MentionDropdown.tsx
+++ b/front/lib/mentions/ui/MentionDropdown.tsx
@@ -13,7 +13,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   EyeIcon,
-  UserIcon,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import React from "react";
@@ -77,31 +76,19 @@ export const MentionDropdown = React.forwardRef<
     );
   }
 
-  // User mention actions.
-  if (isRichUserMention(mention)) {
-    const handleUserSeeDetails = () => {
-      onOpenChangeUserModal(true);
-      setQueryParam(router, "userDetails", mention.id);
-    };
+  const handleUserSeeDetails = () => {
+    onOpenChangeUserModal(true);
+    setQueryParam(router, "userDetails", mention.id);
+  };
 
-    return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <div ref={ref}>{children}</div>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent side="bottom" align="start">
-          <DropdownMenuItem
-            onClick={handleUserSeeDetails}
-            icon={UserIcon}
-            label={`Profile of @${mention.label}: ${mention.description}`}
-          />
-        </DropdownMenuContent>
-      </DropdownMenu>
-    );
-  }
-
-  // Unsupported mention type, render children without dropdown.
-  return <div ref={ref}>{children}</div>;
+  return (
+    <div
+      onClick={isRichUserMention(mention) ? handleUserSeeDetails : undefined}
+      ref={ref}
+    >
+      {children}
+    </div>
+  );
 });
 
 MentionDropdown.displayName = "MentionDropdown";


### PR DESCRIPTION
## Description

This PR aims at enhancing the `MemberDetails` sheet a little!
<img width="544" height="693" alt="Screenshot 2025-12-11 at 11 01 57" src="https://github.com/user-attachments/assets/d998ed69-daf0-4cb6-9a83-4108b4031b8a" />

Disclaimer: this is not final design and hasn't been design approved - will handle the tweaking when we get feedback from design.

**References:**
- https://github.com/dust-tt/tasks/issues/5452

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
