### PR TITLE
[front] chore(skills): cleanup indexes

### DIFF
--- a/front/lib/models/skill/agent_message_skill.ts
+++ b/front/lib/models/skill/agent_message_skill.ts
@@ -74,12 +74,7 @@ AgentMessageSkillModel.init(
   {
     modelName: "agent_message_skills",
     sequelize: frontSequelize,
-    indexes: [
-      {
-        fields: ["workspaceId", "conversationId", "agentConfigurationId"],
-        name: "agent_message_skills_wid_cid_acid",
-      },
-    ],
+    indexes: [],
     validate: {
       eitherGlobalOrCustomSkill() {
         const hasCustomSkill = this.customSkillId !== null;

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -66,13 +66,7 @@ ConversationSkillModel.init(
   {
     modelName: "conversation_skills",
     sequelize: frontSequelize,
-    indexes: [
-      {
-        fields: ["workspaceId", "conversationId", "agentConfigurationId"],
-        name: "conversation_skills_wid_cid_acid",
-        unique: true,
-      },
-    ],
+    indexes: [],
     validate: {
       eitherGlobalOrCustomSkill() {
         const hasCustomSkill = this.customSkillId !== null;

--- a/front/migrations/db/migration_450.sql
+++ b/front/migrations/db/migration_450.sql
@@ -1,0 +1,3 @@
+-- Migration created on Dec 17, 2025
+DROP INDEX "public"."agent_message_skills_wid_cid_acid";
+DROP INDEX "public"."conversation_skills_wid_cid_acid";


### PR DESCRIPTION
## Description

- The unique index `("workspaceId", "conversationId", "agentConfigurationId")` on `conversation_skills` is incorrect as the same agent can enable multiple different skills within the same conversation.
- The same index on `agent_message_skills` is not unique so will not break, but will not optimize any query.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Run migration.
