### PR TITLE
[front] chore(skills): add missing FF check

### DIFF
--- a/front/components/shared/skills/SkillsContext.tsx
+++ b/front/components/shared/skills/SkillsContext.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { createContext, useContext, useMemo } from "react";
 
 import { useSkillConfigurations } from "@app/lib/swr/skill_configurations";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LightWorkspaceType } from "@app/types";
 import type { SkillConfigurationType } from "@app/types/assistant/skill_configuration";
 
@@ -27,12 +28,16 @@ interface SkillsProviderProps {
 }
 
 export const SkillsProvider = ({ owner, children }: SkillsProviderProps) => {
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+  const hasSkillsFeature = hasFeature("skills");
+
   const {
     skillConfigurations,
     isSkillConfigurationsLoading,
     isSkillConfigurationsError,
   } = useSkillConfigurations({
     owner,
+    disabled: !hasSkillsFeature,
   });
 
   const value: SkillsContextType = useMemo(() => {


### PR DESCRIPTION
## Description

- We are currently hitting the `/skills` endpoint quite often, even for workspace that do not have the feature flag enabled.
- This PR disables the `useSkillConfigurations` hook when the FF is not enabled.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
