### PR TITLE
Rename query_tables_v2 to query_tables

### DIFF
--- a/connectors/src/lib/tools_utils.ts
+++ b/connectors/src/lib/tools_utils.ts
@@ -67,7 +67,7 @@ export const getActionName = (action: AgentActionPublicType) => {
     }
   }
 
-  if (internalMCPServerName === "query_tables_v2") {
+  if (internalMCPServerName === "query_tables") {
     if (toolName === GET_DATABASE_SCHEMA_TOOL_NAME) {
       return "Getting database schema";
     }

--- a/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
@@ -164,7 +164,7 @@ export function MCPActionDetails(props: MCPActionDetailsProps) {
     }
   }
 
-  if (internalMCPServerName === "query_tables_v2") {
+  if (internalMCPServerName === "query_tables") {
     if (toolName === GET_DATABASE_SCHEMA_TOOL_NAME) {
       return <MCPGetDatabaseSchemaActionDetails {...props} />;
     }

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -59,7 +59,7 @@ import {
   isInternalMCPServerOfName,
   PROCESS_TOOL_NAME,
   SEARCH_TOOL_NAME,
-  TABLE_QUERY_V2_SERVER_NAME,
+  TABLE_QUERY_SERVER_NAME,
   WEBBROWSER_TOOL_NAME,
   WEBSEARCH_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -233,7 +233,7 @@ export function MCPActionDetails({
     }
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, TABLE_QUERY_V2_SERVER_NAME)) {
+  if (isInternalMCPServerOfName(mcpServerId, TABLE_QUERY_SERVER_NAME)) {
     if (toolName === GET_DATABASE_SCHEMA_TOOL_NAME) {
       return <MCPGetDatabaseSchemaActionDetails {...toolOutputDetailsProps} />;
     }

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -16,7 +16,7 @@ import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { getMCPServerNameForTemplateAction } from "@app/lib/actions/mcp_helper";
 import {
   DATA_WAREHOUSE_SERVER_NAME,
-  TABLE_QUERY_V2_SERVER_NAME,
+  TABLE_QUERY_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { TemplateActionPreset } from "@app/types";
@@ -70,7 +70,7 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
       maxLength: DESCRIPTION_MAX_LENGTH,
     },
   },
-  [TABLE_QUERY_V2_SERVER_NAME]: {
+  [TABLE_QUERY_SERVER_NAME]: {
     icon: TableIcon,
     configPageTitle: "Configure Query Tables",
     configPageDescription:

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -29,7 +29,7 @@ import {
   DATA_WAREHOUSE_SERVER_NAME,
   isInternalMCPServerOfName,
   SEARCH_SERVER_NAME,
-  TABLE_QUERY_V2_SERVER_NAME,
+  TABLE_QUERY_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -92,7 +92,7 @@ export function ProcessingMethodSection() {
       const isTableOrWarehouseServer =
         isInternalMCPServerOfName(
           mcpServerView.server.sId,
-          TABLE_QUERY_V2_SERVER_NAME
+          TABLE_QUERY_SERVER_NAME
         ) ||
         isInternalMCPServerOfName(
           mcpServerView.server.sId,
@@ -139,10 +139,7 @@ export function ProcessingMethodSection() {
 
       if (allTablesOrDatabases) {
         const tableQueryServer = serversToDisplay.find((server) =>
-          isInternalMCPServerOfName(
-            server.server.sId,
-            TABLE_QUERY_V2_SERVER_NAME
-          )
+          isInternalMCPServerOfName(server.server.sId, TABLE_QUERY_SERVER_NAME)
         );
         if (tableQueryServer) {
           setValue("mcpServerView", tableQueryServer, { shouldDirty: false });

--- a/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
@@ -22,7 +22,7 @@ import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MC
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import {
   DATA_WAREHOUSE_SERVER_NAME,
-  TABLE_QUERY_V2_SERVER_NAME,
+  TABLE_QUERY_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import { getVisualForContentNodeType } from "@app/lib/content_nodes";
@@ -36,7 +36,7 @@ import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import type { DataSourceViewType } from "@app/types";
 import { asDisplayName, pluralize } from "@app/types";
 
-const tablesServer = [TABLE_QUERY_V2_SERVER_NAME, DATA_WAREHOUSE_SERVER_NAME];
+const tablesServer = [TABLE_QUERY_SERVER_NAME, DATA_WAREHOUSE_SERVER_NAME];
 
 const getVisualForSourceItem = (
   source: DataSourceFilterItem["selectedSources"][0]

--- a/front/components/shared/tools_picker/MCPServerViewsContext.tsx
+++ b/front/components/shared/tools_picker/MCPServerViewsContext.tsx
@@ -21,7 +21,6 @@ export const sortMCPServerViewsByPriority = (
   const priorityOrder: Record<string, number> = {
     search: 1,
     query_tables: 2,
-    query_tables_v2: 2, // Same priority as query_tables
     include_data: 3,
     extract_data: 4,
   };

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -207,7 +207,7 @@ const TEMPLATE_ACTION_TO_MCP_SERVER: Record<
   InternalMCPServerNameType
 > = {
   RETRIEVAL_SEARCH: "search",
-  TABLES_QUERY: "query_tables_v2",
+  TABLES_QUERY: "query_tables",
   PROCESS: "extract_data",
   WEB_NAVIGATION: "web_search_&_browse",
 };

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -52,7 +52,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "speech_generator", id: 34 },
       { name: "search", id: 1006 },
       { name: "run_agent", id: 1008 },
-      { name: "query_tables_v2", id: 1009 },
+      { name: "query_tables", id: 1009 },
       { name: "data_sources_file_system", id: 1010 },
       { name: "agent_management", id: 1011 },
       { name: "data_warehouses", id: 1012 },

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -55,7 +55,7 @@ export const DATA_WAREHOUSES_QUERY_TOOL_NAME = "query";
 
 export const SEARCH_SERVER_NAME = "search";
 
-export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2"; // Do not change the name until we fixed the extension
+export const TABLE_QUERY_SERVER_NAME = "query_tables";
 export const DATA_WAREHOUSE_SERVER_NAME = "data_warehouses";
 export const AGENT_MEMORY_SERVER_NAME = "agent_memory";
 export const SKILL_MANAGEMENT_SERVER_NAME = "skill_management";
@@ -121,7 +121,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "web_search_&_browse",
   "zendesk",
   SEARCH_SERVER_NAME,
-  TABLE_QUERY_V2_SERVER_NAME,
+  TABLE_QUERY_SERVER_NAME,
   SKILL_MANAGEMENT_SERVER_NAME,
   "schedules_management",
 ] as const;
@@ -1449,7 +1449,7 @@ export const INTERNAL_MCP_SERVERS = {
       instructions: null,
     },
   },
-  [TABLE_QUERY_V2_SERVER_NAME]: {
+  [TABLE_QUERY_SERVER_NAME]: {
     id: 1009,
     availability: "auto",
     allowMultipleInstances: false,
@@ -1459,7 +1459,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
-      name: "query_tables_v2",
+      name: "query_tables",
       version: "1.0.0",
       description:
         "Query structured data like a spreadsheet or database for data analyses.",

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -119,7 +119,7 @@ export async function getInternalMCPServer(
       return generateFileServer(auth, agentLoopContext);
     case "interactive_content":
       return interactiveContentServer(auth, agentLoopContext);
-    case "query_tables_v2":
+    case "query_tables":
       return tablesQueryServerV2(auth, agentLoopContext);
     case "primitive_types_debugger":
       return primitiveTypesDebuggerServer(auth, agentLoopContext);

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
@@ -104,7 +104,7 @@ function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = makeInternalMCPServer("query_tables_v2");
+  const server = makeInternalMCPServer("query_tables");
 
   server.tool(
     GET_DATABASE_SCHEMA_TOOL_NAME,

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -828,16 +828,16 @@ export async function createGenericAgentConfiguration(
     }
   }
 
-  // Add query_tables_v2 tools for data warehouses in global space.
+  // Add query_tables tools for data warehouses in global space.
   const queryTablesV2View =
     await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
       auth,
-      "query_tables_v2"
+      "query_tables"
     );
 
   if (!queryTablesV2View) {
     await cleanupAgentsOnError(auth, agentConfiguration.sId, null);
-    return new Err(new Error("Could not find query_tables_v2 MCP server view"));
+    return new Err(new Error("Could not find query_tables MCP server view"));
   }
 
   const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -325,12 +325,12 @@ export async function getJITServers(
     const queryTablesView =
       await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
         auth,
-        "query_tables_v2"
+        "query_tables"
       );
 
     assert(
       queryTablesView,
-      "MCP server view not found for query_tables_v2. Ensure auto tools are created."
+      "MCP server view not found for query_tables. Ensure auto tools are created."
     );
 
     const tables: TableDataSourceConfiguration[] = [];


### PR DESCRIPTION
## Description

Simple rename. Should be harmless as the tool name is only used for display, and is not a key into anything.

Fixes https://github.com/dust-tt/tasks/issues/5094

## Tests

Manual

## Risk

Low

## Deploy Plan

Front