### PR TITLE
[front] chore(skills): update default icon in Skill Builder

### DIFF
--- a/front/components/skill_builder/SkillBuilderIconSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIconSection.tsx
@@ -1,6 +1,6 @@
 import {
-  ActionBookOpenIcon,
   ActionIcons,
+  ActionPlusIcon,
   Avatar,
   Button,
   IconPicker,
@@ -14,7 +14,7 @@ import { useController } from "react-hook-form";
 
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 
-const DEFAULT_ICON = ActionBookOpenIcon;
+const DEFAULT_ICON = ActionPlusIcon;
 
 export function SkillBuilderIconSection() {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -25,8 +25,9 @@ export function SkillBuilderIconSection() {
   const toActionIconKey = (v?: string | null) =>
     v && v in ActionIcons ? (v as keyof typeof ActionIcons) : undefined;
 
-  const defaultKey = Object.keys(ActionIcons)[0] as keyof typeof ActionIcons;
-  const selectedIconName = toActionIconKey(iconField.value) ?? defaultKey;
+  const selectedIconName =
+    toActionIconKey(iconField.value) ??
+    (DEFAULT_ICON.name as keyof typeof ActionIcons);
   const IconComponent = ActionIcons[selectedIconName] || DEFAULT_ICON;
 
   const closePopover = () => {
@@ -37,7 +38,10 @@ export function SkillBuilderIconSection() {
     <PopoverRoot open={isPopoverOpen}>
       <PopoverTrigger asChild>
         <div className="group relative">
-          <Avatar size="lg" visual={<IconComponent />} />
+          <Avatar
+            size="lg"
+            visual={<IconComponent className="h-8 w-8 text-muted-foreground" />}
+          />
           <Button
             variant="outline"
             size="sm"


### PR DESCRIPTION
## Description

- This PR updates the default icon we see when opening the Skill Builder to match the [Figma](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=860-53735&t=N5KBLyaeZC0lfuwj-0)
- There's potentially something unexpected happening with the dark mode: it seems to control the color of the icon, which displays poorly with Avatars, since Avatars have a fixed color background.

Before
<img width="829" height="529" alt="Screenshot 2025-12-13 at 5 30 21 PM" src="https://github.com/user-attachments/assets/375f2e6c-557f-4ce8-96b3-202028d95701" />

After
<img width="829" height="529" alt="Screenshot 2025-12-13 at 5 29 54 PM" src="https://github.com/user-attachments/assets/922ac067-b26f-4864-8e95-9a8e5713faff" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
