### PR TITLE
[Front] feat(skills): add sparkles button for description auto-generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ qdrant_storage
 core-api-keys.json
 oauth-api-keys.json
 /extension/build/
-**/.claude/settings.local.json
+**/.claude
 **/.yalc
 yalc.lock
 front/public/sitemap.xml

--- a/front/components/skill_builder/SkillBuilderNameSection.tsx
+++ b/front/components/skill_builder/SkillBuilderNameSection.tsx
@@ -8,6 +8,7 @@ const NAME_FIELD_NAME = "name";
 export function SkillBuilderNameSection() {
   return (
     <BaseFormFieldSection
+      title="Name"
       fieldName={NAME_FIELD_NAME}
       triggerValidationOnChange={false}
     >
@@ -16,7 +17,6 @@ export function SkillBuilderNameSection() {
           <div className="flex-grow">
             <Input
               ref={registerRef}
-              label="Name"
               placeholder="Enter skill name"
               onChange={onChange}
               message={errorMessage}

--- a/front/components/skill_builder/SkillBuilderUserFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderUserFacingDescriptionSection.tsx
@@ -1,23 +1,110 @@
-import { Input } from "@dust-tt/sparkle";
+import { Button, Input, SparklesIcon, Spinner } from "@dust-tt/sparkle";
+import { useState } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 
 import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
+import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { getSkillDescriptionSuggestion } from "@app/components/skill_builder/utils";
+import { useSendNotification } from "@app/hooks/useNotification";
 
 const USER_FACING_DESCRIPTION_FIELD_NAME = "userFacingDescription";
+const MIN_INSTRUCTIONS_LENGTH = 20;
 
 export function SkillBuilderUserFacingDescriptionSection() {
+  const { owner } = useSkillBuilderContext();
+  const sendNotification = useSendNotification();
+  const [isGenerating, setIsGenerating] = useState(false);
+  const { setValue } = useFormContext<SkillBuilderFormData>();
+
+  const instructions = useWatch<SkillBuilderFormData, "instructions">({
+    name: "instructions",
+  });
+  const agentFacingDescription = useWatch<
+    SkillBuilderFormData,
+    "agentFacingDescription"
+  >({
+    name: "agentFacingDescription",
+  });
+  const tools = useWatch<SkillBuilderFormData, "tools">({
+    name: "tools",
+  });
+
+  const canGenerate =
+    instructions &&
+    instructions.length >= MIN_INSTRUCTIONS_LENGTH &&
+    agentFacingDescription &&
+    agentFacingDescription.length > 0;
+
+  const handleGenerateDescription = async () => {
+    if (isGenerating || !canGenerate) {
+      return;
+    }
+
+    setIsGenerating(true);
+
+    const result = await getSkillDescriptionSuggestion({
+      owner,
+      instructions,
+      agentFacingDescription,
+      tools: tools.map((t) => ({ name: t.name, description: t.description })),
+    });
+
+    if (result.isErr()) {
+      sendNotification({
+        type: "error",
+        title: "Failed to generate description",
+        description: result.error.message,
+      });
+    } else if (result.value.suggestion) {
+      setValue(USER_FACING_DESCRIPTION_FIELD_NAME, result.value.suggestion, {
+        shouldDirty: true,
+      });
+    }
+
+    setIsGenerating(false);
+  };
+
+  const getTooltip = () => {
+    if (isGenerating) {
+      return "Generating description...";
+    }
+    if (!instructions || instructions.length < MIN_INSTRUCTIONS_LENGTH) {
+      return `Add at least ${MIN_INSTRUCTIONS_LENGTH} characters to instructions`;
+    }
+    if (!agentFacingDescription || agentFacingDescription.length === 0) {
+      return "Add a description of when to use the skill";
+    }
+    return "Generate description";
+  };
+
   return (
     <BaseFormFieldSection
+      title="Description"
       fieldName={USER_FACING_DESCRIPTION_FIELD_NAME}
       triggerValidationOnChange={false}
     >
-      {({ registerRef, registerProps, onChange }) => (
-        <Input
-          ref={registerRef}
-          label="Description"
-          placeholder="Enter skill description"
-          onChange={onChange}
-          {...registerProps}
-        />
+      {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
+        <div className="relative">
+          <Input
+            ref={registerRef}
+            placeholder="Enter skill description"
+            onChange={onChange}
+            message={errorMessage}
+            messageStatus={hasError ? "error" : "default"}
+            className="pr-10"
+            {...registerProps}
+          />
+          <Button
+            icon={isGenerating ? () => <Spinner size="xs" /> : SparklesIcon}
+            variant="outline"
+            size="xs"
+            className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0"
+            disabled={isGenerating || !canGenerate}
+            onClick={handleGenerateDescription}
+            tooltip={getTooltip()}
+          />
+        </div>
       )}
     </BaseFormFieldSection>
   );

--- a/front/components/skill_builder/utils.ts
+++ b/front/components/skill_builder/utils.ts
@@ -1,6 +1,7 @@
 import { clientFetch } from "@app/lib/egress/client";
+import type { PostSkillSuggestionsRequestBody } from "@app/pages/api/w/[wId]/builder/skills/suggestions";
 import type { APIError, Result, WorkspaceType } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 interface SkillDescriptionSuggestionResponse {
   suggestion: string;
@@ -27,12 +28,12 @@ export async function getSkillDescriptionSuggestion({
           instructions,
           agentFacingDescription,
           tools,
-        }),
+        } satisfies PostSkillSuggestionsRequestBody),
       }
     );
 
     if (!res.ok) {
-      const errorData = await res.json().catch(() => ({}));
+      const errorData = await res.json();
       return new Err({
         type: "internal_server_error",
         message:
@@ -46,10 +47,7 @@ export async function getSkillDescriptionSuggestion({
   } catch (error) {
     return new Err({
       type: "internal_server_error",
-      message:
-        error instanceof Error
-          ? error.message
-          : "Network error while getting description suggestion",
+      message: normalizeError(error).message,
     });
   }
 }

--- a/front/components/skill_builder/utils.ts
+++ b/front/components/skill_builder/utils.ts
@@ -1,0 +1,55 @@
+import { clientFetch } from "@app/lib/egress/client";
+import type { APIError, Result, WorkspaceType } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+interface SkillDescriptionSuggestionResponse {
+  suggestion: string;
+}
+
+export async function getSkillDescriptionSuggestion({
+  owner,
+  instructions,
+  agentFacingDescription,
+  tools,
+}: {
+  owner: WorkspaceType;
+  instructions: string;
+  agentFacingDescription: string;
+  tools: { name: string; description: string }[];
+}): Promise<Result<SkillDescriptionSuggestionResponse, APIError>> {
+  try {
+    const res = await clientFetch(
+      `/api/w/${owner.sId}/builder/skills/suggestions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          instructions,
+          agentFacingDescription,
+          tools,
+        }),
+      }
+    );
+
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({}));
+      return new Err({
+        type: "internal_server_error",
+        message:
+          errorData.error?.message ??
+          `HTTP ${res.status}: Failed to get description suggestion`,
+      });
+    }
+
+    const data = await res.json();
+    return new Ok(data);
+  } catch (error) {
+    return new Err({
+      type: "internal_server_error",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Network error while getting description suggestion",
+    });
+  }
+}

--- a/front/pages/api/w/[wId]/builder/skills/suggestions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/suggestions.ts
@@ -15,6 +15,9 @@ const PostSkillSuggestionsRequestBodySchema = t.type({
   agentFacingDescription: t.string,
   tools: t.array(t.type({ name: t.string, description: t.string })),
 });
+export type PostSkillSuggestionsRequestBody = t.TypeOf<
+  typeof PostSkillSuggestionsRequestBodySchema
+>;
 
 type SkillSuggestionsResponseType = {
   suggestion: string;


### PR DESCRIPTION
## Description

- Add sparkles button in Skill Builder to auto-generate user-facing description
- Uses instructions, agentFacingDescription, and tool list as context for LLM generation
- Button disabled until instructions >= 20 chars and agentFacingDescription is filled
- Follows agent builder pattern with extracted fetch utility

## Tests

Manual testing + endpoint tests in previous commit.

https://github.com/user-attachments/assets/08380016-8bef-4d3c-b9b0-1c3446b0d763



## Risk

Low.

## Deploy Plan

Deploy front.
