### PR TITLE
[front] - feat(skills): JIT skills UI

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -60,6 +60,39 @@ function ToolsPickerLoading({ count = 5 }: { count?: number }) {
   );
 }
 
+interface CapabilityItemProps {
+  id: string;
+  icon: React.ComponentType<{ className?: string }> | (() => React.ReactNode);
+  label: string;
+  description: string | null;
+  onClick: () => void;
+  keyPrefix: string;
+}
+
+function CapabilityItem({
+  id,
+  icon,
+  label,
+  description,
+  onClick,
+  keyPrefix,
+}: CapabilityItemProps) {
+  return (
+    <DropdownMenuItem
+      key={`${keyPrefix}-${id}`}
+      icon={icon}
+      label={label}
+      description={description ?? undefined}
+      truncateText
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        onClick();
+      }}
+    />
+  );
+}
+
 interface ToolsPickerProps {
   owner: WorkspaceType;
   selectedMCPServerViews: MCPServerViewType[];
@@ -325,15 +358,14 @@ export function ToolsPicker({
                 Skills
               </div>
               {filteredSkillsUnselected.map((skill) => (
-                <DropdownMenuItem
+                <CapabilityItem
                   key={`skills-picker-${skill.sId}`}
+                  id={skill.sId}
                   icon={SKILL_ICON}
                   label={skill.name}
                   description={skill.userFacingDescription}
-                  truncateText
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
+                  keyPrefix="skills-picker"
+                  onClick={() => {
                     trackEvent({
                       area: TRACKING_AREAS.TOOLS,
                       object: "skill_select",
@@ -356,32 +388,29 @@ export function ToolsPicker({
               <div className="text-element-700 px-4 py-2 text-xs font-semibold">
                 Tools
               </div>
-              {filteredServerViewsUnselected.map((v) => {
-                return (
-                  <DropdownMenuItem
-                    key={`tools-picker-${v.sId}`}
-                    icon={() => getAvatar(v.server)}
-                    label={getMcpServerViewDisplayName(v)}
-                    description={getMcpServerViewDescription(v)}
-                    truncateText
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      e.preventDefault();
-                      trackEvent({
-                        area: TRACKING_AREAS.TOOLS,
-                        object: "tool_select",
-                        action: TRACKING_ACTIONS.SELECT,
-                        extra: {
-                          tool_id: v.sId,
-                          tool_name: v.server.name,
-                        },
-                      });
-                      onSelect(v);
-                      setIsOpen(false);
-                    }}
-                  />
-                );
-              })}
+              {filteredServerViewsUnselected.map((v) => (
+                <CapabilityItem
+                  key={`tools-picker-${v.sId}`}
+                  id={v.sId}
+                  icon={() => getAvatar(v.server)}
+                  label={getMcpServerViewDisplayName(v)}
+                  description={getMcpServerViewDescription(v)}
+                  keyPrefix="tools-picker"
+                  onClick={() => {
+                    trackEvent({
+                      area: TRACKING_AREAS.TOOLS,
+                      object: "tool_select",
+                      action: TRACKING_ACTIONS.SELECT,
+                      extra: {
+                        tool_id: v.sId,
+                        tool_name: v.server.name,
+                      },
+                    });
+                    onSelect(v);
+                    setIsOpen(false);
+                  }}
+                />
+              ))}
             </>
           )}
 

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -62,7 +62,7 @@ function ToolsPickerLoading({ count = 5 }: { count?: number }) {
 
 interface CapabilityItemProps {
   id: string;
-  icon: React.ComponentType<{ className?: string }> | (() => React.ReactNode);
+  icon: React.ComponentType<{ className?: string }>;
   label: string;
   description: string | null;
   onClick?: () => void;

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   BoltIcon,
   Button,
   Chip,

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   BoltIcon,
   Button,
   Chip,
@@ -26,7 +27,7 @@ import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
-import { SKILL_ICON } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import {
   useAvailableMCPServers,
   useMCPServerViewsFromSpaces,
@@ -65,8 +66,11 @@ interface CapabilityItemProps {
   icon: React.ComponentType<{ className?: string }> | (() => React.ReactNode);
   label: string;
   description: string | null;
-  onClick: () => void;
+  onClick?: () => void;
   keyPrefix: string;
+  endComponent?: React.ReactNode;
+  disabled?: boolean;
+  className?: string;
 }
 
 function CapabilityItem({
@@ -76,19 +80,30 @@ function CapabilityItem({
   description,
   onClick,
   keyPrefix,
+  endComponent,
+  disabled,
+  className,
 }: CapabilityItemProps) {
   return (
     <DropdownMenuItem
       key={`${keyPrefix}-${id}`}
+      id={`${keyPrefix}-${id}`}
       icon={icon}
       label={label}
       description={description ?? undefined}
       truncateText
-      onClick={(e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        onClick();
-      }}
+      endComponent={endComponent}
+      disabled={disabled}
+      className={className}
+      onClick={
+        onClick
+          ? (e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              onClick();
+            }
+          : undefined
+      }
     />
   );
 }
@@ -361,7 +376,7 @@ export function ToolsPicker({
                 <CapabilityItem
                   key={`skills-picker-${skill.sId}`}
                   id={skill.sId}
-                  icon={SKILL_ICON}
+                  icon={getSkillAvatarIcon(skill.icon)}
                   label={skill.name}
                   description={skill.userFacingDescription}
                   keyPrefix="skills-picker"
@@ -417,19 +432,17 @@ export function ToolsPicker({
           {isDataReady && filteredUninstalledServers.length > 0 && (
             <>
               {filteredUninstalledServers.map((server) => (
-                <DropdownMenuItem
+                <CapabilityItem
                   key={`tools-to-install-${server.sId}`}
+                  id={server.sId}
                   icon={() => getAvatar(server)}
                   label={asDisplayName(server.name)}
                   description={server.description}
-                  truncateText
+                  keyPrefix="tools-to-install"
                   endComponent={
                     <Chip size="xs" color="golden" label="Configure" />
                   }
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-
+                  onClick={() => {
                     const remoteMcpServerConfig =
                       getDefaultRemoteMCPServerByName(server.name);
 
@@ -455,8 +468,8 @@ export function ToolsPicker({
             filteredSkillsUnselected.length === 0 &&
             filteredServerViewsUnselected.length === 0 &&
             filteredUninstalledServers.length === 0 && (
-              <DropdownMenuItem
-                id="tools-picker-no-selected"
+              <CapabilityItem
+                id="no-selected"
                 icon={() => <Icon visual={BoltIcon} size="xs" />}
                 label={
                   searchText.length > 0
@@ -468,7 +481,9 @@ export function ToolsPicker({
                     ? "No skills or tools found matching your search."
                     : "All available skills and tools are already selected."
                 }
+                keyPrefix="tools-picker"
                 disabled
+                className="italic"
               />
             )}
         </DropdownMenuContent>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -33,6 +33,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { compareAgentsForSort, isEqualNode, isGlobalAgentId } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
@@ -148,6 +149,8 @@ export const InputBar = React.memo(function InputBar({
     MCPServerViewType[]
   >([]);
 
+  const [selectedSkills, setSelectedSkills] = useState<SkillType[]>([]);
+
   const { conversationTools } = useConversationTools({
     conversationId,
     workspaceId: owner.sId,
@@ -175,6 +178,16 @@ export const InputBar = React.memo(function InputBar({
       prev.filter((sv) => sv.sId !== serverView.sId)
     );
     void deleteTool(serverView.sId);
+  };
+
+  const handleSkillSelect = (skill: SkillType) => {
+    setSelectedSkills((prev) => [...prev, skill]);
+    // TODO: Handle enabled skill in conversation
+  };
+
+  const handleSkillDeselect = (skill: SkillType) => {
+    setSelectedSkills((prev) => prev.filter((s) => s.sId !== skill.sId));
+    // TODO: Disabled skill in conversation
   };
 
   const activeAgents = agentConfigurations.filter((a) => a.status === "active");
@@ -349,6 +362,9 @@ export const InputBar = React.memo(function InputBar({
             selectedMCPServerViews={selectedMCPServerViews}
             onMCPServerViewSelect={handleMCPServerViewSelect}
             onMCPServerViewDeselect={handleMCPServerViewDeselect}
+            selectedSkills={selectedSkills}
+            onSkillSelect={handleSkillSelect}
+            onSkillDeselect={handleSkillDeselect}
             attachedNodes={attachedNodes}
             saveDraft={saveDraft}
             getDraft={getDraft}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -34,6 +34,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
+import { SKILL_ICON } from "@app/lib/skill";
 import { getSpaceAccessPriority } from "@app/lib/spaces";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -48,10 +49,11 @@ import type {
 } from "@app/types";
 import {
   assertNever,
+  getSupportedFileExtensions,
   normalizeError,
   toRichAgentMentionType,
 } from "@app/types";
-import { getSupportedFileExtensions } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export const INPUT_BAR_ACTIONS = [
   "tools",
@@ -65,25 +67,28 @@ export const INPUT_BAR_ACTIONS = [
 export type InputBarAction = (typeof INPUT_BAR_ACTIONS)[number];
 
 export interface InputBarContainerProps {
-  allAgents: LightAgentConfigurationType[];
-  onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
-  owner: WorkspaceType;
-  conversationId: string | null;
-  selectedAgent: RichAgentMention | null;
-  stickyMentions?: RichMention[];
   actions: InputBarAction[];
+  allAgents: LightAgentConfigurationType[];
+  attachedNodes: DataSourceViewContentNode[];
+  conversationId: string | null;
   disableAutoFocus: boolean;
-  isSubmitting: boolean;
   disableInput: boolean;
   fileUploaderService: FileUploaderService;
+  getDraft: () => { text: string } | null;
+  isSubmitting: boolean;
+  onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
+  onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
+  onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
-  attachedNodes: DataSourceViewContentNode[];
-  onMCPServerViewSelect: (serverView: MCPServerViewType) => void;
-  onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
-  selectedMCPServerViews: MCPServerViewType[];
+  onSkillDeselect: (skill: SkillType) => void;
+  onSkillSelect: (skill: SkillType) => void;
+  owner: WorkspaceType;
   saveDraft: (markdown: string) => void;
-  getDraft: () => { text: string } | null;
+  selectedAgent: RichAgentMention | null;
+  selectedMCPServerViews: MCPServerViewType[];
+  selectedSkills: SkillType[];
+  stickyMentions?: RichMention[];
 }
 
 const InputBarContainer = ({
@@ -104,6 +109,9 @@ const InputBarContainer = ({
   onMCPServerViewSelect,
   onMCPServerViewDeselect,
   selectedMCPServerViews,
+  onSkillSelect,
+  onSkillDeselect,
+  selectedSkills,
   saveDraft,
   getDraft,
 }: InputBarContainerProps) => {
@@ -580,6 +588,36 @@ const InputBarContainer = ({
         )}
         <div className="flex w-full flex-col py-1.5 sm:pb-2">
           <div className="mb-1 flex flex-wrap items-center px-2">
+            {selectedSkills.map((skill) => (
+              <React.Fragment key={skill.sId}>
+                {/* Two Chips: one for larger screens (desktop), one for smaller screens (mobile). */}
+                <Chip
+                  size="xs"
+                  label={skill.name}
+                  icon={SKILL_ICON}
+                  className="m-0.5 hidden bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:flex"
+                  onRemove={
+                    disableInput
+                      ? undefined
+                      : () => {
+                          onSkillDeselect(skill);
+                        }
+                  }
+                />
+                <Chip
+                  size="xs"
+                  icon={SKILL_ICON}
+                  className="m-0.5 flex bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:hidden"
+                  onRemove={
+                    disableInput
+                      ? undefined
+                      : () => {
+                          onSkillDeselect(skill);
+                        }
+                  }
+                />
+              </React.Fragment>
+            ))}
             {selectedMCPServerViews.map((msv) => (
               <React.Fragment key={msv.sId}>
                 {/* Two Chips: one for larger screens (desktop), one for smaller screens (mobile). */}
@@ -679,6 +717,9 @@ const InputBarContainer = ({
                       selectedMCPServerViews={selectedMCPServerViews}
                       onSelect={onMCPServerViewSelect}
                       onDeselect={onMCPServerViewDeselect}
+                      selectedSkills={selectedSkills}
+                      onSkillSelect={onSkillSelect}
+                      onSkillDeselect={onSkillDeselect}
                       disabled={disableTextInput}
                       buttonSize={buttonSize}
                     />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -34,7 +34,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
-import { SKILL_ICON } from "@app/lib/skill";
+import { getSkillIcon } from "@app/lib/skill";
 import { getSpaceAccessPriority } from "@app/lib/spaces";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -594,7 +594,7 @@ const InputBarContainer = ({
                 <Chip
                   size="xs"
                   label={skill.name}
-                  icon={SKILL_ICON}
+                  icon={getSkillIcon(skill.icon)}
                   className="m-0.5 hidden bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:flex"
                   onRemove={
                     disableInput
@@ -606,7 +606,7 @@ const InputBarContainer = ({
                 />
                 <Chip
                   size="xs"
-                  icon={SKILL_ICON}
+                  icon={getSkillIcon(skill.icon)}
                   className="m-0.5 flex bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:hidden"
                   onRemove={
                     disableInput

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -1,4 +1,46 @@
+import { Avatar } from "@dust-tt/sparkle";
 import { PuzzleIcon } from "lucide-react";
+import React from "react";
+
+import {
+  getAvatarFromIcon,
+  getIcon,
+  isCustomResourceIconType,
+  isInternalAllowedIcon,
+} from "@app/components/resources/resources_icons";
 
 // TODO(skills 2025-12-05): use the right icon
 export const SKILL_ICON = PuzzleIcon;
+
+/**
+ * Returns an avatar component for a skill icon (used in dropdowns).
+ * Validates the icon string and falls back to the default SKILL_ICON if invalid.
+ */
+export function getSkillAvatarIcon(
+  iconString: string | null
+): () => React.ReactNode {
+  if (
+    iconString &&
+    (isCustomResourceIconType(iconString) || isInternalAllowedIcon(iconString))
+  ) {
+    return () => getAvatarFromIcon(iconString);
+  }
+
+  return () => React.createElement(Avatar, { icon: SKILL_ICON, size: "sm" });
+}
+
+/**
+ * Returns a plain icon component for a skill icon (used in chips).
+ * Validates the icon string and falls back to the default SKILL_ICON if invalid.
+ */
+export function getSkillIcon(
+  iconString: string | null
+): React.ComponentType<{ className?: string }> {
+  if (
+    iconString &&
+    (isCustomResourceIconType(iconString) || isInternalAllowedIcon(iconString))
+  ) {
+    return getIcon(iconString);
+  }
+  return SKILL_ICON;
+}

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -12,10 +12,6 @@ import {
 // TODO(skills 2025-12-05): use the right icon
 export const SKILL_ICON = PuzzleIcon;
 
-/**
- * Returns an avatar component for a skill icon (used in dropdowns).
- * Validates the icon string and falls back to the default SKILL_ICON if invalid.
- */
 export function getSkillAvatarIcon(
   iconString: string | null
 ): () => React.ReactNode {
@@ -29,10 +25,6 @@ export function getSkillAvatarIcon(
   return () => React.createElement(Avatar, { icon: SKILL_ICON, size: "sm" });
 }
 
-/**
- * Returns a plain icon component for a skill icon (used in chips).
- * Validates the icon string and falls back to the default SKILL_ICON if invalid.
- */
 export function getSkillIcon(
   iconString: string | null
 ): React.ComponentType<{ className?: string }> {

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -3,7 +3,6 @@ import { PuzzleIcon } from "lucide-react";
 import React from "react";
 
 import {
-  getAvatarFromIcon,
   getIcon,
   isCustomResourceIconType,
   isInternalAllowedIcon,
@@ -14,15 +13,18 @@ export const SKILL_ICON = PuzzleIcon;
 
 export function getSkillAvatarIcon(
   iconString: string | null
-): () => React.ReactNode {
+): React.ComponentType<{ className?: string }> {
   if (
     iconString &&
     (isCustomResourceIconType(iconString) || isInternalAllowedIcon(iconString))
   ) {
-    return () => getAvatarFromIcon(iconString);
+    const icon = getIcon(iconString);
+    return (props) =>
+      React.createElement(Avatar, { icon, size: "sm", ...props });
   }
 
-  return () => React.createElement(Avatar, { icon: SKILL_ICON, size: "sm" });
+  return (props) =>
+    React.createElement(Avatar, { icon: SKILL_ICON, size: "sm", ...props });
 }
 
 export function getSkillIcon(

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -25,15 +25,19 @@ import type {
 export function useSkillConfigurations({
   owner,
   disabled,
+  status,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
+  status?: SkillStatus;
 }) {
   const skillConfigurationsFetcher: Fetcher<GetSkillConfigurationsResponseBody> =
     fetcher;
 
+  const queryParams = status ? `?status=${status}` : "";
+
   const { data, error, isLoading, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/skills`,
+    `/api/w/${owner.sId}/skills${queryParams}`,
     skillConfigurationsFetcher,
     { disabled }
   );


### PR DESCRIPTION
## Description

Adds skills selection to the conversation input bar, unifying the tools and skills picking experience under a single "capabilities" picker. Users can now select and attach skills to conversations alongside MCP server tools. The picker displays both skills and tools in separate sections with appropriate filtering and search functionality.

## Risk

Low - behind FF

## Tests

Locally, with and without FF

## Deploy Plan

Deploy front
