### PR TITLE
[Programmatic Usage] Fix max cumulated cost computation with groupBy

### DIFF
--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -361,8 +361,8 @@ export function BaseProgrammaticCostChart({
     return programmaticCostData?.points.reduce((max, point) => {
       return Math.max(
         max,
-        point.groups.reduce((max, group) => {
-          return Math.max(max, group.cumulatedCostMicroUsd ?? 0);
+        point.groups.reduce((sum, group) => {
+          return sum + (group.cumulatedCostMicroUsd ?? 0);
         }, 0)
       );
     }, 0);


### PR DESCRIPTION
## Description

Context: [slack thread](https://dust4ai.slack.com/archives/C09SB1J0FKM/p1765892724175009)

When using groupBy, each point has multiple groups (e.g., different agents or apps). The `maxCumulatedCost` was incorrectly computed by taking the max of any single group's cumulated cost instead of summing all groups' costs at each point.

This caused the `shouldShowTotalCredits` logic to use an artificially low max value, potentially hiding the total credits line when it should be shown.

## Risks

Blast radius: Programmatic usage cost chart total credits display
Risk: low

## Deploy Plan

- deploy front