### PR TITLE
Fix: in case of a large number of events, we would not fetch complete history resulting in stuck agent until the redis TTL was reached.

### DIFF
--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -40,6 +40,7 @@ procs:
       echo "Expecting file: $READY_FILE"
       while [ ! -f "$READY_FILE" ]; do sleep 1; done
       echo "sdks-js ready. Starting front."
+      rm -rf node_modules/isomorphic-dompurify node_modules/@elevenlabs/
       source ~/.nvm/nvm.sh && nvm install && npm install && ./admin/dev.sh
 
   front-workers:


### PR DESCRIPTION
## Description

Fix a nasty but quite serious issue where we would only see the first X events when replaying history.
This PR fixes it by forcing a "close" event if the history events >= HISTORY_COUNT.
It fixes all clients and both public and private api.

## Tests

Could repro the bug locally 100% with a small history count.

## Risk

Low

## Deploy Plan

Deploy front