### PR TITLE
[front] - fix(skills): missing migration

### DIFF
--- a/front/migrations/db/migration_445.sql
+++ b/front/migrations/db/migration_445.sql
@@ -1,0 +1,2 @@
+-- Migration created on Dec 15, 2025
+ALTER TABLE "public"."skill_versions" DROP COLUMN IF EXISTS "description";


### PR DESCRIPTION
## Description

 Drops the "description" column from the "skill_versions" table to clean up the database schema
