### PR TITLE
chore: create dust avatar url constant

### DIFF
--- a/front/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
@@ -10,11 +10,11 @@ import {
   getCiteDirective,
 } from "@app/components/markdown/CiteBlock";
 import { isAgentPauseOutputResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { DEEP_DIVE_AVATAR_URL } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import {
   agentMentionDirective,
   getAgentMentionPlugin,
 } from "@app/lib/mentions/markdown/plugin";
+import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 
 export function MCPDeepDiveActionDetails({
   owner,
@@ -46,9 +46,7 @@ export function MCPDeepDiveActionDetails({
     <ActionDetailsWrapper
       viewType={viewType}
       actionName="Hand off to Deep dive"
-      visual={() => (
-        <Avatar visual={DEEP_DIVE_AVATAR_URL} size="xs" busy={isBusy} />
-      )}
+      visual={() => <Avatar visual={DUST_AVATAR_URL} size="xs" busy={isBusy} />}
     >
       <div className="flex flex-col gap-4 pl-6 pt-4">
         <div className="flex flex-col gap-4">

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -15,6 +15,7 @@ import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { LightWorkspaceType, UserType } from "@app/types";
+import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type {
   SkillConfigurationRelations,
   SkillConfigurationType,
@@ -75,8 +76,7 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
             [
               {
                 name: "Dust",
-                visual:
-                  "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+                visual: DUST_AVATAR_URL,
               },
             ];
         return (

--- a/front/lib/api/assistant/global_agents/configurations/dust/consts.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/consts.ts
@@ -4,9 +4,6 @@ import { GLOBAL_AGENTS_SID } from "@app/types";
 export const DEEP_DIVE_NAME = "deep-dive";
 export const DEEP_DIVE_DESC =
   "Conducts comprehensive, in-depth analysis across all company data, databases, and web sources—thorough investigation that may take several minutes.";
-export const DEEP_DIVE_AVATAR_URL =
-  "https://dust.tt/static/systemavatar/dust_avatar_full.png";
-
 export const DEEP_DIVE_SERVER_INSTRUCTIONS = `\
 ## HANDOFF TO THE ${DEEP_DIVE_NAME} AGENT
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -2,7 +2,6 @@ import { DEFAULT_WEBSEARCH_ACTION_DESCRIPTION } from "@app/lib/actions/constants
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
-  DEEP_DIVE_AVATAR_URL,
   DEEP_DIVE_DESC,
   DEEP_DIVE_NAME,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
@@ -37,6 +36,7 @@ import {
   isProviderWhitelisted,
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
+import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 
 const MAX_CONCURRENT_SUB_AGENT_TASKS = 6;
 
@@ -442,7 +442,7 @@ export function _getDeepDiveGlobalAgent(
   }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
-  const pictureUrl = DEEP_DIVE_AVATAR_URL;
+  const pictureUrl = DUST_AVATAR_URL;
   const modelConfig = getModelConfig(owner, "anthropic");
 
   const deepAgent: Omit<

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -45,6 +45,7 @@ import {
   isProviderWhitelisted,
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
+import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 
 const INSTRUCTION_SECTIONS = {
   primary: `<primary_goal>
@@ -351,7 +352,7 @@ function _getDustLikeGlobalAgent(
   const owner = auth.getNonNullableWorkspace();
 
   const description = "An agent with context on your company data.";
-  const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
+  const pictureUrl = DUST_AVATAR_URL;
 
   let isPreferredModel = false;
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/noop.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/noop.ts
@@ -4,6 +4,7 @@ import {
   MAX_STEPS_USE_PER_RUN_LIMIT,
   NOOP_MODEL_CONFIG,
 } from "@app/types";
+import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 
 export function _getNoopAgent(): AgentConfigurationType | null {
   return {
@@ -15,7 +16,7 @@ export function _getNoopAgent(): AgentConfigurationType | null {
     name: "noop",
     description: NOOP_MODEL_CONFIG.description,
     instructions: "",
-    pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+    pictureUrl: DUST_AVATAR_URL,
     status: "active",
     scope: "global",
     userFavorite: false,

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -25,6 +25,7 @@ import {
   O1_MODEL_CONFIG,
   O3_MODEL_CONFIG,
 } from "@app/types";
+import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 
 type AgentMetadata = {
   sId: string;
@@ -262,7 +263,7 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         name: "dust-edge",
         description:
           "Same as dust but on another model to experiment internally.",
-        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+        pictureUrl: DUST_AVATAR_URL,
       };
     case GLOBAL_AGENTS_SID.DUST_QUICK:
       return {
@@ -270,28 +271,28 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         name: "dust-quick",
         description:
           "Same as dust but running Gemini 3 with minimal reasoning for faster responses.",
-        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+        pictureUrl: DUST_AVATAR_URL,
       };
     case GLOBAL_AGENTS_SID.DUST_OAI:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_OAI,
         name: "dust-oai",
         description: "Same as dust but running OpenAI models.",
-        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+        pictureUrl: DUST_AVATAR_URL,
       };
     case GLOBAL_AGENTS_SID.DUST:
       return {
         sId: GLOBAL_AGENTS_SID.DUST,
         name: "dust",
         description: "An agent with context on your company data.",
-        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+        pictureUrl: DUST_AVATAR_URL,
       };
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
       return {
         sId: GLOBAL_AGENTS_SID.DEEP_DIVE,
         name: DEEP_DIVE_NAME,
         description: DEEP_DIVE_DESC,
-        pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+        pictureUrl: DUST_AVATAR_URL,
       };
     case GLOBAL_AGENTS_SID.DUST_TASK:
       return {

--- a/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
@@ -15,6 +15,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { getLargeWhitelistedModel } from "@app/types";
+import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 
 export const CreateGenericAgentRequestSchema = t.type({
   name: t.string,
@@ -49,7 +50,7 @@ function getAgentPictureUrl(
       backgroundColor
     );
   } else {
-    return "https://dust.tt/static/systemavatar/dust_avatar_full.png";
+    return DUST_AVATAR_URL;
   }
 }
 

--- a/front/types/assistant/avatar.ts
+++ b/front/types/assistant/avatar.ts
@@ -1,3 +1,6 @@
+export const DUST_AVATAR_URL =
+  "https://dust.tt/static/systemavatar/dust_avatar_full.png";
+
 const TAILWIND_COLOR_NAMES = [
   "gray",
   "blue",


### PR DESCRIPTION
## Description

Addresses this comment : https://github.com/dust-tt/dust/pull/19046#discussion_r2614227351
Rename DEEP_DIVE_AVATAR_URL -> DUST_AVATAR_URL since it was the same and use it everywhere

## Tests

Local

## Risk

Low

## Deploy Plan

Front