### PR TITLE
fix(gdrive): properly handle `insufficientPermissions` error

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -5,7 +5,61 @@ import type {
 } from "@temporalio/worker";
 import { GaxiosError } from "googleapis-common";
 
-import { ProviderWorkflowError } from "@connectors/lib/error";
+import {
+  ExternalOAuthTokenError,
+  ProviderWorkflowError,
+} from "@connectors/lib/error";
+
+const OAUTH_ERROR_REASONS = new Set(["insufficientPermissions"]);
+
+function isObjectWithError(
+  data: unknown
+): data is { error: { errors: unknown } } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "error" in data &&
+    typeof data.error === "object" &&
+    data.error !== null &&
+    "errors" in data.error
+  );
+}
+
+function isErrorWithReason(err: unknown): err is { reason: string } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "reason" in err &&
+    typeof err.reason === "string"
+  );
+}
+
+function isGoogleDriveInsufficientPermissionsError(
+  err: unknown
+): err is GaxiosError {
+  if (!(err instanceof GaxiosError)) {
+    return false;
+  }
+
+  const status = err.response?.status;
+  if (status !== 401 && status !== 403) {
+    return false;
+  }
+
+  const data: unknown = err.response?.data;
+  if (!isObjectWithError(data)) {
+    return false;
+  }
+
+  const errors = data.error.errors;
+  if (!Array.isArray(errors)) {
+    return false;
+  }
+
+  return errors.some(
+    (e) => isErrorWithReason(e) && OAUTH_ERROR_REASONS.has(e.reason)
+  );
+}
 
 export class GoogleDriveCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
@@ -17,6 +71,10 @@ export class GoogleDriveCastKnownErrorsInterceptor
     try {
       return await next(input);
     } catch (err: unknown) {
+      if (isGoogleDriveInsufficientPermissionsError(err)) {
+        throw new ExternalOAuthTokenError(err);
+      }
+
       if (err instanceof GaxiosError) {
         switch (err.response?.status) {
           case 429:


### PR DESCRIPTION
## Description

Currently this error is not handled.
The error indicates that the OAuth connection is missing permissions to access the drive contents, and should be handled as an `ExternalOauthTokenError` to put the connector in "error"

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
