### PR TITLE
[front] feat: Add MCP server to control triggers

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -60,6 +60,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "toolsets", id: 1013 },
       { name: "common_utilities", id: 1017 },
       { name: "skill_management", id: 1019 },
+      { name: "trigger_management", id: 1020 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -60,7 +60,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "toolsets", id: 1013 },
       { name: "common_utilities", id: 1017 },
       { name: "skill_management", id: 1019 },
-      { name: "trigger_management", id: 1020 },
+      { name: "schedules_management", id: 1020 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -124,7 +124,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   SEARCH_SERVER_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
   SKILL_MANAGEMENT_SERVER_NAME,
-  "trigger_management",
+  "schedules_management",
 ] as const;
 
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
@@ -1703,35 +1703,34 @@ export const INTERNAL_MCP_SERVERS = {
       instructions: null,
     },
   },
-  trigger_management: {
+  schedules_management: {
     id: 1020,
-    availability: "auto",
+    availability: "auto_hidden_builder",
     allowMultipleInstances: false,
     isPreview: false,
     isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("triggers_management");
+      return !featureFlags.includes("schedules_management");
     },
     tools_stakes: {
-      create_schedule_trigger: "low",
-      list_triggers: "never_ask",
-      get_trigger: "never_ask",
-      update_trigger: "low",
-      delete_trigger: "high",
+      create_schedule: "high",
+      list_schedules: "never_ask",
+      get_schedule: "never_ask",
+      update_schedule: "high",
+      delete_schedule: "high",
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
-      name: "trigger_management",
+      name: "schedules_management",
       version: "1.0.0",
-      description: "Create scheduled triggers to automate recurring tasks.",
+      description: "Create schedules to automate recurring tasks.",
       icon: "ActionTimeIcon",
       authorization: null,
       documentationUrl: null,
       instructions:
-        "WHEN TO USE: Proactively suggest creating a trigger when the user receives actionable information that benefits from a regular trigger" +
-        "(e.g., 'I can check on this task daily if you'd like', " +
-        "WHEN NOT TO USE: Do not create triggers for one-time requests, general questions, or unless the user explicitly wants recurring automation. " +
-        "Always ask before creating a trigger - never create one without user confirmation.",
+        "Schedules are user-specific: each user can only view and manage their own schedules. " +
+        "When a schedule triggers, it runs this agent with the specified prompt. " +
+        "Limit: 20 schedule creations per user per day.",
     },
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -124,6 +124,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   SEARCH_SERVER_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
   SKILL_MANAGEMENT_SERVER_NAME,
+  "trigger_management",
 ] as const;
 
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
@@ -1700,6 +1701,37 @@ export const INTERNAL_MCP_SERVERS = {
       authorization: null,
       documentationUrl: null,
       instructions: null,
+    },
+  },
+  trigger_management: {
+    id: 1020,
+    availability: "auto",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("triggers_management");
+    },
+    tools_stakes: {
+      create_schedule_trigger: "low",
+      list_triggers: "never_ask",
+      get_trigger: "never_ask",
+      update_trigger: "low",
+      delete_trigger: "high",
+    },
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "trigger_management",
+      version: "1.0.0",
+      description: "Create scheduled triggers to automate recurring tasks.",
+      icon: "ActionTimeIcon",
+      authorization: null,
+      documentationUrl: null,
+      instructions:
+        "WHEN TO USE: Proactively suggest creating a trigger when the user receives actionable information that benefits from a regular trigger" +
+        "(e.g., 'I can check on this task daily if you'd like', " +
+        "WHEN NOT TO USE: Do not create triggers for one-time requests, general questions, or unless the user explicitly wants recurring automation. " +
+        "Always ask before creating a trigger - never create one without user confirmation.",
     },
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -46,6 +46,7 @@ import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions
 import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
 import { default as salesloftServer } from "@app/lib/actions/mcp_internal_actions/servers/salesloft";
