### PR TITLE
Use dedicated workflow to track usage

### DIFF
--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -431,6 +431,10 @@ export async function trackProgrammaticCost(
       });
     }
   }
+
+  return {
+    runsCostMicroUsd,
+  };
 }
 
 // First free credits, then committed credits, lastly pay-as-you-go, by expiration date (earliest first).

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -7,7 +7,7 @@ import {
 import { handleMentionsActivity } from "@app/temporal/agent_loop/activities/mentions";
 import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
 import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
-import { trackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
+import { launchTrackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 export async function finalizeSuccessfulAgentLoopActivity(
@@ -29,7 +29,7 @@ export async function finalizeCancelledAgentLoopActivity(
 ): Promise<void> {
   await Promise.all([
     launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
-    trackProgrammaticUsageActivity(authType, agentLoopArgs),
+    launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
     finalizeCancellationActivity(authType, agentLoopArgs),
     snapshotAgentMessageSkills(authType, agentLoopArgs),
   ]);
@@ -42,7 +42,7 @@ export async function finalizeErroredAgentLoopActivity(
 ): Promise<void> {
   await Promise.all([
     launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
-    trackProgrammaticUsageActivity(authType, agentLoopArgs),
+    launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
     notifyWorkflowError(authType, {
       conversationId: agentLoopArgs.conversationId,
       agentMessageId: agentLoopArgs.agentMessageId,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -16,7 +16,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
 ): Promise<void> {
   await Promise.all([
     launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
-    trackProgrammaticUsageActivity(authType, agentLoopArgs),
+    launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
     handleMentionsActivity(authType, agentLoopArgs),
     snapshotAgentMessageSkills(authType, agentLoopArgs),

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -36,7 +36,7 @@ import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
-import { trackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
+import { launchTrackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import { isDevelopment, removeNulls } from "@app/types";
@@ -73,7 +73,7 @@ export async function runAgentLoopWorker() {
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,
       runToolActivity,
-      trackProgrammaticUsageActivity,
+      launchTrackProgrammaticUsageActivity,
     },
     taskQueue: QUEUE_NAME,
     connection,

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -40,6 +40,10 @@ export async function launchStoreAgentAnalyticsWorkflow({
       args: [authType, { agentLoopArgs }],
       taskQueue: QUEUE_NAME,
       workflowId,
+      searchAttributes: {
+        conversationId: [conversationId],
+        workspaceId: authType.workspaceId ? [authType.workspaceId] : undefined,
+      },
       memo: {
         agentMessageId,
         workspaceId,

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -161,7 +161,7 @@ export async function trackProgrammaticUsageActivity(
 
     localLogger.info("[Programmatic Usage Tracking] Starting activity");
 
-    await trackProgrammaticCost(
+    const result = await trackProgrammaticCost(
       auth,
       {
         dustRunIds: agentMessage.runIds,
@@ -170,7 +170,7 @@ export async function trackProgrammaticUsageActivity(
       localLogger
     );
 
-    return { tracked: true, origin: userMessageOrigin };
+    return { tracked: true, ...(result ?? {}), origin: userMessageOrigin };
   }
 
   return { tracked: false, origin: userMessageOrigin };

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -5,6 +5,7 @@ import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/usage_queue/config";
+import { makeTrackProgrammaticUsageWorkflowId } from "@app/temporal/usage_queue/helpers";
 import {
   trackProgrammaticUsageWorkflow,
   updateWorkspaceUsageWorkflow,
@@ -12,8 +13,6 @@ import {
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
-
-import { makeTrackProgrammaticUsageWorkflowId } from "./helpers";
 
 async function shouldProcessUsageUpdate(workflowId: string) {
   // Compute the max usage of the workspace once per hour.
@@ -100,6 +99,10 @@ export async function launchTrackProgrammaticUsageWorkflow({
       args: [authType, { agentLoopArgs }],
       taskQueue: QUEUE_NAME,
       workflowId,
+      searchAttributes: {
+        conversationId: [conversationId],
+        workspaceId: authType.workspaceId ? [authType.workspaceId] : undefined,
+      },
       memo: {
         agentMessageId,
         workspaceId,

--- a/front/temporal/usage_queue/helpers.ts
+++ b/front/temporal/usage_queue/helpers.ts
@@ -1,0 +1,11 @@
+export function makeTrackProgrammaticUsageWorkflowId({
+  agentMessageId,
+  conversationId,
+  workspaceId,
+}: {
+  agentMessageId: string;
+  conversationId: string;
+  workspaceId: string;
+}): string {
+  return `usage-tracking-${workspaceId}-${conversationId}-${agentMessageId}`;
+}

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -1,9 +1,18 @@
 import { proxyActivities, sleep } from "@temporalio/workflow";
 
+import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/usage_queue/activities";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 const { recordUsageActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
+});
+
+const { trackProgrammaticUsageActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+  retry: {
+    maximumAttempts: 1,
+  },
 });
 
 export async function updateWorkspaceUsageWorkflow(workspaceId: string) {
@@ -11,4 +20,17 @@ export async function updateWorkspaceUsageWorkflow(workspaceId: string) {
   await sleep(60 * 60 * 1000);
 
   await recordUsageActivity(workspaceId);
+}
+
+export async function trackProgrammaticUsageWorkflow(
+  authType: AuthenticatorType,
+  {
+    agentLoopArgs,
+  }: {
+    agentLoopArgs: AgentLoopArgs;
+  }
+): Promise<void> {
+  await trackProgrammaticUsageActivity(authType, {
+    agentLoopArgs,
+  });
 }


### PR DESCRIPTION
## Description

Update the finalize* activities to launch a separate workflow to track programmatic usages, instead of having an activity in the agent loop.
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
