### PR TITLE
[front] fix(validation): update check on blocked actions

### DIFF
--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -199,10 +199,14 @@ export async function validateAction(
       conversation
     );
 
-  // Harmless very rare race condition here where 2 validations get
+  // We only trigger an agent loop after the user has validated all actions
+  // for the current message.
+  // There is a harmless very rare race condition here where 2 validations get
   // blockedActions.length === 0. launchAgentLoopWorkflow will be called twice,
   // but only one will succeed.
-  if (blockedActions.length > 0) {
+  if (
+    blockedActions.filter((action) => action.messageId === messageId).length > 0
+  ) {
     logger.info(
       {
         blockedActions,


### PR DESCRIPTION
## Description

- Follow up on [this thread](https://dust4ai.slack.com/archives/C066R3PMUAU/p1765847003724989).
- This PR fixes a case introduced by making tool approval non blocking: in the `/validate-action` endpoint we only trigger an agent loop if all actions has been validated (there can be multiple ones in the same step). Since tool approvals are non blocking, we can leave one at the top of the conversation, which causes every subsequent one to silently fail.
- Sample log [here](https://app.datadoghq.eu/logs?query=%22Skipping%20agent%20loop%20launch%20because%20there%20are%20remaining%20blocked%20actions%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40url&context_event=AZskl-qvAAARHCjlKPI6OwAF&event=AwAAAZsknI2UhTtqQAAAABhBWnNrbkpJVEFBQkF5QVdQaXFUcmlBQU8AAAAkZjE5YjI0OWUtMWFkNi00MGIwLWE0NWYtM2VkOTQzMzJmZmY4AAPMYQ&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=&from_ts=1764575212756&to_ts=1765871212756&live=true), the action on message `kZojFOavu6` blocked the one on message `79gyDPJVdm` silently. The model sees a function call with no result and believes the tool call succeeded even though it never happened.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