+import { default as schedulesManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/schedules_management";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
 import { default as skillManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/skill_management";
 import { default as slabServer } from "@app/lib/actions/mcp_internal_actions/servers/slab";
@@ -56,7 +57,6 @@ import { default as soundStudio } from "@app/lib/actions/mcp_internal_actions/se
 import { default as speechGenerator } from "@app/lib/actions/mcp_internal_actions/servers/speech_generator";
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query";
 import { default as toolsetsServer } from "@app/lib/actions/mcp_internal_actions/servers/toolsets";
-import { default as triggerManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/trigger_management";
 import { default as valtownServer } from "@app/lib/actions/mcp_internal_actions/servers/valtown";
 import { default as vantaServer } from "@app/lib/actions/mcp_internal_actions/servers/vanta";
 import { default as webtoolsServer } from "@app/lib/actions/mcp_internal_actions/servers/webtools";
@@ -218,8 +218,8 @@ export async function getInternalMCPServer(
       return zendeskServer(auth, agentLoopContext);
     case "skill_management":
       return skillManagementServer(auth, agentLoopContext);
-    case "trigger_management":
-      return triggerManagementServer(auth, agentLoopContext);
+    case "schedules_management":
+      return schedulesManagementServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -56,6 +56,7 @@ import { default as soundStudio } from "@app/lib/actions/mcp_internal_actions/se
 import { default as speechGenerator } from "@app/lib/actions/mcp_internal_actions/servers/speech_generator";
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query";
 import { default as toolsetsServer } from "@app/lib/actions/mcp_internal_actions/servers/toolsets";
+import { default as triggerManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/trigger_management";
 import { default as valtownServer } from "@app/lib/actions/mcp_internal_actions/servers/valtown";
 import { default as vantaServer } from "@app/lib/actions/mcp_internal_actions/servers/vanta";
 import { default as webtoolsServer } from "@app/lib/actions/mcp_internal_actions/servers/webtools";
@@ -217,6 +218,8 @@ export async function getInternalMCPServer(
       return zendeskServer(auth, agentLoopContext);
     case "skill_management":
       return skillManagementServer(auth, agentLoopContext);
+    case "trigger_management":
+      return triggerManagementServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/schedules_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/schedules_management.ts
@@ -137,6 +137,7 @@ function createServer(
           webhookSourceViewId: null,
           executionPerDayLimitOverride: null,
           executionMode: "fair_use",
+          origin: "agent",
         });
 
         if (result.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/servers/schedules_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/schedules_management.ts
@@ -39,7 +39,7 @@ function getToolContext(
 ): Result<
   {
     userId: number;
-    workspaceSId: string;
+    workspaceId: string;
     agentConfiguration: AgentConfigurationType;
   },
   MCPError
@@ -57,7 +57,7 @@ function getToolContext(
   }
   return new Ok({
     userId: user.id,
-    workspaceSId: workspace.sId,
+    workspaceId: workspace.sId,
     agentConfiguration: agentLoopContext.runContext.agentConfiguration,
   });
 }
@@ -196,7 +196,7 @@ function createServer(
           editor: user.id,
           webhookSourceViewId: null,
           executionPerDayLimitOverride: null,
-          executionMode: null,
+          executionMode: "fair_use",
         });
 
         if (result.isErr()) {
@@ -240,8 +240,7 @@ function createServer(
         if (contextResult.isErr()) {
           return contextResult;
         }
-        const { userId, workspaceSId, agentConfiguration } =
-          contextResult.value;
+        const { userId, workspaceId, agentConfiguration } = contextResult.value;
 
         const schedulesResult =
           await TriggerResource.listSchedulesByAgentAndEditor(auth, {
@@ -256,7 +255,7 @@ function createServer(
         }
 
         getStatsDClient().increment("tools.schedules_management.listed", 1, [
-          `workspace_id:${workspaceSId}`,
+          `workspace_id:${workspaceId}`,
           `agent_id:${agentConfiguration.sId}`,
         ]);
 
@@ -370,8 +369,7 @@ function createServer(
         if (contextResult.isErr()) {
           return contextResult;
         }
-        const { userId, workspaceSId, agentConfiguration } =
-          contextResult.value;
+        const { userId, workspaceId, agentConfiguration } = contextResult.value;
 
         const scheduleResult = await TriggerResource.fetchScheduleByIdForEditor(
           auth,
@@ -438,7 +436,7 @@ function createServer(
         }
 
         getStatsDClient().increment("tools.schedules_management.updated", 1, [
-          `workspace_id:${workspaceSId}`,
+          `workspace_id:${workspaceId}`,
           `agent_id:${agentConfiguration.sId}`,
         ]);
 
@@ -480,8 +478,7 @@ function createServer(
         if (contextResult.isErr()) {
           return contextResult;
         }
-        const { userId, workspaceSId, agentConfiguration } =
-          contextResult.value;
+        const { userId, workspaceId, agentConfiguration } = contextResult.value;
 
         const scheduleResult = await TriggerResource.fetchScheduleByIdForEditor(
           auth,
@@ -506,7 +503,7 @@ function createServer(
         }
 
         getStatsDClient().increment("tools.schedules_management.deleted", 1, [
-          `workspace_id:${workspaceSId}`,
+          `workspace_id:${workspaceId}`,
           `agent_id:${agentConfiguration.sId}`,
         ]);
 

--- a/front/lib/actions/mcp_internal_actions/servers/schedules_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/schedules_management.ts
@@ -263,7 +263,7 @@ function createServer(
 
   server.tool(
     "get_schedule",
-    "Get details of a specific schedule by ID. Returns name, timing, prompt, and enabled state.",
+    "Get details of a specific schedule trigger by ID. Returns name, schedule, prompt, and status.",
     {
       scheduleId: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/servers/trigger_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/trigger_management.ts
@@ -431,16 +431,18 @@ function createServer(
           };
         }
 
-        const updateResult = await TriggerResource.updateFields(
-          auth,
-          triggerId,
-          {
-            name,
-            enabled,
-            schedule: scheduleUpdate,
-            customPrompt: prompt,
-          }
-        );
+        const updateResult = await TriggerResource.update(auth, triggerId, {
+          name,
+          enabled,
+          customPrompt: prompt,
+          ...(scheduleUpdate && {
+            configuration: {
+              cron: scheduleUpdate.cron,
+              timezone: scheduleUpdate.timezone,
+            },
+            naturalLanguageDescription: scheduleUpdate.naturalLanguage,
+          }),
+        });
 
         if (updateResult.isErr()) {
           return new Err(

--- a/front/lib/actions/mcp_internal_actions/servers/trigger_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/trigger_management.ts
@@ -1,0 +1,521 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { generateCronRule } from "@app/lib/api/assistant/configuration/triggers";
+import type { Authenticator } from "@app/lib/auth";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { isUserMessageType } from "@app/types/assistant/conversation";
+
+function renderTrigger(trigger: TriggerResource): string {
+  const config = trigger.configuration;
+  const scheduleInfo =
+    trigger.kind === "schedule" && "cron" in config
+      ? `${trigger.naturalLanguageDescription ?? config.cron} (${config.timezone})`
+      : trigger.kind;
+  const lines = [
+    `- **${trigger.name}** (ID: ${trigger.sId()})`,
+    `  Schedule: ${scheduleInfo}`,
+  ];
+  if (trigger.customPrompt) {
+    lines.push(`  Prompt: ${trigger.customPrompt}`);
+  }
+  lines.push(`  Enabled: ${trigger.enabled ? "Yes" : "No"}`);
+  return lines.join("\n");
+}
+
+function getToolContext(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): Result<
+  {
+    userId: number;
+    workspaceSId: string;
+    agentConfiguration: AgentConfigurationType;
+  },
+  MCPError
+> {
+  const user = auth.user();
+  const workspace = auth.workspace();
+  if (!user) {
+    return new Err(new MCPError("User not found"));
+  }
+  if (!workspace) {
+    return new Err(new MCPError("Workspace not found"));
+  }
+  if (!agentLoopContext?.runContext) {
+    return new Err(new MCPError("Agent context is required"));
+  }
+  return new Ok({
+    userId: user.id,
+    workspaceSId: workspace.sId,
+    agentConfiguration: agentLoopContext.runContext.agentConfiguration,
+  });
+}
+
+function getUserTimezone(
+  agentLoopContext?: AgentLoopContextType
+): string | null {
+  const content = agentLoopContext?.runContext?.conversation?.content;
+  if (!content) {
+    return null;
+  }
+
+  const userMessage = content.flat().findLast(isUserMessageType);
+  return userMessage?.context.timezone ?? null;
+}
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("trigger_management");
+
+  server.tool(
+    "create_schedule_trigger",
+    "Create a scheduled trigger that runs this agent at specified times. Use when user says 'remind me every day', 'run this weekly', 'automate this task', 'schedule this to run at 9am', 'set up a recurring task'.",
+    {
+      name: z
+        .string()
+        .max(255)
+        .describe(
+          "A short, descriptive name for the trigger (max 255 chars). Examples: 'Daily email summary', 'Weekly PR review', 'Morning standup prep'"
+        ),
+      schedule: z
+        .string()
+        .describe(
+          "When to run, in natural language. Examples: 'every weekday at 9am', 'every Monday morning', 'daily at 8am', 'first day of each month at noon', 'every Friday at 5pm'"
+        ),
+      prompt: z
+        .string()
+        .describe(
+          "What you should do when triggered. Examples: 'Summarize my emails from yesterday', 'Show PRs that need my review', 'Generate a weekly status report'"
+        ),
+      timezone: z
+        .string()
+        .optional()
+        .describe(
+          "IANA timezone for the schedule. Examples: 'Europe/Paris', 'America/New_York', 'Asia/Tokyo'. If not provided, uses user's timezone from context."
+        ),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: "trigger_management_create_schedule",
+        agentLoopContext,
+      },
+      async ({ name, schedule, prompt, timezone }) => {
+        const owner = auth.workspace();
+        const user = auth.user();
+
+        if (!owner) {
+          return new Err(new MCPError("Workspace not found"));
+        }
+
+        if (!user) {
+          return new Err(new MCPError("User not found"));
+        }
+
+        if (!agentLoopContext?.runContext) {
+          return new Err(new MCPError("Agent context is required"));
+        }
+
+        const { agentConfiguration } = agentLoopContext.runContext;
+
+        const remaining = await rateLimiter({
+          key: `trigger_create:${owner.sId}:${user.sId}`,
+          maxPerTimeframe: 20,
+          timeframeSeconds: 86400,
+          logger,
+        });
+
+        if (remaining === 0) {
+          getStatsDClient().increment(
+            "tools.trigger_management.rate_limit_hit",
+            1,
+            [`workspace_id:${owner.sId}`, `agent_id:${agentConfiguration.sId}`]
+          );
+          return new Err(
+            new MCPError(
+              "Rate limit exceeded: You can create up to 20 triggers per day."
+            )
+          );
+        }
+
+        // Determine timezone: explicit param > context > default
+        const resolvedTimezone = timezone ?? getUserTimezone(agentLoopContext);
+
+        if (!resolvedTimezone) {
+          return new Err(new MCPError("Provide a timezone"));
+        }
+
+        const cronResult = await generateCronRule(auth, {
+          naturalDescription: schedule,
+          defaultTimezone: resolvedTimezone,
+        });
+
+        if (cronResult.isErr()) {
+          logger.error(
+            {
+              error: cronResult.error,
+              workspaceId: owner.id,
+              schedule,
+            },
+            "Error parsing schedule"
+          );
+          return new Err(
+            new MCPError(
+              `Unable to understand the schedule "${schedule}". Please try rephrasing (e.g., "every weekday at 9am", "every Monday at 10am").`
+            )
+          );
+        }
+
+        const { cron, timezone: resultTimezone } = cronResult.value;
+
+        const result = await TriggerResource.makeNew(auth, {
+          workspaceId: owner.id,
+          agentConfigurationId: agentConfiguration.sId,
+          name,
+          kind: "schedule",
+          enabled: true,
+          configuration: {
+            cron,
+            timezone: resultTimezone,
+          },
+          naturalLanguageDescription: schedule,
+          customPrompt: prompt,
+          editor: user.id,
+          webhookSourceViewId: null,
+          executionPerDayLimitOverride: null,
+          executionMode: null,
+        });
+
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Failed to create trigger: ${result.error.message}`)
+          );
+        }
+
+        getStatsDClient().increment("tools.trigger_management.created", 1, [
+          `workspace_id:${owner.sId}`,
+          `agent_id:${agentConfiguration.sId}`,
+        ]);
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text:
+              `Created trigger "${name}"!\n\n` +
+              `Schedule: ${schedule}\n` +
+              `Cron: ${cron} (${resultTimezone})\n\n` +
+              `I'll run "${prompt}" according to this schedule.\n\n` +
+              renderTrigger(result.value),
+          },
+        ]);
+      }
+    )
+  );
+
+  server.tool(
+    "list_triggers",
+    "List all scheduled triggers you have created for this agent. Use when user asks 'what triggers do I have?', 'show my scheduled tasks', 'what's automated?', 'list my triggers'.",
+    {},
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: "trigger_management_list",
+        agentLoopContext,
+      },
+      async () => {
+        const contextResult = getToolContext(auth, agentLoopContext);
+        if (contextResult.isErr()) {
+          return contextResult;
+        }
+        const { userId, workspaceSId, agentConfiguration } =
+          contextResult.value;
+
+        const triggersResult =
+          await TriggerResource.listByAgentConfigurationIdAndEditors(auth, {
+            agentConfigurationId: agentConfiguration.sId,
+            editorIds: [userId],
+          });
+
+        if (triggersResult.isErr()) {
+          return new Err(
+            new MCPError("Error while fetching triggers for this agent")
+          );
+        }
+
+        getStatsDClient().increment("tools.trigger_management.listed", 1, [
+          `workspace_id:${workspaceSId}`,
+          `agent_id:${agentConfiguration.sId}`,
+        ]);
+
+        if (triggersResult.value.length === 0) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: "You have no triggers configured for this agent.",
+            },
+          ]);
+        }
+
+        const triggerList = triggersResult.value
+          .map((trigger) => renderTrigger(trigger))
+          .join("\n\n");
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Your triggers for this agent:\n\n${triggerList}`,
+          },
+        ]);
+      }
+    )
+  );
+
+  server.tool(
+    "get_trigger",
+    "Get details of a specific trigger by ID. Use this to check the current state of a trigger or verify changes after updates.",
+    {
+      triggerId: z
+        .string()
+        .describe("The trigger ID (get this from list_triggers)"),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: "trigger_management_get",
+        agentLoopContext,
+      },
+      async ({ triggerId }) => {
+        const contextResult = getToolContext(auth, agentLoopContext);
+        if (contextResult.isErr()) {
+          return contextResult;
+        }
+        const { userId, agentConfiguration } = contextResult.value;
+
+        const triggerResult =
+          await TriggerResource.fetchByIdAndValidateOwnership(
+            auth,
+            triggerId,
+            agentConfiguration.sId,
+            userId
+          );
+        if (triggerResult.isErr()) {
+          return new Err(new MCPError(triggerResult.error.message));
+        }
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: renderTrigger(triggerResult.value),
+          },
+        ]);
+      }
+    )
+  );
+
+  server.tool(
+    "update_trigger",
+    "Update an existing trigger. Can change name, schedule, prompt, or enabled state. Use 'enabled: false' to pause a trigger, 'enabled: true' to reactivate it. Use when user says 'change trigger settings', 'pause this trigger', 'turn on this trigger', 'update the schedule'.",
+    {
+      triggerId: z
+        .string()
+        .describe("The trigger ID (get this from list_triggers)"),
+      name: z
+        .string()
+        .max(255)
+        .optional()
+        .describe(
+          "New name for the trigger (e.g., 'Daily email summary', 'Weekly PR review')"
+        ),
+      schedule: z
+        .string()
+        .optional()
+        .describe(
+          "New schedule in natural language (e.g., 'every weekday at 9am', 'every Monday morning', 'daily at 8am')"
+        ),
+      prompt: z
+        .string()
+        .optional()
+        .describe(
+          "New prompt - what the agent should do when triggered (e.g., 'Summarize my emails from yesterday')"
+        ),
+      enabled: z
+        .boolean()
+        .optional()
+        .describe(
+          "Set to true to enable the trigger, false to disable/pause it"
+        ),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: "trigger_management_update",
+        agentLoopContext,
+      },
+      async ({ triggerId, name, schedule, prompt, enabled }) => {
+        const contextResult = getToolContext(auth, agentLoopContext);
+        if (contextResult.isErr()) {
+          return contextResult;
+        }
+        const { userId, workspaceSId, agentConfiguration } =
+          contextResult.value;
+
+        const triggerResult =
+          await TriggerResource.fetchByIdAndValidateOwnership(
+            auth,
+            triggerId,
+            agentConfiguration.sId,
+            userId
+          );
+        if (triggerResult.isErr()) {
+          return new Err(new MCPError(triggerResult.error.message));
+        }
+
+        let scheduleUpdate:
+          | { cron: string; timezone: string; naturalLanguage: string }
+          | undefined;
+
+        if (schedule) {
+          const resolvedTimezone = getUserTimezone(agentLoopContext);
+
+          if (!resolvedTimezone) {
+            return new Err(new MCPError("Provide a timezone"));
+          }
+
+          const cronResult = await generateCronRule(auth, {
+            naturalDescription: schedule,
+            defaultTimezone: resolvedTimezone,
+          });
+
+          if (cronResult.isErr()) {
+            return new Err(
+              new MCPError(
+                `Unable to understand the schedule "${schedule}". Please try rephrasing (e.g., "every weekday at 9am", "every Monday at 10am").`
+              )
+            );
+          }
+
+          scheduleUpdate = {
+            cron: cronResult.value.cron,
+            timezone: cronResult.value.timezone,
+            naturalLanguage: schedule,
+          };
+        }
+
+        const updateResult = await TriggerResource.updateFields(
+          auth,
+          triggerId,
+          {
+            name,
+            enabled,
+            schedule: scheduleUpdate,
+            customPrompt: prompt,
+          }
+        );
+
+        if (updateResult.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to update trigger: ${updateResult.error.message}`
+            )
+          );
+        }
+
+        getStatsDClient().increment("tools.trigger_management.updated", 1, [
+          `workspace_id:${workspaceSId}`,
+          `agent_id:${agentConfiguration.sId}`,
+        ]);
+
+        const changedFields = [
+          name !== undefined && "name",
+          schedule !== undefined && "schedule",
+          prompt !== undefined && "prompt",
+          enabled !== undefined && (enabled ? "enabled" : "disabled"),
+        ]
+          .filter(Boolean)
+          .join(", ");
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Updated trigger (changed: ${changedFields}).\n\n${renderTrigger(updateResult.value)}`,
+          },
+        ]);
+      }
+    )
+  );
+
+  server.tool(
+    "delete_trigger",
+    "Permanently delete a trigger. Use when user says 'remove this trigger', 'stop this automation', 'delete the scheduled task'. This action cannot be undone.",
+    {
+      triggerId: z
+        .string()
+        .describe("The trigger ID (get this from list_triggers)"),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: "trigger_management_delete",
+        agentLoopContext,
+      },
+      async ({ triggerId }) => {
+        const contextResult = getToolContext(auth, agentLoopContext);
+        if (contextResult.isErr()) {
+          return contextResult;
+        }
+        const { userId, workspaceSId, agentConfiguration } =
+          contextResult.value;
+
+        const triggerResult =
+          await TriggerResource.fetchByIdAndValidateOwnership(
+            auth,
+            triggerId,
+            agentConfiguration.sId,
+            userId
+          );
+        if (triggerResult.isErr()) {
+          return new Err(new MCPError(triggerResult.error.message));
+        }
+        const trigger = triggerResult.value;
+
+        const triggerName = trigger.name;
+        const result = await trigger.delete(auth);
+
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(`Failed to delete trigger: ${result.error.message}`)
+          );
+        }
+
+        getStatsDClient().increment("tools.trigger_management.deleted", 1, [
+          `workspace_id:${workspaceSId}`,
+          `agent_id:${agentConfiguration.sId}`,
+        ]);
+
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Deleted trigger "${triggerName}".`,
+          },
+        ]);
+      }
+    )
+  );
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/agent_triggers.test.ts
+++ b/front/lib/api/agent_triggers.test.ts
@@ -37,6 +37,7 @@ describe("getWebhookSourcesUsage", () => {
       enabled: true,
       configuration: { includePayload: true },
       webhookSourceViewId,
+      origin: "user",
     });
 
     const usage = await getWebhookSourcesUsage({ auth: authenticator });
