### PR TITLE
[front] Rename Unknown to Non-API programmatic usage in cost chart

### DIFF
--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -337,7 +337,7 @@ export function BaseProgrammaticCostChart({
     const isActive =
       !enabledGroupKeys || enabledGroupKeys.includes(group.groupKey);
     const isVisible = visibleGroupKeys.has(group.groupKey);
-    const canFilter = !["total", "others", "unknown"].includes(group.groupKey);
+    const canFilter = !["total", "others"].includes(group.groupKey);
 
     return {
       key: group.groupKey,


### PR DESCRIPTION
## Description

When grouping by API key in the programmatic cost chart, documents without an `api_key_name` field (e.g., usage via system keys or internal calls) were labeled "Unknown". This was unclear since it's not actually unknown - it's programmatic usage that didn't go through a custom API key.

Changes:
- Use `"non_api_programmatic"` as the ES aggregation `missing` value when grouping by API key
- Keep `"unknown"` for other group types (agent, origin) where it makes semantic sense
- Map `"non_api_programmatic"` to label "Non-API programmatic usage"
- Make this group filterable (previously "unknown" was not filterable)

## Risks

Blast radius: Programmatic cost chart when grouping by API key
Risk: low

## Deploy Plan
- pmrr
- deploy front