### PR TITLE
Adjust Skeleton position

### DIFF
--- a/front/components/assistant/ConversationViewerEmptyState.tsx
+++ b/front/components/assistant/ConversationViewerEmptyState.tsx
@@ -2,7 +2,7 @@ import { LoadingBlock } from "@dust-tt/sparkle";
 
 export function ConversationViewerEmptyState() {
   return (
-    <div className="mx-auto flex h-full w-full min-w-60 max-w-3xl flex-col pt-6 md:pt-10">
+    <div className="mx-auto flex h-full w-full min-w-60 max-w-4xl flex-col pt-6 md:pt-10">
       <FakeUserMessage />
       <FakeAgentMessage />
     </div>
@@ -19,7 +19,7 @@ function FakeUserMessage() {
 
 function FakeAgentMessage() {
   return (
-    <div className="mt-8">
+    <div className="mt-4 p-4">
       <div className="flex flex-col space-y-3">
         <div className="mb-2 flex flex-row items-center gap-x-2">
           <LoadingBlock className="h-[36px] w-[36px]" />


### PR DESCRIPTION
## Description

The conversation skeleton displayed during conversation loading is not aligned with the real agents/users messages.
The width of the conversation body has been increased during the mentions initiative. We need to adapt the width of the skeleton body from `max-w-3xl` to `max-w-4xl`.
The same padding must be applied to Agent messages as well.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

deploy front
