### PR TITLE
Fix colors in dark mode

### DIFF
--- a/front/components/assistant/conversation/DeletedMessage.tsx
+++ b/front/components/assistant/conversation/DeletedMessage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export const DeletedMessage = () => (
-  <div className="italic text-muted-foreground">
+  <div className="italic text-muted-foreground dark:text-muted-foreground-night">
     This message has been deleted
   </div>
 );

--- a/front/lib/mentions/ui/MentionDisplay.tsx
+++ b/front/lib/mentions/ui/MentionDisplay.tsx
@@ -46,13 +46,10 @@ function MentionTrigger({
   return (
     <span
       className={cn(
-        "inline-block cursor-pointer font-light",
-        !userMentionsEnabled || mention.type === "agent"
-          ? "text-highlight-500"
-          : "text-green-700",
+        "inline-block cursor-pointer font-light text-highlight-500 dark:text-highlight-500-night",
         userMentionsEnabled &&
           isCurrentUserMentioned &&
-          "bg-green-200 text-green-700"
+          "bg-green-200 text-green-700 dark:bg-green-200-night dark:text-green-600-night"
       )}
     >
       @{mention.label}


### PR DESCRIPTION
## Description

This PR:
- changes back human mentions to blue (instead of green)
- adapt the colors of the mentions and the "Deleted message" text for Dark mode
<img width="883" height="260" alt="image" src="https://github.com/user-attachments/assets/896025ab-b3e9-4d53-bce7-b06ddaad1981" /> <img width="316" height="248" alt="image" src="https://github.com/user-attachments/assets/67a9dd05-88bc-4d76-ae73-de628b60bb50" />



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
