### PR TITLE
fix: enter on emoji dropdown

### DIFF
--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -15,6 +15,7 @@ import { URLStorageExtension } from "@app/components/editor/extensions/input_bar
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
 import { BlockquoteExtension } from "@app/components/editor/input_bar/BlockquoteExtension";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
+import { emojiPluginKey } from "@app/components/editor/input_bar/emojiSuggestion";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import {
   createMentionSuggestion,
@@ -354,6 +355,12 @@ const useCustomEditor = ({
             const mentionPluginState = mentionPluginKey.getState(view.state);
             // Let the mention extension handle the event if its dropdown is currently opened.
             if (mentionPluginState?.active) {
+              return false;
+            }
+
+            const emojiPluginState = emojiPluginKey.getState(view.state);
+            // Let the emoji extension handle the event if its dropdown is currently opened.
+            if (emojiPluginState?.active) {
               return false;
             }
 


### PR DESCRIPTION
## Description

Fix when typing "enter" to _not_ send the message in the emoji dropdown
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
