### PR TITLE
[Front]: feat(manage-skills): add editable by me and default skills tab

### DIFF
--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -13,7 +13,7 @@ export function transformSkillConfigurationToFormData(
   return {
     name: skillConfiguration.name,
     description: skillConfiguration.description,
-    instructions: skillConfiguration.instructions,
+    instructions: skillConfiguration.instructions ?? "",
     editors: [], // Will be populated reactively from useEditors hook
     tools: [], // Will be populated reactively from MCP server views context
   };

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -13,25 +13,18 @@ export function SkillInfoTab({
       <div className="text-sm text-foreground dark:text-foreground-night">
         {skillConfiguration.description}
       </div>
-      {skillConfiguration.canWrite && (
-        <SkillEdited skillConfiguration={skillConfiguration} />
-      )}
+      <SkillEdited skillConfiguration={skillConfiguration} />
 
       <Page.Separator />
 
-      {skillConfiguration.canWrite &&
-        (skillConfiguration.instructions ? (
-          <div className="dd-privacy-mask flex flex-col gap-5">
-            <div className="heading-lg text-foreground dark:text-foreground-night">
-              Instructions
-            </div>
-            <ReadOnlyTextArea content={skillConfiguration.instructions} />
+      {skillConfiguration.instructions && (
+        <div className="dd-privacy-mask flex flex-col gap-5">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Instructions
           </div>
-        ) : (
-          <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            This agent has no instructions.
-          </div>
-        ))}
+          <ReadOnlyTextArea content={skillConfiguration.instructions} />
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -24,7 +24,7 @@ import type { AgentsUsageType } from "@app/types/data_source";
 type RowData = {
   name: string;
   description: string;
-  editors: UserType[];
+  editors: UserType[] | null;
   usage: AgentsUsageType;
   updatedAt: number;
   onClick: () => void;
@@ -65,16 +65,22 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
       header: "Editors",
       accessorKey: "editors",
       cell: (info: CellContext<RowData, UserType[]>) => {
+        const editors = info.getValue();
+        const items = editors
+          ? editors.map((editor) => ({
+              name: editor.fullName,
+              visual: editor.image,
+            }))
+          : // Only dust managed skills should have no editors
+            [
+              {
+                name: "Dust",
+                visual:
+                  "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+              },
+            ];
         return (
-          <DataTable.CellContent
-            avatarStack={{
-              items: info.getValue().map((editor) => ({
-                name: editor.fullName,
-                visual: editor.image,
-              })),
-              nbVisibleItems: 4,
-            }}
-          />
+          <DataTable.CellContent avatarStack={{ items, nbVisibleItems: 4 }} />
         );
       },
       meta: {

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -1,6 +1,5 @@
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
-import type { UserType } from "@app/types";
 
 export interface GlobalSkillDefinition {
   readonly description: string;
@@ -82,17 +81,3 @@ export class GlobalSkillsRegistry {
     });
   }
 }
-
-export const GLOBAL_DUST_AUTHOR: UserType = {
-  sId: "dust",
-  id: -1,
-  createdAt: 0,
-  provider: "github",
-  username: "dust",
-  email: "",
-  firstName: "Dust",
-  lastName: null,
-  fullName: "Dust",
-  image: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
-  lastLoginAt: null,
-};

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -110,11 +110,15 @@ async function handler(
       if (withRelations === "true") {
         const skillConfigurationsWithRelations = await concurrentExecutor(
           skillConfigurations,
-          async (sc) => ({
-            ...sc.toJSON(auth),
-            usage: await sc.fetchUsage(auth),
-            editors: await sc.listEditors(auth),
-          }),
+          async (sc) => {
+            const usage = await sc.fetchUsage(auth);
+            const editors = await sc.listEditors(auth);
+            return {
+              ...sc.toJSON(auth),
+              usage,
+              editors: editors ? editors.map((e) => e.toJSON()) : null,
+            } satisfies SkillConfigurationType & SkillConfigurationRelations;
+          },
           { concurrency: 10 }
         );
 

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -12,7 +12,7 @@ export type SkillConfigurationType = {
   status: SkillStatus;
   name: string;
   description: string;
-  instructions: string;
+  instructions: string | null;
   requestedSpaceIds: ModelId[];
   tools: { mcpServerViewId: string }[];
   canWrite: boolean;
@@ -20,5 +20,5 @@ export type SkillConfigurationType = {
 
 export type SkillConfigurationRelations = {
   usage: AgentsUsageType;
-  editors: UserType[];
+  editors: UserType[] | null;
 };


### PR DESCRIPTION
## Description

Task : https://github.com/dust-tt/tasks/issues/5591

Adds 'Editable by me' and 'Default' tab similar to what we do for manage agents screen
Hide global skills instructions from frontend entirely
Don't call toJson in listEditors method of skill resource and return UserResource[] directly
 

Note: the All tab also includes the global skills, we'll need to do it for agents in a later PR

## Tests

Local

https://github.com/user-attachments/assets/a9f90ae9-58cf-41f7-aa38-0fba9ed691bf





## Risk

Low

## Deploy Plan

Front