### PR TITLE
[front] - feat(observabilty): cost chart

### DIFF
--- a/front/components/agent_builder/observability/charts/CostChart.tsx
+++ b/front/components/agent_builder/observability/charts/CostChart.tsx
@@ -1,0 +1,318 @@
+import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+import {
+  CHART_HEIGHT,
+  COST_PER_MESSAGE_LEGEND,
+  COST_PER_MESSAGE_PALETTE,
+  COST_TOTAL_LEGEND,
+  COST_TOTAL_PALETTE,
+} from "@app/components/agent_builder/observability/constants";
+import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
+import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
+import { legendFromConstant } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { formatTimeSeriesTitle } from "@app/components/agent_builder/observability/shared/tooltipHelpers";
+import { VersionMarkersDots } from "@app/components/agent_builder/observability/shared/VersionMarkers";
+import {
+  filterTimeSeriesByVersionWindow,
+  padSeriesToTimeRange,
+} from "@app/components/agent_builder/observability/utils";
+import type { AgentVersionMarker } from "@app/lib/api/assistant/observability/version_markers";
+import {
+  useAgentCostMetrics,
+  useAgentVersionMarkers,
+} from "@app/lib/swr/assistants";
+
+type CostChartView = "total" | "perMessage";
+
+type CostChartPoint = {
+  timestamp: number;
+  count: number;
+  totalCostUsd: number;
+  avgCostUsd: number;
+  p95CostUsd: number;
+  date?: string;
+};
+
+function microUsdToUsd(value: number): number {
+  return value / 1_000_000;
+}
+
+function zeroFactory(timestamp: number): CostChartPoint {
+  return {
+    timestamp,
+    count: 0,
+    totalCostUsd: 0,
+    avgCostUsd: 0,
+    p95CostUsd: 0,
+  };
+}
+
+function formatUsd(value: number): string {
+  if (!Number.isFinite(value) || value === 0) {
+    return "$0";
+  }
+  if (Math.abs(value) >= 100) {
+    return `$${value.toFixed(0)}`;
+  }
+  if (Math.abs(value) >= 1) {
+    return `$${value.toFixed(2)}`;
+  }
+  if (Math.abs(value) >= 0.01) {
+    return `$${value.toFixed(2)}`;
+  }
+  return `$${value.toFixed(4)}`;
+}
+
+function isCostChartPoint(data: unknown): data is CostChartPoint {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  return (
+    "totalCostUsd" in data &&
+    "avgCostUsd" in data &&
+    "p95CostUsd" in data &&
+    "timestamp" in data
+  );
+}
+
+function CostMetricsTooltip(
+  props: TooltipContentProps<number, string> & {
+    view: CostChartView;
+    versionMarkers: AgentVersionMarker[];
+  }
+) {
+  const { active, payload, versionMarkers, view } = props;
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const first = payload[0];
+  if (!first?.payload || !isCostChartPoint(first.payload)) {
+    return null;
+  }
+
+  const row = first.payload;
+
+  const rows =
+    view === "total"
+      ? [
+          {
+            label: "Daily total",
+            value: formatUsd(row.totalCostUsd),
+            colorClassName: COST_TOTAL_PALETTE.total,
+          },
+        ]
+      : [
+          {
+            label: "Average cost",
+            value: formatUsd(row.avgCostUsd),
+            colorClassName: COST_PER_MESSAGE_PALETTE.average,
+          },
+          {
+            label: "p95 cost",
+            value: formatUsd(row.p95CostUsd),
+            colorClassName: COST_PER_MESSAGE_PALETTE.p95,
+          },
+        ];
+
+  return (
+    <ChartTooltipCard
+      title={formatTimeSeriesTitle(row.date, row.timestamp, versionMarkers)}
+      rows={rows}
+    />
+  );
+}
+
+export function CostChart({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}) {
+  const { period, mode, selectedVersion } = useObservabilityContext();
+  const [view, setView] = useState<CostChartView>("total");
+
+  const { costMetrics, isCostMetricsLoading, isCostMetricsError } =
+    useAgentCostMetrics({
+      workspaceId,
+      agentConfigurationId,
+      days: period,
+      disabled: !workspaceId || !agentConfigurationId,
+    });
+  const { versionMarkers } = useAgentVersionMarkers({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    disabled: !workspaceId || !agentConfigurationId,
+  });
+
+  const filteredData = filterTimeSeriesByVersionWindow(
+    costMetrics,
+    mode,
+    selectedVersion,
+    versionMarkers
+  );
+
+  const data = useMemo(() => {
+    const normalized = filteredData.map((point) => ({
+      timestamp: point.timestamp,
+      count: point.count,
+      totalCostUsd: microUsdToUsd(point.costMicroUsd),
+      avgCostUsd: microUsdToUsd(point.avgCostMicroUsd),
+      p95CostUsd: microUsdToUsd(point.p95CostMicroUsd),
+    }));
+
+    return padSeriesToTimeRange(normalized, mode, period, zeroFactory);
+  }, [filteredData, mode, period]);
+
+  const includeVersionMarker =
+    mode === "timeRange" && versionMarkers.length > 0;
+
+  const legendItems = useMemo(() => {
+    return view === "total"
+      ? legendFromConstant(COST_TOTAL_LEGEND, COST_TOTAL_PALETTE, {
+          includeVersionMarker,
+        })
+      : legendFromConstant(COST_PER_MESSAGE_LEGEND, COST_PER_MESSAGE_PALETTE, {
+          includeVersionMarker,
+        });
+  }, [view, includeVersionMarker]);
+
+  const emptyMessage =
+    costMetrics.length === 0
+      ? "No cost data available for this selection."
+      : undefined;
+
+  return (
+    <ChartContainer
+      title="Cost"
+      description="Daily spend across all messages, plus average and p95 cost per message."
+      isLoading={isCostMetricsLoading}
+      errorMessage={
+        isCostMetricsError ? "Failed to load cost data." : undefined
+      }
+      emptyMessage={emptyMessage}
+      additionalControls={
+        <ButtonsSwitchList defaultValue={view} size="xs">
+          <ButtonsSwitch
+            value="total"
+            label="Total cost"
+            onClick={() => setView("total")}
+          />
+          <ButtonsSwitch
+            value="perMessage"
+            label="Per message"
+            onClick={() => setView("perMessage")}
+          />
+        </ButtonsSwitchList>
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+    >
+      <LineChart
+        data={data}
+        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+      >
+        <defs>
+          <linearGradient
+            id="fillTotalCost"
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="1"
+            className={COST_TOTAL_PALETTE.total}
+          >
+            <stop offset="5%" stopColor="currentColor" stopOpacity={0.8} />
+            <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid
+          vertical={false}
+          className="stroke-border dark:stroke-border-night"
+        />
+        <XAxis
+          dataKey="date"
+          type="category"
+          scale="point"
+          allowDuplicatedCategory={false}
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={16}
+        />
+        <YAxis
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          type="number"
+          domain={[0, "auto"]}
+          tickFormatter={formatUsd}
+          allowDecimals={true}
+        />
+        <Tooltip
+          content={(props: TooltipContentProps<number, string>) => (
+            <CostMetricsTooltip
+              {...props}
+              view={view}
+              versionMarkers={versionMarkers}
+            />
+          )}
+          cursor={false}
+          wrapperStyle={{ outline: "none" }}
+          contentStyle={{
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            boxShadow: "none",
+          }}
+        />
+        <Line
+          type="monotone"
+          dataKey="totalCostUsd"
+          name="Total cost"
+          className={COST_TOTAL_PALETTE.total}
+          fill="url(#fillTotalCost)"
+          stroke="currentColor"
+          strokeWidth={2}
+          dot={false}
+          hide={view !== "total"}
+        />
+        <Line
+          type="monotone"
+          dataKey="avgCostUsd"
+          name="Average cost"
+          className={COST_PER_MESSAGE_PALETTE.average}
+          stroke="currentColor"
+          strokeWidth={2}
+          dot={false}
+          hide={view !== "perMessage"}
+        />
+        <Line
+          type="monotone"
+          dataKey="p95CostUsd"
+          name="p95 cost"
+          className={COST_PER_MESSAGE_PALETTE.p95}
+          stroke="currentColor"
+          strokeWidth={2}
+          dot={false}
+          hide={view !== "perMessage"}
+        />
+        <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
+      </LineChart>
+    </ChartContainer>
+  );
+}

--- a/front/components/agent_builder/observability/charts/CostChart.tsx
+++ b/front/components/agent_builder/observability/charts/CostChart.tsx
@@ -124,13 +124,15 @@ function CostMetricsTooltip(
   );
 }
 
