### PR TITLE
feat(mentions): add pending mention model and invitation flow backend [Phase 1/4]

### DIFF
--- a/front/lib/api/assistant/conversation/invitation_prompts.ts
+++ b/front/lib/api/assistant/conversation/invitation_prompts.ts
@@ -1,0 +1,75 @@
+import type { Transaction } from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { PendingMentionModel } from "@app/lib/models/agent/conversation";
+import type {
+  ConversationWithoutContentType,
+  MessageType,
+  UserType,
+} from "@app/types";
+
+/**
+ * Creates a content fragment that displays an invitation prompt for a pending mention.
+ * This prompt is visible to all participants but only actionable by the mentioner.
+ *
+ * TODO(Phase 3): Implement content fragment creation for invitation prompts.
+ * For now, this is a placeholder that will be implemented when we add the frontend UI.
+ * The content fragment should include:
+ * - pendingMentionId
+ * - mentionedUser info (sId, name, username)
+ * - mentionerUser info (sId, name)
+ * - status: "pending"
+ * - messageId
+ */
+export async function postInvitationPromptContentFragment(
+  auth: Authenticator,
+  {
+    conversation,
+    message,
+    mentionedUser,
+    mentionerUser,
+    pendingMentionId,
+    transaction,
+  }: {
+    conversation: ConversationWithoutContentType;
+    message: MessageType;
+    mentionedUser: UserType;
+    mentionerUser: UserType;
+    pendingMentionId: number;
+    transaction?: Transaction;
+  }
+): Promise<void> {
+  // Placeholder - will be implemented in Phase 3 with frontend
+  // The content fragment creation will be added here
+  void auth;
+  void conversation;
+  void message;
+  void mentionedUser;
+  void mentionerUser;
+  void pendingMentionId;
+  void transaction;
+}
+
+/**
+ * Updates an existing invitation prompt content fragment with a new status.
+ *
+ * TODO(Phase 3): Implement content fragment update for invitation prompts.
+ */
+export async function updateInvitationPromptContentFragment(
+  auth: Authenticator,
+  {
+    pendingMentionId,
+    status,
+    mentionedUser,
+  }: {
+    pendingMentionId: number;
+    status: "accepted" | "declined";
+    mentionedUser?: UserType;
+  }
+): Promise<void> {
+  // Placeholder - will be implemented in Phase 3 with frontend
+  void auth;
+  void pendingMentionId;
+  void status;
+  void mentionedUser;
+}

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -842,6 +842,34 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     };
   }
 
+  static async getParticipantForUser(
+    auth: Authenticator,
+    {
+      conversationId,
+      userId,
+    }: {
+      conversationId: string;
+      userId: string;
+    }
+  ): Promise<ConversationParticipantModel | null> {
+    const conversationModelId = getResourceIdFromSId(conversationId);
+    const userResource = await UserResource.fetchById(userId);
+
+    if (!conversationModelId || !userResource) {
+      return null;
+    }
+
+    const participant = await ConversationParticipantModel.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversationModelId,
+        userId: userResource.id,
+      },
+    });
+
+    return participant;
+  }
+
   static async upsertParticipation(
     auth: Authenticator,
     {

--- a/front/migrations/db/migration_440.sql
+++ b/front/migrations/db/migration_440.sql
@@ -1,0 +1,22 @@
+-- Create pending_mentions table for mention confirmation flow
+CREATE TABLE IF NOT EXISTS pending_mentions (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "workspaceId" BIGINT NOT NULL REFERENCES workspaces(id) ON DELETE RESTRICT,
+  "conversationId" BIGINT NOT NULL REFERENCES conversations(id) ON DELETE RESTRICT,
+  "messageId" BIGINT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+  "mentionedUserId" BIGINT NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  "mentionerUserId" BIGINT NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  "status" VARCHAR(255) NOT NULL DEFAULT 'pending'
+);
+
+-- Create indexes
+CREATE INDEX pending_mentions_workspace_id_conversation_id_status_idx
+  ON pending_mentions("workspaceId", "conversationId", "status");
+
+CREATE INDEX pending_mentions_workspace_id_message_id_mentioned_user_id_idx
+  ON pending_mentions("workspaceId", "messageId", "mentionedUserId");
+
+CREATE INDEX pending_mentions_mentioner_user_id_status_idx
+  ON pending_mentions("mentionerUserId", "status");


### PR DESCRIPTION
- Create PendingMentionModel to track mention confirmations
- Add database migration for pending_mentions table
- Modify createUserMentions to check for existing participants
- Implement invitation prompt content fragment helpers (placeholder)
- Add feature flag check for mentions_v2
- Add getParticipantForUser method to ConversationResource

When mentions_v2 flag is enabled, users mentioned in conversations
will not be automatically added as participants. Instead, a pending
mention is created and the mentioner sees a prompt to confirm
adding them to the conversation.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
