### PR TITLE
[Programmatic Usage] Tweaks

### DIFF
--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -286,10 +286,10 @@ export async function handleProgrammaticCostRequest(
       const { cycleStart: periodStart, cycleEnd: periodEnd } =
         getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
 
-      // Cap periodEnd to 5 days in the future to avoid empty chart areas.
-      const FIVE_DAYS_IN_MS = 5 * 24 * 60 * 60 * 1000;
+      // Cap periodEnd to 10 days in the future to avoid too big empty chart areas.
+      const TEN_DAYS_IN_MS = 10 * 24 * 60 * 60 * 1000;
       const cappedPeriodEnd = new Date(
-        Math.min(periodEnd.getTime(), Date.now() + FIVE_DAYS_IN_MS)
+        Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_IN_MS)
       );
 
       const timestamps = getTimestampsInRange(periodStart, cappedPeriodEnd);

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -749,7 +749,6 @@ async function handler(
                 );
               }
 
-              // TODO(PPUL): should we enforce that enterprise always has PAYG enabled?
               const paygEnabled = await isPAYGEnabled(auth);
 
               if (isEnterpriseSubscription(stripeSubscription) && paygEnabled) {

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -423,7 +423,31 @@ export default function CreditsUsagePage({
         <Page.Header
           title="Programmatic Usage"
           icon={CardIcon}
-          description="Monitor usage and credits for your API keys and automated workflows."
+          description={
+            <div>
+              <p>
+                Monitor usage and credits for programmatic usage (API keys,
+                automated workflows, etc.). Usage cost is based on token
+                consumption, according to our{" "}
+                <a
+                  href="https://dust-tt.notion.site/API-Pricing-12928599d941805a89dedeed342aacd5"
+                  target="_blank"
+                  className="text-primary underline hover:text-primary-dark"
+                >
+                  pricing page
+                </a>
+                . Learn more in the{" "}
+                <a
+                  href="https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e?pvs=74"
+                  target="_blank"
+                  className="text-primary underline hover:text-primary-dark"
+                >
+                  programmatic usage documentation
+                </a>
+                .
+              </p>
+            </div>
+          }
         />
 
         {shouldShowLowCreditsWarning && (

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -61,7 +61,7 @@ export type LightMessageType =
  * origin here should not overlap with another existing origin and all user
  * messages should have an origin.
  *
- * Avoid adding an origin that:
+ * Please do not add an origin that:
  * - is not directly linked to how the original user sent the message;
  * - overlaps with existing origins (e.g. "linux" and "mac-os" would be terrible
  *   orgins in that respect, overlapping with almost all origins).
@@ -94,6 +94,8 @@ export type UserMessageOrigin =
   | "web"
   | "zapier"
   | "zendesk"
+  // TODO onboarding_conversation isn't a message origin. It has been used so as a hack
+  // but should be removed and most likely handled as message metadata (to be created).
   | "onboarding_conversation";
 
 export type UserMessageContext = {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5299

- Remove resolved TODO in stripe webhook about PAYG for enterprise
- Add clarifying TODO comment for `onboarding_conversation` origin explaining it should be refactored to message metadata
- Update programmatic usage page description with links to pricing and documentation
- Increase chart period cap from 5 to 10 days to show more data

## Risks

Blast radius: Programmatic usage page UI, stripe webhook enterprise handling
Risk: low

## Deploy Plan

- deploy front