### PR TITLE
[Front] refactor(skills): migrate skill configuration POST endpoint to /api/w/[wId]/skills

### DIFF
--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -1,7 +1,7 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PostSkillConfigurationResponseBody } from "@app/pages/api/w/[wId]/assistant/skill_configurations";
 import type { PatchSkillConfigurationResponseBody } from "@app/pages/api/w/[wId]/assistant/skill_configurations/[sId]";
+import type { PostSkillConfigurationResponseBody } from "@app/pages/api/w/[wId]/skills";
 import type { Result, UserType, WorkspaceType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 
@@ -25,7 +25,7 @@ export async function submitSkillBuilderForm({
   try {
     const endpoint = skillConfigurationId
       ? `/api/w/${owner.sId}/assistant/skill_configurations/${skillConfigurationId}`
-      : `/api/w/${owner.sId}/assistant/skill_configurations`;
+      : `/api/w/${owner.sId}/skills`;
 
     const method = skillConfigurationId ? "PATCH" : "POST";
 

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.test.ts
@@ -2,18 +2,10 @@ import type { RequestMethod } from "node-mocks-http";
 import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
-import {
-  SkillConfigurationModel,
-  SkillMCPServerConfigurationModel,
-} from "@app/lib/models/skill";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
-import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { MembershipRoleType } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/assistant/skill_configuration";
 
@@ -229,7 +221,7 @@ describe("GET /api/w/[wId]/assistant/skill_configurations", () => {
 
 describe("Method Support /api/w/[wId]/assistant/skill_configurations", () => {
   it("should return 405 for unsupported methods", async () => {
-    for (const method of ["PUT", "PATCH", "DELETE"] as const) {
+    for (const method of ["PUT", "PATCH", "DELETE", "POST"] as const) {
       const { req, res, workspace, user } = await setupTest(method);
 
       const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -247,135 +239,9 @@ describe("Method Support /api/w/[wId]/assistant/skill_configurations", () => {
       expect(data).toEqual({
         error: {
           type: "method_not_supported_error",
-          message:
-            "The method passed is not supported, GET or POST is expected.",
+          message: "The method passed is not supported, GET is expected.",
         },
       });
     }
-  });
-});
-describe("POST /api/w/[wId]/assistant/skill_configurations", () => {
-  it("creates a simple skill configuration", async () => {
-    const { req, res, workspace } = await setupTest("POST", "admin");
-
-    req.body = {
-      name: "Simple Skill",
-      description: "A simple skill without tools",
-      instructions: "Simple instructions",
-      tools: [],
-    };
-
-    await handler(req, res);
-    expect(res._getStatusCode()).toBe(200);
-
-    const responseData = res._getJSONData();
-    expect(responseData.skillConfiguration).toMatchObject({
-      name: "Simple Skill",
-      description: "A simple skill without tools",
-      instructions: "Simple instructions",
-      status: "active",
-      version: 0,
-      tools: [],
-    });
-
-    // Verify skill was created in the database
-    const skillConfiguration = await SkillConfigurationModel.findOne({
-      where: {
-        workspaceId: workspace.id,
-        name: "Simple Skill",
-      },
-    });
-    expect(skillConfiguration).not.toBeNull();
-  });
-
-  it("creates a skill configuration with 2 tools", async () => {
-    const { req, res, workspace, authenticator, user } = await setupTest(
-      "POST",
-      "admin"
-    );
-
-    // Create spaces (system space is required for MCP servers)
-    await SpaceFactory.system(workspace);
-
-    const globalSpace = await SpaceFactory.global(workspace);
-
-    const server1 = await RemoteMCPServerFactory.create(workspace, {
-      name: "Server 1",
-    });
-    const server2 = await RemoteMCPServerFactory.create(workspace, {
-      name: "Server 2",
-    });
-
-    const serverView1 = await MCPServerViewFactory.create(
-      workspace,
-      server1.sId,
-      globalSpace
-    );
-    const serverView2 = await MCPServerViewFactory.create(
-      workspace,
-      server2.sId,
-      globalSpace
-    );
-
-    req.body = {
-      name: "Test Skill",
-      description: "A test skill description",
-      instructions: "Test instructions for the skill",
-      tools: [
-        { mcpServerViewId: serverView1.sId },
-        { mcpServerViewId: serverView2.sId },
-      ],
-    };
-
-    await handler(req, res);
-    expect(res._getStatusCode()).toBe(200);
-
-    const responseData = res._getJSONData();
-    expect(responseData.skillConfiguration).toMatchObject({
-      name: "Test Skill",
-      description: "A test skill description",
-      instructions: "Test instructions for the skill",
-      status: "active",
-      version: 0,
-      tools: [
-        { mcpServerViewId: serverView1.sId },
-        { mcpServerViewId: serverView2.sId },
-      ],
-    });
-
-    // Verify skill was created in the database
-    const skillConfiguration = await SkillConfigurationModel.findOne({
-      where: {
-        workspaceId: workspace.id,
-        name: "Test Skill",
-      },
-    });
-    expect(skillConfiguration).not.toBeNull();
-    expect(skillConfiguration!.description).toBe("A test skill description");
-    expect(skillConfiguration!.instructions).toBe(
-      "Test instructions for the skill"
-    );
-    expect(skillConfiguration!.authorId).toBe(user.id);
-
-    // Verify tools were created in the database
-    const toolConfigurations = await SkillMCPServerConfigurationModel.findAll({
-      where: {
-        workspaceId: workspace.id,
-        skillConfigurationId: skillConfiguration!.id,
-      },
-    });
-    expect(toolConfigurations).toHaveLength(2);
-
-    const serverViewIds = toolConfigurations.map((t) => t.mcpServerViewId);
-    const view1 = await MCPServerViewResource.fetchById(
-      authenticator,
-      serverView1.sId
-    );
-    const view2 = await MCPServerViewResource.fetchById(
-      authenticator,
-      serverView2.sId
-    );
-    expect(serverViewIds).toContain(view1!.id);
-    expect(serverViewIds).toContain(view2!.id);
   });
 });

--- a/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/skill_configurations/index.ts
@@ -1,52 +1,22 @@
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillConfigurationResource } from "@app/lib/resources/skill/skill_configuration_resource";
-import { withTransaction } from "@app/lib/utils/sql_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isGlobalAgentId, isString } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/assistant/skill_configuration";
 
-export type PostSkillConfigurationResponseBody = {
-  skillConfiguration: SkillConfigurationType;
-};
-
 export interface GetAgentSkillsResponseBody {
   skills: SkillConfigurationType[];
 }
 
-// Request body schema for POST
-const PostSkillConfigurationRequestBodySchema = t.type({
-  name: t.string,
-  description: t.string,
-  instructions: t.string,
-  tools: t.array(
-    t.type({
-      mcpServerViewId: t.string,
-    })
-  ),
-});
-
-type PostSkillConfigurationRequestBody = t.TypeOf<
-  typeof PostSkillConfigurationRequestBodySchema
->;
-
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<
-    | WithAPIErrorResponse<PostSkillConfigurationResponseBody>
-    | WithAPIErrorResponse<GetAgentSkillsResponseBody>
-  >,
+  res: NextApiResponse<WithAPIErrorResponse<GetAgentSkillsResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
@@ -106,123 +76,13 @@ async function handler(
         skills: skills.map((s) => s.toJSON()),
       });
     }
-    case "POST": {
-      if (!auth.isBuilder()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message:
-              "Only users that are `builders` for the current workspace can manage skills.",
-          },
-        });
-      }
-
-      const user = auth.getNonNullableUser();
-
-      const bodyValidation = PostSkillConfigurationRequestBodySchema.decode(
-        req.body
-      );
-
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
-          },
-        });
-      }
-
-      const body: PostSkillConfigurationRequestBody = bodyValidation.right;
-
-      const existingSkill = await SkillConfigurationResource.fetchActiveByName(
-        auth,
-        body.name
-      );
-
-      if (existingSkill) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `A skill with the name "${body.name}" already exists.`,
-          },
-        });
-      }
-
-      // Validate all MCP server views exist before creating anything
-      const mcpServerViews: MCPServerViewResource[] = [];
-      for (const tool of body.tools) {
-        const mcpServerView = await MCPServerViewResource.fetchById(
-          auth,
-          tool.mcpServerViewId
-        );
-        if (!mcpServerView) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "invalid_request_error",
-              message: `MCP server view not found ${tool.mcpServerViewId}`,
-            },
-          });
-        }
-        mcpServerViews.push(mcpServerView);
-      }
-
-      // Use a transaction to ensure all creates succeed or all are rolled back
-      const skillConfiguration = await withTransaction(async (transaction) => {
-        const skill = await SkillConfigurationResource.makeNew(
-          {
-            workspaceId: owner.id,
-            version: 0,
-            status: "active",
-            name: body.name,
-            description: body.description,
-            instructions: body.instructions,
-            authorId: user.id,
-            // TODO(skills): add space restrictions.
-            requestedSpaceIds: [],
-          },
-          { transaction }
-        );
-
-        await GroupResource.makeNewSkillEditorsGroup(auth, skill, {
-          transaction,
-        });
-
-        // Create MCP server configurations (tools) for this skill
-        for (const mcpServerView of mcpServerViews) {
-          // TODO(skills 2025-12-09): move this to the makeNew.
-          await SkillMCPServerConfigurationModel.create(
-            {
-              workspaceId: owner.id,
-              skillConfigurationId: skill.id,
-              mcpServerViewId: mcpServerView.id,
-            },
-            { transaction }
-          );
-        }
-
-        return skill;
-      });
-
-      return res.status(200).json({
-        skillConfiguration: {
-          ...skillConfiguration.toJSON(),
-          tools: body.tools,
-        },
-      });
-    }
 
     default:
       return apiError(req, res, {
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message:
-            "The method passed is not supported, GET or POST is expected.",
+          message: "The method passed is not supported, GET is expected.",
         },
       });
   }

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -2,11 +2,19 @@ import type { RequestMethod } from "node-mocks-http";
 import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
