### PR TITLE
[front] fix(skills): add check on skill being configured on agent

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -42,7 +42,7 @@ export const GET_MENTION_MARKDOWN_TOOL_NAME = "get_mention_markdown";
 export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
   "__dust_conversation_history";
 
-export const DEFAULT_ENABLE_SKILL_TOOL_NAME = "enable_skill";
+export const ENABLE_SKILL_TOOL_NAME = "enable_skill";
 
 export const DEFAULT_MCP_ACTION_NAME = "mcp";
 export const DEFAULT_MCP_ACTION_VERSION = "1.0.0";

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME,
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
   DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
-  DEFAULT_ENABLE_SKILL_TOOL_NAME,
+  ENABLE_SKILL_TOOL_NAME,
   GET_MENTION_MARKDOWN_TOOL_NAME,
   SEARCH_AVAILABLE_USERS_TOOL_NAME,
 } from "@app/lib/actions/constants";
@@ -181,7 +181,7 @@ function constructSkillsSection({
   // Equipped but not yet enabled skills - show name and description only
   if (equippedSkills && equippedSkills.length > 0) {
     skillsSection += "\n### AVAILABLE SKILLS\n";
-    skillsSection += `The following skills are available but not currently enabled, you can enable them with the ${DEFAULT_ENABLE_SKILL_TOOL_NAME} tool.\n`;
+    skillsSection += `The following skills are available but not currently enabled, you can enable them with the ${ENABLE_SKILL_TOOL_NAME} tool.\n`;
     const skillList = equippedSkills
       .map(
         ({ name, agentFacingDescription }) =>

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -908,6 +908,27 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       );
     }
 
+    // For agent_enabled, we need to check that the skill is added to the agent first.
+    if (source === "agent_enabled") {
+      const agentSkill = await AgentSkillModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          agentConfigurationId: agentConfiguration.id,
+          ...(this.globalSId
+            ? { globalSkillId: this.globalSId }
+            : { customSkillId: this.id }),
+        },
+      });
+
+      if (!agentSkill) {
+        return new Err(
+          new Error(
+            `Skill ${this.name} was not added to agent ${agentConfiguration.name}.`
+          )
+        );
+      }
+    }
+
     const conversationSkillBlob = {
       workspaceId: workspace.id,
       agentConfigurationId: agentConfiguration.sId,


### PR DESCRIPTION
## Description

- This PR adds a check to ensure that agents only enable skills that were configured on them instead of any skill.

## Tests

- Tested locally, can't reproduce anymore

## Risk

- Low.

## Deploy Plan

- Deploy front.
