### PR TITLE
[PPUL] Fix total credits line calculation in programmatic cost chart

### DIFF
--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -393,19 +393,6 @@ export function BaseProgrammaticCostChart({
     });
   }
 
-  // Transform points into chart data using labels from availableGroups.
-  // Track the last known cumulative cost for use in future points.
-  const lastKnownPoint = points.reduce((last, point) => {
-    return point.timestamp > last.timestamp && point.timestamp <= now.getTime()
-      ? point
-      : last;
-  }, points[0]);
-
-  const lastKnownCumulativeCost = lastKnownPoint.groups.reduce(
-    (acc, g) => acc + (g.cumulatedCostMicroUsd ?? 0),
-    0
-  );
-
   const chartData = points.map((point) => {
     const dataPoint: ChartDataPoint = {
       timestamp: point.timestamp,
@@ -416,7 +403,7 @@ export function BaseProgrammaticCostChart({
     // (expired credits are no longer in totalInitialCreditsMicroUsd but their consumed
     // usage is still in cumulative cost)--and vice versa in the past when credits are created.
     dataPoint.totalCreditsMicroUsd =
-      lastKnownCumulativeCost + point.totalRemainingCreditsMicroUsd;
+      (maxCumulatedCost ?? 0) + point.totalRemainingCreditsMicroUsd;
 
     // Add each group's cumulative cost to the data point using labels from availableGroups
     // Keep undefined values as-is so Recharts doesn't render those points

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -395,28 +395,28 @@ export function BaseProgrammaticCostChart({
 
   // Transform points into chart data using labels from availableGroups.
   // Track the last known cumulative cost for use in future points.
-  let lastKnownCumulativeCost = 0;
+  const lastKnownPoint = points.reduce((last, point) => {
+    return point.timestamp > last.timestamp && point.timestamp <= now.getTime()
+      ? point
+      : last;
+  }, points[0]);
+
+  const lastKnownCumulativeCost = lastKnownPoint.groups.reduce(
+    (acc, g) => acc + (g.cumulatedCostMicroUsd ?? 0),
+    0
+  );
+
   const chartData = points.map((point) => {
     const dataPoint: ChartDataPoint = {
       timestamp: point.timestamp,
     };
 
-    // Compute total credits as cumulative cost + remaining credits.
+    // Compute total credits as present cumulative cost + remaining credits at that timestamp.
     // This avoids showing a total credits line below cumulative cost when credits expire
     // (expired credits are no longer in totalInitialCreditsMicroUsd but their consumed
-    // usage is still in cumulative cost).
-    // For future points (where cumulatedCostMicroUsd is undefined), use the last known
-    // cumulative cost so the total credits line stays level.
-    const cumulativeCost = point.groups.reduce(
-      (acc, g) => acc + (g.cumulatedCostMicroUsd ?? 0),
-      0
-    );
-    if (cumulativeCost > 0) {
-      lastKnownCumulativeCost = cumulativeCost;
-    }
+    // usage is still in cumulative cost)--and vice versa in the past when credits are created.
     dataPoint.totalCreditsMicroUsd =
-      (cumulativeCost > 0 ? cumulativeCost : lastKnownCumulativeCost) +
-      point.totalRemainingCreditsMicroUsd;
+      lastKnownCumulativeCost + point.totalRemainingCreditsMicroUsd;
 
     // Add each group's cumulative cost to the data point using labels from availableGroups
     // Keep undefined values as-is so Recharts doesn't render those points


### PR DESCRIPTION
## Description

Fix the total credits line in the programmatic cost chart to use the present cumulative cost (from the most recent non-future point) rather than each point's individual cumulative cost.

Previously, the total credits line was computed per-point, which caused inconsistencies when credits were created (line jumped down in the past) or expired. Now the line uses a single reference value computed from the current point, making it consistent across all timestamps.

Before: 
<img width="442" height="316" alt="image" src="https://github.com/user-attachments/assets/b4106424-1d73-40aa-adea-16a6e7df5b79" />

After:
<img width="442" height="316" alt="image" src="https://github.com/user-attachments/assets/423279b1-b10d-4f0a-80eb-80ceb4a03b82" />


## Risks

Blast radius: Programmatic cost chart display
Risk: low

## Deploy Plan
- pmrr
- deploy front