### PR TITLE
[Front] feat(manage-skills): hide edit/archive if user cannot write skill

### DIFF
--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -79,7 +79,7 @@ export function SkillDetailsSheetContent({
 }: SkillDetailsSheetContentProps) {
   const [selectedTab, setSelectedTab] = useState<"info" | "editors">("info");
 
-  const showEditorsTabs = !skillConfiguration.isGlobal;
+  const showEditorsTabs = skillConfiguration.canWrite;
 
   if (showEditorsTabs) {
     return (

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -13,13 +13,13 @@ export function SkillInfoTab({
       <div className="text-sm text-foreground dark:text-foreground-night">
         {skillConfiguration.description}
       </div>
-      {!skillConfiguration.isGlobal && (
+      {skillConfiguration.canWrite && (
         <SkillEdited skillConfiguration={skillConfiguration} />
       )}
 
       <Page.Separator />
 
-      {!skillConfiguration.isGlobal &&
+      {skillConfiguration.canWrite &&
         (skillConfiguration.instructions ? (
           <div className="dd-privacy-mask flex flex-col gap-5">
             <div className="heading-lg text-foreground dark:text-foreground-night">

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -158,6 +158,7 @@ export function SkillsTable({
                 {
                   label: "Edit",
                   icon: PencilSquareIcon,
+                  disabled: !skill.canWrite,
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
                     void router.push(
@@ -178,6 +179,7 @@ export function SkillsTable({
                 {
                   label: "Archive",
                   icon: TrashIcon,
+                  disabled: !skill.canWrite,
                   variant: "warning" as const,
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
@@ -185,7 +187,7 @@ export function SkillsTable({
                   },
                   kind: "item" as const,
                 },
-              ]
+              ].filter((item) => !item.disabled)
             : [],
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -694,7 +694,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  toJSON(): SkillConfigurationType {
+  toJSON(auth: Authenticator): SkillConfigurationType {
     const tools = this.mcpServerConfigurations.map((config) => ({
       mcpServerViewId: makeSId("mcp_server_view", {
         id: config.mcpServerViewId,
@@ -714,7 +714,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       instructions: this.instructions,
       requestedSpaceIds: this.requestedSpaceIds,
       tools,
-      isGlobal: this.isGlobal,
+      canWrite: this.canWrite(auth),
     };
   }
 }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -72,7 +72,7 @@ async function handler(
       );
 
       return res.status(200).json({
-        skills: skills.map((s) => s.toJSON()),
+        skills: skills.map((s) => s.toJSON(auth)),
       });
     }
 

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -110,7 +110,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const skillConfiguration = skillResource.toJSON();
+      const skillConfiguration = skillResource.toJSON(auth);
       return res.status(200).json({ skillConfiguration });
     }
 
@@ -231,7 +231,7 @@ async function handler(
 
       return res.status(200).json({
         skillConfiguration: {
-          ...result.value.updatedSkill.toJSON(),
+          ...result.value.updatedSkill.toJSON(auth),
           tools: result.value.createdTools,
         },
       });

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -111,7 +111,7 @@ async function handler(
         const skillConfigurationsWithRelations = await concurrentExecutor(
           skillConfigurations,
           async (sc) => ({
-            ...sc.toJSON(),
+            ...sc.toJSON(auth),
             usage: await sc.fetchUsage(auth),
             editors: await sc.listEditors(auth),
           }),
@@ -124,7 +124,7 @@ async function handler(
       }
 
       return res.status(200).json({
-        skillConfigurations: skillConfigurations.map((sc) => sc.toJSON()),
+        skillConfigurations: skillConfigurations.map((sc) => sc.toJSON(auth)),
       });
     }
 
@@ -206,7 +206,7 @@ async function handler(
 
       return res.status(200).json({
         skillConfiguration: {
-          ...skillResource.toJSON(),
+          ...skillResource.toJSON(auth),
           tools: body.tools,
         },
       });

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -54,7 +54,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   return {
     props: {
-      skillConfiguration: skillResource.toJSON(),
+      skillConfiguration: skillResource.toJSON(auth),
       owner,
       subscription,
       user: auth.getNonNullableUser().toJSON(),

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -16,7 +16,7 @@ export type SkillConfigurationType = {
   instructions: string;
   requestedSpaceIds: ModelId[];
   tools: { mcpServerViewId: string }[];
-  isGlobal: boolean;
+  canWrite: boolean;
 };
 
 export type SkillConfigurationRelations = {


### PR DESCRIPTION


## Description

Similar to agent configurations, we don't want to display edit/archive actions to users that are not allowed to
Replaced isGlobal field with canWrite on client side skill configuration type as it hides custom/global abstraction already (should only be managed in skill resource) 

## Tests

Local

## Risk

Low

## Deploy Plan

Front