### PR TITLE
[skills] Add a delete button for restricted spaces, with pop up listing deleted resources

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -81,7 +81,6 @@ export function AgentBuilderSpacesBlock() {
     }
 
     // Remove actions (knowledge + tools) that belong to this space
-    // TODO(skill): if knowledge have data from several spaces, edit the knowledge to only remove the data from this space
     const actionIdsToRemove = new Set(actionsToRemove.map((a) => a.id));
     const newActions = actions.filter((a) => !actionIdsToRemove.has(a.id));
     setValue("actions", newActions, { shouldDirty: true });

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -1,0 +1,130 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { SKILL_ICON } from "@app/lib/skill";
+import { getSpaceName } from "@app/lib/spaces";
+import type { SpaceType } from "@app/types";
+
+import type { BuilderAction } from "./tools_picker/types";
+
+function getActionDisplayName(
+  action: BuilderAction,
+  mcpServerViews: MCPServerViewType[]
+): string {
+  const mcpServerView = mcpServerViews.find(
+    (view) => view.sId === action.configuration.mcpServerViewId
+  );
+  if (mcpServerView) {
+    return getMcpServerViewDisplayName(mcpServerView, action);
+  }
+  return action.name;
+}
+
+function getActionIcon(
+  action: BuilderAction,
+  mcpServerViews: MCPServerViewType[]
+): React.ReactNode {
+  const mcpServerView = mcpServerViews.find(
+    (view) => view.sId === action.configuration.mcpServerViewId
+  );
+  if (mcpServerView?.server) {
+    return getAvatar(mcpServerView.server, "xs");
+  }
+  return null;
+}
+
+export interface SkillItem {
+  sId: string;
+  name: string;
+}
+
+interface RemoveSpaceDialogProps {
+  space: SpaceType | null;
+  entityName: "agent" | "skill";
+  actions?: BuilderAction[];
+  skills?: SkillItem[];
+  mcpServerViews: MCPServerViewType[];
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function RemoveSpaceDialog({
+  space,
+  entityName,
+  actions = [],
+  skills = [],
+  mcpServerViews,
+  onClose,
+  onConfirm,
+}: RemoveSpaceDialogProps) {
+  if (!space) {
+    return null;
+  }
+
+  const SkillIcon = SKILL_ICON;
+
+  // Build list of all items to remove
+  const allItems: Array<{ id: string; name: string; icon: React.ReactNode }> = [
+    ...skills.map((skill) => ({
+      id: skill.sId,
+      name: skill.name,
+      // TODO(skills): use actual skill icon
+      icon: <SkillIcon className="h-4 w-4 shrink-0" />,
+    })),
+    ...actions.map((action) => ({
+      id: action.id,
+      name: getActionDisplayName(action, mcpServerViews),
+      icon: getActionIcon(action, mcpServerViews),
+    })),
+  ];
+
+  return (
+    <Dialog open={!!space} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md" isAlertDialog>
+        <DialogHeader hideButton>
+          <DialogTitle>Remove {getSpaceName(space)} space</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <p className="text-sm">
+            This will remove the following elements from the {entityName}:
+            <div className="mt-4 flex flex-wrap items-center gap-1">
+              {allItems.map((item, index) => (
+                <span key={item.id} className="inline-flex items-center gap-1">
+                  {item.icon}
+                  <span className="text-sm text-foreground dark:text-foreground-night">
+                    {item.name}
+                  </span>
+                  {index < allItems.length - 1 && (
+                    <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      ,
+                    </span>
+                  )}
+                </span>
+              ))}
+            </div>
+          </p>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: "OK",
+            variant: "warning",
+            onClick: onConfirm,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -76,7 +76,6 @@ export function SkillBuilderRequestedSpacesSection() {
           />
         ))}
       </div>
-
     </div>
   );
 }


### PR DESCRIPTION
## Description

Related https://github.com/dust-tt/tasks/issues/5561

Add option to delete the space in agent builder or in skill builder.

This opens a pop up with all the tools/skills/knowledge that will be deleted

This deletes the whole knowledge if it needs the deleted space, even if it has knowledge from other spaces.
The handling of mixed knowledge will be done in subsequent PR if needed, see https://github.com/dust-tt/tasks/issues/5561#issuecomment-3655502047

<img width="2044" height="962" alt="image" src="https://github.com/user-attachments/assets/2c4399e9-489b-4826-9dd8-3a978016c39d" />

<img width="3006" height="1514" alt="image" src="https://github.com/user-attachments/assets/a5bb927c-4ab5-4e84-bf7b-a4903d325dcf" />



## Tests

Manual test

## Risk

low

## Deploy Plan

deploy front
