### PR TITLE
[Poke] Add text input variant for number fields in plugins

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -194,9 +194,12 @@ export function PluginForm({
                           <PokeFormInput
                             type={arg.variant === "text" ? "text" : "number"}
                             {...field}
-                            onChange={(e) =>
-                              field.onChange(Number(e.target.value))
-                            }
+                            onChange={(e) => {
+                              const parsed = Number(e.target.value);
+                              if (isFinite(parsed)) {
+                                field.onChange(parsed);
+                              }
+                            }}
                           />
                         )}
                         {arg.type === "boolean" && arg.variant === "toggle" && (

--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -192,7 +192,7 @@ export function PluginForm({
                         {arg.type === "string" && <PokeFormInput {...field} />}
                         {arg.type === "number" && (
                           <PokeFormInput
-                            type="number"
+                            type={arg.variant === "input" ? "text" : "number"}
                             {...field}
                             onChange={(e) =>
                               field.onChange(Number(e.target.value))

--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -192,7 +192,7 @@ export function PluginForm({
                         {arg.type === "string" && <PokeFormInput {...field} />}
                         {arg.type === "number" && (
                           <PokeFormInput
-                            type={arg.variant === "input" ? "text" : "number"}
+                            type={arg.variant === "text" ? "text" : "number"}
                             {...field}
                             onChange={(e) =>
                               field.onChange(Number(e.target.value))

--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -56,6 +56,7 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
     args: {
       amountDollars: {
         type: "number",
+        variant: "input",
         label: "Credit Amount (US$)",
         description:
           "Committed credits amount in USD. Note: this is different from billed amount, as it  excludes VAT, currency conversion and discounts",
@@ -77,6 +78,7 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
       },
       discountPercent: {
         type: "number",
+        variant: "input",
         async: true,
         label: "Billing Discount (%)",
         description: "Discount applied to the actual credit purchase",

--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -56,7 +56,7 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
     args: {
       amountDollars: {
         type: "number",
-        variant: "input",
+        variant: "text",
         label: "Credit Amount (US$)",
         description:
           "Committed credits amount in USD. Note: this is different from billed amount, as it  excludes VAT, currency conversion and discounts",
@@ -78,7 +78,7 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
       },
       discountPercent: {
         type: "number",
-        variant: "input",
+        variant: "text",
         async: true,
         label: "Billing Discount (%)",
         description: "Discount applied to the actual credit purchase",

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -102,6 +102,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       },
       freeCreditsDollars: {
         type: "number",
+        variant: "text",
         label: "Negotiated Monthly Free Credits (USD)",
         description: `Negotiated monthly free credits ($1-$${MAX_FREE_CREDITS_DOLLARS.toLocaleString()}). ⚠️This will top-up next billing cycle's free credits. If you want an immediate top-up, use "Buy Committed Credits" plugin in free mode.`,
         async: true,
@@ -109,6 +110,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       },
       defaultDiscountPercent: {
         type: "number",
+        variant: "text",
         label: "Default Discount (%)",
         description:
           "Discount applied by default to programmatic credit purchases, PAYG or committed.",
@@ -124,6 +126,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       },
       paygCapDollars: {
         type: "number",
+        variant: "text",
         label: "Pay-as-you-go Spending Cap (US$)",
         description: `Maximum monthly PAYG spending (required to enable PAYG). Range: $1-$${MAX_PAYG_CAP_DOLLARS.toLocaleString()}.`,
         async: true,

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -57,7 +57,7 @@ interface StringArgDefinition extends BaseArgDefinition {
 interface NumberArgDefinition extends BaseArgDefinition {
   type: "number";
   values?: never;
-  variant?: "input" | "ticker";
+  variant?: "text" | "spinner";
 }
 
 interface TextArgDefinition extends BaseArgDefinition {

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -57,6 +57,7 @@ interface StringArgDefinition extends BaseArgDefinition {
 interface NumberArgDefinition extends BaseArgDefinition {
   type: "number";
   values?: never;
+  variant?: "input" | "ticker";
 }
 
 interface TextArgDefinition extends BaseArgDefinition {


### PR DESCRIPTION
## Description

Add a `variant` option to number arg type in Poke plugins, allowing regular text inputs (`variant: "input"`) instead of browser number inputs with ticker/spinner buttons (`variant: "ticker"`, or default).

Applied to the "Buy Committed Credits" plugin where users want to type credit amounts directly.

## Risks

Blast radius: Poke plugin number inputs only
Risk: low

## Deploy Plan
- pmrr
- deploy front