### PR TITLE
[front] - feat(skills): JIT

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -66,7 +66,8 @@ export function ConversationContainerVirtuoso({
       input: string,
       mentions: RichMention[],
       contentFragments: ContentFragmentsType,
-      selectedMCPServerViewIds?: string[]
+      selectedMCPServerViewIds?: string[],
+      selectedSkillIds?: string[]
     ): Promise<Result<undefined, DustError>> => {
       if (isSubmitting) {
         return new Err({
@@ -84,6 +85,7 @@ export function ConversationContainerVirtuoso({
           mentions: mentions.map(toMentionType),
           contentFragments,
           selectedMCPServerViewIds,
+          selectedSkillIds,
         },
       });
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -14,6 +14,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { DustError } from "@app/lib/error";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
+  useAddDeleteConversationSkill,
   useAddDeleteConversationTool,
   useConversationTools,
 } from "@app/lib/swr/conversations";
@@ -169,6 +170,18 @@ export const InputBar = React.memo(function InputBar({
     workspaceId: owner.sId,
   });
 
+  // Get agent configuration ID from sticky mentions (first agent mention)
+  const agentConfigurationId = useMemo(() => {
+    const agentMention = stickyMentions?.find((m) => m.type === "agent");
+    return agentMention?.id ?? null;
+  }, [stickyMentions]);
+
+  const { addSkill, deleteSkill } = useAddDeleteConversationSkill({
+    conversationId,
+    workspaceId: owner.sId,
+    agentConfigurationId,
+  });
+
   const handleMCPServerViewSelect = (serverView: MCPServerViewType) => {
     // Optimistic update
     setSelectedMCPServerViews((prev) => [...prev, serverView]);
@@ -185,12 +198,12 @@ export const InputBar = React.memo(function InputBar({
 
   const handleSkillSelect = (skill: SkillType) => {
     setSelectedSkills((prev) => [...prev, skill]);
-    // TODO: Handle enabled skill in conversation
+    void addSkill(skill.sId);
   };
 
   const handleSkillDeselect = (skill: SkillType) => {
     setSelectedSkills((prev) => prev.filter((s) => s.sId !== skill.sId));
-    // TODO: Disabled skill in conversation
+    void deleteSkill(skill.sId);
   };
 
   const activeAgents = agentConfigurations.filter((a) => a.status === "active");

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -37,6 +37,7 @@ export function useCreateConversationWithMessage({
         contentFragments: ContentFragmentsType;
         clientSideMCPServerIds?: string[];
         selectedMCPServerViewIds?: string[];
+        selectedSkillIds?: string[];
       };
       visibility?: ConversationVisibility;
       title?: string;
@@ -56,6 +57,7 @@ export function useCreateConversationWithMessage({
         contentFragments,
         clientSideMCPServerIds,
         selectedMCPServerViewIds,
+        selectedSkillIds,
       } = messageData;
 
       const body: t.TypeOf<typeof InternalPostConversationsRequestBodySchema> =
@@ -71,6 +73,7 @@ export function useCreateConversationWithMessage({
               profilePictureUrl: user.image,
               clientSideMCPServerIds,
               selectedMCPServerViewIds,
+              selectedSkillIds,
             },
             mentions,
           },

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -1,7 +1,6 @@
 import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
   AgentMessageModel,
   ConversationModel,
@@ -82,9 +81,7 @@ export class ConversationSkillModel extends WorkspaceAwareModel<ConversationSkil
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare agentConfigurationId: ForeignKey<
-    AgentConfigurationModel["id"]
-  > | null;
+  declare agentConfigurationId: string | null;
 
   declare customSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
   declare globalSkillId: string | null;

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -1,6 +1,7 @@
 import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
   AgentMessageModel,
   ConversationModel,
@@ -24,7 +25,7 @@ const SKILL_IN_CONVERSATION_MODEL_ATTRIBUTES = {
   },
   agentConfigurationId: {
     type: DataTypes.STRING,
-    allowNull: false,
+    allowNull: true,
   },
   customSkillId: {
     type: DataTypes.BIGINT,
@@ -81,7 +82,9 @@ export class ConversationSkillModel extends WorkspaceAwareModel<ConversationSkil
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare agentConfigurationId: string;
+  declare agentConfigurationId: ForeignKey<
+    AgentConfigurationModel["id"]
+  > | null;
 
   declare customSkillId: ForeignKey<SkillConfigurationModel["id"]> | null;
   declare globalSkillId: string | null;

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1256,7 +1256,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       conversation: ConversationWithoutContentType;
       skills: SkillResource[];
       enabled: boolean;
-      agentConfigurationId: string | null | undefined;
+      agentConfigurationId: string | null;
     }
   ): Promise<Result<undefined, Error>> {
     const user = auth.user();

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1274,7 +1274,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     });
 
     if (!agentConfiguration) {
-      return new Err(new Error("Agent configuration not found"));
+      console.error("Agent configuration not found:", {
+        sId: agentConfigurationId,
+        workspaceId: workspace.id,
+      });
+      return new Err(
+        new Error(
+          `Agent configuration not found: sId=${agentConfigurationId}, workspaceId=${workspace.id}`
+        )
+      );
     }
 
     const existingConversationSkills = await this.fetchSkills(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1320,7 +1320,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         await ConversationSkillModel.create({
           conversationId: conversation.id,
           workspaceId: workspace.id,
-          agentConfigurationId: agentConfigurationModelId ?? undefined,
+          agentConfigurationId:
+            agentConfigurationModelId?.toString() ?? undefined,
           customSkillId: isGlobalSkill ? null : skill.id,
           globalSkillId: isGlobalSkill ? skillSId : null,
           source: "conversation",

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -12,7 +12,6 @@ import { col, fn, literal, Op, QueryTypes, Sequelize, where } from "sequelize";
 import { getMaximalVersionAgentStepContent } from "@app/lib/api/assistant/configuration/steps";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationMCPServerViewModel } from "@app/lib/models/agent/actions/conversation_mcp_server_view";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
   AgentMessageModel,
@@ -33,10 +32,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import {
-  getResourceIdFromSId,
-  isResourceSId,
-} from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -22,6 +22,9 @@ import type { FetchConversationMessagesResponse } from "@app/pages/api/w/[wId]/a
 import type { FetchConversationMessageResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]";
 import type { FetchConversationParticipantsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/participants";
 import type {
+  ConversationSkillActionRequest,
+} from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/skills";
+import type {
   ConversationToolActionRequest,
   FetchConversationToolsResponse,
 } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/tools";
@@ -423,6 +426,96 @@ export function useAddDeleteConversationTool({
   );
 
   return { addTool, deleteTool };
+}
+
+export function useAddDeleteConversationSkill({
+  conversationId,
+  workspaceId,
+  agentConfigurationId,
+}: {
+  conversationId: string | null;
+  workspaceId: string;
+  agentConfigurationId: string | null;
+}) {
+  const addSkill = useCallback(
+    async (skillId: string): Promise<boolean> => {
+      console.log("addSkill called", {
+        skillId,
+        conversationId,
+        agentConfigurationId,
+      });
+      if (!conversationId || !agentConfigurationId) {
+        console.log("addSkill: missing conversationId or agentConfigurationId");
+        return false;
+      }
+
+      try {
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/assistant/conversations/${conversationId}/skills`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              action: "add",
+              skill_id: skillId,
+              agent_configuration_id: agentConfigurationId,
+            } as ConversationSkillActionRequest),
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to add skill to conversation");
+        }
+
+        const result = await response.json();
+        return result.success === true;
+      } catch (error) {
+        console.error("Error adding skill to conversation:", error);
+        return false;
+      }
+    },
+    [conversationId, workspaceId, agentConfigurationId]
+  );
+
+  const deleteSkill = useCallback(
+    async (skillId: string): Promise<boolean> => {
+      if (!conversationId || !agentConfigurationId) {
+        return false;
+      }
+
+      try {
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/assistant/conversations/${conversationId}/skills`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              action: "delete",
+              skill_id: skillId,
+              agent_configuration_id: agentConfigurationId,
+            } as ConversationSkillActionRequest),
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to remove skill from conversation");
+        }
+
+        const result = await response.json();
+        return result.success === true;
+      } catch (error) {
+        console.error("Error removing skill from conversation:", error);
+        return false;
+      }
+    },
+    [conversationId, workspaceId, agentConfigurationId]
+  );
+
+  return { addSkill, deleteSkill };
 }
 
 export function useVisualizationRevert({

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -36,6 +36,7 @@ import type {
   ConversationWithoutContentType,
   LightWorkspaceType,
 } from "@app/types";
+import { normalizeError } from "@app/types";
 
 const DELAY_BEFORE_MARKING_AS_READ = 2000;
 
@@ -501,7 +502,14 @@ export function useAddDeleteConversationSkill({
         const result = await response.json();
         return result.success === true;
       } catch (error) {
-        console.error("Error adding skill to conversation:", error);
+        datadogLogger.error(
+          {
+            error: normalizeError(error),
+            conversationId,
+            workspaceId,
+          },
+          "[JIT Skill] Error adding skill to conversation"
+        );
         return false;
       }
     },
@@ -537,7 +545,15 @@ export function useAddDeleteConversationSkill({
         const result = await response.json();
         return result.success === true;
       } catch (error) {
-        console.error("Error removing skill from conversation:", error);
+        datadogLogger.error(
+          {
+            error: normalizeError(error),
+            conversationId,
+            workspaceId,
+            skillId,
+          },
+          "[JIT Skill] Error removing skill from conversation"
+        );
         return false;
       }
     },

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -317,13 +317,9 @@ export function useConversationSkills({
   );
 
   return {
-    conversationSkills: useMemo(
-      () =>
-        data
-          ? data.skills
-          : emptyArray<FetchConversationSkillsResponse["skills"][number]>(),
-      [data]
-    ),
+    conversationSkills: data
+      ? data.skills
+      : emptyArray<FetchConversationSkillsResponse["skills"][number]>(),
     isConversationSkillsLoading: !error && !data,
     isConversationSkillsError: error,
     mutateConversationSkills: mutate,
@@ -490,8 +486,8 @@ export function useAddDeleteConversationSkill({
             },
             body: JSON.stringify({
               action: "add",
-              skill_id: skillId,
-              agent_configuration_id: agentConfigurationId,
+              skillId,
+              agentConfigurationId,
             } satisfies ConversationSkillActionRequest),
           }
         );
@@ -539,8 +535,8 @@ export function useAddDeleteConversationSkill({
             },
             body: JSON.stringify({
               action: "delete",
-              skill_id: skillId,
-              agent_configuration_id: agentConfigurationId,
+              skillId,
+              agentConfigurationId,
             } satisfies ConversationSkillActionRequest),
           }
         );

--- a/front/migrations/db/migration_456.sql
+++ b/front/migrations/db/migration_456.sql
@@ -1,0 +1,9 @@
+-- Make agentConfigurationId nullable in conversation_skills table
+-- to support JIT skills that apply to all agents (agentConfigurationId = NULL)
+ALTER TABLE "conversation_skills"
+    ALTER COLUMN "agentConfigurationId" DROP NOT NULL;
+
+-- Make agentConfigurationId nullable in agent_message_skills table
+-- to support JIT skills that apply to all agents (agentConfigurationId = NULL)
+ALTER TABLE "agent_message_skills"
+    ALTER COLUMN "agentConfigurationId" DROP NOT NULL;

--- a/front/migrations/db/migration_456.sql
+++ b/front/migrations/db/migration_456.sql
@@ -7,3 +7,5 @@ ALTER TABLE "conversation_skills"
 -- to support JIT skills that apply to all agents (agentConfigurationId = NULL)
 ALTER TABLE "agent_message_skills"
     ALTER COLUMN "agentConfigurationId" DROP NOT NULL;
+
+CREATE INDEX CONCURRENTLY "conversation_skills_workspace_id_conversation_id" ON "conversation_skills" ("workspaceId", "conversationId");

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -20,7 +20,7 @@ export type FetchConversationSkillsResponse = {
 const ConversationSkillActionRequestSchema = z.object({
   action: z.enum(["add", "delete"]),
   skill_id: z.string(),
-  agent_configuration_id: z.string(),
+  agent_configuration_id: z.string().nullable().optional(),
 });
 
 export type ConversationSkillActionRequest = z.infer<

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -10,7 +10,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { normalizeError } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export type FetchConversationSkillsResponse = {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -1,0 +1,207 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { normalizeError } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+export type FetchConversationSkillsResponse = {
+  skills: SkillType[];
+};
+
+const ConversationSkillActionRequestSchema = z.object({
+  action: z.enum(["add", "delete"]),
+  skill_id: z.string(),
+  agent_configuration_id: z.string(),
+});
+
+export type ConversationSkillActionRequest = z.infer<
+  typeof ConversationSkillActionRequestSchema
+>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<FetchConversationSkillsResponse | { success: boolean }>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!(typeof req.query.cId === "string")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  const conversationId = req.query.cId;
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const conversationWithoutContent = conversationRes.value;
+
+  switch (req.method) {
+    case "GET":
+      try {
+        const conversationSkills = await ConversationResource.fetchSkills(
+          auth,
+          conversationWithoutContent
+        );
+
+        const skills: SkillType[] = [];
+        for (const conversationSkill of conversationSkills) {
+          let skillId: string;
+          if (conversationSkill.globalSkillId) {
+            skillId = conversationSkill.globalSkillId;
+          } else if (conversationSkill.customSkillId) {
+            skillId = SkillResource.modelIdToSId({
+              id: conversationSkill.customSkillId,
+              workspaceId: conversationSkill.workspaceId,
+            });
+          } else {
+            continue;
+          }
+
+          const skillRes = await SkillResource.fetchById(auth, skillId);
+          if (skillRes) {
+            skills.push(skillRes.toJSON(auth));
+          }
+        }
+
+        res.status(200).json({ skills });
+      } catch (error) {
+        logger.error(
+          {
+            error: normalizeError(error),
+            conversationId,
+            workspaceId: req.query.wId,
+          },
+          "Error fetching conversation skills"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to fetch conversation skills",
+          },
+        });
+      }
+      break;
+
+    case "POST":
+      const parseResult = ConversationSkillActionRequestSchema.safeParse(
+        req.body
+      );
+
+      if (!parseResult.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: fromError(parseResult.error).toString(),
+          },
+        });
+      }
+
+      const { action, skill_id, agent_configuration_id } = parseResult.data;
+
+      try {
+        const skillRes = await SkillResource.fetchById(auth, skill_id);
+
+        if (!skillRes) {
+          logger.error(
+            {
+              skillId: skill_id,
+              conversationId,
+              workspaceId: req.query.wId,
+            },
+            "Skill not found"
+          );
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "skill_not_found",
+              message: "Skill not found",
+            },
+          });
+        }
+
+        const r = await ConversationResource.upsertSkills(auth, {
+          conversation: conversationWithoutContent,
+          skills: [skillRes],
+          enabled: action === "add",
+          agentConfigurationId: agent_configuration_id,
+        });
+        if (r.isErr()) {
+          logger.error(
+            {
+              error: r.error,
+              skillId: skill_id,
+              conversationId,
+              agentConfigurationId: agent_configuration_id,
+              action,
+              workspaceId: req.query.wId,
+            },
+            "Failed to upsert skill to conversation"
+          );
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to add skill to conversation",
+            },
+          });
+        }
+
+        res.status(200).json({ success: true });
+      } catch (error) {
+        logger.error(
+          {
+            error: normalizeError(error),
+            skillId: skill_id,
+            conversationId,
+            agentConfigurationId: agent_configuration_id,
+            action,
+            workspaceId: req.query.wId,
+          },
+          "Error updating conversation skills"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to update conversation skills",
+          },
+        });
+      }
+      break;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET or POST expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -60,9 +60,9 @@ async function handler(
   switch (req.method) {
     case "GET":
       try {
-        const conversationSkills = await ConversationResource.fetchSkills(
+        const conversationSkills = await SkillResource.fetchConversationSkills(
           auth,
-          conversationWithoutContent
+          conversationWithoutContent.id
         );
 
         const skills: SkillType[] = [];
@@ -143,8 +143,8 @@ async function handler(
           });
         }
 
-        const r = await ConversationResource.upsertSkills(auth, {
-          conversation: conversationWithoutContent,
+        const r = await SkillResource.upsertConversationSkills(auth, {
+          conversationId: conversationWithoutContent.id,
           skills: [skillRes],
           enabled: action === "add",
           agentConfigurationId: agent_configuration_id ?? null,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -147,7 +147,7 @@ async function handler(
           conversation: conversationWithoutContent,
           skills: [skillRes],
           enabled: action === "add",
-          agentConfigurationId: agent_configuration_id,
+          agentConfigurationId: agent_configuration_id ?? null,
         });
         if (r.isErr()) {
           logger.error(

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -221,6 +221,7 @@ async function handler(
             enabled: true,
             agentConfigurationId: null, // JIT skills apply to all agents in conversation
           });
+
           if (r.isErr()) {
             return apiError(req, res, {
               status_code: 500,

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -215,8 +215,8 @@ async function handler(
             message.context.selectedSkillIds
           );
 
-          const r = await ConversationResource.upsertSkills(auth, {
-            conversation,
+          const r = await SkillResource.upsertConversationSkills(auth, {
+            conversationId: conversation.id,
             skills,
             enabled: true,
             agentConfigurationId: null, // JIT skills apply to all agents in conversation

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -14,6 +14,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
@@ -202,6 +203,30 @@ async function handler(
               api_error: {
                 type: "internal_server_error",
                 message: "Failed to add MCP server views to conversation",
+              },
+            });
+          }
+        }
+
+        // If JIT skills are selected, add them to the conversation before posting the message.
+        if (message.context.selectedSkillIds) {
+          const skills = await SkillResource.fetchByIds(
+            auth,
+            message.context.selectedSkillIds
+          );
+
+          const r = await ConversationResource.upsertSkills(auth, {
+            conversation,
+            skills,
+            enabled: true,
+            agentConfigurationId: null, // JIT skills apply to all agents in conversation
+          });
+          if (r.isErr()) {
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to add skills to conversation",
               },
             });
           }

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -25,6 +25,7 @@ export const MessageBaseSchema = t.type({
     t.partial({
       clientSideMCPServerIds: t.array(t.string),
       selectedMCPServerViewIds: t.array(t.string),
+      selectedSkillIds: t.array(t.string),
       originMessageId: t.string,
     }),
   ]),

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -399,6 +399,27 @@ export type ConversationMCPServerViewType = {
   updatedAt: Date;
 };
 
+type ConversationSkillTypeBase = {
+  id: ModelId;
+  workspaceId: ModelId;
+  conversationId: ModelId;
+  agentConfigurationId: ModelId;
+  source: string;
+  addedByUserId: ModelId | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type ConversationSkillType =
+  | (ConversationSkillTypeBase & {
+      customSkillId: ModelId;
+      globalSkillId: null;
+    })
+  | (ConversationSkillTypeBase & {
+      customSkillId: null;
+      globalSkillId: string;
+    });
+
 export type MCPActionValidationRequest = Omit<
   MCPApproveExecutionEvent,
   "type" | "created" | "configurationId"

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -400,27 +400,6 @@ export type ConversationMCPServerViewType = {
   updatedAt: Date;
 };
 
-type ConversationSkillTypeBase = {
-  id: ModelId;
-  workspaceId: ModelId;
-  conversationId: ModelId;
-  agentConfigurationId: string | null;
-  source: string;
-  addedByUserId: ModelId | null;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-export type ConversationSkillType =
-  | (ConversationSkillTypeBase & {
-      customSkillId: ModelId;
-      globalSkillId: null;
-    })
-  | (ConversationSkillTypeBase & {
-      customSkillId: null;
-      globalSkillId: string;
-    });
-
 export type MCPActionValidationRequest = Omit<
   MCPApproveExecutionEvent,
   "type" | "created" | "configurationId"

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -108,6 +108,7 @@ export type UserMessageContext = {
   lastTriggerRunAt?: number | null;
   clientSideMCPServerIds?: string[];
   selectedMCPServerViewIds?: string[];
+  selectedSkillIds?: string[];
 };
 
 export type AgenticMessageData = {
@@ -403,7 +404,7 @@ type ConversationSkillTypeBase = {
   id: ModelId;
   workspaceId: ModelId;
   conversationId: ModelId;
-  agentConfigurationId: ModelId;
+  agentConfigurationId: ModelId | null;
   source: string;
   addedByUserId: ModelId | null;
   createdAt: Date;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -404,7 +404,7 @@ type ConversationSkillTypeBase = {
   id: ModelId;
   workspaceId: ModelId;
   conversationId: ModelId;
-  agentConfigurationId: ModelId | null;
+  agentConfigurationId: string | null;
   source: string;
   addedByUserId: ModelId | null;
   createdAt: Date;


### PR DESCRIPTION
## Description

This PR implements Just-In-Time (JIT) skills for conversations. JIT skills are skills that apply to all agents in a conversation (rather than being scoped to a specific agent configuration), allowing users to dynamically enable skills when starting a new conversation.

The implementation makes `agentConfigurationId` nullable in the `conversation_skills` and `agent_message_skills` tables. When `agentConfigurationId` is `NULL`, the skill applies globally to all agents in that conversation.

Key changes:
- Frontend components now pass `selectedSkillIds` through the conversation creation flow
- Added new API endpoint `/api/w/[wId]/assistant/conversations/[cId]/skills` to manage JIT skills
- Created SWR hooks (`useConversationSkills`, `useAddDeleteConversationSkill`) for skill management
- Updated `ConversationResource.upsertSkills` to handle both JIT skills (null `agentConfigurationId`) and agent-scoped skills

## Risk

Database schema migration is required to make `agentConfigurationId` nullable in both `conversation_skills` and `agent_message_skills` tables.

## Tests

Tested locally with the skills feature flag enabled.

## Deploy Plan

1. Run migration 454 to alter the `conversation_skills` and `agent_message_skills` tables
2. Deploy front
