### PR TITLE
Move Unread Conversation workflow into a new queue

### DIFF
--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -53,6 +53,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/labs/transcripts");
     case "mentions_count":
       return path.join(baseDir, "temporal/mentions_count_queue");
+    case "notifications_queue":
+      return path.join(baseDir, "temporal/notifications_queue");
     case "poke":
       return path.join(baseDir, "poke/temporal");
     case "production_checks":

--- a/front/temporal/notifications_queue/activities.ts
+++ b/front/temporal/notifications_queue/activities.ts
@@ -7,8 +7,6 @@ import {
 } from "@app/lib/notifications/workflows/conversation-unread";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
-import { NOTIFICATION_DELAY_MS } from "@app/temporal/agent_loop/workflows";
-import { isDevelopment } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 /**
@@ -47,11 +45,6 @@ export async function sendUnreadConversationNotificationActivity(
   if (!featureFlags.includes("notifications")) {
     return;
   }
-
-  // Wait 30 seconds before triggering the notification.
-  await new Promise((resolve) =>
-    setTimeout(resolve, isDevelopment() ? 3000 : NOTIFICATION_DELAY_MS)
-  );
 
   // Get conversation participants
   const conversation = await ConversationResource.fetchById(

--- a/front/temporal/notifications_queue/activities.ts
+++ b/front/temporal/notifications_queue/activities.ts
@@ -1,0 +1,82 @@
+import { isUserMessageOrigin } from "@app/components/agent_builder/observability/utils";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import {
+  shouldSendNotificationForAgentAnswer,
+  triggerConversationUnreadNotifications,
+} from "@app/lib/notifications/workflows/conversation-unread";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import { NOTIFICATION_DELAY_MS } from "@app/temporal/agent_loop/workflows";
+import { isDevelopment } from "@app/types";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+/**
+ * Activity to send conversation unread notifications.
+ */
+export async function sendUnreadConversationNotificationActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  // Construct back an authenticator from the auth type.
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    logger.error(
+      { authType, error: authResult.error },
+      "Failed to construct authenticator from auth type"
+    );
+    return;
+  }
+
+  const auth = authResult.value;
+  if (!isUserMessageOrigin(agentLoopArgs.userMessageOrigin)) {
+    logger.info(
+      { userMessageOrigin: agentLoopArgs.userMessageOrigin },
+      "User message origin is not a valid origin."
+    );
+    return;
+  }
+
+  // Check if the user message origin is valid for sending notifications.
+  if (!shouldSendNotificationForAgentAnswer(agentLoopArgs.userMessageOrigin)) {
+    return;
+  }
+
+  // Check if the workspace has notifications enabled.
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  if (!featureFlags.includes("notifications")) {
+    return;
+  }
+
+  // Wait 30 seconds before triggering the notification.
+  await new Promise((resolve) =>
+    setTimeout(resolve, isDevelopment() ? 3000 : NOTIFICATION_DELAY_MS)
+  );
+
+  // Get conversation participants
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    agentLoopArgs.conversationId
+  );
+
+  if (!conversation) {
+    logger.warn(
+      { conversationId: agentLoopArgs.conversationId },
+      "Conversation not found after delay"
+    );
+    return;
+  }
+
+  const r = await triggerConversationUnreadNotifications(auth, {
+    conversation,
+    messageId: agentLoopArgs.agentMessageId,
+  });
+
+  if (r.isErr()) {
+    logger.error(
+      { error: r.error },
+      "Failed to trigger conversation unread notification"
+    );
+    return;
+  }
+}