@@ -74,6 +75,7 @@ describe("getWebhookSourcesUsage", () => {
       enabled: true,
       configuration: { includePayload: true },
       webhookSourceViewId,
+      origin: "user",
     });
 
     const usage = await getWebhookSourcesUsage({ auth: authenticator });
@@ -116,6 +118,7 @@ describe("getWebhookSourcesUsage", () => {
       enabled: true,
       configuration: { includePayload: true },
       webhookSourceViewId,
+      origin: "user",
     });
 
     await TriggerModel.create({
@@ -128,6 +131,7 @@ describe("getWebhookSourcesUsage", () => {
       enabled: true,
       configuration: { includePayload: true },
       webhookSourceViewId,
+      origin: "user",
     });
 
     const usage = await getWebhookSourcesUsage({ auth: authenticator });

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -206,6 +206,56 @@ export async function getJITServers(
     }
   }
 
+  // Add schedules_management MCP server if this is an onboarding conversation
+  const userResource = auth.user();
+  if (userResource) {
+    const onboardingMetadata = await userResource.getMetadata(
+      "onboarding:conversation"
+    );
+    if (onboardingMetadata?.value === conversation.sId) {
+      const schedulesManagementView =
+        await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+          auth,
+          "schedules_management"
+        );
+
+      // Only add if the view exists (workspace has schedules_management feature flag)
+      if (
+        schedulesManagementView &&
+        !agentMcpServerViewIds.includes(schedulesManagementView.sId)
+      ) {
+        const schedulesManagementViewJSON = schedulesManagementView.toJSON();
+        const schedulesManagementServer: ServerSideMCPServerConfigurationType =
+          {
+            id: -1,
+            sId: generateRandomModelSId(),
+            type: "mcp_server_configuration",
+            name:
+              schedulesManagementViewJSON.name ??
+              schedulesManagementViewJSON.server.name ??
+              "schedules_management",
+            description:
+              schedulesManagementViewJSON.description ??
+              schedulesManagementViewJSON.server.description ??
+              "Create schedules to automate recurring tasks.",
+            dataSources: null,
+            tables: null,
+            childAgentId: null,
+            reasoningModel: null,
+            timeFrame: null,
+            jsonSchema: null,
+            secretName: null,
+            additionalConfiguration: {},
+            mcpServerViewId: schedulesManagementViewJSON.sId,
+            dustAppConfiguration: null,
+            internalMCPServerId: schedulesManagementView.mcpServerId,
+          };
+
+        jitServers.push(schedulesManagementServer);
+      }
+    }
+  }
+
   if (attachments.length === 0) {
     return jitServers;
   }

