### PR TITLE
fix: InstructionBlockExtension allow all blocks in it

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -139,8 +139,7 @@ export const InstructionBlockExtension =
     name: "instructionBlock",
     group: "block",
     priority: 1000,
-    // Allow only specific blocks inside the instruction block
-    content: "(paragraph|heading|codeBlock)+",
+    content: "block+",
     defining: true,
     // Prevents auto-merging two blocks when they're not separated by a paragraph
     isolating: true,


### PR DESCRIPTION
## Description

We had a bug where we couldn't remove the first list item in a block, now we can
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
