### PR TITLE
[front] - chore(navigation): conversation in new tab when cmd+click

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -793,6 +793,8 @@ const ConversationListItem = memo(
             selected={router.query.cId === conversation.sId}
             status={getConversationDotStatus(conversation)}
             label={conversationLabel}
+            href={getConversationRoute(owner.sId, conversation.sId)}
+            shallow
             moreMenu={
               <ConversationMenu
                 activeConversationId={conversation.sId}
@@ -813,13 +815,6 @@ const ConversationListItem = memo(
                 // Wait a bit before moving to the new conversation to avoid the sidebar from flickering.
                 await new Promise((resolve) => setTimeout(resolve, 600));
               }
-              await router.push(
-                getConversationRoute(owner.sId, conversation.sId),
-                undefined,
-                {
-                  shallow: true,
-                }
-              );
             }}
           />
         )}


### PR DESCRIPTION
## Description

Refactors the conversation navigation in the sidebar by moving the routing logic from the `onClick` handler to native `href` and `shallow` props on the `NavigationListItem` component. This enables standard browser navigation behaviors such as opening conversations in a new tab when cmd/ctrl+clicking.

## Risk

Low

## Tests

- [x] Locally
- [x] front-edge

## Deploy plan

- Deploy front
