### PR TITLE
Refactor SkillResource Write Permission Logic

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -331,7 +331,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const skillEditorGroupsMap = new Map<number, GroupResource>();
 
       // Batch fetch all editor groups for all skills.
-      const editorGroupIds = await GroupSkillModel.findAll({
+      const editorGroupSkills = await GroupSkillModel.findAll({
         where: {
           skillConfigurationId: {
             [Op.in]: customSkills.map((s) => s.id),
@@ -341,11 +341,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         attributes: ["groupId", "skillConfigurationId"],
       });
 
-      // TODO(SKILLS 2025-12-11): Ensure all skills have a group.
+      // TODO(SKILLS 2025-12-11): Ensure all skills have ONE group.
 
-      if (editorGroupIds.length > 0) {
+      if (editorGroupSkills.length > 0) {
         const uniqueGroupIds = Array.from(
-          new Set(editorGroupIds.map((eg) => eg.groupId))
+          new Set(editorGroupSkills.map((eg) => eg.groupId))
         );
         const editorGroups = await GroupResource.fetchByModelIds(
           auth,
@@ -353,12 +353,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
 
         // Build map from skill ID to editor group.
-        for (const editorGroupId of editorGroupIds) {
+        for (const editorGroupSkill of editorGroupSkills) {
           const group = editorGroups.find(
-            (g) => g.id === editorGroupId.groupId
+            (g) => g.id === editorGroupSkill.groupId
           );
           if (group) {
-            skillEditorGroupsMap.set(editorGroupId.skillConfigurationId, group);
+            skillEditorGroupsMap.set(
+              editorGroupSkill.skillConfigurationId,
+              group
+            );
           }
         }
       }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -145,9 +145,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<SkillResource> {
     // Use a transaction to ensure all creates succeed or all are rolled back.
     const skillResource = await withTransaction(async (transaction) => {
-      const skill = await this.model.create(blob, {
-        transaction,
-      });
+      const skill = await this.model.create(
+        {
+          ...blob,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        {
+          transaction,
+        }
+      );
 
       const editorGroup = await GroupResource.makeNewSkillEditorsGroup(
         auth,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -106,10 +106,10 @@ export interface SkillResource
 export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static model: ModelStatic<SkillConfigurationModel> = SkillConfigurationModel;
 
+  readonly editorGroup: GroupResource | null = null;
   readonly mcpServerConfigurations: Attributes<SkillMCPServerConfigurationModel>[];
 
   private readonly globalSId?: string;
-  private readonly editorGroup: GroupResource | null = null;
 
   private constructor(
     model: ModelStatic<SkillConfigurationModel>,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -436,18 +436,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return [GLOBAL_DUST_AUTHOR];
     }
 
-    const editorGroupRes = await GroupResource.findEditorGroupForSkill(
-      auth,
-      this.id
-    );
+    const members = await this.editorGroup?.getActiveMembers(auth);
 
-    if (editorGroupRes.isErr()) {
-      return [];
-    }
-
-    const members = await editorGroupRes.value.getActiveMembers(auth);
-
-    return members.map((m) => m.toJSON());
+    return (members ?? []).map((m) => m.toJSON());
   }
 
   async archive(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -515,6 +515,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
+  // TODO(SKILLS 2025-12-11): Remove and hide behind canWrite.
   private get isGlobal(): boolean {
     return this.globalSId !== undefined;
   }

--- a/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
@@ -61,7 +61,6 @@ async function handler(
   }
 
   const skillResource = await SkillResource.fetchById(auth, sId);
-
   if (!skillResource) {
     return apiError(req, res, {
       status_code: 404,
@@ -72,7 +71,7 @@ async function handler(
     });
   }
 
-  if (!skillResource.canEdit && !auth.isAdmin()) {
+  if (!skillResource.canWrite(auth)) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -78,7 +78,7 @@ async function handler(
   const { editorGroup } = skillRes;
   if (!editorGroup) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 400,
       api_error: {
         type: "invalid_request_error",
         message: "The skill does not have an editors group.",

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -1,13 +1,12 @@
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
+import isString from "lodash/isString";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { SkillConfigurationModel } from "@app/lib/models/skill";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import { getIdsFromSId } from "@app/lib/resources/string_ids";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { UserType, WithAPIErrorResponse } from "@app/types";
@@ -53,10 +52,9 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-  const skillSId = req.query.sId;
+  const skillId = req.query.sId;
 
-  if (typeof skillSId !== "string") {
+  if (!isString(skillId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -66,107 +64,33 @@ async function handler(
     });
   }
 
-  const skillIdRes = getIdsFromSId(skillSId);
-  if (skillIdRes.isErr()) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill id.",
-      },
-    });
-  }
-
-  const { resourceModelId: skillId } = skillIdRes.value;
-
-  const skill = await SkillConfigurationModel.findOne({
-    where: {
-      id: skillId,
-      workspaceId: owner.id,
-    },
-  });
-
-  if (!skill) {
+  const skillRes = await SkillResource.fetchById(auth, skillId);
+  if (!skillRes) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
         type: "skill_not_found",
-        message: "The skill configuration was not found.",
+        message: "The skill was not found.",
       },
     });
   }
 
-  const editorGroupRes = await GroupResource.findEditorGroupForSkill(
-    auth,
-    skill
-  );
-  if (editorGroupRes.isErr()) {
-    switch (editorGroupRes.error.code) {
-      case "unauthorized":
-        return apiError(req, res, {
-          status_code: 401,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "You are not authorized to update the skill editors.",
-          },
-        });
-      case "invalid_id":
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Some of the passed ids are invalid.",
-          },
-        });
-      case "group_not_found":
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "group_not_found",
-            message: "Unable to find the editor group for the skill.",
-          },
-        });
-      case "internal_error":
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: editorGroupRes.error.message,
-          },
-        });
-      default:
-        assertNever(editorGroupRes.error.code);
-    }
-  }
-
-  const editorGroup = editorGroupRes.value;
-
   switch (req.method) {
     case "GET": {
-      if (!editorGroup.canRead(auth)) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "User is not authorized to read the skill editors.",
-          },
-        });
-      }
-
-      const members = await editorGroup.getActiveMembers(auth);
+      const members = await skillRes.getActiveMembers(auth);
       const memberUsers = members.map((m) => m.toJSON());
 
       return res.status(200).json({ editors: memberUsers });
     }
 
     case "PATCH": {
-      if (!editorGroup.canWrite(auth)) {
+      if (!skillRes.canEdit) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
             message:
-              "Only editors of the skill or workspace admins can modify editors.",
+              "User is not authorized to view or edit the skill editors list.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -75,22 +75,32 @@ async function handler(
     });
   }
 
