### PR TITLE
Bump Sparkle for paragraph spacing

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.20",
-        "@dust-tt/sparkle": "^0.4.20",
+        "@dust-tt/sparkle": "^0.4.21",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1286,9 +1286,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.20.tgz",
-      "integrity": "sha512-IY42ju1frZkymn5nX7AbR13rGkFy504pOf/pTc2cSY07pKaBlqBN9QBLBdKR4V6AmskTP33OWAGxhswescqpYw==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.21.tgz",
+      "integrity": "sha512-AdH8iEloUPFBWxX5pH06X/GAwtAMpSYnIFcbqPaZ5KuuI9WvI/92myL8Cjd1d1JIOKvZORv3Kg9I0h23qbuKXw==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.20",
-    "@dust-tt/sparkle": "^0.4.20",
+    "@dust-tt/sparkle": "^0.4.21",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/extension/ui/components/conversation/UserMessage.tsx
+++ b/extension/ui/components/conversation/UserMessage.tsx
@@ -77,6 +77,7 @@ export function UserMessage({
                 isLastMessage={isLastMessage}
                 additionalMarkdownComponents={additionalMarkdownComponents}
                 additionalMarkdownPlugins={additionalMarkdownPlugins}
+                compactSpacing
               />
             </div>
             {message.mentions.length === 0 && isLastMessage && (

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -142,6 +142,7 @@ function UserMessageContent({
       isLastMessage={isLastMessage}
       additionalMarkdownComponents={additionalMarkdownComponents}
       additionalMarkdownPlugins={additionalMarkdownPlugins}
+      compactSpacing
     />
   );
 }
@@ -402,6 +403,7 @@ export function UserMessage({
               isLastMessage={isLastMessage}
               additionalMarkdownComponents={additionalMarkdownComponents}
               additionalMarkdownPlugins={additionalMarkdownPlugins}
+              compactSpacing
             />
           )}
         </ConversationMessage>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.20",
+        "@dust-tt/sparkle": "^0.4.21",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1330,9 +1330,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.20.tgz",
-      "integrity": "sha512-IY42ju1frZkymn5nX7AbR13rGkFy504pOf/pTc2cSY07pKaBlqBN9QBLBdKR4V6AmskTP33OWAGxhswescqpYw==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.21.tgz",
+      "integrity": "sha512-AdH8iEloUPFBWxX5pH06X/GAwtAMpSYnIFcbqPaZ5KuuI9WvI/92myL8Cjd1d1JIOKvZORv3Kg9I0h23qbuKXw==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -38,7 +38,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.20",
+    "@dust-tt/sparkle": "^0.4.21",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

This PR updates Sparkle version and use the new `compactSpacing` to harmonize the rendering of the paragraphs in the user messages content with the input bar.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
