### PR TITLE
Don't fail search when we don't have datasource views

### DIFF
--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -174,13 +174,14 @@ export async function handleSearch(
     spacesToSearch
   );
 
+  // If we don't have any data source views, we return an empty result without
+  // failing, allowing the caller to still use other search sources
   if (!allDatasourceViews.length) {
-    return new Err({
-      status: 400,
-      error: {
-        type: "invalid_request_error",
-        message: "No datasource views found in accessible spaces.",
-      },
+    return new Ok({
+      nodes: [],
+      resultsCount: 0,
+      warningCode: null,
+      nextPageCursor: null,
     });
   }
 


### PR DESCRIPTION
## Description

In Universal Search, we may not have Data Source Views but may still have searchable tools. So we just return empty result instead of failing.

## Tests

Manual

## Risk

Low

## Deploy Plan

Front