### PR TITLE
fix(agent-loop): gracefully handle subscription change while msg in flight

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -45,7 +45,13 @@ export async function ensureConversationTitleFromAgentLoop(
 
   const { conversation, userMessage } = runAgentDataRes.value;
 
-  const auth = await Authenticator.fromJSON(authType);
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
 
   return ensureConversationTitle(auth, { conversation, userMessage });
 }

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -219,7 +219,13 @@ export async function notifyWorkflowError(
     error: Error;
   }
 ): Promise<void> {
-  const auth = await AuthenticatorClass.fromJSON(authType);
+  const authResult = await AuthenticatorClass.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
 
   // Use lighter fetchConversationWithoutContent
   const conversationRes =

--- a/front/temporal/agent_loop/activities/mentions.ts
+++ b/front/temporal/agent_loop/activities/mentions.ts
@@ -15,14 +15,15 @@ export async function handleMentionsActivity(
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
   // Contruct back an authenticator from the auth type.
-  const auth = await Authenticator.fromJSON(authType);
-  if (!auth) {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
     logger.error(
-      { authType },
+      { authType, error: authResult.error },
       "Failed to construct authenticator from auth type"
     );
     return;
   }
+  const auth = authResult.value;
 
   const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
   if (!featureFlags.includes("mentions_v2")) {

--- a/front/temporal/agent_loop/activities/notification.ts
+++ b/front/temporal/agent_loop/activities/notification.ts
@@ -19,14 +19,15 @@ export async function conversationUnreadNotificationActivity(
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
   // Contruct back an authenticator from the auth type.
-  const auth = await Authenticator.fromJSON(authType);
-  if (!auth) {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
     logger.error(
-      { authType },
+      { authType, error: authResult.error },
       "Failed to construct authenticator from auth type"
     );
     return;
   }
+  const auth = authResult.value;
   if (!isUserMessageOrigin(agentLoopArgs.userMessageOrigin)) {
     logger.info(
       { userMessageOrigin: agentLoopArgs.userMessageOrigin },

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -30,7 +30,13 @@ export async function runToolActivity(
     runIds?: string[];
   }
 ): Promise<ToolExecutionResult> {
-  const auth = await Authenticator.fromJSON(authType);
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
   const runAgentDataRes = await getAgentLoopData(authType, runAgentArgs);

--- a/front/temporal/agent_loop/activities/usage_tracking.ts
+++ b/front/temporal/agent_loop/activities/usage_tracking.ts
@@ -18,7 +18,13 @@ export async function trackProgrammaticUsageActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<{ tracked: boolean; origin: UserMessageOrigin }> {
-  const auth = await Authenticator.fromJSON(authType);
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
   const workspace = auth.getNonNullableWorkspace();
 
   const { agentMessageId, userMessageId } = agentLoopArgs;

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -37,7 +37,13 @@ export async function storeAgentAnalyticsActivity(
     agentLoopArgs: AgentLoopArgs;
   }
 ): Promise<void> {
-  const auth = await Authenticator.fromJSON(authType);
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
   const workspace = auth.getNonNullableWorkspace();
 
   const { agentMessageId, userMessageId } = agentLoopArgs;
@@ -328,7 +334,13 @@ export async function storeAgentMessageFeedbackActivity(
     message: AgentMessageRef;
   }
 ): Promise<void> {
-  const auth = await Authenticator.fromJSON(authType);
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
 
   const workspace = auth.getNonNullableWorkspace();
 


### PR DESCRIPTION
## Description

  Convert the subscription mismatch assertion in `Authenticator.fromJSON` to a Result error to prevent process crashes when a workspace changes their subscription while a message is running.

  **Changes:**
  - Changed `Authenticator.fromJSON` return type from `Promise<Authenticator>` to `Promise<Result<Authenticator, { code: "subscription_mismatch" }>>`
  - Replaced `assert` with a conditional returning `Err({ code: "subscription_mismatch" })`
  - Updated all 8 callers to handle the new Result type
  - Modified `getAgentLoopData` to gracefully handle subscription mismatches by fetching a fresh auth with the current subscription and logging the event

  ## Tests

  ## Risk

  **Low risk.**
  - The change converts a crash scenario into graceful error handling
  - When a subscription mismatch occurs during message processing, the system now continues with a fresh auth instead of crashing
  - All callers have been updated to handle the new Result type appropriately
  - Safe to rollback if needed

  ## Deploy Plan

  Standard deployment