### PR TITLE
[connectors] perf: Improve memory usage of gdrive connector

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/garbage_collector.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/garbage_collector.ts
@@ -1,4 +1,3 @@
-import PQueue from "p-queue";
 import { Op } from "sequelize";
 
 import { fixParentsConsistency } from "@connectors/connectors/google_drive/lib";
@@ -11,6 +10,7 @@ import {
 } from "@connectors/connectors/google_drive/temporal/activities/common/utils";
 import { getFoldersToSync } from "@connectors/connectors/google_drive/temporal/activities/get_folders_to_sync";
 import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -45,39 +45,37 @@ export async function garbageCollector(
     limit: 100,
   });
 
-  const queue = new PQueue({ concurrency: FILES_GC_CONCURRENCY });
   const selectedFolders = await getFoldersToSync(connectorId);
-  await Promise.all(
-    files.map(async (file) => {
-      return queue.add(async () => {
-        const driveFile = await getGoogleDriveObject({
-          connectorId,
-          authCredentials,
-          driveObjectId: file.driveFileId,
-          cacheKey: { connectorId, ts },
-        });
-        if (!driveFile) {
-          // Could not find the file on Gdrive, deleting our local reference to it.
-          await deleteFile(file);
-          return null;
-        }
-        const isInFolderSelection = await objectIsInFolderSelection(
-          connectorId,
-          authCredentials,
-          driveFile,
-          selectedFolders,
-          lastSeenTs
-        );
-
-        if (isInFolderSelection === false || driveFile.trashed) {
-          await deleteOneFile(connectorId, driveFile);
-        } else {
-          await file.update({
-            lastSeenTs: new Date(),
-          });
-        }
+  await concurrentExecutor(
+    files,
+    async (file) => {
+      const driveFile = await getGoogleDriveObject({
+        connectorId,
+        authCredentials,
+        driveObjectId: file.driveFileId,
+        cacheKey: { connectorId, ts },
       });
-    })
+      if (!driveFile) {
+        await deleteFile(file);
+        return null;
+      }
+      const isInFolderSelection = await objectIsInFolderSelection(
+        connectorId,
+        authCredentials,
+        driveFile,
+        selectedFolders,
+        lastSeenTs
+      );
+
+      if (isInFolderSelection === false || driveFile.trashed) {
+        await deleteOneFile(connectorId, driveFile);
+      } else {
+        await file.update({
+          lastSeenTs: new Date(),
+        });
+      }
+    },
+    { concurrency: FILES_GC_CONCURRENCY }
   );
 
   // TODO(nodes-core): Run fixParents in dry run mode to check parentIds validity

--- a/connectors/src/lib/async_utils.ts
+++ b/connectors/src/lib/async_utils.ts
@@ -46,3 +46,18 @@ export async function concurrentExecutor<T, V>(
 
 export const setTimeoutAsync = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+export function getAdaptiveConcurrency(
+  files: { size?: number | null }[],
+  maxFileSize: number,
+  defaultConcurrency: number
+): number {
+  const maxFoundFileSize = files
+    .filter((file) => file.size && file.size <= maxFileSize)
+    .reduce((max, file) => Math.max(max, file.size ?? 0), 0);
+
+  return Math.min(
+    Math.floor(maxFileSize / maxFoundFileSize),
+    defaultConcurrency
+  );
+}


### PR DESCRIPTION
## Description

- Reduce concurrency (down to 1 if necessary) based on file size. This is to decrease the memory footprint of google drive connector, where as of now a single workflow can take 8GiB of RAM.
- Also cleanup the code a bit by removing usage of PQueue in favor of concurrentExecutor

## Tests

N/A

## Risk

Low
Blast radius: G drive sync

## Deploy Plan

- [ ] Deploy connector