### PR TITLE
Make notifications delay configurable

### DIFF
--- a/front/components/me/AccountSettings.tsx
+++ b/front/components/me/AccountSettings.tsx
@@ -21,6 +21,8 @@ import { useEffect, useRef, useState } from "react";
 import { useController, useForm } from "react-hook-form";
 import { z } from "zod";
 
+import type { NotificationPreferencesRef } from "@app/components/me/NotificationPreferences";
+import { NotificationPreferences } from "@app/components/me/NotificationPreferences";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
@@ -28,10 +30,6 @@ import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { usePatchUser, useUser } from "@app/lib/swr/user";
 import type { WorkspaceType } from "@app/types";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types";
-import {
-  NotificationPreferences,
-  type NotificationPreferencesRef,
-} from "@app/components/me/NotificationPreferences";
 
 interface AccountSettingsProps {
   owner: WorkspaceType;

--- a/front/components/me/AccountSettings.tsx
+++ b/front/components/me/AccountSettings.tsx
@@ -10,6 +10,7 @@ import {
   Label,
   LightModeIcon,
   MoonIcon,
+  Page,
   PencilSquareIcon,
   Spinner,
   SunIcon,
@@ -24,13 +25,15 @@ import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
-import { usePatchUser } from "@app/lib/swr/user";
-import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types";
+import { usePatchUser, useUser } from "@app/lib/swr/user";
+import type { WorkspaceType } from "@app/types";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types";
+import {
+  NotificationPreferences,
+  type NotificationPreferencesRef,
+} from "@app/components/me/NotificationPreferences";
 
 interface AccountSettingsProps {
-  user: UserTypeWithWorkspaces | null;
-  isUserLoading: boolean;
   owner: WorkspaceType;
 }
 
@@ -44,11 +47,8 @@ const AccountSettingsSchema = z.object({
 
 type AccountSettingsType = z.infer<typeof AccountSettingsSchema>;
 
-export function AccountSettings({
-  user,
-  isUserLoading,
-  owner,
-}: AccountSettingsProps) {
+export function AccountSettings({ owner }: AccountSettingsProps) {
+  const { user, isUserLoading } = useUser();
   const { theme: currentTheme, setTheme } = useTheme();
 
   const { patchUser } = usePatchUser();
@@ -56,6 +56,8 @@ export function AccountSettings({
 
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const notificationPreferencesRef = useRef<NotificationPreferencesRef>(null);
+  const [hasNotificationChanges, setHasNotificationChanges] = useState(false);
 
   const fileUploaderService = useFileUploaderService({
     owner,
@@ -141,6 +143,12 @@ export function AccountSettings({
       if (typeof window !== "undefined") {
         localStorage.setItem("submitMessageKey", data.submitMessageKey);
       }
+
+      // Save notification preferences if available
+      if (notificationPreferencesRef.current) {
+        await notificationPreferencesRef.current.savePreferences();
+        setHasNotificationChanges(false);
+      }
     }
   };
 
@@ -158,6 +166,20 @@ export function AccountSettings({
       submitMessageKey:
         storedKey && isSubmitMessageKey(storedKey) ? storedKey : "enter",
     });
+
+    // Reset notification preferences
+    if (notificationPreferencesRef.current) {
+      notificationPreferencesRef.current.reset();
+      setHasNotificationChanges(false);
+    }
+  };
+
+  // Check if notification preferences have changed
+  const checkNotificationChanges = () => {
+    if (notificationPreferencesRef.current) {
+      const isDirty = notificationPreferencesRef.current.isDirty();
+      setHasNotificationChanges(isDirty);
+    }
   };
 
   if (isUserLoading) {
@@ -324,19 +346,35 @@ export function AccountSettings({
           </div>
         </div>
 
+        {user?.subscriberHash && (
+          <div className="mt-6 flex flex-col gap-4">
+            <Page.SectionHeader title="Notifications" />
+            <NotificationPreferences
+              ref={notificationPreferencesRef}
+              onChanged={checkNotificationChanges}
+            />
+          </div>
+        )}
+
         <div className="flex justify-end gap-2">
           <Button
             label="Cancel"
             variant="ghost"
             onClick={handleCancel}
             type="button"
-            disabled={!form.formState.isDirty || form.formState.isSubmitting}
+            disabled={
+              (!form.formState.isDirty && !hasNotificationChanges) ||
+              form.formState.isSubmitting
+            }
           />
           <Button
             label="Save"
             variant="primary"
             type="submit"
-            disabled={!form.formState.isDirty || form.formState.isSubmitting}
+            disabled={
+              (!form.formState.isDirty && !hasNotificationChanges) ||
+              form.formState.isSubmitting
+            }
             loading={form.formState.isSubmitting}
           />
         </div>

--- a/front/components/me/AccountSettings.tsx
+++ b/front/components/me/AccountSettings.tsx
@@ -21,7 +21,7 @@ import { useEffect, useRef, useState } from "react";
 import { useController, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import type { NotificationPreferencesRef } from "@app/components/me/NotificationPreferences";
+import type { NotificationPreferencesRefProps } from "@app/components/me/NotificationPreferences";
 import { NotificationPreferences } from "@app/components/me/NotificationPreferences";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
@@ -54,7 +54,8 @@ export function AccountSettings({ owner }: AccountSettingsProps) {
 
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const notificationPreferencesRef = useRef<NotificationPreferencesRef>(null);
+  const notificationPreferencesRef =
+    useRef<NotificationPreferencesRefProps>(null);
   const [hasNotificationChanges, setHasNotificationChanges] = useState(false);
 
   const fileUploaderService = useFileUploaderService({
@@ -220,6 +221,10 @@ export function AccountSettings({ owner }: AccountSettingsProps) {
     return input;
   };
 
+  const buttonDisabled =
+    (!form.formState.isDirty && !hasNotificationChanges) ||
+    form.formState.isSubmitting;
+
   return (
     <FormProvider form={form} onSubmit={updateUserProfile}>
       <input
@@ -360,19 +365,13 @@ export function AccountSettings({ owner }: AccountSettingsProps) {
             variant="ghost"
             onClick={handleCancel}
             type="button"
-            disabled={
-              (!form.formState.isDirty && !hasNotificationChanges) ||
-              form.formState.isSubmitting
-            }
+            disabled={buttonDisabled}
           />
           <Button
             label="Save"
             variant="primary"
             type="submit"
-            disabled={
-              (!form.formState.isDirty && !hasNotificationChanges) ||
-              form.formState.isSubmitting
-            }
+            disabled={buttonDisabled}
             loading={form.formState.isSubmitting}
           />
         </div>

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -22,8 +22,8 @@ import {
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useNovuClient } from "@app/hooks/useNovuClient";
 import { useUserMetadata } from "@app/lib/swr/user";
-import { type NotificationPreferencesDelay } from "@app/types/notification_preferences";
 import { setUserMetadataFromClient } from "@app/lib/user";
+import type { NotificationPreferencesDelay } from "@app/types/notification_preferences";
 
 const CHANNELS_TO_NAMES: Record<keyof ChannelPreference, string> = {
   in_app: "In-App",

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -23,10 +23,10 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useNovuClient } from "@app/hooks/useNovuClient";
 import { useUserMetadata } from "@app/lib/swr/user";
 import { setUserMetadataFromClient } from "@app/lib/user";
+import type {NotificationPreferencesDelay} from "@app/types/notification_preferences";
 import {
   isNotificationPreferencesDelay,
-  makeNotificationPreferencesUserMetadata,
-  type NotificationPreferencesDelay,
+  makeNotificationPreferencesUserMetadata
 } from "@app/types/notification_preferences";
 
 const CHANNELS_TO_NAMES: Record<keyof ChannelPreference, string> = {

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -1,107 +1,271 @@
-import { Checkbox, Label, Spinner } from "@dust-tt/sparkle";
-import type { Preference } from "@novu/js";
+import {
+  Button,
+  Checkbox,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Label,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ChannelPreference, Preference } from "@novu/js";
 import { PreferenceLevel } from "@novu/js";
-import type { ChannelPreference } from "@novu/react";
 import cloneDeep from "lodash/cloneDeep";
-import { useEffect, useState } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useNovuClient } from "@app/hooks/useNovuClient";
+import { useUserMetadata } from "@app/lib/swr/user";
+import { type NotificationPreferencesDelay } from "@app/types/notification_preferences";
+import { setUserMetadataFromClient } from "@app/lib/user";
 
-const CHANNELS_TO_NAMES: Map<keyof ChannelPreference, string> = new Map([
-  ["in_app", "In-App"],
-  ["email", "Email"],
-  ["sms", "SMS"],
-  ["chat", "Chat"],
-  ["push", "Push"],
-]);
+const CHANNELS_TO_NAMES: Record<keyof ChannelPreference, string> = {
+  in_app: "In-App",
+  email: "Email",
+  sms: "SMS",
+  chat: "Chat",
+  push: "Push",
+};
 
-export const NotificationPreferences = () => {
+const NOTIFICATION_PREFERENCES_DELAY_LABELS: Record<
+  NotificationPreferencesDelay,
+  string
+> = {
+  "5_minutes": "Every 5 minutes",
+  "15_minutes": "Every 15 minutes",
+  "30_minutes": "Every 30 minutes",
+  "1_hour": "Every hour",
+  daily: "Once a day",
+};
+
+const NOTIFICATION_DELAY_OPTIONS = Object.keys(
+  NOTIFICATION_PREFERENCES_DELAY_LABELS
+) as NotificationPreferencesDelay[];
+
+export interface NotificationPreferencesRef {
+  savePreferences: () => Promise<boolean>;
+  isDirty: () => boolean;
+  reset: () => void;
+}
+
+interface NotificationPreferencesProps {
+  onChanged: () => void;
+}
+
+export const NotificationPreferences = forwardRef<
+  NotificationPreferencesRef,
+  NotificationPreferencesProps
+>(({ onChanged }, ref) => {
   const sendNotification = useSendNotification();
   const [globalPreferences, setGlobalPreferences] = useState<
     Preference | undefined
   >();
+  const [emailDelay, setEmailDelay] =
+    useState<NotificationPreferencesDelay>("1_hour");
 
   const { novuClient } = useNovuClient();
+  const { metadata: emailDelayMetadata, mutateMetadata: mutateEmailDelay } =
+    useUserMetadata("email_notification_preferences");
+
+  // Store the original preferences to allow resetting on cancel
+  const originalPreferencesRef = useRef<Preference | undefined>();
+  const originalEmailDelayRef = useRef<NotificationPreferencesDelay>("1_hour");
+
+  // Load email delay from user metadata
+  useEffect(() => {
+    if (emailDelayMetadata?.value) {
+      const delay = emailDelayMetadata.value as NotificationPreferencesDelay;
+      setEmailDelay(delay);
+      originalEmailDelayRef.current = delay;
+    }
+  }, [emailDelayMetadata]);
 
   useEffect(() => {
+    // Load global preferences from Novu
     void novuClient?.preferences.list().then((preferences) => {
-      setGlobalPreferences(
-        preferences.data?.find(
-          (preference) => preference.level === PreferenceLevel.GLOBAL
-        )
+      const globalPref = preferences.data?.find(
+        (preference) => preference.level === PreferenceLevel.GLOBAL
       );
+      setGlobalPreferences(globalPref);
+      originalPreferencesRef.current = globalPref;
     });
   }, [novuClient]);
+
+  // Expose methods to parent component
+  useImperativeHandle(
+    ref,
+    () => ({
+      savePreferences: async () => {
+        if (!globalPreferences || !novuClient) {
+          return false;
+        }
+
+        try {
+          // Save global preferences in Novu
+          const result = await novuClient.preferences.update({
+            preference: globalPreferences,
+            channels: globalPreferences.channels,
+          });
+
+          if (result.error) {
+            sendNotification({
+              type: "error",
+              title: "Error updating notification preferences",
+              description: result.error.message,
+            });
+            return false;
+          }
+
+          // Save email delay in user metadata
+          await setUserMetadataFromClient({
+            key: "email_notification_preferences",
+            value: emailDelay,
+          });
+          await mutateEmailDelay((current) => {
+            if (current) {
+              return {
+                ...current,
+                value: emailDelay,
+              };
+            }
+            return current;
+          });
+
+          // Update the original references on successful save
+          originalPreferencesRef.current = globalPreferences;
+          originalEmailDelayRef.current = emailDelay;
+          return true;
+        } catch (error) {
+          sendNotification({
+            type: "error",
+            title: "Error updating notification preferences",
+            description: error instanceof Error ? error.message : String(error),
+          });
+          return false;
+        }
+      },
+      isDirty: () => {
+        if (!originalPreferencesRef.current || !globalPreferences) {
+          return false;
+        }
+
+        const original = originalPreferencesRef.current;
+        const current = globalPreferences;
+
+        // Compare channel preferences
+        for (const channel of Object.keys(original.channels) as Array<
+          keyof typeof original.channels
+        >) {
+          if (original.channels[channel] !== current.channels[channel]) {
+            return true;
+          }
+        }
+
+        // Compare email delay
+        if (emailDelay !== originalEmailDelayRef.current) {
+          return true;
+        }
+
+        return false;
+      },
+      reset: () => {
+        // Reset to original preferences
+        if (originalPreferencesRef.current) {
+          setGlobalPreferences(cloneDeep(originalPreferencesRef.current));
+        }
+        setEmailDelay(originalEmailDelayRef.current);
+      },
+    }),
+    [globalPreferences, emailDelay]
+  );
+
+  useEffect(() => {
+    // Notify parent component of changes
+    onChanged();
+  }, [globalPreferences, emailDelay, onChanged]);
 
   return (
     <div>
       {!globalPreferences ? (
         <Spinner />
       ) : (
-        <div className="flex flex-row gap-4">
-          {Array.from(CHANNELS_TO_NAMES.entries()).map(([channel, name]) =>
-            globalPreferences.channels[channel] === undefined ? null : (
-              <>
-                <Checkbox
-                  id={`${channel}-preference`}
-                  key={channel}
-                  checked={
-                    globalPreferences.channels[channel] &&
-                    globalPreferences.enabled
-                  }
-                  onCheckedChange={(checked) => {
-                    setGlobalPreferences((prev) => {
-                      if (!prev) {
-                        return undefined;
-                      }
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-row gap-6">
+            {(
+              Object.entries(CHANNELS_TO_NAMES) as [
+                keyof typeof CHANNELS_TO_NAMES,
+                string,
+              ][]
+            ).map(([channel, name]) =>
+              globalPreferences.channels[channel] === undefined ? null : (
+                <div key={channel} className="flex items-center gap-1.5">
+                  <Checkbox
+                    id={`${channel}-preference`}
+                    checked={
+                      globalPreferences.channels[channel] &&
+                      globalPreferences.enabled
+                    }
+                    onCheckedChange={(checked) => {
+                      setGlobalPreferences((prev) => {
+                        if (!prev) {
+                          return undefined;
+                        }
 
-                      const newPreferences = cloneDeep(prev);
+                        const newPreferences = cloneDeep(prev);
 
-                      // Modifying in place because the preference class is not just a plain object.
-                      newPreferences.channels[channel] =
-                        checked === true ? true : false;
+                        // Modifying in place because the preference class is not just a plain object.
+                        newPreferences.channels[channel] =
+                          checked === true ? true : false;
 
-                      void novuClient?.preferences
-                        .update({
-                          preference: newPreferences,
-                          channels: newPreferences.channels,
-                        })
-                        .then((result) => {
-                          if (result.error) {
-                            sendNotification({
-                              type: "error",
-                              title: "Error updating notification preferences",
-                              description: result.error.message,
-                            });
-                            setGlobalPreferences(prev);
-                          }
-                        })
-                        .catch((error) => {
-                          sendNotification({
-                            type: "error",
-                            title: "Error updating notification preferences",
-                            description: error.message,
-                          });
-                          setGlobalPreferences(prev);
-                        });
+                        // Need to clone the preference to trigger the state update.
+                        return newPreferences;
+                      });
+                    }}
+                  />
+                  <Label
+                    htmlFor={`${channel}-preference`}
+                    className="cursor-pointer"
+                  >
+                    {name}
+                  </Label>
+                </div>
+              )
+            )}
+          </div>
 
-                      // Need to clone the preference to trigger the state update.
-                      return newPreferences;
-                    });
-                  }}
+          <div className="flex items-center gap-2">
+            <Label>Email notification delay:</Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  isSelect
+                  label={NOTIFICATION_PREFERENCES_DELAY_LABELS[emailDelay]}
+                  disabled={!globalPreferences.channels.email}
                 />
-                <Label
-                  htmlFor={`${channel}-preference`}
-                  className="cursor-pointer"
-                >
-                  {name}
-                </Label>
-              </>
-            )
-          )}
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                {NOTIFICATION_DELAY_OPTIONS.map((delay) => (
+                  <DropdownMenuItem
+                    key={delay}
+                    label={NOTIFICATION_PREFERENCES_DELAY_LABELS[delay]}
+                    onClick={() => {
+                      setEmailDelay(delay);
+                    }}
+                  />
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
       )}
     </div>
   );
-};
+});

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -23,10 +23,10 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useNovuClient } from "@app/hooks/useNovuClient";
 import { useUserMetadata } from "@app/lib/swr/user";
 import { setUserMetadataFromClient } from "@app/lib/user";
-import type {NotificationPreferencesDelay} from "@app/types/notification_preferences";
+import type { NotificationPreferencesDelay } from "@app/types/notification_preferences";
 import {
   isNotificationPreferencesDelay,
-  makeNotificationPreferencesUserMetadata
+  makeNotificationPreferencesUserMetadata,
 } from "@app/types/notification_preferences";
 
 const CHANNELS_TO_NAMES: Record<keyof ChannelPreference, string> = {

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -122,20 +122,22 @@ export const NotificationPreferences = forwardRef<
             return false;
           }
 
-          // Save email delay in user metadata
-          await setUserMetadataFromClient({
-            key: "email_notification_preferences",
-            value: emailDelay,
-          });
-          await mutateEmailDelay((current) => {
-            if (current) {
-              return {
-                ...current,
-                value: emailDelay,
-              };
-            }
-            return current;
-          });
+          // Save email delay in user metadata only if it changed
+          if (emailDelay !== originalEmailDelayRef.current) {
+            await setUserMetadataFromClient({
+              key: "email_notification_preferences",
+              value: emailDelay,
+            });
+            await mutateEmailDelay((current) => {
+              if (current) {
+                return {
+                  ...current,
+                  value: emailDelay,
+                };
+              }
+              return current;
+            });
+          }
 
           // Update the original references on successful save
           originalPreferencesRef.current = globalPreferences;

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -27,6 +27,7 @@ import type { NotificationPreferencesDelay } from "@app/types/notification_prefe
 import {
   isNotificationPreferencesDelay,
   makeNotificationPreferencesUserMetadata,
+  NOTIFICATION_DELAY_OPTIONS,
 } from "@app/types/notification_preferences";
 
 const CHANNELS_TO_NAMES: Record<keyof ChannelPreference, string> = {
@@ -47,10 +48,6 @@ const NOTIFICATION_PREFERENCES_DELAY_LABELS: Record<
   "1_hour": "Every hour",
   daily: "Once a day",
 };
-
-const NOTIFICATION_DELAY_OPTIONS = Object.keys(
-  NOTIFICATION_PREFERENCES_DELAY_LABELS
-) as NotificationPreferencesDelay[];
 
 const DEFAULT_NOTIFICATION_DELAY = "1_hour";
 

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -22,10 +22,10 @@ import {
   isUserMessageType,
   Ok,
 } from "@app/types";
+import type { NotificationPreferencesDelay } from "@app/types/notification_preferences";
 import {
   isNotificationPreferencesDelay,
   makeNotificationPreferencesUserMetadata,
-  type NotificationPreferencesDelay,
 } from "@app/types/notification_preferences";
 
 const CONVERSATION_UNREAD_TRIGGER_ID = "conversation-unread";

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -1,5 +1,7 @@
 import { workflow } from "@novu/framework";
+import type { ChannelPreference } from "@novu/react";
 import uniqBy from "lodash/uniqBy";
+import { Op } from "sequelize";
 import z from "zod";
 
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
@@ -9,6 +11,7 @@ import type { NotificationAllowedTags } from "@app/lib/notifications";
 import { getNovuClient } from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/conversations-unread";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { Result, UserMessageOrigin } from "@app/types";
 import {
@@ -19,10 +22,7 @@ import {
   isUserMessageType,
   Ok,
 } from "@app/types";
-import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
-import { Op } from "sequelize";
-import { NotificationPreferencesDelay } from "@app/types/notification_preferences";
-import { ChannelPreference } from "@novu/react";
+import type { NotificationPreferencesDelay } from "@app/types/notification_preferences";
 
 const CONVERSATION_UNREAD_TRIGGER_ID = "conversation-unread";
 
@@ -96,13 +96,13 @@ type NotificationDelayConfig = {
  */
 const NOTIFICATION_PREFERENCES_DELAYS: Record<
   NotificationPreferencesDelay,
-  NotificationDelayConfig
+  NotificationDelayConfig | { cron: string }
 > = {
   "5_minutes": { amount: 5, unit: "minutes" },
   "15_minutes": { amount: 15, unit: "minutes" },
   "30_minutes": { amount: 30, unit: "minutes" },
   "1_hour": { amount: 1, unit: "hours" },
-  daily: { amount: 1, unit: "days" },
+  daily: { cron: "0 6 * * *" }, // Every day at 6am
 };
 
 const getConversationDetails = async ({

--- a/front/pages/w/[wId]/me/index.tsx
+++ b/front/pages/w/[wId]/me/index.tsx
@@ -13,7 +13,6 @@ import type { InferGetServerSidePropsType } from "next";
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { AccountSettings } from "@app/components/me/AccountSettings";
-import { NotificationPreferences } from "@app/components/me/NotificationPreferences";
 import { PendingInvitationsTable } from "@app/components/me/PendingInvitationsTable";
 import { ProfileTriggersTab } from "@app/components/me/ProfileTriggersTab";
 import { UserToolsTable } from "@app/components/me/UserToolsTable";
@@ -22,7 +21,6 @@ import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
-import { useUser } from "@app/lib/swr/user";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 
@@ -74,8 +72,6 @@ export default function ProfilePage({
   subscription,
   pendingInvitations,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const { user, isUserLoading } = useUser();
-
   return (
     <AppCenteredLayout
       subscription={subscription}
@@ -87,24 +83,13 @@ export default function ProfilePage({
         <Page.Header title="Profile Settings" icon={UserIcon} />
         <Page.Layout direction="vertical">
           <Page.SectionHeader title="Account Settings" />
-          <AccountSettings
-            user={user}
-            isUserLoading={isUserLoading}
-            owner={owner}
-          />
+          <AccountSettings owner={owner} />
 
           {pendingInvitations.length > 0 && (
             <>
               <Separator />
               <Page.SectionHeader title="Pending Invitations" />
               <PendingInvitationsTable invitations={pendingInvitations} />
-            </>
-          )}
-          {user?.subscriberHash && (
-            <>
-              <Separator />
-              <Page.SectionHeader title="Notifications" />
-              <NotificationPreferences />
             </>
           )}
 

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -1,9 +1,29 @@
+import { ChannelPreference } from "@novu/react";
+
 /**
  * Available delay options for email digest notifications.
  */
-export type NotificationPreferencesDelay =
-  | "5_minutes"
-  | "15_minutes"
-  | "30_minutes"
-  | "1_hour"
-  | "daily";
+const VALID_DELAYS = [
+  "5_minutes",
+  "15_minutes",
+  "30_minutes",
+  "1_hour",
+  "daily",
+] as const;
+
+export type NotificationPreferencesDelay = (typeof VALID_DELAYS)[number];
+
+export const isNotificationPreferencesDelay = (
+  value: unknown
+): value is NotificationPreferencesDelay => {
+  return (
+    typeof value === "string" &&
+    (VALID_DELAYS as readonly string[]).includes(value)
+  );
+};
+
+export function makeNotificationPreferencesUserMetadata(
+  channel: keyof ChannelPreference
+): string {
+  return `${channel}_notification_preferences`;
+}

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -3,7 +3,7 @@ import type { ChannelPreference } from "@novu/react";
 /**
  * Available delay options for email digest notifications.
  */
-const VALID_DELAYS = [
+export const NOTIFICATION_DELAY_OPTIONS = [
   "5_minutes",
   "15_minutes",
   "30_minutes",
@@ -11,14 +11,15 @@ const VALID_DELAYS = [
   "daily",
 ] as const;
 
-export type NotificationPreferencesDelay = (typeof VALID_DELAYS)[number];
+export type NotificationPreferencesDelay =
+  (typeof NOTIFICATION_DELAY_OPTIONS)[number];
 
 export const isNotificationPreferencesDelay = (
   value: unknown
 ): value is NotificationPreferencesDelay => {
   return (
     typeof value === "string" &&
-    (VALID_DELAYS as readonly string[]).includes(value)
+    (NOTIFICATION_DELAY_OPTIONS as readonly string[]).includes(value)
   );
 };
 

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -1,4 +1,4 @@
-import { ChannelPreference } from "@novu/react";
+import type { ChannelPreference } from "@novu/react";
 
 /**
  * Available delay options for email digest notifications.

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -1,0 +1,9 @@
+/**
+ * Available delay options for email digest notifications.
+ */
+export type NotificationPreferencesDelay =
+  | "5_minutes"
+  | "15_minutes"
+  | "30_minutes"
+  | "1_hour"
+  | "daily";


### PR DESCRIPTION
## Description

- Moves notification preferences into the Account Settings section and changes the interaction pattern from auto-save to manual save with a form. 
- Adds an email notification delay selector that allows users to configure the digest frequency for conversation unread notifications (5 minutes, 15 minutes, 30 minutes, 1 hour, or daily). 
- The email delay preference is stored in user metadata and consumed by the conversation-unread workflow to configure the Novu digest step accordingly.

<img width="917" height="651" alt="image" src="https://github.com/user-attachments/assets/0bc76352-f46f-44ad-8582-80412d45b87c" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
