### PR TITLE
Make a lightbox for rich text images and author image size rendering

### DIFF
--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -122,7 +122,7 @@ function ContentfulLightboxImage({
 
       {open && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm animate-in fade-in duration-200"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm duration-200 animate-in fade-in"
           role="dialog"
           aria-modal="true"
           onClick={() => setOpen(false)}
@@ -149,11 +149,10 @@ function ContentfulLightboxImage({
               <line x1="6" y1="6" x2="18" y2="18" />
             </svg>
           </button>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={`${src}?w=1920&fm=webp&q=85`}
             alt={alt}
-            className="max-h-[90vh] max-w-[90vw] cursor-zoom-out object-contain animate-in zoom-in-95 duration-200"
+            className="max-h-[90vh] max-w-[90vw] cursor-zoom-out object-contain duration-200 animate-in zoom-in-95"
             onClick={() => setOpen(false)}
           />
         </div>

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -15,6 +15,7 @@ import {
   getBlogPostBySlug,
   getRelatedPosts,
 } from "@app/lib/contentful/client";
+import { contentfulImageLoader } from "@app/lib/contentful/imageLoader";
 import { renderRichTextFromContentful } from "@app/lib/contentful/richTextRenderer";
 import type { BlogPostPageProps } from "@app/lib/contentful/types";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
@@ -220,12 +221,14 @@ export default function BlogPost({
                           alt={author.name}
                           width={40}
                           height={40}
-                          className="rounded-full ring-2 ring-white"
+                          loader={contentfulImageLoader}
+                          sizes="40px"
+                          className="rounded-full"
                         />
                       ) : (
                         <div
                           key={author.name}
-                          className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 text-sm font-medium text-gray-600 ring-2 ring-white"
+                          className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-200 text-sm font-medium text-gray-600"
                         >
                           {author.name.charAt(0).toUpperCase()}
                         </div>


### PR DESCRIPTION
## Description

Adds lightbox functionality to blog post images. Users can now click on images in blog posts to view them in a full-screen modal with zoom capabilities. The lightbox can be closed by clicking outside the image, on the close button, or pressing the Escape key. Images now use the `contentfulImageLoader` for optimized loading with WebP format and proper sizing.

## Risk

Low. Changes only affect blog post image rendering and are purely additive. The lightbox uses standard React hooks for state management and event listeners are properly cleaned up.


https://github.com/user-attachments/assets/07bf0c43-afa6-4341-a12f-252b9e86b3e5