+import {
+  SkillConfigurationModel,
+  SkillMCPServerConfigurationModel,
+} from "@app/lib/models/skill";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillConfigurationResource } from "@app/lib/resources/skill/skill_configuration_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { MembershipRoleType } from "@app/types";
 import type {
   SkillConfigurationRelations,
@@ -361,9 +369,135 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
   });
 });
 
+describe("POST /api/w/[wId]/skills", () => {
+  it("creates a simple skill configuration", async () => {
+    const { req, res, workspace } = await setupTest("POST", "admin");
+
+    req.body = {
+      name: "Simple Skill",
+      description: "A simple skill without tools",
+      instructions: "Simple instructions",
+      tools: [],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData.skillConfiguration).toMatchObject({
+      name: "Simple Skill",
+      description: "A simple skill without tools",
+      instructions: "Simple instructions",
+      status: "active",
+      version: 0,
+      tools: [],
+    });
+
+    // Verify skill was created in the database
+    const skillConfiguration = await SkillConfigurationModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        name: "Simple Skill",
+      },
+    });
+    expect(skillConfiguration).not.toBeNull();
+  });
+
+  it("creates a skill configuration with 2 tools", async () => {
+    const { req, res, workspace, authenticator, user } = await setupTest(
+      "POST",
+      "admin"
+    );
+
+    // Create spaces (system space is required for MCP servers)
+    await SpaceFactory.system(workspace);
+
+    const globalSpace = await SpaceFactory.global(workspace);
+
+    const server1 = await RemoteMCPServerFactory.create(workspace, {
+      name: "Server 1",
+    });
+    const server2 = await RemoteMCPServerFactory.create(workspace, {
+      name: "Server 2",
+    });
+
+    const serverView1 = await MCPServerViewFactory.create(
+      workspace,
+      server1.sId,
+      globalSpace
+    );
+    const serverView2 = await MCPServerViewFactory.create(
+      workspace,
+      server2.sId,
+      globalSpace
+    );
+
+    req.body = {
+      name: "Test Skill",
+      description: "A test skill description",
+      instructions: "Test instructions for the skill",
+      tools: [
+        { mcpServerViewId: serverView1.sId },
+        { mcpServerViewId: serverView2.sId },
+      ],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData.skillConfiguration).toMatchObject({
+      name: "Test Skill",
+      description: "A test skill description",
+      instructions: "Test instructions for the skill",
+      status: "active",
+      version: 0,
+      tools: [
+        { mcpServerViewId: serverView1.sId },
+        { mcpServerViewId: serverView2.sId },
+      ],
+    });
+
+    // Verify skill was created in the database
+    const skillConfiguration = await SkillConfigurationModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        name: "Test Skill",
+      },
+    });
+    expect(skillConfiguration).not.toBeNull();
+    expect(skillConfiguration!.description).toBe("A test skill description");
+    expect(skillConfiguration!.instructions).toBe(
+      "Test instructions for the skill"
+    );
+    expect(skillConfiguration!.authorId).toBe(user.id);
+
+    // Verify tools were created in the database
+    const toolConfigurations = await SkillMCPServerConfigurationModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        skillConfigurationId: skillConfiguration!.id,
+      },
+    });
+    expect(toolConfigurations).toHaveLength(2);
+
+    const serverViewIds = toolConfigurations.map((t) => t.mcpServerViewId);
+    const view1 = await MCPServerViewResource.fetchById(
+      authenticator,
+      serverView1.sId
+    );
+    const view2 = await MCPServerViewResource.fetchById(
+      authenticator,
+      serverView2.sId
+    );
+    expect(serverViewIds).toContain(view1!.id);
+    expect(serverViewIds).toContain(view2!.id);
+  });
+});
+
 describe("Method Support /api/w/[wId]/skills", () => {
   it("should return 405 for unsupported methods", async () => {
-    for (const method of ["POST", "PUT", "PATCH", "DELETE"] as const) {
+    for (const method of ["PUT", "PATCH", "DELETE"] as const) {
       const { req, res, workspace } = await setupTest(method);
 
       req.query = { ...req.query, wId: workspace.sId };
@@ -374,7 +508,7 @@ describe("Method Support /api/w/[wId]/skills", () => {
       expect(res._getJSONData()).toMatchObject({
         error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
+          message: "The method passed is not supported, GET or POST expected.",
         },
       });
     }

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -1,10 +1,17 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillConfigurationResource } from "@app/lib/resources/skill/skill_configuration_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isBuilder } from "@app/types";
@@ -21,12 +28,33 @@ export type GetSkillConfigurationsWithRelationsResponseBody = {
   skillConfigurations: (SkillConfigurationType & SkillConfigurationRelations)[];
 };
 
+export type PostSkillConfigurationResponseBody = {
+  skillConfiguration: SkillConfigurationType;
+};
+
+// Request body schema for POST
+const PostSkillConfigurationRequestBodySchema = t.type({
+  name: t.string,
+  description: t.string,
+  instructions: t.string,
+  tools: t.array(
+    t.type({
+      mcpServerViewId: t.string,
+    })
+  ),
+});
+
+type PostSkillConfigurationRequestBody = t.TypeOf<
+  typeof PostSkillConfigurationRequestBodySchema
+>;
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<
       | GetSkillConfigurationsResponseBody
       | GetSkillConfigurationsWithRelationsResponseBody
+      | PostSkillConfigurationResponseBody
     >
   >,
   auth: Authenticator
@@ -85,12 +113,111 @@ async function handler(
       });
     }
 
+    case "POST": {
+      const user = auth.getNonNullableUser();
+
+      const bodyValidation = PostSkillConfigurationRequestBodySchema.decode(
+        req.body
+      );
+
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const body: PostSkillConfigurationRequestBody = bodyValidation.right;
+
+      const existingSkill = await SkillConfigurationResource.fetchActiveByName(
+        auth,
+        body.name
+      );
+
+      if (existingSkill) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `A skill with the name "${body.name}" already exists.`,
+          },
+        });
+      }
+
+      // Validate all MCP server views exist before creating anything
+      const mcpServerViews: MCPServerViewResource[] = [];
+      for (const tool of body.tools) {
+        const mcpServerView = await MCPServerViewResource.fetchById(
+          auth,
+          tool.mcpServerViewId
+        );
+        if (!mcpServerView) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "invalid_request_error",
+              message: `MCP server view not found ${tool.mcpServerViewId}`,
+            },
+          });
+        }
+        mcpServerViews.push(mcpServerView);
+      }
+
+      // Use a transaction to ensure all creates succeed or all are rolled back
+      const skillConfiguration = await withTransaction(async (transaction) => {
+        const skill = await SkillConfigurationResource.makeNew(
+          {
+            workspaceId: owner.id,
+            version: 0,
+            status: "active",
+            name: body.name,
+            description: body.description,
+            instructions: body.instructions,
+            authorId: user.id,
+            // TODO(skills): add space restrictions.
+            requestedSpaceIds: [],
+          },
+          { transaction }
+        );
+
+        await GroupResource.makeNewSkillEditorsGroup(auth, skill, {
+          transaction,
+        });
+
+        // Create MCP server configurations (tools) for this skill
+        for (const mcpServerView of mcpServerViews) {
+          // TODO(skills 2025-12-09): move this to the makeNew.
+          await SkillMCPServerConfigurationModel.create(
+            {
+              workspaceId: owner.id,
+              skillConfigurationId: skill.id,
+              mcpServerViewId: mcpServerView.id,
+            },
+            { transaction }
+          );
+        }
+
+        return skill;
+      });
+
+      return res.status(200).json({
+        skillConfiguration: {
+          ...skillConfiguration.toJSON(),
+          tools: body.tools,
+        },
+      });
+    }
+
     default:
       return apiError(req, res, {
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
+          message: "The method passed is not supported, GET or POST expected.",
         },
       });
   }


### PR DESCRIPTION
## Description

Migrate api post endpoint from `/api/w/[wId]/assistant/skill_configurations` -> `/api/w/[wId]/skills` as it's creating a skill and has nothing to do with agent

## Tests

Local

## Risk

Low

## Deploy Plan

Front