### PR TITLE
Add CTA under customer stories

### DIFF
--- a/front/components/home/TrustedBy.tsx
+++ b/front/components/home/TrustedBy.tsx
@@ -11,6 +11,8 @@ import { classNames } from "@app/lib/utils";
 
 const CASE_STUDIES: Record<string, string> = {
   alan: "/customers/alans-pmm-team-transforms-sales-conversations-into-intelligence-with-ai-agents",
+  assembled:
+    "/customers/how-assembled-cut-knowledge-retrieval-time-by-hundreds-of-hours-with-dust",
   blueground: "/customers/customer-support-blueground",
   clay: "/customers/clay-scaling-gtme-team",
   doctolib:

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -526,6 +526,7 @@ const CustomerStoryFieldsSchema = z.object({
   companySize: z.string().nullable().optional(),
   region: z.array(z.string()).default([]),
   featured: z.boolean().default(false),
+  utmCampaign: z.string().nullable().optional(),
 });
 
 function contentfulEntryToCustomerStory(
@@ -585,6 +586,7 @@ function contentfulEntryToCustomerStory(
     featured: parsed.featured,
     createdAt: parsed.publishedAt ?? sys.createdAt,
     updatedAt: sys.updatedAt,
+    utmCampaign: parsed.utmCampaign ?? null,
   };
 }
 

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -106,6 +106,9 @@ export interface CustomerStoryFields {
 
   // SEO
   metaDescription?: string;
+
+  // UTM tracking
+  utmCampaign?: string;
 }
 
 export type CustomerStorySkeleton = EntrySkeletonType<
@@ -137,6 +140,7 @@ export interface CustomerStory {
   featured: boolean;
   createdAt: string;
   updatedAt: string;
+  utmCampaign: string | null;
 }
 
 export interface CustomerStorySummary {

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { ReactElement } from "react";
 
-import { Grid, H1, H2, H5 } from "@app/components/home/ContentComponents";
+import { A, Grid, H1, H2, H5 } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
 import {
@@ -214,15 +214,6 @@ export default function CustomerStoryPage({
             <H1 mono>{story.title}</H1>
 
             <div className="mt-4 flex flex-wrap items-center gap-2">
-              {story.companyLogo && (
-                <Image
-                  src={story.companyLogo.url}
-                  alt={story.companyLogo.alt}
-                  width={120}
-                  height={40}
-                  className="mr-2 h-8 w-auto object-contain"
-                />
-              )}
               {story.industries.map((ind) => (
                 <span
                   key={ind}
@@ -283,6 +274,27 @@ export default function CustomerStoryPage({
                 </div>
               </div>
             )}
+
+            <div className="mt-12 rounded-2xl border border-highlight/20 bg-highlight/5 p-6">
+              <p className="font-sans text-foreground">
+                Interested in learning more about how Dust can help your team?
+                Visit our{" "}
+                <A
+                  rel="noopener noreferrer"
+                  href={`/home/product?utm_source=customer_story&utm_medium=article${story.utmCampaign ? `&utm_campaign=${story.utmCampaign}` : ""}&utm_content=visit_product_page`}
+                >
+                  solutions page
+                </A>{" "}
+                or reach out to{" "}
+                <A
+                  rel="noopener noreferrer"
+                  href={`/home/contact?utm_source=customer_story&utm_medium=article${story.utmCampaign ? `&utm_campaign=${story.utmCampaign}` : ""}&utm_content=contact_sales`}
+                >
+                  our sales team
+                </A>
+                .
+              </p>
+            </div>
           </div>
 
           <aside className={classNames(SIDEBAR_CLASSES, "mt-6")}>

--- a/front/pages/customers/[slug].tsx
+++ b/front/pages/customers/[slug].tsx
@@ -281,14 +281,14 @@ export default function CustomerStoryPage({
                 Visit our{" "}
                 <A
                   rel="noopener noreferrer"
-                  href={`/home/product?utm_source=customer_story&utm_medium=article${story.utmCampaign ? `&utm_campaign=${story.utmCampaign}` : ""}&utm_content=visit_product_page`}
+                  href={`/home/product?utm_source=blog&utm_medium=customer_story${story.utmCampaign ? `&utm_campaign=${story.utmCampaign}` : ""}&utm_content=visit_product_page`}
                 >
                   solutions page
                 </A>{" "}
                 or reach out to{" "}
                 <A
                   rel="noopener noreferrer"
-                  href={`/home/contact?utm_source=customer_story&utm_medium=article${story.utmCampaign ? `&utm_campaign=${story.utmCampaign}` : ""}&utm_content=contact_sales`}
+                  href={`/home/contact?utm_source=blog&utm_medium=customer_story${story.utmCampaign ? `&utm_campaign=${story.utmCampaign}` : ""}&utm_content=contact_sales`}
                 >
                   our sales team
                 </A>


### PR DESCRIPTION
## Description

Adds a call-to-action banner at the bottom of customer story pages to drive conversions. The CTA includes links to the solutions page and contact sales form with UTM tracking parameters for marketing attribution (`utm_source=customer_story`, `utm_medium=article`). Introduces an optional `utmCampaign` field in the Contentful customer story schema, allowing each story to define a custom campaign parameter. Removes the company logo from the header area (now only displayed in the sidebar). Adds the "assembled" customer story to the `TrustedBy` component.

## Risk

None. Changes are purely additive to the customer stories display and don't affect any core functionality or data flows.