+interface CostChartProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+}
+
 export function CostChart({
   workspaceId,
   agentConfigurationId,
-}: {
-  workspaceId: string;
-  agentConfigurationId: string;
-}) {
+}: CostChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
   const [view, setView] = useState<CostChartView>("total");
 

--- a/front/components/agent_builder/observability/charts/CostChart.tsx
+++ b/front/components/agent_builder/observability/charts/CostChart.tsx
@@ -284,7 +284,7 @@ export function CostChart({
         <Line
           type="monotone"
           dataKey="avgCostUsd"
-          name="Average cost"
+          name="Average"
           className={COST_PER_MESSAGE_PALETTE.average}
           stroke="currentColor"
           strokeWidth={2}
@@ -294,7 +294,7 @@ export function CostChart({
         <Line
           type="monotone"
           dataKey="p95CostUsd"
-          name="p95 cost"
+          name="Percentile 95"
           className={COST_PER_MESSAGE_PALETTE.p95}
           stroke="currentColor"
           strokeWidth={2}

--- a/front/components/agent_builder/observability/charts/CostChart.tsx
+++ b/front/components/agent_builder/observability/charts/CostChart.tsx
@@ -58,22 +58,6 @@ function zeroFactory(timestamp: number): CostChartPoint {
   };
 }
 
-function formatUsd(value: number): string {
-  if (!Number.isFinite(value) || value === 0) {
-    return "$0";
-  }
-  if (Math.abs(value) >= 100) {
-    return `$${value.toFixed(0)}`;
-  }
-  if (Math.abs(value) >= 1) {
-    return `$${value.toFixed(2)}`;
-  }
-  if (Math.abs(value) >= 0.01) {
-    return `$${value.toFixed(2)}`;
-  }
-  return `$${value.toFixed(4)}`;
-}
-
 function isCostChartPoint(data: unknown): data is CostChartPoint {
   if (typeof data !== "object" || data === null) {
     return false;
@@ -85,6 +69,12 @@ function isCostChartPoint(data: unknown): data is CostChartPoint {
     "timestamp" in data
   );
 }
+
+const USD_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 4,
+});
 
 function CostMetricsTooltip(
   props: TooltipContentProps<number, string> & {
@@ -109,19 +99,19 @@ function CostMetricsTooltip(
       ? [
           {
             label: "Daily total",
-            value: formatUsd(row.totalCostUsd),
+            value: USD_FORMATTER.format(row.totalCostUsd),
             colorClassName: COST_TOTAL_PALETTE.total,
           },
         ]
       : [
           {
-            label: "Average cost",
-            value: formatUsd(row.avgCostUsd),
+            label: "Average",
+            value: USD_FORMATTER.format(row.avgCostUsd),
             colorClassName: COST_PER_MESSAGE_PALETTE.average,
           },
           {
-            label: "p95 cost",
-            value: formatUsd(row.p95CostUsd),
+            label: "Percentile 95",
+            value: USD_FORMATTER.format(row.p95CostUsd),
             colorClassName: COST_PER_MESSAGE_PALETTE.p95,
           },
         ];
@@ -260,7 +250,7 @@ export function CostChart({
           tickMargin={8}
           type="number"
           domain={[0, "auto"]}
-          tickFormatter={formatUsd}
+          tickFormatter={(value) => USD_FORMATTER.format(value ?? 0)}
           allowDecimals={true}
         />
         <Tooltip

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -33,6 +33,24 @@ export const COST_PALETTE = {
   totalCredits: "text-orange-400 dark:text-orange-400-night",
 } as const;
 
+export const COST_TOTAL_PALETTE = {
+  total: "text-blue-400 dark:text-blue-400-night",
+} as const;
+
+export const COST_TOTAL_LEGEND = [
+  { key: "total", label: "Daily total" },
+] as const;
+
+export const COST_PER_MESSAGE_PALETTE = {
+  average: "text-violet-300 dark:text-violet-300-night",
+  p95: "text-rose-300 dark:text-rose-300-night",
+} as const;
+
+export const COST_PER_MESSAGE_LEGEND = [
+  { key: "average", label: "Average cost" },
+  { key: "p95", label: "p95 cost" },
+] as const;
+
 export const CHART_HEIGHT = 260;
 
 export const INDEXED_COLORS = [

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -47,8 +47,8 @@ export const COST_PER_MESSAGE_PALETTE = {
 } as const;
 
 export const COST_PER_MESSAGE_LEGEND = [
-  { key: "average", label: "Average cost" },
-  { key: "p95", label: "p95 cost" },
+  { key: "average", label: "Average" },
+  { key: "p95", label: "Percentile 95" },
 ] as const;
 
 export const CHART_HEIGHT = 260;

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -10,6 +10,7 @@ import {
   ValueCard,
 } from "@dust-tt/sparkle";
 
+import { CostChart } from "@app/components/agent_builder/observability/charts/CostChart";
 import { LatencyChart } from "@app/components/agent_builder/observability/charts/LatencyChart";
 import { SourceChart } from "@app/components/agent_builder/observability/charts/SourceChart";
 import { ToolUsageChart } from "@app/components/agent_builder/observability/charts/ToolUsageChart";
@@ -181,6 +182,11 @@ export function AgentObservability({
 
       <TabContentChildSectionLayout title="Details">
         <UsageMetricsChart
+          workspaceId={workspaceId}
+          agentConfigurationId={agentConfigurationId}
+        />
+        <Separator />
+        <CostChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
         />

--- a/front/lib/api/assistant/observability/messages_metrics.ts
+++ b/front/lib/api/assistant/observability/messages_metrics.ts
@@ -21,6 +21,8 @@ type Metrics = {
   conversations: number;
   activeUsers: number;
   costMicroUsd: number;
+  avgCostMicroUsd: number;
+  p95CostMicroUsd: number;
   avgLatencyMs: number;
   percentilesLatencyMs: number;
   failedMessages: number;
@@ -48,6 +50,8 @@ export type MetricsBucket = {
   unique_conversations?: estypes.AggregationsCardinalityAggregate;
   active_users?: estypes.AggregationsCardinalityAggregate;
   cost_micro_usd?: estypes.AggregationsSumAggregate;
+  avg_cost_micro_usd?: estypes.AggregationsAverageAggregate;
+  percentiles_cost_micro_usd?: KeyedTDigestPercentiles;
   avg_latency_ms?: estypes.AggregationsCardinalityAggregate;
   percentiles_latency_ms?: KeyedTDigestPercentiles;
   failed_messages?: estypes.AggregationsFilterAggregate;
@@ -82,6 +86,22 @@ export function buildMetricAggregates<K extends readonly MetricName[]>(
 
   if (metrics.includes("costMicroUsd")) {
     aggregates.cost_micro_usd = { sum: { field: "tokens.cost_micro_usd" } };
+  }
+
+  if (metrics.includes("avgCostMicroUsd")) {
+    aggregates.avg_cost_micro_usd = {
+      avg: { field: "tokens.cost_micro_usd" },
+    };
+  }
+
+  if (metrics.includes("p95CostMicroUsd")) {
+    aggregates.percentiles_cost_micro_usd = {
+      percentiles: {
+        field: "tokens.cost_micro_usd",
+        percents: [95],
+        keyed: true,
+      },
+    };
   }
 
   if (metrics.includes("avgLatencyMs")) {
@@ -134,6 +154,19 @@ export function parseMetricsFromBucket<K extends readonly MetricName[]>(
   if (metrics.includes("costMicroUsd")) {
     point.costMicroUsd = Math.round(
       bucket.cost_micro_usd?.value ?? DEFAULT_METRIC_VALUE
+    );
+  }
+
+  if (metrics.includes("avgCostMicroUsd")) {
+    point.avgCostMicroUsd = Math.round(
+      bucket.avg_cost_micro_usd?.value ?? DEFAULT_METRIC_VALUE
+    );
+  }
+
+  if (metrics.includes("p95CostMicroUsd")) {
+    point.p95CostMicroUsd = Math.round(
+      bucket.percentiles_cost_micro_usd?.values?.["95.0"] ??
+        DEFAULT_METRIC_VALUE
     );
   }
 

--- a/front/lib/api/assistant/observability/messages_metrics.ts
+++ b/front/lib/api/assistant/observability/messages_metrics.ts
@@ -50,7 +50,7 @@ export type MetricsBucket = {
   unique_conversations?: estypes.AggregationsCardinalityAggregate;
   active_users?: estypes.AggregationsCardinalityAggregate;
   cost_micro_usd?: estypes.AggregationsSumAggregate;
-  avg_cost_micro_usd?: estypes.AggregationsAverageAggregate;
+  avg_cost_micro_usd?: estypes.AggregationsAvgAggregate;
   percentiles_cost_micro_usd?: KeyedTDigestPercentiles;
   avg_latency_ms?: estypes.AggregationsCardinalityAggregate;
   percentiles_latency_ms?: KeyedTDigestPercentiles;

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -20,6 +20,7 @@ import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentMcpConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations";
+import type { GetCostMetricsResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/cost";
 import type { GetErrorRateResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate";
 import type { GetFeedbackDistributionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution";
 import type { GetLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency";
@@ -872,6 +873,33 @@ export function useAgentUsageMetrics({
     isUsageMetricsLoading: !error && !data && !disabled,
     isUsageMetricsError: error,
     isUsageMetricsValidating: isValidating,
+  };
+}
+
+export function useAgentCostMetrics({
+  workspaceId,
+  agentConfigurationId,
+  days = DEFAULT_PERIOD_DAYS,
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetCostMetricsResponse> = fetcher;
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/cost?days=${days}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    costMetrics: data?.points ?? emptyArray(),
+    isCostMetricsLoading: !error && !data && !disabled,
+    isCostMetricsError: error,
+    isCostMetricsValidating: isValidating,
   };
 }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/cost.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/cost.ts
@@ -1,0 +1,126 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { MessageMetricsPoint } from "@app/lib/api/assistant/observability/messages_metrics";
+import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional(),
+  version: z.string().optional(),
+});
+
+export type GetCostMetricsResponse = {
+  points: Pick<
+    MessageMetricsPoint,
+    | "timestamp"
+    | "count"
+    | "costMicroUsd"
+    | "avgCostMicroUsd"
+    | "p95CostMicroUsd"
+  >[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetCostMetricsResponse>>,
+  auth: Authenticator
+) {
+  if (typeof req.query.aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent configuration ID.",
+      },
+    });
+  }
+
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: req.query.aId,
+    variant: "light",
+  });
+
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  if (!assistant.canEdit && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only editors can get agent observability.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        agentId: assistant.sId,
+        days,
+        version: q.data.version,
+      });
+
+      const costMetricsResult = await fetchMessageMetrics(baseQuery, "day", [
+        "costMicroUsd",
+        "avgCostMicroUsd",
+        "p95CostMicroUsd",
+      ] as const);
+
+      if (costMetricsResult.isErr()) {
+        const e = costMetricsResult.error;
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve cost metrics: ${e.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        points: costMetricsResult.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Adds a cost chart to the agent observability page showing cost metrics over time. The chart displays daily total spend, average cost per message, and p95 cost per message with a toggle to switch between "Total cost" and "Per message" views. A new "Avg message cost" value card is added to the summary section.

## Risk

Low

## Tests

- [x] Locally
- [x] front-edge

## Deploy plan

Deploy front
