### PR TITLE
[front] Deduplicate MCP servers in `tryListMCPTools`

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -644,7 +644,7 @@ type AgentLoopListToolsContextWithoutConfigurationType = Omit<
 >;
 
 /**
- * Deduplicates MCP server configurations by view ID.
+ * Deduplicates MCP server configurations by view ID and name.
  * Priority order: agent actions > client-side > skill servers > JIT servers.
  */
 function deduplicateMCPServerConfigurations({
@@ -665,9 +665,10 @@ function deduplicateMCPServerConfigurations({
     ...skillServers,
     ...jitServers,
   ].filter((config) => {
-    const key = isServerSideMCPServerConfiguration(config)
+    const viewId = isServerSideMCPServerConfiguration(config)
       ? config.mcpServerViewId
       : config.clientSideMcpServerId;
+    const key = `${viewId}:${config.name}`;
 
     if (seen.has(key)) {
       return false;

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -10,7 +10,6 @@ import type {
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
 import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
-import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import type {
   DataSourceConfiguration,
   TableDataSourceConfiguration,
@@ -57,13 +56,6 @@ export async function getJITServers(
 ): Promise<MCPServerConfigurationType[]> {
   const jitServers: MCPServerConfigurationType[] = [];
 
-  // Get the list of tools from the agent configuration to avoid duplicates.
-  const agentMcpServerViewIds = agentConfiguration.actions
-    .map((action) =>
-      isServerSideMCPServerConfiguration(action) ? action.mcpServerViewId : null
-    )
-    .filter((mcpServerViewId) => mcpServerViewId !== null);
-
   // Get the conversation MCP server views (aka Tools)
   const conversationMCPServerViews =
     await ConversationResource.fetchMCPServerViews(auth, conversation, true);
@@ -80,10 +72,7 @@ export async function getJITServers(
       conversationMCPServerView.mcpServerViewId
     );
 
-    if (
-      !mcpServerViewResource ||
-      agentMcpServerViewIds.includes(mcpServerViewResource.sId)
-    ) {
+    if (!mcpServerViewResource) {
       continue;
     }
 
@@ -123,7 +112,7 @@ export async function getJITServers(
       },
       "MCP server view not found for common_utilities. Ensure auto tools are created."
     );
-  } else if (!agentMcpServerViewIds.includes(commonUtilitiesView.sId)) {
+  } else {
     const commonUtilitiesViewJSON = commonUtilitiesView.toJSON();
     const commonUtilitiesServer: ServerSideMCPServerConfigurationType = {
       id: -1,
@@ -181,7 +170,7 @@ export async function getJITServers(
           },
           "MCP server view not found for skill_management. Ensure auto tools are created."
         );
-      } else if (!agentMcpServerViewIds.includes(skillManagementView.sId)) {
+      } else {
         const skillManagementServer: ServerSideMCPServerConfigurationType = {
           id: -1,
           sId: generateRandomModelSId(),


### PR DESCRIPTION
## Description

- We currently have an MCP server deduplication in `getJITServers`, which does not cover potential duplicates coming from skills.
- This PR adds a more centralized deduplication downstream on all MCP servers.

## Tests

- Tested locally with JIT tools.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
