### PR TITLE
Change action bar wording

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -29,7 +29,7 @@ import { useCancelMessage, useConversation } from "@app/lib/swr/conversations";
 import { emptyArray } from "@app/lib/swr/swr";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { RichMention } from "@app/types";
-import { conjugate, pluralize, toRichAgentMentionType } from "@app/types";
+import { pluralize, toRichAgentMentionType } from "@app/types";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 
@@ -192,14 +192,14 @@ export const AgentInputBar = ({
           className="max-h-dvh mb-5 flex w-full"
         >
           <span className="font-bold">
-            {blockedActions.length} action
+            {blockedActions.length} manual action
             {pluralize(blockedActions.length)}
           </span>{" "}
-          require{conjugate(blockedActions.length)} a manual action
+          required
           {/* If there are pending validations, we show a button allowing to cycle through the blocked actions messages. */}
           {hasPendingValidations(context.user.sId) && (
             <ContentMessageAction
-              label="Review actions"
+              label="Review"
               variant="outline"
               size="xs"
               onClick={() => {


### PR DESCRIPTION
## Description

Improve the wording of the new "action bar" at the bottom of the conversation, in order to remove the redundancy while keeping the meaning clear.

Before:
<img width="933" height="110" alt="image" src="https://github.com/user-attachments/assets/7b7b62c8-f5d8-44df-82c1-c774873b60e2" />

After
<img width="933" height="110" alt="image" src="https://github.com/user-attachments/assets/5206c31e-04fe-4681-a487-e4f09873fa69" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
