### PR TITLE
Optimize check-package-lock-sync.sh -> run only if changes on a package.json

### DIFF
--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -110,6 +110,8 @@ export function ensureFileSize(
     return fileSize <= MAX_FILE_SIZES[format.cat];
   }
 
+  console.log("is this used?");
+
   return false;
 }
 


### PR DESCRIPTION
## Description

  - Optimize check-package-lock-sync.sh to only run when package.json files are actually changed in the commit
  - Skip the sync check entirely if no package.json files were modified, avoiding unnecessary npm install --package-lock-only
  operations

## Tests

Locally. 

## Risk

Rollback possible. 

## Deploy Plan

/ 