### PR TITLE
[front] fix(Fathom): whitelist header names used for signature verification

### DIFF
--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -50,8 +50,10 @@ export const HEADERS_ALLOWED_LIST = [
       .filter((preset) => preset.eventCheck?.type === "headers")
       .map((preset) => preset.eventCheck?.field.toLowerCase())
   ),
-  // Header used by Fathom.
+  // Headers used by Fathom.
+  "webhook-id",
   "webhook-signature",
+  "webhook-timestamp",
 ];
 
 export function checkSignature({


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/dust/issues/19001.
- All webhook trigger requests for Fathom fail with the "Invalid Fathom webhook signature: Missing required headers" error ([logs](https://app.datadoghq.eu/logs?query=status%3Aerror%20fathom&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZsOWahV6LCAvAAAABhBWnNPV2J1N0FBQ243V096dEVEb3R3QUIAAAAkZjE5YjBlNWEtMzBmZC00YmY5LWExMWEtZmYyNzcyY2M3NWQ2AALltw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1733653464474&to_ts=1733657064474&live=true)).
- Comparing the payloads we received with what's expected in the SDK code we are indeed missing some headers.
- This PR allows these specific headers.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
