### PR TITLE
[Programmatic Usage] Enforce minimum $10 for credit purchases

### DIFF
--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -20,6 +20,7 @@ import { useCallback, useMemo, useState } from "react";
 
 import { getPriceAsString } from "@app/lib/client/subscription";
 import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
+import { MIN_CREDIT_PURCHASE_MICRO_USD } from "@app/lib/credits/limits";
 import { usePurchaseCredits } from "@app/lib/swr/credits";
 import type { StripePricingData } from "@app/lib/types/stripe/pricing";
 import { assertNever } from "@app/types";
@@ -28,9 +29,7 @@ import { CURRENCY_SYMBOLS, isSupportedCurrency } from "@app/types/currency";
 type PurchaseState = "idle" | "processing" | "success" | "redirect" | "error";
 
 const SUPPORT_EMAIL = "support@dust.tt";
-
-// Minimum purchase amount in microUsd ($1).
-const MIN_PURCHASE_MICRO_USD = 1_000_000;
+const MIN_PURCHASE_DOLLARS = MIN_CREDIT_PURCHASE_MICRO_USD / 1_000_000;
 
 interface BuyCreditDialogProps {
   isOpen: boolean;
@@ -96,6 +95,11 @@ export function BuyCreditDialog({
     return !isNaN(amount) && amount > maxAmountDollars;
   }, [amountDollars, maxAmountDollars]);
 
+  const amountBelowMin = useMemo(() => {
+    const amount = parseFloat(amountDollars);
+    return !isNaN(amount) && amount > 0 && amount < MIN_PURCHASE_DOLLARS;
+  }, [amountDollars]);
+
   const handlePurchase = async () => {
     setPurchaseState("processing");
     const result = await purchaseCredits(parseFloat(amountDollars));
@@ -144,7 +148,8 @@ export function BuyCreditDialog({
     isValidAmount &&
     acceptedTerms &&
     acceptedNonRefundable &&
-    !amountExceedsMax;
+    !amountExceedsMax &&
+    !amountBelowMin;
 
   const renderContent = () => {
     switch (purchaseState) {
@@ -236,24 +241,26 @@ export function BuyCreditDialog({
                 <Input
                   id="amount"
                   type="number"
-                  placeholder="10"
+                  placeholder={`${MIN_PURCHASE_DOLLARS}`}
                   value={amountDollars}
                   onChange={(e) => setAmountDollars(e.target.value)}
-                  min="0"
+                  min={MIN_PURCHASE_DOLLARS}
                   max={maxAmountDollars ?? undefined}
                   step="1"
                   className="pl-7 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                  isError={amountExceedsMax}
+                  isError={amountExceedsMax || amountBelowMin}
                   message={
-                    amountExceedsMax
-                      ? `Maximum purchase amount is ${maxAmountFormatted}`
-                      : undefined
+                    amountBelowMin
+                      ? `Minimum purchase amount is $${MIN_PURCHASE_DOLLARS}`
+                      : amountExceedsMax
+                        ? `Maximum purchase amount is ${maxAmountFormatted}`
+                        : undefined
                   }
                 />
               </div>
             </div>
 
-            {isValidAmount && !amountExceedsMax && (
+            {isValidAmount && !amountExceedsMax && !amountBelowMin && (
               <div className="flex flex-col gap-1 rounded-md border border-border bg-muted-background p-3 text-sm dark:border-border-night dark:bg-muted-background-night">
                 <div className="flex justify-between">
                   <span className="text-muted-foreground dark:text-muted-foreground-night">
@@ -547,7 +554,7 @@ export function BuyCreditDialog({
   if (
     creditPurchaseLimits &&
     creditPurchaseLimits.canPurchase &&
-    creditPurchaseLimits.maxAmountMicroUsd < MIN_PURCHASE_MICRO_USD
+    creditPurchaseLimits.maxAmountMicroUsd < MIN_CREDIT_PURCHASE_MICRO_USD
   ) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/front/lib/credits/limits.ts
+++ b/front/lib/credits/limits.ts
@@ -7,6 +7,8 @@ import { isEnterpriseSubscription } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 
+// Minimum purchase amount: $10.
+export const MIN_CREDIT_PURCHASE_MICRO_USD = 10_000_000;
 // $50 per user per month for Pro subscriptions.
 const MAX_PRO_CREDIT_PER_USER_MICRO_USD = 50_000_000;
 // $1000 absolute cap for Pro subscriptions.


### PR DESCRIPTION
## Description
Enforce a minimum $10 purchase amount for programmatic usage credits at multiple levels:
- API endpoint validation with clear error message
- Sequelize model validation for committed/payg credit types (free credits exempt)
- Frontend UI validation with error state and messaging in BuyCreditDialog

## Risks
Blast radius: Credit purchase flow for programmatic usage
Risk: low

## Deploy Plan
- deploy front