### PR TITLE
[Connectors] fix(slack): always define provider when calling listForTeamId

### DIFF
--- a/connectors/src/api/sync_webhook_router_config.ts
+++ b/connectors/src/api/sync_webhook_router_config.ts
@@ -83,8 +83,10 @@ const _syncWebhookRouterEntryHandler = async (
     }
   } else if (provider === "slack") {
     // Find all connectors for this Slack team in this region
-    const slackConfigs =
-      await SlackConfigurationResource.listForTeamId(providerWorkspaceId);
+    const slackConfigs = await SlackConfigurationResource.listForTeamId(
+      providerWorkspaceId,
+      provider
+    );
 
     if (slackConfigs.length > 0) {
       // Get the connector for this Slack configuration

--- a/connectors/src/api/webhooks/slack/deprecated_bot.ts
+++ b/connectors/src/api/webhooks/slack/deprecated_bot.ts
@@ -64,8 +64,10 @@ export async function handleDeprecatedChatBot(
     slackTeamId,
   });
 
-  const slackConfigurations =
-    await SlackConfigurationResource.listForTeamId(slackTeamId);
+  const slackConfigurations = await SlackConfigurationResource.listForTeamId(
+    slackTeamId,
+    "slack"
+  );
   // If there are no slack configurations, return 200.
   if (slackConfigurations.length === 0) {
     localLogger.info("No deprecated Slack configurations found.", slackTeamId);

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -80,8 +80,10 @@ const _webhookSlackAPIHandler = async (
       slackTeamId: teamId,
     });
 
-    const slackConfigurations =
-      await SlackConfigurationResource.listForTeamId(teamId);
+    const slackConfigurations = await SlackConfigurationResource.listForTeamId(
+      teamId,
+      "slack"
+    );
     if (slackConfigurations.length === 0) {
       return apiError(req, res, {
         api_error: {

--- a/connectors/src/api/webhooks/webhook_slack_bot.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot.ts
@@ -63,8 +63,10 @@ const _webhookSlackBotAPIHandler = async (
       slackTeamId: teamId,
     });
 
-    const slackConfigurations =
-      await SlackConfigurationResource.listForTeamId(teamId);
+    const slackConfigurations = await SlackConfigurationResource.listForTeamId(
+      teamId,
+      "slack_bot"
+    );
     if (slackConfigurations.length === 0) {
       const error: {
         type: "connector_configuration_not_found";

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -26,8 +26,10 @@ export async function autoReadChannel(
   slackChannelId: string,
   provider: Extract<ConnectorProvider, "slack_bot" | "slack"> = "slack"
 ): Promise<Result<boolean, Error>> {
-  const slackConfigurations =
-    await SlackConfigurationResource.listForTeamId(teamId);
+  const slackConfigurations = await SlackConfigurationResource.listForTeamId(
+    teamId,
+    provider
+  );
   const connectorIds = slackConfigurations.map((c) => c.connectorId);
   const connectors = await ConnectorResource.fetchByIds(provider, connectorIds);
   const connector = connectors.find((c) => c.type === provider);

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -133,8 +133,10 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
 
       const newTeamId = teamInfoRes.team.id;
       if (newTeamId !== currentSlackConfig.slackTeamId) {
-        const configurations =
-          await SlackConfigurationResource.listForTeamId(newTeamId);
+        const configurations = await SlackConfigurationResource.listForTeamId(
+          newTeamId,
+          "slack_bot"
+        );
 
         // Revoke the token if no other slack connector is active on the same slackTeamId.
         if (configurations.length == 0) {
@@ -213,7 +215,8 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
     }
 
     const configurations = await SlackConfigurationResource.listForTeamId(
-      configuration.slackTeamId
+      configuration.slackTeamId,
+      "slack_bot"
     );
 
     // We deactivate our connections only if we are the only live slack connection for this team.


### PR DESCRIPTION
## Description

Discovered when [inspecting webhook configurations](https://console.firebase.google.com/u/0/project/dust-infra/database/dust-infra-default-rtdb/data), some `slack_bot` connectorIds were link to the configuration but we only want `slack` ones.

This PR assures we fetch the correct slack configurations everywhere

## Tests

None

## Risk

Low

## Deploy Plan

Connectors