### PR TITLE
[front] fix lint on unused symbol in `getJITServers`

### DIFF
--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -209,10 +209,7 @@ export async function getJITServers(
         );
 
       // Only add if the view exists (workspace has schedules_management feature flag)
-      if (
-        schedulesManagementView &&
-        !agentMcpServerViewIds.includes(schedulesManagementView.sId)
-      ) {
+      if (schedulesManagementView) {
         const schedulesManagementViewJSON = schedulesManagementView.toJSON();
         const schedulesManagementServer: ServerSideMCPServerConfigurationType =
           {


### PR DESCRIPTION
## Description

- Two commits got crossed, one that added a JIT server and one that removed the server deduplication in `getJITServers`.

## Tests

## Risk

## Deploy Plan

- Deploy front.
