### PR TITLE
[skills] add the sheet for selection additional spaces in Agent Builder

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -88,6 +88,9 @@ const skillsSchema = z.object({
   description: z.string(),
 });
 
+// Additional space IDs selected by the user for global skills
+const additionalSpacesSchema = z.array(z.string());
+
 export type AgentBuilderWebhookTriggerType = z.infer<
   typeof webhookTriggerSchema
 >;
@@ -100,6 +103,7 @@ export const agentBuilderFormSchema = z.object({
   instructions: z.string().min(1, "Instructions are required"),
   generationSettings: generationSettingsSchema,
   skills: z.array(skillsSchema),
+  additionalSpaces: additionalSpacesSchema,
   actions: z.array(actionSchema),
   triggersToCreate: z.array(triggerSchema),
   triggersToUpdate: z.array(triggerSchema),

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -1,6 +1,6 @@
 import { Chip } from "@dust-tt/sparkle";
 import { useMemo } from "react";
-import { useFormContext } from "react-hook-form";
+import { useFormContext, useWatch } from "react-hook-form";
 
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
@@ -13,15 +13,21 @@ import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types";
 
 export function AgentBuilderSpacesBlock() {
-  const { watch, setValue } = useFormContext<AgentBuilderFormData>();
+  const { setValue } = useFormContext<AgentBuilderFormData>();
 
   const { mcpServerViews } = useMCPServerViewsContext();
   const { skills: allSkills } = useSkillsContext();
   const { spaces } = useSpacesContext();
 
-  const selectedSkills = watch("skills");
-  const actions = watch("actions");
-  const additionalSpaces = watch("additionalSpaces");
+  const selectedSkills = useWatch<AgentBuilderFormData, "skills">({
+    name: "skills",
+  });
+  const actions = useWatch<AgentBuilderFormData, "actions">({
+    name: "actions",
+  });
+  const additionalSpaces = useWatch<AgentBuilderFormData, "additionalSpaces">({
+    name: "additionalSpaces",
+  });
 
   const confirmRemoveSpace = useRemoveSpaceConfirm({
     entityName: "agent",

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -99,6 +99,7 @@ export function AgentBuilderSkillsBlock({
     name: "skills",
   });
 
+  // TODO(skills Jules): make a pass on the way we use reacthookform here
   const { mcpServerViews } = useMCPServerViewsContext();
   const { skills: allSkills } = useSkillsContext();
 

--- a/front/components/agent_builder/skills/skillSheet/SkillsSheet.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SkillsSheet.tsx
@@ -1,5 +1,5 @@
 import { MultiPageSheet, MultiPageSheetContent } from "@dust-tt/sparkle";
-import React from "react";
+import React, { useCallback, useState } from "react";
 
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { SkillsSheetMode } from "@app/components/agent_builder/skills/skillSheet/types";
@@ -9,10 +9,16 @@ import type { UserType, WorkspaceType } from "@app/types";
 interface SkillsSheetProps {
   mode: SkillsSheetMode | null;
   onClose: () => void;
-  onSave: (skills: AgentBuilderSkillsType[]) => void;
+  onSave: (
+    skills: AgentBuilderSkillsType[],
+    additionalSpaces: string[]
+  ) => void;
   onModeChange: (mode: SkillsSheetMode | null) => void;
   owner: WorkspaceType;
   user: UserType;
+  initialSelectedSkills: AgentBuilderSkillsType[];
+  initialAdditionalSpaces: string[];
+  alreadyRequestedSpaceIds: Set<string>;
 }
 
 export function SkillsSheet(props: SkillsSheetProps) {
@@ -35,14 +41,34 @@ function SkillsSheetContent({
   onModeChange,
   owner,
   user,
+  initialSelectedSkills,
+  initialAdditionalSpaces,
+  alreadyRequestedSpaceIds,
 }: SkillsSheetProps & { mode: SkillsSheetMode }) {
+  const [localSelectedSkills, setLocalSelectedSkills] = useState<
+    AgentBuilderSkillsType[]
+  >(initialSelectedSkills);
+  const [localAdditionalSpaces, setLocalAdditionalSpaces] = useState<string[]>(
+    initialAdditionalSpaces
+  );
+
+  const handleSave = useCallback(() => {
+    onSave(localSelectedSkills, localAdditionalSpaces);
+    onClose();
+  }, [localSelectedSkills, localAdditionalSpaces, onSave, onClose]);
+
   const { page, leftButton, rightButton } = getPageAndFooter({
     mode,
     onModeChange,
     onClose,
-    onSave,
+    handleSave,
     owner,
     user,
+    alreadyRequestedSpaceIds,
+    localSelectedSkills,
+    setLocalSelectedSkills,
+    localAdditionalSpaces,
+    setLocalAdditionalSpaces,
   });
 
   return (

--- a/front/components/agent_builder/skills/skillSheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SpaceSelectionPage.tsx
@@ -16,11 +16,11 @@ type SpaceRowData = {
   onClick?: () => void;
 };
 
-type SpaceSelectionPageProps = {
+interface SpaceSelectionPageProps {
   alreadyRequestedSpaceIds: Set<string>;
   draftSelectedSpaces: string[];
   setDraftSelectedSpaces: React.Dispatch<React.SetStateAction<string[]>>;
-};
+}
 
 export function SpaceSelectionPageContent({
   alreadyRequestedSpaceIds,

--- a/front/components/agent_builder/skills/skillSheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SpaceSelectionPage.tsx
@@ -1,0 +1,146 @@
+import { Checkbox, DataTable, Tooltip } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import React, { useCallback, useMemo } from "react";
+
+import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
+import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
+import type { SpaceType } from "@app/types";
+
+type SpaceRowData = {
+  sId: string;
+  name: string;
+  space: SpaceType;
+  isSelected: boolean;
+  isAlreadyRequested: boolean;
+  onToggle: () => void;
+  onClick?: () => void;
+};
+
+type SpaceSelectionPageProps = {
+  alreadyRequestedSpaceIds: Set<string>;
+  draftSelectedSpaces: string[];
+  setDraftSelectedSpaces: React.Dispatch<React.SetStateAction<string[]>>;
+};
+
+export function SpaceSelectionPageContent({
+  alreadyRequestedSpaceIds,
+  draftSelectedSpaces,
+  setDraftSelectedSpaces,
+}: SpaceSelectionPageProps) {
+  const { spaces } = useSpacesContext();
+
+  const selectableSpaces = useMemo(() => {
+    return spaces.filter((s) => s.kind !== "global");
+  }, [spaces]);
+
+  const localSelectedSpaceIds = useMemo(
+    () => new Set(draftSelectedSpaces),
+    [draftSelectedSpaces]
+  );
+
+  const handleSpaceToggle = useCallback(
+    (space: SpaceType) => {
+      setDraftSelectedSpaces((prev) => {
+        const newSpaces = prev.includes(space.sId)
+          ? prev.filter((id) => id !== space.sId)
+          : [...prev, space.sId];
+        return newSpaces;
+      });
+    },
+    [setDraftSelectedSpaces]
+  );
+
+  const tableData: SpaceRowData[] = useMemo(() => {
+    return selectableSpaces.map((space) => {
+      const isAlreadyRequested = alreadyRequestedSpaceIds.has(space.sId);
+      return {
+        sId: space.sId,
+        name: getSpaceName(space),
+        space,
+        isSelected: localSelectedSpaceIds.has(space.sId) || isAlreadyRequested,
+        isAlreadyRequested,
+        onToggle: () => handleSpaceToggle(space),
+      };
+    });
+  }, [
+    selectableSpaces,
+    alreadyRequestedSpaceIds,
+    localSelectedSpaceIds,
+    handleSpaceToggle,
+  ]);
+
+  const columns: ColumnDef<SpaceRowData>[] = useMemo(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        header: "Name",
+        cell: ({ row }) => {
+          const SpaceIcon = getSpaceIcon(row.original.space);
+          const cellContent = (
+            <DataTable.CellContent
+              onClick={
+                row.original.isAlreadyRequested
+                  ? undefined
+                  : row.original.onToggle
+              }
+            >
+              <div
+                className={`flex items-center gap-3 ${
+                  row.original.isAlreadyRequested
+                    ? "cursor-not-allowed opacity-60"
+                    : "cursor-pointer"
+                }`}
+              >
+                <Checkbox
+                  checked={row.original.isSelected}
+                  disabled={row.original.isAlreadyRequested}
+                  onCheckedChange={row.original.onToggle}
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                  size="xs"
+                />
+                <SpaceIcon className="h-4 w-4 text-muted-foreground dark:text-muted-foreground-night" />
+                <span>{row.original.name}</span>
+              </div>
+            </DataTable.CellContent>
+          );
+
+          if (row.original.isAlreadyRequested) {
+            return (
+              <Tooltip
+                label="Used by other resources"
+                side="right"
+                trigger={cellContent}
+              />
+            );
+          }
+
+          return cellContent;
+        },
+        meta: {
+          sizeRatio: 100,
+        },
+      },
+    ],
+    []
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Select spaces
+      </p>
+      {selectableSpaces.length > 0 ? (
+        <DataTable
+          data={tableData}
+          columns={columns}
+          sorting={[{ id: "name", desc: false }]}
+        />
+      ) : (
+        <div className="py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+          No spaces available
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -8,17 +8,17 @@ import type {
   SkillsSheetMode,
 } from "@app/components/agent_builder/skills/skillSheet/types";
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
-import { isGlobalSkillId } from "@app/lib/resources/skill/global/registry";
+import { doesSkillTriggerSelectSpaces } from "@app/lib/skill";
 import { useSkillConfigurationsWithRelations } from "@app/lib/swr/skill_configurations";
 import type {
   SkillRelations,
   SkillType,
 } from "@app/types/assistant/skill_configuration";
 
-function isGlobalSkill(
+function isGlobalSkillWithSpaceSelection(
   skill: SkillType & { relations: SkillRelations }
 ): boolean {
-  return isGlobalSkillId(skill.sId);
+  return doesSkillTriggerSelectSpaces(skill.sId);
 }
 
 function getSelectionMode(mode: SkillsSheetMode): SelectionMode {
@@ -82,7 +82,7 @@ export const useSkillSelection = ({
           prev.filter((s) => s.sId !== skill.sId)
         );
       } else {
-        if (isGlobalSkill(skill)) {
+        if (isGlobalSkillWithSpaceSelection(skill)) {
           onModeChange({
             type: SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION,
             skillConfiguration: skill,

--- a/front/components/agent_builder/skills/skillSheet/types.tsx
+++ b/front/components/agent_builder/skills/skillSheet/types.tsx
@@ -1,3 +1,5 @@
+import type React from "react";
+
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { UserType, WorkspaceType } from "@app/types";
 import type {
@@ -8,15 +10,20 @@ import type {
 export const SKILLS_SHEET_PAGE_IDS = {
   SELECTION: "add",
   INFO: "info",
+  SPACE_SELECTION: "space_selection",
 } as const;
 
 export type SkillsSheetMode =
   | {
       type: typeof SKILLS_SHEET_PAGE_IDS.SELECTION;
-      selectedSkills: AgentBuilderSkillsType[];
     }
   | {
       type: typeof SKILLS_SHEET_PAGE_IDS.INFO;
+      skillConfiguration: SkillType & { relations: SkillRelations };
+      previousMode: SelectionMode;
+    }
+  | {
+      type: typeof SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION;
       skillConfiguration: SkillType & { relations: SkillRelations };
       previousMode: SelectionMode;
     };
@@ -26,11 +33,23 @@ export type SelectionMode = Extract<
   { type: typeof SKILLS_SHEET_PAGE_IDS.SELECTION }
 >;
 
+export type SpaceSelectionMode = Extract<
+  SkillsSheetMode,
+  { type: typeof SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION }
+>;
+
 export type PageContentProps = {
   mode: SkillsSheetMode;
   onModeChange: (mode: SkillsSheetMode | null) => void;
   onClose: () => void;
-  onSave: (skills: AgentBuilderSkillsType[]) => void;
+  handleSave: () => void;
   owner: WorkspaceType;
   user: UserType;
+  alreadyRequestedSpaceIds: Set<string>;
+  localSelectedSkills: AgentBuilderSkillsType[];
+  setLocalSelectedSkills: React.Dispatch<
+    React.SetStateAction<AgentBuilderSkillsType[]>
+  >;
+  localAdditionalSpaces: string[];
+  setLocalAdditionalSpaces: React.Dispatch<React.SetStateAction<string[]>>;
 };

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -482,7 +482,7 @@ export async function submitAgentBuilderForm({
       editors: formData.agentSettings.editors.map((editor) => ({
         sId: editor.sId,
       })),
-      additionalRequestedSpaceIds: [],
+      additionalRequestedSpaceIds: formData.additionalSpaces,
     },
   };
 

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -49,6 +49,7 @@ export function transformAgentConfigurationToFormData(
     },
     actions: [], // Will be populated reactively from useAgentConfigurationActions hook
     skills: [], // Will be populated reactively from useAgentConfigurationSkills hook
+    additionalSpaces: [], // Will be populated reactively if needed
     triggersToCreate: [],
     triggersToUpdate: [], // Will be populated reactively from the hook
     triggersToDelete: [],
@@ -96,6 +97,7 @@ export function getDefaultAgentFormData({
     },
     actions: [],
     skills: [],
+    additionalSpaces: [],
     triggersToCreate: [],
     triggersToUpdate: [],
     triggersToDelete: [],
@@ -141,6 +143,7 @@ export function transformTemplateToFormData(
     },
     actions: [],
     skills: [],
+    additionalSpaces: [],
     triggersToCreate: [],
     triggersToUpdate: [],
     triggersToDelete: [],

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -83,3 +83,7 @@ export class GlobalSkillsRegistry {
     });
   }
 }
+
+export function isGlobalSkillId(sId: string): sId is GlobalSkillId {
+  return GLOBAL_SKILLS_BY_ID.has(sId);
+}

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -83,7 +83,3 @@ export class GlobalSkillsRegistry {
     });
   }
 }
-
-export function isGlobalSkillId(sId: string): sId is GlobalSkillId {
-  return GLOBAL_SKILLS_BY_ID.has(sId);
-}

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -7,6 +7,7 @@ import {
   isCustomResourceIconType,
   isInternalAllowedIcon,
 } from "@app/components/resources/resources_icons";
+import { framesSkill } from "@app/lib/resources/skill/global/frames";
 
 // TODO(skills 2025-12-05): use the right icon
 export const SKILL_ICON = PuzzleIcon;
@@ -37,4 +38,12 @@ export function getSkillIcon(
     return getIcon(iconString);
   }
   return SKILL_ICON;
+}
+
+const IDS_OF_SKILLS_TRIGGERING_SELECT_SPACES_OPTIONS: string[] = [
+  framesSkill.sId, // TODO(skills) Remove frames from this list when we have real global skills with space selection
+];
+
+export function doesSkillTriggerSelectSpaces(sId: string): boolean {
+  return IDS_OF_SKILLS_TRIGGERING_SELECT_SPACES_OPTIONS.includes(sId);
 }


### PR DESCRIPTION
## Description

partially solves https://github.com/dust-tt/tasks/issues/5480

Add a new screen when we click on a global skill to pick the spaces (among all avaialable spaces)
These are then sent to the backend as an additional array.
On edit of the agent they are added back by inferring the additional spaces from the one not in skills/tools

<img width="3038" height="1750" alt="image" src="https://github.com/user-attachments/assets/a9fd98ee-359d-4c65-93ea-408f5189caf5" />

https://github.com/user-attachments/assets/9d0d5377-8b54-4ffa-a8bc-ad02219793ef

When other skill are using the space, they are disabled:

<img width="3034" height="1746" alt="image" src="https://github.com/user-attachments/assets/a5ddc474-4001-4be8-b1b5-016aef5c263d" />

## Tests

Manual test

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
