### PR TITLE
fix: instruction blocks regex

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
@@ -202,4 +202,27 @@ code block
       "<instructions>:mention[agent-name]{sId=agent-123}</instructions>\n\n"
     );
   });
+
+  it("should serialize instruction block with _", () => {
+    editor.commands.setContent(`<instructions_toto></instructions_toto>`, {
+      contentType: "markdown",
+    });
+
+    const json = editor.getJSON();
+    expect(json.content).toEqual([
+      {
+        attrs: {
+          isCollapsed: false,
+          type: "instructions_toto",
+        },
+        type: "instructionBlock",
+      },
+      {
+        type: "paragraph",
+      },
+    ]);
+
+    const result = editor.getMarkdown();
+    expect(result).toBe("<instructions_toto></instructions_toto>\n\n");
+  });
 });

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -19,6 +19,8 @@ import React, { useState } from "react";
 
 import {
   CLOSING_TAG_REGEX,
+  INSTRUCTION_BLOCK_REGEX,
+  OPENING_TAG_BEGINNING_REGEX,
   OPENING_TAG_REGEX,
 } from "@app/components/editor/extensions/agent_builder/instructionBlockUtils";
 
@@ -846,7 +848,7 @@ export const InstructionBlockExtension =
       name: "instructionBlock",
       level: "block",
       start: (src) => {
-        const match = src.match(/^<([a-z][a-z0-9-]*)>/i);
+        const match = src.match(OPENING_TAG_BEGINNING_REGEX);
         return match?.index ?? -1;
       },
       tokenize: (
@@ -855,7 +857,7 @@ export const InstructionBlockExtension =
         lexer: MarkdownLexerConfiguration
       ) => {
         // Match opening tag, content, and closing tag
-        const match = src.match(/^<([a-z][a-z0-9-]*)>([\s\S]*?)<\/\1>/i);
+        const match = src.match(INSTRUCTION_BLOCK_REGEX);
         if (!match) {
           return undefined;
         }

--- a/front/components/editor/extensions/agent_builder/instructionBlockUtils.ts
+++ b/front/components/editor/extensions/agent_builder/instructionBlockUtils.ts
@@ -7,4 +7,13 @@ export const TAG_NAME_PATTERN = "[A-Za-z_][A-Za-z0-9._:-]*";
  * Regex pattern for matching opening/closing XML tags (including empty <> when typing).
  */
 export const OPENING_TAG_REGEX = new RegExp(`<(${TAG_NAME_PATTERN})?>$`);
+export const OPENING_TAG_BEGINNING_REGEX = new RegExp(
+  "^" + OPENING_TAG_REGEX.source,
+  "i"
+);
 export const CLOSING_TAG_REGEX = new RegExp(`^</(${TAG_NAME_PATTERN})?>$`);
+
+export const INSTRUCTION_BLOCK_REGEX = new RegExp(
+  `^<(${TAG_NAME_PATTERN})>([\\s\\S]*?)</\\1>`,
+  "i"
+);


### PR DESCRIPTION
## Description

I made a mistake and didn't reuse the previous regex for instructions blocks.

The old one handled `_`, the new one not. This basically fixes that
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
