### PR TITLE
[front] fix(skills): use sparkle's puzzle icon instead of lucide's

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.20",
-        "@dust-tt/sparkle": "^0.4.24",
+        "@dust-tt/sparkle": "^0.4.25",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1285,9 +1285,10 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.24.tgz",
-      "integrity": "sha512-hl3Dt46YrCxpsoF1kg4t6sZcDUXW/wrE+UGlTdSfcsnbzWK1N7nvTwjssoISAYcfv22R9cRoLKcZMDCxwRp8Jw==",
+      "version": "0.4.25",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.25.tgz",
+      "integrity": "sha512-uYL3LH++icQ8t4RGZeEX8aOzQ86VY/zYWzHWVgsabmGZRXg7BtzYuz66VyV4gFCzb0rPkshSOKdvTUoUXlhlaA==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.20",
-    "@dust-tt/sparkle": "^0.4.24",
+    "@dust-tt/sparkle": "^0.4.25",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -1,5 +1,4 @@
-import { Avatar } from "@dust-tt/sparkle";
-import { PuzzleIcon } from "lucide-react";
+import { Avatar, PuzzleIcon } from "@dust-tt/sparkle";
 import React from "react";
 
 import {
@@ -14,7 +13,6 @@ import type {
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 
-// TODO(skills 2025-12-05): use the right icon
 export const SKILL_ICON = PuzzleIcon;
 
 export function getSkillAvatarIcon(

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.4.24",
+        "@dust-tt/sparkle": "^0.4.25",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@google-cloud/bigquery": "^7.9.1",
@@ -1309,9 +1309,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.24.tgz",
-      "integrity": "sha512-hl3Dt46YrCxpsoF1kg4t6sZcDUXW/wrE+UGlTdSfcsnbzWK1N7nvTwjssoISAYcfv22R9cRoLKcZMDCxwRp8Jw==",
+      "version": "0.4.25",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.4.25.tgz",
+      "integrity": "sha512-uYL3LH++icQ8t4RGZeEX8aOzQ86VY/zYWzHWVgsabmGZRXg7BtzYuz66VyV4gFCzb0rPkshSOKdvTUoUXlhlaA==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -38,7 +38,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.4.24",
+    "@dust-tt/sparkle": "^0.4.25",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@google-cloud/bigquery": "^7.9.1",


### PR DESCRIPTION
## Description

- This PR updates the icon used to represent skills in the product.
- Sparkle's version was bumped to get the latest one with the icon.

<img width="507" height="383" alt="Screenshot 2025-12-17 at 3 18 41 PM" src="https://github.com/user-attachments/assets/04a2ebc2-7c63-48df-8955-33f9b14b2abe" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