--- a/front/temporal/notifications_queue/client.ts
+++ b/front/temporal/notifications_queue/client.ts
@@ -1,0 +1,56 @@
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+import type { AuthenticatorType } from "@app/lib/auth";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/notifications_queue/config";
+import { makeConversationUnreadNotificationWorkflowId } from "@app/temporal/notifications_queue/helpers";
+import { sendUnreadConversationNotificationWorkflow } from "@app/temporal/notifications_queue/workflows";
+import type { Result } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+export async function launchConversationUnreadNotificationWorkflow({
+  authType,
+  agentLoopArgs,
+}: {
+  authType: AuthenticatorType;
+  agentLoopArgs: AgentLoopArgs;
+}): Promise<Result<undefined, Error>> {
+  const { workspaceId } = authType;
+  const { agentMessageId, conversationId } = agentLoopArgs;
+
+  const client = await getTemporalClientForFrontNamespace();
+
+  const workflowId = makeConversationUnreadNotificationWorkflowId({
+    agentMessageId,
+    conversationId,
+    workspaceId,
+  });
+
+  try {
+    await client.workflow.start(sendUnreadConversationNotificationWorkflow, {
+      args: [authType, { agentLoopArgs }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: {
+        agentMessageId,
+        workspaceId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
+      logger.error(
+        {
+          workflowId,
+          agentMessageId,
+          error: e,
+        },
+        "Failed starting conversation unread notification workflow"
+      );
+    }
+
+    return new Err(normalizeError(e));
+  }
+}

--- a/front/temporal/notifications_queue/client.ts
+++ b/front/temporal/notifications_queue/client.ts
@@ -1,11 +1,8 @@
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 
 import { isUserMessageOrigin } from "@app/components/agent_builder/observability/utils";
-import type {AuthenticatorType} from "@app/lib/auth";
-import {
-  Authenticator,
-  getFeatureFlags
-} from "@app/lib/auth";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { shouldSendNotificationForAgentAnswer } from "@app/lib/notifications/workflows/conversation-unread";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";

--- a/front/temporal/notifications_queue/client.ts
+++ b/front/temporal/notifications_queue/client.ts
@@ -1,6 +1,12 @@
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 
-import type { AuthenticatorType } from "@app/lib/auth";
+import { isUserMessageOrigin } from "@app/components/agent_builder/observability/utils";
+import type {AuthenticatorType} from "@app/lib/auth";
+import {
+  Authenticator,
+  getFeatureFlags
+} from "@app/lib/auth";
+import { shouldSendNotificationForAgentAnswer } from "@app/lib/notifications/workflows/conversation-unread";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/notifications_queue/config";
@@ -28,9 +34,39 @@ export async function launchConversationUnreadNotificationWorkflow({
     workspaceId,
   });
 
+  // Construct back an authenticator from the auth type.
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    logger.error(
+      { authType, error: authResult.error },
+      "Failed to construct authenticator from auth type"
+    );
+    return new Ok(undefined);
+  }
+
+  const auth = authResult.value;
+  if (!isUserMessageOrigin(agentLoopArgs.userMessageOrigin)) {
+    logger.info(
+      { userMessageOrigin: agentLoopArgs.userMessageOrigin },
+      "User message origin is not a valid origin."
+    );
+    return new Ok(undefined);
+  }
+
+  // Check if the user message origin is valid for sending notifications.
+  if (!shouldSendNotificationForAgentAnswer(agentLoopArgs.userMessageOrigin)) {
+    return new Ok(undefined);
+  }
+
+  // Check if the workspace has notifications enabled.
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  if (!featureFlags.includes("notifications")) {
+    return new Ok(undefined);
+  }
+
   try {
     await client.workflow.start(sendUnreadConversationNotificationWorkflow, {
-      args: [authType, { agentLoopArgs }],
+      args: [auth, { agentLoopArgs }],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: {

--- a/front/temporal/notifications_queue/config.ts
+++ b/front/temporal/notifications_queue/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `notifications-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/notifications_queue/helpers.ts
+++ b/front/temporal/notifications_queue/helpers.ts
@@ -1,0 +1,11 @@
+export function makeConversationUnreadNotificationWorkflowId({
+  agentMessageId,
+  conversationId,
+  workspaceId,
+}: {
+  agentMessageId: string;
+  conversationId: string;
+  workspaceId: string;
+}): string {
+  return `conversation-unread-notification-${workspaceId}-${conversationId}-${agentMessageId}`;
+}

--- a/front/temporal/notifications_queue/worker.ts
+++ b/front/temporal/notifications_queue/worker.ts
@@ -1,0 +1,39 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/notifications_queue/activities";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runNotificationsQueueWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "notifications_queue",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 16,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/notifications_queue/workflows.ts
+++ b/front/temporal/notifications_queue/workflows.ts
@@ -1,0 +1,25 @@
+import { proxyActivities } from "@temporalio/workflow";
+
+import type { AuthenticatorType } from "@app/lib/auth";
+import type * as activities from "@app/temporal/notifications_queue/activities";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+const { sendUnreadConversationNotificationActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "5 minutes",
+  retry: {
+    maximumAttempts: 2,
+  },
+});
+
+export async function sendUnreadConversationNotificationWorkflow(
+  authType: AuthenticatorType,
+  {
+    agentLoopArgs,
+  }: {
+    agentLoopArgs: AgentLoopArgs;
+  }
+): Promise<void> {
+  await sendUnreadConversationNotificationActivity(authType, agentLoopArgs);
+}

--- a/front/temporal/notifications_queue/workflows.ts
+++ b/front/temporal/notifications_queue/workflows.ts
@@ -1,7 +1,9 @@
-import { proxyActivities } from "@temporalio/workflow";
+import { proxyActivities, sleep } from "@temporalio/workflow";
 
 import type { AuthenticatorType } from "@app/lib/auth";
+import { NOTIFICATION_DELAY_MS } from "@app/temporal/agent_loop/workflows";
 import type * as activities from "@app/temporal/notifications_queue/activities";
+import { isDevelopment } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 const { sendUnreadConversationNotificationActivity } = proxyActivities<
@@ -21,5 +23,8 @@ export async function sendUnreadConversationNotificationWorkflow(
     agentLoopArgs: AgentLoopArgs;
   }
 ): Promise<void> {
+  // Wait before triggering the notification (3s in dev, 30s in prod).
+  await sleep(isDevelopment() ? 3000 : NOTIFICATION_DELAY_MS);
+
   await sendUnreadConversationNotificationActivity(authType, agentLoopArgs);
 }

--- a/front/temporal/notifications_queue/workflows.ts
+++ b/front/temporal/notifications_queue/workflows.ts
@@ -1,6 +1,6 @@
 import { proxyActivities, sleep } from "@temporalio/workflow";
 
-import type { AuthenticatorType } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { NOTIFICATION_DELAY_MS } from "@app/temporal/agent_loop/workflows";
 import type * as activities from "@app/temporal/notifications_queue/activities";
 import { isDevelopment } from "@app/types";
@@ -16,15 +16,15 @@ const { sendUnreadConversationNotificationActivity } = proxyActivities<
 });
 
 export async function sendUnreadConversationNotificationWorkflow(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   {
     agentLoopArgs,
   }: {
     agentLoopArgs: AgentLoopArgs;
   }
 ): Promise<void> {
-  // Wait before triggering the notification (3s in dev, 30s in prod).
+  // Wait before triggering the notification.
   await sleep(isDevelopment() ? 3000 : NOTIFICATION_DELAY_MS);
 
-  await sendUnreadConversationNotificationActivity(authType, agentLoopArgs);
+  await sendUnreadConversationNotificationActivity(auth, agentLoopArgs);
 }

--- a/front/temporal/notifications_queue/workflows.ts
+++ b/front/temporal/notifications_queue/workflows.ts
@@ -9,7 +9,7 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 const { sendUnreadConversationNotificationActivity } = proxyActivities<
   typeof activities
 >({
-  startToCloseTimeout: "5 minutes",
+  startToCloseTimeout: "1 minute",
   retry: {
     maximumAttempts: 2,
   },

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -7,6 +7,7 @@ import { runESIndexationQueueWorker } from "@app/temporal/es_indexation/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runLabsTranscriptsWorker } from "@app/temporal/labs/transcripts/worker";
 import { runMentionsCountWorker } from "@app/temporal/mentions_count_queue/worker";
+import { runNotificationsQueueWorker } from "@app/temporal/notifications_queue/worker";
 import { runProductionChecksWorker } from "@app/temporal/production_checks/worker";
 import { runRelocationWorker } from "@app/temporal/relocation/worker";
 import { runRemoteToolsSyncWorker } from "@app/temporal/remote_tools/worker";
@@ -34,6 +35,7 @@ export type WorkerName =
   | "hard_delete"
   | "labs"
   | "mentions_count"
+  | "notifications_queue"
   | "poke"
   | "production_checks"
   | "relocation"
@@ -56,6 +58,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   hard_delete: runHardDeleteWorker,
   labs: runLabsTranscriptsWorker,
   mentions_count: runMentionsCountWorker,
+  notifications_queue: runNotificationsQueueWorker,
   poke: runPokeWorker,
   production_checks: runProductionChecksWorker,
   relocation: runRelocationWorker,


### PR DESCRIPTION
## Description

`conversationUnreadNotificationActivity` was recently added to the agent loop workflow and adds a 30-second delay, which is not acceptable (agent loop should be fast).
`conversationUnreadNotificationActivity` should be moved to its own queue to maintain performance.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
