### PR TITLE
[front] chore(skills): hide `lastEditedAt` for global skills in Manage Skills

### DIFF
--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -13,7 +13,14 @@ export function SkillInfoTab({
       <div className="text-sm text-foreground dark:text-foreground-night">
         {skillConfiguration.description}
       </div>
-      <SkillEdited skillConfiguration={skillConfiguration} />
+      {skillConfiguration.updatedAt && (
+        <SkillEdited
+          skillConfiguration={{
+            ...skillConfiguration,
+            updatedAt: skillConfiguration.updatedAt,
+          }}
+        />
+      )}
 
       <Page.Separator />
 
@@ -30,7 +37,7 @@ export function SkillInfoTab({
 }
 
 interface SkillEditedProps {
-  skillConfiguration: SkillConfigurationType;
+  skillConfiguration: SkillConfigurationType & { updatedAt: number };
 }
 
 export function SkillEdited({ skillConfiguration }: SkillEditedProps) {

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -26,7 +26,7 @@ type RowData = {
   description: string;
   editors: UserType[] | null;
   usage: AgentsUsageType;
-  updatedAt: number;
+  updatedAt: number | null;
   onClick: () => void;
   menuItems: MenuItem[];
 };
@@ -102,16 +102,15 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
     {
       header: "Last Edited",
       accessorKey: "updatedAt",
-      cell: (info: CellContext<RowData, number>) => (
-        <DataTable.BasicCellContent
-          tooltip={formatTimestampToFriendlyDate(info.getValue(), "long")}
-          label={
-            info.getValue()
-              ? formatTimestampToFriendlyDate(info.getValue(), "compact")
-              : "-"
-          }
-        />
-      ),
+      cell: (info: CellContext<RowData, number | null>) => {
+        const value = info.getValue();
+        return (
+          <DataTable.BasicCellContent
+            tooltip={value ? formatTimestampToFriendlyDate(value, "long") : ""}
+            label={value ? formatTimestampToFriendlyDate(value, "compact") : ""}
+          />
+        );
+      },
       meta: { className: "hidden @sm:w-32 @sm:table-cell" },
     },
     {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -773,7 +773,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       id: this.id,
       sId: this.sId,
       createdAt: this.createdAt.getTime(),
-      updatedAt: this.updatedAt.getTime(),
+      updatedAt: this.globalSId ? null : this.updatedAt.getTime(),
       status: this.status,
       name: this.name,
       description: this.description,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -772,7 +772,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return {
       id: this.id,
       sId: this.sId,
-      createdAt: this.createdAt.getTime(),
+      createdAt: this.globalSId ? null : this.createdAt.getTime(),
       updatedAt: this.globalSId ? null : this.updatedAt.getTime(),
       status: this.status,
       name: this.name,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -7,7 +7,7 @@ export type SkillStatus = "active" | "archived";
 export type SkillConfigurationType = {
   id: number;
   sId: string;
-  createdAt: number;
+  createdAt: number | null;
   updatedAt: number | null;
   status: SkillStatus;
   name: string;

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -8,7 +8,7 @@ export type SkillConfigurationType = {
   id: number;
   sId: string;
   createdAt: number;
-  updatedAt: number;
+  updatedAt: number | null;
   status: SkillStatus;
   name: string;
   description: string;


### PR DESCRIPTION
## Description

- This PR shows an empty cell for the `Last Edited` column for global skill.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
