### PR TITLE
[front] - fix: update CostChart description

### DIFF
--- a/front/components/agent_builder/observability/charts/CostChart.tsx
+++ b/front/components/agent_builder/observability/charts/CostChart.tsx
@@ -190,7 +190,7 @@ export function CostChart({
   return (
     <ChartContainer
       title="Cost"
-      description="Daily spend across all messages, plus average and p95 cost per message."
+      description="Daily spend across all messages."
       isLoading={isCostMetricsLoading}
       errorMessage={
         isCostMetricsError ? "Failed to load cost data." : undefined


### PR DESCRIPTION
 
## Description

Simplified the description of the CostChart component by removing details about average and p95 costs per message
