### PR TITLE
[front] enh: consolidate activities sent on agent loop completion

### DIFF
--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -9,11 +9,7 @@ import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop
 import { trackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
-/**
- * Consolidated activity that runs all finalization tasks at the end of a successful agent loop.
- * This replaces the previous pattern of running 4 separate activities in Promise.all.
- */
-export async function finalizeAgentLoopActivity(
+export async function finalizeSuccessfulAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
@@ -25,9 +21,6 @@ export async function finalizeAgentLoopActivity(
   ]);
 }
 
-/**
- * Consolidated activity that runs finalization tasks when an agent loop is cancelled.
- */
 export async function finalizeCancelledAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
@@ -39,9 +32,6 @@ export async function finalizeCancelledAgentLoopActivity(
   ]);
 }
 
-/**
- * Consolidated activity that runs finalization tasks when an agent loop errors.
- */
 export async function finalizeErroredAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -1,0 +1,60 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import { launchAgentMessageAnalyticsActivity } from "@app/temporal/agent_loop/activities/analytics";
+import {
+  finalizeCancellationActivity,
+  notifyWorkflowError,
+} from "@app/temporal/agent_loop/activities/common";
+import { handleMentionsActivity } from "@app/temporal/agent_loop/activities/mentions";
+import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
+import { trackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+/**
+ * Consolidated activity that runs all finalization tasks at the end of a successful agent loop.
+ * This replaces the previous pattern of running 4 separate activities in Promise.all.
+ */
+export async function finalizeAgentLoopActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  await Promise.all([
+    launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
+    trackProgrammaticUsageActivity(authType, agentLoopArgs),
+    conversationUnreadNotificationActivity(authType, agentLoopArgs),
+    handleMentionsActivity(authType, agentLoopArgs),
+  ]);
+}
+
+/**
+ * Consolidated activity that runs finalization tasks when an agent loop is cancelled.
+ */
+export async function finalizeCancelledAgentLoopActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  await Promise.all([
+    launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
+    trackProgrammaticUsageActivity(authType, agentLoopArgs),
+    finalizeCancellationActivity(authType, agentLoopArgs),
+  ]);
+}
+
+/**
+ * Consolidated activity that runs finalization tasks when an agent loop errors.
+ */
+export async function finalizeErroredAgentLoopActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs,
+  error: Error
+): Promise<void> {
+  await Promise.all([
+    launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
+    trackProgrammaticUsageActivity(authType, agentLoopArgs),
+    notifyWorkflowError(authType, {
+      conversationId: agentLoopArgs.conversationId,
+      agentMessageId: agentLoopArgs.agentMessageId,
+      agentMessageVersion: agentLoopArgs.agentMessageVersion,
+      error,
+    }),
+  ]);
+}

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -22,6 +22,11 @@ import {
 } from "@app/temporal/agent_loop/activities/common";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {
+  finalizeAgentLoopActivity,
+  finalizeCancelledAgentLoopActivity,
+  finalizeErroredAgentLoopActivity,
+} from "@app/temporal/agent_loop/activities/finalize";
+import {
   logAgentLoopPhaseCompletionActivity,
   logAgentLoopPhaseStartActivity,
   logAgentLoopStepCompletionActivity,
@@ -55,6 +60,9 @@ export async function runAgentLoopWorker() {
     activities: {
       conversationUnreadNotificationActivity,
       ensureConversationTitleActivity,
+      finalizeAgentLoopActivity,
+      finalizeCancelledAgentLoopActivity,
+      finalizeErroredAgentLoopActivity,
       finalizeCancellationActivity,
       handleMentionsActivity,
       launchAgentMessageAnalyticsActivity,

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -22,9 +22,9 @@ import {
 } from "@app/temporal/agent_loop/activities/common";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {
-  finalizeAgentLoopActivity,
   finalizeCancelledAgentLoopActivity,
   finalizeErroredAgentLoopActivity,
+  finalizeSuccessfulAgentLoopActivity,
 } from "@app/temporal/agent_loop/activities/finalize";
 import {
   logAgentLoopPhaseCompletionActivity,
@@ -60,7 +60,7 @@ export async function runAgentLoopWorker() {
     activities: {
       conversationUnreadNotificationActivity,
       ensureConversationTitleActivity,
-      finalizeAgentLoopActivity,
+      finalizeAgentLoopActivity: finalizeSuccessfulAgentLoopActivity,
       finalizeCancelledAgentLoopActivity,
       finalizeErroredAgentLoopActivity,
       finalizeCancellationActivity,

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -60,7 +60,7 @@ export async function runAgentLoopWorker() {
     activities: {
       conversationUnreadNotificationActivity,
       ensureConversationTitleActivity,
-      finalizeAgentLoopActivity: finalizeSuccessfulAgentLoopActivity,
+      finalizeSuccessfulAgentLoopActivity,
       finalizeCancelledAgentLoopActivity,
       finalizeErroredAgentLoopActivity,
       finalizeCancellationActivity,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -143,7 +143,7 @@ const { trackProgrammaticUsageActivity } = proxyActivities<
 });
 
 const {
-  finalizeAgentLoopActivity,
+  finalizeSuccessfulAgentLoopActivity,
   finalizeCancelledAgentLoopActivity,
   finalizeErroredAgentLoopActivity,
 } = proxyActivities<typeof finalizeActivities>({

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -280,7 +280,7 @@ export async function agentLoopWorkflow({
       // Ensure analytics runs even if workflow is cancelled
       await CancellationScope.nonCancellable(async () => {
         if (patched("finalize-activity-consolidation")) {
-          await finalizeAgentLoopActivity(authType, agentLoopArgs);
+          await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);
         } else {
           await Promise.all([
             launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -153,6 +153,8 @@ const {
   },
 });
 
+const PATCH_NAME = "finalize-activity-consolidation";
+
 export async function agentLoopConversationTitleWorkflow({
   authType,
   agentLoopArgs,
@@ -279,7 +281,7 @@ export async function agentLoopWorkflow({
 
       // Ensure analytics runs even if workflow is cancelled
       await CancellationScope.nonCancellable(async () => {
-        if (patched("finalize-activity-consolidation")) {
+        if (patched(PATCH_NAME)) {
           await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);
         } else {
           await Promise.all([
@@ -302,7 +304,7 @@ export async function agentLoopWorkflow({
     await CancellationScope.nonCancellable(async () => {
       if (cancelRequested) {
         // Ensure analytics runs even when workflow is cancelled
-        if (patched("finalize-activity-consolidation")) {
+        if (patched(PATCH_NAME)) {
           await finalizeCancelledAgentLoopActivity(authType, agentLoopArgs);
         } else {
           await Promise.all([
@@ -314,7 +316,7 @@ export async function agentLoopWorkflow({
         return;
       } else {
         // Ensure analytics runs even when workflow errors
-        if (patched("finalize-activity-consolidation")) {
+        if (patched(PATCH_NAME)) {
           await finalizeErroredAgentLoopActivity(
             authType,
             agentLoopArgs,


### PR DESCRIPTION
## Description

- We currently run several lightweight activities concurrently when completing an agent loop (`launchAgentMessageAnalyticsActivity`, `trackProgrammaticUsageActivity`, `conversationUnreadNotificationActivity`, `handleMentionsActivity`).
- This pattern causes an unneeded load as it consumes several worker slots and scales poorly as adding an action on agent loop completion requires careful versioning on the Temporal workflow.
- This PR consolidates these activities into a single one (with variants depending on whether we're cancelling, erroring or succeeding), which runs the code that was in the individual activities.
- No functional change expected.

## Tests

- Tested locally.

## Risk

- High.

## Deploy Plan

- Deploy front.
- Do a follow up PR with a `deprecatedPatch`.
- Remove the `deprecatedPatch`.
