### PR TITLE
[front] - chore: member & agent details sheet

### DIFF
--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -139,73 +139,97 @@ export function AgentDetails({
     (agentConfiguration?.canEdit || isAdmin(owner)) &&
     !isGlobalAgent;
 
-  const DescriptionSection = () => (
-    <div className="flex flex-col gap-5">
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <Avatar
-          name="Agent avatar"
-          visual={agentConfiguration?.pictureUrl}
-          size="lg"
-        />
-        <div className="flex grow flex-col gap-1">
-          <div className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">{`${agentConfiguration?.name ?? ""}`}</div>
-          {agentConfiguration?.status === "active" && (
-            <div>
+  const DescriptionSection = () => {
+    const lastAuthor = agentConfiguration?.lastAuthors?.[0];
+    const editedDate =
+      agentConfiguration?.versionCreatedAt &&
+      new Date(agentConfiguration.versionCreatedAt).toLocaleDateString(
+        "en-US",
+        {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+        }
+      );
+
+    return (
+      <div className="flex flex-col items-center gap-4 pt-4">
+        <div className="relative flex items-center justify-center">
+          <div className="relative flex flex-col items-center gap-2">
+            <Avatar
+              name="Agent avatar"
+              visual={agentConfiguration?.pictureUrl}
+              size="xl"
+            />
+            {agentConfiguration?.status === "active" && (
               <Chip
+                size="mini"
                 color={SCOPE_INFO[agentConfiguration.scope].color}
                 icon={SCOPE_INFO[agentConfiguration.scope].icon ?? undefined}
-              >
-                {SCOPE_INFO[agentConfiguration.scope].label}
-              </Chip>
-            </div>
+                label={SCOPE_INFO[agentConfiguration.scope].label}
+                className="absolute -bottom-3 shadow-sm"
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Title and edit info */}
+        <div className="flex flex-col items-center gap-1">
+          <h2 className="text-xl font-semibold text-foreground dark:text-foreground-night">
+            {agentConfiguration?.name ?? ""}
+          </h2>
+          {editedDate && (
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Last edited: {editedDate}
+              {lastAuthor && ` by ${lastAuthor}`}
+            </p>
           )}
         </div>
-      </div>
-      {agentConfiguration?.status === "active" && (
-        <AgentDetailsButtonBar
-          owner={owner}
-          agentConfiguration={agentConfiguration}
-          isAgentConfigurationValidating={isAgentConfigurationValidating}
-        />
-      )}
 
-      {agentConfiguration?.status === "archived" && (
-        <>
-          <ContentMessage
-            title="This agent has been archived."
-            variant="warning"
-            icon={InformationCircleIcon}
-            size="sm"
-          >
-            It is no longer active and cannot be used.
-            <br />
-            <div className="mt-2">
-              <Button
-                variant="outline"
-                label="Restore"
-                onClick={() => {
-                  setShowRestoreModal(true);
-                }}
-                classname="mt-2"
-                icon={ArrowPathIcon}
-              />
-            </div>
-          </ContentMessage>
-
-          <RestoreAgentDialog
+        {agentConfiguration?.status === "active" && (
+          <AgentDetailsButtonBar
             owner={owner}
-            isOpen={showRestoreModal}
             agentConfiguration={agentConfiguration}
-            onClose={() => {
-              setShowRestoreModal(false);
-            }}
+            isAgentConfigurationValidating={isAgentConfigurationValidating}
           />
+        )}
 
-          <div className="flex justify-center"></div>
-        </>
-      )}
-    </div>
-  );
+        {agentConfiguration?.status === "archived" && (
+          <>
+            <ContentMessage
+              title="This agent has been archived."
+              variant="warning"
+              icon={InformationCircleIcon}
+              size="sm"
+            >
+              It is no longer active and cannot be used.
+              <br />
+              <div className="mt-2">
+                <Button
+                  variant="outline"
+                  label="Restore"
+                  onClick={() => {
+                    setShowRestoreModal(true);
+                  }}
+                  classname="mt-2"
+                  icon={ArrowPathIcon}
+                />
+              </div>
+            </ContentMessage>
+
+            <RestoreAgentDialog
+              owner={owner}
+              isOpen={showRestoreModal}
+              agentConfiguration={agentConfiguration}
+              onClose={() => {
+                setShowRestoreModal(false);
+              }}
+            />
+          </>
+        )}
+      </div>
+    );
+  };
 
   return (
     <Sheet open={!!agentId} onOpenChange={onClose}>

--- a/front/components/assistant/details/MemberDetails.tsx
+++ b/front/components/assistant/details/MemberDetails.tsx
@@ -3,23 +3,44 @@ import {
   Chip,
   ContentMessage,
   LockIcon,
+  Separator,
   Sheet,
-  SheetContainer,
   SheetContent,
-  SheetHeader,
+  SheetFooter,
   SheetTitle,
   Spinner,
 } from "@dust-tt/sparkle";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 
-import { UserInfoTab } from "@app/components/assistant/details/tabs/UserInfoTab";
+import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { useMemberDetails } from "@app/lib/swr/assistants";
-import type { WorkspaceType } from "@app/types";
+import type { RoleType, WorkspaceType } from "@app/types";
 
 type MemberDetailsProps = {
   owner: WorkspaceType;
   onClose: () => void;
   userId: string | null;
+};
+
+const formatDate = (dateString: string | null) => {
+  if (!dateString) {
+    return null;
+  }
+  const date = new Date(dateString);
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+};
+
+const getRoleBadgeColor = (
+  role: RoleType
+): "golden" | "rose" | "green" | "primary" => {
+  if (role === "none") {
+    return "primary";
+  }
+  return ROLES_DATA[role].color;
 };
 
 export function MemberDetails({ userId, onClose, owner }: MemberDetailsProps) {
@@ -31,7 +52,7 @@ export function MemberDetails({ userId, onClose, owner }: MemberDetailsProps) {
 
   return (
     <Sheet open={!!userId} onOpenChange={onClose}>
-      <SheetContent size="lg">
+      <SheetContent>
         <VisuallyHidden>
           <SheetTitle />
         </VisuallyHidden>
@@ -39,47 +60,93 @@ export function MemberDetails({ userId, onClose, owner }: MemberDetailsProps) {
           <div className="flex h-full w-full items-center justify-center">
             <Spinner size="lg" />
           </div>
+        ) : isUserDetailsError ? (
+          <ContentMessage title="Not Available" icon={LockIcon} size="md">
+            This user is not available.
+          </ContentMessage>
         ) : (
-          <>
-            <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
-              <SheetTitle>Profile</SheetTitle>
-            </SheetHeader>
-            <SheetContainer className="pb-4">
-              <div className="flex w-full items-center">
-                {userDetails && (
-                  <div className="flex w-full flex-col items-center gap-4">
-                    <div className="relative flex flex-col items-center pb-5 sm:pb-3">
-                      <Avatar
-                        name={userDetails.fullName ?? "User avatar"}
-                        visual={userDetails.image ?? undefined}
-                        size="xl"
-                        isRounded
-                      />
-                      <Chip
-                        size="mini"
-                        color={userDetails.revoked ? "rose" : "success"}
-                        label={userDetails.revoked ? "Revoked" : "Active"}
-                        className="absolute -bottom-0 shadow-sm"
-                      />
+          userDetails && (
+            <div className="flex h-full w-full flex-col items-center pt-8">
+              <div className="flex w-full max-w-sm flex-col items-center gap-6">
+                {/* Avatar with role badge */}
+
+                <div className="relative flex flex-col items-center gap-3">
+                  <Avatar
+                    name={userDetails.fullName ?? "User avatar"}
+                    visual={userDetails.image ?? undefined}
+                    size="xl"
+                    isRounded
+                    className={
+                      userDetails.revoked ? "opacity-50 grayscale" : undefined
+                    }
+                  />
+                  <Chip
+                    size="xs"
+                    color={
+                      userDetails.revoked
+                        ? "primary"
+                        : getRoleBadgeColor(userDetails.role)
+                    }
+                    label={
+                      userDetails.revoked
+                        ? "Former member"
+                        : displayRole(userDetails.role)
+                    }
+                    className="absolute -bottom-3 shadow-sm"
+                  />
+                </div>
+                <div className="flex flex-col items-center gap-1">
+                  <h2 className="text-xl font-semibold text-foreground dark:text-foreground-night">
+                    {userDetails.fullName}
+                  </h2>
+                  {(userDetails.startAt ?? userDetails.endAt) && (
+                    <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      {userDetails.revoked && userDetails.endAt
+                        ? `Left the workspace: ${formatDate(userDetails.endAt)}`
+                        : userDetails.startAt
+                          ? `Joined the workspace: ${formatDate(userDetails.startAt)}`
+                          : null}
+                    </p>
+                  )}
+                </div>
+
+                <Separator />
+                <div className="grid w-full grid-cols-2 gap-4">
+                  <div className="col-span-1">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+                      Username
                     </div>
-                    <div className="flex grow flex-col gap-1 text-center sm:text-left">
-                      <div className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">
-                        {userDetails.fullName}
-                      </div>
+                    <div className="mt-1 text-sm text-foreground dark:text-foreground-night">
+                      {userDetails.username}
                     </div>
                   </div>
-                )}
+                  <div className="col-span-1">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+                      Full name
+                    </div>
+                    <div className="mt-1 text-sm text-foreground dark:text-foreground-night">
+                      {userDetails.fullName}
+                    </div>
+                  </div>
+                  <div className="col-span-2">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+                      Email
+                    </div>
+                    <div className="mt-1 text-sm text-foreground dark:text-foreground-night">
+                      {userDetails.email}
+                    </div>
+                  </div>
+                </div>
               </div>
-              {isUserDetailsError ? (
-                <ContentMessage title="Not Available" icon={LockIcon} size="md">
-                  This user is not available.
-                </ContentMessage>
-              ) : (
-                <UserInfoTab userDetails={userDetails} owner={owner} />
-              )}
-            </SheetContainer>
-          </>
+            </div>
+          )
         )}
+        <SheetFooter
+          leftButtonProps={{
+            label: "Close",
+            variant: "outline",
+          }}
+        />
       </SheetContent>
     </Sheet>
   );

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -2,7 +2,6 @@ import { Chip, cn, Page } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AgentMessageMarkdown } from "@app/components/assistant/AgentMessageMarkdown";
-import { AssistantEditedSection } from "@app/components/assistant/details/tabs/AgentInfoTab/AssistantEditedSection";
 import { AssistantKnowledgeSection } from "@app/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection";
 import { AssistantToolsSection } from "@app/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection";
 import type { AgentConfigurationType, WorkspaceType } from "@app/types";
@@ -15,7 +14,7 @@ export function AgentInfoTab({
   owner: WorkspaceType;
 }) {
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-5">
       {agentConfiguration.tags.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {agentConfiguration.tags.map((tag) => (
@@ -24,17 +23,15 @@ export function AgentInfoTab({
         </div>
       )}
 
-      <div className="text-sm text-foreground dark:text-foreground-night">
-        {agentConfiguration.description}
-      </div>
-      {agentConfiguration && (
-        <AssistantEditedSection agentConfiguration={agentConfiguration} />
+      {agentConfiguration.description && (
+        <div className="text-sm text-foreground dark:text-foreground-night">
+          {agentConfiguration.description}
+        </div>
       )}
-      {/* No per-agent configuration button for global Dust agent anymore. */}
-      <Page.Separator />
 
       {agentConfiguration.scope !== "global" && (
         <>
+          <Page.Separator />
           <AssistantKnowledgeSection
             agentConfiguration={agentConfiguration}
             owner={owner}
@@ -54,11 +51,13 @@ export function AgentInfoTab({
                 <AgentMessageMarkdown
                   content={agentConfiguration.instructions}
                   owner={owner}
-                ></AgentMessageMarkdown>
+                />
               </div>
             </div>
           ) : (
-            "This agent has no instructions."
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Instructions
+            </div>
           )}
         </>
       )}

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -28,6 +28,8 @@ export type GetMemberResponseBody = {
     image: string | null;
     revoked: boolean;
     role: RoleType;
+    startAt: string | null;
+    endAt: string | null;
   };
 };
 
@@ -95,6 +97,8 @@ async function handler(
           image: user.imageUrl,
           revoked: membership.isRevoked(),
           role: membership.isRevoked() ? "none" : membership.role,
+          startAt: membership.startAt?.toISOString() ?? null,
+          endAt: membership.endAt?.toISOString() ?? null,
         },
       };
 


### PR DESCRIPTION



## Description

This PR improves the visual layout and information hierarchy of the `AgentDetails` and `MemberDetails` sheets. The changes center the content, enhance the avatar presentation with overlaid badges, and restructure the information display for better readability. Additionally, the PR adds last edited date and author information to the agent details, and join/leave dates to member details.

<img width="422" height="948" alt="Screenshot 2025-12-12 at 17 03 22" src="https://github.com/user-attachments/assets/e466e320-94bf-4bd0-a7e2-36303bc11ada" />
<img width="533" height="957" alt="Screenshot 2025-12-12 at 17 03 30" src="https://github.com/user-attachments/assets/854694ed-4c7c-49cc-ac2e-c7e8909f1b13" />


## Risk

Low

## Tests

Locally

## Deploy Plan

Deploy front
