### PR TITLE
Tool uploaded file: Polish and allow opening sourceUrl

### DIFF
--- a/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
@@ -1,12 +1,12 @@
 import {
   ArrowDownOnSquareIcon,
-  Button,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  ExternalLinkIcon,
   Markdown,
   Spinner,
 } from "@dust-tt/sparkle";
@@ -17,7 +17,12 @@ import type {
   MCPAttachmentCitation,
 } from "@app/components/assistant/conversation/attachment/types";
 import { isAudioContentType } from "@app/components/assistant/conversation/attachment/utils";
+import { getIcon } from "@app/components/resources/resources_icons";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
+import {
+  INTERNAL_MCP_SERVERS,
+  isInternalMCPServerName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   getFileDownloadUrl,
   getFileViewUrl,
@@ -25,6 +30,7 @@ import {
   useFileProcessedContent,
 } from "@app/lib/swr/files";
 import type { LightWorkspaceType } from "@app/types";
+import { asDisplayToolName } from "@app/types";
 
 export const AttachmentViewer = ({
   viewerOpen,
@@ -166,21 +172,32 @@ export const AttachmentViewer = ({
     }
   };
 
+  const sourceUrl = attachmentCitation.sourceUrl;
+  const provider = attachmentCitation.provider;
+
+  const onClickOpenSourceUrl = () => {
+    if (sourceUrl) {
+      window.open(sourceUrl, "_blank");
+    }
+  };
+
+  const sourceUrlButtonLabel = provider
+    ? `Open on ${asDisplayToolName(provider)}`
+    : "Open source";
+
+  const getSourceUrlButtonIcon = () => {
+    if (provider && isInternalMCPServerName(provider)) {
+      const serverIcon = INTERNAL_MCP_SERVERS[provider].serverInfo.icon;
+      return getIcon(serverIcon);
+    }
+    return ExternalLinkIcon;
+  };
+
   return (
     <Dialog open={viewerOpen} onOpenChange={setViewerOpen}>
       <DialogContent size="xl" height="lg">
         <DialogHeader>
           <DialogTitle>
-            {canDownload && (
-              <Button
-                onClick={onClickDownload}
-                icon={ArrowDownOnSquareIcon}
-                size="mini"
-                tooltip="Download file"
-                variant="ghost"
-                className={"mr-2 align-middle"}
-              />
-            )}
             <span className="mr-2 inline-flex align-middle">
               {attachmentCitation.visual}
             </span>
@@ -202,9 +219,19 @@ export const AttachmentViewer = ({
           )}
         </DialogContainer>
         <DialogFooter
+          leftButtonProps={{
+            label: "Download file",
+            variant: "outline",
+            onClick: onClickDownload,
+            disabled: !canDownload,
+            icon: ArrowDownOnSquareIcon,
+          }}
           rightButtonProps={{
-            label: "Close",
-            variant: "highlight",
+            label: sourceUrlButtonLabel,
+            variant: "outline",
+            disabled: !sourceUrl,
+            onClick: onClickOpenSourceUrl,
+            icon: getSourceUrlButtonIcon(),
           }}
         />
       </DialogContent>

--- a/front/components/assistant/conversation/attachment/types.ts
+++ b/front/components/assistant/conversation/attachment/types.ts
@@ -19,6 +19,7 @@ export type FileAttachment = {
   description?: string;
   sourceUrl?: string;
   iconName?: string;
+  provider?: string;
   // Server-side file resource sId for API calls (fetching content, downloading).
   // Null while the file is still uploading.
   fileId: string | null;
@@ -44,6 +45,7 @@ interface BaseAttachmentCitation {
   title: string;
   sourceUrl: string | null;
   visual: React.ReactNode;
+  provider?: string;
   onRemove?: () => void;
 }
 

--- a/front/components/assistant/conversation/attachment/utils.tsx
+++ b/front/components/assistant/conversation/attachment/utils.tsx
@@ -183,6 +183,7 @@ export function contentFragmentToAttachmentCitation(
           sourceUrl={contentFragment.sourceUrl ?? undefined}
         />
       ),
+      provider: provider ?? undefined,
       spaceName: contentFragment.contentNodeData.spaceName,
       attachmentCitationType: "fragment",
     };
@@ -236,6 +237,7 @@ export function attachmentToAttachmentCitation(
       contentType: attachment.contentType,
       onRemove: attachment.onRemove,
       attachmentCitationType: "inputBar",
+      provider: attachment.provider,
     };
   } else {
     return {
@@ -272,6 +274,7 @@ export function markdownCitationToAttachmentCitation(
         sourceUrl={citation.href}
       />
     ),
+    provider: citation.provider,
     isUploading: false,
   };
 }

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -93,6 +93,7 @@ export function InputBarAttachments({
         isUploading: blob.isUploading,
         description: uploadDate,
         iconName: blob.iconName,
+        provider: blob.provider,
         fileId: blob.fileId,
         onRemove: disable ? undefined : () => fileService.removeFile(blob.id),
       };

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -36,6 +36,7 @@ export interface FileBlob {
   size: number;
   publicUrl?: string;
   iconName?: string;
+  provider?: string;
 }
 export type FileBlobWithFileId = FileBlob & { fileId: string };
 
@@ -379,6 +380,7 @@ export function useFileUploaderService({
     id?: string;
     sourceUrl?: string;
     iconName?: string;
+    provider?: string;
   }) => {
     const blob: FileBlob = {
       contentType: fileData.contentType,
@@ -390,6 +392,7 @@ export function useFileUploaderService({
       size: fileData.size,
       sourceUrl: fileData.sourceUrl,
       iconName: fileData.iconName,
+      provider: fileData.provider,
     };
 
     setFileBlobs((prevFiles) => [...prevFiles, blob]);

--- a/front/hooks/useToolFileUpload.ts
+++ b/front/hooks/useToolFileUpload.ts
@@ -78,6 +78,7 @@ export function useToolFileUpload({
           size: file.fileSize,
           sourceUrl: toolFile.sourceUrl ?? undefined,
           iconName: toolFile.serverIcon,
+          provider: toolFile.serverName,
         });
       } catch (error) {
         sendNotification({


### PR DESCRIPTION
## Description

Before

<kbd>
<img width="829" height="624" alt="Screenshot 2025-12-11 at 13 13 05" src="https://github.com/user-attachments/assets/fac4397e-5f8a-4231-85ca-e7df6f5b69a0" />
</kbd>

After

<kbd>
<img width="828" height="631" alt="Screenshot 2025-12-11 at 13 12 51" src="https://github.com/user-attachments/assets/2dc636b1-1811-4665-a92d-11ac54f496e6" />
</kbd>


-> This works well only when the tool is in the input bar, once it's uploaded and displayed in the UserMessage we loose the Provider info, there's already a task for it!

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 