### PR TITLE
[Front] feat(manage-skills): add editors column to manage skills table

### DIFF
--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -7,7 +7,7 @@ import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { LightWorkspaceType } from "@app/types";
+import type { LightWorkspaceType, UserType } from "@app/types";
 import type {
   SkillConfigurationRelations,
   SkillConfigurationType,
@@ -24,6 +24,7 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
   /**
    * Columns order:
    * - Name (always)
+   * - Editors (hidden on mobile)
    * - Used by (hidden on mobile)
    * - Last Edited (hidden on mobile)
    * - Actions (always)
@@ -47,6 +48,29 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
       ),
       meta: {
         className: "w-40 @lg:w-full",
+      },
+    },
+    {
+      header: "Editors",
+      accessorKey: "editors",
+      cell: (info: CellContext<RowData, UserType[]>) => {
+        return (
+          <DataTable.CellContent
+            avatarStack={{
+              items:
+                info.row.original.skillConfigurationWithRelations.editors.map(
+                  (editor) => ({
+                    name: editor.fullName,
+                    visual: editor.image,
+                  })
+                ),
+              nbVisibleItems: 4,
+            }}
+          />
+        );
+      },
+      meta: {
+        className: "hidden @sm:w-32 @sm:table-cell",
       },
     },
     {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -14,7 +14,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
-import type { SkillConfigurationModel } from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { KeyResource } from "@app/lib/resources/key_resource";
@@ -279,7 +278,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    */
   static async findEditorGroupForSkill(
     auth: Authenticator,
-    skill: SkillConfigurationModel
+    skillModelId: ModelId
   ): Promise<
     Result<
       GroupResource,
@@ -292,7 +291,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     const groupSkills = await GroupSkillModel.findAll({
       where: {
-        skillConfigurationId: skill.id,
+        skillConfigurationId: skillModelId,
         workspaceId: owner.id,
       },
       attributes: ["groupId"],

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -1,8 +1,6 @@
-import type { Attributes } from "sequelize";
-
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
-import type { UserModel } from "@app/lib/resources/storage/models/user";
+import type { UserType } from "@app/types";
 
 export interface GlobalSkillDefinition {
   readonly description: string;
@@ -85,20 +83,16 @@ export class GlobalSkillsRegistry {
   }
 }
 
-export const GLOBAL_DUST_AUTHOR: Attributes<UserModel> = {
-  createdAt: new Date(),
-  email: "",
-  firstName: "",
-  id: -1,
-  imageUrl: null,
-  isDustSuperUser: false,
-  lastLoginAt: null,
-  lastName: null,
-  name: "Dust",
-  provider: null,
-  providerId: null,
+export const GLOBAL_DUST_AUTHOR: UserType = {
   sId: "dust",
-  updatedAt: new Date(),
-  username: "",
-  workOSUserId: null,
+  id: -1,
+  createdAt: 0,
+  provider: "github",
+  username: "dust",
+  email: "",
+  firstName: "Dust",
+  lastName: null,
+  fullName: "Dust",
+  image: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+  lastLoginAt: null,
 };

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -98,7 +98,7 @@ async function handler(
 
   const editorGroupRes = await GroupResource.findEditorGroupForSkill(
     auth,
-    skill
+    skill.id
   );
   if (editorGroupRes.isErr()) {
     switch (editorGroupRes.error.code) {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -90,15 +90,12 @@ async function handler(
         await SkillResource.fetchAllAvailableSkills(auth);
 
       if (withRelations === "true") {
-        // Fetch usage for each skill individually.
-        // Each skill is used by N agents and each agent uses on average n skills
-        // with N >> n, so the performance gain from batching is minimal.
-        // Starting simple with per-skill queries.
         const skillConfigurationsWithRelations = await concurrentExecutor(
           skillConfigurations,
           async (sc) => ({
             ...sc.toJSON(),
             usage: await sc.fetchUsage(auth),
+            editors: await sc.listEditors(auth),
           }),
           { concurrency: 10 }
         );

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -1,5 +1,6 @@
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
+import type { UserType } from "@app/types/user";
 
 export type SkillStatus = "active" | "archived";
 
@@ -19,4 +20,5 @@ export type SkillConfigurationType = {
 
 export type SkillConfigurationRelations = {
   usage: AgentsUsageType;
+  editors: UserType[];
 };


### PR DESCRIPTION
## Description

Task: https://github.com/dust-tt/tasks/issues/5523

Adds editors column to manage skills table

## Tests

Local
<img width="2222" height="1212" alt="image" src="https://github.com/user-attachments/assets/5497aa29-7abb-47ae-91f6-834251aed4b3" />


## Risk

Low

## Deploy Plan

Front