### PR TITLE
[Front] feat(skills): add LLM description suggestion endpoint

### DIFF
--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -21,6 +21,7 @@ export interface LLMTraceContext {
     | "conversation_title_suggestion"
     | "process_data_sources"
     | "process_schema_generator"
+    | "skill_builder_description_suggestion"
     | "trigger_cron_timezone_generator"
     | "trigger_webhook_filter_generator"
     | "voice_agent_finder"

--- a/front/lib/api/skill/suggestions.ts
+++ b/front/lib/api/skill/suggestions.ts
@@ -2,7 +2,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions, Result } from "@app/types";
-import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
+import { Err, getLargeWhitelistedModel, Ok } from "@app/types";
 
 const FUNCTION_NAME = "send_suggestion";
 
@@ -38,21 +38,19 @@ function getConversationContext(
 
   if (inputs.agentFacingDescription) {
     parts.push(
-      "Skill purpose (when to use):\n======\n" + inputs.agentFacingDescription
+      `## Skill purpose (when to use)\n\n${inputs.agentFacingDescription}`
     );
   }
 
   if (inputs.instructions) {
-    parts.push(
-      "Skill instructions (how to use):\n======\n" + inputs.instructions
-    );
+    parts.push(`## Skill instructions (how to use)\n\n${inputs.instructions}`);
   }
 
   if (inputs.tools.length > 0) {
     const toolsText = inputs.tools
-      .map((t) => `- ${t.name}: ${t.description}`)
+      .map((t) => `- **${t.name}**: ${t.description}`)
       .join("\n");
-    parts.push("Available tools (what to use):\n======\n" + toolsText);
+    parts.push(`## Available tools (what to use)\n\n${toolsText}`);
   }
 
   return {
@@ -71,7 +69,7 @@ export async function getSkillDescriptionSuggestion(
   inputs: SkillDescriptionSuggestionInputs
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
-  const model = getSmallWhitelistedModel(owner);
+  const model = getLargeWhitelistedModel(owner);
 
   if (!model) {
     return new Err(

--- a/front/lib/api/skill/suggestions.ts
+++ b/front/lib/api/skill/suggestions.ts
@@ -1,0 +1,123 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import type { ModelConversationTypeMultiActions, Result } from "@app/types";
+import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
+
+const FUNCTION_NAME = "send_suggestion";
+
+const specifications: AgentActionSpecification[] = [
+  {
+    name: FUNCTION_NAME,
+    description: "Send a suggestion of description for the skill",
+    inputSchema: {
+      type: "object",
+      properties: {
+        suggestion: {
+          type: "string",
+          description:
+            "A description of the skill using 1 short sentence. Be factual, clear and concise. " +
+            "Do not use more than 15 words.",
+        },
+      },
+      required: ["suggestion"],
+    },
+  },
+];
+
+export interface SkillDescriptionSuggestionInputs {
+  instructions: string;
+  agentFacingDescription: string;
+  tools: { name: string; description: string }[];
+}
+
+function getConversationContext(
+  inputs: SkillDescriptionSuggestionInputs
+): ModelConversationTypeMultiActions {
+  const parts: string[] = [];
+
+  if (inputs.agentFacingDescription) {
+    parts.push(
+      "Skill purpose (when to use):\n======\n" + inputs.agentFacingDescription
+    );
+  }
+
+  if (inputs.instructions) {
+    parts.push(
+      "Skill instructions (how to use):\n======\n" + inputs.instructions
+    );
+  }
+
+  if (inputs.tools.length > 0) {
+    const toolsText = inputs.tools
+      .map((t) => `- ${t.name}: ${t.description}`)
+      .join("\n");
+    parts.push("Available tools (what to use):\n======\n" + toolsText);
+  }
+
+  return {
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: parts.join("\n\n") }],
+        name: "",
+      },
+    ],
+  };
+}
+
+export async function getSkillDescriptionSuggestion(
+  auth: Authenticator,
+  inputs: SkillDescriptionSuggestionInputs
+): Promise<Result<string, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const model = getSmallWhitelistedModel(owner);
+
+  if (!model) {
+    return new Err(
+      new Error("No whitelisted models were found for the workspace.")
+    );
+  }
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      functionCall: FUNCTION_NAME,
+      modelId: model.modelId,
+      providerId: model.providerId,
+      temperature: 0.5,
+      useCache: false,
+    },
+    {
+      conversation: getConversationContext(inputs),
+      prompt:
+        "The user is creating a skill (reusable capability) for an AI assistant. " +
+        "Based on the provided purpose, instructions, and available tools, " +
+        "suggest a short user-facing description of the skill. " +
+        "Focus on what the skill does for the user.",
+      specifications,
+      forceToolCall: FUNCTION_NAME,
+    },
+    {
+      context: {
+        operationType: "skill_builder_description_suggestion",
+        userId: auth.user()?.sId,
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  if (res.value.actions?.[0]?.arguments?.suggestion) {
+    const { suggestion } = res.value.actions[0].arguments;
+
+    if (typeof suggestion === "string") {
+      return new Ok(suggestion);
+    }
+  }
+
+  return new Err(new Error("No suggestion found"));
+}

--- a/front/pages/api/w/[wId]/builder/skills/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/builder/skills/suggestions.test.ts
@@ -1,0 +1,162 @@
+import type { RequestMethod } from "node-mocks-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Err, Ok } from "@app/types";
+
+import handler from "./suggestions";
+
+vi.mock("@app/lib/api/skill/suggestions", () => ({
+  getSkillDescriptionSuggestion: vi.fn(),
+}));
+
+import { getSkillDescriptionSuggestion } from "@app/lib/api/skill/suggestions";
+
+async function setupTest(options: { method?: RequestMethod } = {}) {
+  const method = options.method ?? "POST";
+
+  const { req, res, workspace } = await createPrivateApiMockRequest({
+    role: "builder",
+    method,
+  });
+
+  req.query = { wId: workspace.sId };
+
+  return { req, res, workspace };
+}
+
+describe("POST /api/w/[wId]/builder/skills/suggestions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns suggestion with valid inputs", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      instructions: "Help users analyze data",
+      agentFacingDescription: "Use when user wants data analysis",
+      tools: [{ name: "query_db", description: "Query the database" }],
+    };
+
+    vi.mocked(getSkillDescriptionSuggestion).mockResolvedValue(
+      new Ok("Analyzes and visualizes your data")
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      suggestion: "Analyzes and visualizes your data",
+    });
+  });
+
+  it("returns suggestion with empty tools array", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      instructions: "Help users with writing",
+      agentFacingDescription: "Use for writing tasks",
+      tools: [],
+    };
+
+    vi.mocked(getSkillDescriptionSuggestion).mockResolvedValue(
+      new Ok("Helps you write better content")
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      suggestion: "Helps you write better content",
+    });
+  });
+
+  it("returns 500 when suggestion generation fails", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      instructions: "Help users",
+      agentFacingDescription: "Use for help",
+      tools: [],
+    };
+
+    vi.mocked(getSkillDescriptionSuggestion).mockResolvedValue(
+      new Err(new Error("Model unavailable"))
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData().error.type).toBe("internal_server_error");
+    expect(res._getJSONData().error.message).toBe("Model unavailable");
+  });
+
+  it("returns 400 for missing instructions", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      agentFacingDescription: "Use for analysis",
+      tools: [],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for missing agentFacingDescription", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      instructions: "Help users",
+      tools: [],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for missing tools", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      instructions: "Help users",
+      agentFacingDescription: "Use for help",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for invalid tools format", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = {
+      instructions: "Help users",
+      agentFacingDescription: "Use for help",
+      tools: [{ name: "tool1" }], // Missing description
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    for (const method of ["GET", "PUT", "DELETE", "PATCH"] as const) {
+      const { req, res } = await setupTest({ method });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData().error.type).toBe("method_not_supported_error");
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/builder/skills/suggestions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/suggestions.ts
@@ -1,0 +1,71 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { SkillDescriptionSuggestionInputs } from "@app/lib/api/skill/suggestions";
+import { getSkillDescriptionSuggestion } from "@app/lib/api/skill/suggestions";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const PostSkillSuggestionsRequestBodySchema = t.type({
+  instructions: t.string,
+  agentFacingDescription: t.string,
+  tools: t.array(t.type({ name: t.string, description: t.string })),
+});
+
+type SkillSuggestionsResponseType = {
+  suggestion: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<SkillSuggestionsResponseType>>,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostSkillSuggestionsRequestBodySchema.decode(
+        req.body
+      );
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const inputs: SkillDescriptionSuggestionInputs = bodyValidation.right;
+
+      const suggestionRes = await getSkillDescriptionSuggestion(auth, inputs);
+      if (suggestionRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: suggestionRes.error.message,
+          },
+        });
+      }
+
+      return res.status(200).json({ suggestion: suggestionRes.value });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
Step 1 of : https://github.com/dust-tt/tasks/issues/5605

## Description

- Add POST `/api/w/{wId}/builder/skills/suggestions` endpoint for LLM-based skill description generation
- Uses `getSmallWhitelistedModel()` to respect workspace model whitelisting
- Takes instructions, agentFacingDescription, and tools as input, returns suggested user-facing description

## Tests

Added endpoint tests covering validation, error handling, and happy path.

## Risk

Low.

## Deploy Plan

Deploy front.
