### PR TITLE
feat: display instructions blocks in agent details

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -7,6 +7,11 @@ import {
   getCiteDirective,
 } from "@app/components/markdown/CiteBlock";
 import { getImgPlugin, imgDirective } from "@app/components/markdown/Image";
+import {
+  InstructionBlock,
+  instructionBlockDirective,
+  preprocessInstructionBlocks,
+} from "@app/components/markdown/InstructionBlock";
 import { quickReplyDirective } from "@app/components/markdown/QuickReplyBlock";
 import { toolDirective } from "@app/components/markdown/tool/tool";
 import { visualizationDirective } from "@app/components/markdown/VisualizationBlock";
@@ -31,6 +36,12 @@ export const AgentMessageMarkdown = ({
   isStreaming?: boolean;
   additionalMarkdownComponents?: Components;
 }) => {
+  // Preprocess content to handle instruction blocks
+  const processedContent = React.useMemo(
+    () => preprocessInstructionBlocks(content),
+    [content]
+  );
+
   const markdownComponents: Components = React.useMemo(
     () => ({
       sup: CiteBlock,
@@ -38,6 +49,7 @@ export const AgentMessageMarkdown = ({
       mention: getAgentMentionPlugin(owner),
       mention_user: getUserMentionPlugin(owner),
       dustimg: getImgPlugin(owner),
+      instruction_block: InstructionBlock,
       ...additionalMarkdownComponents,
     }),
     [owner, additionalMarkdownComponents]
@@ -52,13 +64,14 @@ export const AgentMessageMarkdown = ({
       imgDirective,
       toolDirective,
       quickReplyDirective,
+      instructionBlockDirective,
     ],
     []
   );
 
   return (
     <Markdown
-      content={content}
+      content={processedContent}
       additionalMarkdownComponents={markdownComponents}
       additionalMarkdownPlugins={additionalMarkdownPlugins}
       isLastMessage={isLastMessage}

--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -128,15 +128,13 @@ export function AgentDetails({
   );
 
   const showPerformanceTabs =
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    (agentConfiguration?.canEdit || isAdmin(owner)) &&
+    (agentConfiguration?.canEdit ?? isAdmin(owner)) &&
     agentId != null &&
     !isGlobalAgent;
 
   const showInsightsTabs =
     agentId != null &&
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    (agentConfiguration?.canEdit || isAdmin(owner)) &&
+    (agentConfiguration?.canEdit ?? isAdmin(owner)) &&
     !isGlobalAgent;
 
   const DescriptionSection = () => {

--- a/front/components/markdown/InstructionBlock.test.ts
+++ b/front/components/markdown/InstructionBlock.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { preprocessInstructionBlocks } from "./InstructionBlock";
+
+describe("preprocessInstructionBlocks", () => {
+  it("converts simple instruction blocks", () => {
+    const input = "<instructions>Some content</instructions>";
+    const expected = ":::instruction_block[instructions]\nSome content\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("handles custom tag names", () => {
+    const input = "<my_custom_tag>Content here</my_custom_tag>";
+    const expected = ":::instruction_block[my_custom_tag]\nContent here\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("preserves multiline content", () => {
+    const input = "<instructions>\nLine 1\nLine 2\n</instructions>";
+    const expected =
+      ":::instruction_block[instructions]\n\nLine 1\nLine 2\n\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("handles multiple instruction blocks", () => {
+    const input = "<tag1>Content 1</tag1>\n<tag2>Content 2</tag2>";
+    const expected =
+      ":::instruction_block[tag1]\nContent 1\n:::\n:::instruction_block[tag2]\nContent 2\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("handles empty instruction blocks", () => {
+    const input = "<empty></empty>";
+    const expected = ":::instruction_block[empty]\n\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("handles mixed content", () => {
+    const input =
+      "Regular text\n<instructions>Block content</instructions>\nMore text";
+    const expected =
+      "Regular text\n:::instruction_block[instructions]\nBlock content\n:::\nMore text";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("preserves case in tag names", () => {
+    const input = "<MyTag>Content</MyTag>";
+    const expected = ":::instruction_block[MyTag]\nContent\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("handles nested markdown in content", () => {
+    const input = "<instructions>**bold** and `code`</instructions>";
+    const expected =
+      ":::instruction_block[instructions]\n**bold** and `code`\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("handles tags with hyphens", () => {
+    const input = "<my-custom-tag>Content</my-custom-tag>";
+    const expected = ":::instruction_block[my-custom-tag]\nContent\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("handles tags with dots", () => {
+    const input = "<my.custom.tag>Content</my.custom.tag>";
+    const expected = ":::instruction_block[my.custom.tag]\nContent\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("handles tags with colons", () => {
+    const input = "<my:custom:tag>Content</my:custom:tag>";
+    const expected = ":::instruction_block[my:custom:tag]\nContent\n:::";
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
+  it("does not convert mismatched tags", () => {
+    const input = "<tag1>Content</tag2>";
+    // The regex requires matching tags, so this won't match
+    expect(preprocessInstructionBlocks(input)).toBe(input);
+  });
+
+  it("handles content with line breaks and formatting", () => {
+    const input = `<example>
+# Heading
+
+Some **bold** text and _italic_ text.
+
+- List item 1
+- List item 2
+</example>`;
+    const expected = `:::instruction_block[example]\n
+# Heading
+
+Some **bold** text and _italic_ text.
+
+- List item 1
+- List item 2
+\n:::`;
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+});

--- a/front/components/markdown/InstructionBlock.tsx
+++ b/front/components/markdown/InstructionBlock.tsx
@@ -1,0 +1,110 @@
+import { ChevronDownIcon, Chip, cn } from "@dust-tt/sparkle";
+import React from "react";
+import { visit } from "unist-util-visit";
+
+import { TAG_NAME_PATTERN } from "@app/components/editor/extensions/agent_builder/instructionBlockUtils";
+
+type InstructionBlockProps = {
+  tagName: string;
+  children: React.ReactNode;
+};
+
+/**
+ * Renders an instruction block with styled tag chips in readonly markdown display.
+ * This matches the visual style used in the agent builder editor, but always expanded.
+ */
+export function InstructionBlock({ tagName, children }: InstructionBlockProps) {
+  const displayType = tagName.toUpperCase();
+
+  return (
+    <div className="my-2 rounded-lg px-1 py-2">
+      <div className="flex items-start gap-1">
+        {/* Static chevron - matches editor but non-interactive */}
+        <div className="mt-[3px] p-0.5">
+          <ChevronDownIcon className="text-element-600 dark:text-element-600-night h-4 w-4" />
+        </div>
+        <div className="mt-0.5 w-full">
+          <Chip
+            size="mini"
+            className="bg-gray-100 transition-colors dark:bg-gray-800"
+          >
+            {`<${displayType}>`}
+          </Chip>
+          <div
+            className={cn(
+              "prose prose-sm",
+              // Match heading styles from editor
+              "[&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:text-xl",
+              "[&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:font-semibold",
+              "[&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:mt-4",
+              "[&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:mb-3"
+            )}
+          >
+            {children}
+          </div>
+          <Chip
+            size="mini"
+            className="bg-gray-100 transition-colors dark:bg-gray-800"
+          >
+            {`</${displayType}>`}
+          </Chip>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Remark directive that transforms :::instruction_block[tagName] containers
+ * into instruction_block elements.
+ */
+export function instructionBlockDirective() {
+  return (tree: any) => {
+    visit(tree, ["containerDirective"], (node) => {
+      if (node.name === "instruction_block") {
+        const data = node.data ?? (node.data = {});
+        // Get tag name from the directive label (the [tagName] part)
+        const tagName = node.children?.[0]?.value ?? "instructions";
+
+        data.hName = "instruction_block";
+        data.hProperties = {
+          tagName: tagName,
+        };
+
+        // Remove the label node from children since we extracted it
+        // The remaining children are the actual content
+        if (node.children?.[0]?.type === "text") {
+          node.children = node.children.slice(1);
+        }
+      }
+    });
+  };
+}
+
+/**
+ * Preprocesses markdown content to convert XML-style instruction blocks
+ * to remark-directive syntax for proper rendering.
+ *
+ * Converts: <tagname>content</tagname>
+ * To: :::instruction_block[tagname]\ncontent\n:::
+ *
+ * This enables react-markdown with remark-directive to parse and render
+ * instruction blocks correctly.
+ */
+export function preprocessInstructionBlocks(content: string): string {
+  // Match opening tag, content, and closing tag
+  // Uses the same pattern as InstructionBlockExtension for consistency
+  const INSTRUCTION_BLOCK_REGEX = new RegExp(
+    `<(${TAG_NAME_PATTERN})>([\\s\\S]*?)</\\1>`,
+    "gi"
+  );
+
+  return content.replace(
+    INSTRUCTION_BLOCK_REGEX,
+    (match, tagName, innerContent) => {
+      // Convert to remark-directive container syntax
+      // The tagName goes in brackets as a label
+      return `:::instruction_block[${tagName}]\n${innerContent}\n:::`;
+    }
+  );
+}


### PR DESCRIPTION
## Description

We were not rendering instructions blocks correctly in the agent details, now we do
## Tests

<img width="561" height="497" alt="image" src="https://github.com/user-attachments/assets/6b8573fb-43cb-47c3-9f5c-39547fa4533e" />

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
