### PR TITLE
feat: save input bar content in local storage

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -27,6 +27,7 @@ import {
 import { useRouter } from "next/router";
 import { useMemo } from "react";
 
+import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { WorkspacePickerRadioGroup } from "@app/components/WorkspacePicker";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePrivacyMask } from "@app/hooks/usePrivacyMask";
@@ -59,6 +60,11 @@ export function UserMenu({
 
   const sendNotification = useSendNotification();
   const privacyMask = usePrivacyMask();
+  const { clearAllDraftsFromUser } = useConversationDrafts({
+    workspaceId: owner.sId,
+    userId: user.sId,
+    conversationId: null,
+  });
 
   const forceRoleUpdate = useMemo(
     () => async (role: "user" | "builder" | "admin") => {
@@ -191,6 +197,9 @@ export function UserMenu({
           label="Sign&nbsp;out"
           icon={LogoutIcon}
           onClick={() => {
+            // Clear all conversation drafts for this user.
+            clearAllDraftsFromUser();
+
             datadogLogs.clearUser();
             window.DD_RUM.onReady(() => {
               window.DD_RUM.clearUser();

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -114,6 +114,7 @@ function PreviewContent({
             <InputBar
               isSubmitting={isSavingDraftAgent}
               owner={owner}
+              user={user}
               onSubmit={createConversation}
               stickyMentions={
                 draftAgent ? [toRichAgentMentionType(draftAgent)] : []

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -228,6 +228,7 @@ export const AgentInputBar = ({
       )}
       <InputBar
         owner={context.owner}
+        user={context.user}
         onSubmit={context.handleSubmit}
         stickyMentions={autoMentions}
         conversationId={context.conversationId}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -167,6 +167,7 @@ export function ConversationContainerVirtuoso({
           >
             <InputBar
               owner={owner}
+              user={user}
               onSubmit={handleConversationCreation}
               conversationId={null}
               disableAutoFocus={false}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -8,6 +8,7 @@ import InputBarContainer, {
   INPUT_BAR_ACTIONS,
 } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { DustError } from "@app/lib/error";
@@ -28,6 +29,7 @@ import type {
   DataSourceViewContentNode,
   Result,
   RichMention,
+  UserType,
   WorkspaceType,
 } from "@app/types";
 import { compareAgentsForSort, isEqualNode, isGlobalAgentId } from "@app/types";
@@ -36,6 +38,7 @@ const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
 interface InputBarProps {
   owner: WorkspaceType;
+  user: UserType | null;
   onSubmit: (
     input: string,
     mentions: RichMention[],
@@ -54,6 +57,7 @@ interface InputBarProps {
 
 export const InputBar = React.memo(function InputBar({
   owner,
+  user,
   onSubmit,
   conversationId,
   stickyMentions,
@@ -83,6 +87,12 @@ export const InputBar = React.memo(function InputBar({
   });
 
   const { droppedFiles, setDroppedFiles } = useFileDrop();
+
+  const { saveDraft, getDraft, clearDraft } = useConversationDrafts({
+    workspaceId: owner.sId,
+    userId: user?.sId ?? null,
+    conversationId,
+  });
 
   useEffect(() => {
     if (droppedFiles.length > 0) {
@@ -245,6 +255,7 @@ export const InputBar = React.memo(function InputBar({
       setIsLocalSubmitting(false);
       if (r.isOk()) {
         resetEditorText();
+        clearDraft();
         fileUploaderService.resetUpload();
       }
     } else {
@@ -260,6 +271,7 @@ export const InputBar = React.memo(function InputBar({
       });
 
       resetEditorText();
+      clearDraft();
       fileUploaderService.resetUpload();
       setAttachedNodes([]);
     }
@@ -338,6 +350,8 @@ export const InputBar = React.memo(function InputBar({
             onMCPServerViewSelect={handleMCPServerViewSelect}
             onMCPServerViewDeselect={handleMCPServerViewDeselect}
             attachedNodes={attachedNodes}
+            saveDraft={saveDraft}
+            getDraft={getDraft}
           />
         </div>
       </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -82,6 +82,8 @@ export interface InputBarContainerProps {
   onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
   onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
   selectedMCPServerViews: MCPServerViewType[];
+  saveDraft: (markdown: string) => void;
+  getDraft: () => { text: string } | null;
 }
 
 const InputBarContainer = ({
@@ -102,6 +104,8 @@ const InputBarContainer = ({
   onMCPServerViewSelect,
   onMCPServerViewDeselect,
   selectedMCPServerViews,
+  saveDraft,
+  getDraft,
 }: InputBarContainerProps) => {
   const isMobile = useIsMobile();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
@@ -375,6 +379,10 @@ const InputBarContainer = ({
   useEffect(() => {
     const handleUpdate = () => {
       setIsEmpty(editorService.isEmpty());
+
+      // Auto-save draft when content changes.
+      const { markdown } = editorService.getMarkdownAndMentions();
+      saveDraft(markdown);
     };
 
     if (editorRef.current) {
@@ -391,7 +399,7 @@ const InputBarContainer = ({
         editor.off("update", handleUpdate);
       }
     };
-  }, [editor, editorService]);
+  }, [editor, editorService, saveDraft]);
 
   const disableTextInput = isSubmitting || disableInput;
 
@@ -427,8 +435,7 @@ const InputBarContainer = ({
         }
       : {
           // TextSearchParams
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          search: nodeOrUrlCandidate?.url || "",
+          search: nodeOrUrlCandidate?.url ?? "",
           searchSourceUrls: true,
           includeDataSources: false,
           owner,
@@ -506,6 +513,19 @@ const InputBarContainer = ({
       queueMicrotask(() => editorService.focusEnd());
     }
   }, [animate, editorService]);
+
+  // Restore draft when switching conversations (including new conversations).
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const draft = getDraft();
+    // Only restore draft if editor is empty to avoid overwriting existing content or sticky mentions.
+    if (draft && editorService.isEmpty()) {
+      editorService.setContent(draft.text);
+    }
+  }, [conversationId, editor, editorService, getDraft]);
 
   useHandleMentions(
     editorService,

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -1,0 +1,169 @@
+import debounce from "lodash/debounce";
+import { useCallback, useRef } from "react";
+
+import logger from "@app/logger/logger";
+
+interface ConversationDraft {
+  text: string;
+  timestamp: number;
+}
+
+type KeyId = string;
+
+const getKeyId = (
+  workspaceId: string,
+  userId: string,
+  conversationId: string
+) => `${userId}::${workspaceId}::${conversationId}` satisfies KeyId;
+
+interface DraftStorage {
+  [keyId: KeyId]: ConversationDraft;
+}
+
+const STORAGE_KEY = "conversation-drafts";
+const DRAFT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Hook to manage per-conversation input drafts in localStorage.
+ * Provides auto-save, retrieval, and cleanup functionality.
+ */
+export function useConversationDrafts({
+  workspaceId,
+  userId,
+  conversationId,
+}: {
+  workspaceId: string;
+  userId: string | null;
+  conversationId: string | null;
+}) {
+  const internalConversationId = conversationId ?? "new";
+  const internalUserId = userId ?? "anonymous";
+
+  // Get all drafts from localStorage.
+  const getDraftsFromStorage = useCallback((): DraftStorage => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return {};
+      }
+      const parsed = JSON.parse(stored) as DraftStorage;
+
+      // Clean up expired drafts (older than DRAFT_EXPIRY_DAYS).
+      const now = Date.now();
+      const cleaned: DraftStorage = {};
+
+      Object.entries(parsed).forEach(([id, draft]) => {
+        if (now - draft.timestamp < DRAFT_EXPIRY_MS) {
+          cleaned[id] = draft;
+        }
+      });
+
+      return cleaned;
+    } catch (error) {
+      logger.error(
+        "Failed to read conversation drafts from localStorage, cleaning localStorage:",
+        error
+      );
+      delete localStorage[STORAGE_KEY];
+      return {};
+    }
+  }, []);
+
+  // Save drafts to localStorage.
+  const saveDraftsToStorage = useCallback((drafts: DraftStorage) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(drafts));
+    } catch (error) {
+      logger.error(
+        "Failed to save conversation drafts to localStorage:",
+        error
+      );
+    }
+  }, []);
+
+  // Debounced save function.
+  const debouncedSave = useRef(
+    debounce(
+      ({
+        workspaceId,
+        userId,
+        conversationId,
+        text,
+        timestamp,
+      }: {
+        workspaceId: string;
+        userId: string;
+        conversationId: string;
+        text: string;
+        timestamp: number;
+      }) => {
+        const drafts = getDraftsFromStorage();
+        drafts[getKeyId(workspaceId, userId, conversationId)] = {
+          text,
+          timestamp,
+        };
+        saveDraftsToStorage(drafts);
+      },
+      500
+    )
+  ).current;
+
+  // Save draft for current conversation (debounced).
+  const saveDraft = useCallback(
+    (text: string) => {
+      debouncedSave({
+        workspaceId,
+        userId: internalUserId,
+        conversationId: internalConversationId,
+        text,
+        timestamp: Date.now(),
+      });
+    },
+    [debouncedSave, workspaceId, internalUserId, internalConversationId]
+  );
+
+  // Get draft for current conversation.
+  const getDraft = useCallback((): ConversationDraft | null => {
+    const drafts = getDraftsFromStorage();
+    return (
+      drafts[getKeyId(workspaceId, internalUserId, internalConversationId)] ??
+      null
+    );
+  }, [
+    getDraftsFromStorage,
+    workspaceId,
+    internalUserId,
+    internalConversationId,
+  ]);
+
+  // Clear draft for the current conversation.
+  const clearDraft = useCallback(() => {
+    const drafts = getDraftsFromStorage();
+    delete drafts[
+      getKeyId(workspaceId, internalUserId, internalConversationId)
+    ];
+    saveDraftsToStorage(drafts);
+
+    // Also, cancel any pending debounced save.
+    debouncedSave.cancel();
+  }, [
+    getDraftsFromStorage,
+    workspaceId,
+    internalUserId,
+    internalConversationId,
+    saveDraftsToStorage,
+    debouncedSave,
+  ]);
+
+  const clearAllDraftsFromUser = useCallback(() => {
+    const drafts = getDraftsFromStorage();
+    Object.keys(drafts).forEach((key) => {
+      if (key.startsWith(`${internalUserId}::`)) {
+        delete drafts[key];
+      }
+    });
+    saveDraftsToStorage(drafts);
+  }, [getDraftsFromStorage, internalUserId, saveDraftsToStorage]);
+
+  return { saveDraft, getDraft, clearDraft, clearAllDraftsFromUser };
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -79,7 +79,6 @@
         "@typescript/native-preview": "^7.0.0-dev.20251201.1",
         "@uiw/react-textarea-code-editor": "^3.0.2",
         "@valtown/sdk": "^2.0.0",
-        "@vercel/otel": "^2.1.0",
         "@virtuoso.dev/message-list": "^1.14.0",
         "@workos-inc/node": "^7.77.0",
         "adm-zip": "^0.5.16",
@@ -12441,24 +12440,6 @@
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@vercel/otel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/otel/-/otel-2.1.0.tgz",
-      "integrity": "sha512-Zwu2Cu4t46DzBnY1DQSTxZ4MBLVfYsOjnlWuZuLRWnmVPX+SNrVHbs3ssiJ6uvY1J1JJswor4zSn8mHYxzYeBA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <2.0.0",
-        "@opentelemetry/api-logs": ">=0.200.0 <0.300.0",
-        "@opentelemetry/instrumentation": ">=0.200.0 <0.300.0",
-        "@opentelemetry/resources": ">=2.0.0 <3.0.0",
-        "@opentelemetry/sdk-logs": ">=0.200.0 <0.300.0",
-        "@opentelemetry/sdk-metrics": ">=2.0.0 <3.0.0",
-        "@opentelemetry/sdk-trace-base": ">=2.0.0 <3.0.0"
       }
     },
     "node_modules/@vercel/stega": {


### PR DESCRIPTION
## Description

Add a local storage draft mode for conversations:
* keeps it by conversations
* clears it when a message is sent
* handles the "new" conversations
* works with markdown and mentions
* cleans up after itself on logout, prevent storing user data
* ⚠️ doesn't save attachments

it's _not_ behind a feature flag

## Tests

https://github.com/user-attachments/assets/54135e28-7e8c-4e6b-9319-0028202fb03a



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
