### PR TITLE
[Agent Loop] Add Redis caching for conversation fetches in runToolActivity

### DIFF
--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -5,7 +5,7 @@ import { distributedLock, distributedUnlock } from "@app/lib/lock";
 type JsonPrimitive = string | number | boolean | null;
 
 // Recursive type to check if a type is JSON-serializable.
-type RecursiveJsonSerializable<T> = T extends JsonPrimitive
+type RecursiveJsonSerializable<T> = T extends JsonPrimitive | []
   ? T
   : T extends Array<infer U>
     ? RecursiveJsonSerializable<U>[]

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -39,7 +39,10 @@ export async function runToolActivity(
   const auth = authResult.value;
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
-  const runAgentDataRes = await getAgentLoopData(authType, runAgentArgs);
+  const runAgentDataRes = await getAgentLoopData(authType, {
+    ...runAgentArgs,
+    step,
+  });
   if (runAgentDataRes.isErr()) {
     // If the conversation is not found, we cannot run the tool and should stop execution here.
     if (

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -29,6 +29,8 @@ export type ConversationCaching =
   | { useCachedGetConversation: false }
   | { useCachedGetConversation: true; unicitySuffix: string; ttlMs: number };
 
+// Throws on error because cacheWithRedis expects functions that throw (not Result types).
+// Errors are caught and converted back to Result in getAgentLoopData.
 async function getConversationForAgentLoop(
   auth: Authenticator,
   conversationId: string,


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/5055

Add Redis caching for conversation fetches in `runToolActivity` to reduce database load when multiple parallel tool activities fetch the same conversation during the same step.

- Uses `cacheWithRedis` with distributed lock
- Caller provides `unicitySuffix` and `ttlMs` via `caching` parameter
- Fix `JsonSerializable` type to handle empty tuple `[]`

## Risks
Blast radius: agent loop tool execution, cacheWithRedis utility
Risk: low

## Deploy Plan
- deploy front