### PR TITLE
[front] - feat(skill): add icon selection

### DIFF
--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -14,6 +14,7 @@ export const skillBuilderFormSchema = z.object({
   instructions: z.string().min(1, "Skill instructions are required"),
   editors: z.array(editorUserSchema),
   tools: z.array(actionSchema),
+  icon: z.string().nullable(),
 });
 
 export type SkillBuilderFormData = z.infer<typeof skillBuilderFormSchema>;

--- a/front/components/skill_builder/SkillBuilderIconSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIconSection.tsx
@@ -1,0 +1,65 @@
+import {
+  ActionBookOpenIcon,
+  ActionIcons,
+  Avatar,
+  Button,
+  IconPicker,
+  PencilSquareIcon,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+import { useController } from "react-hook-form";
+
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+
+export function SkillBuilderIconSection() {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const { field: iconField } = useController<SkillBuilderFormData, "icon">({
+    name: "icon",
+  });
+
+  const toActionIconKey = (v?: string | null) =>
+    v && v in ActionIcons ? (v as keyof typeof ActionIcons) : undefined;
+
+  const defaultKey = Object.keys(ActionIcons)[0] as keyof typeof ActionIcons;
+  const selectedIconName = toActionIconKey(iconField.value) ?? defaultKey;
+  const IconComponent = ActionIcons[selectedIconName] || ActionBookOpenIcon;
+
+  const closePopover = () => {
+    setIsPopoverOpen(false);
+  };
+
+  return (
+    <PopoverRoot open={isPopoverOpen}>
+      <PopoverTrigger asChild>
+        <div className="group relative">
+          <Avatar size="lg" visual={<IconComponent />} />
+          <Button
+            variant="outline"
+            size="sm"
+            icon={PencilSquareIcon}
+            type="button"
+            onClick={() => setIsPopoverOpen(true)}
+            className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100"
+          />
+        </div>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-fit py-0"
+        onInteractOutside={closePopover}
+        onEscapeKeyDown={closePopover}
+      >
+        <IconPicker
+          icons={ActionIcons}
+          selectedIcon={selectedIconName}
+          onIconSelect={(iconName: string) => {
+            iconField.onChange(iconName);
+            closePopover();
+          }}
+        />
+      </PopoverContent>
+    </PopoverRoot>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderIconSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIconSection.tsx
@@ -14,6 +14,8 @@ import { useController } from "react-hook-form";
 
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 
+const DEFAULT_ICON = ActionBookOpenIcon;
+
 export function SkillBuilderIconSection() {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const { field: iconField } = useController<SkillBuilderFormData, "icon">({
@@ -25,7 +27,7 @@ export function SkillBuilderIconSection() {
 
   const defaultKey = Object.keys(ActionIcons)[0] as keyof typeof ActionIcons;
   const selectedIconName = toActionIconKey(iconField.value) ?? defaultKey;
-  const IconComponent = ActionIcons[selectedIconName] || ActionBookOpenIcon;
+  const IconComponent = ActionIcons[selectedIconName] || DEFAULT_ICON;
 
   const closePopover = () => {
     setIsPopoverOpen(false);

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -1,6 +1,7 @@
 import { Input } from "@dust-tt/sparkle";
 
 import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
+import { SkillBuilderIconSection } from "@app/components/skill_builder/SkillBuilderIconSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
 
 export function SkillBuilderSettingsSection() {
@@ -13,15 +14,24 @@ export function SkillBuilderSettingsSection() {
         triggerValidationOnChange={false}
       >
         {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
-          <Input
-            ref={registerRef}
-            label="Skill name"
-            placeholder="Enter skill name"
-            onChange={onChange}
-            message={errorMessage}
-            messageStatus={hasError ? "error" : "default"}
-            {...registerProps}
-          />
+          <div className="space-y-3">
+            <div className="flex space-x-2">
+              <div className="flex-grow">
+                <Input
+                  ref={registerRef}
+                  label="Skill name"
+                  placeholder="Enter skill name"
+                  onChange={onChange}
+                  message={errorMessage}
+                  messageStatus={hasError ? "error" : "default"}
+                  {...registerProps}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <SkillBuilderIconSection />
+              </div>
+            </div>
+          </div>
         )}
       </BaseFormFieldSection>
       <div className="flex flex-col gap-2">

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -38,6 +38,7 @@ export async function submitSkillBuilderForm({
         name: formData.name,
         description: formData.description,
         instructions: formData.instructions,
+        icon: formData.icon,
         tools: formData.tools.map((tool) => ({
           mcpServerViewId: tool.configuration.mcpServerViewId,
         })),

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -16,6 +16,7 @@ export function transformSkillConfigurationToFormData(
     instructions: skillConfiguration.instructions ?? "",
     editors: [], // Will be populated reactively from useEditors hook
     tools: [], // Will be populated reactively from MCP server views context
+    icon: skillConfiguration.icon ?? null,
   };
 }
 
@@ -33,5 +34,6 @@ export function getDefaultSkillFormData({
     instructions: "",
     editors: [user],
     tools: [],
+    icon: null,
   };
 }

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -55,6 +55,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   declare name: string;
   declare description: string;
   declare instructions: string;
+  declare icon: string | null;
 
   declare authorId: ForeignKey<UserModel["id"]>;
 

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -92,6 +92,9 @@ SkillVersionModel.init(
       type: DataTypes.ARRAY(DataTypes.BIGINT),
       allowNull: false,
     },
+    version: {
+      type: DataTypes.INTEGER,
+    },
   },
   {
     modelName: "skill_version",

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -44,6 +44,10 @@ const SKILL_MODEL_ATTRIBUTES = {
     type: DataTypes.ARRAY(DataTypes.BIGINT),
     allowNull: false,
   },
+  icon: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  },
 } as const satisfies ModelAttributes<Model>;
 
 export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurationModel> {
@@ -94,6 +98,7 @@ SkillVersionModel.init(
     },
     version: {
       type: DataTypes.INTEGER,
+      allowNull: false,
     },
   },
   {

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -7,6 +7,7 @@ export interface GlobalSkillDefinition {
   readonly name: string;
   readonly sId: string;
   readonly version: number;
+  readonly icon?: string;
 }
 
 // Helper function that enforces unique sIds.

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -678,7 +678,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     transaction?: Transaction
   ): Promise<[affectedCount: number]> {
     // TODO(SKILLS 2025-12-12): Refactor BaseResource.update to accept auth.
-    if (!this.globalSId) {
+    if (this.globalSId) {
       throw new Error("Cannot update a global skill configuration.");
     }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -779,8 +779,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       description: this.description,
       // We don't want to leak global skills instructions to frontend
       instructions: this.globalSId ? null : this.instructions,
-      icon: this.icon ?? null,
       requestedSpaceIds: this.requestedSpaceIds,
+      icon: this.icon ?? null,
       tools,
       canWrite: this.canWrite(auth),
     };

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -779,7 +779,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       description: this.description,
       // We don't want to leak global skills instructions to frontend
       instructions: this.globalSId ? null : this.instructions,
-      icon: this.icon,
+      icon: this.icon ?? null,
       requestedSpaceIds: this.requestedSpaceIds,
       tools,
       canWrite: this.canWrite(auth),

--- a/front/migrations/db/migration_440.sql
+++ b/front/migrations/db/migration_440.sql
@@ -1,0 +1,3 @@
+-- Migration created on Dec 12, 2024
+ALTER TABLE "skill_configuration"
+ADD COLUMN "icon" TEXT;

--- a/front/migrations/db/migration_440.sql
+++ b/front/migrations/db/migration_440.sql
@@ -1,5 +1,5 @@
 -- Migration created on Dec 12, 2024
-ALTER TABLE "skill_configuration"
+ALTER TABLE "skill_configurations"
     ADD COLUMN "icon" TEXT;
 
 ALTER TABLE "skill_versions"

--- a/front/migrations/db/migration_440.sql
+++ b/front/migrations/db/migration_440.sql
@@ -1,3 +1,6 @@
 -- Migration created on Dec 12, 2024
 ALTER TABLE "skill_configuration"
-ADD COLUMN "icon" TEXT;
+    ADD COLUMN "icon" TEXT;
+
+ALTER TABLE "skill_versions"
+    ADD COLUMN "icon" TEXT;

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -136,6 +136,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       name: "Unauthorized Update",
       description: "Description",
       instructions: "Instructions",
+      icon: null,
       tools: [],
     };
 
@@ -165,6 +166,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       name: "Other Skill",
       description: "Description",
       instructions: "Instructions",
+      icon: null,
       tools: [],
     };
 
@@ -188,6 +190,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       name: "Updated Skill",
       description: "Description",
       instructions: "Instructions",
+      icon: null,
       tools: [{ mcpServerViewId: "invalid_id" }],
     };
 

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -40,6 +40,7 @@ const PatchSkillConfigurationRequestBodySchema = t.type({
   name: t.string,
   description: t.string,
   instructions: t.string,
+  icon: t.union([t.string, t.null]),
   tools: t.array(
     t.type({
       mcpServerViewId: t.string,
@@ -180,6 +181,7 @@ async function handler(
             name: body.name,
             description: body.description,
             instructions: body.instructions,
+            icon: body.icon,
           },
           { transaction }
         );

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -377,6 +377,7 @@ describe("POST /api/w/[wId]/skills", () => {
       name: "Simple Skill",
       description: "A simple skill without tools",
       instructions: "Simple instructions",
+      icon: null,
       tools: [],
     };
 
@@ -435,6 +436,7 @@ describe("POST /api/w/[wId]/skills", () => {
       name: "Test Skill",
       description: "A test skill description",
       instructions: "Test instructions for the skill",
+      icon: null,
       tools: [
         { mcpServerViewId: serverView1.sId },
         { mcpServerViewId: serverView2.sId },

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -42,6 +42,7 @@ const PostSkillConfigurationRequestBodySchema = t.type({
   name: t.string,
   description: t.string,
   instructions: t.string,
+  icon: t.union([t.string, t.null]),
   tools: t.array(
     t.type({
       mcpServerViewId: t.string,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -13,6 +13,7 @@ export type SkillConfigurationType = {
   name: string;
   description: string;
   instructions: string | null;
+  icon: string | null;
   requestedSpaceIds: ModelId[];
   tools: { mcpServerViewId: string }[];
   canWrite: boolean;


### PR DESCRIPTION





## Description
Adds icon selection capability to the skill builder, allowing users to pick custom icons for their skills using the Sparkle `IconPicker` component. The icon field is stored in both `skill_configuration` and `skill_versions` tables.



<img width="1005" height="343" alt="Screenshot 2025-12-12 at 15 53 27" src="https://github.com/user-attachments/assets/462a6938-4d58-49f6-a058-51c0670492a9" />

**References**
- https://github.com/dust-tt/tasks/issues/5568

## Risk
Database schema migration adds nullable `icon` columns to two tables.

## Tests
Tested locally with skill creation and editing flows.

## Deploy Plan
1. Merge and deploy front
2. Run migration to add `icon` column to `skill_configuration` and `skill_versions` tables