### PR TITLE
[front] refactor(skills): rename skill-related hooks

### DIFF
--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -39,13 +39,11 @@ export const useSkillSelection = ({
     localAdditionalSpaces
   );
 
-  const {
-    skillsWithRelations,
-    isSkillsWithRelationsLoading,
-  } = useSkillsWithRelations({
-    owner,
-    status: "active",
-  });
+  const { skillsWithRelations, isSkillsWithRelationsLoading } =
+    useSkillsWithRelations({
+      owner,
+      status: "active",
+    });
 
   const selectedSkillIds = useMemo(
     () => new Set(localSelectedSkills.map((s) => s.sId)),

--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -9,7 +9,7 @@ import type {
 } from "@app/components/agent_builder/skills/skillSheet/types";
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
 import { doesSkillTriggerSelectSpaces } from "@app/lib/skill";
-import { useSkillConfigurationsWithRelations } from "@app/lib/swr/skill_configurations";
+import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 function isGlobalSkillWithSpaceSelection(skill: SkillType): boolean {
@@ -40,9 +40,9 @@ export const useSkillSelection = ({
   );
 
   const {
-    skillConfigurationsWithRelations,
-    isSkillConfigurationsWithRelationsLoading,
-  } = useSkillConfigurationsWithRelations({
+    skillsWithRelations,
+    isSkillsWithRelationsLoading,
+  } = useSkillsWithRelations({
     owner,
     status: "active",
   });
@@ -54,15 +54,15 @@ export const useSkillSelection = ({
 
   const filteredSkills = useMemo(() => {
     if (!searchQuery.trim()) {
-      return skillConfigurationsWithRelations;
+      return skillsWithRelations;
     }
     const query = searchQuery.toLowerCase();
-    return skillConfigurationsWithRelations.filter(
+    return skillsWithRelations.filter(
       (skill) =>
         skill.name.toLowerCase().includes(query) ||
         skill.userFacingDescription.toLowerCase().includes(query)
     );
-  }, [skillConfigurationsWithRelations, searchQuery]);
+  }, [skillsWithRelations, searchQuery]);
 
   const selectionMode = getSelectionMode(mode);
 
@@ -125,7 +125,7 @@ export const useSkillSelection = ({
   return {
     handleSkillToggle,
     filteredSkills,
-    isSkillsLoading: isSkillConfigurationsWithRelationsLoading,
+    isSkillsLoading: isSkillsWithRelationsLoading,
     searchQuery,
     selectedSkillIds,
     setSearchQuery,

--- a/front/components/shared/skills/SkillsContext.tsx
+++ b/front/components/shared/skills/SkillsContext.tsx
@@ -31,26 +31,18 @@ export const SkillsProvider = ({ owner, children }: SkillsProviderProps) => {
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   const hasSkillsFeature = hasFeature("skills");
 
-  const {
-    skillConfigurations,
-    isSkillConfigurationsLoading,
-    isSkillConfigurationsError,
-  } = useSkills({
+  const { skills, isSkillsLoading, isSkillsError } = useSkills({
     owner,
     disabled: !hasSkillsFeature,
   });
 
   const value: SkillsContextType = useMemo(() => {
     return {
-      skills: skillConfigurations,
-      isSkillsLoading: isSkillConfigurationsLoading,
-      isSkillsError: isSkillConfigurationsError,
+      skills: skills,
+      isSkillsLoading: isSkillsLoading,
+      isSkillsError: isSkillsError,
     };
-  }, [
-    skillConfigurations,
-    isSkillConfigurationsLoading,
-    isSkillConfigurationsError,
-  ]);
+  }, [skills, isSkillsLoading, isSkillsError]);
 
   return (
     <SkillsContext.Provider value={value}>{children}</SkillsContext.Provider>

--- a/front/components/shared/skills/SkillsContext.tsx
+++ b/front/components/shared/skills/SkillsContext.tsx
@@ -38,9 +38,9 @@ export const SkillsProvider = ({ owner, children }: SkillsProviderProps) => {
 
   const value: SkillsContextType = useMemo(() => {
     return {
-      skills: skills,
-      isSkillsLoading: isSkillsLoading,
-      isSkillsError: isSkillsError,
+      skills,
+      isSkillsLoading,
+      isSkillsError,
     };
   }, [skills, isSkillsLoading, isSkillsError]);
 

--- a/front/components/shared/skills/SkillsContext.tsx
+++ b/front/components/shared/skills/SkillsContext.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { createContext, useContext, useMemo } from "react";
 
-import { useSkillConfigurations } from "@app/lib/swr/skill_configurations";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LightWorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -35,7 +35,7 @@ export const SkillsProvider = ({ owner, children }: SkillsProviderProps) => {
     skillConfigurations,
     isSkillConfigurationsLoading,
     isSkillConfigurationsError,
-  } = useSkillConfigurations({
+  } = useSkills({
     owner,
     disabled: !hasSkillsFeature,
   });

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -31,7 +31,7 @@ import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useSkillConfigurationTools } from "@app/lib/swr/actions";
+import { useSkillTools } from "@app/lib/swr/actions";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
@@ -47,7 +47,7 @@ export default function SkillBuilder({
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
 
-  const { actions, isActionsLoading } = useSkillConfigurationTools(
+  const { actions, isActionsLoading } = useSkillTools(
     owner,
     skillConfiguration?.sId ?? null
   );

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -6,10 +6,7 @@ import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSectio
 import { SimilarSkillsDisplay } from "@app/components/skill_builder/SimilarSkillsDisplay";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
-import {
-  useSimilarSkills,
-  useSkillConfigurations,
-} from "@app/lib/swr/skill_configurations";
+import { useSimilarSkills, useSkills } from "@app/lib/swr/skill_configurations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
@@ -23,7 +20,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
   const isSimilarSkillsEnabled = hasFeature("skills_similar_display");
 
   const { getSimilarSkills } = useSimilarSkills({ owner });
-  const { skillConfigurations } = useSkillConfigurations({
+  const { skillConfigurations } = useSkills({
     owner,
     disabled: !isSimilarSkillsEnabled,
   });

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -20,7 +20,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
   const isSimilarSkillsEnabled = hasFeature("skills_similar_display");
 
   const { getSimilarSkills } = useSimilarSkills({ owner });
-  const { skillConfigurations } = useSkills({
+  const { skills } = useSkills({
     owner,
     disabled: !isSimilarSkillsEnabled,
   });
@@ -47,14 +47,14 @@ export function SkillBuilderAgentFacingDescriptionSection() {
         setIsLoading(false);
         if (result.isOk()) {
           const similarSkillIds = result.value;
-          const matchedSkills = skillConfigurations.filter((skill) =>
+          const matchedSkills = skills.filter((skill) =>
             similarSkillIds.includes(skill.sId)
           );
           setSimilarSkills(matchedSkills);
         }
       }
     },
-    [getSimilarSkills, isSimilarSkillsEnabled, skillConfigurations]
+    [getSimilarSkills, isSimilarSkillsEnabled, skills]
   );
 
   const triggerSimilarSkillsFetch = useDebounceWithAbort(fetchSimilarSkills, {

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -30,7 +30,7 @@ export function SkillBuilderInstructionsSection({
   const [compareVersion, setCompareVersion] = useState<SkillType | null>(null);
   const [isInstructionDiffMode, setIsInstructionDiffMode] = useState(false);
 
-  const { skillConfigurationHistory } = useSkillHistory({
+  const { skillHistory } = useSkillHistory({
     owner,
     skillConfiguration,
     disabled: !skillConfiguration,
@@ -51,18 +51,17 @@ export function SkillBuilderInstructionsSection({
     setIsInstructionDiffMode(false);
   };
 
-  const headerActions = skillConfigurationHistory &&
-    skillConfigurationHistory.length > 1 && (
-      <SkillInstructionsHistory
-        history={skillConfigurationHistory}
-        selectedConfig={compareVersion}
-        onSelect={(config) => {
-          setCompareVersion(config);
-          setIsInstructionDiffMode(true);
-        }}
-        owner={owner}
-      />
-    );
+  const headerActions = skillHistory && skillHistory.length > 1 && (
+    <SkillInstructionsHistory
+      history={skillHistory}
+      selectedConfig={compareVersion}
+      onSelect={(config) => {
+        setCompareVersion(config);
+        setIsInstructionDiffMode(true);
+      }}
+      owner={owner}
+    />
+  );
 
   return (
     <section className="flex flex-col gap-3">

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -13,7 +13,7 @@ import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuild
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { SkillBuilderInstructionsEditor } from "@app/components/skill_builder/SkillBuilderInstructionsEditor";
 import { SkillInstructionsHistory } from "@app/components/skill_builder/SkillInstructionsHistory";
-import { useSkillConfigurationHistory } from "@app/lib/swr/skill_configurations";
+import { useSkillHistory } from "@app/lib/swr/skill_configurations";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
@@ -30,7 +30,7 @@ export function SkillBuilderInstructionsSection({
   const [compareVersion, setCompareVersion] = useState<SkillType | null>(null);
   const [isInstructionDiffMode, setIsInstructionDiffMode] = useState(false);
 
-  const { skillConfigurationHistory } = useSkillConfigurationHistory({
+  const { skillConfigurationHistory } = useSkillHistory({
     owner,
     skillConfiguration,
     disabled: !skillConfiguration,
@@ -51,21 +51,18 @@ export function SkillBuilderInstructionsSection({
     setIsInstructionDiffMode(false);
   };
 
-  const headerActions = (
-    <>
-      {skillConfigurationHistory && skillConfigurationHistory.length > 1 && (
-        <SkillInstructionsHistory
-          history={skillConfigurationHistory}
-          selectedConfig={compareVersion}
-          onSelect={(config) => {
-            setCompareVersion(config);
-            setIsInstructionDiffMode(true);
-          }}
-          owner={owner}
-        />
-      )}
-    </>
-  );
+  const headerActions = skillConfigurationHistory &&
+    skillConfigurationHistory.length > 1 && (
+      <SkillInstructionsHistory
+        history={skillConfigurationHistory}
+        selectedConfig={compareVersion}
+        onSelect={(config) => {
+          setCompareVersion(config);
+          setIsInstructionDiffMode(true);
+        }}
+        owner={owner}
+      />
+    );
 
   return (
     <section className="flex flex-col gap-3">

--- a/front/components/skills/ArchiveSkillDialog.tsx
+++ b/front/components/skills/ArchiveSkillDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
-import { useArchiveSkillConfiguration } from "@app/lib/swr/skill_configurations";
+import { useArchiveSkill } from "@app/lib/swr/skill_configurations";
 import type { LightWorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
@@ -27,7 +27,7 @@ export function ArchiveSkillDialog({
   owner,
 }: DeleteSkillDialogProps) {
   const [isArchiving, setIsArchiving] = useState(false);
-  const doArchive = useArchiveSkillConfiguration({ owner, skillConfiguration });
+  const doArchive = useArchiveSkill({ owner, skillConfiguration });
 
   return (
     <Dialog

--- a/front/components/skills/RestoreSkillDialog.tsx
+++ b/front/components/skills/RestoreSkillDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
-import { useRestoreSkillConfiguration } from "@app/lib/swr/skill_configurations";
+import { useRestoreSkill } from "@app/lib/swr/skill_configurations";
 import type { LightWorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
@@ -27,7 +27,7 @@ export function RestoreSkillDialog({
   owner,
 }: RestoreSkillDialogProps) {
   const [isRestoring, setIsRestoring] = useState(false);
-  const doRestore = useRestoreSkillConfiguration({
+  const doRestore = useRestoreSkill({
     owner,
     skill: skill,
   });

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -40,7 +40,7 @@ export function useAgentConfigurationActions(
   };
 }
 
-export function useSkillConfigurationTools(
+export function useSkillTools(
   owner: LightWorkspaceType,
   skillConfigurationId: string | null
 ) {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -23,7 +23,7 @@ import type {
   SkillType,
 } from "@app/types/assistant/skill_configuration";
 
-export function useSkillConfigurations({
+export function useSkills({
   owner,
   disabled,
   status,
@@ -51,7 +51,7 @@ export function useSkillConfigurations({
   };
 }
 
-export function useSkillConfigurationsWithRelations({
+export function useSkillsWithRelations({
   owner,
   disabled,
   status,
@@ -98,7 +98,7 @@ export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
   return { getSimilarSkills };
 }
 
-export function useArchiveSkillConfiguration({
+export function useArchiveSkill({
   owner,
   skillConfiguration,
 }: {
@@ -107,13 +107,13 @@ export function useArchiveSkillConfiguration({
 }) {
   const sendNotification = useSendNotification();
   const { mutateSkillConfigurationsWithRelations: mutateArchivedSkills } =
-    useSkillConfigurationsWithRelations({
+    useSkillsWithRelations({
       owner,
       status: "archived",
       disabled: true,
     });
   const { mutateSkillConfigurationsWithRelations: mutateActiveSkills } =
-    useSkillConfigurationsWithRelations({
+    useSkillsWithRelations({
       owner,
       status: "active",
       disabled: true,
@@ -154,7 +154,7 @@ export function useArchiveSkillConfiguration({
   return doArchive;
 }
 
-export function useRestoreSkillConfiguration({
+export function useRestoreSkill({
   owner,
   skill,
 }: {
@@ -163,13 +163,13 @@ export function useRestoreSkillConfiguration({
 }) {
   const sendNotification = useSendNotification();
   const { mutateSkillConfigurationsWithRelations: mutateArchivedSkills } =
-    useSkillConfigurationsWithRelations({
+    useSkillsWithRelations({
       owner,
       status: "archived",
       disabled: true,
     });
   const { mutateSkillConfigurationsWithRelations: mutateActiveSkills } =
-    useSkillConfigurationsWithRelations({
+    useSkillsWithRelations({
       owner,
       status: "active",
       disabled: true,
@@ -210,7 +210,7 @@ export function useRestoreSkillConfiguration({
   return doRestore;
 }
 
-export function useSkillConfigurationHistory({
+export function useSkillHistory({
   owner,
   skillConfiguration,
   limit,

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -44,10 +44,10 @@ export function useSkills({
   );
 
   return {
-    skillConfigurations: data?.skillConfigurations ?? emptyArray(),
-    isSkillConfigurationsError: !!error,
-    isSkillConfigurationsLoading: isLoading,
-    mutateSkillConfigurations: mutate,
+    skills: data?.skillConfigurations ?? emptyArray(),
+    isSkillsError: !!error,
+    isSkillsLoading: isLoading,
+    mutateSkills: mutate,
   };
 }
 
@@ -70,9 +70,9 @@ export function useSkillsWithRelations({
   );
 
   return {
-    skillConfigurationsWithRelations: data?.skillConfigurations ?? emptyArray(),
-    isSkillConfigurationsWithRelationsLoading: isLoading,
-    mutateSkillConfigurationsWithRelations: mutate,
+    skillsWithRelations: data?.skillConfigurations ?? emptyArray(),
+    isSkillsWithRelationsLoading: isLoading,
+    mutateSkillsWithRelations: mutate,
   };
 }
 
@@ -106,13 +106,13 @@ export function useArchiveSkill({
   skillConfiguration: SkillType;
 }) {
   const sendNotification = useSendNotification();
-  const { mutateSkillConfigurationsWithRelations: mutateArchivedSkills } =
+  const { mutateSkillsWithRelations: mutateArchivedSkills } =
     useSkillsWithRelations({
       owner,
       status: "archived",
       disabled: true,
     });
-  const { mutateSkillConfigurationsWithRelations: mutateActiveSkills } =
+  const { mutateSkillsWithRelations: mutateActiveSkills } =
     useSkillsWithRelations({
       owner,
       status: "active",
@@ -162,13 +162,13 @@ export function useRestoreSkill({
   skill: SkillType;
 }) {
   const sendNotification = useSendNotification();
-  const { mutateSkillConfigurationsWithRelations: mutateArchivedSkills } =
+  const { mutateSkillsWithRelations: mutateArchivedSkills } =
     useSkillsWithRelations({
       owner,
       status: "archived",
       disabled: true,
     });
-  const { mutateSkillConfigurationsWithRelations: mutateActiveSkills } =
+  const { mutateSkillsWithRelations: mutateActiveSkills } =
     useSkillsWithRelations({
       owner,
       status: "active",
@@ -234,10 +234,10 @@ export function useSkillHistory({
   );
 
   return {
-    skillConfigurationHistory: data?.history,
-    isSkillConfigurationHistoryLoading: !error && !data && !disabled,
-    isSkillConfigurationHistoryError: error,
-    mutateSkillConfigurationHistory: mutate,
+    skillHistory: data?.history,
+    isSkillHistoryLoading: !error && !data && !disabled,
+    isSkillHistoryError: error,
+    mutateSkillHistory: mutate,
   };
 }
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -32,14 +32,13 @@ export function useSkills({
   disabled?: boolean;
   status?: SkillStatus;
 }) {
-  const skillConfigurationsFetcher: Fetcher<GetSkillConfigurationsResponseBody> =
-    fetcher;
+  const skillsFetcher: Fetcher<GetSkillConfigurationsResponseBody> = fetcher;
 
   const statusQueryParam = status ? `?status=${status}` : "";
 
   const { data, error, isLoading, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/skills${statusQueryParam}`,
-    skillConfigurationsFetcher,
+    skillsFetcher,
     { disabled }
   );
 
@@ -60,12 +59,12 @@ export function useSkillsWithRelations({
   disabled?: boolean;
   status: SkillStatus;
 }) {
-  const skillConfigurationsFetcher: Fetcher<GetSkillConfigurationsWithRelationsResponseBody> =
+  const skillsFetcher: Fetcher<GetSkillConfigurationsWithRelationsResponseBody> =
     fetcher;
 
   const { data, isLoading, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/skills?withRelations=true&status=${status}`,
-    skillConfigurationsFetcher,
+    skillsFetcher,
     { disabled }
   );
 
@@ -221,7 +220,7 @@ export function useSkillHistory({
   limit?: number;
   disabled?: boolean;
 }) {
-  const skillConfigurationHistoryFetcher: Fetcher<GetSkillConfigurationsHistoryResponseBody> =
+  const skillHistoryFetcher: Fetcher<GetSkillConfigurationsHistoryResponseBody> =
     fetcher;
 
   const queryParams = limit ? `?limit=${limit}` : "";
@@ -229,7 +228,7 @@ export function useSkillHistory({
     skillConfiguration
       ? `/api/w/${owner.sId}/skills/${skillConfiguration.sId}/history${queryParams}`
       : null,
-    skillConfigurationHistoryFetcher,
+    skillHistoryFetcher,
     { disabled }
   );
 
@@ -250,12 +249,11 @@ export function useSkillWithRelations({
   disabled?: boolean;
   skillId: string;
 }) {
-  const skillConfigurationsFetcher: Fetcher<GetSkillWithRelationsResponseBody> =
-    fetcher;
+  const skillsFetcher: Fetcher<GetSkillWithRelationsResponseBody> = fetcher;
 
   const { data, isLoading } = useSWRWithDefaults(
     `/api/w/${owner.sId}/skills/${skillId}?withRelations=true`,
-    skillConfigurationsFetcher,
+    skillsFetcher,
     { disabled }
   );
 

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -126,16 +126,16 @@ export default function WorkspaceSkills({
   }, [selectedTab, skillSearch]);
 
   const {
-    skillConfigurationsWithRelations: activeSkills,
-    isSkillConfigurationsWithRelationsLoading: isActiveLoading,
+    skillsWithRelations: activeSkills,
+    isSkillsWithRelationsLoading: isActiveLoading,
   } = useSkillsWithRelations({
     owner,
     status: "active",
   });
 
   const {
-    skillConfigurationsWithRelations: archivedSkills,
-    isSkillConfigurationsWithRelationsLoading: isArchivedLoading,
+    skillsWithRelations: archivedSkills,
+    isSkillsWithRelationsLoading: isArchivedLoading,
   } = useSkillsWithRelations({
     owner,
     status: "archived",

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -23,7 +23,7 @@ import { useHashParam } from "@app/hooks/useHashParams";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SKILL_ICON } from "@app/lib/skill";
-import { useSkillConfigurationsWithRelations } from "@app/lib/swr/skill_configurations";
+import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
@@ -128,7 +128,7 @@ export default function WorkspaceSkills({
   const {
     skillConfigurationsWithRelations: activeSkills,
     isSkillConfigurationsWithRelationsLoading: isActiveLoading,
-  } = useSkillConfigurationsWithRelations({
+  } = useSkillsWithRelations({
     owner,
     status: "active",
   });
@@ -136,7 +136,7 @@ export default function WorkspaceSkills({
   const {
     skillConfigurationsWithRelations: archivedSkills,
     isSkillConfigurationsWithRelationsLoading: isArchivedLoading,
-  } = useSkillConfigurationsWithRelations({
+  } = useSkillsWithRelations({
     owner,
     status: "archived",
     disabled: activeTab !== "archived",


### PR DESCRIPTION
## Description

- This PR shortens the name of the hooks relative to skills by removing the `Configuration` prefix (`SkillConfiguration` -> `Skill`).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
