### PR TITLE
[skills] Correctly filter the additional spaces to only contain non requested spaces

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -14,6 +14,7 @@ import { useFormContext, useWatch } from "react-hook-form";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { SpaceSelectionPageContent } from "@app/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
+import { getActionsAndSkillsRequestedSpaceIds } from "@app/components/agent_builder/utils";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
 import { useRemoveSpaceConfirm } from "@app/components/shared/RemoveSpaceDialog";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
@@ -48,29 +49,19 @@ export function AgentBuilderSpacesBlock() {
     mcpServerViews,
   });
 
-  // Compute requested spaces from tools/knowledge (actions)
   const spaceIdToActions = useMemo(() => {
     return getSpaceIdToActionsMap(actions, mcpServerViews);
   }, [actions, mcpServerViews]);
 
-  // Merge requested spaces from skills, actions, and additional spaces (from global skills)
-  const actionsAndSkillsRequestedSpaceIds = useMemo(() => {
-    const selectedSkillIds = new Set(selectedSkills.map((s) => s.sId));
-    const skillRequestedSpaceIds = new Set(
-      allSkills
-        .filter((skill) => selectedSkillIds.has(skill.sId))
-        .flatMap((skill) => skill.requestedSpaceIds)
-    );
-
-    const actionRequestedSpaceIds = new Set<string>();
-    for (const spaceId of Object.keys(spaceIdToActions)) {
-      if (spaceIdToActions[spaceId]?.length > 0) {
-        actionRequestedSpaceIds.add(spaceId);
-      }
-    }
-
-    return new Set([...skillRequestedSpaceIds, ...actionRequestedSpaceIds]);
-  }, [selectedSkills, allSkills, spaceIdToActions]);
+  const actionsAndSkillsRequestedSpaceIds = useMemo(
+    () =>
+      getActionsAndSkillsRequestedSpaceIds(
+        selectedSkills,
+        allSkills,
+        spaceIdToActions
+      ),
+    [selectedSkills, allSkills, spaceIdToActions]
+  );
 
   const nonGlobalSpacesWithRestrictions = useMemo(() => {
     const nonGlobalSpaces = spaces.filter((s) => s.kind !== "global");

--- a/front/components/agent_builder/utils.ts
+++ b/front/components/agent_builder/utils.ts
@@ -1,8 +1,11 @@
 import { useController } from "react-hook-form";
 
+import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import type { ActionType } from "@app/components/shared/getSpaceIdToActionsMap";
 import type { AssistantTemplateListType } from "@app/pages/api/templates";
 import type { TemplateTagCodeType } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export const isInvalidJson = (value: string | null | undefined): boolean => {
   if (!value) {
@@ -30,4 +33,26 @@ export function getUniqueTemplateTags(
  */
 export function useSourcesFormController() {
   return useController<CapabilityFormData, "sources">({ name: "sources" });
+}
+
+export function getActionsAndSkillsRequestedSpaceIds(
+  selectedSkills: AgentBuilderSkillsType[],
+  allSkills: SkillType[],
+  spaceIdToActions: Record<string, ActionType[]>
+): Set<string> {
+  const selectedSkillIds = new Set(selectedSkills.map((s) => s.sId));
+  const skillRequestedSpaceIds = new Set(
+    allSkills
+      .filter((skill) => selectedSkillIds.has(skill.sId))
+      .flatMap((skill) => skill.requestedSpaceIds)
+  );
+
+  const actionRequestedSpaceIds = new Set<string>();
+  for (const spaceId of Object.keys(spaceIdToActions)) {
+    if (spaceIdToActions[spaceId]?.length > 0) {
+      actionRequestedSpaceIds.add(spaceId);
+    }
+  }
+
+  return new Set([...skillRequestedSpaceIds, ...actionRequestedSpaceIds]);
 }

--- a/front/components/shared/getSpaceIdToActionsMap.ts
+++ b/front/components/shared/getSpaceIdToActionsMap.ts
@@ -3,7 +3,7 @@ import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { assertNever } from "@app/types";
 
-type ActionType = AgentBuilderMCPConfigurationWithId | BuilderAction;
+export type ActionType = AgentBuilderMCPConfigurationWithId | BuilderAction;
 
 export const getSpaceIdToActionsMap = (
   actions: ActionType[],


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/5480

We are sometime adding too many spaces in additional spaces
This is an issue because when removing the skill using the space, the space was not correctly removed

## Tests

manual test of removing a skill so the space is removed even if added as additional space before

## Risk

low

## Deploy Plan

deploy front
