### PR TITLE
Change quotes color and hide copy button

### DIFF
--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -30,7 +30,7 @@ export const blockquoteVariants = cva(
 interface BlockquoteBlockProps {
   children: React.ReactNode;
   variant?: "surface";
-  buttonDisplay?: "inside" | "outside" | null;
+  buttonDisplay?: "inside" | "outside" | null; // null to hide buttons
 }
 
 export function BlockquoteBlock({

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -21,6 +21,7 @@ export const blockquoteVariants = cva(
       },
       buttonDisplay: {
         inside: ["s-pr-12"],
+        outside: [],
       },
     },
   }

--- a/sparkle/src/components/markdown/BlockquoteBlock.tsx
+++ b/sparkle/src/components/markdown/BlockquoteBlock.tsx
@@ -5,10 +5,10 @@ import { ContentBlockWrapper } from "@sparkle/components";
 
 export const blockquoteVariants = cva(
   [
-    "s-w-full s-text-base s-italic s-py-3 s-pl-3 s-pr-12",
+    "s-w-full s-text-base s-italic s-p-3",
     "s-relative",
     "before:s-content-[''] before:s-absolute before:s-left-0 before:s-top-3 before:s-bottom-3",
-    "before:s-w-1 before:s-bg-border-night dark:before:s-bg-border",
+    "before:s-w-1 before:s-bg-faint dark:before:s-bg-faint-night",
     "before:s-rounded-full",
   ],
   {
@@ -19,6 +19,9 @@ export const blockquoteVariants = cva(
           "s-bg-transparent",
         ],
       },
+      buttonDisplay: {
+        inside: ["s-pr-12"],
+      },
     },
   }
 );
@@ -26,11 +29,13 @@ export const blockquoteVariants = cva(
 interface BlockquoteBlockProps {
   children: React.ReactNode;
   variant?: "surface";
+  buttonDisplay?: "inside" | "outside" | null;
 }
 
 export function BlockquoteBlock({
   children,
   variant = "surface",
+  buttonDisplay = "inside",
 }: BlockquoteBlockProps) {
   const elementAt1 = React.Children.toArray(children)[1];
   const childrenContent =
@@ -52,9 +57,9 @@ export function BlockquoteBlock({
     <ContentBlockWrapper
       content={clipboardContent}
       className="s-my-2"
-      buttonDisplay="inside"
+      buttonDisplay={buttonDisplay}
     >
-      <blockquote className={blockquoteVariants({ variant })}>
+      <blockquote className={blockquoteVariants({ variant, buttonDisplay })}>
         {children}
       </blockquote>
     </ContentBlockWrapper>

--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -83,7 +83,7 @@ interface ContentBlockWrapperProps {
   getContentToDownload?: GetContentToDownloadFunction;
   actions?: React.ReactNode[] | React.ReactNode;
   displayActions?: "hover" | "always";
-  buttonDisplay?: "inside" | "outside";
+  buttonDisplay?: "inside" | "outside" | null;
 }
 
 export function ContentBlockWrapper({
@@ -152,32 +152,34 @@ export function ContentBlockWrapper({
       id="BlockWrapper"
       className={cn(wrapperVariants({ buttonDisplay }), className)}
     >
-      <div className={stickyContainerVariants({ buttonDisplay })}>
-        <div
-          id="BlockActions"
-          className={actionsVariants({ buttonDisplay, displayActions })}
-        >
-          {actions && actions}
-          {getContentToDownload && (
-            <Button
-              variant={"outline"}
-              size="xs"
-              icon={ArrowDownOnSquareIcon}
-              onClick={handleDownload}
-              tooltip="Download"
-            />
-          )}
-          {content && (
-            <Button
-              variant={"outline"}
-              size="xs"
-              icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
-              onClick={handleCopyToClipboard}
-              tooltip="Copy"
-            />
-          )}
+      {buttonDisplay !== null && (
+        <div className={stickyContainerVariants({ buttonDisplay })}>
+          <div
+            id="BlockActions"
+            className={actionsVariants({ buttonDisplay, displayActions })}
+          >
+            {actions && actions}
+            {getContentToDownload && (
+              <Button
+                variant={"outline"}
+                size="xs"
+                icon={ArrowDownOnSquareIcon}
+                onClick={handleDownload}
+                tooltip="Download"
+              />
+            )}
+            {content && (
+              <Button
+                variant={"outline"}
+                size="xs"
+                icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+                onClick={handleCopyToClipboard}
+                tooltip="Copy"
+              />
+            )}
+          </div>
         </div>
-      </div>
+      )}
       <div className={cn("s-z-0 s-w-full", innerClassName)}>{children}</div>
     </div>
   );

--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -83,7 +83,7 @@ interface ContentBlockWrapperProps {
   getContentToDownload?: GetContentToDownloadFunction;
   actions?: React.ReactNode[] | React.ReactNode;
   displayActions?: "hover" | "always";
-  buttonDisplay?: "inside" | "outside" | null;
+  buttonDisplay?: "inside" | "outside" | null; // null to hide buttons
 }
 
 export function ContentBlockWrapper({

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -66,6 +66,7 @@ export function Markdown({
   compactSpacing = false,
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
+  canCopyQuotes = true,
 }: {
   content: string;
   isStreaming?: boolean;
@@ -75,6 +76,7 @@ export function Markdown({
   forcedTextSize?: string;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
+  canCopyQuotes?: boolean;
 }) {
   const processedContent = useMemo(() => {
     let sanitized = sanitizeContent(content);
@@ -214,7 +216,11 @@ export function Markdown({
         </strong>
       ),
       input: Input,
-      blockquote: BlockquoteBlock,
+      blockquote: ({ children }) => (
+        <BlockquoteBlock buttonDisplay={canCopyQuotes ? "inside" : null}>
+          {children}
+        </BlockquoteBlock>
+      ),
       hr: () => (
         <div className="s-my-6 s-border-b s-border-primary-150 dark:s-border-primary-150-night" />
       ),


### PR DESCRIPTION
## Description

This PR:
- Hides the "copy to clipboard" button for quotes on a user message
- Uses the faint color on the border

<img width="842" height="308" alt="image" src="https://github.com/user-attachments/assets/966b6c58-7b49-4bd1-bd5a-c4a5e9031f2c" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Publish Sparkle
