### PR TITLE
sort mcp servers alphabetically

### DIFF
--- a/front/components/actions/mcp/AddToolsMenu.tsx
+++ b/front/components/actions/mcp/AddToolsMenu.tsx
@@ -105,6 +105,9 @@ export const AddToolsMenu = ({
               )
           )
           .filter((mcpServer) => filterMCPServer(mcpServer, searchText))
+          .sort((a, b) =>
+            getMcpServerDisplayName(a).localeCompare(getMcpServerDisplayName(b))
+          )
           .map((mcpServer) => (
             <DropdownMenuItem
               key={mcpServer.sId}

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -193,7 +193,12 @@ export const AdminActionsList = ({
             },
           };
         })
-        .sort(mcpServersSortingFn),
+        .sort((a, b) =>
+          mcpServersSortingFn(
+            { mcpServer: a.mcpServer, mcpServerView: a.mcpServerView },
+            { mcpServer: b.mcpServer, mcpServerView: b.mcpServerView }
+          )
+        ),
     [
       connections,
       mcpServers,
@@ -217,8 +222,15 @@ export const AdminActionsList = ({
         filterFn: (row, id, filterValue) =>
           filterMCPServer(row.original.mcpServer, filterValue),
         sortingFn: (rowA, rowB) => {
-          return rowA.original.mcpServer.name.localeCompare(
-            rowB.original.mcpServer.name
+          return mcpServersSortingFn(
+            {
+              mcpServer: rowA.original.mcpServer,
+              mcpServerView: rowA.original.mcpServerView,
+            },
+            {
+              mcpServer: rowB.original.mcpServer,
+              mcpServerView: rowB.original.mcpServerView,
+            }
           );
         },
         meta: {

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -155,12 +155,14 @@ export const SpaceActionsList = ({
 
   const rows: RowData[] = React.useMemo(
     () =>
-      serverViews.map((serverView) => ({
-        id: serverView.sId,
-        name: getMcpServerViewDisplayName(serverView),
-        description: getMcpServerViewDescription(serverView),
-        avatar: getAvatar(serverView.server),
-      })) || [],
+      serverViews
+        .map((serverView) => ({
+          id: serverView.sId,
+          name: getMcpServerViewDisplayName(serverView),
+          description: getMcpServerViewDescription(serverView),
+          avatar: getAvatar(serverView.server),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name)) || [],
     [serverViews]
   );
 

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -88,6 +88,9 @@ export default function SpaceManagedActionsViewsModel({
         )}
         {availableMCPServers
           .filter((s) => filterMCPServer(s, searchText))
+          .sort((a, b) =>
+            getMcpServerDisplayName(a).localeCompare(getMcpServerDisplayName(b))
+          )
           .map((server) => (
             <DropdownMenuItem
               key={server.sId}

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -104,21 +104,22 @@ export const mcpServerViewSortingFn = (
 };
 
 export const mcpServersSortingFn = (
-  a: { mcpServer: MCPServerType | MCPServerTypeWithViews },
-  b: { mcpServer: MCPServerType | MCPServerTypeWithViews }
-) => {
-  const { serverType: aServerType } = getServerTypeAndIdFromSId(
-    a.mcpServer.sId
-  );
-  const { serverType: bServerType } = getServerTypeAndIdFromSId(
-    b.mcpServer.sId
-  );
-  if (aServerType === bServerType) {
-    const aDisplayName = getMcpServerDisplayName(a.mcpServer);
-    const bDisplayName = getMcpServerDisplayName(b.mcpServer);
-    return aDisplayName.localeCompare(bDisplayName);
+  a: {
+    mcpServer: MCPServerType | MCPServerTypeWithViews;
+    mcpServerView?: MCPServerViewType;
+  },
+  b: {
+    mcpServer: MCPServerType | MCPServerTypeWithViews;
+    mcpServerView?: MCPServerViewType;
   }
-  return aServerType < bServerType ? -1 : 1;
+) => {
+  const aDisplayName = a.mcpServerView
+    ? getMcpServerViewDisplayName(a.mcpServerView)
+    : getMcpServerDisplayName(a.mcpServer);
+  const bDisplayName = b.mcpServerView
+    ? getMcpServerViewDisplayName(b.mcpServerView)
+    : getMcpServerDisplayName(b.mcpServer);
+  return aDisplayName.localeCompare(bDisplayName);
 };
 
 export function isRemoteMCPServerType(


### PR DESCRIPTION
## Description

Sort MCP server views by alphabetical order of the given name, no longer taking the server type into account (internal vs remote)

<img width="784" height="608" alt="image" src="https://github.com/user-attachments/assets/b04c45f9-0017-4ed2-b4b2-7e4be25d7878" />


Sort the "Add tools" menu alphabetically too, ignoring server type (internal vs remote)

<img width="401" height="687" alt="image" src="https://github.com/user-attachments/assets/e5d83dfc-1c53-4985-b8d3-3bca8c9e8f66" />




## Tests

locally

## Risk

low

## Deploy Plan

front only
