### PR TITLE
[front] fix: Split migration 449 in two

### DIFF
--- a/front/migrations/db/migration_449.sql
+++ b/front/migrations/db/migration_449.sql
@@ -1,3 +1,1 @@
 ALTER TABLE "triggers" ADD COLUMN "origin" VARCHAR(255);
-UPDATE "triggers" SET "origin" = 'user' WHERE "origin" IS NULL;
-ALTER TABLE "triggers" ALTER COLUMN "origin" SET NOT NULL;

--- a/front/migrations/db/migration_451.sql
+++ b/front/migrations/db/migration_451.sql
@@ -1,0 +1,2 @@
+UPDATE "triggers" SET "origin" = 'user' WHERE "origin" IS NULL;
+ALTER TABLE "triggers" ALTER COLUMN "origin" SET NOT NULL;


### PR DESCRIPTION
## Description

- Split 449 in two to avoid having null origin being inserted (and crash) during deploy

## Tests

N/A

## Risk

- Low
- Blast Radius: Trigger

## Deploy Plan

- [x] run 449
- [x] deploy front
- [ ] run 451