### PR TITLE
Fix tool attachment source info display in posted messages

### DIFF
--- a/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
@@ -151,7 +151,7 @@ export const InputBarAttachmentsPicker = ({
             <DropdownMenuSearchbar
               autoFocus
               name="search-files"
-              placeholder="Search knowledge"
+              placeholder="Search"
               value={search}
               onChange={setSearch}
               disabled={isLoading}

--- a/front/components/assistant/conversation/attachment/utils.tsx
+++ b/front/components/assistant/conversation/attachment/utils.tsx
@@ -204,12 +204,16 @@ export function contentFragmentToAttachmentCitation(
       title,
       sourceUrl: contentFragment.sourceUrl,
       visual: (
-        <IconForAttachmentCitation contentType={contentFragment.contentType} />
+        <IconForAttachmentCitation
+          contentType={contentFragment.contentType}
+          iconName={contentFragment.sourceIcon ?? undefined}
+        />
       ),
       description: description ?? null,
       fileId: contentFragment.fileId,
       contentType: contentFragment.contentType,
       attachmentCitationType: "fragment",
+      provider: contentFragment.sourceProvider ?? undefined,
     };
   }
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -255,6 +255,7 @@ export const InputBar = React.memo(function InputBar({
               title: cf.filename,
               fileId: cf.fileId,
               contentType: cf.contentType,
+              url: cf.sourceUrl,
             };
           }),
           contentNodes: attachedNodes,
@@ -278,6 +279,7 @@ export const InputBar = React.memo(function InputBar({
             title: cf.filename,
             fileId: cf.fileId,
             contentType: cf.contentType,
+            url: cf.sourceUrl,
           };
         }),
         contentNodes: attachedNodes,

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -418,7 +418,7 @@ export const InputBarAttachmentsPicker = ({
             <DropdownMenuSearchbar
               autoFocus
               name="search-files"
-              placeholder="Search knowledge"
+              placeholder="Search"
               value={search}
               onChange={setSearch}
               disabled={isLoading}

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -95,6 +95,8 @@ export function createPlaceholderUserMessage({
             contentFragmentId: "placeholder-content-fragment",
             contentFragmentVersion: "latest" as const,
             expiredReason: null,
+            sourceProvider: null,
+            sourceIcon: null,
           }) satisfies FileContentFragmentType
       ),
       ...(contentFragments?.contentNodes ?? []).map(
@@ -223,6 +225,7 @@ export async function submitMessage({
             body: JSON.stringify({
               title: contentFragment.title,
               fileId: contentFragment.fileId,
+              url: contentFragment.url,
               context: {
                 timezone:
                   Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
@@ -384,7 +387,7 @@ export async function createConversationWithMessage({
     contentFragments: [
       ...contentFragments.uploaded.map((cf) => ({
         title: cf.title,
-
+        url: cf.url,
         context: {
           profilePictureUrl: user.image,
         },

--- a/front/hooks/useToolFileUpload.ts
+++ b/front/hooks/useToolFileUpload.ts
@@ -59,6 +59,8 @@ export function useToolFileUpload({
               serverViewId: toolFile.serverViewId,
               externalId: toolFile.externalId,
               conversationId,
+              serverName: toolFile.serverName,
+              serverIcon: toolFile.serverIcon,
             }),
           }
         );

--- a/front/lib/api/assistant/conversation/getRelatedContentFragments.test.ts
+++ b/front/lib/api/assistant/conversation/getRelatedContentFragments.test.ts
@@ -39,6 +39,8 @@ function createMockContentFragment(
     generatedTables: [],
     textUrl: "https://example.com/text",
     textBytes: 100,
+    sourceProvider: null,
+    sourceIcon: null,
   };
 }
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -324,6 +324,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           generatedTables: [],
           textUrl: null,
           textBytes: null,
+          sourceProvider: null,
+          sourceIcon: null,
         };
       } else if (contentFragmentType === "content_node") {
         return {
@@ -350,6 +352,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       let fileStringId: string | null = null;
       let snippet: string | null = null;
       let generatedTables: string[] = [];
+      let sourceProvider: string | null = null;
+      let sourceIcon: string | null = null;
       let file: FileResource | null = null;
       if (this.fileId) {
         file = await FileResource.fetchByModelIdWithAuth(auth, this.fileId);
@@ -360,6 +364,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         fileStringId = file.sId;
         snippet = file.snippet;
         generatedTables = file.useCaseMetadata?.generatedTables ?? [];
+        sourceProvider = file.useCaseMetadata?.sourceProvider ?? null;
+        sourceIcon = file.useCaseMetadata?.sourceIcon ?? null;
       }
 
       return {
@@ -371,6 +377,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         generatedTables,
         textUrl: location.downloadUrl,
         textBytes: this.textBytes,
+        sourceProvider,
+        sourceIcon,
       } satisfies FileContentFragmentType;
     } else if (contentFragmentType === "content_node") {
       assert(

--- a/front/lib/search/tools/search.ts
+++ b/front/lib/search/tools/search.ts
@@ -242,6 +242,8 @@ export async function downloadAndUploadToolFile({
   externalId,
   conversationId,
   metadata,
+  serverName,
+  serverIcon,
 }: {
   auth: Authenticator;
   tool: SearchableTool;
@@ -249,6 +251,8 @@ export async function downloadAndUploadToolFile({
   externalId: string;
   conversationId?: string;
   metadata?: Record<string, string>;
+  serverName?: string;
+  serverIcon?: string;
 }): Promise<Result<FileType, Error>> {
   const user = auth.getNonNullableUser();
   const owner = auth.getNonNullableWorkspace();
@@ -291,7 +295,11 @@ export async function downloadAndUploadToolFile({
     userId: user.id,
     workspaceId: owner.id,
     useCase: "conversation",
-    useCaseMetadata: conversationId ? { conversationId } : null,
+    useCaseMetadata: {
+      ...(conversationId ? { conversationId } : {}),
+      ...(serverName ? { sourceProvider: serverName } : {}),
+      ...(serverIcon ? { sourceIcon: serverIcon } : {}),
+    },
   });
 
   const processResult = await processAndStoreFile(auth, {

--- a/front/pages/api/w/[wId]/search/tools/upload.ts
+++ b/front/pages/api/w/[wId]/search/tools/upload.ts
@@ -8,6 +8,7 @@ import {
 } from "@app/lib/search/tools/search";
 import { apiError } from "@app/logger/withlogging";
 import type { FileType, WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 interface ToolUploadResponseBody {
   file: FileType;
@@ -28,7 +29,8 @@ async function handler(
     });
   }
 
-  const { serverViewId, externalId, conversationId } = req.body;
+  const { serverViewId, externalId, conversationId, serverName, serverIcon } =
+    req.body;
 
   if (typeof serverViewId !== "string" || serverViewId.length < 1) {
     return apiError(req, res, {
@@ -60,6 +62,26 @@ async function handler(
     });
   }
 
+  if (serverName !== undefined && !isString(serverName)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "serverName must be a string.",
+      },
+    });
+  }
+
+  if (serverIcon !== undefined && !isString(serverIcon)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "serverIcon must be a string.",
+      },
+    });
+  }
+
   const tokenResult = await getToolAccessToken({ auth, serverViewId });
   if (tokenResult.isErr()) {
     return apiError(req, res, {
@@ -79,6 +101,8 @@ async function handler(
     externalId,
     conversationId,
     metadata,
+    serverName,
+    serverIcon,
   });
 
   if (result.isErr()) {

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -83,6 +83,8 @@ export type FileContentFragmentType = BaseContentFragmentType & {
         generatedTables: string[];
         textUrl: string;
         textBytes: number | null;
+        sourceProvider: string | null;
+        sourceIcon: string | null;
       }
     | {
         expiredReason: ContentFragmentExpiredReason;
@@ -91,6 +93,8 @@ export type FileContentFragmentType = BaseContentFragmentType & {
         generatedTables: [];
         textUrl: null;
         textBytes: null;
+        sourceProvider: null;
+        sourceIcon: null;
       }
   );
 
@@ -102,6 +106,7 @@ export type UploadedContentFragment = {
   fileId: string;
   title: string;
   contentType: SupportedContentFragmentType;
+  url?: string;
 };
 
 export type ContentFragmentsType = {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -29,6 +29,8 @@ export type FileUseCaseMetadata = {
   spaceId?: string;
   generatedTables?: string[];
   lastEditedByAgentConfigurationId?: string;
+  sourceProvider?: string;
+  sourceIcon?: string;
 };
 
 export function isConversationFileUseCase(


### PR DESCRIPTION
## Description

### Goal of this PR

- Fixes tool attachments (e.g., from Notion, Google Drive) losing their source information (icon, provider name, source URL) after the message is posted
- Before: attachments showed the correct tool icon in the input bar, but reverted to a generic file icon once submitted
- After: attachments retain their source icon, provider name, and source URL throughout the conversation

| On input bar  | When posted|
| ------------- | ------------- |
| <img width="830" height="307" alt="Screenshot 2025-12-17 at 10 02 51" src="https://github.com/user-attachments/assets/a2640d32-3d9e-44d2-a3af-779d919fe3ca" />  | <img width="451" height="250" alt="Screenshot 2025-12-17 at 10 03 23" src="https://github.com/user-attachments/assets/029ed17f-76ca-461f-b890-da5e18742ca0" /> |





### Design choices to be challenged


We needed to persist three pieces of source information: **sourceUrl**, **sourceProvider**, and **sourceIcon**.
  
For **sourceUrl**:  
We reuse the existing url field in ContentFragmentInputWithFileIdType. This field was already designed for this purpose and flows directly from the frontend to ContentFragmentModel.sourceUrl. No new storage needed.

For **sourceProvider** and **sourceIcon**: 
We store these in FileUseCaseMetadata (JSONB field on FileModel). When rendering the content fragment, we read them from the associated file. This approach:
- Requires no database migration
- Has zero additional query cost since we already fetch the file to get snippet and generatedTables
- Keeps a single source of truth in file metadata

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
