### PR TITLE
feat: fix auth on deleting datasources/folders/etc

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -307,7 +307,7 @@ const dataSource = async (command: string, args: parseArgs.ParsedArgs) => {
         );
       }
 
-      await softDeleteDataSourceAndLaunchScrubWorkflow(auth, dataSource);
+      await softDeleteDataSourceAndLaunchScrubWorkflow(auth, { dataSource });
 
       console.log(`Data Source deleted: ${args.dsId}`);
 

--- a/front/lib/api/data_sources.test.ts
+++ b/front/lib/api/data_sources.test.ts
@@ -1,5 +1,13 @@
-import { vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { softDeleteDataSourceAndLaunchScrubWorkflow } from "@app/lib/api/data_sources";
+import type { Authenticator } from "@app/lib/auth";
+import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { launchScrubDataSourceWorkflow } from "@app/poke/temporal/client";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { CoreAPI, Ok } from "@app/types";
 
 // Mock distributed lock to avoid Redis dependency
@@ -55,3 +63,156 @@ vi.spyOn(CoreAPI.prototype, "createDataSource").mockImplementation(
     });
   }
 );
+
+// Mock the dependencies
+vi.mock("@app/poke/temporal/client", () => ({
+  launchScrubDataSourceWorkflow: vi.fn(),
+}));
+
+describe("softDeleteDataSourceAndLaunchScrubWorkflow", () => {
+  let builderAuth: Authenticator;
+  let userAuth: Authenticator;
+  let folderDataSource: DataSourceResource;
+
+  beforeEach(async () => {
+    // Setup builder user
+    const builderSetup = await createResourceTest({ role: "builder" });
+    builderAuth = builderSetup.authenticator;
+
+    // Setup regular user
+    const userSetup = await createResourceTest({
+      role: "user",
+    });
+    userAuth = userSetup.authenticator;
+
+    // Create a folder data source owned by the builder in their workspace
+    const dataSourceView = await DataSourceViewFactory.folder(
+      builderSetup.workspace,
+      builderSetup.globalSpace,
+      builderSetup.user
+    );
+    folderDataSource = dataSourceView.dataSource;
+
+    // Spy on the view listing to return empty array by default
+    vi.spyOn(DataSourceViewResource, "listForDataSources").mockResolvedValue(
+      []
+    );
+
+    // Clear mocks before each test
+    vi.clearAllMocks();
+  });
+
+  describe("authorization checks", () => {
+    it("should not allow user to delete folder created by another user", async () => {
+      // Create another user
+      const anotherUser = await UserFactory.basic();
+      const anotherUserSetup = await createResourceTest({ role: "user" });
+
+      // Create a folder owned by the other user
+      const otherUserDataSourceView = await DataSourceViewFactory.folder(
+        anotherUserSetup.workspace,
+        anotherUserSetup.globalSpace,
+        anotherUser
+      );
+
+      const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
+        userAuth,
+        { dataSource: otherUserDataSourceView.dataSource }
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("unauthorized_deletion");
+        expect(result.error.message).toContain(
+          "Only builders can delete data sources"
+        );
+      }
+      expect(launchScrubDataSourceWorkflow).not.toHaveBeenCalled();
+    });
+
+    it("should not allow user to delete connector-based data source", async () => {
+      // Create a mock connector data source
+      const connectorDataSource = {
+        ...folderDataSource,
+        connectorProvider: "slack",
+        connectorId: "conn-123",
+      } as unknown as DataSourceResource;
+
+      const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
+        userAuth,
+        { dataSource: connectorDataSource }
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("unauthorized_deletion");
+      }
+      expect(launchScrubDataSourceWorkflow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("successful deletions", () => {
+    it("should allow builder to delete folder data source", async () => {
+      const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
+        builderAuth,
+        { dataSource: folderDataSource }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(launchScrubDataSourceWorkflow).toHaveBeenCalledWith(
+        builderAuth.workspace(),
+        folderDataSource
+      );
+      expect(launchScrubDataSourceWorkflow).toHaveBeenCalledTimes(1);
+    });
+
+    it("should soft delete all data source views before deleting data source", async () => {
+      // Create multiple views for the data source
+      const view1 = {
+        id: 1,
+        delete: vi.fn().mockResolvedValue({ isErr: () => false }),
+      };
+      const view2 = {
+        id: 2,
+        delete: vi.fn().mockResolvedValue({ isErr: () => false }),
+      };
+
+      vi.spyOn(DataSourceViewResource, "listForDataSources").mockResolvedValue([
+        view1,
+        view2,
+      ] as any);
+
+      const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
+        builderAuth,
+        { dataSource: folderDataSource }
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(view1.delete).toHaveBeenCalledWith(builderAuth, {
+        transaction: undefined,
+        hardDelete: false,
+      });
+      expect(view2.delete).toHaveBeenCalledWith(builderAuth, {
+        transaction: undefined,
+        hardDelete: false,
+      });
+      expect(launchScrubDataSourceWorkflow).toHaveBeenCalled();
+    });
+
+    it("should launch scrub workflow with correct workspace and data source", async () => {
+      const result = await softDeleteDataSourceAndLaunchScrubWorkflow(
+        builderAuth,
+        { dataSource: folderDataSource }
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.sId).toBe(folderDataSource.sId);
+      }
+      expect(launchScrubDataSourceWorkflow).toHaveBeenCalledWith(
+        builderAuth.workspace(),
+        folderDataSource
+      );
+    });
+  });
+});

--- a/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
+++ b/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
@@ -58,10 +58,9 @@ export const deleteDataSourcePlugin = createPlugin({
       );
     }
 
-    const delRes = await softDeleteDataSourceAndLaunchScrubWorkflow(
-      auth,
-      dataSource
-    );
+    const delRes = await softDeleteDataSourceAndLaunchScrubWorkflow(auth, {
+      dataSource,
+    });
 
     if (delRes.isErr()) {
       return new Err(

--- a/front/migrations/20250717_slackstorm_delete_rate_limited_slack_connections.ts
+++ b/front/migrations/20250717_slackstorm_delete_rate_limited_slack_connections.ts
@@ -80,10 +80,9 @@ makeScript(
       }
 
       if (execute) {
-        const delRes = await softDeleteDataSourceAndLaunchScrubWorkflow(
-          auth,
-          dataSource
-        );
+        const delRes = await softDeleteDataSourceAndLaunchScrubWorkflow(auth, {
+          dataSource,
+        });
         if (delRes.isErr()) {
           logger.error(
             { error: delRes.error, connectorId },

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
@@ -100,10 +100,9 @@ async function handler(
         });
       }
 
-      const delRes = await softDeleteDataSourceAndLaunchScrubWorkflow(
-        auth,
-        dataSource
-      );
+      const delRes = await softDeleteDataSourceAndLaunchScrubWorkflow(auth, {
+        dataSource,
+      });
       if (delRes.isErr()) {
         switch (delRes.error.code) {
           case "unauthorized_deletion":

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/index.ts
@@ -138,10 +138,9 @@ async function handler(
         });
       }
 
-      const dRes = await softDeleteDataSourceAndLaunchScrubWorkflow(
-        auth,
-        dataSource
-      );
+      const dRes = await softDeleteDataSourceAndLaunchScrubWorkflow(auth, {
+        dataSource,
+      });
       if (dRes.isErr()) {
         return apiError(req, res, {
           status_code: 500,

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -251,7 +251,9 @@ async function deleteDatasources(auth: Authenticator) {
 
   for (const ds of dataSources) {
     // Perform a soft delete and initiate a workflow for permanent deletion of the data source.
-    const r = await softDeleteDataSourceAndLaunchScrubWorkflow(auth, ds);
+    const r = await softDeleteDataSourceAndLaunchScrubWorkflow(auth, {
+      dataSource: ds,
+    });
     if (r.isErr()) {
       throw new Error(`Failed to delete data source: ${r.error.message}`);
     }

--- a/sdks/js/.node_modules-oYZmCWGV
+++ b/sdks/js/.node_modules-oYZmCWGV
@@ -1,1 +1,0 @@
-/Users/rcs/Projects/dust/sdks/js/node_modules


### PR DESCRIPTION
## Description

Users couldn't delete the files/folders/crawling they added, only builders could.

This PR fixes that

Use the same auth check in the resource than in the route. 


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
