### PR TITLE
[front] feat: Ensure programmatic usage is setup before upgrading to ent

### DIFF
--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -23,16 +23,22 @@ import {
 import { clientFetch } from "@app/lib/egress/client";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
-import type { EnterpriseUpgradeFormType, WorkspaceType } from "@app/types";
+import type {
+  EnterpriseUpgradeFormType,
+  ProgrammaticUsageConfigurationType,
+  WorkspaceType,
+} from "@app/types";
 import { EnterpriseUpgradeFormSchema, removeNulls } from "@app/types";
+
+interface EnterpriseUpgradeDialogProps {
+  owner: WorkspaceType;
+  programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
+}
 
 export default function EnterpriseUpgradeDialog({
   owner,
-  hasProgrammaticUsageConfig,
-}: {
-  owner: WorkspaceType;
-  hasProgrammaticUsageConfig: boolean;
-}) {
+  programmaticUsageConfig,
+}: EnterpriseUpgradeDialogProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
@@ -115,7 +121,7 @@ export default function EnterpriseUpgradeDialog({
           </DialogDescription>
         </DialogHeader>
         <DialogContainer>
-          {!hasProgrammaticUsageConfig && (
+          {!programmaticUsageConfig && (
             <div className="mb-4 rounded-md border border-warning-200 bg-warning-100 p-3 text-warning-800">
               Programmatic usage configuration must be set before upgrading to
               enterprise. Please use the "Manage Programmatic Usage
@@ -162,7 +168,7 @@ export default function EnterpriseUpgradeDialog({
                     type="submit"
                     variant="warning"
                     label="Upgrade"
-                    disabled={!hasProgrammaticUsageConfig}
+                    disabled={!programmaticUsageConfig}
                   />
                 </DialogFooter>
               </form>

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -28,8 +28,10 @@ import { EnterpriseUpgradeFormSchema, removeNulls } from "@app/types";
 
 export default function EnterpriseUpgradeDialog({
   owner,
+  hasProgrammaticUsageConfig,
 }: {
   owner: WorkspaceType;
+  hasProgrammaticUsageConfig: boolean;
 }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -113,6 +115,13 @@ export default function EnterpriseUpgradeDialog({
           </DialogDescription>
         </DialogHeader>
         <DialogContainer>
+          {!hasProgrammaticUsageConfig && (
+            <div className="mb-4 rounded-md border border-warning-200 bg-warning-100 p-3 text-warning-800">
+              Programmatic usage configuration must be set before upgrading to
+              enterprise. Please use the "Manage Programmatic Usage
+              Configuration" plugin first.
+            </div>
+          )}
           {error && <div className="text-warning">{error}</div>}
           {isSubmitting && (
             <div className="flex justify-center">
@@ -149,7 +158,12 @@ export default function EnterpriseUpgradeDialog({
                   </div>
                 </div>
                 <DialogFooter>
-                  <Button type="submit" variant="warning" label="Upgrade" />
+                  <Button
+                    type="submit"
+                    variant="warning"
+                    label="Upgrade"
+                    disabled={!hasProgrammaticUsageConfig}
+                  />
                 </DialogFooter>
               </form>
             </PokeForm>

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -36,7 +36,12 @@ import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { FREE_NO_PLAN_CODE, isProPlanPrefix } from "@app/lib/plans/plan_codes";
 import { usePokePlans } from "@app/lib/swr/poke";
-import type { PlanType, SubscriptionType, WorkspaceType } from "@app/types";
+import type {
+  PlanType,
+  ProgrammaticUsageConfigurationType,
+  SubscriptionType,
+  WorkspaceType,
+} from "@app/types";
 import { isDevelopment } from "@app/types";
 
 interface SubscriptionsDataTableProps {
@@ -85,17 +90,19 @@ export function SubscriptionsDataTable({
   );
 }
 
+interface ActiveSubscriptionTableProps {
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  subscriptions: SubscriptionType[];
+  programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
+}
+
 export function ActiveSubscriptionTable({
   owner,
   subscription,
   subscriptions,
-  hasProgrammaticUsageConfig,
-}: {
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  subscriptions: SubscriptionType[];
-  hasProgrammaticUsageConfig: boolean;
-}) {
+  programmaticUsageConfig,
+}: ActiveSubscriptionTableProps) {
   return (
     <div className="flex flex-col">
       <div className="flex justify-between gap-3">
@@ -111,7 +118,7 @@ export function ActiveSubscriptionTable({
             <UpgradeDowngradeModal
               owner={owner}
               subscription={subscription}
-              hasProgrammaticUsageConfig={hasProgrammaticUsageConfig}
+              programmaticUsageConfig={programmaticUsageConfig}
             />
           </div>
           <PokeTable>
@@ -298,15 +305,17 @@ export function PlanLimitationsTable({
   );
 }
 
+interface UpgradeDowngradeModalProps {
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
+}
+
 function UpgradeDowngradeModal({
   owner,
   subscription,
-  hasProgrammaticUsageConfig,
-}: {
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  hasProgrammaticUsageConfig: boolean;
-}) {
+  programmaticUsageConfig,
+}: UpgradeDowngradeModalProps) {
   const router = useRouter();
   const { plans } = usePokePlans();
 
@@ -389,11 +398,21 @@ function UpgradeDowngradeModal({
               description="This action will downgrade the workspace to having no plan. This means that all the features will be disabled and members of
           the workspaces will be redirected to the paywall page. After 15 days, the workspace data will be deleted."
             />
+            {programmaticUsageConfig?.paygCapMicroUsd && (
+              <div className="rounded-md border border-warning-200 bg-warning-100 p-3 text-warning-800">
+                Cannot downgrade while Pay-as-you-go is enabled. Please disable
+                PAYG in the "Manage Programmatic Usage Configuration" plugin
+                first.
+              </div>
+            )}
             <div>
               <Button
                 variant="warning"
                 onClick={onDowngrade}
-                disabled={subscription.plan.code === FREE_NO_PLAN_CODE}
+                disabled={
+                  subscription.plan.code === FREE_NO_PLAN_CODE ||
+                  programmaticUsageConfig?.paygCapMicroUsd
+                }
                 label="Downgrade to NO PLAN"
               />
             </div>
@@ -413,7 +432,7 @@ function UpgradeDowngradeModal({
             <div>
               <EnterpriseUpgradeDialog
                 owner={owner}
-                hasProgrammaticUsageConfig={hasProgrammaticUsageConfig}
+                programmaticUsageConfig={programmaticUsageConfig}
               />
             </div>
             {isProPlanPrefix(subscription.plan.code) && (

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -89,10 +89,12 @@ export function ActiveSubscriptionTable({
   owner,
   subscription,
   subscriptions,
+  hasProgrammaticUsageConfig,
 }: {
   owner: WorkspaceType;
   subscription: SubscriptionType;
   subscriptions: SubscriptionType[];
+  hasProgrammaticUsageConfig: boolean;
 }) {
   return (
     <div className="flex flex-col">
@@ -106,7 +108,11 @@ export function ActiveSubscriptionTable({
               owner={owner}
               subscriptions={subscriptions}
             />
-            <UpgradeDowngradeModal owner={owner} subscription={subscription} />
+            <UpgradeDowngradeModal
+              owner={owner}
+              subscription={subscription}
+              hasProgrammaticUsageConfig={hasProgrammaticUsageConfig}
+            />
           </div>
           <PokeTable>
             <PokeTableBody>
@@ -295,9 +301,11 @@ export function PlanLimitationsTable({
 function UpgradeDowngradeModal({
   owner,
   subscription,
+  hasProgrammaticUsageConfig,
 }: {
   owner: WorkspaceType;
   subscription: SubscriptionType;
+  hasProgrammaticUsageConfig: boolean;
 }) {
   const router = useRouter();
   const { plans } = usePokePlans();
@@ -403,7 +411,10 @@ function UpgradeDowngradeModal({
               description="Go to the Enterprise billing form page to upgrade this workspace to a new Enterprise plan ."
             />
             <div>
-              <EnterpriseUpgradeDialog owner={owner} />
+              <EnterpriseUpgradeDialog
+                owner={owner}
+                hasProgrammaticUsageConfig={hasProgrammaticUsageConfig}
+              />
             </div>
             {isProPlanPrefix(subscription.plan.code) && (
               <>

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -63,7 +63,8 @@ const ManageProgrammaticUsageConfigurationSchema = z
       return true;
     },
     {
-      message: "Free credits amount is required when override is enabled",
+      message:
+        "Free credits amount is required when negotiated credits are enabled",
       path: ["freeCreditsDollars"],
     }
   )
@@ -95,14 +96,14 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       freeCreditsOverrideEnabled: {
         type: "boolean",
         variant: "toggle",
-        label: "Override Monthly Free Credits",
+        label: "Negotiated Free Credits",
         async: true,
         asyncDescription: true,
       },
       freeCreditsDollars: {
         type: "number",
-        label: "Monthly Free Credits (USD)",
-        description: `Custom monthly free credits ($1-$${MAX_FREE_CREDITS_DOLLARS.toLocaleString()}). ⚠️This will top-up next billing cycle's free credits. If you want an immediate top-up, use "Buy Committed Credits" plugin in free mode.`,
+        label: "Negotiated Monthly Free Credits (USD)",
+        description: `Negotiated monthly free credits ($1-$${MAX_FREE_CREDITS_DOLLARS.toLocaleString()}). ⚠️This will top-up next billing cycle's free credits. If you want an immediate top-up, use "Buy Committed Credits" plugin in free mode.`,
         async: true,
         dependsOn: { field: "freeCreditsOverrideEnabled", value: true },
       },
@@ -138,7 +139,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       calculateFreeCreditAmountMicroUsd(userCount);
     const automaticCreditsDollars = automaticCreditsMicroUsd / 1_000_000;
 
-    const freeCreditsDescription = `Override automatic free credits. Current automatic amount: $${automaticCreditsDollars.toLocaleString()}`;
+    const freeCreditsDescription = `Enable negotiated free monthly credits to replace seat-based amount. Current seat-based amount: $${automaticCreditsDollars.toLocaleString()}`;
 
     const config =
       await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -139,7 +139,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       calculateFreeCreditAmountMicroUsd(userCount);
     const automaticCreditsDollars = automaticCreditsMicroUsd / 1_000_000;
 
-    const freeCreditsDescription = `Enable negotiated free monthly credits to replace seat-based amount. Current seat-based amount: $${automaticCreditsDollars.toLocaleString()}`;
+    const freeCreditsDescription = `Enable negotiated free monthly credits to replace default free credits amount. Current default amount (seat-based): $${automaticCreditsDollars.toLocaleString()}`;
 
     const config =
       await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -60,6 +60,7 @@ import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/progr
 import { usePokeDataRetention } from "@app/poke/swr/data_retention";
 import type {
   ExtensionConfigurationType,
+  ProgrammaticUsageConfigurationType,
   SubscriptionType,
   WhitelistableFeature,
   WorkspaceDomain,
@@ -72,8 +73,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   activeSubscription: SubscriptionType;
   baseUrl: string;
   extensionConfig: ExtensionConfigurationType | null;
-  hasProgrammaticUsageConfig: boolean;
   owner: WorkspaceType;
+  programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   registry: ActionRegistry;
   stripeSubscription: Stripe.Subscription | null;
   subscriptions: SubscriptionType[];
@@ -138,7 +139,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       workspaceVerifiedDomains,
       workspaceCreationDay: format(workspaceCreationDay, "yyyy-MM-dd"),
       extensionConfig: extensionConfig?.toJSON() ?? null,
-      hasProgrammaticUsageConfig: programmaticUsageConfig !== null,
+      programmaticUsageConfig: programmaticUsageConfig?.toJSON() ?? null,
       baseUrl: config.getClientFacingUrl(),
       workosEnvironmentId: config.getWorkOSEnvironmentId(),
     },
@@ -155,7 +156,7 @@ const WorkspacePage = ({
   workspaceVerifiedDomains,
   workspaceCreationDay,
   extensionConfig,
-  hasProgrammaticUsageConfig,
+  programmaticUsageConfig,
   baseUrl,
   workosEnvironmentId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
@@ -286,7 +287,7 @@ const WorkspacePage = ({
                   owner={owner}
                   subscription={activeSubscription}
                   subscriptions={subscriptions}
-                  hasProgrammaticUsageConfig={hasProgrammaticUsageConfig}
+                  programmaticUsageConfig={programmaticUsageConfig}
                 />
               </TabsContent>
               <TabsContent value="planlimitations">

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -56,6 +56,7 @@ import { getStripeSubscription } from "@app/lib/plans/stripe";
 import type { ActionRegistry } from "@app/lib/registry";
 import { getDustProdActionRegistry } from "@app/lib/registry";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { usePokeDataRetention } from "@app/poke/swr/data_retention";
 import type {
   ExtensionConfigurationType,
@@ -71,6 +72,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   activeSubscription: SubscriptionType;
   baseUrl: string;
   extensionConfig: ExtensionConfigurationType | null;
+  hasProgrammaticUsageConfig: boolean;
   owner: WorkspaceType;
   registry: ActionRegistry;
   stripeSubscription: Stripe.Subscription | null;
@@ -115,6 +117,9 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   const extensionConfig =
     await ExtensionConfigurationResource.fetchForWorkspace(auth);
 
+  const programmaticUsageConfig =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+
   let stripeSubscription: Stripe.Subscription | null = null;
   if (activeSubscription.stripeSubscriptionId) {
     stripeSubscription = await getStripeSubscription(
@@ -133,6 +138,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       workspaceVerifiedDomains,
       workspaceCreationDay: format(workspaceCreationDay, "yyyy-MM-dd"),
       extensionConfig: extensionConfig?.toJSON() ?? null,
+      hasProgrammaticUsageConfig: programmaticUsageConfig !== null,
       baseUrl: config.getClientFacingUrl(),
       workosEnvironmentId: config.getWorkOSEnvironmentId(),
     },
@@ -149,6 +155,7 @@ const WorkspacePage = ({
   workspaceVerifiedDomains,
   workspaceCreationDay,
   extensionConfig,
+  hasProgrammaticUsageConfig,
   baseUrl,
   workosEnvironmentId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
@@ -279,6 +286,7 @@ const WorkspacePage = ({
                   owner={owner}
                   subscription={activeSubscription}
                   subscriptions={subscriptions}
+                  hasProgrammaticUsageConfig={hasProgrammaticUsageConfig}
                 />
               </TabsContent>
               <TabsContent value="planlimitations">

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -66,6 +66,7 @@ export * from "./oauth/oauth_api";
 export * from "./plan";
 export * from "./poke";
 export * from "./poke/plugins";
+export * from "./programmatic_usage";
 export * from "./project";
 export * from "./provider";
 export * from "./resource_permissions";

--- a/front/types/programmatic_usage.ts
+++ b/front/types/programmatic_usage.ts
@@ -1,0 +1,7 @@
+export type ProgrammaticUsageConfigurationType = {
+  sId: string;
+  createdAt: number;
+  freeCreditMicroUsd: number | null;
+  defaultDiscountPercent: number;
+  paygCapMicroUsd: number | null;
+};


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/5553

## Description

Ensures that programmatic usage configuration is set up _**before**_ upgrading a workspace to enterprise

The process should be:
1. Create stripe subscription and set up an enterprise plan (REPORT_USAGE)
2. Create programmatic usage configuration in poke (will create the PAGY handle credits)
3. Upgrade workspace to enterprise

## Tests

Tested manually, also tested the downgrade path (remove payg actually removes the handle, and you cannot downgrade enterprise if payg is enabled)

## Risk

Low

## Deploy Plan

- [ ] Deploy front