### PR TITLE
feat(mentions): add frontend UI for pending mention invitations [Phase 3/4]

### DIFF
--- a/front/components/assistant/conversation/PendingMentionPrompt.tsx
+++ b/front/components/assistant/conversation/PendingMentionPrompt.tsx
@@ -1,0 +1,109 @@
+import { Button, Chip } from "@dust-tt/sparkle";
+import type { WorkspaceType } from "@dust-tt/types";
+import { useCallback, useState } from "react";
+
+import type { PendingMentionType } from "@app/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/pending";
+
+interface PendingMentionPromptProps {
+  conversationId: string;
+  currentUserSId: string;
+  owner: WorkspaceType;
+  pendingMention: PendingMentionType;
+  onResolved: () => void;
+}
+
+export function PendingMentionPrompt({
+  conversationId,
+  currentUserSId,
+  owner,
+  pendingMention,
+  onResolved,
+}: PendingMentionPromptProps) {
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isMentioner = currentUserSId === pendingMention.mentionerUser.sId;
+
+  const handleAction = useCallback(
+    async (action: "confirm" | "decline") => {
+      setIsProcessing(true);
+      setError(null);
+
+      try {
+        const response = await fetch(
+          `/api/v1/w/${owner.sId}/assistant/conversations/${conversationId}/mentions/${pendingMention.id}/${action}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(
+            errorData.error?.message || `Failed to ${action} invitation`
+          );
+        }
+
+        // Notify parent to refresh
+        onResolved();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : `Failed to ${action}`);
+      } finally {
+        setIsProcessing(false);
+      }
+    },
+    [conversationId, owner.sId, pendingMention.id, onResolved]
+  );
+
+  return (
+    <div className="border-structure-200 bg-structure-50 my-4 rounded-lg border p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <Chip color="amber" size="xs">
+              Pending Invitation
+            </Chip>
+          </div>
+          <div className="text-element-700 mt-2 text-sm">
+            {isMentioner ? (
+              <>
+                <strong>@{pendingMention.mentionedUser.username}</strong> is not
+                in this conversation yet.
+              </>
+            ) : (
+              <>
+                Waiting for{" "}
+                <strong>@{pendingMention.mentionerUser.username}</strong> to add{" "}
+                <strong>@{pendingMention.mentionedUser.username}</strong>...
+              </>
+            )}
+          </div>
+          {error && (
+            <div className="mt-2 text-sm text-warning-500">{error}</div>
+          )}
+        </div>
+        {isMentioner && (
+          <div className="flex gap-2">
+            <Button
+              label="Add to conversation"
+              size="xs"
+              variant="primary"
+              disabled={isProcessing}
+              onClick={() => handleAction("confirm")}
+            />
+            <Button
+              label="Don't add"
+              size="xs"
+              variant="tertiary"
+              disabled={isProcessing}
+              onClick={() => handleAction("decline")}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/lib/swr/conversations/pending_mentions.ts
+++ b/front/lib/swr/conversations/pending_mentions.ts
@@ -1,0 +1,39 @@
+import type {
+  GetPendingMentionsResponseBody,
+  PendingMentionType,
+} from "@app/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/pending";
+import { useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { Fetcher } from "swr";
+
+export function usePendingMentions({
+  conversationId,
+  workspaceId,
+}: {
+  conversationId: string;
+  workspaceId: string;
+}) {
+  const pendingMentionsFetcher: Fetcher<GetPendingMentionsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/v1/w/${workspaceId}/assistant/conversations/${conversationId}/mentions/pending`,
+    pendingMentionsFetcher
+  );
+
+  return {
+    pendingMentions: data?.pendingMentions ?? [],
+    isPendingMentionsLoading: !error && !data,
+    isPendingMentionsError: error,
+    mutatePendingMentions: mutate,
+  };
+}
+
+async function fetcher(url: string): Promise<GetPendingMentionsResponseBody> {
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch pending mentions");
+  }
+
+  return res.json();
+}

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/pending.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/pending.ts
@@ -1,0 +1,118 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { getUserForWorkspace } from "@app/lib/api/user";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { PendingMentionModel } from "@app/lib/models/agent/conversation";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type PendingMentionType = {
+  id: number;
+  mentionedUser: {
+    sId: string;
+    fullName: string;
+    username: string;
+  };
+  mentionerUser: {
+    sId: string;
+    fullName: string;
+    username: string;
+  };
+  messageId: string;
+  status: "pending" | "accepted" | "declined";
+  createdAt: number;
+};
+
+export type GetPendingMentionsResponseBody = {
+  pendingMentions: PendingMentionType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetPendingMentionsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { cId } = req.query;
+
+  if (!cId || typeof cId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid conversation ID.",
+      },
+    });
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const featureFlags = await getFeatureFlags(workspace);
+
+  if (!featureFlags.includes("mentions_v2")) {
+    // Feature not enabled, return empty list
+    return res.status(200).json({ pendingMentions: [] });
+  }
+
+  // Fetch all pending mentions for this conversation
+  const pendingMentions = await PendingMentionModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      conversationId: cId,
+      status: "pending",
+    },
+    order: [["createdAt", "ASC"]],
+  });
+
+  // Fetch user details for all mentions
+  const pendingMentionTypes: PendingMentionType[] = await Promise.all(
+    pendingMentions.map(async (pm) => {
+      const mentionedUser = await getUserForWorkspace(auth, {
+        userId: pm.mentionedUserId,
+      });
+      const mentionerUser = await getUserForWorkspace(auth, {
+        userId: pm.mentionerUserId,
+      });
+
+      if (!mentionedUser || !mentionerUser) {
+        return null;
+      }
+
+      return {
+        id: pm.id,
+        mentionedUser: {
+          sId: mentionedUser.sId,
+          fullName: mentionedUser.fullName || mentionedUser.username,
+          username: mentionedUser.username,
+        },
+        mentionerUser: {
+          sId: mentionerUser.sId,
+          fullName: mentionerUser.fullName || mentionerUser.username,
+          username: mentionerUser.username,
+        },
+        messageId: pm.messageId.toString(),
+        status: pm.status,
+        createdAt: pm.createdAt.getTime(),
+      };
+    })
+  );
+
+  // Filter out any nulls
+  const validPendingMentions = pendingMentionTypes.filter(
+    (pm): pm is PendingMentionType => pm !== null
+  );
+
+  return res.status(200).json({ pendingMentions: validPendingMentions });
+}
+
+export default withPublicAPIAuthentication(handler, { isStreaming: false });


### PR DESCRIPTION
- Create GET endpoint to fetch pending mentions for a conversation
- Add PendingMentionPrompt React component with confirm/decline buttons
- Implement usePendingMentions SWR hook for data fetching
- Display different UI for mentioner vs other participants

The component shows a pending invitation prompt that allows the
mentioner to confirm or decline adding the mentioned user. Other
participants see a waiting message.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
