### PR TITLE
[skills] Temporary make additionalRequestedSpaceIds and skills optional in agent builder endpoint

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -328,7 +328,7 @@ export async function createOrUpgradeAgentConfiguration({
   if (featureFlags.includes("skills")) {
     const skillResources = await SkillResource.fetchByIds(
       auth,
-      assistant.skills.map((s) => s.sId)
+      (assistant.skills ?? []).map((s) => s.sId)
     );
 
     const skillRequestedSpaceIds = new Set<number>();
@@ -479,7 +479,7 @@ export async function createOrUpgradeAgentConfiguration({
   // Create skill associations
   const owner = auth.getNonNullableWorkspace();
   await concurrentExecutor(
-    assistant.skills,
+    assistant.skills ?? [],
     async (skill) => {
       // Validate the skill exists and belongs to this workspace
       const skillResource = await SkillResource.fetchById(auth, skill.sId);

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -191,25 +191,30 @@ const SkillSchema = t.type({
 });
 
 export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
-  assistant: t.type({
-    name: t.string,
-    description: t.string,
-    instructions: t.union([t.string, t.null]),
-    pictureUrl: t.string,
-    status: t.union([
-      t.literal("active"),
-      t.literal("archived"),
-      t.literal("draft"),
-    ]),
-    scope: t.union([t.literal("hidden"), t.literal("visible")]),
-    model: t.intersection([ModelConfigurationSchema, IsSupportedModelSchema]),
-    actions: t.array(MCPServerActionConfigurationSchema),
-    templateId: t.union([t.string, t.null, t.undefined]),
-    tags: t.array(TagSchema),
-    editors: t.array(EditorSchema),
-    skills: t.array(SkillSchema),
-    additionalRequestedSpaceIds: t.array(t.string),
-  }),
+  assistant: t.intersection([
+    t.type({
+      name: t.string,
+      description: t.string,
+      instructions: t.union([t.string, t.null]),
+      pictureUrl: t.string,
+      status: t.union([
+        t.literal("active"),
+        t.literal("archived"),
+        t.literal("draft"),
+      ]),
+      scope: t.union([t.literal("hidden"), t.literal("visible")]),
+      model: t.intersection([ModelConfigurationSchema, IsSupportedModelSchema]),
+      actions: t.array(MCPServerActionConfigurationSchema),
+      templateId: t.union([t.string, t.null, t.undefined]),
+      tags: t.array(TagSchema),
+      editors: t.array(EditorSchema),
+    }),
+    t.partial({
+      // temporary partial so opened windows can save without refreshing
+      skills: t.array(SkillSchema),
+      additionalRequestedSpaceIds: t.array(t.string),
+    }),
+  ]),
 });
 
 export type PostOrPatchAgentConfigurationRequestBody = t.TypeOf<


### PR DESCRIPTION
## Description

We are still seeing a few errors so let's make these optional for now and fix the people not refreshing the page

## Tests

no

## Risk
low

## Deploy Plan

deploy front
