### PR TITLE
[front] - fix(AB): version author list

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -61,7 +61,6 @@ export function AgentBuilderInstructionsBlock({
             setIsInstructionDiffMode(true);
           }}
           owner={owner}
-          agentConfigurationId={agentConfigurationId}
         />
       )}
     </>

--- a/front/components/agent_builder/instructions/AgentInstructionsHistory.tsx
+++ b/front/components/agent_builder/instructions/AgentInstructionsHistory.tsx
@@ -12,10 +12,9 @@ import {
 } from "@dust-tt/sparkle";
 import { compareDesc } from "date-fns";
 import { format } from "date-fns/format";
-import { useCallback, useMemo } from "react";
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 
-import { useEditors } from "@app/lib/swr/agent_editors";
+import { useMembersLookup } from "@app/lib/swr/memberships";
 import type {
   LightAgentConfigurationType,
   LightWorkspaceType,
@@ -26,7 +25,6 @@ interface AgentInstructionsHistoryProps {
   selectedConfig: LightAgentConfigurationType | null;
   onSelect: (config: LightAgentConfigurationType) => void;
   owner: LightWorkspaceType;
-  agentConfigurationId: string | null;
 }
 
 export function AgentInstructionsHistory({
@@ -34,21 +32,32 @@ export function AgentInstructionsHistory({
   onSelect,
   selectedConfig,
   owner,
-  agentConfigurationId,
 }: AgentInstructionsHistoryProps) {
-  const { editors, isEditorsLoading } = useEditors({
-    owner,
-    agentConfigurationId,
-    disabled: !agentConfigurationId,
-  });
+  const authorIdsToLookup = useMemo(() => {
+    const ids = new Set<number>();
+    history.forEach((config) => {
+      if (config.versionAuthorId) {
+        ids.add(Number(config.versionAuthorId));
+      }
+    });
+
+    return Array.from(ids);
+  }, [history]);
+
+  const { members: authorLookupMembers, isMembersLookupLoading } =
+    useMembersLookup({
+      workspaceId: owner.sId,
+      memberIds: authorIdsToLookup,
+      disabled: authorIdsToLookup.length === 0,
+    });
 
   const authorMap = useMemo(() => {
     const map: Record<string, string> = {};
-    editors.forEach((editor) => {
-      map[editor.id] = editor.fullName || editor.firstName;
+    authorLookupMembers.forEach((user) => {
+      map[user.id.toString()] = user.fullName || user.firstName || "Unknown";
     });
     return map;
-  }, [editors]);
+  }, [authorLookupMembers]);
 
   const formatVersionLabel = useCallback(
     (config: LightAgentConfigurationType) => {
@@ -64,7 +73,7 @@ export function AgentInstructionsHistory({
       if (!config.versionAuthorId) {
         return "System";
       }
-      return authorMap[config.versionAuthorId] || "Unknown";
+      return authorMap[config.versionAuthorId.toString()] || "Unknown";
     },
     [authorMap]
   );
@@ -138,7 +147,7 @@ export function AgentInstructionsHistory({
           </>
         }
       >
-        {isEditorsLoading ? (
+        {isMembersLookupLoading ? (
           <div className="flex h-full w-full items-center justify-center">
             <Spinner />
           </div>

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -5,6 +5,7 @@ import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
+import type { MembersLookupResponseBody } from "@app/pages/api/w/[wId]/members/lookup";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { GroupKind, LightWorkspaceType } from "@app/types";
 import { isGroupKind } from "@app/types";
@@ -142,5 +143,34 @@ export function useSearchMembers({
     isError: !!error,
     mutate,
     mutateRegardlessOfQueryParams,
+  };
+}
+
+export function useMembersLookup({
+  workspaceId,
+  memberIds,
+  disabled,
+}: {
+  workspaceId: string;
+  memberIds: number[];
+  disabled?: boolean;
+}) {
+  const membersLookupFetcher: Fetcher<MembersLookupResponseBody> = fetcher;
+
+  const query =
+    memberIds.length > 0
+      ? `/api/w/${workspaceId}/members/lookup?${memberIds
+          .map((id) => `ids=${id}`)
+          .join("&")}`
+      : null;
+
+  const { data, error } = useSWRWithDefaults(query, membersLookupFetcher, {
+    disabled,
+  });
+
+  return {
+    members: data?.users ?? emptyArray(),
+    isMembersLookupLoading: !error && !data && !!query,
+    isMembersLookupError: !!error,
   };
 }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -170,7 +170,7 @@ export function useMembersLookup({
 
   return {
     members: data?.users ?? emptyArray(),
-    isMembersLookupLoading: !error && !data && !!query,
+    isMembersLookupLoading: !error && !data && !!query && !disabled,
     isMembersLookupError: !!error,
   };
 }

--- a/front/pages/api/w/[wId]/members/lookup.ts
+++ b/front/pages/api/w/[wId]/members/lookup.ts
@@ -1,0 +1,91 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import { NumberFromString } from "io-ts-types";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { UserType, WithAPIErrorResponse } from "@app/types";
+
+const MEMBERS_LOOKUP_MAX_IDS = 50;
+
+const MembersLookupQuery = t.type({
+  ids: t.union([NumberFromString, t.array(NumberFromString)]),
+});
+
+export type MembersLookupResponseBody = {
+  users: UserType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<MembersLookupResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "GET": {
+      const queryValidation = MembersLookupQuery.decode(req.query);
+      if (isLeft(queryValidation)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The query parameter `ids` is required.",
+          },
+        });
+      }
+
+      const rawIds = queryValidation.right.ids;
+      const ids = Array.isArray(rawIds) ? rawIds : [rawIds];
+
+      if (ids.length === 0) {
+        return res.status(200).json({ users: [] });
+      }
+
+      if (ids.length > MEMBERS_LOOKUP_MAX_IDS) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Too many ids provided. Maximum is ${MEMBERS_LOOKUP_MAX_IDS}.`,
+          },
+        });
+      }
+
+      const uniqueIds = Array.from(new Set(ids));
+      const users = await UserResource.fetchByModelIds(uniqueIds);
+
+      if (users.length === 0) {
+        return res.status(200).json({ users: [] });
+      }
+
+      const owner = auth.getNonNullableWorkspace();
+
+      const { memberships } = await MembershipResource.getLatestMemberships({
+        users,
+        workspace: owner,
+      });
+
+      const validUserIds = new Set(memberships.map((m) => m.userId));
+      const filteredUsers = users.filter((user) => validUserIds.has(user.id));
+
+      return res.status(200).json({
+        users: filteredUsers.map((user) => user.toJSON()),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

This PR fixes the following issue in the Agent Builder: to display authors of previous versions we used to fetch agent's editors. However, since admins can also edit agents without being part of the editors' list -> lookup wasn't working and we were displaying an "editing by Unknown"

We now fetch all members who edited the agent.

**References:**
- https://github.com/dust-tt/tasks/issues/5588

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
