### PR TITLE
[Slack MCP] Support user group mention (post message & more)

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -564,7 +564,7 @@ export const INTERNAL_MCP_SERVERS = {
       // Read operations - never ask
       search_messages: "never_ask",
       semantic_search_messages: "never_ask",
-      list_users: "never_ask",
+      list_users_and_groups: "never_ask",
       list_public_channels: "never_ask",
       list_channels: "never_ask",
       list_joined_channels: "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -564,7 +564,7 @@ export const INTERNAL_MCP_SERVERS = {
       // Read operations - never ask
       search_messages: "never_ask",
       semantic_search_messages: "never_ask",
-      list_users_and_groups: "never_ask",
+      list_users: "never_ask",
       list_public_channels: "never_ask",
       list_channels: "never_ask",
       list_joined_channels: "never_ask",

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -283,10 +283,13 @@ export async function resolveChannelId({
 
 // Helper function to resolve user ID to display name.
 // Returns the user's display name or real name, or null if not found.
-export async function resolveUserDisplayName(
-  userId: string,
-  accessToken: string
-): Promise<string | null> {
+export async function resolveUserDisplayName({
+  userId,
+  accessToken,
+}: {
+  userId: string;
+  accessToken: string;
+}): Promise<string | null> {
   const slackClient = await getSlackClient(accessToken);
 
   try {
@@ -311,10 +314,13 @@ export async function resolveUserDisplayName(
 // Resolves a channel ID to a human-readable display name.
 // Handles DMs (direct messages) and regular channels.
 // This function expects a normalized channel ID from resolveChannelId.
-export async function resolveChannelDisplayName(
-  channelId: string,
-  accessToken: string
-): Promise<string> {
+export async function resolveChannelDisplayName({
+  channelId,
+  accessToken,
+}: {
+  channelId: string;
+  accessToken: string;
+}): Promise<string> {
   const slackClient = await getSlackClient(accessToken);
 
   try {
@@ -325,10 +331,10 @@ export async function resolveChannelDisplayName(
     if (channelInfo.ok && channelInfo.channel) {
       // For DMs, channelId starts with "D" and channel.name contains the user ID.
       if (channelId.startsWith("D") && channelInfo.channel.name) {
-        const userName = await resolveUserDisplayName(
-          channelInfo.channel.name,
-          accessToken
-        );
+        const userName = await resolveUserDisplayName({
+          userId: channelInfo.channel.name,
+          accessToken,
+        });
         return userName ? `@${userName}` : `@${channelInfo.channel.name}`;
       }
 
@@ -683,7 +689,11 @@ export async function executeScheduleMessage(
   ]);
 }
 
-export async function executeListUserGroups(accessToken: string) {
+export async function executeListUserGroups({
+  accessToken,
+}: {
+  accessToken: string;
+}) {
   const slackClient = await getSlackClient(accessToken);
 
   try {
@@ -738,7 +748,7 @@ export async function executeListUsers({
   // Load user groups first if requested.
   let userGroupsContent: Array<{ type: "text"; text: string }> = [];
   if (includeUserGroups) {
-    const userGroupsResult = await executeListUserGroups(accessToken);
+    const userGroupsResult = await executeListUserGroups({ accessToken });
     if (userGroupsResult.isOk()) {
       userGroupsContent = userGroupsResult.value;
     }
@@ -820,7 +830,13 @@ export async function executeListUsers({
   return new Ok([...userGroupsContent, ...usersResponse.value]);
 }
 
-export async function executeGetUser(userId: string, accessToken: string) {
+export async function executeGetUser({
+  userId,
+  accessToken,
+}: {
+  userId: string;
+  accessToken: string;
+}) {
   const slackClient = await getSlackClient(accessToken);
   const response = await slackClient.users.info({ user: userId });
 
@@ -961,16 +977,25 @@ export async function executeListJoinedChannels(
   );
 }
 
-export async function executeReadThreadMessages(
-  channel: string,
-  threadTs: string,
-  limit: number | undefined,
-  cursor: string | undefined,
-  oldest: string | undefined,
-  latest: string | undefined,
-  accessToken: string,
-  mcpServerId: string
-) {
+export async function executeReadThreadMessages({
+  channel,
+  threadTs,
+  limit,
+  cursor,
+  oldest,
+  latest,
+  accessToken,
+  mcpServerId,
+}: {
+  channel: string;
+  threadTs: string;
+  limit: number | undefined;
+  cursor: string | undefined;
+  oldest: string | undefined;
+  latest: string | undefined;
+  accessToken: string;
+  mcpServerId: string;
+}) {
   const slackClient = await getSlackClient(accessToken);
 
   // Resolve channel name/ID to channel ID (supports public/private channels and DMs).

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -14,7 +14,7 @@ import { removeDiacritics } from "@app/lib/utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 // Constants for Slack API limits and pagination.
 export const SLACK_API_PAGE_SIZE = 100;
@@ -684,7 +684,11 @@ export async function executeListUserGroups(accessToken: string) {
       },
     ]);
   } catch (error) {
-    return new Err(new MCPError(`Error listing user groups: ${error}`));
+    return new Err(
+      new MCPError(
+        `Error listing user groups: ${normalizeError(error).message}`
+      )
+    );
   }
 }
 

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -112,7 +112,7 @@ async function createServer(
         }
 
         try {
-          return await executeListUsers(nameFilter, accessToken);
+          return await executeListUsers({ nameFilter, accessToken });
         } catch (error) {
           return new Err(
             new MCPError(`Error listing users: ${normalizeError(error)}`)

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -143,7 +143,7 @@ async function createServer(
         }
 
         try {
-          return await executeGetUser(userId, accessToken);
+          return await executeGetUser({ userId, accessToken });
         } catch (error) {
           return new Err(
             new MCPError(`Error retrieving user info: ${normalizeError(error)}`)

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -834,7 +834,7 @@ async function createServer(
         }
 
         try {
-          return await executeGetUser(userId, accessToken);
+          return await executeGetUser({ userId, accessToken });
         } catch (error) {
           const authError = handleSlackAuthError(error);
           if (authError) {
@@ -1089,10 +1089,10 @@ async function createServer(
         }
 
         // Get display name for the channel.
-        const displayName = await resolveChannelDisplayName(
+        const displayName = await resolveChannelDisplayName({
           channelId,
-          accessToken
-        );
+          accessToken,
+        });
 
         const { citationsOffset } = agentLoopContext.runContext.stepContext;
 
@@ -1105,7 +1105,10 @@ async function createServer(
         const threadsWithAuthors = await Promise.all(
           matches.map(async (match) => {
             const authorName = match.user
-              ? await resolveUserDisplayName(match.user, accessToken)
+              ? await resolveUserDisplayName({
+                  userId: match.user,
+                  accessToken,
+                })
               : null;
             return {
               ...match,
@@ -1183,7 +1186,7 @@ async function createServer(
           return new Err(new MCPError("Access token not found"));
         }
 
-        return executeReadThreadMessages(
+        return executeReadThreadMessages({
           channel,
           threadTs,
           limit,
@@ -1191,8 +1194,8 @@ async function createServer(
           oldest,
           latest,
           accessToken,
-          mcpServerId
-        );
+          mcpServerId,
+        });
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -770,7 +770,7 @@ async function createServer(
   );
 
   server.tool(
-    "list_users_and_groups",
+    "list_users",
     "List all users in the workspace, and optionally user groups",
     {
       nameFilter: z
@@ -797,11 +797,11 @@ async function createServer(
         }
 
         try {
-          return await executeListUsers(
+          return await executeListUsers({
             nameFilter,
             accessToken,
-            includeUserGroups
-          );
+            includeUserGroups,
+          });
         } catch (error) {
           const authError = handleSlackAuthError(error);
           if (authError) {

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -61,6 +61,7 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
             // User info scopes.
             "users:read.email",
             "users:read",
+            "usergroups:read",
           ];
         default:
           assert(


### PR DESCRIPTION
## Description
Adds support for listing Slack user groups in the personal Slack MCP server. The `list_users` tool has been renamed to `list_users_and_groups` and now accepts an optional `includeUserGroups` parameter. When enabled, the tool returns both users and user groups in the workspace. The change also updates message posting tool descriptions to document the syntax for mentioning user groups (`<!subteam^user_group_id>`). A new OAuth scope `usergroups:read` has been added to support fetching user group information.
I didn't want to add a tool just for that feature, happy to be challenged on this.

## Risk
Low. The change is backward compatible - the new parameter is optional and defaults to false, preserving existing behavior. A new OAuth scope (`usergroups:read`) is required, which will need to be granted when users reconnect. A reconnection is needed for the tool to work.

## Tests
Local

## Deploy Plan
Run Front - disconnect + reconnect slack tool
