### PR TITLE
[front] - fix: workspace 

### DIFF
--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -27,6 +27,7 @@ import {
 } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { RegionType } from "@app/lib/api/regions/config";
 import { canUseModel } from "@app/lib/assistant";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFeatureFlags, useWorkspace } from "@app/lib/swr/workspaces";
@@ -50,11 +51,13 @@ const prettyfiedProviderNames: { [key in ModelProviderIdType]: string } = {
 interface ProviderManagementModalProps {
   owner: WorkspaceType;
   plan: PlanType;
+  region: RegionType;
 }
 
 export function ProviderManagementModal({
   owner,
   plan,
+  region,
 }: ProviderManagementModalProps) {
   const { isDark } = useTheme();
   const sendNotifications = useSendNotification();
@@ -81,7 +84,8 @@ export function ProviderManagementModal({
     [...USED_MODEL_CONFIGS, ...REASONING_MODEL_CONFIGS],
     (m) => m.modelId
   ).filter(
-    (model) => !model.isLegacy && canUseModel(model, featureFlags, plan, owner)
+    (model) =>
+      !model.isLegacy && canUseModel(model, featureFlags, plan, owner, region)
   );
 
   const modelProviders = filteredModels.reduce(

--- a/front/components/workspace/settings/ModelSelectionSection.tsx
+++ b/front/components/workspace/settings/ModelSelectionSection.tsx
@@ -1,14 +1,17 @@
 import { Page } from "@dust-tt/sparkle";
 
 import { ProviderManagementModal } from "@app/components/workspace/ProviderManagementModal";
+import type { RegionType } from "@app/lib/api/regions/config";
 import type { PlanType, WorkspaceType } from "@app/types";
 
 export function ModelSelectionSection({
   owner,
   plan,
+  region,
 }: {
   owner: WorkspaceType;
   plan: PlanType;
+  region: RegionType;
 }) {
   return (
     <Page.Vertical align="stretch" gap="md">
@@ -19,7 +22,7 @@ export function ModelSelectionSection({
             Select the models you want available to your workspace.
           </Page.P>
         </div>
-        <ProviderManagementModal owner={owner} plan={plan} />
+        <ProviderManagementModal owner={owner} plan={plan} region={region} />
       </div>
     </Page.Vertical>
   );

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,4 +1,4 @@
-import { config as regionConfig } from "@app/lib/api/regions/config";
+import type { RegionType } from "@app/lib/api/regions/config";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import type {
   AgentModelConfigurationType,
@@ -43,7 +43,8 @@ export function canUseModel(
   m: ModelConfigurationType,
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null,
-  owner: WorkspaceType
+  owner: WorkspaceType,
+  region: RegionType
 ) {
   if (m.featureFlag && !featureFlags.includes(m.featureFlag)) {
     return false;
@@ -61,10 +62,7 @@ export function canUseModel(
   }
 
   // GPT 5.2 is not available in EU region
-  if (
-    m.modelId === GPT_5_2_MODEL_ID &&
-    regionConfig.getCurrentRegion() === "europe-west1"
-  ) {
+  if (m.modelId === GPT_5_2_MODEL_ID && region === "europe-west1") {
     return false;
   }
 

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -4,6 +4,7 @@ import {
   REASONING_MODEL_CONFIGS,
   USED_MODEL_CONFIGS,
 } from "@app/components/providers/types";
+import { config as regionConfig } from "@app/lib/api/regions/config";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { canUseModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -27,12 +28,13 @@ async function handler(
   switch (req.method) {
     case "GET":
       const featureFlags = await getFeatureFlags(owner);
+      const region = regionConfig.getCurrentRegion();
       const models: ModelConfigurationType[] = USED_MODEL_CONFIGS.filter((m) =>
-        canUseModel(m, featureFlags, plan, owner)
+        canUseModel(m, featureFlags, plan, owner, region)
       );
       const reasoningModels: ModelConfigurationType[] =
         REASONING_MODEL_CONFIGS.filter((m) =>
-          canUseModel(m, featureFlags, plan, owner)
+          canUseModel(m, featureFlags, plan, owner, region)
         );
 
       return res.status(200).json({ models, reasoningModels });

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -4,8 +4,8 @@ import {
   REASONING_MODEL_CONFIGS,
   USED_MODEL_CONFIGS,
 } from "@app/components/providers/types";
-import { config as regionConfig } from "@app/lib/api/regions/config";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { config as regionConfig } from "@app/lib/api/regions/config";
 import { canUseModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -9,6 +9,8 @@ import { CapabilitiesSection } from "@app/components/workspace/settings/Capabili
 import { IntegrationsSection } from "@app/components/workspace/settings/IntegrationsSection";
 import { ModelSelectionSection } from "@app/components/workspace/settings/ModelSelectionSection";
 import { WorkspaceNameEditor } from "@app/components/workspace/settings/WorkspaceNameEditor";
+import type { RegionType } from "@app/lib/api/regions/config";
+import { config as regionConfig } from "@app/lib/api/regions/config";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -29,6 +31,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   microsoftBotDataSource: DataSourceType | null;
   discordBotDataSource: DataSourceType | null;
   systemSpace: SpaceType;
+  region: RegionType;
 }>(async (_, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -62,6 +65,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       microsoftBotDataSource: microsoftBotDataSource?.toJSON() ?? null,
       discordBotDataSource: discordBotDataSource?.toJSON() ?? null,
       systemSpace: systemSpace.toJSON(),
+      region: regionConfig.getCurrentRegion(),
     },
   };
 });
@@ -74,6 +78,7 @@ export default function WorkspaceAdmin({
   microsoftBotDataSource,
   discordBotDataSource,
   systemSpace,
+  region,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
@@ -92,7 +97,11 @@ export default function WorkspaceAdmin({
         <Page.Vertical align="stretch" gap="md">
           <WorkspaceNameEditor owner={owner} />
         </Page.Vertical>
-        <ModelSelectionSection owner={owner} plan={subscription.plan} />
+        <ModelSelectionSection
+          owner={owner}
+          plan={subscription.plan}
+          region={region}
+        />
         <CapabilitiesSection
           owner={owner}
           showRestrictAgentsPublishing={featureFlags.includes(


### PR DESCRIPTION
## Description

This PR:
 - Add `region` prop to `ProviderManagementModal` and `ModelSelectionSection` components to enable model availability checks based on region
 - Update `canUseModel` function to accept `region` parameter and utilize it in filtering models, especially for handling GPT 5.2 unavailability in the EU region
 - Pass the current region from the server-side to the workspace admin page to ensure correct region-based filtering of models

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front