### PR TITLE
[Front]: feat(manage-skills): add skill restoring on skill details sheet

### DIFF
--- a/front/components/skills/RestoreSkillDialog.tsx
+++ b/front/components/skills/RestoreSkillDialog.tsx
@@ -1,0 +1,77 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import { useRestoreSkillConfiguration } from "@app/lib/swr/skill_configurations";
+import type { LightWorkspaceType } from "@app/types";
+import type { SkillConfigurationType } from "@app/types/assistant/skill_configuration";
+
+interface RestoreSkillDialogProps {
+  skillConfiguration: SkillConfigurationType;
+  isOpen: boolean;
+  onClose: () => void;
+  owner: LightWorkspaceType;
+}
+
+export function RestoreSkillDialog({
+  skillConfiguration,
+  isOpen,
+  onClose,
+  owner,
+}: RestoreSkillDialogProps) {
+  const [isRestoring, setIsRestoring] = useState(false);
+  const doRestore = useRestoreSkillConfiguration({ owner, skillConfiguration });
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md" isAlertDialog>
+        <DialogHeader hideButton>
+          <DialogTitle>Restoring the skill</DialogTitle>
+          <DialogDescription>
+            <div>
+              This will restore the skill{" "}
+              <span className="font-bold">{skillConfiguration.name}</span> for
+              everyone.
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="font-bold">Are you sure you want to proceed?</div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            disabled: isRestoring,
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: "Restore the skill",
+            disabled: isRestoring,
+            variant: "warning",
+            onClick: async (e: React.MouseEvent) => {
+              e.preventDefault();
+              setIsRestoring(true);
+              await doRestore();
+              setIsRestoring(false);
+              onClose();
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -1,5 +1,7 @@
 import {
+  ArrowPathIcon,
   Avatar,
+  Button,
   ContentMessage,
   InformationCircleIcon,
   Sheet,
@@ -16,6 +18,7 @@ import {
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useState } from "react";
 
+import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
 import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
 import { SKILL_ICON } from "@app/lib/skill";
@@ -52,7 +55,11 @@ export function SkillDetailsSheet({
           <SheetTitle />
         </VisuallyHidden>
         <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
-          <DescriptionSection skillConfiguration={skillConfiguration} />
+          <DescriptionSection
+            skillConfiguration={skillConfiguration}
+            owner={owner}
+            onClose={onClose}
+          />
         </SheetHeader>
         <SheetContainer className="pb-4">
           <SkillDetailsSheetContent
@@ -119,30 +126,62 @@ export function SkillDetailsSheetContent({
 
 type DescriptionSectionProps = {
   skillConfiguration: SkillConfigurationType;
+  owner: WorkspaceType;
+  onClose: () => void;
 };
 
 const DescriptionSection = ({
   skillConfiguration,
-}: DescriptionSectionProps) => (
-  <div className="flex flex-col gap-5">
-    <div className="flex flex-col gap-3 sm:flex-row">
-      <Avatar name="Skill avatar" visual={<SKILL_ICON />} size="lg" />
-      <div className="flex grow flex-col gap-1">
-        <div className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">
-          {skillConfiguration.name}
+  owner,
+  onClose,
+}: DescriptionSectionProps) => {
+  const [showRestoreModal, setShowRestoreModal] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <Avatar name="Skill avatar" visual={<SKILL_ICON />} size="lg" />
+        <div className="flex grow flex-col gap-1">
+          <div className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">
+            {skillConfiguration.name}
+          </div>
         </div>
       </div>
-    </div>
 
-    {skillConfiguration.status === "archived" && (
-      <ContentMessage
-        title="This skill has been archived."
-        variant="warning"
-        icon={InformationCircleIcon}
-        size="sm"
-      >
-        It is no longer active and cannot be used.
-      </ContentMessage>
-    )}
-  </div>
-);
+      {skillConfiguration.status === "archived" && (
+        <>
+          <ContentMessage
+            title="This skill has been archived."
+            variant="warning"
+            icon={InformationCircleIcon}
+            size="sm"
+          >
+            It is no longer active and cannot be used.
+            {skillConfiguration.canWrite && (
+              <div className="mt-2">
+                <Button
+                  variant="outline"
+                  label="Restore"
+                  onClick={() => {
+                    setShowRestoreModal(true);
+                  }}
+                  icon={ArrowPathIcon}
+                />
+              </div>
+            )}
+          </ContentMessage>
+
+          <RestoreSkillDialog
+            owner={owner}
+            isOpen={showRestoreModal}
+            skillConfiguration={skillConfiguration}
+            onClose={() => {
+              setShowRestoreModal(false);
+              onClose();
+            }}
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -555,6 +555,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return { affectedCount };
   }
 
+  async restore(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<{ affectedCount: number }> {
+    const [affectedCount] = await this.update(
+      {
+        status: "active",
+      },
+      transaction
+    );
+
+    return { affectedCount };
+  }
+
   async updateSkill(
     auth: Authenticator,
     {
@@ -626,7 +640,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     transaction?: Transaction
   ): Promise<[affectedCount: number]> {
     // TODO(SKILLS 2025-12-12): Refactor BaseResource.update to accept auth.
-    if (!this.globalSId) {
+    if (this.globalSId) {
       throw new Error("Cannot update a global skill configuration.");
     }
 

--- a/front/pages/api/w/[wId]/skills/[sId]/restore.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/restore.test.ts
@@ -1,0 +1,128 @@
+import type { RequestMethod } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+
+import handler from "./restore";
+
+async function setupTest(
+  options: { method?: RequestMethod; canWrite?: boolean } = {}
+) {
+  const method = options.method ?? "POST";
+  const canWrite = options.canWrite ?? true;
+
+  const { req, res, workspace, user } = await createPrivateApiMockRequest({
+    role: "builder",
+    method,
+  });
+
+  await FeatureFlagFactory.basic("skills", workspace);
+
+  let skillOwnerAuth: Authenticator;
+  if (canWrite) {
+    skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+  } else {
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, { role: "admin" });
+    skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+  }
+
+  const skill = await SkillConfigurationFactory.create(skillOwnerAuth, {
+    status: "archived",
+  });
+
+  req.query = { ...req.query, wId: workspace.sId, sId: skill.sId };
+
+  return { req, res, workspace, user, auth: skillOwnerAuth, skill };
+}
+
+describe("POST /api/w/[wId]/skills/[sId]/restore", () => {
+  it("should return 200 and restore skill when user can write", async () => {
+    const { req, res, skill, auth } = await setupTest({ canWrite: true });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+
+    const updatedSkill = await SkillResource.fetchById(auth, skill.sId);
+    expect(updatedSkill?.status).toBe("active");
+  });
+
+  it("should return 403 when user cannot write", async () => {
+    const { req, res } = await setupTest({ canWrite: false });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "app_auth_error",
+        message: "Only editors can restore this skill.",
+      },
+    });
+  });
+
+  it("should return 403 when skills feature flag is not enabled", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      role: "builder",
+      method: "POST",
+    });
+    req.query = { ...req.query, wId: workspace.sId, sId: "some_skill_id" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "app_auth_error",
+        message: "Skill builder is not enabled for this workspace.",
+      },
+    });
+  });
+
+  it("should return 404 when skill does not exist", async () => {
+    const { req, res } = await setupTest({ canWrite: true });
+    req.query.sId = "non_existent_skill_id";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "skill_not_found",
+        message: "The skill you're trying to access was not found.",
+      },
+    });
+  });
+});
+
+describe("Method Support /api/w/[wId]/skills/[sId]/restore", () => {
+  it("only supports POST method", async () => {
+    for (const method of ["GET", "PUT", "PATCH", "DELETE"] as const) {
+      const { req, res } = await setupTest({ method });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/skills/[sId]/restore.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/restore.ts
@@ -1,0 +1,86 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+export type RestoreSkillConfigurationResponseBody = {
+  success: true;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<RestoreSkillConfigurationResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (!featureFlags.includes("skills")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Skill builder is not enabled for this workspace.",
+      },
+    });
+  }
+
+  if (!isString(req.query.sId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid skill ID.",
+      },
+    });
+  }
+
+  const sId = req.query.sId;
+  const skillResource = await SkillResource.fetchById(auth, sId);
+
+  if (!skillResource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "The skill you're trying to access was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      if (!skillResource.canWrite(auth)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message: "Only editors can restore this skill.",
+          },
+        });
+      }
+
+      await skillResource.restore(auth);
+
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Task : https://github.com/dust-tt/tasks/issues/5599
Added modal, new endpoint, test, and resource method for restoring an archived skill from the UI

## Tests

Local

https://github.com/user-attachments/assets/a54979f7-ad60-4e94-a5ac-d6d3203a9507

## Risk

Low

## Deploy Plan

Front