### PR TITLE
fix(gpt5.2): upg globals in US, remove from builder in EU

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -7,6 +7,7 @@ import {
   _getDefaultWebActionsForGlobalAgent,
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
+import { config as regionConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -19,6 +20,7 @@ import {
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_1_MODEL_CONFIG,
   GPT_5_1_MODEL_CONFIG,
+  GPT_5_2_MODEL_CONFIG,
   GPT_5_MINI_MODEL_CONFIG,
   GPT_5_NANO_MODEL_CONFIG,
   MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -171,6 +173,10 @@ export function _getGPT5GlobalAgent({
   const sId = GLOBAL_AGENTS_SID.GPT5;
   const metadata = getGlobalAgentMetadata(sId);
 
+  // GPT 5.2 is only available in non-EU regions (US)
+  const isEuRegion = regionConfig.getCurrentRegion() === "europe-west1";
+  const modelConfig = isEuRegion ? GPT_5_1_MODEL_CONFIG : GPT_5_2_MODEL_CONFIG;
+
   return {
     id: -1,
     sId,
@@ -187,8 +193,8 @@ export function _getGPT5GlobalAgent({
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: GPT_5_1_MODEL_CONFIG.providerId,
-      modelId: GPT_5_1_MODEL_CONFIG.modelId,
+      providerId: modelConfig.providerId,
+      modelId: modelConfig.modelId,
       temperature: 0.7,
       /**
        * WARNING: Because the default in ChatGPT is no reasoning, we do the same
@@ -242,6 +248,10 @@ export function _getGPT5ThinkingGlobalAgent({
   const sId = GLOBAL_AGENTS_SID.GPT5_THINKING;
   const metadata = getGlobalAgentMetadata(sId);
 
+  // GPT 5.2 is only available in non-EU regions (US)
+  const isEuRegion = regionConfig.getCurrentRegion() === "europe-west1";
+  const modelConfig = isEuRegion ? GPT_5_1_MODEL_CONFIG : GPT_5_2_MODEL_CONFIG;
+
   return {
     id: -1,
     sId,
@@ -259,10 +269,10 @@ export function _getGPT5ThinkingGlobalAgent({
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: GPT_5_1_MODEL_CONFIG.providerId,
-      modelId: GPT_5_1_MODEL_CONFIG.modelId,
+      providerId: modelConfig.providerId,
+      modelId: modelConfig.modelId,
       temperature: 0.7,
-      reasoningEffort: GPT_5_1_MODEL_CONFIG.defaultReasoningEffort,
+      reasoningEffort: modelConfig.defaultReasoningEffort,
     },
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,3 +1,4 @@
+import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import type {
   AgentModelConfigurationType,
@@ -7,7 +8,11 @@ import type {
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
-import { isProviderWhitelisted, SUPPORTED_MODEL_CONFIGS } from "@app/types";
+import {
+  GPT_5_2_MODEL_ID,
+  isProviderWhitelisted,
+  SUPPORTED_MODEL_CONFIGS,
+} from "@app/types";
 
 export function isLargeModel(model: unknown): model is SupportedModel {
   const maybeSupportedModel = model as SupportedModel;
@@ -52,6 +57,14 @@ export function canUseModel(
   }
 
   if (m.largeModel && !isUpgraded(plan)) {
+    return false;
+  }
+
+  // GPT 5.2 is not available in EU region
+  if (
+    m.modelId === GPT_5_2_MODEL_ID &&
+    regionConfig.getCurrentRegion() === "europe-west1"
+  ) {
     return false;
   }
 

--- a/front/vite.globalSetup.ts
+++ b/front/vite.globalSetup.ts
@@ -34,6 +34,7 @@ export default async function setup() {
     DUST_APPS_HELPER_DATASOURCE_VIEW_ID: "dsv_xx",
     DUST_APPS_WORKSPACE_ID: "xx",
     VIZ_JWT_SECRET: "viz-secret-for-tests",
+    REGION: "us-central1",
   };
 
   // Execute the db migration script


### PR DESCRIPTION
## Description

Model is not available in EU yet

This change:
- hides it from the builder in EU
- upgrades gpt5 and gpt5-thinking global agents to gpt5.2 in US

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