--- a/front/lib/models/agent/triggers/triggers.ts
+++ b/front/lib/models/agent/triggers/triggers.ts
@@ -10,6 +10,7 @@ import type {
   TriggerConfigurationType,
   TriggerExecutionMode,
   TriggerKind,
+  TriggerOrigin,
 } from "@app/types/assistant/triggers";
 import { isValidTriggerKind } from "@app/types/assistant/triggers";
 
@@ -24,6 +25,7 @@ export class TriggerModel extends WorkspaceAwareModel<TriggerModel> {
   declare kind: TriggerKind;
   declare configuration: TriggerConfigurationType;
   declare naturalLanguageDescription: string | null;
+  declare origin: TriggerOrigin;
 
   /**
    * Webhooks specifics
@@ -81,6 +83,10 @@ TriggerModel.init(
     },
     configuration: {
       type: DataTypes.JSONB,
+      allowNull: false,
+    },
+    origin: {
+      type: DataTypes.STRING,
       allowNull: false,
     },
     webhookSourceViewId: {

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -49,6 +49,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1", // Every Monday at 9 AM
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(triggerResult.isOk()).toBe(true);
@@ -103,6 +104,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(triggerResult.isOk()).toBe(true);
@@ -153,6 +155,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(triggerResult.isOk()).toBe(true);
@@ -211,6 +214,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(triggerResult.isOk()).toBe(true);
@@ -275,6 +279,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(triggerResult.isOk()).toBe(true);
@@ -345,6 +350,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(triggerResult.isOk()).toBe(true);
@@ -403,6 +409,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(triggerResult.isOk()).toBe(true);
@@ -466,6 +473,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(triggerResult.isOk()).toBe(true);
@@ -535,6 +543,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(triggerResult.isOk()).toBe(true);
@@ -631,6 +640,7 @@ describe("TriggerResource", () => {
           cron: "0 9 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       const trigger2Result = await TriggerResource.makeNew(authenticator, {
@@ -646,6 +656,7 @@ describe("TriggerResource", () => {
           cron: "0 10 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       const trigger3Result = await TriggerResource.makeNew(authenticator, {
@@ -661,6 +672,7 @@ describe("TriggerResource", () => {
           cron: "0 11 * * 1",
           timezone: "UTC",
         },
+        origin: "user",
       });
 
       expect(trigger1Result.isOk()).toBe(true);
@@ -777,6 +789,7 @@ describe("TriggerResource", () => {
             cron: "0 9 * * 1",
             timezone: "UTC",
           },
+          origin: "user",
         }
       );
 
@@ -795,6 +808,7 @@ describe("TriggerResource", () => {
             cron: "0 10 * * 1",
             timezone: "UTC",
           },
+          origin: "user",
         }
       );
 
@@ -813,6 +827,7 @@ describe("TriggerResource", () => {
             cron: "0 11 * * 1",
             timezone: "UTC",
           },
+          origin: "user",
         }
       );
 

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -781,6 +781,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       enabled: this.enabled,
       naturalLanguageDescription: this.naturalLanguageDescription,
       createdAt: this.createdAt.getTime(),
+      origin: this.origin,
     };
 
     if (this.kind === "webhook") {

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -251,40 +251,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(trigger);
   }
 
-  static async updateFields(
-    auth: Authenticator,
-    triggerId: string,
-    updates: {
-      name?: string;
-      enabled?: boolean;
-      schedule?: { cron: string; timezone: string; naturalLanguage: string };
-      customPrompt?: string;
-    }
-  ): Promise<Result<TriggerResource, Error>> {
-    const updateBlob: Partial<
-      InferAttributes<TriggerModel, { omit: "workspaceId" }>
-    > = {};
-
-    if (updates.name !== undefined) {
-      updateBlob.name = updates.name;
-    }
-    if (updates.enabled !== undefined) {
-      updateBlob.enabled = updates.enabled;
-    }
-    if (updates.customPrompt !== undefined) {
-      updateBlob.customPrompt = updates.customPrompt;
-    }
-    if (updates.schedule) {
-      updateBlob.configuration = {
-        cron: updates.schedule.cron,
-        timezone: updates.schedule.timezone,
-      };
-      updateBlob.naturalLanguageDescription = updates.schedule.naturalLanguage;
-    }
-
-    return this.update(auth, triggerId, updateBlob);
-  }
-
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction | undefined } = {}

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -154,58 +154,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(triggers);
   }
 
-  static async listSchedulesByAgentAndEditor(
-    auth: Authenticator,
-    {
-      agentConfigurationId,
-      editorIds,
-    }: {
-      agentConfigurationId: string;
-      editorIds: ModelId[];
-    }
-  ): Promise<Result<TriggerResource[], Error>> {
-    if (editorIds.length === 0) {
-      return new Ok([]);
-    }
-    const triggers = await this.baseFetch(auth, {
-      where: {
-        agentConfigurationId,
-        editor: { [Op.in]: editorIds },
-        kind: "schedule",
-      },
-    });
-    return new Ok(triggers);
-  }
-
-  static async fetchScheduleByIdForEditor(
-    auth: Authenticator,
-    sId: string,
-    {
-      agentConfigurationId,
-      editorId,
-    }: {
-      agentConfigurationId: string;
-      editorId: ModelId;
-    }
-  ): Promise<Result<TriggerResource, Error>> {
-    const trigger = await this.fetchById(auth, sId);
-    if (!trigger) {
-      return new Err(new Error("Schedule not found"));
-    }
-    if (trigger.kind !== "schedule") {
-      return new Err(
-        new Error("This operation only supports schedule triggers")
-      );
-    }
-    if (trigger.agentConfigurationId !== agentConfigurationId) {
-      return new Err(new Error("This schedule does not belong to this agent"));
-    }
-    if (trigger.editor !== editorId) {
-      return new Err(new Error("You can only modify schedules you created"));
-    }
-    return new Ok(trigger);
-  }
-
   static listByWorkspace(auth: Authenticator) {
     return this.baseFetch(auth);
   }

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -251,25 +251,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(trigger);
   }
 
-  static async fetchByIdAndValidateOwnership(
-    auth: Authenticator,
-    triggerId: string,
-    agentConfigurationSId: string,
-    userId: number
-  ): Promise<Result<TriggerResource, Error>> {
-    const trigger = await this.fetchById(auth, triggerId);
-    if (!trigger) {
-      return new Err(new Error("Trigger not found"));
-    }
-    if (trigger.agentConfigurationId !== agentConfigurationSId) {
-      return new Err(new Error("This trigger does not belong to this agent"));
-    }
-    if (trigger.editor !== userId) {
-      return new Err(new Error("You can only modify triggers you created"));
-    }
-    return new Ok(trigger);
-  }
-
   static async updateFields(
     auth: Authenticator,
     triggerId: string,

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -154,6 +154,58 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(triggers);
   }
 
+  static async listSchedulesByAgentAndEditor(
+    auth: Authenticator,
+    {
+      agentConfigurationId,
+      editorIds,
+    }: {
+      agentConfigurationId: string;
+      editorIds: ModelId[];
+    }
+  ): Promise<Result<TriggerResource[], Error>> {
+    if (editorIds.length === 0) {
+      return new Ok([]);
+    }
+    const triggers = await this.baseFetch(auth, {
+      where: {
+        agentConfigurationId,
+        editor: { [Op.in]: editorIds },
+        kind: "schedule",
+      },
+    });
+    return new Ok(triggers);
+  }
+
+  static async fetchScheduleByIdForEditor(
+    auth: Authenticator,
+    sId: string,
+    {
+      agentConfigurationId,
+      editorId,
+    }: {
+      agentConfigurationId: string;
+      editorId: ModelId;
+    }
+  ): Promise<Result<TriggerResource, Error>> {
+    const trigger = await this.fetchById(auth, sId);
+    if (!trigger) {
+      return new Err(new Error("Schedule not found"));
+    }
+    if (trigger.kind !== "schedule") {
+      return new Err(
+        new Error("This operation only supports schedule triggers")
+      );
+    }
+    if (trigger.agentConfigurationId !== agentConfigurationId) {
+      return new Err(new Error("This schedule does not belong to this agent"));
+    }
+    if (trigger.editor !== editorId) {
+      return new Err(new Error("You can only modify schedules you created"));
+    }
+    return new Ok(trigger);
+  }
+
   static listByWorkspace(auth: Authenticator) {
     return this.baseFetch(auth);
   }

--- a/front/migrations/db/migration_449.sql
+++ b/front/migrations/db/migration_449.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "triggers" ADD COLUMN "origin" VARCHAR(255);
+UPDATE "triggers" SET "origin" = 'user' WHERE "origin" IS NULL;
+ALTER TABLE "triggers" ALTER COLUMN "origin" SET NOT NULL;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -345,6 +345,7 @@ async function handler(
           executionPerDayLimitOverride: executionPerDay,
           executionMode:
             validatedTrigger.kind === "webhook" ? "fair_use" : null,
+          origin: "user",
         });
 
         if (newTrigger.isErr()) {

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -42,6 +42,7 @@ export type TriggerType = {
   enabled: boolean;
   createdAt: number;
   naturalLanguageDescription: string | null;
+  origin: TriggerOrigin;
 } & TriggerConfiguration;
 
 export type TriggerKind = TriggerType["kind"];
@@ -51,6 +52,12 @@ export function isValidTriggerKind(kind: string): kind is TriggerKind {
 }
 
 export type TriggerExecutionMode = "fair_use" | "programmatic";
+
+export type TriggerOrigin = "user" | "agent";
+
+export function isValidTriggerOrigin(origin: string): origin is TriggerOrigin {
+  return ["user", "agent"].includes(origin);
+}
 
 export type WebhookTriggerType = TriggerType & {
   kind: "webhook";

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -234,6 +234,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Display similar skills when creating a new skill to avoid duplicates",
     stage: "dust_only",
   },
+  schedules_management: {
+    description:
+      "Access to schedule management tools for creating scheduled automations",
+    stage: "dust_only",
+  },
   universal_search: {
     description:
       "WIP - Search from Input bar search in Knowledge and MCP tools. ",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -234,6 +234,16 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Display similar skills when creating a new skill to avoid duplicates",
     stage: "dust_only",
   },
+  universal_search: {
+    description:
+      "WIP - Search from Input bar search in Knowledge and MCP tools. ",
+    stage: "dust_only",
+  },
+  triggers_management: {
+    description:
+      "Access to trigger management tools for creating scheduled automations",
+    stage: "dust_only",
+  },
   conversations_groups: {
     description: "Enable conversations groups in Spaces",
     stage: "dust_only",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -244,11 +244,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "WIP - Search from Input bar search in Knowledge and MCP tools. ",
     stage: "dust_only",
   },
-  triggers_management: {
-    description:
-      "Access to trigger management tools for creating scheduled automations",
-    stage: "dust_only",
-  },
   conversations_groups: {
     description: "Enable conversations groups in Spaces",
     stage: "dust_only",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -239,11 +239,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Access to schedule management tools for creating scheduled automations",
     stage: "dust_only",
   },
-  universal_search: {
-    description:
-      "WIP - Search from Input bar search in Knowledge and MCP tools. ",
-    stage: "dust_only",
-  },
   conversations_groups: {
     description: "Enable conversations groups in Spaces",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -691,7 +691,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_message_splitting"
   | "slideshow"
   | "schedules_management"
-  | "universal_search"
   | "usage_data_api"
   | "vanta_tool"
   | "web_summarization"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -690,7 +690,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_enhanced_default_agent"
   | "slack_message_splitting"
   | "slideshow"
-  | "triggers_management"
+  | "schedules_management"
   | "universal_search"
   | "usage_data_api"
   | "vanta_tool"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -690,6 +690,8 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_enhanced_default_agent"
   | "slack_message_splitting"
   | "slideshow"
+  | "triggers_management"
+  | "universal_search"
   | "usage_data_api"
   | "vanta_tool"
   | "web_summarization"


### PR DESCRIPTION
## Description

Add an auto_hide_builder mcp server to create/read/update/delete triggers for a given user x agent.
The goal is to empower agents with the ability to create triggers based on the conversation context.
A subsequent PR will update the onboarding prompt to skew the agent to offer a trigger setup, both as a way to increase touch point with new customers, but also to demo the trigger feature.

## Tests

Tested manually (CRUD operations)

## Risk

Level: Low
Blast Radius: Limited, behind a feature flag

## Deploy Plan

- [ ] Deploy front
- [ ] Enable the feature flag for dust