### PR TITLE
[front] chore(skills): use user facing description

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -148,7 +148,7 @@ export default function AgentBuilder({
     return skills.map((skill) => ({
       sId: skill.sId,
       name: skill.name,
-      description: skill.agentFacingDescription,
+      description: skill.userFacingDescription,
     }));
   }, [skills]);
 

--- a/front/components/agent_builder/skills/skillSheet/SkillCard.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SkillCard.tsx
@@ -21,7 +21,7 @@ export function SkillCard({
     <ActionCard
       icon={SKILL_ICON}
       label={skill.name}
-      description={skill.agentFacingDescription}
+      description={skill.userFacingDescription}
       isSelected={isSelected}
       canAdd
       onClick={onClick}

--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -46,7 +46,7 @@ export const useLocalSelectedSkills = ({
     return skillConfigurationsWithRelations.filter(
       (skill) =>
         skill.name.toLowerCase().includes(query) ||
-        skill.agentFacingDescription.toLowerCase().includes(query)
+        skill.userFacingDescription.toLowerCase().includes(query)
     );
   }, [skillConfigurationsWithRelations, searchQuery]);
 
@@ -63,7 +63,7 @@ export const useLocalSelectedSkills = ({
           {
             sId: skill.sId,
             name: skill.name,
-            description: skill.agentFacingDescription,
+            description: skill.userFacingDescription,
           },
         ];
       }

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -43,7 +43,7 @@ export function getPageAndFooter(props: PageContentProps): {
       return {
         page: {
           title: mode.skillConfiguration.name,
-          description: mode.skillConfiguration.agentFacingDescription,
+          description: mode.skillConfiguration.userFacingDescription,
           id: props.mode.type,
           icon: SKILL_ICON,
           content: (

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -49,11 +49,9 @@ export function SimilarSkillsDisplay({
               <span className="text-sm font-medium text-foreground dark:text-foreground-night">
                 {skill.name}
               </span>
-              {skill.agentFacingDescription && (
-                <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                  {skill.agentFacingDescription}
-                </span>
-              )}
+              <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                {skill.agentFacingDescription}
+              </span>
             </div>
           </div>
         ))}

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -11,8 +11,9 @@ export function SkillInfoTab({
   return (
     <div className="flex flex-col gap-4">
       <div className="text-sm text-foreground dark:text-foreground-night">
-        {skillConfiguration.agentFacingDescription}
+        {skillConfiguration.userFacingDescription}
       </div>
+      {/* TODO(skills 2025-12-12): display agent facing description here */}
       {skillConfiguration.updatedAt && (
         <SkillEdited
           skillConfiguration={{

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -150,7 +150,7 @@ export function SkillsTable({
     () =>
       skills.map((skill) => ({
         name: skill.name,
-        description: skill.agentFacingDescription,
+        description: skill.userFacingDescription,
         editors: skill.editors,
         usage: skill.usage,
         updatedAt: skill.updatedAt,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5603
- This PR uses the user facing description in Agent Builder and Manage Skills.

<img width="794" height="433" alt="Screenshot 2025-12-13 at 4 53 56 PM" src="https://github.com/user-attachments/assets/1f83b35b-4205-46c0-afdd-c3dbf3200280" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
