### PR TITLE
[skills] Use skill custom icon everywhere

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -86,6 +86,7 @@ const skillsSchema = z.object({
   sId: z.string(),
   name: z.string(),
   description: z.string(),
+  icon: z.string().nullable(),
 });
 
 // Additional space IDs selected by the user for global skills

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -46,7 +46,6 @@ export function AgentBuilderSpacesBlock() {
   const confirmRemoveSpace = useRemoveSpaceConfirm({
     entityName: "agent",
     mcpServerViews,
-    allSkills,
   });
 
   // Compute requested spaces from tools/knowledge (actions)
@@ -100,7 +99,9 @@ export function AgentBuilderSpacesBlock() {
       const confirmed = await confirmRemoveSpace(
         space,
         actionsToRemove,
-        skillsToRemove
+        allSkills.filter((skill) =>
+          skillsToRemove.some((s) => s.sId === skill.sId)
+        )
       );
 
       if (!confirmed) {

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -46,6 +46,7 @@ export function AgentBuilderSpacesBlock() {
   const confirmRemoveSpace = useRemoveSpaceConfirm({
     entityName: "agent",
     mcpServerViews,
+    allSkills,
   });
 
   // Compute requested spaces from tools/knowledge (actions)

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -41,9 +41,7 @@ interface SkillCardProps {
 }
 
 function SkillCard({ skill, onRemove }: SkillCardProps) {
-  const { skills } = useSkillsContext();
-  const skillData = skills.find((s) => s.sId === skill.sId);
-  const SkillIcon = getSkillIcon(skillData?.icon ?? null);
+  const SkillIcon = getSkillIcon(skill.icon);
 
   return (
     <Card

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -19,10 +19,11 @@ import { AgentBuilderSectionContainer } from "@app/components/agent_builder/Agen
 import { SkillsSheet } from "@app/components/agent_builder/skills/skillSheet/SkillsSheet";
 import type { SkillsSheetMode } from "@app/components/agent_builder/skills/skillSheet/types";
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
+import { ResourceAvatar } from "@app/components/resources/resources_icons";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import { SKILL_ICON } from "@app/lib/skill";
+import { getSkillIcon } from "@app/lib/skill";
 import type { UserType, WorkspaceType } from "@app/types";
 
 const BACKGROUND_IMAGE_PATH = "/static/SkillsBar.svg";
@@ -40,7 +41,9 @@ interface SkillCardProps {
 }
 
 function SkillCard({ skill, onRemove }: SkillCardProps) {
-  const SkillIcon = SKILL_ICON;
+  const { skills } = useSkillsContext();
+  const skillData = skills.find((s) => s.sId === skill.sId);
+  const SkillIcon = getSkillIcon(skillData?.icon ?? null);
 
   return (
     <Card
@@ -59,7 +62,7 @@ function SkillCard({ skill, onRemove }: SkillCardProps) {
     >
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
-          <SkillIcon className="h-4 w-4 shrink-0" />
+          <ResourceAvatar icon={SkillIcon} size="sm" />
           <span className="truncate">{skill.name}</span>
         </div>
 

--- a/front/components/agent_builder/skills/skillSheet/SkillCard.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SkillCard.tsx
@@ -1,7 +1,7 @@
 import { ActionCard } from "@dust-tt/sparkle";
 import React from "react";
 
-import { SKILL_ICON } from "@app/lib/skill";
+import { getSkillIcon } from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 interface SkillCardProps {
@@ -19,7 +19,7 @@ export function SkillCard({
 }: SkillCardProps) {
   return (
     <ActionCard
-      icon={SKILL_ICON}
+      icon={getSkillIcon(skill.icon)}
       label={skill.name}
       description={skill.userFacingDescription}
       isSelected={isSelected}

--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -88,6 +88,7 @@ export const useSkillSelection = ({
               sId: skill.sId,
               name: skill.name,
               description: skill.userFacingDescription,
+              icon: skill.icon,
             },
           ]);
         }
@@ -107,6 +108,7 @@ export const useSkillSelection = ({
           sId: skill.sId,
           name: skill.name,
           description: skill.userFacingDescription,
+          icon: skill.icon,
         },
       ]);
       onModeChange(selectionMode);

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -7,7 +7,7 @@ import { SkillWithRelationsDetailsSheetContent } from "@app/components/agent_bui
 import { SpaceSelectionPageContent } from "@app/components/agent_builder/skills/skillSheet/SpaceSelectionPage";
 import type { PageContentProps } from "@app/components/agent_builder/skills/skillSheet/types";
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
-import { SKILL_ICON } from "@app/lib/skill";
+import { getSkillIcon } from "@app/lib/skill";
 import { assertNever } from "@app/types";
 
 export function getPageAndFooter(props: PageContentProps): {
@@ -59,7 +59,7 @@ export function getPageAndFooter(props: PageContentProps): {
           title: mode.skill.name,
           description: mode.skill.userFacingDescription,
           id: props.mode.type,
-          icon: SKILL_ICON,
+          icon: getSkillIcon(mode.skill.icon),
           content: (
             <SkillWithRelationsDetailsSheetContent
               skill={mode.skill}

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
@@ -16,7 +16,7 @@ import {
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
 import type { MCPServerTypeWithViews } from "@app/lib/api/mcp";
-import { SKILL_ICON } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useMCPServers } from "@app/lib/swr/mcp_servers";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -137,16 +137,19 @@ export function AssistantToolsSection({
                 <Spinner size="xs" />
               </div>
             ) : (
-              sortedSkills.map((skill) => (
-                <div
-                  className="flex flex-row items-center gap-2"
-                  key={skill.sId}
-                >
-                  {/* TODO(skills 2025-12-08): Add custom icon support (pictureUrl) */}
-                  <Avatar icon={SKILL_ICON} size="xs" />
-                  <div>{skill.name}</div>
-                </div>
-              ))
+              sortedSkills.map((skill) => {
+                const SkillAvatar = getSkillAvatarIcon(skill.icon);
+                return (
+                  <div
+                    className="flex flex-row items-center gap-2"
+                    key={skill.sId}
+                  >
+                    {/* TODO(skills 2025-12-08): Add custom icon support (pictureUrl) */}
+                    <SkillAvatar size="xs" />
+                    <div>{skill.name}</div>
+                  </div>
+                );
+              })
             )}
           </div>
         </div>

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -1,13 +1,14 @@
-import { useContext } from "react";
+import React, { useContext } from "react";
 
 import { ConfirmContext } from "@app/components/Confirm";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { SKILL_ICON } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceName } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 function getActionDisplayName(
   action: BuilderAction,
@@ -35,6 +36,16 @@ function getActionIcon(
   return null;
 }
 
+function getSkillIcon(
+  skill: SkillToRemove,
+  allSkills: SkillType[]
+): React.ReactNode {
+  const fullSkill = allSkills.find((s) => s.sId === skill.sId);
+  return React.createElement(
+    getSkillAvatarIcon(fullSkill ? fullSkill.icon : null)
+  );
+}
+
 interface ItemToRemove {
   id: string;
   name: string;
@@ -49,15 +60,15 @@ interface SkillToRemove {
 interface UseRemoveSpaceConfirmParams {
   entityName: "agent" | "skill";
   mcpServerViews: MCPServerViewType[];
+  allSkills: SkillType[];
 }
 
 export function useRemoveSpaceConfirm({
   entityName,
   mcpServerViews,
+  allSkills,
 }: UseRemoveSpaceConfirmParams) {
   const confirm = useContext(ConfirmContext);
-
-  const SkillIcon = SKILL_ICON;
 
   return async (
     space: SpaceType,
@@ -68,7 +79,7 @@ export function useRemoveSpaceConfirm({
       ...skills.map((skill) => ({
         id: skill.sId,
         name: skill.name,
-        icon: <SkillIcon className="h-4 w-4 shrink-0" />,
+        icon: getSkillIcon(skill, allSkills),
       })),
       ...actions.map((action) => ({
         id: action.id,

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -8,7 +8,6 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceName } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 function getActionDisplayName(
   action: BuilderAction,
@@ -36,14 +35,8 @@ function getActionIcon(
   return null;
 }
 
-function getSkillIcon(
-  skill: SkillToRemove,
-  allSkills: SkillType[]
-): React.ReactNode {
-  const fullSkill = allSkills.find((s) => s.sId === skill.sId);
-  return React.createElement(
-    getSkillAvatarIcon(fullSkill ? fullSkill.icon : null)
-  );
+function getSkillIcon(skill: SkillToRemove): React.ReactNode {
+  return React.createElement(getSkillAvatarIcon(skill.icon));
 }
 
 interface ItemToRemove {
@@ -55,18 +48,17 @@ interface ItemToRemove {
 interface SkillToRemove {
   sId: string;
   name: string;
+  icon: string | null;
 }
 
 interface UseRemoveSpaceConfirmParams {
   entityName: "agent" | "skill";
   mcpServerViews: MCPServerViewType[];
-  allSkills: SkillType[];
 }
 
 export function useRemoveSpaceConfirm({
   entityName,
   mcpServerViews,
-  allSkills,
 }: UseRemoveSpaceConfirmParams) {
   const confirm = useContext(ConfirmContext);
 
@@ -79,7 +71,7 @@ export function useRemoveSpaceConfirm({
       ...skills.map((skill) => ({
         id: skill.sId,
         name: skill.name,
-        icon: getSkillIcon(skill, allSkills),
+        icon: getSkillIcon(skill),
       })),
       ...actions.map((action) => ({
         id: action.id,

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -5,7 +5,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 
-import { SKILL_ICON } from "@app/lib/skill";
+import { getSkillIcon } from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 type SimilarSkillsDisplayProps = {
@@ -42,7 +42,7 @@ export function SimilarSkillsDisplay({
           <div key={skill.sId} className="flex items-start gap-2">
             <Avatar
               name={skill.name}
-              visual={<SKILL_ICON className="text-element-700" />}
+              icon={getSkillIcon(skill.icon)}
               size="xs"
             />
             <div className="flex flex-col">

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -22,7 +22,6 @@ export function SkillBuilderRequestedSpacesSection() {
   const confirmRemoveSpace = useRemoveSpaceConfirm({
     entityName: "skill",
     mcpServerViews,
-    allSkills: [],
   });
 
   const spaceIdToActions = useMemo(() => {

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -22,6 +22,7 @@ export function SkillBuilderRequestedSpacesSection() {
   const confirmRemoveSpace = useRemoveSpaceConfirm({
     entityName: "skill",
     mcpServerViews,
+    allSkills: [],
   });
 
   const spaceIdToActions = useMemo(() => {

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowPathIcon,
-  Avatar,
   Button,
   ContentMessage,
   InformationCircleIcon,
@@ -18,11 +17,12 @@ import {
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useState } from "react";
 
+import { ResourceAvatar } from "@app/components/resources/resources_icons";
 import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
 import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
 import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
-import { hasRelations, SKILL_ICON } from "@app/lib/skill";
+import { getSkillIcon, hasRelations } from "@app/lib/skill";
 import type { UserType, WorkspaceType } from "@app/types";
 import type {
   SkillRelations,
@@ -144,7 +144,11 @@ const DescriptionSection = ({
   return (
     <div className="flex flex-col items-center gap-4 pt-4">
       <div className="relative flex items-center justify-center">
-        <Avatar name="Agent avatar" visual={<SKILL_ICON />} size="xl" />
+        <ResourceAvatar
+          icon={getSkillIcon(skill.icon)}
+          name="Skill avatar"
+          size="xl"
+        />
       </div>
 
       {/* Title and edit info */}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -1,6 +1,5 @@
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
-  Avatar,
   DataTable,
   EyeIcon,
   PencilSquareIcon,
@@ -13,6 +12,7 @@ import { useMemo, useState } from "react";
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { LightWorkspaceType, UserType } from "@app/types";
@@ -48,23 +48,27 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
     {
       header: "Name",
       accessorKey: "name",
-      cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent>
-          <div className="flex flex-row items-center gap-2 py-3">
-            <div>
-              <Avatar visual={info.row.original.icon} size="sm" />
-            </div>
-            <div className="flex min-w-0 grow flex-col">
-              <div className="heading-sm overflow-hidden truncate text-foreground dark:text-foreground-night">
-                {info.getValue()}
+      cell: (info: CellContext<RowData, string>) => {
+        const SkillAvatar = getSkillAvatarIcon(info.row.original.icon);
+
+        return (
+          <DataTable.CellContent>
+            <div className="flex flex-row items-center gap-2 py-3">
+              <div>
+                <SkillAvatar />
               </div>
-              <div className="overflow-hidden truncate text-sm text-muted-foreground dark:text-muted-foreground-night">
-                {info.row.original.description}
+              <div className="flex min-w-0 grow flex-col">
+                <div className="heading-sm overflow-hidden truncate text-foreground dark:text-foreground-night">
+                  {info.getValue()}
+                </div>
+                <div className="overflow-hidden truncate text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  {info.row.original.description}
+                </div>
               </div>
             </div>
-          </div>
-        </DataTable.CellContent>
-      ),
+          </DataTable.CellContent>
+        );
+      },
       meta: {
         className: "w-40 @lg:w-full",
       },

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -1,10 +1,12 @@
-import { Avatar, PuzzleIcon } from "@dust-tt/sparkle";
+import { PuzzleIcon } from "@dust-tt/sparkle";
+import type { AvatarSizeType } from "@dust-tt/sparkle/dist/esm/components/Avatar";
 import React from "react";
 
 import {
   getIcon,
   isCustomResourceIconType,
   isInternalAllowedIcon,
+  ResourceAvatar,
 } from "@app/components/resources/resources_icons";
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import type {
@@ -17,18 +19,26 @@ export const SKILL_ICON = PuzzleIcon;
 
 export function getSkillAvatarIcon(
   iconString: string | null
-): React.ComponentType<{ className?: string }> {
+): React.ComponentType<{
+  className?: string;
+  size?: AvatarSizeType;
+  name?: string;
+}> {
   if (
     iconString &&
     (isCustomResourceIconType(iconString) || isInternalAllowedIcon(iconString))
   ) {
     const icon = getIcon(iconString);
     return (props) =>
-      React.createElement(Avatar, { icon, size: "sm", ...props });
+      React.createElement(ResourceAvatar, { icon, size: "sm", ...props });
   }
 
   return (props) =>
-    React.createElement(Avatar, { icon: SKILL_ICON, size: "sm", ...props });
+    React.createElement(ResourceAvatar, {
+      icon: SKILL_ICON,
+      size: "sm",
+      ...props,
+    });
 }
 
 export function getSkillIcon(


### PR DESCRIPTION
## Description

 - Use the custom icon of the skill every time we display an icon for a skill
 - Use ResourceAvatar to display the icon as it handle the light/dark theme


### Skill table:

<img width="2808" height="1758" alt="image" src="https://github.com/user-attachments/assets/7c655804-5ab2-4320-a316-970228580e58" />

### Skill details
<img width="2806" height="1758" alt="image" src="https://github.com/user-attachments/assets/5cb7cd18-df2a-46c1-909b-44029cd7133e" />

### Agent builder:
<img width="2808" height="1752" alt="image" src="https://github.com/user-attachments/assets/2580b6ee-3919-4664-8344-ba5ec8786353" />

<img width="2810" height="1760" alt="image" src="https://github.com/user-attachments/assets/63b51827-052b-4ae9-9ea7-fc54db67c208" />

### Agent builder delete pop up:
<img width="2804" height="1752" alt="image" src="https://github.com/user-attachments/assets/f5f47960-2eea-492d-a1a8-03a5c18653b1" />


## Tests

manual tests locally

## Risk

low

## Deploy Plan

deploy front
