### PR TITLE
[front] refactor(skills): rename `description` into `agentFacingDescription`

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -148,7 +148,7 @@ export default function AgentBuilder({
     return skills.map((skill) => ({
       sId: skill.sId,
       name: skill.name,
-      description: skill.description,
+      description: skill.agentFacingDescription,
     }));
   }, [skills]);
 

--- a/front/components/agent_builder/skills/skillSheet/SkillCard.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SkillCard.tsx
@@ -21,7 +21,7 @@ export function SkillCard({
     <ActionCard
       icon={SKILL_ICON}
       label={skill.name}
-      description={skill.description}
+      description={skill.agentFacingDescription}
       isSelected={isSelected}
       canAdd
       onClick={onClick}

--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -46,7 +46,7 @@ export const useLocalSelectedSkills = ({
     return skillConfigurationsWithRelations.filter(
       (skill) =>
         skill.name.toLowerCase().includes(query) ||
-        skill.description.toLowerCase().includes(query)
+        skill.agentFacingDescription.toLowerCase().includes(query)
     );
   }, [skillConfigurationsWithRelations, searchQuery]);
 
@@ -63,7 +63,7 @@ export const useLocalSelectedSkills = ({
           {
             sId: skill.sId,
             name: skill.name,
-            description: skill.description,
+            description: skill.agentFacingDescription,
           },
         ];
       }

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -43,7 +43,7 @@ export function getPageAndFooter(props: PageContentProps): {
       return {
         page: {
           title: mode.skillConfiguration.name,
-          description: mode.skillConfiguration.description,
+          description: mode.skillConfiguration.agentFacingDescription,
           id: props.mode.type,
           icon: SKILL_ICON,
           content: (

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -49,9 +49,9 @@ export function SimilarSkillsDisplay({
               <span className="text-sm font-medium text-foreground dark:text-foreground-night">
                 {skill.name}
               </span>
-              {skill.description && (
+              {skill.agentFacingDescription && (
                 <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                  {skill.description}
+                  {skill.agentFacingDescription}
                 </span>
               )}
             </div>

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -12,7 +12,7 @@ export function transformSkillConfigurationToFormData(
 ): SkillBuilderFormData {
   return {
     name: skillConfiguration.name,
-    description: skillConfiguration.description,
+    description: skillConfiguration.agentFacingDescription,
     instructions: skillConfiguration.instructions ?? "",
     editors: [], // Will be populated reactively from useEditors hook
     tools: [], // Will be populated reactively from MCP server views context

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -11,7 +11,7 @@ export function SkillInfoTab({
   return (
     <div className="flex flex-col gap-4">
       <div className="text-sm text-foreground dark:text-foreground-night">
-        {skillConfiguration.description}
+        {skillConfiguration.agentFacingDescription}
       </div>
       <SkillEdited skillConfiguration={skillConfiguration} />
 

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -151,7 +151,7 @@ export function SkillsTable({
     () =>
       skills.map((skill) => ({
         name: skill.name,
-        description: skill.description,
+        description: skill.agentFacingDescription,
         editors: skill.editors,
         usage: skill.usage,
         updatedAt: skill.updatedAt,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,5 +1,4 @@
 import moment from "moment-timezone";
-import { errors } from "rehype-parse/lib/errors";
 
 import {
   DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME,
@@ -29,7 +28,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { CHAIN_OF_THOUGHT_META_PROMPT } from "@app/types/assistant/chain_of_thought_meta_prompt";
-import description = errors.abandonedHeadElementChild.description;
 
 function constructContextSection({
   userMessage,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,4 +1,5 @@
 import moment from "moment-timezone";
+import { errors } from "rehype-parse/lib/errors";
 
 import {
   DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME,
@@ -28,6 +29,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { CHAIN_OF_THOUGHT_META_PROMPT } from "@app/types/assistant/chain_of_thought_meta_prompt";
+import description = errors.abandonedHeadElementChild.description;
 
 function constructContextSection({
   userMessage,
@@ -182,7 +184,10 @@ function constructSkillsSection({
     skillsSection += "\n### AVAILABLE SKILLS\n";
     skillsSection += `The following skills are available but not currently enabled, you can enable them with the ${DEFAULT_ENABLE_SKILL_TOOL_NAME} tool.\n`;
     const skillList = equippedSkills
-      .map(({ name, description }) => `- **${name}**: ${description}`)
+      .map(
+        ({ name, agentFacingDescription }) =>
+          `- **${name}**: ${agentFacingDescription}`
+      )
       .join("\n");
     skillsSection += skillList + "\n";
   }

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -122,7 +122,7 @@ export async function getSimilarSkills(
   const existingSkills = skills
     .map(
       (s) => `Skill ID ${s.sId}:
-"${truncateDescription(s.description)}"`
+"${truncateDescription(s.agentFacingDescription)}"`
     )
     .join("\n---\n");
   const inputText = `Input description:"${inputs.naturalDescription}"

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -32,7 +32,7 @@ const SKILL_MODEL_ATTRIBUTES = {
     type: DataTypes.TEXT,
     allowNull: false,
   },
-  description: {
+  agentFacingDescription: {
     type: DataTypes.TEXT,
     allowNull: false,
   },

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -57,7 +57,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   declare status: SkillStatus;
 
   declare name: string;
-  declare description: string;
+  declare agentFacingDescription: string;
   declare instructions: string;
   declare icon: string | null;
 

--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -4,7 +4,8 @@ import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/regi
 export const framesSkill = {
   sId: "frames",
   name: "Frames",
-  description: "Create dashboards, presentations, or any interactive content.",
+  agentFacingDescription:
+    "Create dashboards, presentations, or any interactive content.",
   instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
   version: 1,
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -2,7 +2,7 @@ import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 
 export interface GlobalSkillDefinition {
-  readonly description: string;
+  readonly agentFacingDescription: string;
   readonly instructions: string;
   readonly name: string;
   readonly sId: string;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -512,7 +512,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       {
         authorId: -1,
         createdAt: new Date(),
-        description: def.description,
+        agentFacingDescription: def.agentFacingDescription,
         // We fake the id here. We should rely exclusively on sId for global skills.
         id: -1,
         instructions: def.instructions,
@@ -625,7 +625,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     await this.update(
       {
         name,
-        description,
+        agentFacingDescription: description,
         instructions,
         icon,
       },
@@ -776,7 +776,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       updatedAt: this.updatedAt.getTime(),
       status: this.status,
       name: this.name,
-      description: this.description,
+      agentFacingDescription: this.agentFacingDescription,
       // We don't want to leak global skills instructions to frontend
       instructions: this.globalSId ? null : this.instructions,
       requestedSpaceIds: this.requestedSpaceIds,
@@ -826,7 +826,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       version: versionNumber,
       status: this.status,
       name: this.name,
-      description: this.description,
+      agentFacingDescription: this.agentFacingDescription,
       instructions: this.instructions,
       requestedSpaceIds: this.requestedSpaceIds,
       authorId: this.authorId,

--- a/front/migrations/db/migration_441.sql
+++ b/front/migrations/db/migration_441.sql
@@ -1,0 +1,3 @@
+-- Migration created on Dec 12, 2025
+ALTER TABLE "public"."skill_configurations" ADD COLUMN "agentFacingDescription" TEXT;
+UPDATE "public"."skill_configurations" SET "agentFacingDescription" = "description";

--- a/front/migrations/db/migration_442.sql
+++ b/front/migrations/db/migration_442.sql
@@ -1,0 +1,2 @@
+-- Migration created on Dec 12, 2025
+ALTER TABLE "public"."skill_configurations" DROP COLUMN "description";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
@@ -58,11 +58,11 @@ describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/skills", () => {
     // Create skills and link them to the agent
     const skill1 = await SkillConfigurationFactory.create(auth, {
       name: "Test Skill 1",
-      description: "First test skill",
+      agentFacingDescription: "First test skill",
     });
     const skill2 = await SkillConfigurationFactory.create(auth, {
       name: "Test Skill 2",
-      description: "Second test skill",
+      agentFacingDescription: "Second test skill",
     });
 
     await SkillConfigurationFactory.linkToAgent(auth, {
@@ -83,7 +83,7 @@ describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/skills", () => {
     expect(data.skills).toHaveLength(2);
     expect(data.skills[0]).toHaveProperty("sId");
     expect(data.skills[0]).toHaveProperty("name");
-    expect(data.skills[0]).toHaveProperty("description");
+    expect(data.skills[0]).toHaveProperty("agentFacingDescription");
 
     const skillNames = data.skills.map((s: SkillConfigurationType) => s.name);
     expect(skillNames).toContain("Test Skill 1");

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -466,7 +466,9 @@ describe("POST /api/w/[wId]/skills", () => {
       },
     });
     expect(skillConfiguration).not.toBeNull();
-    expect(skillConfiguration!.description).toBe("A test skill description");
+    expect(skillConfiguration!.agentFacingDescription).toBe(
+      "A test skill description"
+    );
     expect(skillConfiguration!.instructions).toBe(
       "Test instructions for the skill"
     );

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -51,11 +51,11 @@ describe("GET /api/w/[wId]/skills", () => {
 
     await SkillConfigurationFactory.create(auth, {
       name: "Test Skill 1",
-      description: "First test skill",
+      agentFacingDescription: "First test skill",
     });
     await SkillConfigurationFactory.create(auth, {
       name: "Test Skill 2",
-      description: "Second test skill",
+      agentFacingDescription: "Second test skill",
     });
 
     req.query = { ...req.query, wId: workspace.sId };
@@ -375,7 +375,7 @@ describe("POST /api/w/[wId]/skills", () => {
 
     req.body = {
       name: "Simple Skill",
-      description: "A simple skill without tools",
+      agentFacingDescription: "A simple skill without tools",
       instructions: "Simple instructions",
       icon: null,
       tools: [],
@@ -387,7 +387,7 @@ describe("POST /api/w/[wId]/skills", () => {
     const responseData = res._getJSONData();
     expect(responseData.skillConfiguration).toMatchObject({
       name: "Simple Skill",
-      description: "A simple skill without tools",
+      agentFacingDescription: "A simple skill without tools",
       instructions: "Simple instructions",
       status: "active",
       tools: [],
@@ -434,7 +434,7 @@ describe("POST /api/w/[wId]/skills", () => {
 
     req.body = {
       name: "Test Skill",
-      description: "A test skill description",
+      agentFacingDescription: "A test skill agent facing description",
       instructions: "Test instructions for the skill",
       icon: null,
       tools: [
@@ -449,7 +449,7 @@ describe("POST /api/w/[wId]/skills", () => {
     const responseData = res._getJSONData();
     expect(responseData.skillConfiguration).toMatchObject({
       name: "Test Skill",
-      description: "A test skill description",
+      agentFacingDescription: "A test skill agent facing description",
       instructions: "Test instructions for the skill",
       status: "active",
       tools: [
@@ -467,7 +467,7 @@ describe("POST /api/w/[wId]/skills", () => {
     });
     expect(skillConfiguration).not.toBeNull();
     expect(skillConfiguration!.agentFacingDescription).toBe(
-      "A test skill description"
+      "A test skill agent facing description"
     );
     expect(skillConfiguration!.instructions).toBe(
       "Test instructions for the skill"

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -375,7 +375,7 @@ describe("POST /api/w/[wId]/skills", () => {
 
     req.body = {
       name: "Simple Skill",
-      agentFacingDescription: "A simple skill without tools",
+      description: "A simple skill without tools",
       instructions: "Simple instructions",
       icon: null,
       tools: [],
@@ -434,7 +434,7 @@ describe("POST /api/w/[wId]/skills", () => {
 
     req.body = {
       name: "Test Skill",
-      agentFacingDescription: "A test skill agent facing description",
+      description: "A test skill agent facing description",
       instructions: "Test instructions for the skill",
       icon: null,
       tools: [

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -191,7 +191,7 @@ async function handler(
       const skillResource = await SkillResource.makeNew(auth, {
         status: "active",
         name: body.name,
-        description: body.description,
+        agentFacingDescription: body.description,
         instructions: body.instructions,
         authorId: user.id,
         // TODO(skills): add space restrictions.

--- a/front/tests/utils/SkillConfigurationFactory.ts
+++ b/front/tests/utils/SkillConfigurationFactory.ts
@@ -10,7 +10,7 @@ export class SkillConfigurationFactory {
     auth: Authenticator,
     overrides: Partial<{
       name: string;
-      description: string;
+      agentFacingDescription: string;
       instructions: string;
       status: "active" | "archived";
     }> = {}
@@ -19,13 +19,14 @@ export class SkillConfigurationFactory {
     assert(user, "User is required");
 
     const name = overrides.name ?? "Test Skill";
-    const description = overrides.description ?? "Test skill description";
+    const agentFacingDescription =
+      overrides.agentFacingDescription ?? "Test skill agentFacingDescription";
     const instructions = overrides.instructions ?? "Test skill instructions";
     const status = overrides.status ?? "active";
 
     return SkillResource.makeNew(auth, {
       authorId: user.id,
-      agentFacingDescription: description,
+      agentFacingagentFacingDescription: agentFacingDescription,
       instructions,
       name,
       requestedSpaceIds: [],

--- a/front/tests/utils/SkillConfigurationFactory.ts
+++ b/front/tests/utils/SkillConfigurationFactory.ts
@@ -25,7 +25,7 @@ export class SkillConfigurationFactory {
 
     return SkillResource.makeNew(auth, {
       authorId: user.id,
-      description,
+      agentFacingDescription: description,
       instructions,
       name,
       requestedSpaceIds: [],

--- a/front/tests/utils/SkillConfigurationFactory.ts
+++ b/front/tests/utils/SkillConfigurationFactory.ts
@@ -26,7 +26,7 @@ export class SkillConfigurationFactory {
 
     return SkillResource.makeNew(auth, {
       authorId: user.id,
-      agentFacingagentFacingDescription: agentFacingDescription,
+      agentFacingDescription,
       instructions,
       name,
       requestedSpaceIds: [],

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -11,7 +11,7 @@ export type SkillConfigurationType = {
   updatedAt: number;
   status: SkillStatus;
   name: string;
-  description: string;
+  agentFacingDescription: string;
   instructions: string | null;
   icon: string | null;
   requestedSpaceIds: ModelId[];


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/5603
- We'll add a column `userFacingDescription` for the user-facing description (which will be much more concise and used to describe the skill to users who will be using it in the Agent Builder.
- This PR only renames the existing file (scattered across various files).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Run migration to add column.
- Deploy front.
- Run migration to delete column.
