### PR TITLE
[Credits] Fix poke billing cycle start day to use Stripe period

### DIFF
--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -1,3 +1,5 @@
+import type Stripe from "stripe";
+
 import { makeColumnsForCredits } from "@app/components/poke/credits/columns";
 import { PokeProgrammaticCostChart } from "@app/components/poke/credits/PokeProgrammaticCostChart";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
@@ -9,6 +11,7 @@ import type { SubscriptionType, WorkspaceType } from "@app/types";
 interface CreditsDataTableProps {
   owner: WorkspaceType;
   subscription: SubscriptionType;
+  stripeSubscription: Stripe.Subscription | null;
   loadOnInit?: boolean;
 }
 
@@ -34,12 +37,20 @@ function sortByExpirationDate(credits: PokeCreditType[]): PokeCreditType[] {
 export function CreditsDataTable({
   owner,
   subscription,
+  stripeSubscription,
   loadOnInit,
 }: CreditsDataTableProps) {
-  // Get the billing cycle start day from the subscription start date
-  const billingCycleStartDay = subscription.startDate
-    ? new Date(subscription.startDate).getDate()
-    : null;
+  // Get the billing cycle start day from Stripe subscription, fallback to Dust subscription
+  const getBillingCycleStartDay = (): number | null => {
+    if (stripeSubscription?.current_period_start) {
+      return new Date(stripeSubscription.current_period_start * 1000).getDate();
+    }
+    if (subscription.startDate) {
+      return new Date(subscription.startDate).getDate();
+    }
+    return null;
+  };
+  const billingCycleStartDay = getBillingCycleStartDay();
 
   return (
     <>

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -334,10 +334,17 @@ export default function CreditsUsagePage({
     workspaceId: owner.sId,
   });
 
-  // Get the billing cycle start day from the stripesubscription
-  const billingCycleStartDay = stripeSubscription?.current_period_start
-    ? new Date(stripeSubscription.current_period_start * 1000).getDate()
-    : null;
+  // Get the billing cycle start day from Stripe subscription, fallback to Dust subscription
+  const getBillingCycleStartDay = (): number | null => {
+    if (stripeSubscription?.current_period_start) {
+      return new Date(stripeSubscription.current_period_start * 1000).getDate();
+    }
+    if (subscription.startDate) {
+      return new Date(subscription.startDate).getDate();
+    }
+    return null;
+  };
+  const billingCycleStartDay = getBillingCycleStartDay();
 
   const creditsByType = useMemo(() => {
     const activeCredits = credits.filter((c) => isActive(c));


### PR DESCRIPTION
## Description
Follows up on #19008 to apply the same fix to both the poke credits page and the regular credits-usage page.

Uses `stripeSubscription.current_period_start` to determine the billing cycle start day, with a fallback to `subscription.startDate` when Stripe subscription is not available. This ensures the billing cycle aligns with Stripe's actual billing period when possible.

## Risks
Blast radius: Credits usage page and poke credits tab billing cycle calculation
Risk: low

## Deploy Plan
- deploy front