### PR TITLE
[Front] refactor(skills): migrate skill configuration GET endpoint to new route

### DIFF
--- a/front/lib/swr/skills.ts
+++ b/front/lib/swr/skills.ts
@@ -1,7 +1,7 @@
 import type { Fetcher } from "swr";
 
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetAgentSkillsResponseBody } from "@app/pages/api/w/[wId]/assistant/skill_configurations";
+import type { GetAgentSkillsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills";
 import type { LightWorkspaceType } from "@app/types";
 
 export function useAgentConfigurationSkills({
@@ -16,7 +16,7 @@ export function useAgentConfigurationSkills({
   const skillsFetcher: Fetcher<GetAgentSkillsResponseBody> = fetcher;
 
   const { data, isLoading } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/assistant/skill_configurations?aId=${agentConfigurationSId}`,
+    `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationSId}/skills`,
     skillsFetcher,
     { disabled }
   );

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
@@ -9,7 +9,7 @@ import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFa
 import type { MembershipRoleType } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/assistant/skill_configuration";
 
-import handler from "./index";
+import handler from "./skills";
 
 async function setupTest(
   method: RequestMethod = "GET",
@@ -25,7 +25,7 @@ async function setupTest(
   return mockRequest;
 }
 
-describe("GET /api/w/[wId]/assistant/skill_configurations", () => {
+describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/skills", () => {
   it("should return 200 with empty array when agent has no skills", async () => {
     const { req, res, workspace, user } = await setupTest();
 
@@ -125,6 +125,7 @@ describe("GET /api/w/[wId]/assistant/skill_configurations", () => {
     expect(res._getStatusCode()).toBe(400);
     const data = res._getJSONData();
     expect(data.error.type).toBe("invalid_request_error");
+    expect(data.error.message).toBe("Invalid agent configuration ID.");
   });
 
   it("should return empty array for global agents", async () => {
@@ -203,23 +204,9 @@ describe("GET /api/w/[wId]/assistant/skill_configurations", () => {
       expect(data.skills[0].name).toBe(`Skill for ${role}`);
     }
   });
-
-  it("should return 400 when aId query param is missing", async () => {
-    const { req, res, workspace } = await setupTest("GET");
-
-    req.query = { ...req.query, wId: workspace.sId };
-    // aId is intentionally not set
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(400);
-    const data = res._getJSONData();
-    expect(data.error.type).toBe("invalid_request_error");
-    expect(data.error.message).toBe("Invalid agent configuration ID.");
-  });
 });
 
-describe("Method Support /api/w/[wId]/assistant/skill_configurations", () => {
+describe("Method Support /api/w/[wId]/assistant/agent_configurations/[aId]/skills", () => {
   it("should return 405 for unsupported methods", async () => {
     for (const method of ["PUT", "PATCH", "DELETE", "POST"] as const) {
       const { req, res, workspace, user } = await setupTest(method);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -32,33 +32,33 @@ async function handler(
     });
   }
 
+  const { aId } = req.query;
+  if (!isString(aId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent configuration ID.",
+      },
+    });
+  }
+
+  const agent = await getAgentConfiguration(auth, {
+    agentId: aId,
+    variant: "light",
+  });
+  if (!agent) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration was not found.",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET": {
-      const { aId } = req.query;
-      if (!isString(aId)) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Invalid agent configuration ID.",
-          },
-        });
-      }
-
-      const agent = await getAgentConfiguration(auth, {
-        agentId: aId,
-        variant: "light",
-      });
-      if (!agent) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "agent_configuration_not_found",
-            message: "The agent configuration was not found.",
-          },
-        });
-      }
-
       if (isGlobalAgentId(agent.sId)) {
         // TODO(skills 2025-12-09): Implement fetching skills for global agents.
         return res.status(200).json({


### PR DESCRIPTION

## Description

Follow-up PR of : https://github.com/dust-tt/dust/pull/18973

Moved the GET endpoint for fetching agent skills from `/api/w/[wId]/assistant/skill_configurations?aId=...` to `/api/w/[wId]/assistant/agent_configurations/[aId]/skills`.

## Tests

Local

## Risk

Low

## Deploy Plan

Front