+  const { editorGroup } = skillRes;
+  if (!editorGroup) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The skill does not have an editors group.",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET": {
-      const members = await skillRes.getActiveMembers(auth);
+      const members = await editorGroup.getActiveMembers(auth);
       const memberUsers = members.map((m) => m.toJSON());
 
       return res.status(200).json({ editors: memberUsers });
     }
 
     case "PATCH": {
-      if (!skillRes.canEdit) {
+      if (!skillRes.canWrite(auth)) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message:
-              "User is not authorized to view or edit the skill editors list.",
+            message: "User is not authorized to edit the skill editors list.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -2,7 +2,6 @@ import type { RequestMethod } from "node-mocks-http";
 import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -69,9 +68,6 @@ async function setupTest(
   if (!skill) {
     throw new Error("Failed to create skill");
   }
-
-  // Create editor group for the skill
-  await GroupResource.makeNewSkillEditorsGroup(skillOwnerAuth, skill);
 
   // Regenerate auth to pick up the new group membership
   skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -160,7 +160,7 @@ describe("PATCH /api/w/[wId]/assistant/skill_configurations/[sId]", () => {
       name: "Other Skill",
     });
 
-    // Try to update to the name of the other skill
+    // Try to update the skill anme to the duplicate name
     req.body = {
       name: "Other Skill",
       description: "Description",

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -132,8 +132,8 @@ async function handler(
 
       const body: PatchSkillConfigurationRequestBody = bodyValidation.right;
 
-      // Check if user can edit
-      if (!skillResource.canEdit && !auth.isAdmin()) {
+      // Check if user can write.
+      if (!skillResource.canWrite(auth)) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -238,8 +238,8 @@ async function handler(
     }
 
     case "DELETE": {
-      // Check if user can edit
-      if (!skillResource.canEdit && !auth.isAdmin()) {
+      // Check if user can write.
+      if (!skillResource.canWrite(auth)) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -7,11 +7,9 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { withTransaction } from "@app/lib/utils/sql_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isBuilder } from "@app/types";
@@ -168,45 +166,30 @@ async function handler(
       }
 
       // Use a transaction to ensure all creates succeed or all are rolled back
-      const skillConfiguration = await withTransaction(async (transaction) => {
-        const skill = await SkillResource.makeNew(
-          {
-            workspaceId: owner.id,
-            version: 0,
-            status: "active",
-            name: body.name,
-            description: body.description,
-            instructions: body.instructions,
-            authorId: user.id,
-            // TODO(skills): add space restrictions.
-            requestedSpaceIds: [],
-          },
-          { transaction }
-        );
-
-        await GroupResource.makeNewSkillEditorsGroup(auth, skill, {
-          transaction,
-        });
-
-        // Create MCP server configurations (tools) for this skill
-        for (const mcpServerView of mcpServerViews) {
-          // TODO(skills 2025-12-09): move this to the makeNew.
-          await SkillMCPServerConfigurationModel.create(
-            {
-              workspaceId: owner.id,
-              skillConfigurationId: skill.id,
-              mcpServerViewId: mcpServerView.id,
-            },
-            { transaction }
-          );
-        }
-
-        return skill;
+      const skillResource = await SkillResource.makeNew(auth, {
+        version: 0,
+        status: "active",
+        name: body.name,
+        description: body.description,
+        instructions: body.instructions,
+        authorId: user.id,
+        // TODO(skills): add space restrictions.
+        requestedSpaceIds: [],
       });
+
+      // Create MCP server configurations (tools) for this skill
+      for (const mcpServerView of mcpServerViews) {
+        // TODO(skills 2025-12-09): move this to the makeNew.
+        await SkillMCPServerConfigurationModel.create({
+          workspaceId: owner.id,
+          skillConfigurationId: skillResource.id,
+          mcpServerViewId: mcpServerView.id,
+        });
+      }
 
       return res.status(200).json({
         skillConfiguration: {
-          ...skillConfiguration.toJSON(),
+          ...skillResource.toJSON(),
           tools: body.tools,
         },
       });

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -46,7 +46,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  if (!skillResource.canEdit && !auth.isAdmin()) {
+  if (!skillResource.canWrite(auth)) {
     return {
       notFound: true,
     };

--- a/front/tests/utils/SkillConfigurationFactory.ts
+++ b/front/tests/utils/SkillConfigurationFactory.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
-import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ModelId } from "@app/types";
 
 export class SkillConfigurationFactory {
@@ -15,8 +15,7 @@ export class SkillConfigurationFactory {
       status: "active" | "archived";
       version: number;
     }> = {}
-  ): Promise<SkillConfigurationModel> {
-    const workspace = auth.getNonNullableWorkspace();
+  ): Promise<SkillResource> {
     const user = auth.user();
     assert(user, "User is required");
 
@@ -26,18 +25,15 @@ export class SkillConfigurationFactory {
     const status = overrides.status ?? "active";
     const version = overrides.version ?? 1;
 
-    const skill = await SkillConfigurationModel.create({
-      workspaceId: workspace.id,
+    return SkillResource.makeNew(auth, {
       authorId: user.id,
-      name,
       description,
       instructions,
+      name,
+      requestedSpaceIds: [],
       status,
       version,
-      requestedSpaceIds: [],
     });
-
-    return skill;
   }
 
   static async linkToAgent(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors the `canEdit` logic on `SkillResource` to fully leverage the group approach. The method `baseFetch` responsibility is to ensure one can read the resource before returning it. A skill can be read by members of the editor group. Members of the editor group also have the write privilege. This logic is encoded in the `requestedPermissions` of the `GroupResource`. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
