### PR TITLE
[front] feat(skills): add icon in `SkillTable`

### DIFF
--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -1,5 +1,6 @@
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
+  Avatar,
   DataTable,
   EyeIcon,
   PencilSquareIcon,
@@ -24,6 +25,7 @@ import type { AgentsUsageType } from "@app/types/data_source";
 
 type RowData = {
   name: string;
+  icon: string | null;
   description: string;
   editors: UserType[] | null;
   usage: AgentsUsageType;
@@ -48,12 +50,17 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
       accessorKey: "name",
       cell: (info: CellContext<RowData, string>) => (
         <DataTable.CellContent>
-          <div className="flex min-w-0 grow flex-col py-3">
-            <div className="heading-sm overflow-hidden truncate text-foreground dark:text-foreground-night">
-              {info.getValue()}
+          <div className="flex flex-row items-center gap-2 py-3">
+            <div>
+              <Avatar visual={info.row.original.icon} size="sm" />
             </div>
-            <div className="overflow-hidden truncate text-sm text-muted-foreground dark:text-muted-foreground-night">
-              {info.row.original.description}
+            <div className="flex min-w-0 grow flex-col">
+              <div className="heading-sm overflow-hidden truncate text-foreground dark:text-foreground-night">
+                {info.getValue()}
+              </div>
+              <div className="overflow-hidden truncate text-sm text-muted-foreground dark:text-muted-foreground-night">
+                {info.row.original.description}
+              </div>
             </div>
           </div>
         </DataTable.CellContent>
@@ -150,6 +157,7 @@ export function SkillsTable({
     () =>
       skills.map((skill) => ({
         name: skill.name,
+        icon: skill.icon,
         description: skill.userFacingDescription,
         editors: skill.editors,
         usage: skill.usage,

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -352,20 +352,20 @@ export default function WorkspaceAssistants({
             )}
           </div>
           {selectedTags.length > 0 && (
-              <div className="flex flex-row gap-2">
-                {selectedTags.map((tag) => (
-                  <Chip
-                    key={tag.sId}
-                    label={tag.name}
-                    size="xs"
-                    color="golden"
-                    onRemove={() =>
-                      setSelectedTags(selectedTags.filter((t) => t !== tag))
-                    }
-                  />
-                ))}
-              </div>
-            )}
+            <div className="flex flex-row gap-2">
+              {selectedTags.map((tag) => (
+                <Chip
+                  key={tag.sId}
+                  label={tag.name}
+                  size="xs"
+                  color="golden"
+                  onRemove={() =>
+                    setSelectedTags(selectedTags.filter((t) => t !== tag))
+                  }
+                />
+              ))}
+            </div>
+          )}
           <div className="flex flex-col pt-3">
             {isBatchEdit ? (
               <AgentEditBar

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -351,19 +351,21 @@ export default function WorkspaceAssistants({
               </div>
             )}
           </div>
-          <div className="flex flex-row gap-2">
-            {selectedTags.map((tag) => (
-              <Chip
-                key={tag.sId}
-                label={tag.name}
-                size="xs"
-                color="golden"
-                onRemove={() =>
-                  setSelectedTags(selectedTags.filter((t) => t !== tag))
-                }
-              />
-            ))}
-          </div>
+          {selectedTags.length > 0 && (
+              <div className="flex flex-row gap-2">
+                {selectedTags.map((tag) => (
+                  <Chip
+                    key={tag.sId}
+                    label={tag.name}
+                    size="xs"
+                    color="golden"
+                    onRemove={() =>
+                      setSelectedTags(selectedTags.filter((t) => t !== tag))
+                    }
+                  />
+                ))}
+              </div>
+            )}
           <div className="flex flex-col pt-3">
             {isBatchEdit ? (
               <AgentEditBar


### PR DESCRIPTION
## Description

- This PR adds the icon in the `SkillTable`.
- This PR also aligns the space underneath the search bar between Manage Agents and Manage Skills

<img width="1607" height="485" alt="Screenshot 2025-12-13 at 5 09 01 PM" src="https://github.com/user-attachments/assets/1d823d0d-ac6e-4477-824f-11606a93ac0e" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
