### PR TITLE
Limit the size of Teams tools outputs

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams.ts
@@ -223,7 +223,7 @@ function createServer(
               id: channel.id,
               createdDateTime: channel.createdDateTime,
               displayName: channel.displayName,
-              description: channel.description || null,
+              description: channel.description ?? null,
               email: channel.email,
               tenantId: channel.tenantId,
               webUrl: channel.webUrl,
@@ -306,7 +306,7 @@ function createServer(
           // Map to TeamsChat type with only essential fields
           const chats: TeamsChat[] = response.value.map((chat: any) => ({
             id: chat.id,
-            topic: chat.topic || null,
+            topic: chat.topic ?? null,
             createdDateTime: chat.createdDateTime,
             lastUpdatedDateTime: chat.lastUpdatedDateTime,
             chatType: chat.chatType,

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams.ts
@@ -159,13 +159,7 @@ function createServer(
 
           const response = await apiCall.get();
 
-          // Map to TeamsUser type with only essential fields
-          const users: TeamsUser[] = response.value.map((user: any) => ({
-            id: user.id,
-            displayName: user.displayName,
-            mail: user.mail,
-            userPrincipalName: user.userPrincipalName,
-          }));
+          const users: TeamsUser[] = (response.value as TeamsUser[]) ?? [];
 
           return new Ok([
             {
@@ -217,18 +211,8 @@ function createServer(
 
           const response = await apiCall.get();
 
-          // Map to TeamsChannel type with only essential fields
-          const channels: TeamsChannel[] = response.value.map(
-            (channel: any) => ({
-              id: channel.id,
-              createdDateTime: channel.createdDateTime,
-              displayName: channel.displayName,
-              description: channel.description ?? null,
-              email: channel.email,
-              tenantId: channel.tenantId,
-              webUrl: channel.webUrl,
-            })
-          );
+          const channels: TeamsChannel[] =
+            (response.value as TeamsChannel[]) ?? [];
 
           return new Ok([
             {
@@ -303,16 +287,7 @@ function createServer(
 
           const response = await apiCall.get();
 
-          // Map to TeamsChat type with only essential fields
-          const chats: TeamsChat[] = response.value.map((chat: any) => ({
-            id: chat.id,
-            topic: chat.topic ?? null,
-            createdDateTime: chat.createdDateTime,
-            lastUpdatedDateTime: chat.lastUpdatedDateTime,
-            chatType: chat.chatType,
-            webUrl: chat.webUrl,
-            tenantId: chat.tenantId,
-          }));
+          const chats: TeamsChat[] = (response.value as TeamsChat[]) ?? [];
 
           return new Ok([
             {

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams_rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/microsoft_teams_rendering.ts
@@ -1,0 +1,83 @@
+import type {
+  TeamsChannel,
+  TeamsChat,
+  TeamsUser,
+} from "@app/lib/actions/mcp_internal_actions/servers/microsoft/utils";
+
+export function renderUsers(users: TeamsUser[]): string {
+  if (users.length === 0) {
+    return "No users found.";
+  }
+
+  return users
+    .map((user) => {
+      const lines = [
+        `ID: ${user.id}`,
+        `Display Name: ${user.displayName}`,
+        `Principal Name: ${user.userPrincipalName}`,
+      ];
+
+      if (user.mail) {
+        lines.push(`Mail: ${user.mail}`);
+      }
+
+      return lines.join("\n");
+    })
+    .join("\n-----\n");
+}
+
+export function renderChannels(channels: TeamsChannel[]): string {
+  if (channels.length === 0) {
+    return "No channels found.";
+  }
+
+  return channels
+    .map((channel) => {
+      const lines = [
+        `ID: ${channel.id}`,
+        `Display Name: ${channel.displayName}`,
+        `Email: ${channel.email}`,
+        `Web URL: ${channel.webUrl}`,
+        `Created: ${new Date(channel.createdDateTime).toISOString()}`,
+      ];
+
+      if (channel.description) {
+        lines.push(`Description: ${channel.description}`);
+      }
+
+      if (channel.tenantId) {
+        lines.push(`Tenant ID: ${channel.tenantId}`);
+      }
+
+      return lines.join("\n");
+    })
+    .join("\n-----\n");
+}
+
+export function renderChats(chats: TeamsChat[]): string {
+  if (chats.length === 0) {
+    return "No chats found.";
+  }
+
+  return chats
+    .map((chat) => {
+      const lines = [
+        `ID: ${chat.id}`,
+        `Chat Type: ${chat.chatType}`,
+        `Web URL: ${chat.webUrl}`,
+        `Created: ${new Date(chat.createdDateTime).toISOString()}`,
+        `Last Updated: ${new Date(chat.lastUpdatedDateTime).toISOString()}`,
+      ];
+
+      if (chat.topic) {
+        lines.push(`Topic: ${chat.topic}`);
+      }
+
+      if (chat.tenantId) {
+        lines.push(`Tenant ID: ${chat.tenantId}`);
+      }
+
+      return lines.join("\n");
+    })
+    .join("\n-----\n");
+}

--- a/front/lib/actions/mcp_internal_actions/servers/microsoft/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/microsoft/utils.ts
@@ -77,6 +77,33 @@ export interface TeamsMessage {
   messageHistory: unknown[];
 }
 
+export interface TeamsChat {
+  id: string;
+  topic: string | null;
+  createdDateTime: string;
+  lastUpdatedDateTime: string;
+  chatType: "oneOnOne" | "group" | "meeting";
+  webUrl: string;
+  tenantId: string;
+}
+
+export interface TeamsChannel {
+  id: string;
+  createdDateTime: string;
+  displayName: string;
+  description: string | null;
+  email: string;
+  tenantId: string;
+  webUrl: string;
+}
+
+export interface TeamsUser {
+  id: string;
+  displayName: string;
+  mail: string;
+  userPrincipalName: string;
+}
+
 export async function getGraphClient(
   authInfo?: AuthInfo
 ): Promise<Client | null> {


### PR DESCRIPTION
## Description

Limits the output size of Microsoft Teams MCP tools (`list_users`, `list_channels`, `list_chats`) to prevent context window overflow and improve agent reliability. 
Replaces raw JSON output with custom rendering functions that return only essential fields in a concise text format. Adds filtering capabilities to reduce unnecessary data retrieval.

Key changes:
- Reduces list_users max limit from 999 to 25
- Adds nameFilter parameter to all three list tools for server-side filtering
- Introduces dedicated TypeScript interfaces (`TeamsUser`, `TeamsChannel`, `TeamsChat`) with only essential fields
- Creates microsoft_teams_rendering.ts with human-readable text formatters instead of verbose JSON
- Removes unnecessary API calls (e.g., .expand("members") on `list_chats`)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
