### PR TITLE
fix: rendering of XML blocks

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
@@ -46,7 +46,13 @@ describe("InstructionBlockExtension", () => {
     ]);
 
     const result = editor.getMarkdown();
-    expect(result).toBe("<instructions>hello</instructions>\n\n");
+    expect(result).toBe(`<instructions>
+
+hello
+
+</instructions>
+
+`);
   });
 
   it("should serialize instruction block with headings to markdown", () => {
@@ -83,7 +89,13 @@ describe("InstructionBlockExtension", () => {
     ]);
 
     const result = editor.getMarkdown();
-    expect(result).toBe("<instructions># header1</instructions>\n\n");
+    expect(result).toBe(`<instructions>
+
+# header1
+
+</instructions>
+
+`);
   });
 
   it("should serialize instruction block with code blocks to markdown", () => {
@@ -129,9 +141,15 @@ code block
     ]);
 
     const result = editor.getMarkdown();
-    expect(result).toBe(
-      "<instructions>```\n" + "code block\n" + "```</instructions>\n" + "\n"
-    );
+    expect(result).toBe(`<instructions>
+
+\`\`\`
+code block
+\`\`\`
+
+</instructions>
+
+`);
   });
 
   it("should create instruction block using command", () => {
@@ -157,7 +175,13 @@ code block
     ]);
 
     const result = editor.getMarkdown();
-    expect(result).toBe("<instructions></instructions>\n" + "\n");
+    expect(result).toBe(`<instructions>
+
+
+
+</instructions>
+
+`);
   });
 
   it("should serialize instruction block with mentions", () => {
@@ -198,9 +222,13 @@ code block
     ]);
 
     const result = editor.getMarkdown();
-    expect(result).toBe(
-      "<instructions>:mention[agent-name]{sId=agent-123}</instructions>\n\n"
-    );
+    expect(result).toBe(`<instructions>
+
+:mention[agent-name]{sId=agent-123}
+
+</instructions>
+
+`);
   });
 
   it("should serialize instruction block with _", () => {
@@ -223,7 +251,13 @@ code block
     ]);
 
     const result = editor.getMarkdown();
-    expect(result).toBe("<instructions_toto></instructions_toto>\n\n");
+    expect(result).toBe(`<instructions_toto>
+
+
+
+</instructions_toto>
+
+`);
   });
 
   it("should serialize instruction block to markdown with paragraph then list", () => {
@@ -313,12 +347,15 @@ Toto:
 
     const result = editor.getMarkdown();
     expect(result).toBe(`<instructions>
+
 Toto:
 
 - hello
 - darkness
 - my old friend
+
 </instructions>
+
 `);
   });
 });

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
@@ -225,4 +225,100 @@ code block
     const result = editor.getMarkdown();
     expect(result).toBe("<instructions_toto></instructions_toto>\n\n");
   });
+
+  it("should serialize instruction block to markdown with paragraph then list", () => {
+    editor.commands.setContent(
+      `<instructions>
+Toto:
+* hello
+* darkness
+* my old friend
+</instructions>`,
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const json = editor.getJSON();
+    expect(json.content).toEqual([
+      {
+        attrs: {
+          isCollapsed: false,
+          type: "instructions",
+        },
+        content: [
+          {
+            content: [
+              {
+                text: "Toto:",
+                type: "text",
+              },
+            ],
+            type: "paragraph",
+          },
+          {
+            content: [
+              {
+                content: [
+                  {
+                    content: [
+                      {
+                        text: "hello",
+                        type: "text",
+                      },
+                    ],
+                    type: "paragraph",
+                  },
+                ],
+                type: "listItem",
+              },
+              {
+                content: [
+                  {
+                    content: [
+                      {
+                        text: "darkness",
+                        type: "text",
+                      },
+                    ],
+                    type: "paragraph",
+                  },
+                ],
+                type: "listItem",
+              },
+              {
+                content: [
+                  {
+                    content: [
+                      {
+                        text: "my old friend",
+                        type: "text",
+                      },
+                    ],
+                    type: "paragraph",
+                  },
+                ],
+                type: "listItem",
+              },
+            ],
+            type: "bulletList",
+          },
+        ],
+        type: "instructionBlock",
+      },
+      {
+        type: "paragraph",
+      },
+    ]);
+
+    const result = editor.getMarkdown();
+    expect(result).toBe(`<instructions>
+Toto:
+
+- hello
+- darkness
+- my old friend
+</instructions>
+`);
+  });
 });

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -754,7 +754,10 @@ export const InstructionBlockExtension =
 
     renderMarkdown: (node, helpers) => {
       const tagType = node.attrs?.type ?? "instructions";
-      const content = helpers.renderChildren(node.content ?? []);
-      return `<${tagType}>${content}</${tagType}>`;
+      const children = node.content ?? [];
+
+      // We use "\n\n" as a separator, because of a weird bug, see unit tests
+      const content = helpers.renderChildren(children, "\n\n");
+      return `<${tagType}>\n\n${content}\n\n</${tagType}>`;
     },
   });

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -732,6 +732,7 @@ export const InstructionBlockExtension =
           attrs: {
             type: tagName.toLowerCase(),
           },
+          text: match[2],
           tokens: lexer.blockTokens(match[2]),
         };
       },


### PR DESCRIPTION
## Description

Fixes a weird bug when we had paragraph then lists in an xml block. 

Input 
```
<d>
Test:
1. toto
</d>
```

was rendering
```
<d>
Test:1. toto
</d>
```

It's fixed

## Tests

Locally, unit test, and in front-edge
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
