### PR TITLE
feat: do not display text content from previous steps

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -489,7 +489,10 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
 
         if (reasoningContents.length > 0) {
           return {
-            content: textFragments.join(""),
+            content:
+              textFragments.length > 0
+                ? textFragments[textFragments.length - 1]
+                : "",
             chainOfThought: reasoningContents
               .map((sc) => sc.content.value.reasoning)
               .filter((r) => !!r)

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -490,6 +490,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         if (reasoningContents.length > 0) {
           return {
             content:
+              // For mutliple steps outputing text content, we want to display only the last one as the final answer.
               textFragments.length > 0
                 ? textFragments[textFragments.length - 1]
                 : "",


### PR DESCRIPTION
## Description

There is a difference between message rendering behavior in streaming mode and when we refresh.
If an agent loop has multiple steps with text content output (not reasoning) in every steps, then message rendering in streaming mode will render only the last text contetn output (of the last step)
But when refreshing the page, the rendering will include all the text outputs from the previous steps.

This pr fixes this, by displaying only the last step text content 

## Tests

local

## Risk

low

## Deploy Plan

front
