### PR TITLE
fix(intercom-conn): automatically skip on `DataSourceQuotaExceededError`

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -22,6 +22,7 @@ import {
   renderMarkdownSection,
   upsertDataSourceDocument,
 } from "@connectors/lib/data_sources";
+import { DataSourceQuotaExceededError } from "@connectors/lib/error";
 import {
   IntercomConversationModel,
   IntercomTeamModel,
@@ -323,24 +324,41 @@ export async function syncConversation({
     parents.push(getTeamsInternalId(connectorId));
   }
 
-  await upsertDataSourceDocument({
-    dataSourceConfig,
-    documentId,
-    documentContent: renderedPage,
-    documentUrl: conversationUrl,
-    timestampMs: updatedAtDate.getTime(),
-    tags: datasourceTags,
-    parents,
-    parentId: parents[1] || null,
-    loggerArgs: {
-      ...loggerArgs,
-      conversationId: conversation.id,
-    },
-    upsertContext: {
-      sync_type: syncType,
-    },
-    title: convoTitle,
-    mimeType: INTERNAL_MIME_TYPES.INTERCOM.CONVERSATION,
-    async: true,
-  });
+  try {
+    await upsertDataSourceDocument({
+      dataSourceConfig,
+      documentId,
+      documentContent: renderedPage,
+      documentUrl: conversationUrl,
+      timestampMs: updatedAtDate.getTime(),
+      tags: datasourceTags,
+      parents,
+      parentId: parents[1] || null,
+      loggerArgs: {
+        ...loggerArgs,
+        conversationId: conversation.id,
+      },
+      upsertContext: {
+        sync_type: syncType,
+      },
+      title: convoTitle,
+      mimeType: INTERNAL_MIME_TYPES.INTERCOM.CONVERSATION,
+      async: true,
+    });
+  } catch (error) {
+    if (error instanceof DataSourceQuotaExceededError) {
+      logger.warn(
+        {
+          connectorId,
+          error,
+          documentId,
+          conversationId: conversation.id,
+          ...loggerArgs,
+        },
+        "Skipping Intercom conversation exceeding plan document size limit."
+      );
+      return;
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Description

Consistent with how we handle this error in other connectors.
Currently, if the conversation exceeds the allowed size, the activity fails consistently, leading to a stuck sync.


## Tests


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
