### PR TITLE
fix(builder): allow skipping personal tool connection

### DIFF
--- a/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
+++ b/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
@@ -192,6 +192,12 @@ export function PersonalConnectionRequiredDialog({
                 </div>
               )
             )}
+            <p className="mt-4">
+              {disconnectedCount}{" "}
+              {disconnectedCount > 1 ? "connections are" : "connection is"}{" "}
+              required. If you proceed without connecting, the agent will
+              request credentials when they use the tool.
+            </p>
           </DialogDescription>
         </DialogContainer>
 
@@ -203,8 +209,7 @@ export function PersonalConnectionRequiredDialog({
           }}
           rightButtonProps={{
             label: "Save",
-            variant: "primary",
-            disabled: disconnectedCount > 0,
+            variant: disconnectedCount > 0 ? "warning" : "primary",
             onClick: onClose,
           }}
         />


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

<img width="408" height="344" alt="Capture d’écran 2025-12-15 à 17 05 47" src="https://github.com/user-attachments/assets/9dd3319a-3c3b-40de-873b-93023f853dba" />

This PR moves the down right button from disabled to warning when the user have to connect some tools.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front