### PR TITLE
[front] feat(skills): add agent message skills snapshotting

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -72,11 +72,6 @@ type SkillVersionCreationAttributes =
     mcpServerConfigurationIds: number[];
   };
 
-type AgentMessageSkillCreationAttributes =
-  CreationAttributes<ConversationSkillModel> & {
-    agentMessageId: number;
-  };
-
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -871,13 +866,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source,
       addedByUserId: user && source === "conversation" ? user.id : null,
     };
-
-    const agentMessageSkillBlob: AgentMessageSkillCreationAttributes = {
-      ...conversationSkillBlob,
-      agentMessageId: agentMessage.agentMessageId,
-    };
-
-    await AgentMessageSkillModel.create(agentMessageSkillBlob);
 
     await ConversationSkillModel.create(conversationSkillBlob);
 

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/temporal/agent_loop/activities/common";
 import { handleMentionsActivity } from "@app/temporal/agent_loop/activities/mentions";
 import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
-import { snapshotAgentMessageSkillsActivity } from "@app/temporal/agent_loop/activities/snapshot_skills";
+import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
 import { trackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
@@ -19,7 +19,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
     trackProgrammaticUsageActivity(authType, agentLoopArgs),
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
     handleMentionsActivity(authType, agentLoopArgs),
-    snapshotAgentMessageSkillsActivity(authType, agentLoopArgs),
+    snapshotAgentMessageSkills(authType, agentLoopArgs),
   ]);
 }
 
@@ -31,7 +31,7 @@ export async function finalizeCancelledAgentLoopActivity(
     launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
     trackProgrammaticUsageActivity(authType, agentLoopArgs),
     finalizeCancellationActivity(authType, agentLoopArgs),
-    snapshotAgentMessageSkillsActivity(authType, agentLoopArgs),
+    snapshotAgentMessageSkills(authType, agentLoopArgs),
   ]);
 }
 
@@ -49,6 +49,6 @@ export async function finalizeErroredAgentLoopActivity(
       agentMessageVersion: agentLoopArgs.agentMessageVersion,
       error,
     }),
-    snapshotAgentMessageSkillsActivity(authType, agentLoopArgs),
+    snapshotAgentMessageSkills(authType, agentLoopArgs),
   ]);
 }

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/temporal/agent_loop/activities/common";
 import { handleMentionsActivity } from "@app/temporal/agent_loop/activities/mentions";
 import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
+import { snapshotAgentMessageSkillsActivity } from "@app/temporal/agent_loop/activities/snapshot_skills";
 import { trackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
@@ -18,6 +19,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
     trackProgrammaticUsageActivity(authType, agentLoopArgs),
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
     handleMentionsActivity(authType, agentLoopArgs),
+    snapshotAgentMessageSkillsActivity(authType, agentLoopArgs),
   ]);
 }
 
@@ -29,6 +31,7 @@ export async function finalizeCancelledAgentLoopActivity(
     launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
     trackProgrammaticUsageActivity(authType, agentLoopArgs),
     finalizeCancellationActivity(authType, agentLoopArgs),
+    snapshotAgentMessageSkillsActivity(authType, agentLoopArgs),
   ]);
 }
 
@@ -46,5 +49,6 @@ export async function finalizeErroredAgentLoopActivity(
       agentMessageVersion: agentLoopArgs.agentMessageVersion,
       error,
     }),
+    snapshotAgentMessageSkillsActivity(authType, agentLoopArgs),
   ]);
 }

--- a/front/temporal/agent_loop/activities/snapshot_skills.ts
+++ b/front/temporal/agent_loop/activities/snapshot_skills.ts
@@ -7,7 +7,7 @@ import {
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
-export async function snapshotAgentMessageSkillsActivity(
+export async function snapshotAgentMessageSkills(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {

--- a/front/temporal/agent_loop/activities/snapshot_skills.ts
+++ b/front/temporal/agent_loop/activities/snapshot_skills.ts
@@ -26,7 +26,14 @@ export async function snapshotAgentMessageSkills(
       sId: agentMessageId,
       workspaceId: owner.id,
     },
-    include: [{ model: AgentMessageModel, as: "agentMessage", required: true }],
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        attributes: ["id", "agentConfigurationId"],
+        required: true,
+      },
+    ],
   });
 
   if (!messageRow?.agentMessage) {

--- a/front/temporal/agent_loop/activities/snapshot_skills.ts
+++ b/front/temporal/agent_loop/activities/snapshot_skills.ts
@@ -1,0 +1,41 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+export async function snapshotAgentMessageSkillsActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    return;
+  }
+
+  const auth = authResult.value;
+  const owner = auth.getNonNullableWorkspace();
+
+  const { agentMessageId } = agentLoopArgs;
+
+  const messageRow = await MessageModel.findOne({
+    where: {
+      sId: agentMessageId,
+      workspaceId: owner.id,
+    },
+    include: [{ model: AgentMessageModel, as: "agentMessage", required: true }],
+  });
+
+  if (!messageRow?.agentMessage) {
+    return;
+  }
+
+  await SkillResource.snapshotConversationSkillsForMessage(auth, {
+    agentConfigurationId: messageRow.agentMessage.agentConfigurationId,
+    agentMessageId: messageRow.agentMessage.id,
+    conversationId: messageRow.conversationId,
+  });
+}


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5612
- This PR adds a snapshot of the agent message skills at the end of each agent loop.
- No new activity added, only added to an existing one.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
