### PR TITLE
[front] chore(skills): remove non attributes and unused belongsTo getters

### DIFF
--- a/front/lib/models/agent/agent_skill.ts
+++ b/front/lib/models/agent/agent_skill.ts
@@ -1,10 +1,5 @@
 import isNil from "lodash/isNil";
-import type {
-  BelongsToGetAssociationMixin,
-  CreationOptional,
-  ForeignKey,
-  NonAttribute,
-} from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -16,15 +11,10 @@ export class AgentSkillModel extends WorkspaceAwareModel<AgentSkillModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare customSkill: NonAttribute<SkillConfigurationModel> | null;
   declare customSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
   declare globalSkillId: string | null;
 
-  declare agentConfiguration: NonAttribute<AgentConfigurationModel>;
   declare agentConfigurationId: ForeignKey<AgentConfigurationModel["id"]>;
-
-  declare getCustomSkill: BelongsToGetAssociationMixin<SkillConfigurationModel>;
-  declare getAgentConfigurationModel: BelongsToGetAssociationMixin<AgentConfigurationModel>;
 }
 
 AgentSkillModel.init(

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -2,7 +2,6 @@ import type {
   CreationOptional,
   ForeignKey,
   ModelAttributes,
-  NonAttribute,
 } from "sequelize";
 import { DataTypes } from "sequelize";
 
@@ -68,11 +67,6 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   declare authorId: ForeignKey<UserModel["id"]>;
 
   declare requestedSpaceIds: number[];
-
-  declare author: NonAttribute<UserModel>;
-  declare mcpServerConfigurations: NonAttribute<
-    SkillMCPServerConfigurationModel[]
-  >;
 }
 
 SkillConfigurationModel.init(SKILL_MODEL_ATTRIBUTES, {
@@ -85,7 +79,6 @@ SkillConfigurationModel.init(SKILL_MODEL_ATTRIBUTES, {
 
 export class SkillVersionModel extends SkillConfigurationModel {
   declare skillConfigurationId: ForeignKey<SkillConfigurationModel["id"]>;
-  declare skillConfiguration: NonAttribute<SkillConfigurationModel>;
   declare mcpServerConfigurationIds: number[];
   declare version: number;
 }
@@ -146,9 +139,6 @@ export class SkillMCPServerConfigurationModel extends WorkspaceAwareModel<SkillM
 
   declare skillConfigurationId: ForeignKey<SkillConfigurationModel["id"]>;
   declare mcpServerViewId: ForeignKey<MCPServerViewModel["id"]>;
-
-  declare skillConfiguration: NonAttribute<SkillConfigurationModel>;
-  declare mcpServerView: NonAttribute<MCPServerViewModel>;
 }
 
 SkillMCPServerConfigurationModel.init(

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -1,8 +1,4 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  ModelAttributes,
-} from "sequelize";
+import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -2,7 +2,6 @@ import type {
   CreationOptional,
   ForeignKey,
   ModelAttributes,
-  NonAttribute,
 } from "sequelize";
 import { DataTypes } from "sequelize";
 
@@ -88,7 +87,6 @@ export class ConversationSkillModel extends WorkspaceAwareModel<ConversationSkil
 
   declare agentConfigurationId: string;
 
-  declare customSkill: NonAttribute<SkillConfigurationModel> | null;
   declare customSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
   declare globalSkillId: string | null;
 

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -1,8 +1,4 @@
-import type {
-  CreationOptional,
-  ForeignKey,
-  ModelAttributes,
-} from "sequelize";
+import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import {

--- a/front/lib/models/skill/group_skill.ts
+++ b/front/lib/models/skill/group_skill.ts
@@ -1,8 +1,4 @@
-import type {
-  BelongsToGetAssociationMixin,
-  CreationOptional,
-  ForeignKey,
-} from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { SkillConfigurationModel } from "@app/lib/models/skill";
@@ -17,9 +13,6 @@ export class GroupSkillModel extends WorkspaceAwareModel<GroupSkillModel> {
 
   declare groupId: ForeignKey<GroupModel["id"]>;
   declare skillConfigurationId: ForeignKey<SkillConfigurationModel["id"]>;
-
-  declare getGroup: BelongsToGetAssociationMixin<GroupModel>;
-  declare getSkillConfiguration: BelongsToGetAssociationMixin<SkillConfigurationModel>;
 }
 
 GroupSkillModel.init(


### PR DESCRIPTION
## Description

- This PR removes unused NonAttributes and belongsTo getters on skill models.
- We will very rarely use those, and rely on separate queries instead.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
- No migration actually, the changes on model files are only non attributes and getters, no data model change
