### PR TITLE
Allow self-mention in agent builder

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -154,7 +154,11 @@ export function AgentBuilderInstructionsEditor({
             class:
               "min-w-0 px-0 py-0 border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0 text-highlight-500 font-semibold",
           },
-          suggestion: createMentionSuggestion({ owner, conversationId: null }),
+          suggestion: createMentionSuggestion({
+            owner,
+            conversationId: null,
+            includeCurrentUser: true,
+          }),
         })
       );
     }

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -26,192 +26,208 @@ import { classNames } from "@app/lib/utils";
 export const MentionDropdown = forwardRef<
   MentionDropdownOnKeyDown,
   MentionDropdownProps
->(({ query, clientRect, command, onClose, owner, conversationId }, ref) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  // Call clientRect() on every render to get the latest position.
-  // This avoids caching stale coordinates that may be invalid (0,0) when typing @ quickly after refresh.
-  const triggerRect = clientRect?.();
-  const featureFlags = useFeatureFlags({ workspaceId: owner.sId });
-  const mentionsV2 = featureFlags.hasFeature("mentions_v2");
-
-  // Fetch suggestions from server using the query.
-  // Backend handles all prioritization logic (participants, preferred agent, etc.)
-  const { suggestions, isLoading } = useMentionSuggestions({
-    workspaceId: owner.sId,
-    conversationId,
-    query,
-    select: { agents: true, users: true },
-  });
-
-  const triggerRef = useRef<HTMLDivElement>(null);
-  const [virtualTriggerStyle, setVirtualTriggerStyle] =
-    useState<React.CSSProperties>({});
-  const selectedItemRef = useRef<HTMLButtonElement>(null);
-
-  const selectItem = (index: number) => {
-    const item = suggestions[index];
-
-    if (item) {
-      command(item);
-    }
-  };
-
-  const updateTriggerPosition = useCallback(() => {
-    if (triggerRect && triggerRef.current) {
-      setVirtualTriggerStyle({
-        position: "fixed",
-        left: triggerRect.left,
-        // On iOS based browsers, the position is not correct without adding the offsetTop.
-        // Something related to the position calculation when there is a scrollable area.
-        top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
-        width: 1,
-        height: triggerRect.height || 1,
-        pointerEvents: "none",
-        zIndex: -1,
-      });
-    }
-  }, [triggerRect]);
-
-  useImperativeHandle(ref, () => ({
-    onKeyDown: ({ event }) => {
-      if (event.key === "ArrowUp") {
-        setSelectedIndex(
-          (selectedIndex + suggestions.length - 1) % suggestions.length
-        );
-        return true;
-      }
-
-      if (event.key === "ArrowDown") {
-        if (suggestions.length === 0) {
-          return false;
-        }
-        setSelectedIndex((selectedIndex + 1) % suggestions.length);
-        return true;
-      }
-
-      if (event.key === "Enter" || event.key === "Tab") {
-        selectItem(selectedIndex);
-        return true;
-      }
-
-      return false;
+>(
+  (
+    {
+      query,
+      clientRect,
+      command,
+      onClose,
+      owner,
+      conversationId,
+      includeCurrentUser,
     },
-  }));
+    ref
+  ) => {
+    const [selectedIndex, setSelectedIndex] = useState(0);
 
-  useEffect(() => {
-    updateTriggerPosition();
-  }, [updateTriggerPosition]);
+    // Call clientRect() on every render to get the latest position.
+    // This avoids caching stale coordinates that may be invalid (0,0) when typing @ quickly after refresh.
+    const triggerRect = clientRect?.();
 
-  // Reset the selected index when items change (e.g., when query changes).
-  useEffect(() => {
-    setSelectedIndex(0);
-  }, [suggestions]);
+    const featureFlags = useFeatureFlags({ workspaceId: owner.sId });
+    const mentionsV2 = featureFlags.hasFeature("mentions_v2");
 
-  // Scroll selected item into view when selection changes.
-  useEffect(() => {
-    if (selectedItemRef.current) {
-      selectedItemRef.current.scrollIntoView({
-        block: "nearest",
-        behavior: "smooth",
-      });
+    // Fetch suggestions from server using the query.
+    // Backend handles all prioritization logic (participants, preferred agent, etc.)
+    const { suggestions, isLoading } = useMentionSuggestions({
+      workspaceId: owner.sId,
+      conversationId,
+      query,
+      select: { agents: true, users: true },
+      includeCurrentUser,
+    });
+
+    const triggerRef = useRef<HTMLDivElement>(null);
+    const [virtualTriggerStyle, setVirtualTriggerStyle] =
+      useState<React.CSSProperties>({});
+    const selectedItemRef = useRef<HTMLButtonElement>(null);
+
+    const selectItem = (index: number) => {
+      const item = suggestions[index];
+
+      if (item) {
+        command(item);
+      }
+    };
+
+    const updateTriggerPosition = useCallback(() => {
+      if (triggerRect && triggerRef.current) {
+        setVirtualTriggerStyle({
+          position: "fixed",
+          left: triggerRect.left,
+          // On iOS based browsers, the position is not correct without adding the offsetTop.
+          // Something related to the position calculation when there is a scrollable area.
+          top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
+          width: 1,
+          height: triggerRect.height || 1,
+          pointerEvents: "none",
+          zIndex: -1,
+        });
+      }
+    }, [triggerRect]);
+
+    useImperativeHandle(ref, () => ({
+      onKeyDown: ({ event }) => {
+        if (event.key === "ArrowUp") {
+          setSelectedIndex(
+            (selectedIndex + suggestions.length - 1) % suggestions.length
+          );
+          return true;
+        }
+
+        if (event.key === "ArrowDown") {
+          if (suggestions.length === 0) {
+            return false;
+          }
+          setSelectedIndex((selectedIndex + 1) % suggestions.length);
+          return true;
+        }
+
+        if (event.key === "Enter" || event.key === "Tab") {
+          selectItem(selectedIndex);
+          return true;
+        }
+
+        return false;
+      },
+    }));
+
+    useEffect(() => {
+      updateTriggerPosition();
+    }, [updateTriggerPosition]);
+
+    // Reset the selected index when items change (e.g., when query changes).
+    useEffect(() => {
+      setSelectedIndex(0);
+    }, [suggestions]);
+
+    // Scroll selected item into view when selection changes.
+    useEffect(() => {
+      if (selectedItemRef.current) {
+        selectedItemRef.current.scrollIntoView({
+          block: "nearest",
+          behavior: "smooth",
+        });
+      }
+    }, [selectedIndex]);
+
+    // Only render the dropdown if we have a valid trigger.
+    if (!triggerRect) {
+      return null;
     }
-  }, [selectedIndex]);
 
-  // Only render the dropdown if we have a valid trigger.
-  if (!triggerRect) {
-    return null;
+    // Generate a key based on content state to force remount when content size changes significantly.
+    // This ensures Radix UI recalculates collision detection and positioning.
+    const contentKey = isLoading
+      ? "loading"
+      : suggestions.length === 0
+        ? "empty"
+        : `results-${suggestions.length}`;
+
+    // Don't render the dropdown if there are no results
+    if (mentionsV2 && suggestions.length === 0 && !isLoading) {
+      return null;
+    }
+
+    return (
+      <DropdownMenu open={true}>
+        <DropdownMenuTrigger asChild>
+          <div ref={triggerRef} style={virtualTriggerStyle} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          key={contentKey}
+          className="w-72"
+          align="start"
+          side="bottom"
+          sideOffset={4}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onEscapeKeyDown={() => {
+            onClose?.();
+          }}
+          onInteractOutside={() => {
+            onClose?.();
+          }}
+        >
+          {isLoading ? (
+            <div className="flex h-12 w-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : suggestions.length > 0 ? (
+            <div className="flex max-h-60 flex-col gap-y-1 overflow-y-auto p-1">
+              {suggestions.map((suggestion, index) => (
+                <div key={suggestion.id}>
+                  <button
+                    ref={index === selectedIndex ? selectedItemRef : null}
+                    className={classNames(
+                      "flex items-center px-2 py-1",
+                      "w-full flex-initial cursor-pointer text-left text-sm",
+                      index === selectedIndex
+                        ? "text-highlight-500"
+                        : "text-foreground dark:text-foreground-night"
+                    )}
+                    onClick={() => {
+                      selectItem(index);
+                    }}
+                    onMouseEnter={() => {
+                      setSelectedIndex(index);
+                    }}
+                  >
+                    <div className="flex min-w-0 flex-1 items-center gap-x-2">
+                      <Avatar
+                        size="xs"
+                        visual={suggestion.pictureUrl}
+                        isRounded={suggestion.type === "user"}
+                      />
+                      <span
+                        className="truncate font-semibold"
+                        title={suggestion.label}
+                      >
+                        {suggestion.label}
+                      </span>
+                    </div>
+                    {suggestion.type === "user" && (
+                      <Chip
+                        size="mini"
+                        color="primary"
+                        label="User"
+                        className="ml-2 shrink-0"
+                      />
+                    )}
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex h-12 w-full items-center justify-center text-sm text-muted-foreground">
+              No result
+            </div>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
   }
-
-  // Generate a key based on content state to force remount when content size changes significantly.
-  // This ensures Radix UI recalculates collision detection and positioning.
-  const contentKey = isLoading
-    ? "loading"
-    : suggestions.length === 0
-      ? "empty"
-      : `results-${suggestions.length}`;
-
-  // Don't render the dropdown if there are no results
-  if (mentionsV2 && suggestions.length === 0 && !isLoading) {
-    return null;
-  }
-
-  return (
-    <DropdownMenu open={true}>
-      <DropdownMenuTrigger asChild>
-        <div ref={triggerRef} style={virtualTriggerStyle} />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        key={contentKey}
-        className="w-72"
-        align="start"
-        side="bottom"
-        sideOffset={4}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        onEscapeKeyDown={() => {
-          onClose?.();
-        }}
-        onInteractOutside={() => {
-          onClose?.();
-        }}
-      >
-        {isLoading ? (
-          <div className="flex h-12 w-full items-center justify-center">
-            <Spinner />
-          </div>
-        ) : suggestions.length > 0 ? (
-          <div className="flex max-h-60 flex-col gap-y-1 overflow-y-auto p-1">
-            {suggestions.map((suggestion, index) => (
-              <div key={suggestion.id}>
-                <button
-                  ref={index === selectedIndex ? selectedItemRef : null}
-                  className={classNames(
-                    "flex items-center px-2 py-1",
-                    "w-full flex-initial cursor-pointer text-left text-sm",
-                    index === selectedIndex
-                      ? "text-highlight-500"
-                      : "text-foreground dark:text-foreground-night"
-                  )}
-                  onClick={() => {
-                    selectItem(index);
-                  }}
-                  onMouseEnter={() => {
-                    setSelectedIndex(index);
-                  }}
-                >
-                  <div className="flex min-w-0 flex-1 items-center gap-x-2">
-                    <Avatar
-                      size="xs"
-                      visual={suggestion.pictureUrl}
-                      isRounded={suggestion.type === "user"}
-                    />
-                    <span
-                      className="truncate font-semibold"
-                      title={suggestion.label}
-                    >
-                      {suggestion.label}
-                    </span>
-                  </div>
-                  {suggestion.type === "user" && (
-                    <Chip
-                      size="mini"
-                      color="primary"
-                      label="User"
-                      className="ml-2 shrink-0"
-                    />
-                  )}
-                </button>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="flex h-12 w-full items-center justify-center text-sm text-muted-foreground">
-            No result
-          </div>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-});
+);
 
 MentionDropdown.displayName = "MentionDropdown";

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -18,9 +18,11 @@ export const mentionPluginKey = new PluginKey("mention-suggestion");
 export function createMentionSuggestion({
   owner,
   conversationId,
+  includeCurrentUser = false,
 }: {
   owner: WorkspaceType;
   conversationId: string | null;
+  includeCurrentUser?: boolean;
 }) {
   return {
     pluginKey: mentionPluginKey,
@@ -49,6 +51,7 @@ export function createMentionSuggestion({
               ...props,
               owner,
               conversationId,
+              includeCurrentUser,
               onClose: closeDropdown,
             },
           });

--- a/front/components/editor/input_bar/types.ts
+++ b/front/components/editor/input_bar/types.ts
@@ -10,6 +10,7 @@ export interface MentionDropdownProps {
   query: string;
   owner: WorkspaceType;
   conversationId: string | null;
+  includeCurrentUser?: boolean;
   command: (item: RichMention) => void;
   clientRect?: (() => DOMRect | null) | null;
   onClose?: () => void;

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -128,7 +128,6 @@ export const suggestionsOfMentions = async (
   }
 ): Promise<RichMention[]> => {
   const normalizedQuery = query.toLowerCase();
-  const currentUserSId = auth.getNonNullableUser().sId;
 
   // Id of the last user or agent mentioned by the current user in the conversation
   let lastMentionedId: string | null = null;
@@ -157,17 +156,15 @@ export const suggestionsOfMentions = async (
         const participants = participantsRes.value;
 
         // Convert participants to RichMention format
-        participantUsers = participants.users
-          .filter((u) => u.sId !== currentUserSId)
-          .map((u) => ({
-            type: "user" as const,
-            id: u.sId,
-            label: u.fullName ?? u.username,
-            pictureUrl: u.pictureUrl ?? "/static/humanavatar/anonymous.png",
-            description: u.username,
-            lastActivityAt: u.lastActivityAt,
-            isParticipant: true,
-          }));
+        participantUsers = participants.users.map((u) => ({
+          type: "user" as const,
+          id: u.sId,
+          label: u.fullName ?? u.username,
+          pictureUrl: u.pictureUrl ?? "/static/humanavatar/anonymous.png",
+          description: u.username,
+          lastActivityAt: u.lastActivityAt,
+          isParticipant: true,
+        }));
 
         participantAgents = participants.agents.map((a) => ({
           type: "agent" as const,
@@ -229,14 +226,12 @@ export const suggestionsOfMentions = async (
     if (res.isOk()) {
       const { users } = res.value;
 
-      const filteredUsers: RichUserMentionInConversation[] = users
-        .filter((u) => u.sId !== currentUserSId)
-        .map((u) => ({
-          ...toRichUserMentionType(u.toJSON()),
-          isParticipant: participantUsers.some((pu) => pu.id === u.sId),
-          lastActivityAt:
-            participantUsers.find((pu) => pu.id === u.sId)?.lastActivityAt ?? 0,
-        }));
+      const filteredUsers: RichUserMentionInConversation[] = users.map((u) => ({
+        ...toRichUserMentionType(u.toJSON()),
+        isParticipant: participantUsers.some((pu) => pu.id === u.sId),
+        lastActivityAt:
+          participantUsers.find((pu) => pu.id === u.sId)?.lastActivityAt ?? 0,
+      }));
       const sortedUsers = sortEditorSuggestionUsers(filteredUsers);
       if (!normalizedQuery) {
         // It's a special case when there's no query: all the conversation participants may not be in the users list (as it's limited).

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -118,6 +118,7 @@ export const suggestionsOfMentions = async (
       agents: true,
       users: true,
     },
+    current = false,
   }: {
     query: string;
     conversationId?: string | null;
@@ -125,9 +126,11 @@ export const suggestionsOfMentions = async (
       agents: boolean;
       users: boolean;
     };
+    current?: boolean; // Include current user in suggestions
   }
 ): Promise<RichMention[]> => {
   const normalizedQuery = query.toLowerCase();
+  const currentUserSId = auth.getNonNullableUser().sId;
 
   // Id of the last user or agent mentioned by the current user in the conversation
   let lastMentionedId: string | null = null;
@@ -156,15 +159,17 @@ export const suggestionsOfMentions = async (
         const participants = participantsRes.value;
 
         // Convert participants to RichMention format
-        participantUsers = participants.users.map((u) => ({
-          type: "user" as const,
-          id: u.sId,
-          label: u.fullName ?? u.username,
-          pictureUrl: u.pictureUrl ?? "/static/humanavatar/anonymous.png",
-          description: u.username,
-          lastActivityAt: u.lastActivityAt,
-          isParticipant: true,
-        }));
+        participantUsers = participants.users
+          .filter((u) => current || u.sId !== currentUserSId)
+          .map((u) => ({
+            type: "user" as const,
+            id: u.sId,
+            label: u.fullName ?? u.username,
+            pictureUrl: u.pictureUrl ?? "/static/humanavatar/anonymous.png",
+            description: u.username,
+            lastActivityAt: u.lastActivityAt,
+            isParticipant: true,
+          }));
 
         participantAgents = participants.agents.map((a) => ({
           type: "agent" as const,
@@ -226,12 +231,14 @@ export const suggestionsOfMentions = async (
     if (res.isOk()) {
       const { users } = res.value;
 
-      const filteredUsers: RichUserMentionInConversation[] = users.map((u) => ({
-        ...toRichUserMentionType(u.toJSON()),
-        isParticipant: participantUsers.some((pu) => pu.id === u.sId),
-        lastActivityAt:
-          participantUsers.find((pu) => pu.id === u.sId)?.lastActivityAt ?? 0,
-      }));
+      const filteredUsers: RichUserMentionInConversation[] = users
+        .filter((u) => current || u.sId !== currentUserSId)
+        .map((u) => ({
+          ...toRichUserMentionType(u.toJSON()),
+          isParticipant: participantUsers.some((pu) => pu.id === u.sId),
+          lastActivityAt:
+            participantUsers.find((pu) => pu.id === u.sId)?.lastActivityAt ?? 0,
+        }));
       const sortedUsers = sortEditorSuggestionUsers(filteredUsers);
       if (!normalizedQuery) {
         // It's a special case when there's no query: all the conversation participants may not be in the users list (as it's limited).

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import { useUser } from "@app/lib/swr/user";
 import { debounce } from "@app/lib/utils/debounce";
 import type { RichMention } from "@app/types";
 

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useUser } from "@app/lib/swr/user";
 import { debounce } from "@app/lib/utils/debounce";
 import type { RichMention } from "@app/types";
 
@@ -15,6 +16,7 @@ export function useMentionSuggestions({
   query = "",
   select,
   disabled = false,
+  includeCurrentUser = false,
 }: {
   workspaceId: string;
   conversationId: string | null;
@@ -24,7 +26,9 @@ export function useMentionSuggestions({
     users: boolean;
   };
   disabled?: boolean;
+  includeCurrentUser?: boolean;
 }) {
+  const { user } = useUser();
   const suggestionsFetcher: Fetcher<MentionSuggestionsResponseBody> = fetcher;
 
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -65,8 +69,12 @@ export function useMentionSuggestions({
     disabled,
   });
 
+  const suggestions = includeCurrentUser
+    ? (data?.suggestions ?? [])
+    : (data?.suggestions.filter((s) => s.id !== user?.sId) ?? []);
+
   return {
-    suggestions: data?.suggestions ?? [],
+    suggestions,
     isLoading: !error && !data,
     isError: !!error,
     mutate,

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -28,7 +28,6 @@ export function useMentionSuggestions({
   disabled?: boolean;
   includeCurrentUser?: boolean;
 }) {
-  const { user } = useUser();
   const suggestionsFetcher: Fetcher<MentionSuggestionsResponseBody> = fetcher;
 
   const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -50,6 +50,9 @@ export function useMentionSuggestions({
   if (select.users) {
     searchParams.append("select", "users");
   }
+  if (includeCurrentUser) {
+    searchParams.append("current", "true");
+  }
 
   const url =
     (conversationId
@@ -69,12 +72,8 @@ export function useMentionSuggestions({
     disabled,
   });
 
-  const suggestions = includeCurrentUser
-    ? (data?.suggestions ?? [])
-    : (data?.suggestions.filter((s) => s.id !== user?.sId) ?? []);
-
   return {
-    suggestions,
+    suggestions: data?.suggestions ?? [],
     isLoading: !error && !data,
     isError: !!error,
     mutate,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -48,6 +48,12 @@ import type { WithAPIErrorResponse } from "@app/types";
  *             enum:
  *               - agents
  *               - users
+ *       - in: query
+ *         name: current
+ *         required: false
+ *         description: Whether to include the current user in the suggestions.
+ *         schema:
+ *           type: boolean
  *     security:
  *       - BearerAuth: []
  *     responses:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -117,7 +117,7 @@ async function handler(
   }
 
   const parsedQuery = GetMentionSuggestionsRequestQuerySchema.parse(req.query);
-  const { query, select: selectParam } = parsedQuery;
+  const { query, select: selectParam, current } = parsedQuery;
 
   const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
   const mentions_v2_enabled = featureFlags.includes("mentions_v2");
@@ -145,6 +145,7 @@ async function handler(
   const suggestions = await suggestionsOfMentions(auth, {
     query,
     select,
+    current,
   });
 
   return res.status(200).json({ suggestions });

--- a/front/pages/api/v1/w/[wId]/assistant/mentions/suggestions.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/mentions/suggestions.ts
@@ -41,6 +41,12 @@ import type { WithAPIErrorResponse } from "@app/types";
  *             enum:
  *               - agents
  *               - users
+ *       - in: query
+ *         name: current
+ *         required: false
+ *         description: Whether to include the current user in the suggestions.
+ *         schema:
+ *           type: boolean
  *     security:
  *       - BearerAuth: []
  *     responses:

--- a/front/pages/api/v1/w/[wId]/assistant/mentions/suggestions.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/mentions/suggestions.ts
@@ -82,7 +82,7 @@ async function handler(
   }
 
   const parsedQuery = GetMentionSuggestionsRequestQuerySchema.parse(req.query);
-  const { query, select: selectParam } = parsedQuery;
+  const { query, select: selectParam, current } = parsedQuery;
 
   const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
   const mentions_v2_enabled = featureFlags.includes("mentions_v2");
@@ -110,6 +110,7 @@ async function handler(
   const suggestions = await suggestionsOfMentions(auth, {
     query,
     select,
+    current,
   });
 
   return res.status(200).json({ suggestions });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -54,7 +54,7 @@ async function handler(
     });
   }
 
-  const { select: selectParam } = req.query;
+  const { select: selectParam, current } = req.query;
 
   const { query: queryParam } = req.query;
   const query = isString(queryParam) ? queryParam.trim().toLowerCase() : "";
@@ -80,6 +80,7 @@ async function handler(
     query,
     conversationId,
     select,
+    current: current === "true",
   });
 
   return res.status(200).json({ suggestions });

--- a/front/pages/api/w/[wId]/assistant/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/mentions/suggestions.ts
@@ -27,7 +27,7 @@ async function handler(
     });
   }
 
-  const { select: selectParam } = req.query;
+  const { select: selectParam, current } = req.query;
 
   const { query: queryParam } = req.query;
   const query = isString(queryParam) ? queryParam.trim().toLowerCase() : "";
@@ -52,6 +52,7 @@ async function handler(
   const suggestions = await suggestionsOfMentions(auth, {
     query,
     select,
+    current: current === "true",
   });
 
   return res.status(200).json({ suggestions });

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -848,6 +848,15 @@
                 ]
               }
             }
+          },
+          {
+            "in": "query",
+            "name": "current",
+            "required": false,
+            "description": "Whether to include the current user in the suggestions.",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "security": [
@@ -1629,6 +1638,15 @@
                   "users"
                 ]
               }
+            }
+          },
+          {
+            "in": "query",
+            "name": "current",
+            "required": false,
+            "description": "Whether to include the current user in the suggestions.",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -693,16 +693,19 @@ export class DustAPI {
    * @param query - Search query string to filter suggestions
    * @param select - Optional array of mention types to include. Can be "agents", "users", or both.
    * @param conversationId - Optional conversation ID to scope suggestions to a specific conversation
+   * @param current - Optional boolean to include the current user in the suggestions
    * @returns A promise that resolves to a Result containing an array of mention suggestions
    */
   async getMentionsSuggestions({
     query,
     select,
     conversationId,
+    current,
   }: {
     query: string;
     select?: "agents" | "users" | ("agents" | "users")[];
     conversationId?: string;
+    current?: boolean;
   }) {
     const queryParams = new URLSearchParams({ query });
     if (select) {
@@ -711,6 +714,9 @@ export class DustAPI {
       } else {
         queryParams.append("select", select);
       }
+    }
+    if (current !== undefined) {
+      queryParams.append("current", current ? "true" : "false");
     }
 
     const path = conversationId

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3370,6 +3370,7 @@ export const GetMentionSuggestionsRequestQuerySchema = z.object({
   select: z
     .union([z.array(z.enum(["agents", "users"])), z.enum(["agents", "users"])])
     .optional(),
+  current: z.boolean().optional(),
 });
 
 export const GetMentionSuggestionsResponseBodySchema = z.object({


### PR DESCRIPTION
## Description

Adds an optional `includeCurrentUser` parameter to the mention suggestions system to control whether the current user appears in the dropdown. This is necessary for the agent builder instructions editor where users should be able to mention themselves in agent instructions (e.g., for routing or handoff scenarios). The parameter defaults to false to maintain the existing behavior in conversations where self-mentions are not useful, but is set to true in the agent builder.

The backend always returns the current user and the frontend applies the filter or not.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
