### PR TITLE
[front] fix(`AgentInfoTab`): fix missing colors

### DIFF
--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -205,7 +205,7 @@ export function AssistantKnowledgeSection({
   );
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-4">
       <div className="heading-lg text-foreground dark:text-foreground-night">
         Knowledge
       </div>

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -1,4 +1,4 @@
-import { Chip, Page } from "@dust-tt/sparkle";
+import { Chip, cn, Page } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AgentMessageMarkdown } from "@app/components/assistant/AgentMessageMarkdown";
@@ -41,7 +41,7 @@ export function AgentInfoTab({
           />
 
           {agentConfiguration?.instructions ? (
-            <div className="dd-privacy-mask flex flex-col gap-5">
+            <div className="dd-privacy-mask flex flex-col gap-4">
               <div className="heading-lg text-foreground dark:text-foreground-night">
                 Instructions
               </div>

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -45,7 +45,12 @@ export function AgentInfoTab({
               <div className="heading-lg text-foreground dark:text-foreground-night">
                 Instructions
               </div>
-              <div className="border-structure-200 bg-structure-50 rounded-lg border p-4">
+              <div
+                className={cn(
+                  "rounded-lg border border-border bg-muted-background px-3 py-2 " +
+                    "dark:border-border-night dark:bg-muted-background-night"
+                )}
+              >
                 <AgentMessageMarkdown
                   content={agentConfiguration.instructions}
                   owner={owner}


### PR DESCRIPTION
## Description

- This PR fixes the colors in the instructions block in `AgentInfoTab` (there is no `structure` color anymore).
- Also fixes the padding around the instructions and the gap between sections in this tab (gap under a title used to be larger than above it).

Before
<img width="507" height="383" alt="Screenshot 2025-12-15 at 11 38 32 PM" src="https://github.com/user-attachments/assets/9d3f437a-6b96-4aa5-90d1-64df4b18f374" />

After
<img width="507" height="356" alt="Screenshot 2025-12-15 at 11 37 58 PM" src="https://github.com/user-attachments/assets/d77a8eef-2965-4f1a-bfd8-151127840986" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
