### PR TITLE
[Programmatic Usage] Enforce minimum $10 for credit purchases

### DIFF
--- a/front/lib/credits/limits.ts
+++ b/front/lib/credits/limits.ts
@@ -6,6 +6,10 @@ import { getCustomerPaymentStatus } from "@app/lib/credits/free";
 import { isEnterpriseSubscription } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { MIN_CREDIT_PURCHASE_MICRO_USD } from "@app/types/credits";
+
+// Re-export for backend consumers.
+export { MIN_CREDIT_PURCHASE_MICRO_USD };
 
 // $50 per user per month for Pro subscriptions.
 const MAX_PRO_CREDIT_PER_USER_MICRO_USD = 50_000_000;

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -11,6 +11,9 @@ export function isCreditType(value: unknown): value is CreditType {
 // Credit expiration duration in days (default: 1 year)
 export const CREDIT_EXPIRATION_DAYS = 365;
 
+// Minimum purchase amount: $10 in microUsd.
+export const MIN_CREDIT_PURCHASE_MICRO_USD = 10_000_000;
+
 export type CreditDisplayData = {
   sId: string;
   type: CreditType;

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -41,6 +41,7 @@ export * from "./connectors/slack";
 export * from "./connectors/webcrawler";
 export * from "./connectors/workflows";
 export * from "./content_fragment";
+export * from "./credits";
 export * from "./core/content_node";
 export * from "./core/core_api";
 export * from "./core/data_source";


### PR DESCRIPTION
## Description
Enforce a minimum $10 purchase amount for programmatic usage credits at multiple levels:
- API endpoint validation with clear error message
- Sequelize model validation for committed/payg credit types (free credits exempt)
- Frontend UI validation with error state and messaging in BuyCreditDialog

## Risks
Blast radius: Credit purchase flow for programmatic usage
Risk: low

## Deploy Plan
- deploy front