### PR TITLE
[front] - chore(AttachmentPicker): use DropdownMenuFilters

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.20",
-        "@dust-tt/sparkle": "^0.4.23",
+        "@dust-tt/sparkle": "^0.4.24",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1285,10 +1285,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.23.tgz",
-      "integrity": "sha512-rIJYE/UdQbaC/Xe5ByNiaGedkYhdtrQjWgb9cfWLhuqh+KZM4Sf7ffvVebFSQ+8La5i8LVaQgdr79HZsq3rs9w==",
-      "license": "ISC",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.24.tgz",
+      "integrity": "sha512-hl3Dt46YrCxpsoF1kg4t6sZcDUXW/wrE+UGlTdSfcsnbzWK1N7nvTwjssoISAYcfv22R9cRoLKcZMDCxwRp8Jw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.20",
-    "@dust-tt/sparkle": "^0.4.23",
+    "@dust-tt/sparkle": "^0.4.24",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -454,19 +454,21 @@ export const InputBarAttachmentsPicker = ({
       >
         {searchQuery ? (
           <div ref={itemsContainerRef}>
-            {showLoader && (
-              <div className="flex h-7 items-center justify-center last:grow">
-                <Spinner variant="dark" size="xs" />
-              </div>
-            )}
-            {availableSources.length > 1 && (
-              <DropdownMenuFilters
-                filters={availableSources}
-                selectedValues={selectedFilterKeys}
-                onSelectFilter={handleFilterClick}
-                className="grow"
-              />
-            )}
+            <div className="flex flex-wrap items-center gap-0.5 p-2">
+              {showLoader && (
+                <div className="flex h-7 items-center justify-center last:grow">
+                  <Spinner variant="dark" size="xs" />
+                </div>
+              )}
+              {availableSources.length > 1 && (
+                <DropdownMenuFilters
+                  filters={[{ label: "test", value: "test" }]}
+                  selectedValues={selectedFilterKeys}
+                  onSelectFilter={handleFilterClick}
+                  className="grow"
+                />
+              )}
+            </div>
             {Object.keys(serversWithResults).length === 0 ? (
               // No tools results - show knowledge nodes as returned by the search
               dataSourcesNodes

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -1,3 +1,4 @@
+import type { DropdownMenuFilterOption } from "@dust-tt/sparkle";
 import {
   AttachmentIcon,
   Button,
@@ -6,6 +7,7 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuFilters,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -362,20 +364,26 @@ export const InputBarAttachmentsPicker = ({
   const showLoader =
     isSearchLoading || isLoadingNextPage || isSearchValidating || isDebouncing;
 
-  const availableSources = [
+  const availableSources: DropdownMenuFilterOption[] = [
     ...Object.entries(dataSourcesWithResults).map(([key, r]) => ({
-      key,
+      value: key,
       label: getDisplayNameForDataSource(r.dataSource, true),
     })),
     ...Object.entries(serversWithResults).map(([key, s]) => ({
-      key,
+      value: key,
       label: asDisplayToolName(s.server.serverName),
     })),
   ];
 
-  const allUnselected = Object.values(selectedDataSourcesAndTools).every(
-    (value) => !value
+  const selectedFilterKeys = useMemo(
+    () =>
+      Object.entries(selectedDataSourcesAndTools)
+        .filter(([, value]) => value)
+        .map(([key]) => key),
+    [selectedDataSourcesAndTools]
   );
+
+  const allUnselected = selectedFilterKeys.length === 0;
   return (
     <DropdownMenu
       open={isOpen}
@@ -446,29 +454,19 @@ export const InputBarAttachmentsPicker = ({
       >
         {searchQuery ? (
           <div ref={itemsContainerRef}>
-            <div className="flex flex-wrap items-center gap-0.5 p-2">
-              {showLoader && (
-                <div className="flex h-7 items-center justify-center last:grow">
-                  <Spinner variant="dark" size="xs" />
-                </div>
-              )}
-              {availableSources.length > 1 &&
-                availableSources.map(({ key, label }) => (
-                  <Button
-                    size="xs"
-                    variant={
-                      selectedDataSourcesAndTools[key] ? "outline" : "ghost"
-                    }
-                    className={
-                      selectedDataSourcesAndTools[key]
-                        ? "text-blue-500 hover:text-blue-500"
-                        : ""
-                    }
-                    label={label}
-                    onClick={() => handleFilterClick(key)}
-                  />
-                ))}
-            </div>
+            {showLoader && (
+              <div className="flex h-7 items-center justify-center last:grow">
+                <Spinner variant="dark" size="xs" />
+              </div>
+            )}
+            {availableSources.length > 1 && (
+              <DropdownMenuFilters
+                filters={availableSources}
+                selectedValues={selectedFilterKeys}
+                onSelectFilter={handleFilterClick}
+                className="grow"
+              />
+            )}
             {Object.keys(serversWithResults).length === 0 ? (
               // No tools results - show knowledge nodes as returned by the search
               dataSourcesNodes

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.23",
+        "@dust-tt/sparkle": "^0.4.24",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1309,10 +1309,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.23.tgz",
-      "integrity": "sha512-rIJYE/UdQbaC/Xe5ByNiaGedkYhdtrQjWgb9cfWLhuqh+KZM4Sf7ffvVebFSQ+8La5i8LVaQgdr79HZsq3rs9w==",
-      "license": "ISC",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.24.tgz",
+      "integrity": "sha512-hl3Dt46YrCxpsoF1kg4t6sZcDUXW/wrE+UGlTdSfcsnbzWK1N7nvTwjssoISAYcfv22R9cRoLKcZMDCxwRp8Jw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -38,7 +38,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.23",
+    "@dust-tt/sparkle": "^0.4.24",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

This PR upgrades `@dust-tt/sparkle` to `0.4.24` and refactors the `InputBarAttachmentsPicker` to use the new `DropdownMenuFilters` component instead of custom filter buttons. The new component provides a more consistent and maintainable approach to displaying filter chips for data sources and tools in the attachments picker.

## Risk
Low - UI refactoring using a new Sparkle component, with library upgrade from 0.4.23 to 0.4.24.

## Tests
Manual testing of the attachment picker filtering UI.

## Deploy Plan
* Publish Sparkle 0.4.24
* Deploy front and extension
