### PR TITLE
[front] fix: slugify titles used as node ID in folders

### DIFF
--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -337,7 +337,7 @@ export const DocumentUploadOrEditModal = ({
     } else if (document && isCoreAPIDocumentType(document)) {
       setDocumentState((prev) => ({
         ...prev,
-        title: initialId,
+        title: document.title ?? initialId,
         text: document.text ?? "",
         tags: document.tags,
         sourceUrl: document.source_url ?? "",

--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -177,7 +177,7 @@ export const DocumentUploadOrEditModal = ({
       // When editing (initialId is set), keep the original ID.
       const documentId = initialId ?? slugify(document.title);
       const body = {
-        title: initialId ?? document.title,
+        title: document.title,
         document_id: documentId,
         mime_type: document.mimeType ?? "text/plain",
         timestamp: null,

--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -38,6 +38,7 @@ import {
   Err,
   getSupportedNonImageFileExtensions,
   normalizeError,
+  slugify,
 } from "@app/types";
 
 const MAX_NAME_CHARS = 32;
@@ -172,12 +173,16 @@ export const DocumentUploadOrEditModal = ({
   const handleDocumentUpload = useCallback(
     async (document: Document) => {
       setIsUpsertingDocument(true);
+      // Use slugified title as document_id for LLM-friendly node IDs.
+      // When editing (initialId is set), keep the original ID.
+      const documentId = initialId ?? slugify(document.title);
       const body = {
         title: initialId ?? document.title,
+        document_id: documentId,
         mime_type: document.mimeType ?? "text/plain",
         timestamp: null,
         parent_id: null,
-        parents: [initialId ?? document.title],
+        parents: [documentId],
         section: { prefix: null, content: document.text, sections: [] },
         text: null,
         source_url: document.sourceUrl || undefined,

--- a/front/components/data_source/MultipleFilesUpload.tsx
+++ b/front/components/data_source/MultipleFilesUpload.tsx
@@ -30,6 +30,7 @@ import type {
 import {
   getSupportedNonImageFileExtensions,
   isSupportedDelimitedTextContentType,
+  slugify,
 } from "@app/types";
 
 // Helper to check if a file should be treated as a table based on its MIME type
@@ -169,7 +170,7 @@ export const MultipleFilesUpload = ({
                 fileId: blob.fileId,
                 upsertArgs: {
                   title: blob.filename,
-                  document_id: blob.filename,
+                  document_id: slugify(blob.filename),
                 },
               });
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -108,13 +108,13 @@ async function handler(
         light_document_output,
         mime_type,
         title,
+        document_id,
       } = bodyValidation.right;
 
       const upsertResult = await upsertDocument({
-        // For folders documents created from the app (this endpoint) we use the document title as
-        // ID. This is inherited behavior that is perfectly valid but we might want to move to
-        // generating IDs in the future.
-        document_id: title,
+        // Use document_id if provided (e.g., slugified for LLM-friendly node IDs),
+        // otherwise fall back to title for backwards compatibility.
+        document_id: document_id ?? title,
         source_url,
         text,
         section,

--- a/front/types/api/public/data_sources.ts
+++ b/front/types/api/public/data_sources.ts
@@ -40,6 +40,9 @@ export const PostDataSourceDocumentRequestBodySchema = t.type({
   async: t.union([t.boolean, t.undefined, t.null]),
   title: t.string,
   mime_type: t.string,
+  // Optional document_id for LLM-friendly node IDs (e.g., slugified).
+  // Falls back to title if not provided.
+  document_id: t.union([t.string, t.undefined]),
 });
 
 export type PostDataSourceDocumentRequestBody = t.TypeOf<


### PR DESCRIPTION
## Description

- Surfaced [here](https://dust4ai.slack.com/archives/C08BQL7RSBF/p1761601629618409).
- The agent struggled to `cat` conversation files that have a title with unicode characters, which is due to the fact that the title is used as the node ID for folders.
- This PR slugifies the title when used as a node ID.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- No backfill.
