### PR TITLE
[skills] Take additional requested space ids in agent builder endpoints

### DIFF
--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -482,6 +482,7 @@ export async function submitAgentBuilderForm({
       editors: formData.agentSettings.editors.map((editor) => ({
         sId: editor.sId,
       })),
+      additionalRequestedSpaceIds: [],
     },
   };
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -1,11 +1,14 @@
 import type { RequestMethod } from "node-mocks-http";
 import { describe, expect, it, vi } from "vitest";
 
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 
@@ -78,6 +81,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - Skills with 
         tags: [],
         editors: [{ sId: user.sId }],
         skills: [{ sId: skillResource!.sId }],
+        additionalRequestedSpaceIds: [],
       },
     };
 
@@ -88,6 +92,68 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - Skills with 
     expect(data).toHaveProperty("agentConfiguration");
     expect(data.agentConfiguration.requestedSpaceIds).toContain(
       restrictedSpace.sId
+    );
+  });
+});
+
+describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - additionalRequestedSpaceIds", () => {
+  it("should include additionalRequestedSpaceIds when updating agent", async () => {
+    const { req, res, workspace, user, authenticator, globalGroup } =
+      await createPrivateApiMockRequest({
+        role: "admin",
+        method: "PATCH",
+      });
+
+    await SpaceFactory.defaults(authenticator);
+
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    // Create an open space (with global group) that the user has access to
+    const openSpace = await SpaceFactory.regular(workspace);
+    await GroupSpaceFactory.associate(openSpace, globalGroup);
+
+    req.query = { ...req.query, wId: workspace.sId, aId: agent.sId };
+    req.body = {
+      assistant: {
+        name: agent.name,
+        description: agent.description,
+        instructions: "Updated instructions",
+        pictureUrl: agent.pictureUrl,
+        status: "active",
+        scope: agent.scope,
+        model: {
+          providerId: agent.model.providerId,
+          modelId: agent.model.modelId,
+          temperature: agent.model.temperature,
+        },
+        actions: [],
+        templateId: null,
+        tags: [],
+        editors: [{ sId: user.sId }],
+        skills: [],
+        additionalRequestedSpaceIds: [openSpace.sId],
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty("agentConfiguration");
+    expect(data.agentConfiguration.requestedSpaceIds).toContain(openSpace.sId);
+
+    // Verify the resource was correctly stored in the database
+    const agentConfigurationModel = await AgentConfigurationModel.findOne({
+      where: {
+        sId: data.agentConfiguration.sId,
+        version: data.agentConfiguration.version,
+      },
+    });
+    expect(agentConfigurationModel).not.toBeNull();
+    const openSpaceModelId = getResourceIdFromSId(openSpace.sId);
+    expect(agentConfigurationModel?.requestedSpaceIds).toContain(
+      openSpaceModelId?.toString()
     );
   });
 });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -20,6 +25,29 @@ import handler from "./index";
 
 let testAgents: LightAgentConfigurationType[];
 let workspaceId: string;
