### PR TITLE
[Front] feat(skills): add tool types and useToolSelection hook

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -6,7 +6,7 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useMemo } from "react";
 
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SelectedTool } from "@app/components/agent_builder/skills/skillSheet/types";
 import {
   InternalActionIcons,
   isCustomResourceIconType,

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
@@ -1,11 +1,11 @@
 import { Chip } from "@dust-tt/sparkle";
 import React from "react";
 
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
 import {
   getSelectedToolIcon,
   getSelectedToolLabel,
 } from "@app/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils";
+import type { SelectedTool } from "@app/components/agent_builder/skills/skillSheet/types";
 
 interface MCPServerViewsFooterProps {
   selectedToolsInSheet: SelectedTool[];

--- a/front/components/agent_builder/capabilities/mcp/utils/actionNameUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/actionNameUtils.ts
@@ -1,4 +1,4 @@
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SelectedTool } from "@app/components/agent_builder/skills/skillSheet/types";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 
 interface GenerateUniqueActionNameParams {

--- a/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
@@ -2,10 +2,8 @@ import type { Dispatch, SetStateAction } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import type {
-  SelectedTool,
-  SheetMode,
-} from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SheetMode } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SelectedTool } from "@app/components/agent_builder/skills/skillSheet/types";
 import type { ConfigurationPagePageId } from "@app/components/agent_builder/types";
 import { TOOLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";

--- a/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
@@ -1,7 +1,7 @@
 import { ActionIcons, BookOpenIcon } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SelectedTool } from "@app/components/agent_builder/skills/skillSheet/types";
 import {
   InternalActionIcons,
   isCustomResourceIconType,

--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -4,13 +4,115 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type {
   PageContentProps,
+  SelectedTool,
   SelectionMode,
   SkillsSheetMode,
 } from "@app/components/agent_builder/skills/skillSheet/types";
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
+import { getDefaultMCPAction } from "@app/components/agent_builder/types";
+import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
+import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { doesSkillTriggerSelectSpaces } from "@app/lib/skill";
 import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+export const TOP_MCP_SERVER_VIEWS = [
+  "web_search_&_browse",
+  "image_generation",
+  AGENT_MEMORY_SERVER_NAME,
+  "deep_dive",
+  "interactive_content",
+  "slack",
+  "gmail",
+  "google_calendar",
+];
+
+/**
+ * Hook for filtering and organizing MCP server views.
+ * Shared between SkillsSheet and MCPServerViewsSheet.
+ */
+interface UseMCPServerViewsFilterProps {
+  selectedActions: BuilderAction[];
+  searchQuery: string;
+  filterMCPServerViews?: (view: MCPServerViewTypeWithLabel) => boolean;
+}
+
+export const useMCPServerViewsFilter = ({
+  selectedActions,
+  searchQuery,
+  filterMCPServerViews,
+}: UseMCPServerViewsFilterProps) => {
+  const { mcpServerViewsWithoutKnowledge, isMCPServerViewsLoading } =
+    useMCPServerViewsContext();
+
+  // Filter out already added actions and apply custom filter
+  const shouldFilterServerView = useCallback(
+    (view: MCPServerViewTypeWithLabel, actions: BuilderAction[]) => {
+      const alreadyAddedServerIds = new Set(
+        actions
+          .filter(
+            (a) =>
+              a.type === "MCP" &&
+              a.configuration?.mcpServerViewId &&
+              !a.configurationRequired
+          )
+          .map((a) => a.configuration!.mcpServerViewId)
+      );
+      if (alreadyAddedServerIds.has(view.sId)) {
+        return true;
+      }
+      return filterMCPServerViews ? !filterMCPServerViews(view) : false;
+    },
+    [filterMCPServerViews]
+  );
+
+  const topMCPServerViews = useMemo(() => {
+    const views = mcpServerViewsWithoutKnowledge.filter((view) =>
+      TOP_MCP_SERVER_VIEWS.includes(view.server.name)
+    );
+    return views.filter(
+      (view) => !shouldFilterServerView(view, selectedActions)
+    );
+  }, [mcpServerViewsWithoutKnowledge, shouldFilterServerView, selectedActions]);
+
+  const nonTopMCPServerViews = useMemo(() => {
+    const views = mcpServerViewsWithoutKnowledge.filter(
+      (view) => !TOP_MCP_SERVER_VIEWS.includes(view.server.name)
+    );
+    return views.filter(
+      (view) => !shouldFilterServerView(view, selectedActions)
+    );
+  }, [mcpServerViewsWithoutKnowledge, shouldFilterServerView, selectedActions]);
+
+  // Filter by search term
+  const filteredViews = useMemo(() => {
+    const filterViews = (views: MCPServerViewTypeWithLabel[]) => {
+      if (!searchQuery.trim()) {
+        return views;
+      }
+      const term = searchQuery.toLowerCase();
+      return views.filter(
+        (view) =>
+          view.label.toLowerCase().includes(term) ||
+          view.server.description?.toLowerCase().includes(term)
+      );
+    };
+    return {
+      topViews: filterViews(topMCPServerViews),
+      nonTopViews: filterViews(nonTopMCPServerViews),
+    };
+  }, [searchQuery, topMCPServerViews, nonTopMCPServerViews]);
+
+  return {
+    topMCPServerViews: filteredViews.topViews,
+    nonTopMCPServerViews: filteredViews.nonTopViews,
+    isMCPServerViewsLoading,
+  };
+};
 
 function isGlobalSkillWithSpaceSelection(skill: SkillType): boolean {
   return doesSkillTriggerSelectSpaces(skill.sId);
@@ -20,7 +122,11 @@ function getSelectionMode(mode: SkillsSheetMode): SelectionMode {
   if (mode.type === SKILLS_SHEET_PAGE_IDS.SELECTION) {
     return mode;
   }
-  return mode.previousMode;
+  if ("previousMode" in mode) {
+    return mode.previousMode;
+  }
+  // Fallback to selection mode for now, will be removed in a later PR
+  return { type: SKILLS_SHEET_PAGE_IDS.SELECTION };
 }
 
 export const useSkillSelection = ({
@@ -130,5 +236,104 @@ export const useSkillSelection = ({
     handleSpaceSelectionSave,
     draftSelectedSpaces,
     setDraftSelectedSpaces,
+  };
+};
+
+/**
+ * Hook for toggling tool selection in a sheet.
+ * Shared between SkillsSheet and MCPServerViewsSheet.
+ */
+export const useToggleToolSelection = (
+  setSelectedToolsInSheet: React.Dispatch<React.SetStateAction<SelectedTool[]>>
+) => {
+  return useCallback(
+    (tool: SelectedTool) => {
+      setSelectedToolsInSheet((prev) => {
+        const isAlreadySelected = prev.some(
+          (t) => t.type === "MCP" && t.view.sId === tool.view.sId
+        );
+        if (isAlreadySelected) {
+          return prev.filter(
+            (t) => !(t.type === "MCP" && t.view.sId === tool.view.sId)
+          );
+        }
+        return [...prev, tool];
+      });
+    },
+    [setSelectedToolsInSheet]
+  );
+};
+
+interface UseToolSelectionProps {
+  selectedActions: BuilderAction[];
+  selectedToolsInSheet: SelectedTool[];
+  setSelectedToolsInSheet: React.Dispatch<React.SetStateAction<SelectedTool[]>>;
+  onModeChange: (mode: SkillsSheetMode | null) => void;
+  searchQuery: string;
+  filterMCPServerViews?: (view: MCPServerViewTypeWithLabel) => boolean;
+}
+
+export const useToolSelection = ({
+  selectedActions,
+  setSelectedToolsInSheet,
+  onModeChange,
+  searchQuery,
+  filterMCPServerViews,
+}: UseToolSelectionProps) => {
+  const { owner } = useAgentBuilderContext();
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+
+  const { topMCPServerViews, nonTopMCPServerViews, isMCPServerViewsLoading } =
+    useMCPServerViewsFilter({
+      selectedActions,
+      searchQuery,
+      filterMCPServerViews,
+    });
+
+  const toggleToolSelection = useToggleToolSelection(setSelectedToolsInSheet);
+
+  const onClickMCPServer = useCallback(
+    (mcpServerView: MCPServerViewTypeWithLabel) => {
+      const tool: SelectedTool = { type: "MCP", view: mcpServerView };
+      const requirements = getMCPServerRequirements(
+        mcpServerView,
+        featureFlags
+      );
+
+      if (requirements.noRequirement) {
+        toggleToolSelection(tool);
+      } else {
+        // Navigate to configuration page
+        const action = getDefaultMCPAction(mcpServerView);
+        onModeChange({
+          type: SKILLS_SHEET_PAGE_IDS.CONFIGURATION,
+          action,
+          mcpServerView,
+        });
+      }
+    },
+    [featureFlags, toggleToolSelection, onModeChange]
+  );
+
+  const handleToolInfoClick = useCallback(
+    (view: MCPServerViewTypeWithLabel) => {
+      const action = getDefaultMCPAction(view);
+      onModeChange({
+        type: SKILLS_SHEET_PAGE_IDS.TOOL_INFO,
+        action,
+        source: "toolDetails",
+      });
+    },
+    [onModeChange]
+  );
+
+  return {
+    topMCPServerViews,
+    nonTopMCPServerViews,
+    isMCPServerViewsLoading,
+    toggleToolSelection,
+    onClickMCPServer,
+    handleToolInfoClick,
+    featureFlags,
   };
 };

--- a/front/components/agent_builder/skills/skillSheet/types.tsx
+++ b/front/components/agent_builder/skills/skillSheet/types.tsx
@@ -1,16 +1,26 @@
 import type React from "react";
 
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { UserType, WorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export const SKILLS_SHEET_PAGE_IDS = {
+  // Skills modes
   SELECTION: "add",
-  INFO: "info",
+  INFO: "info", // Keep as INFO for backward compatibility, will rename SKILL_INFO later
   SPACE_SELECTION: "space_selection",
+  // Tool modes (from MCPServerViewsSheet)
+  TOOL_INFO: "tool-info",
+  CONFIGURATION: "configuration",
+  TOOL_EDIT: "tool-edit",
 } as const;
 
+export type CapabilityFilterType = "all" | "tools" | "skills";
+
 export type SkillsSheetMode =
+  // Skills modes
   | {
       type: typeof SKILLS_SHEET_PAGE_IDS.SELECTION;
     }
@@ -23,6 +33,22 @@ export type SkillsSheetMode =
       type: typeof SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION;
       skillConfiguration: SkillType;
       previousMode: SelectionMode;
+    }
+  // Tool modes (from MCPServerViewsSheet)
+  | {
+      type: typeof SKILLS_SHEET_PAGE_IDS.TOOL_INFO;
+      action: BuilderAction;
+      source: "toolDetails" | "addedTool";
+    }
+  | {
+      type: typeof SKILLS_SHEET_PAGE_IDS.CONFIGURATION;
+      action: BuilderAction;
+      mcpServerView: MCPServerViewTypeWithLabel;
+    }
+  | {
+      type: typeof SKILLS_SHEET_PAGE_IDS.TOOL_EDIT;
+      action: BuilderAction;
+      index: number;
     };
 
 export type SelectionMode = Extract<
@@ -34,6 +60,12 @@ export type SpaceSelectionMode = Extract<
   SkillsSheetMode,
   { type: typeof SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION }
 >;
+
+export type SelectedTool = {
+  type: "MCP";
+  view: MCPServerViewTypeWithLabel;
+  configuredAction?: BuilderAction;
+};
 
 export type PageContentProps = {
   mode: SkillsSheetMode;
@@ -49,4 +81,9 @@ export type PageContentProps = {
   >;
   localAdditionalSpaces: string[];
   setLocalAdditionalSpaces: React.Dispatch<React.SetStateAction<string[]>>;
+  // Tool-related props (optional for backward compatibility until PR3)
+  selectedToolsInSheet?: SelectedTool[];
+  setSelectedToolsInSheet?: React.Dispatch<
+    React.SetStateAction<SelectedTool[]>
+  >;
 };

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -104,6 +104,18 @@ export function getPageAndFooter(props: PageContentProps): {
             skillSelection.handleSpaceSelectionSave(mode.skillConfiguration),
         },
       };
+    // Tool modes - placeholders until PR3/PR4
+    case SKILLS_SHEET_PAGE_IDS.TOOL_INFO:
+    case SKILLS_SHEET_PAGE_IDS.CONFIGURATION:
+    case SKILLS_SHEET_PAGE_IDS.TOOL_EDIT:
+      return {
+        page: {
+          title: "Tool",
+          id: mode.type,
+          content: <div>Tool configuration coming soon</div>,
+        },
+        leftButton: getCancelButton(onClose),
+      };
     default:
       assertNever(mode);
   }


### PR DESCRIPTION
Step 1 of implementing https://github.com/dust-tt/tasks/issues/5565

Splitting https://github.com/dust-tt/dust/pull/19233/changes in 5 PRs

## Description

Here I only extract tool selection logic of `MCPServerViewsSheet` in a custom hook and define the page types that will be used for the tool views (info, edit, configuration)

## Tests

Local, shouldn't do anything

## Risk

Low

## Deploy Plan

Front