### PR TITLE
[front] refactor(skills): bundle skill listing in `listSkillsForConversation`

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -649,12 +649,11 @@ type AgentLoopListToolsContextWithoutConfigurationType = Omit<
  */
 export async function tryListMCPTools(
   auth: Authenticator,
+  agentLoopListToolsContext: AgentLoopListToolsContextWithoutConfigurationType,
   {
-    agentLoopListToolsContext,
     jitServers,
     skillServers,
   }: {
-    agentLoopListToolsContext: AgentLoopListToolsContextWithoutConfigurationType;
     jitServers: MCPServerConfigurationType[];
     skillServers: MCPServerConfigurationType[];
   }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -341,7 +341,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   /**
    * List skills for a conversation, returning both enabled and equipped (not yet enabled) skills.
    */
-  static async listSkillsForConversation(
+  static async listForConversation(
     auth: Authenticator,
     {
       agentConfiguration,
@@ -354,7 +354,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     enabledSkills: SkillResource[];
     equippedSkills: SkillResource[];
   }> {
-    const enabledSkills = await this.listEnabledSkillsForConversation(auth, {
+    const enabledSkills = await this.listEnabledForConversation(auth, {
       agentConfiguration,
       conversation,
     });
@@ -376,7 +376,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    * List enabled skills for a given conversation and agent configuration.
    * Returns only active skills.
    */
-  private static async listEnabledSkillsForConversation(
+  private static async listEnabledForConversation(
     auth: Authenticator,
     {
       agentConfiguration,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -339,40 +339,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * List skills for a conversation, returning both enabled and equipped (not yet enabled) skills.
-   */
-  static async listForConversation(
-    auth: Authenticator,
-    {
-      agentConfiguration,
-      conversation,
-    }: {
-      agentConfiguration: AgentConfigurationType;
-      conversation: ConversationType;
-    }
-  ): Promise<{
-    enabledSkills: SkillResource[];
-    equippedSkills: SkillResource[];
-  }> {
-    const enabledSkills = await this.listEnabledForConversation(auth, {
-      agentConfiguration,
-      conversation,
-    });
-    const allAgentSkills = await this.listByAgentConfiguration(
-      auth,
-      agentConfiguration
-    );
-
-    // Skills that are already enabled are not equipped.
-    const enabledSkillIds = new Set(enabledSkills.map((s) => s.sId));
-    const equippedSkills = allAgentSkills.filter(
-      (s) => !enabledSkillIds.has(s.sId)
-    );
-
-    return { enabledSkills, equippedSkills };
-  }
-
-  /**
    * List enabled skills for a given conversation and agent configuration.
    * Returns only active skills.
    */
@@ -418,6 +384,40 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     return SkillResource.fetchByIds(auth, allSkillIds);
+  }
+
+  /**
+   * List skills for a conversation, returning both enabled and equipped (not yet enabled) skills.
+   */
+  static async listForConversation(
+    auth: Authenticator,
+    {
+      agentConfiguration,
+      conversation,
+    }: {
+      agentConfiguration: AgentConfigurationType;
+      conversation: ConversationType;
+    }
+  ): Promise<{
+    enabledSkills: SkillResource[];
+    equippedSkills: SkillResource[];
+  }> {
+    const enabledSkills = await this.listEnabledForConversation(auth, {
+      agentConfiguration,
+      conversation,
+    });
+    const allAgentSkills = await this.listByAgentConfiguration(
+      auth,
+      agentConfiguration
+    );
+
+    // Skills that are already enabled are not equipped.
+    const enabledSkillIds = new Set(enabledSkills.map((s) => s.sId));
+    const equippedSkills = allAgentSkills.filter(
+      (s) => !enabledSkillIds.has(s.sId)
+    );
+
+    return { enabledSkills, equippedSkills };
   }
 
   private static async baseFetch(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -363,7 +363,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       agentConfiguration: AgentConfigurationType;
       conversation: ConversationType;
     }
-  ) {
+  ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
 
     const conversationSkills = await ConversationSkillModel.findAll({

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -387,7 +387,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * List skills for a conversation, returning both enabled and equipped (not yet enabled) skills.
+   * List skills for a conversation, returning both enabled and equipped skills.
    */
   static async listForConversation(
     auth: Authenticator,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -328,18 +328,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
-  static async fetchAllAvailableSkills(
-    auth: Authenticator,
-    limit?: number
-  ): Promise<SkillResource[]> {
-    return this.baseFetch(auth, {
-      where: {
-        status: "active",
-      },
-      ...(limit ? { limit } : {}),
-    });
-  }
-
   static async listSkills(
     auth: Authenticator,
     { status = "active", limit }: { status?: SkillStatus; limit?: number } = {}

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -164,7 +164,7 @@ async function handler(
       });
 
       const { enabledSkills, equippedSkills } =
-        await SkillResource.listSkillsForConversation(auth, {
+        await SkillResource.listForConversation(auth, {
           agentConfiguration,
           conversation,
         });

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -25,7 +25,7 @@ import type {
   UserMessageType,
   WithAPIErrorResponse,
 } from "@app/types";
-import { isUserMessageType } from "@app/types";
+import { isString, isUserMessageType } from "@app/types";
 
 export type PostRenderConversationRequestBody = {
   agentId: string;
@@ -50,8 +50,8 @@ async function handler(
   >,
   session: SessionWithUser
 ): Promise<void> {
-  const { wId, cId } = req.query as { wId?: string; cId?: string };
-  if (!wId || typeof wId !== "string") {
+  const { wId, cId } = req.query;
+  if (!isString(wId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -60,7 +60,7 @@ async function handler(
       },
     });
   }
-  if (!cId || typeof cId !== "string") {
+  if (!isString(cId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -91,7 +91,7 @@ async function handler(
         onMissingAction,
       } = req.body as PostRenderConversationRequestBody;
 
-      if (!agentId || typeof agentId !== "string") {
+      if (!isString(agentId)) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -222,16 +222,19 @@ async function handler(
       };
 
       const { serverToolsAndInstructions, error: mcpToolsListingError } =
-        await tryListMCPTools(auth, {
-          agentLoopListToolsContext: {
+        await tryListMCPTools(
+          auth,
+          {
             agentConfiguration,
             conversation,
             agentMessage: placeholderAgentMessage,
             clientSideActionConfigurations: clientSideMCPActionConfigurations,
           },
-          jitServers,
-          skillServers,
-        });
+          {
+            jitServers,
+            skillServers,
+          }
+        );
 
       const availableActions = serverToolsAndInstructions.flatMap(
         (s) => s.tools

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -163,22 +163,11 @@ async function handler(
         attachments,
       });
 
-      const enabledSkills = await SkillResource.listEnabledForConversation(
-        auth,
-        {
+      const { enabledSkills, equippedSkills } =
+        await SkillResource.listSkillsForConversation(auth, {
           agentConfiguration,
           conversation,
-        }
-      );
-      const allAgentSkills = await SkillResource.listByAgentConfiguration(
-        auth,
-        agentConfiguration
-      );
-
-      const enabledSkillIds = new Set(enabledSkills.map((s) => s.sId));
-      const equippedSkills = allAgentSkills.filter(
-        (s) => !enabledSkillIds.has(s.sId)
-      );
+        });
 
       // Fetch MCP server configurations from enabled skills.
       const skillServers = await fetchSkillMCPServerConfigurations(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -197,7 +197,7 @@ export async function runModelActivity(
     );
 
   const { enabledSkills, equippedSkills } =
-    await SkillResource.listSkillsForConversation(auth, {
+    await SkillResource.listForConversation(auth, {
       agentConfiguration,
       conversation,
     });

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -219,16 +219,19 @@ export async function runModelActivity(
   const {
     serverToolsAndInstructions: mcpActions,
     error: mcpToolsListingError,
-  } = await tryListMCPTools(auth, {
-    agentLoopListToolsContext: {
+  } = await tryListMCPTools(
+    auth,
+    {
       agentConfiguration,
       conversation,
       agentMessage,
       clientSideActionConfigurations: clientSideMCPActionConfigurations,
     },
-    jitServers,
-    skillServers,
-  });
+    {
+      jitServers,
+      skillServers,
+    }
+  );
 
   if (mcpToolsListingError) {
     localLogger.error(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -277,8 +277,8 @@ export async function runModelActivity(
     agentsList,
     conversationId: conversation.sId,
     serverToolsAndInstructions: mcpActions,
-    enabledSkills: enabledSkills,
-    equippedSkills: equippedSkills,
+    enabledSkills,
+    equippedSkills,
     featureFlags,
   });
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -196,19 +196,11 @@ export async function runModelActivity(
       userMessage.context.clientSideMCPServerIds
     );
 
-  const enabledSkills = await SkillResource.listEnabledForConversation(auth, {
-    agentConfiguration,
-    conversation,
-  });
-  const allAgentSkills = await SkillResource.listByAgentConfiguration(
-    auth,
-    agentConfiguration
-  );
-
-  const enabledSkillIds = new Set(enabledSkills.map((s) => s.sId));
-  const equippedSkills = allAgentSkills.filter(
-    (s) => !enabledSkillIds.has(s.sId)
-  );
+  const { enabledSkills, equippedSkills } =
+    await SkillResource.listSkillsForConversation(auth, {
+      agentConfiguration,
+      conversation,
+    });
 
   // Fetch MCP server configurations from enabled skills.
   const skillServers = await fetchSkillMCPServerConfigurations(


### PR DESCRIPTION
## Description

- This PR groups enabled and equipped skills listing in a single method `listSkillsForConversation`.
- This bundles the logic of fetching enabled ones first, then all skills and filter out enabled ones and centralizes this logic of enable vs equipped in the resource rather than leaving it be the caller's responsibility.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
