### PR TITLE
enh: upg gpt5 global to 5.2 and add dust-oai global

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -41,6 +41,7 @@ import {
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   GLOBAL_AGENTS_SID,
+  GPT_5_2_MODEL_CONFIG,
   isProviderWhitelisted,
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
@@ -631,6 +632,31 @@ export function _getDustQuickGlobalAgent(
     agentId: GLOBAL_AGENTS_SID.DUST_QUICK,
     name: "dust-quick",
     preferredModelConfiguration: GEMINI_3_PRO_MODEL_CONFIG,
+    preferredReasoningEffort: "light",
+  });
+}
+
+export function _getDustOaiGlobalAgent(
+  auth: Authenticator,
+  args: {
+    settings: GlobalAgentSettingsModel | null;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
+    agentRouterMCPServerView: MCPServerViewResource | null;
+    webSearchBrowseMCPServerView: MCPServerViewResource | null;
+    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
+    toolsetsMCPServerView: MCPServerViewResource | null;
+    deepDiveMCPServerView: MCPServerViewResource | null;
+    interactiveContentMCPServerView: MCPServerViewResource | null;
+    dataWarehousesMCPServerView: MCPServerViewResource | null;
+    agentMemoryMCPServerView: MCPServerViewResource | null;
+    memories: AgentMemoryResource[];
+    availableToolsets: MCPServerViewResource[];
+  }
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_OAI,
+    name: "dust-oai",
+    preferredModelConfiguration: GPT_5_2_MODEL_CONFIG,
     preferredReasoningEffort: "light",
   });
 }

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -18,8 +18,8 @@ import {
   GLOBAL_AGENTS_SID,
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_1_MODEL_CONFIG,
+  GPT_5_2_MODEL_CONFIG,
   GPT_5_MINI_MODEL_CONFIG,
-  GPT_5_MODEL_CONFIG,
   GPT_5_NANO_MODEL_CONFIG,
   MAX_STEPS_USE_PER_RUN_LIMIT,
   O1_MINI_MODEL_CONFIG,
@@ -187,8 +187,8 @@ export function _getGPT5GlobalAgent({
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: GPT_5_MODEL_CONFIG.providerId,
-      modelId: GPT_5_MODEL_CONFIG.modelId,
+      providerId: GPT_5_2_MODEL_CONFIG.providerId,
+      modelId: GPT_5_2_MODEL_CONFIG.modelId,
       temperature: 0.7,
       /**
        * WARNING: Because the default in ChatGPT is no reasoning, we do the same
@@ -259,10 +259,10 @@ export function _getGPT5ThinkingGlobalAgent({
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: GPT_5_MODEL_CONFIG.providerId,
-      modelId: GPT_5_MODEL_CONFIG.modelId,
+      providerId: GPT_5_2_MODEL_CONFIG.providerId,
+      modelId: GPT_5_2_MODEL_CONFIG.modelId,
       temperature: 0.7,
-      reasoningEffort: GPT_5_MODEL_CONFIG.defaultReasoningEffort,
+      reasoningEffort: GPT_5_2_MODEL_CONFIG.defaultReasoningEffort,
     },
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -272,6 +272,13 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
           "Same as dust but running Gemini 3 with minimal reasoning for faster responses.",
         pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
       };
+    case GLOBAL_AGENTS_SID.DUST_OAI:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_OAI,
+        name: "dust-oai",
+        description: "Same as dust but running OpenAI models.",
+        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+      };
     case GLOBAL_AGENTS_SID.DUST:
       return {
         sId: GLOBAL_AGENTS_SID.DUST,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -18,6 +18,7 @@ import {
 import {
   _getDustEdgeGlobalAgent,
   _getDustGlobalAgent,
+  _getDustOaiGlobalAgent,
   _getDustQuickGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import { _getNoopAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/noop";
@@ -380,6 +381,22 @@ function getGlobalAgent({
         availableToolsets,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_OAI:
+      agentConfiguration = _getDustOaiGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        agentRouterMCPServerView,
+        webSearchBrowseMCPServerView,
+        dataSourcesFileSystemMCPServerView,
+        toolsetsMCPServerView,
+        deepDiveMCPServerView,
+        interactiveContentMCPServerView,
+        dataWarehousesMCPServerView,
+        agentMemoryMCPServerView,
+        memories,
+        availableToolsets,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
       agentConfiguration = _getDeepDiveGlobalAgent(auth, {
         settings,
@@ -605,6 +622,11 @@ export async function getGlobalAgents(
       (sId) => sId !== GLOBAL_AGENTS_SID.DUST_QUICK
     );
   }
+  if (!flags.includes("dust_oai_global_agent")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.DUST_OAI
+    );
+  }
 
   let memories: AgentMemoryResource[] = [];
   if (
@@ -613,7 +635,8 @@ export async function getGlobalAgents(
     auth.user() &&
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK))
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK) ||
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_OAI))
   ) {
     memories = await AgentMemoryResource.findByAgentConfigurationIdAndUser(
       auth,
@@ -629,7 +652,8 @@ export async function getGlobalAgents(
     toolsetsMCPServerView &&
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK))
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK) ||
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_OAI))
   ) {
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
     availableToolsets = await MCPServerViewResource.listBySpace(

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -109,6 +109,7 @@ export enum GLOBAL_AGENTS_SID {
   DUST = "dust",
   DUST_EDGE = "dust-edge",
   DUST_QUICK = "dust-quick",
+  DUST_OAI = "dust-oai",
   DEEP_DIVE = "deep-dive",
   DUST_TASK = "dust-task",
   DUST_BROWSER_SUMMARY = "dust-browser-summary",
@@ -184,7 +185,6 @@ export function getGlobalAgentAuthorName(agentId: string): string {
 // Not exhaustive.
 const GLOBAL_AGENTS_SORT_ORDER: string[] = [
   GLOBAL_AGENTS_SID.DUST,
-  GLOBAL_AGENTS_SID.DUST_EDGE,
   GLOBAL_AGENTS_SID.DEEP_DIVE,
   GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET,
   GLOBAL_AGENTS_SID.GPT5,
@@ -193,6 +193,9 @@ const GLOBAL_AGENTS_SORT_ORDER: string[] = [
   GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU,
   GLOBAL_AGENTS_SID.GPT5_MINI,
   GLOBAL_AGENTS_SID.GPT4,
+  GLOBAL_AGENTS_SID.DUST_EDGE,
+  GLOBAL_AGENTS_SID.DUST_QUICK,
+  GLOBAL_AGENTS_SID.DUST_OAI,
 ];
 const globalAgentIndexMap = new Map(
   GLOBAL_AGENTS_SORT_ORDER.map((id, index) => [id, index])

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -18,6 +18,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Access to dust-quick global agent running Gemini 3 with minimal reasoning",
     stage: "dust_only",
   },
+  dust_oai_global_agent: {
+    description: "Access to dust-oai global agent running OpenAI models",
+    stage: "dust_only",
+  },
   notion_private_integration: {
     description: "Setup Notion private integration tokens",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -655,6 +655,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "discord_bot"
   | "dust_edge_global_agent"
   | "dust_quick_global_agent"
+  | "dust_oai_global_agent"
   | "fireworks_new_model_feature"
   | "freshservice_tool"
   | "front_tool"


### PR DESCRIPTION
## Description

Upgrades the 2 existing gpt-5 global agents to gpt 5.2, and add a gated dust-oai agent (will be used for benchmarks)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