+
+const TEST_MODEL = {
+  providerId: "openai",
+  modelId: "gpt-4-turbo",
+  temperature: 0.7,
+};
+
+/** Reasonnable default parameters for test agents */
+
+const TEST_AGENT_PARAMS = {
+  name: "Test Agent",
+  description: "Test Agent Description",
+  instructions: "Test instructions",
+  pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+  status: "active",
+  scope: "visible",
+  model: TEST_MODEL,
+  actions: [],
+  templateId: null,
+  tags: [],
+  skills: [],
+  additionalRequestedSpaceIds: [],
+};
 
 export async function setupAgentOwner(
   workspace: LightWorkspaceType,
@@ -227,20 +255,8 @@ describe("POST /api/w/[wId]/assistant/agent_configurations - Skills with restric
 
     req.body = {
       assistant: {
+        ...TEST_AGENT_PARAMS,
         name: "Test Agent with Skill",
-        description: "Test Agent Description",
-        instructions: "Test instructions",
-        pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
-        status: "active",
-        scope: "visible",
-        model: {
-          providerId: "openai",
-          modelId: "gpt-4-turbo",
-          temperature: 0.7,
-        },
-        actions: [],
-        templateId: null,
-        tags: [],
         editors: [{ sId: user.sId }],
         skills: [{ sId: skillResource!.sId }],
       },
@@ -254,5 +270,150 @@ describe("POST /api/w/[wId]/assistant/agent_configurations - Skills with restric
     expect(data.agentConfiguration.requestedSpaceIds).toContain(
       restrictedSpace.sId
     );
+  });
+});
+
+describe("POST /api/w/[wId]/assistant/agent_configurations - additionalRequestedSpaceIds", () => {
+  it("should include additionalRequestedSpaceIds when creating agent", async () => {
+    const { req, res, workspace, user, authenticator, globalGroup } =
+      await createPrivateApiMockRequest({
+        role: "admin",
+        method: "POST",
+      });
+
+    await SpaceFactory.defaults(authenticator);
+
+    const openSpace = await SpaceFactory.regular(workspace);
+    await GroupSpaceFactory.associate(openSpace, globalGroup);
+
+    req.body = {
+      assistant: {
+        ...TEST_AGENT_PARAMS,
+        name: "Test Agent with Additional Space",
+        editors: [{ sId: user.sId }],
+        // Additional space IDs to request not included by tool or skill.
+        additionalRequestedSpaceIds: [openSpace.sId],
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty("agentConfiguration");
+    expect(data.agentConfiguration.requestedSpaceIds).toContain(openSpace.sId);
+
+    // Verify the resource was correctly stored in the database
+    const agentConfigurationModel = await AgentConfigurationModel.findOne({
+      where: {
+        sId: data.agentConfiguration.sId,
+        version: data.agentConfiguration.version,
+      },
+    });
+    expect(agentConfigurationModel).not.toBeNull();
+    const openSpaceModelId = getResourceIdFromSId(openSpace.sId);
+    expect(agentConfigurationModel?.requestedSpaceIds).toContain(
+      openSpaceModelId?.toString()
+    );
+  });
+
+  it("should fail when user does not have access to additional space", async () => {
+    // Use a regular user (not admin) who won't have access to all spaces
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      role: "user",
+      method: "POST",
+    });
+
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await SpaceFactory.defaults(internalAdminAuth);
+
+    // Create a restricted space without adding the global group
+    // Regular users won't have access to this space
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+
+    req.body = {
+      assistant: {
+        ...TEST_AGENT_PARAMS,
+        name: "Test Agent with Restricted Space",
+        editors: [{ sId: user.sId }],
+        // Use a restricted space that the user doesn't have access to
+        additionalRequestedSpaceIds: [restrictedSpace.sId],
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const data = res._getJSONData();
+    expect(data.error.type).toBe("assistant_saving_error");
+    expect(data.error.message).toContain(
+      `User does not have access to the following spaces: ${restrictedSpace.sId}`
+    );
+  });
+
+  it("should deduplicate additionalRequestedSpaceIds that overlap with tool spaces", async () => {
+    const { req, res, workspace, user, authenticator, globalGroup } =
+      await createPrivateApiMockRequest({
+        role: "admin",
+        method: "POST",
+      });
+
+    await SpaceFactory.defaults(authenticator);
+
+    const openSpace = await SpaceFactory.regular(workspace);
+    await GroupSpaceFactory.associate(openSpace, globalGroup);
+    const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+
+    // Get the system view for the remote MCP server
+    const systemMcpServerView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        authenticator,
+        remoteMCPServer.sId
+      );
+    expect(systemMcpServerView).not.toBeNull();
+
+    const mcpServerView = await MCPServerViewResource.create(authenticator, {
+      systemView: systemMcpServerView!,
+      space: openSpace,
+    });
+
+    req.body = {
+      assistant: {
+        ...TEST_AGENT_PARAMS,
+        name: "Test Agent with Overlapping Space",
+        actions: [
+          {
+            type: "mcp_server_configuration",
+            mcpServerViewId: mcpServerView.sId,
+            name: "search",
+            description: "Search data",
+            dataSources: null,
+            tables: null,
+            childAgentId: null,
+            reasoningModel: null,
+            timeFrame: null,
+            jsonSchema: null,
+            additionalConfiguration: {},
+            dustAppConfiguration: null,
+            secretName: null,
+          },
+        ],
+        editors: [{ sId: user.sId }],
+        // Request the same space that the tool is in
+        additionalRequestedSpaceIds: [openSpace.sId],
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty("agentConfiguration");
+    // The space should appear only once (deduplicated)
+    const actualRequestedSpaceIds = data.agentConfiguration.requestedSpaceIds;
+    expect(actualRequestedSpaceIds).toHaveLength(1);
+    expect(actualRequestedSpaceIds).toContain(openSpace.sId);
   });
 });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -26,6 +26,8 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -341,6 +343,40 @@ export async function createOrUpgradeAgentConfiguration({
         ...requirements.requestedSpaceIds,
         ...skillRequestedSpaceIds,
       ]),
+    ];
+  }
+
+  // Collect additional requestedSpaceIds
+  if (
+    assistant.additionalRequestedSpaceIds &&
+    assistant.additionalRequestedSpaceIds.length > 0
+  ) {
+    const additionalSpaces = await SpaceResource.fetchByIds(
+      auth,
+      assistant.additionalRequestedSpaceIds
+    );
+
+    // Validate that all requested spaces were found and user can read them
+    const readableSpaceIds = new Set(
+      additionalSpaces.filter((s) => s.canRead(auth)).map((s) => s.sId)
+    );
+    const inaccessibleSpaces = assistant.additionalRequestedSpaceIds.filter(
+      (sId) => !readableSpaceIds.has(sId)
+    );
+    if (inaccessibleSpaces.length > 0) {
+      return new Err(
+        new Error(
+          `User does not have access to the following spaces: ${inaccessibleSpaces.join(", ")}`
+        )
+      );
+    }
+
+    const additionalSpaceModelIds = additionalSpaces
+      .map((s) => getResourceIdFromSId(s.sId))
+      .filter((id) => id !== null);
+
+    allRequestedSpaceIds = [
+      ...new Set([...allRequestedSpaceIds, ...additionalSpaceModelIds]),
     ];
   }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -132,6 +132,7 @@ async function handler(
       sId: editor.user_id,
     })),
     skills: [],
+    additionalRequestedSpaceIds: [],
   };
 
   const agentConfigurationRes = await createOrUpgradeAgentConfiguration({

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -208,6 +208,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
     tags: t.array(TagSchema),
     editors: t.array(EditorSchema),
     skills: t.array(SkillSchema),
+    additionalRequestedSpaceIds: t.array(t.string),
   }),
 });
 


### PR DESCRIPTION
## Description

Add the endpoint to provide additional space ids in when creating or updating an agent
The purpose is to let users select some spaces to restrict their agent to when they add global skills like go deep.

## Tests

Additional unit tests

## Risk

low

## Deploy Plan

deploy front
