### PR TITLE
[LLM Pricing] Update Gemini3 pro preview pricing

### DIFF
--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -177,8 +177,9 @@ const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
     output: 2.8,
   },
   // Conservative: pricing is 2/12 for first 200k tokens
+  // then 4/18 beyond that.
   "gemini-3-pro-preview": {
-    input: 4,
+    input: 2,
     output: 18,
   },
   "gemini-2.5-flash": {


### PR DESCRIPTION
## Description

**Context**
Gemini pro models pricing depends on token volume. For example, [Gemini3 pro preview](https://ai.google.dev/gemini-api/docs/pricing#gemini-3-pro-preview):
- I/O = $2.00/$12.00 for first 200k tokens
- I/O = $4.00/$18.00 for additional ones

This PR update Gemini3 pro preview price report:
- assuming that our input prompts are less than 200k tokens
- being conservative for output tokens and take the >200k token price

## Tests

no

## Risk

low - main risk is to report less than we are actually billed for if input tokens volume went > 200k tokens

## Deploy Plan

front
