### PR TITLE
[front] Add constraint drops in migration script 452

### DIFF
--- a/front/migrations/db/migration_452.sql
+++ b/front/migrations/db/migration_452.sql
@@ -1,3 +1,5 @@
 -- Migration created on Dec 17, 2025
+ALTER TABLE "conversation_skills" DROP CONSTRAINT "conversation_skills_agentConfigurationId_fkey";
 ALTER TABLE "conversation_skills" ALTER COLUMN "agentConfigurationId" TYPE VARCHAR(255);
+ALTER TABLE "agent_message_skills" DROP CONSTRAINT "agent_message_skills_agentConfigurationId_fkey";
 ALTER TABLE "agent_message_skills" ALTER COLUMN "agentConfigurationId" TYPE VARCHAR(255);


### PR DESCRIPTION
## Description

- The migration 452 was missing the constraints drop, which prevents the script from running

## Tests

## Risk

## Deploy Plan

- No deploy.
