### PR TITLE
[Front] feat(manage-skills): add archived & all tab to manage skills table

### DIFF
--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -30,6 +30,7 @@ export const useLocalSelectedSkills = ({
   } = useSkillConfigurationsWithRelations({
     owner,
     disabled: !open,
+    status: "active",
   });
 
   const selectedSkillIds = useMemo(

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -1,5 +1,6 @@
 import {
   Avatar,
+  ContentMessage,
   InformationCircleIcon,
   Sheet,
   SheetContainer,
@@ -125,12 +126,23 @@ const DescriptionSection = ({
 }: DescriptionSectionProps) => (
   <div className="flex flex-col gap-5">
     <div className="flex flex-col gap-3 sm:flex-row">
-      <Avatar name="Agent avatar" visual={<SKILL_ICON />} size="lg" />
+      <Avatar name="Skill avatar" visual={<SKILL_ICON />} size="lg" />
       <div className="flex grow flex-col gap-1">
         <div className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">
           {skillConfiguration.name}
         </div>
       </div>
     </div>
+
+    {skillConfiguration.status === "archived" && (
+      <ContentMessage
+        title="This skill has been archived."
+        variant="warning"
+        icon={InformationCircleIcon}
+        size="sm"
+      >
+        It is no longer active and cannot be used.
+      </ContentMessage>
+    )}
   </div>
 );

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -122,88 +122,74 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
 };
 
 type SkillsTableProps = {
-  skillConfigurationsWithRelations: (SkillConfigurationType &
-    SkillConfigurationRelations)[];
+  skills: (SkillConfigurationType & SkillConfigurationRelations)[];
   owner: LightWorkspaceType;
-  setSkillConfigurationWithRelations: (
+  onSkillClick: (
     skill: SkillConfigurationType & SkillConfigurationRelations
   ) => void;
   onAgentClick: (agentId: string) => void;
 };
 
 export function SkillsTable({
-  skillConfigurationsWithRelations,
+  skills,
   owner,
-  setSkillConfigurationWithRelations,
+  onSkillClick,
   onAgentClick,
 }: SkillsTableProps) {
   const router = useRouter();
   const { pagination, setPagination } = usePaginationFromUrl({});
-  const [skillConfigurationToArchive, setSkillConfigurationToArchive] =
+  const [skillToArchive, setSkillToArchive] =
     useState<SkillConfigurationType | null>(null);
 
   const rows: RowData[] = useMemo(
     () =>
-      skillConfigurationsWithRelations.map(
-        (skillConfigurationWithRelations) => ({
-          name: skillConfigurationWithRelations.name,
-          description: skillConfigurationWithRelations.description,
-          editors: skillConfigurationWithRelations.editors,
-          usage: skillConfigurationWithRelations.usage,
-          updatedAt: skillConfigurationWithRelations.updatedAt,
-          onClick: () => {
-            setSkillConfigurationWithRelations(skillConfigurationWithRelations);
-          },
-          menuItems:
-            skillConfigurationWithRelations.status !== "archived"
-              ? [
-                  {
-                    label: "Edit",
-                    icon: PencilSquareIcon,
-                    onClick: (e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      void router.push(
-                        getSkillBuilderRoute(
-                          owner.sId,
-                          skillConfigurationWithRelations.sId
-                        )
-                      );
-                    },
-                    kind: "item" as const,
+      skills.map((skill) => ({
+        name: skill.name,
+        description: skill.description,
+        editors: skill.editors,
+        usage: skill.usage,
+        updatedAt: skill.updatedAt,
+        onClick: () => {
+          onSkillClick(skill);
+        },
+        menuItems:
+          skill.status !== "archived"
+            ? [
+                {
+                  label: "Edit",
+                  icon: PencilSquareIcon,
+                  onClick: (e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    void router.push(
+                      getSkillBuilderRoute(owner.sId, skill.sId)
+                    );
                   },
-                  {
-                    label: "More info",
-                    icon: EyeIcon,
-                    onClick: (e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      setSkillConfigurationWithRelations(
-                        skillConfigurationWithRelations
-                      );
-                    },
-                    kind: "item" as const,
+                  kind: "item" as const,
+                },
+                {
+                  label: "More info",
+                  icon: EyeIcon,
+                  onClick: (e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    onSkillClick(skill);
                   },
-                  {
-                    label: "Archive",
-                    icon: TrashIcon,
-                    variant: "warning" as const,
-                    onClick: (e: React.MouseEvent) => {
-                      e.stopPropagation();
-                      setSkillConfigurationToArchive(
-                        skillConfigurationWithRelations
-                      );
-                    },
-                    kind: "item" as const,
+                  kind: "item" as const,
+                },
+                {
+                  label: "Archive",
+                  icon: TrashIcon,
+                  variant: "warning" as const,
+                  onClick: (e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    setSkillToArchive(skill);
                   },
-                ]
-              : [],
-        })
-      ),
+                  kind: "item" as const,
+                },
+              ]
+            : [],
+      })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
-    [
-      skillConfigurationsWithRelations,
-      setSkillConfigurationWithRelations,
-      owner.sId,
-    ]
+    [skills, onSkillClick, owner.sId]
   );
 
   if (rows.length === 0) {
@@ -212,13 +198,13 @@ export function SkillsTable({
 
   return (
     <>
-      {skillConfigurationToArchive && (
+      {skillToArchive && (
         <ArchiveSkillDialog
           owner={owner}
           isOpen={true}
-          skillConfiguration={skillConfigurationToArchive}
+          skillConfiguration={skillToArchive}
           onClose={() => {
-            setSkillConfigurationToArchive(null);
+            setSkillToArchive(null);
           }}
         />
       )}

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -109,10 +109,9 @@ export async function getSimilarSkills(
   }
 
   // Retrieve existing skills
-  const skills: SkillResource[] = await SkillResource.fetchAllAvailableSkills(
-    auth,
-    MAX_SKILLS_SENT_TO_LLM
-  );
+  const skills: SkillResource[] = await SkillResource.listSkills(auth, {
+    limit: MAX_SKILLS_SENT_TO_LLM,
+  });
   if (skills.length === MAX_SKILLS_SENT_TO_LLM) {
     logger.warn(
       { workspaceId: owner.sId },

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -44,7 +44,10 @@ import type {
 } from "@app/types";
 import { Err, normalizeError, Ok, removeNulls } from "@app/types";
 import type { ConversationSkillOrigin } from "@app/types/assistant/conversation_skills";
-import type { SkillConfigurationType } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillConfigurationType,
+  SkillStatus,
+} from "@app/types/assistant/skill_configuration";
 
 type SkillResourceConstructorOptions =
   | {
@@ -427,14 +430,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return [...customSkillsRes, ...globalSkills];
   }
 
-  static async fetchAllAvailableSkills(
+  static async listSkills(
     auth: Authenticator,
-    limit?: number
+    { status = "active", limit }: { status?: SkillStatus; limit?: number } = {}
   ): Promise<SkillResource[]> {
     return this.baseFetch(auth, {
-      where: {
-        status: "active",
-      },
+      where: { status },
       ...(limit ? { limit } : {}),
     });
   }

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -16,7 +16,10 @@ import type {
 import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
 import type { LightWorkspaceType } from "@app/types";
 import { Ok } from "@app/types";
-import type { SkillConfigurationType } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillConfigurationType,
+  SkillStatus,
+} from "@app/types/assistant/skill_configuration";
 
 export function useSkillConfigurations({
   owner,
@@ -45,15 +48,17 @@ export function useSkillConfigurations({
 export function useSkillConfigurationsWithRelations({
   owner,
   disabled,
+  status,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
+  status: SkillStatus;
 }) {
   const skillConfigurationsFetcher: Fetcher<GetSkillConfigurationsWithRelationsResponseBody> =
     fetcher;
 
   const { data, isLoading } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/skills?withRelations=true`,
+    `/api/w/${owner.sId}/skills?withRelations=true&status=${status}`,
     skillConfigurationsFetcher,
     { disabled }
   );


### PR DESCRIPTION



## Description

Task : https://github.com/dust-tt/tasks/issues/5521
- Add All & Archived tab followin same pattern as manage agents screen
- Added disclaimer message on archived skills sheet

## Tests

Local

https://github.com/user-attachments/assets/3a9c58ec-bfb8-4991-9151-c4ee5fb61d2e


## Risk

Low


## Deploy Plan

Front