### PR TITLE
[skills] Always display the 'company space' chip in Spaces (AgentBuilder and SkillBuilder)

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Chip,
   PlanetIcon,
   Sheet,
   SheetContainer,
@@ -18,10 +17,11 @@ import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
 import { useRemoveSpaceConfirm } from "@app/components/shared/RemoveSpaceDialog";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
+import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
-import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types";
+import { removeNulls } from "@app/types";
 
 export function AgentBuilderSpacesBlock() {
   const { setValue } = useFormContext<AgentBuilderFormData>();
@@ -143,6 +143,14 @@ export function AgentBuilderSpacesBlock() {
     handleCloseSheet();
   };
 
+  const globalSpace = useMemo(() => {
+    return spaces.find((s) => s.kind === "global");
+  }, [spaces]);
+
+  const spacesToDisplay = useMemo(() => {
+    return removeNulls([globalSpace, ...nonGlobalSpacesWithRestrictions]);
+  }, [globalSpace, nonGlobalSpacesWithRestrictions]);
+
   return (
     <div className="space-y-3 px-6">
       <div className="flex items-start justify-between">
@@ -161,18 +169,7 @@ export function AgentBuilderSpacesBlock() {
           onClick={handleOpenSheet}
         />
       </div>
-      {nonGlobalSpacesWithRestrictions.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {nonGlobalSpacesWithRestrictions.map((space) => (
-            <Chip
-              key={space.sId}
-              label={getSpaceName(space)}
-              icon={getSpaceIcon(space)}
-              onRemove={() => handleRemoveSpace(space)}
-            />
-          ))}
-        </div>
-      )}
+      <SpaceChips spaces={spacesToDisplay} onRemoveSpace={handleRemoveSpace} />
 
       <Sheet open={isSheetOpen} onOpenChange={handleCloseSheet}>
         <SheetContent>

--- a/front/components/shared/SpaceChips.tsx
+++ b/front/components/shared/SpaceChips.tsx
@@ -1,0 +1,26 @@
+import { Chip } from "@dust-tt/sparkle";
+
+import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
+import type { SpaceType } from "@app/types";
+
+interface SpaceChipsProps {
+  spaces: SpaceType[];
+  onRemoveSpace: (space: SpaceType) => void;
+}
+
+export function SpaceChips({ spaces, onRemoveSpace }: SpaceChipsProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {spaces.map((space) => (
+        <Chip
+          key={space.sId}
+          label={getSpaceName(space)}
+          icon={getSpaceIcon(space)}
+          onRemove={
+            space.kind !== "global" ? () => onRemoveSpace(space) : undefined
+          }
+        />
+      ))}
+    </div>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -1,15 +1,15 @@
-import { Chip } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 import { useFormContext } from "react-hook-form";
 
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
 import { useRemoveSpaceConfirm } from "@app/components/shared/RemoveSpaceDialog";
+import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types";
+import { removeNulls } from "@app/types";
 
 export function SkillBuilderRequestedSpacesSection() {
   const { watch, setValue } = useFormContext<SkillBuilderFormData>();
@@ -52,9 +52,12 @@ export function SkillBuilderRequestedSpacesSection() {
     setValue("tools", newTools, { shouldDirty: true });
   };
 
-  if (nonGlobalSpacesUsedInActions.length === 0) {
-    return null;
-  }
+  const globalSpace = useMemo(() => {
+    return spaces.find((s) => s.kind === "global");
+  }, [spaces]);
+  const spacesToDisplay = useMemo(() => {
+    return removeNulls([globalSpace, ...nonGlobalSpacesUsedInActions]);
+  }, [globalSpace, nonGlobalSpacesUsedInActions]);
 
   return (
     <div className="space-y-3">
@@ -66,16 +69,7 @@ export function SkillBuilderRequestedSpacesSection() {
           Determines who can use this skill and what data it can access
         </p>
       </div>
-      <div className="flex flex-wrap gap-2">
-        {nonGlobalSpacesUsedInActions.map((space) => (
-          <Chip
-            key={space.sId}
-            label={getSpaceName(space)}
-            icon={getSpaceIcon(space)}
-            onRemove={() => handleRemoveSpace(space)}
-          />
-        ))}
-      </div>
+      <SpaceChips spaces={spacesToDisplay} onRemoveSpace={handleRemoveSpace} />
     </div>
   );
 }


### PR DESCRIPTION
## Description

As per figma, we always display the "company space" un-removable chip

Agent builder:

<img width="2800" height="1754" alt="image" src="https://github.com/user-attachments/assets/4e57c7e6-83ec-41ce-a1f7-5bbae638034b" />


Skill builder:

<img width="2796" height="1750" alt="image" src="https://github.com/user-attachments/assets/29ab07df-67e9-4504-8802-a42fdc549ce0" />


## Tests

manual

## Risk

low

## Deploy Plan

deploy front
