### PR TITLE
[SKILLS] MCP server views in skill details

### DIFF
--- a/front/components/agent_builder/skills/skillSheet/SelectionPage.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SelectionPage.tsx
@@ -68,7 +68,7 @@ export function SelectionPageContent({
               onMoreInfoClick={() => {
                 onModeChange({
                   type: SKILLS_SHEET_PAGE_IDS.INFO,
-                  skillConfiguration: skill,
+                  skill,
                   previousMode: mode,
                 });
               }}

--- a/front/components/agent_builder/skills/skillSheet/SelectionPage.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SelectionPage.tsx
@@ -7,15 +7,12 @@ import type {
   SelectionMode,
 } from "@app/components/agent_builder/skills/skillSheet/types";
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
-import type {
-  SkillRelations,
-  SkillType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 type SelectionPageProps = PageContentProps & {
   mode: SelectionMode;
-  handleSkillToggle: (skill: SkillType & { relations: SkillRelations }) => void;
-  filteredSkills: (SkillType & { relations: SkillRelations })[];
+  handleSkillToggle: (skill: SkillType) => void;
+  filteredSkills: SkillType[];
   isSkillsLoading: boolean;
   searchQuery: string;
   selectedSkillIds: Set<string>;

--- a/front/components/agent_builder/skills/skillSheet/SkillWithRelationsDetailsSheetContent.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SkillWithRelationsDetailsSheetContent.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { SkillDetailsSheetContent } from "@app/components/skills/SkillDetailsSheet";
+import { useSkillConfigurationWithRelations } from "@app/lib/swr/skill_configurations";
+import type { UserType, WorkspaceType } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+type SkillWithRelationsDetailsSheetContentProps = {
+  owner: WorkspaceType;
+  user: UserType;
+  skill: SkillType;
+};
+
+export function SkillWithRelationsDetailsSheetContent({
+  owner,
+  user,
+  skill,
+}: SkillWithRelationsDetailsSheetContentProps) {
+  const { skillWithRelations } = useSkillConfigurationWithRelations({
+    owner,
+    id: skill.sId,
+  });
+
+  return (
+    <SkillDetailsSheetContent
+      skill={skillWithRelations ?? skill}
+      owner={owner}
+      user={user}
+    />
+  );
+}

--- a/front/components/agent_builder/skills/skillSheet/SkillWithRelationsDetailsSheetContent.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SkillWithRelationsDetailsSheetContent.tsx
@@ -18,7 +18,7 @@ export function SkillWithRelationsDetailsSheetContent({
 }: SkillWithRelationsDetailsSheetContentProps) {
   const { skillWithRelations } = useSkillWithRelations({
     owner,
-    id: skill.sId,
+    skillId: skill.sId,
   });
 
   return (

--- a/front/components/agent_builder/skills/skillSheet/SkillWithRelationsDetailsSheetContent.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SkillWithRelationsDetailsSheetContent.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { SkillDetailsSheetContent } from "@app/components/skills/SkillDetailsSheet";
-import { useSkillConfigurationWithRelations } from "@app/lib/swr/skill_configurations";
+import { useSkillWithRelations } from "@app/lib/swr/skill_configurations";
 import type { UserType, WorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
@@ -16,7 +16,7 @@ export function SkillWithRelationsDetailsSheetContent({
   user,
   skill,
 }: SkillWithRelationsDetailsSheetContentProps) {
-  const { skillWithRelations } = useSkillConfigurationWithRelations({
+  const { skillWithRelations } = useSkillWithRelations({
     owner,
     id: skill.sId,
   });

--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -10,14 +10,9 @@ import type {
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
 import { doesSkillTriggerSelectSpaces } from "@app/lib/skill";
 import { useSkillConfigurationsWithRelations } from "@app/lib/swr/skill_configurations";
-import type {
-  SkillRelations,
-  SkillType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-function isGlobalSkillWithSpaceSelection(
-  skill: SkillType & { relations: SkillRelations }
-): boolean {
+function isGlobalSkillWithSpaceSelection(skill: SkillType): boolean {
   return doesSkillTriggerSelectSpaces(skill.sId);
 }
 
@@ -72,7 +67,7 @@ export const useSkillSelection = ({
   const selectionMode = getSelectionMode(mode);
 
   const handleSkillToggle = useCallback(
-    (skill: SkillType & { relations: SkillRelations }) => {
+    (skill: SkillType) => {
       const isAlreadySelected = localSelectedSkills.some(
         (s) => s.sId === skill.sId
       );
@@ -104,7 +99,7 @@ export const useSkillSelection = ({
   );
 
   const handleSpaceSelectionSave = useCallback(
-    (skill: SkillType & { relations: SkillRelations }) => {
+    (skill: SkillType) => {
       // Commit draft spaces to actual state
       setLocalAdditionalSpaces(draftSelectedSpaces);
       // Add the skill

--- a/front/components/agent_builder/skills/skillSheet/types.tsx
+++ b/front/components/agent_builder/skills/skillSheet/types.tsx
@@ -16,12 +16,12 @@ export type SkillsSheetMode =
     }
   | {
       type: typeof SKILLS_SHEET_PAGE_IDS.INFO;
-      skillConfiguration: SkillType;
+      skill: SkillType;
       previousMode: SelectionMode;
     }
   | {
       type: typeof SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION;
-      skillConfiguration: SkillType & { relations: SkillRelations };
+      skillConfiguration: SkillType;
       previousMode: SelectionMode;
     };
 

--- a/front/components/agent_builder/skills/skillSheet/types.tsx
+++ b/front/components/agent_builder/skills/skillSheet/types.tsx
@@ -2,10 +2,7 @@ import type React from "react";
 
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { UserType, WorkspaceType } from "@app/types";
-import type {
-  SkillRelations,
-  SkillType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export const SKILLS_SHEET_PAGE_IDS = {
   SELECTION: "add",
@@ -19,7 +16,7 @@ export type SkillsSheetMode =
     }
   | {
       type: typeof SKILLS_SHEET_PAGE_IDS.INFO;
-      skillConfiguration: SkillType & { relations: SkillRelations };
+      skillConfiguration: SkillType;
       previousMode: SelectionMode;
     }
   | {

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -20,8 +20,6 @@ export function getPageAndFooter(props: PageContentProps): {
     onModeChange,
     onClose,
     handleSave,
-    owner,
-    user,
     alreadyRequestedSpaceIds,
     localAdditionalSpaces,
   } = props;
@@ -58,15 +56,15 @@ export function getPageAndFooter(props: PageContentProps): {
     case SKILLS_SHEET_PAGE_IDS.INFO:
       return {
         page: {
-          title: mode.skillConfiguration.name,
-          description: mode.skillConfiguration.userFacingDescription,
-          id: mode.type,
+          title: mode.skill.name,
+          description: mode.skill.userFacingDescription,
+          id: props.mode.type,
           icon: SKILL_ICON,
           content: (
             <SkillDetailsSheetContent
-              skillConfiguration={mode.skillConfiguration}
-              owner={owner}
-              user={user}
+              skillConfiguration={mode.skill}
+              owner={props.owner}
+              user={props.user}
             />
           ),
         },

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -3,10 +3,10 @@ import React from "react";
 
 import { useSkillSelection } from "@app/components/agent_builder/skills/skillSheet/hooks";
 import { SelectionPageContent } from "@app/components/agent_builder/skills/skillSheet/SelectionPage";
+import { SkillWithRelationsDetailsSheetContent } from "@app/components/agent_builder/skills/skillSheet/SkillWithRelationsDetailsSheetContent";
 import { SpaceSelectionPageContent } from "@app/components/agent_builder/skills/skillSheet/SpaceSelectionPage";
 import type { PageContentProps } from "@app/components/agent_builder/skills/skillSheet/types";
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
-import { SkillDetailsSheetContent } from "@app/components/skills/SkillDetailsSheet";
 import { SKILL_ICON } from "@app/lib/skill";
 import { assertNever } from "@app/types";
 
@@ -61,7 +61,7 @@ export function getPageAndFooter(props: PageContentProps): {
           id: props.mode.type,
           icon: SKILL_ICON,
           content: (
-            <SkillDetailsSheetContent
+            <SkillWithRelationsDetailsSheetContent
               skill={mode.skill}
               owner={props.owner}
               user={props.user}

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -62,7 +62,7 @@ export function getPageAndFooter(props: PageContentProps): {
           icon: SKILL_ICON,
           content: (
             <SkillDetailsSheetContent
-              skillConfiguration={mode.skill}
+              skill={mode.skill}
               owner={props.owner}
               user={props.user}
             />

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -29,21 +29,21 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 
 type SkillDetailsProps = {
-  skillConfiguration: SkillType & { relations: SkillRelations };
+  skill: SkillType & { relations: SkillRelations };
   onClose: () => void;
   owner: WorkspaceType;
   user: UserType;
 };
 
 export function SkillDetailsSheet({
-  skillConfiguration,
+  skill,
   onClose,
   user,
   owner,
 }: SkillDetailsProps) {
   return (
     <Sheet
-      open={!!skillConfiguration}
+      open={!!skill}
       onOpenChange={(open) => {
         if (!open) {
           onClose();
@@ -56,17 +56,13 @@ export function SkillDetailsSheet({
         </VisuallyHidden>
         <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
           <DescriptionSection
-            skillConfiguration={skillConfiguration}
+            skillConfiguration={skill}
             owner={owner}
             onClose={onClose}
           />
         </SheetHeader>
         <SheetContainer className="pb-4">
-          <SkillDetailsSheetContent
-            skillConfiguration={skillConfiguration}
-            user={user}
-            owner={owner}
-          />
+          <SkillDetailsSheetContent skill={skill} user={user} owner={owner} />
         </SheetContainer>
       </SheetContent>
     </Sheet>
@@ -74,19 +70,19 @@ export function SkillDetailsSheet({
 }
 
 type SkillDetailsSheetContentProps = {
-  skillConfiguration: SkillType & { relations?: SkillRelations };
+  skill: SkillType & { relations?: SkillRelations };
   owner: WorkspaceType;
   user: UserType;
 };
 
 export function SkillDetailsSheetContent({
-  skillConfiguration,
+  skill,
   owner,
   user,
 }: SkillDetailsSheetContentProps) {
   const [selectedTab, setSelectedTab] = useState<"info" | "editors">("info");
 
-  const showEditorsTabs = skillConfiguration.canWrite;
+  const showEditorsTabs = skill.canWrite;
 
   if (showEditorsTabs) {
     return (
@@ -107,12 +103,12 @@ export function SkillDetailsSheetContent({
         </TabsList>
         <div className="mt-4">
           <TabsContent value="info">
-            <SkillInfoTab skillConfiguration={skillConfiguration} />
+            <SkillInfoTab skillConfiguration={skill} />
           </TabsContent>
           <TabsContent value="editors">
-            {hasRelations(skillConfiguration) && (
+            {hasRelations(skill) && (
               <SkillEditorsTab
-                skillConfiguration={skillConfiguration}
+                skillConfiguration={skill}
                 owner={owner}
                 user={user}
               />
@@ -123,7 +119,7 @@ export function SkillDetailsSheetContent({
     );
   }
 
-  return <SkillInfoTab skillConfiguration={skillConfiguration} />;
+  return <SkillInfoTab skillConfiguration={skill} />;
 }
 
 type DescriptionSectionProps = {

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -103,7 +103,7 @@ export function SkillDetailsSheetContent({
         </TabsList>
         <div className="mt-4">
           <TabsContent value="info">
-            <SkillInfoTab skillConfiguration={skill} />
+            <SkillInfoTab skill={skill} />
           </TabsContent>
           <TabsContent value="editors">
             {hasRelations(skill) && (
@@ -119,7 +119,7 @@ export function SkillDetailsSheetContent({
     );
   }
 
-  return <SkillInfoTab skillConfiguration={skill} />;
+  return <SkillInfoTab skill={skill} />;
 }
 
 type DescriptionSectionProps = {

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -21,7 +21,7 @@ import { useState } from "react";
 import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
 import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
-import { SKILL_ICON } from "@app/lib/skill";
+import { hasRelations, SKILL_ICON } from "@app/lib/skill";
 import type { UserType, WorkspaceType } from "@app/types";
 import type {
   SkillRelations,
@@ -74,7 +74,7 @@ export function SkillDetailsSheet({
 }
 
 type SkillDetailsSheetContentProps = {
-  skillConfiguration: SkillType & { relations: SkillRelations };
+  skillConfiguration: SkillType & { relations?: SkillRelations };
   owner: WorkspaceType;
   user: UserType;
 };
@@ -110,11 +110,13 @@ export function SkillDetailsSheetContent({
             <SkillInfoTab skillConfiguration={skillConfiguration} />
           </TabsContent>
           <TabsContent value="editors">
-            <SkillEditorsTab
-              skillConfiguration={skillConfiguration}
-              owner={owner}
-              user={user}
-            />
+            {hasRelations(skillConfiguration) && (
+              <SkillEditorsTab
+                skillConfiguration={skillConfiguration}
+                owner={owner}
+                user={user}
+              />
+            )}
           </TabsContent>
         </div>
       </Tabs>

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -1,9 +1,30 @@
 import { Page, ReadOnlyTextArea } from "@dust-tt/sparkle";
+import sortBy from "lodash/sortBy";
+import { useMemo } from "react";
 
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { timeAgoFrom } from "@app/lib/utils";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillRelations,
+  SkillType,
+} from "@app/types/assistant/skill_configuration";
 
-export function SkillInfoTab({ skill }: { skill: SkillType }) {
+export function SkillInfoTab({
+  skill,
+}: {
+  skill: SkillType & { relations?: SkillRelations };
+}) {
+  const sortedMCPServerViews = useMemo(
+    () =>
+      sortBy(
+        (skill.relations?.mcpServerViews ?? []).map(renderMCPServerView),
+        "title"
+      ),
+    [skill.relations?.mcpServerViews]
+  );
+
   return (
     <div className="flex flex-col gap-4">
       <div className="text-sm text-foreground dark:text-foreground-night">
@@ -29,6 +50,27 @@ export function SkillInfoTab({ skill }: { skill: SkillType }) {
           <ReadOnlyTextArea content={skill.instructions} />
         </div>
       )}
+
+      {sortedMCPServerViews.length > 0 && (
+        <div className="flex flex-col gap-5">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Tools
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {sortedMCPServerViews.map((view) => (
+              <div
+                className="flex min-w-0 flex-row items-center gap-2"
+                key={view.title}
+              >
+                {view.avatar}
+                <div className="truncate" title={view.title}>
+                  {view.title}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -47,3 +89,8 @@ export function SkillEdited({ skillConfiguration }: SkillEditedProps) {
     </div>
   );
 }
+
+const renderMCPServerView = (view: MCPServerViewType) => ({
+  title: getMcpServerViewDisplayName(view),
+  avatar: getAvatar(view.server, "xs"),
+});

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -3,34 +3,30 @@ import { Page, ReadOnlyTextArea } from "@dust-tt/sparkle";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-export function SkillInfoTab({
-  skillConfiguration,
-}: {
-  skillConfiguration: SkillType;
-}) {
+export function SkillInfoTab({ skill }: { skill: SkillType }) {
   return (
     <div className="flex flex-col gap-4">
       <div className="text-sm text-foreground dark:text-foreground-night">
-        {skillConfiguration.userFacingDescription}
+        {skill.userFacingDescription}
       </div>
       {/* TODO(skills 2025-12-12): display agent facing description here */}
-      {skillConfiguration.updatedAt && (
+      {skill.updatedAt && (
         <SkillEdited
           skillConfiguration={{
-            ...skillConfiguration,
-            updatedAt: skillConfiguration.updatedAt,
+            ...skill,
+            updatedAt: skill.updatedAt,
           }}
         />
       )}
 
       <Page.Separator />
 
-      {skillConfiguration.instructions && (
+      {skill.instructions && (
         <div className="dd-privacy-mask flex flex-col gap-5">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Instructions
           </div>
-          <ReadOnlyTextArea content={skillConfiguration.instructions} />
+          <ReadOnlyTextArea content={skill.instructions} />
         </div>
       )}
     </div>

--- a/front/lib/models/agent/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/agent/actions/mcp_server_view_helper.ts
@@ -9,6 +9,7 @@ import {
   AgentMCPServerConfigurationModel,
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
+import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
 import type { ModelId } from "@app/types";
 
 export const destroyMCPServerViewDependencies = async (
@@ -72,6 +73,14 @@ export const destroyMCPServerViewDependencies = async (
   });
 
   await ConversationMCPServerViewModel.destroy({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      mcpServerViewId: mcpServerViewId,
+    },
+    transaction,
+  });
+
+  await SkillMCPServerConfigurationModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       mcpServerViewId: mcpServerViewId,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -780,6 +780,25 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return new Ok(updated);
   }
 
+  async listMCPServerViews(
+    auth: Authenticator
+  ): Promise<MCPServerViewResource[]> {
+    const mcpServerViewIds = this.mcpServerConfigurations.map(
+      (config) => config.mcpServerViewId
+    );
+
+    if (mcpServerViewIds.length === 0) {
+      return [];
+    }
+
+    const mcpServerViews = await MCPServerViewResource.fetchByModelIds(
+      auth,
+      mcpServerViewIds
+    );
+
+    return mcpServerViews;
+  }
+
   async updateTools(
     auth: Authenticator,
     {

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -8,6 +8,10 @@ import {
   isInternalAllowedIcon,
 } from "@app/components/resources/resources_icons";
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
+import type {
+  SkillRelations,
+  SkillType,
+} from "@app/types/assistant/skill_configuration";
 
 // TODO(skills 2025-12-05): use the right icon
 export const SKILL_ICON = PuzzleIcon;
@@ -47,3 +51,7 @@ const IDS_OF_SKILLS_TRIGGERING_SELECT_SPACES_OPTIONS: string[] = [
 export function doesSkillTriggerSelectSpaces(sId: string): boolean {
   return IDS_OF_SKILLS_TRIGGERING_SELECT_SPACES_OPTIONS.includes(sId);
 }
+export const hasRelations = (
+  skillConfiguration: SkillType & { relations?: SkillRelations }
+): skillConfiguration is SkillType & { relations: SkillRelations } =>
+  skillConfiguration.relations !== undefined;

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -241,7 +241,7 @@ export function useSkillConfigurationHistory({
   };
 }
 
-export function useSkillConfigurationWithRelations({
+export function useSkillWithRelations({
   owner,
   disabled,
   id,

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -244,17 +244,17 @@ export function useSkillConfigurationHistory({
 export function useSkillWithRelations({
   owner,
   disabled,
-  id,
+  skillId,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
-  id: string;
+  skillId: string;
 }) {
   const skillConfigurationsFetcher: Fetcher<GetSkillWithRelationsResponseBody> =
     fetcher;
 
   const { data, isLoading } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/skills/${id}?withRelations=true`,
+    `/api/w/${owner.sId}/skills/${skillId}?withRelations=true`,
     skillConfigurationsFetcher,
     { disabled }
   );

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -34,10 +34,10 @@ export function useSkillConfigurations({
   const skillConfigurationsFetcher: Fetcher<GetSkillConfigurationsResponseBody> =
     fetcher;
 
-  const queryParams = status ? `?status=${status}` : "";
+  const statusQueryParam = status ? `?status=${status}` : "";
 
   const { data, error, isLoading, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/skills${queryParams}`,
+    `/api/w/${owner.sId}/skills${statusQueryParam}`,
     skillConfigurationsFetcher,
     { disabled }
   );

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -12,6 +12,7 @@ import {
 import type {
   GetSkillConfigurationsResponseBody,
   GetSkillConfigurationsWithRelationsResponseBody,
+  GetSkillWithRelationsResponseBody,
 } from "@app/pages/api/w/[wId]/skills";
 import type { GetSkillConfigurationsHistoryResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]/history";
 import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
@@ -237,5 +238,29 @@ export function useSkillConfigurationHistory({
     isSkillConfigurationHistoryLoading: !error && !data && !disabled,
     isSkillConfigurationHistoryError: error,
     mutateSkillConfigurationHistory: mutate,
+  };
+}
+
+export function useSkillConfigurationWithRelations({
+  owner,
+  disabled,
+  id,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+  id: string;
+}) {
+  const skillConfigurationsFetcher: Fetcher<GetSkillWithRelationsResponseBody> =
+    fetcher;
+
+  const { data, isLoading } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/skills/${id}?withRelations=true`,
+    skillConfigurationsFetcher,
+    { disabled }
+  );
+
+  return {
+    skillWithRelations: data?.skill ?? null,
+    isSkillWithRelationsLoading: isLoading,
   };
 }

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -123,6 +123,7 @@ async function handler(
       if (withRelations === "true") {
         const usage = await skillResource.fetchUsage(auth);
         const editors = await skillResource.listEditors(auth);
+        const mcpServerViews = await skillResource.listMCPServerViews(auth);
 
         const skillConfigurationWithRelations: SkillType & {
           relations: SkillRelations;
@@ -131,6 +132,7 @@ async function handler(
           relations: {
             usage,
             editors: editors ? editors.map((e) => e.toJSON()) : null,
+            mcpServerViews: mcpServerViews.map((view) => view.toJSON()),
           },
         };
 

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -14,7 +14,10 @@ import { withTransaction } from "@app/lib/utils/sql_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { Err, isBuilder, isString, Ok } from "@app/types";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillRelations,
+  SkillType,
+} from "@app/types/assistant/skill_configuration";
 
 export type GetSkillConfigurationResponseBody = {
   skillConfiguration: SkillType;
@@ -113,7 +116,28 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
+      const { withRelations } = req.query;
+
       const skillConfiguration = skillResource.toJSON(auth);
+
+      if (withRelations === "true") {
+        const usage = await skillResource.fetchUsage(auth);
+        const editors = await skillResource.listEditors(auth);
+
+        const skillConfigurationWithRelations: SkillType & {
+          relations: SkillRelations;
+        } = {
+          ...skillConfiguration,
+          relations: {
+            usage,
+            editors: editors ? editors.map((e) => e.toJSON()) : null,
+          },
+        };
+
+        res.status(200).json({
+          skillConfiguration: skillConfigurationWithRelations,
+        });
+      }
       return res.status(200).json({ skillConfiguration });
     }
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -23,6 +23,10 @@ export type GetSkillConfigurationsResponseBody = {
   skillConfigurations: SkillType[];
 };
 
+export type GetSkillWithRelationsResponseBody = {
+  skill: SkillType & { relations: SkillRelations };
+};
+
 export type GetSkillConfigurationsWithRelationsResponseBody = {
   skillConfigurations: (SkillType & { relations: SkillRelations })[];
 };

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -120,11 +120,14 @@ async function handler(
           async (sc) => {
             const usage = await sc.fetchUsage(auth);
             const editors = await sc.listEditors(auth);
+            const mcpServerViews = await sc.listMCPServerViews(auth);
+
             return {
               ...sc.toJSON(auth),
               relations: {
                 usage,
                 editors: editors ? editors.map((e) => e.toJSON()) : null,
+                mcpServerViews: mcpServerViews.map((view) => view.toJSON()),
               },
             } satisfies SkillType & { relations: SkillRelations };
           },

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -206,7 +206,7 @@ export default function WorkspaceSkills({
     <>
       {!!selectedSkill && (
         <SkillDetailsSheet
-          skillConfiguration={selectedSkill}
+          skill={selectedSkill}
           onClose={() => setSelectedSkill(null)}
           user={user}
           owner={owner}

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -1,3 +1,4 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { UserType } from "@app/types/user";
 
@@ -23,4 +24,5 @@ export type SkillType = {
 export type SkillRelations = {
   usage: AgentsUsageType;
   editors: UserType[] | null;
+  mcpServerViews: MCPServerViewType[];
 };


### PR DESCRIPTION
## Description

[Task](https://github.com/orgs/dust-tt/projects/3/views/9?filterQuery=stream%3A%22Skills%22&pane=issue&itemId=144737558&issue=dust-tt%7Ctasks%7C5593)

- Fetch relations on skill click in AB
- Display skill's mcp server views

<img width="1663" height="984" alt="image" src="https://github.com/user-attachments/assets/a8a1cc79-1406-4d8a-9356-a67c9f3e83bb" />


## Tests

local

## Risk

low

## Deploy Plan

/models has been modified because we forgot to destroy skills when destroying mcpServerView
So front deployment is ok
