### PR TITLE
Extension: Graceful fail of tool requiring personal oauth

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -264,13 +264,12 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.20.tgz",
-      "integrity": "sha512-KEJsfUyco1deqSQWcctnZOfWmW3/+PzF4ggw41po1SQWBUNMA57jXwrn8IelIZEdbVln1+MeJ6dIY3aCSAO5lw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.22.tgz",
+      "integrity": "sha512-HE/wntlVwQmoDEpVwZJFjSapxIhHDKHCu3EfzrwC2jqMiegvZcUPS1RZHpBTc1UXdKdqlOEARzm12vBL3L5YtA==",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],
-      "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "git://github.com/dust-tt/typescript-sdk.git#628ebe48388549faae7e35504611af9ac2c6f5e4",
         "@types/json-schema": "^7.0.15",
@@ -5374,22 +5373,41 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
         "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bonjour-service": {
@@ -6712,9 +6730,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -10120,9 +10138,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11872,9 +11890,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "dev": true,
       "engines": {
         "node": ">= 6.13.0"
@@ -13154,17 +13172,51 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react": {
@@ -14818,9 +14870,9 @@
       }
     },
     "node_modules/sucrase/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",

--- a/extension/ui/components/conversation/MCPServerAuthRequired.tsx
+++ b/extension/ui/components/conversation/MCPServerAuthRequired.tsx
@@ -1,0 +1,98 @@
+import { asDisplayName } from "@app/shared/lib/utils";
+import {
+  Button,
+  CloudArrowLeftRightIcon,
+  ConfluenceLogo,
+  ContentMessage,
+  DriveLogo,
+  GithubLogo,
+  GmailLogo,
+  HubspotLogo,
+  InformationCircleIcon,
+  JiraLogo,
+  LinearLogo,
+  MicrosoftLogo,
+  MicrosoftOutlookLogo,
+  MicrosoftTeamsLogo,
+  NotionLogo,
+  SalesforceLogo,
+  SlackLogo,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+const PROVIDER_ICONS: Record<string, ComponentType<{ className?: string }>> = {
+  gmail: GmailLogo,
+  "google drive": DriveLogo,
+  drive: DriveLogo,
+  slack: SlackLogo,
+  notion: NotionLogo,
+  github: GithubLogo,
+  confluence: ConfluenceLogo,
+  jira: JiraLogo,
+  linear: LinearLogo,
+  hubspot: HubspotLogo,
+  salesforce: SalesforceLogo,
+  microsoft: MicrosoftLogo,
+  outlook: MicrosoftOutlookLogo,
+  "microsoft outlook": MicrosoftOutlookLogo,
+  teams: MicrosoftTeamsLogo,
+  "microsoft teams": MicrosoftTeamsLogo,
+};
+
+function getProviderIcon(
+  displayName: string
+): ComponentType<{ className?: string }> {
+  return PROVIDER_ICONS[displayName.toLowerCase()] ?? InformationCircleIcon;
+}
+
+interface MCPServerAuthRequiredProps {
+  dustDomain: string;
+  workspaceId: string;
+  conversationId: string;
+  mcpServerDisplayName: string;
+}
+
+export function MCPServerAuthRequired({
+  dustDomain,
+  workspaceId,
+  conversationId,
+  mcpServerDisplayName,
+}: MCPServerAuthRequiredProps) {
+  const formattedDisplayName = asDisplayName(mcpServerDisplayName);
+  const IconComponent = getProviderIcon(mcpServerDisplayName);
+
+  const onConnectClick = () => {
+    const conversationUrl = `${dustDomain}/w/${workspaceId}/assistant/${conversationId}`;
+    window.open(conversationUrl, "_blank");
+  };
+
+  return (
+    <ContentMessage
+      title={formattedDisplayName || "Personal authentication required"}
+      variant="primary"
+      className="flex w-80 min-w-[500px] flex-col gap-3"
+      icon={IconComponent}
+    >
+      <div className="font-sm whitespace-normal break-words text-foreground dark:text-foreground-night">
+        Your agent is trying to use{" "}
+        <span className="font-semibold">
+          {formattedDisplayName || "a tool"}
+        </span>
+        .
+        <br />
+        <span className="font-semibold">
+          Connect your account from our website to continue.
+        </span>
+      </div>
+      <div className="mt-3 flex flex-row justify-end">
+        <Button
+          label="Open conversation on Dust"
+          variant="highlight"
+          size="xs"
+          icon={CloudArrowLeftRightIcon}
+          onClick={onConnectClick}
+        />
+      </div>
+    </ContentMessage>
+  );
+}


### PR DESCRIPTION
## Description

I did not plan to work on that but I fell in the trap. Here's what happened. 

- I was supposed to fix a logo size on the "upgrade" page of the extension. So I `cd extension && npm install`
- That shows many high severity issues so I decide to run an `npm audit fix` 
- That bumps the SDK so now I have an error when running the extension, which does not handle a new event added last week called `tool_personal_auth_required`
- I decide to handle it. I try the personal auth flow on the extension, and it's really bad. Here's the same convo, left on web and right on the extension. The button on the extension are "Retry" but you can retry for ever if you don't do the auth flow, and a "Details" that shows an error code.  

<kbd>
<img width="1483" height="1021" alt="Screenshot 2025-12-12 at 16 24 47" src="https://github.com/user-attachments/assets/d616696d-52db-49f8-8e78-b33a58af678d" />
</kbd>


- So I decide to fix that. I implement the component and open the oAuth flow in a new tab. I quickly realize it's going to be too demanding so I fallback to offer opening the conversation to do the flow on web. 
- Works but then I got streaming issue, streaming is closed when message is in status failed. I fix that. 

Here's the result: 

<kbd>
<img width="603" height="1005" alt="Screenshot 2025-12-12 at 17 07 55" src="https://github.com/user-attachments/assets/c954d45c-aeb1-4ebc-88c4-7cc14577fd1d" />
</kbd>

It's not a perfect flow but it's better than before 🙏🏻 

## Tests

Locally. 

## Risk

Technically can break anything with the npm audit fix + break streaming I guess 😅 
Only extension code though! 

## Deploy Plan

Merge. 
Test on a prod build. 
If good bump and submit version. 
