### PR TITLE
Scroll conversation only if agent replies

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -66,7 +66,6 @@ import type {
 } from "@app/types";
 import {
   isRichAgentMention,
-  isRichUserMention,
   isUserMessageTypeWithContentFragments,
   toMentionType,
 } from "@app/types";

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -30,7 +30,6 @@ import type {
 import {
   areSameRank,
   getMessageRank,
-  hasHumansInteracting,
   isMessageTemporayState,
   isUserMessage,
   makeInitialMessageStreamState,
@@ -67,6 +66,7 @@ import type {
 } from "@app/types";
 import {
   isRichAgentMention,
+  isRichUserMention,
   isUserMessageTypeWithContentFragments,
   toMentionType,
 } from "@app/types";
@@ -501,13 +501,9 @@ export const ConversationViewer = ({
         }
       }
 
-      // Objective is to dermine if an agent is going to answer immediately to change the scroll behavior.
-      const isMentioningAgent =
-        //TODO(mentions v2) if dust agent is disabled at the workspace level, hasMoreThan2HumansInteracting might say false but we wouldn't have an auto mention of dust.
-        (mentions.length === 0 &&
-          !hasHumansInteracting(ref.current.data.get())) ||
-        // An agent is mentioned manually.
-        mentions.some(isRichAgentMention);
+      // An agent will answer immediately only if it is explicitely mentioned.
+      // In that case, we want to scroll to put the user message at the top.
+      const isMentioningAgent = mentions.some(isRichAgentMention);
 
       const nbMessages = ref.current.data.get().length;
       ref.current.data.append(


### PR DESCRIPTION
## Description

Fixes an issue where the conversation would incorrectly scroll to position the user message at the top when mentioning no agent. 
With mentions v2, the @Dust auto-mention behavior changed, but the scroll logic wasn't updated accordingly. This PR simplifies the scroll behavior to only trigger the "scroll to top" behavior when an agent is explicitly mentioned, as that's the only scenario where an agent will answer immediately.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
