### PR TITLE
fix(poke): prevent loading full screen width on server

### DIFF
--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -99,7 +99,7 @@ export function ChartContainer({
           </>
         )}
       </div>
-      {isAllowFullScreen && (
+      {isAllowFullScreen && isFullscreen && (
         <Sheet open={isFullscreen} onOpenChange={setIsFullscreen}>
           <SheetContent size="xl" className="max-w-[75%]">
             <SheetHeader>

--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -99,7 +99,7 @@ export function ChartContainer({
           </>
         )}
       </div>
-      {isAllowFullScreen && isFullscreen && (
+      {isAllowFullScreen && (
         <Sheet open={isFullscreen} onOpenChange={setIsFullscreen}>
           <SheetContent size="xl" className="max-w-[75%]">
             <SheetHeader>
@@ -113,7 +113,11 @@ export function ChartContainer({
                 <div className="flex-1 overflow-hidden">
                   <ResponsiveContainer
                     width="100%"
-                    height={window.innerHeight - 250}
+                    height={
+                      typeof window !== "undefined"
+                        ? window.innerHeight - 250
+                        : undefined
+                    }
                   >
                     {children}
                   </ResponsiveContainer>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/5600

**Bug**: Loading Poké workspace page with ?tab=credits caused HTTP 500 error
**Root cause**: ChartContainer.tsx accessed window.innerHeight unconditionally, which fails during SSR when the credits tab is rendered server-side
**Fix**: Only render the fullscreen Sheet content when isFullscreen is true, ensuring window is only accessed client-side after user interaction

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front