### PR TITLE
[front] Lower Sequelize pool acquire timeout to 30s

### DIFF
--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -43,6 +43,7 @@ export const frontSequelize = new SequelizeWithComments(
       // Default is 5.
       // TODO(2025-11-29 flav) Revisit all Sequelize pool settings.
       max: 25,
+      acquire: 30000,
     },
     logging: isDevelopment() && DB_LOGGING_ENABLED ? sequelizeLogger : false,
     hooks: {


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/5055

Lowers the Sequelize connection pool acquire timeout from the default 60s to 30s.

**Context:** We observed heartbeat timeouts on `runToolActivity` where the activity never reached `action.updateStatus("running")`. Investigation showed that `getAgentLoopData()` (which fetches the full conversation with all actions/outputs) could be blocked waiting for a DB connection when the pool is exhausted.

The default Sequelize acquire timeout (60s) matches the Temporal heartbeat timeout (60s), creating a race condition where:
1. Activity waits for DB connection
2. Temporal heartbeat timeout fires at 60s
3. Activity is marked as failed/retried before the explicit Sequelize timeout error

By lowering acquire timeout to 30s, pool exhaustion will manifest as explicit `ConnectionAcquireTimeoutError` rather than mysterious heartbeat timeouts, making the issue easier to diagnose and debug.

We'll also try to optimize getConversation fetching

## Risks

Blast radius: All front services using the main database connection pool
Risk: low (fail-fast behavior, no functional change - just earlier explicit failure)

## Deploy Plan

- deploy front