### PR TITLE
Changing self-mentions background-color

### DIFF
--- a/front/lib/mentions/ui/MentionDisplay.tsx
+++ b/front/lib/mentions/ui/MentionDisplay.tsx
@@ -49,7 +49,7 @@ function MentionTrigger({
         "inline-block cursor-pointer font-light text-highlight-500 dark:text-highlight-500-night",
         userMentionsEnabled &&
           isCurrentUserMentioned &&
-          "bg-green-200 text-green-700 dark:bg-green-200-night dark:text-green-600-night"
+          "bg-golden-100 dark:bg-golden-100-night"
       )}
     >
       @{mention.label}


### PR DESCRIPTION
## Description

Changing the background color when the current user is mentioned.

Here are the new colors:
<img width="360" height="187" alt="image" src="https://github.com/user-attachments/assets/75efab96-d6b8-4f87-9123-882112242020" />
<img width="360" height="187" alt="image" src="https://github.com/user-attachments/assets/ef1141d9-48d0-450c-b82a-81248f73deef" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
