### PR TITLE
[front] chore(skills): minor fixes/component renames

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -174,7 +174,7 @@ export default function SkillBuilder({
                     Create new skill
                   </h2>
                   <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    Create custom capabilities for specific tasks
+                    Create a custom capability for specific tasks
                   </p>
                 </div>
                 <SkillBuilderRequestedSpacesSection />

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -19,7 +19,7 @@ import {
   skillBuilderFormSchema,
 } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { SkillBuilderInstructionsSection } from "@app/components/skill_builder/SkillBuilderInstructionsSection";
-import { SkillBuilderRequestedSpace } from "@app/components/skill_builder/SkillBuilderRequestedSpace";
+import { SkillBuilderRequestedSpacesSection } from "@app/components/skill_builder/SkillBuilderRequestedSpacesSection";
 import { SkillBuilderSettingsSection } from "@app/components/skill_builder/SkillBuilderSettingsSection";
 import { SkillBuilderToolsSection } from "@app/components/skill_builder/SkillBuilderToolsSection";
 import { submitSkillBuilderForm } from "@app/components/skill_builder/submitSkillBuilderForm";
@@ -177,7 +177,7 @@ export default function SkillBuilder({
                     Create custom capabilities for specific tasks
                   </p>
                 </div>
-                <SkillBuilderRequestedSpace />
+                <SkillBuilderRequestedSpacesSection />
                 <SkillBuilderAgentFacingDescriptionSection />
                 <SkillBuilderInstructionsSection />
                 <SkillBuilderToolsSection />

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -11,8 +11,8 @@ import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 
+import { SkillBuilderAgentFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderAgentFacingDescriptionSection";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
-import { SkillBuilderDescriptionSection } from "@app/components/skill_builder/SkillBuilderDescriptionSection";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import {
   SkillBuilderFormContext,
@@ -178,7 +178,7 @@ export default function SkillBuilder({
                   </p>
                 </div>
                 <SkillBuilderRequestedSpace />
-                <SkillBuilderDescriptionSection />
+                <SkillBuilderAgentFacingDescriptionSection />
                 <SkillBuilderInstructionsSection />
                 <SkillBuilderToolsSection />
                 <SkillBuilderSettingsSection />

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -92,7 +92,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
         <div className="space-y-3">
           <TextArea
             ref={registerRef}
-            placeholder="When should this skill be used? What will this skill be good for?"
+            placeholder="When should this skill be used? What is this skill good for?"
             className="min-h-24"
             onChange={(e) => handleDescriptionChange(e, onChange)}
             error={hasError ? errorMessage : undefined}

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -17,7 +17,7 @@ const AGENT_FACING_DESCRIPTION_FIELD_NAME = "agentFacingDescription";
 const DEBOUNCE_DELAY_MS = 250;
 const MIN_DESCRIPTION_LENGTH = 10;
 
-export function SkillBuilderDescriptionSection() {
+export function SkillBuilderAgentFacingDescriptionSection() {
   const { owner } = useSkillBuilderContext();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   const isSimilarSkillsEnabled = hasFeature("skills_similar_display");

--- a/front/components/skill_builder/SkillBuilderNameSection.tsx
+++ b/front/components/skill_builder/SkillBuilderNameSection.tsx
@@ -16,7 +16,7 @@ export function SkillBuilderNameSection() {
           <div className="flex-grow">
             <Input
               ref={registerRef}
-              label="Skill name"
+              label="Name"
               placeholder="Enter skill name"
               onChange={onChange}
               message={errorMessage}

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -8,7 +8,7 @@ import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MC
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 
-export function SkillBuilderRequestedSpace() {
+export function SkillBuilderRequestedSpacesSection() {
   const { watch } = useFormContext<SkillBuilderFormData>();
   const tools = watch("tools");
 

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -83,7 +83,7 @@ export function SkillBuilderToolsSection() {
                 variant="outline"
               />
             }
-            className="py-6"
+            className="py-9"
           />
         ) : (
           <CardGrid>

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -60,9 +60,6 @@ export function SkillBuilderToolsSection() {
           <h3 className="heading-base font-semibold text-foreground dark:text-foreground-night">
             Tools
           </h3>
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Add tools to enhance your skill's abilities.
-          </p>
         </div>
         {headerActions}
       </div>

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -83,7 +83,7 @@ export function SkillBuilderToolsSection() {
                 variant="outline"
               />
             }
-            className="pb-5"
+            className="py-6"
           />
         ) : (
           <CardGrid>

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -83,7 +83,7 @@ export function SkillBuilderToolsSection() {
                 variant="outline"
               />
             }
-            className="py-9"
+            className="py-8"
           />
         ) : (
           <CardGrid>

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -56,11 +56,9 @@ export function SkillBuilderToolsSection() {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <div>
-          <h3 className="heading-base font-semibold text-foreground dark:text-foreground-night">
-            Tools
-          </h3>
-        </div>
+        <h3 className="heading-base font-semibold text-foreground dark:text-foreground-night">
+          Tools
+        </h3>
         {headerActions}
       </div>
 


### PR DESCRIPTION
## Description

- This PR renames the component `SkillBuilderDescriptionSection` into `SkillBuilderAgentFacingDescriptionSection` to match the updated property name.
- This PR also fixes the copy, updates the padding around the Add tools button, removes the subtitle under Tools.

<img width="994" height="1054" alt="Screenshot 2025-12-15 at 1 33 33 PM" src="https://github.com/user-attachments/assets/07f3548a-5cbc-4251-b882-67df29ccfb04" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
