### PR TITLE
[Front] feat(skills): add tool types and useToolSelection hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ qdrant_storage
 core-api-keys.json
 oauth-api-keys.json
 /extension/build/
-**/.claude/settings.local.json
+**/.claude
 **/.yalc
 yalc.lock
 front/public/sitemap.xml

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -135,7 +135,7 @@ export function AgentBuilderSkillsBlock({
 
   const handleOpenSheet = useCallback(() => {
     setSheetMode({
-      type: SKILLS_SHEET_PAGE_IDS.SELECTION,
+      pageId: SKILLS_SHEET_PAGE_IDS.SELECTION,
     });
   }, []);
 

--- a/front/components/agent_builder/skills/skillSheet/SelectionPage.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SelectionPage.tsx
@@ -2,15 +2,11 @@ import { SearchInput, Spinner } from "@dust-tt/sparkle";
 import React from "react";
 
 import { SkillCard } from "@app/components/agent_builder/skills/skillSheet/SkillCard";
-import type {
-  PageContentProps,
-  SelectionMode,
-} from "@app/components/agent_builder/skills/skillSheet/types";
+import type { PageContentProps } from "@app/components/agent_builder/skills/skillSheet/types";
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 type SelectionPageProps = PageContentProps & {
-  mode: SelectionMode;
   handleSkillToggle: (skill: SkillType) => void;
   filteredSkills: SkillType[];
   isSkillsLoading: boolean;
@@ -21,7 +17,6 @@ type SelectionPageProps = PageContentProps & {
 
 export function SelectionPageContent({
   onModeChange,
-  mode,
   handleSkillToggle,
   filteredSkills,
   isSkillsLoading,
@@ -67,9 +62,9 @@ export function SelectionPageContent({
               onClick={() => handleSkillToggle(skill)}
               onMoreInfoClick={() => {
                 onModeChange({
-                  type: SKILLS_SHEET_PAGE_IDS.INFO,
+                  pageId: SKILLS_SHEET_PAGE_IDS.SKILL_INFO,
                   skill,
-                  previousMode: mode,
+                  hasPreviousPage: true,
                 });
               }}
             />

--- a/front/components/agent_builder/skills/skillSheet/SkillsSheet.tsx
+++ b/front/components/agent_builder/skills/skillSheet/SkillsSheet.tsx
@@ -74,7 +74,7 @@ function SkillsSheetContent({
   return (
     <MultiPageSheetContent
       pages={[page]}
-      currentPageId={mode.type}
+      currentPageId={mode.pageId}
       onPageChange={() => {}}
       size="xl"
       addFooterSeparator

--- a/front/components/agent_builder/skills/skillSheet/hooks.ts
+++ b/front/components/agent_builder/skills/skillSheet/hooks.ts
@@ -1,3 +1,4 @@
+import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useMemo, useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -8,8 +9,17 @@ import type {
   SkillsSheetMode,
 } from "@app/components/agent_builder/skills/skillSheet/types";
 import { SKILLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/skills/skillSheet/types";
+import { getDefaultMCPAction } from "@app/components/agent_builder/types";
+import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
+import { useBuilderContext } from "@app/components/shared/useBuilderContext";
+import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { doesSkillTriggerSelectSpaces } from "@app/lib/skill";
 import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 function isGlobalSkillWithSpaceSelection(skill: SkillType): boolean {
@@ -17,10 +27,14 @@ function isGlobalSkillWithSpaceSelection(skill: SkillType): boolean {
 }
 
 function getSelectionMode(mode: SkillsSheetMode): SelectionMode {
-  if (mode.type === SKILLS_SHEET_PAGE_IDS.SELECTION) {
-    return mode;
+  if (
+    mode.type === SKILLS_SHEET_PAGE_IDS.INFO ||
+    mode.type === SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION
+  ) {
+    return mode.previousMode;
   }
-  return mode.previousMode;
+
+  return { type: SKILLS_SHEET_PAGE_IDS.SELECTION };
 }
 
 export const useSkillSelection = ({
@@ -132,5 +146,188 @@ export const useSkillSelection = ({
     handleSpaceSelectionSave,
     draftSelectedSpaces,
     setDraftSelectedSpaces,
+  };
+};
+
+// TODO(skills 2025-12-18): duplicated from MCPServerViewsSheet, to cleanup later
+const TOP_MCP_SERVER_VIEWS = [
+  "web_search_&_browse",
+  "image_generation",
+  AGENT_MEMORY_SERVER_NAME,
+  "deep_dive",
+  "interactive_content",
+  "slack",
+  "gmail",
+  "google_calendar",
+];
+type SelectedTool = {
+  type: "MCP";
+  view: MCPServerViewTypeWithLabel;
+  configuredAction?: BuilderAction;
+};
+
+export const useToolSelection = ({
+  selectedActions,
+  setSelectedToolsInSheet,
+  onModeChange,
+  searchTerm,
+  filterMCPServerViews,
+}: {
+  selectedActions: BuilderAction[];
+  setSelectedToolsInSheet: Dispatch<SetStateAction<SelectedTool[]>>;
+  onModeChange: (mode: SkillsSheetMode | null) => void;
+  searchTerm: string;
+  filterMCPServerViews?: (view: MCPServerViewTypeWithLabel) => boolean;
+}) => {
+  const { owner } = useBuilderContext();
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+
+  const {
+    mcpServerViews: allMcpServerViews,
+    mcpServerViewsWithoutKnowledge,
+    isMCPServerViewsLoading,
+  } = useMCPServerViewsContext();
+
+  const shouldFilterServerView = useCallback(
+    (view: MCPServerViewTypeWithLabel, actions: BuilderAction[]) => {
+      // Build the set of server.sId already selected by actions (via their selected view).
+      const selectedServerIds = new Set<string>();
+      for (const action of actions) {
+        if (
+          action.type === "MCP" &&
+          action.configuration &&
+          action.configuration.mcpServerViewId &&
+          !action.configurationRequired
+        ) {
+          const selectedView = allMcpServerViews.find(
+            (mcpServerView) =>
+              mcpServerView.sId === action.configuration.mcpServerViewId
+          );
+          if (selectedView) {
+            selectedServerIds.add(selectedView.server.sId);
+          }
+        }
+      }
+      return selectedServerIds.has(view.server.sId);
+    },
+    [allMcpServerViews]
+  );
+
+  const topMCPServerViews = useMemo(() => {
+    const views = mcpServerViewsWithoutKnowledge.filter((view) =>
+      TOP_MCP_SERVER_VIEWS.includes(view.server.name)
+    );
+    return filterMCPServerViews ? views.filter(filterMCPServerViews) : views;
+  }, [mcpServerViewsWithoutKnowledge, filterMCPServerViews]);
+
+  const nonTopMCPServerViews = useMemo(() => {
+    const views = mcpServerViewsWithoutKnowledge.filter(
+      (view) => !TOP_MCP_SERVER_VIEWS.includes(view.server.name)
+    );
+    return filterMCPServerViews ? views.filter(filterMCPServerViews) : views;
+  }, [mcpServerViewsWithoutKnowledge, filterMCPServerViews]);
+
+  const selectableTopMCPServerViews = useMemo(() => {
+    const filteredList = topMCPServerViews.filter(
+      (view) => !shouldFilterServerView(view, selectedActions)
+    );
+
+    return filteredList;
+  }, [topMCPServerViews, selectedActions, shouldFilterServerView]);
+
+  const selectableNonTopMCPServerViews = useMemo(
+    () =>
+      nonTopMCPServerViews.filter(
+        (view) => !shouldFilterServerView(view, selectedActions)
+      ),
+    [nonTopMCPServerViews, selectedActions, shouldFilterServerView]
+  );
+
+  const filteredViews = useMemo(() => {
+    const filterViews = (views: MCPServerViewTypeWithLabel[]) =>
+      !searchTerm.trim()
+        ? views
+        : views.filter((view) => {
+            const term = searchTerm.toLowerCase();
+            return [view.label, view.server.description, view.server.name].some(
+              (field) => field?.toLowerCase().includes(term)
+            );
+          });
+
+    return {
+      topViews: filterViews(selectableTopMCPServerViews),
+      nonTopViews: filterViews(selectableNonTopMCPServerViews),
+    };
+  }, [searchTerm, selectableTopMCPServerViews, selectableNonTopMCPServerViews]);
+
+  const toggleToolSelection = useCallback(
+    (tool: SelectedTool) => {
+      setSelectedToolsInSheet((prev) => {
+        const isAlreadySelected = prev.some((selected) => {
+          if (tool.type === "MCP" && selected.type === "MCP") {
+            return tool.view.sId === selected.view.sId;
+          }
+          return false;
+        });
+
+        if (isAlreadySelected) {
+          return prev.filter((selected) => {
+            if (tool.type === "MCP" && selected.type === "MCP") {
+              return tool.view.sId !== selected.view.sId;
+            }
+            return true;
+          });
+        }
+
+        return [...prev, tool];
+      });
+    },
+    [setSelectedToolsInSheet]
+  );
+
+  const onClickMCPServer = useCallback(
+    (mcpServerView: MCPServerViewTypeWithLabel) => {
+      const tool = { type: "MCP", view: mcpServerView } satisfies SelectedTool;
+      const requirements = getMCPServerRequirements(
+        mcpServerView,
+        featureFlags
+      );
+
+      if (!requirements.noRequirement) {
+        const action = getDefaultMCPAction(mcpServerView);
+
+        onModeChange({
+          type: SKILLS_SHEET_PAGE_IDS.TOOL_CONFIGURATION,
+          action,
+          mcpServerView,
+        });
+        return;
+      }
+
+      // No configuration required, add to selected tools
+      toggleToolSelection(tool);
+    },
+    [featureFlags, toggleToolSelection, onModeChange]
+  );
+
+  const handleToolInfoClick = useCallback(
+    (mcpServerView: MCPServerViewType) => {
+      const action = getDefaultMCPAction(mcpServerView);
+      onModeChange({
+        type: SKILLS_SHEET_PAGE_IDS.TOOL_INFO,
+        action,
+        source: "toolDetails",
+      });
+    },
+    [onModeChange]
+  );
+
+  return {
+    filteredViews,
+    isMCPServerViewsLoading,
+    toggleToolSelection,
+    onClickMCPServer,
+    handleToolInfoClick,
+    featureFlags,
   };
 };

--- a/front/components/agent_builder/skills/skillSheet/types.tsx
+++ b/front/components/agent_builder/skills/skillSheet/types.tsx
@@ -1,14 +1,23 @@
 import type React from "react";
 
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { UserType, WorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export const SKILLS_SHEET_PAGE_IDS = {
+  // Skill pages
   SELECTION: "add",
   INFO: "info",
   SPACE_SELECTION: "space_selection",
+  // Tool pages
+  TOOL_INFO: "tool-info",
+  TOOL_CONFIGURATION: "tool-configuration",
+  TOOL_EDIT: "tool-edit",
 } as const;
+
+export type CapabilityFilterType = "all" | "tools" | "skills";
 
 export type SkillsSheetMode =
   | {
@@ -23,6 +32,21 @@ export type SkillsSheetMode =
       type: typeof SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION;
       skillConfiguration: SkillType;
       previousMode: SelectionMode;
+    }
+  | {
+      type: typeof SKILLS_SHEET_PAGE_IDS.TOOL_INFO;
+      action: BuilderAction;
+      source: "toolDetails" | "addedTool";
+    }
+  | {
+      type: typeof SKILLS_SHEET_PAGE_IDS.TOOL_CONFIGURATION;
+      action: BuilderAction;
+      mcpServerView: MCPServerViewTypeWithLabel;
+    }
+  | {
+      type: typeof SKILLS_SHEET_PAGE_IDS.TOOL_EDIT;
+      action: BuilderAction;
+      index: number;
     };
 
 export type SelectionMode = Extract<

--- a/front/components/agent_builder/skills/skillSheet/types.tsx
+++ b/front/components/agent_builder/skills/skillSheet/types.tsx
@@ -3,48 +3,61 @@ import type React from "react";
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
+import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { UserType, WorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-export const SKILLS_SHEET_PAGE_IDS = {
-  // Skill pages
-  SELECTION: "add",
-  INFO: "info",
-  SPACE_SELECTION: "space_selection",
-  // Tool pages
-  TOOL_INFO: "tool-info",
-  TOOL_CONFIGURATION: "tool-configuration",
-  TOOL_EDIT: "tool-edit",
-} as const;
+// TODO(skills 2025-12-18): duplicated from MCPServerViewsSheet, to cleanup later
+export const TOP_MCP_SERVER_VIEWS = [
+  "web_search_&_browse",
+  "image_generation",
+  AGENT_MEMORY_SERVER_NAME,
+  "deep_dive",
+  "interactive_content",
+  "slack",
+  "gmail",
+  "google_calendar",
+];
+export type SelectedTool = {
+  type: "MCP";
+  view: MCPServerViewTypeWithLabel;
+  configuredAction?: BuilderAction;
+};
 
 export type CapabilityFilterType = "all" | "tools" | "skills";
 
+export const SKILLS_SHEET_PAGE_IDS = {
+  SELECTION: "selection",
+  SKILL_INFO: "skill_info",
+  SKILL_SPACE_SELECTION: "skill_space_selection",
+  TOOL_INFO: "tool_info",
+  TOOL_CONFIGURATION: "tool_configuration",
+  TOOL_EDIT: "tool_edit",
+} as const;
+
 export type SkillsSheetMode =
+  | { pageId: typeof SKILLS_SHEET_PAGE_IDS.SELECTION }
   | {
-      type: typeof SKILLS_SHEET_PAGE_IDS.SELECTION;
-    }
-  | {
-      type: typeof SKILLS_SHEET_PAGE_IDS.INFO;
+      pageId: typeof SKILLS_SHEET_PAGE_IDS.SKILL_INFO;
       skill: SkillType;
-      previousMode: SelectionMode;
+      hasPreviousPage: boolean;
     }
   | {
-      type: typeof SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION;
+      pageId: typeof SKILLS_SHEET_PAGE_IDS.SKILL_SPACE_SELECTION;
       skillConfiguration: SkillType;
-      previousMode: SelectionMode;
     }
   | {
-      type: typeof SKILLS_SHEET_PAGE_IDS.TOOL_INFO;
+      pageId: typeof SKILLS_SHEET_PAGE_IDS.TOOL_INFO;
       action: BuilderAction;
-      source: "toolDetails" | "addedTool";
+      hasPreviousPage: boolean;
     }
   | {
-      type: typeof SKILLS_SHEET_PAGE_IDS.TOOL_CONFIGURATION;
+      pageId: typeof SKILLS_SHEET_PAGE_IDS.TOOL_CONFIGURATION;
       action: BuilderAction;
       mcpServerView: MCPServerViewTypeWithLabel;
     }
   | {
-      type: typeof SKILLS_SHEET_PAGE_IDS.TOOL_EDIT;
+      pageId: typeof SKILLS_SHEET_PAGE_IDS.TOOL_EDIT;
       action: BuilderAction;
       index: number;
     };
@@ -56,7 +69,7 @@ export type SelectionMode = Extract<
 
 export type SpaceSelectionMode = Extract<
   SkillsSheetMode,
-  { type: typeof SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION }
+  { type: typeof SKILLS_SHEET_PAGE_IDS.SKILL_SPACE_SELECTION }
 >;
 
 export type PageContentProps = {

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -27,12 +27,12 @@ export function getPageAndFooter(props: PageContentProps): {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const skillSelection = useSkillSelection(props);
 
-  switch (mode.type) {
+  switch (mode.pageId) {
     case SKILLS_SHEET_PAGE_IDS.SELECTION:
       return {
         page: {
           title: "Add skills",
-          id: mode.type,
+          id: mode.pageId,
           content: (
             <SelectionPageContent
               {...props}
@@ -46,19 +46,25 @@ export function getPageAndFooter(props: PageContentProps): {
             />
           ),
         },
-        leftButton: getCancelButton(onClose),
+        leftButton: {
+          label: "Cancel",
+          variant: "outline",
+          onClick: () => {
+            onClose();
+          },
+        },
         rightButton: {
           label: "Add skills",
           onClick: handleSave,
           variant: "primary",
         },
       };
-    case SKILLS_SHEET_PAGE_IDS.INFO:
+    case SKILLS_SHEET_PAGE_IDS.SKILL_INFO:
       return {
         page: {
           title: mode.skill.name,
           description: mode.skill.userFacingDescription,
-          id: props.mode.type,
+          id: props.mode.pageId,
           icon: getSkillIcon(mode.skill.icon),
           content: (
             <SkillWithRelationsDetailsSheetContent
@@ -71,16 +77,18 @@ export function getPageAndFooter(props: PageContentProps): {
         leftButton: {
           label: "Back",
           variant: "outline",
-          onClick: () => onModeChange(mode.previousMode),
+          onClick: () => {
+            onModeChange({ pageId: SKILLS_SHEET_PAGE_IDS.SELECTION });
+          },
         },
       };
-    case SKILLS_SHEET_PAGE_IDS.SPACE_SELECTION:
+    case SKILLS_SHEET_PAGE_IDS.SKILL_SPACE_SELECTION:
       return {
         page: {
           title: `Select spaces`,
           description:
             "Automatically grant access to all knowledge sources discovery from your selected spaces",
-          id: mode.type,
+          id: mode.pageId,
           content: (
             <SpaceSelectionPageContent
               alreadyRequestedSpaceIds={alreadyRequestedSpaceIds}
@@ -94,7 +102,7 @@ export function getPageAndFooter(props: PageContentProps): {
           variant: "outline",
           onClick: () => {
             skillSelection.setDraftSelectedSpaces(localAdditionalSpaces);
-            onModeChange(mode.previousMode);
+            onModeChange({ pageId: SKILLS_SHEET_PAGE_IDS.SELECTION });
           },
         },
         rightButton: {
@@ -111,18 +119,18 @@ export function getPageAndFooter(props: PageContentProps): {
       return {
         page: {
           title: "Tool",
-          id: mode.type,
+          id: mode.pageId,
           content: <div>Tool configuration coming soon</div>,
         },
-        leftButton: getCancelButton(onClose),
+        leftButton: {
+          label: "Cancel",
+          variant: "outline",
+          onClick: () => {
+            onModeChange({ pageId: SKILLS_SHEET_PAGE_IDS.SELECTION });
+          },
+        },
       };
     default:
       assertNever(mode);
   }
 }
-
-export const getCancelButton = (onClose: () => void) => ({
-  label: "Cancel",
-  variant: "outline",
-  onClick: onClose,
-});

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -104,6 +104,18 @@ export function getPageAndFooter(props: PageContentProps): {
             skillSelection.handleSpaceSelectionSave(mode.skillConfiguration),
         },
       };
+    // TODO(skills 2025-12-18): placeholder to satisfy type for now, will be implemented in future PRs
+    case SKILLS_SHEET_PAGE_IDS.TOOL_INFO:
+    case SKILLS_SHEET_PAGE_IDS.TOOL_CONFIGURATION:
+    case SKILLS_SHEET_PAGE_IDS.TOOL_EDIT:
+      return {
+        page: {
+          title: "Tool",
+          id: mode.type,
+          content: <div>Tool configuration coming soon</div>,
+        },
+        leftButton: getCancelButton(onClose),
+      };
     default:
       assertNever(mode);
   }

--- a/front/components/agent_builder/skills/skillSheet/utils.tsx
+++ b/front/components/agent_builder/skills/skillSheet/utils.tsx
@@ -49,9 +49,7 @@ export function getPageAndFooter(props: PageContentProps): {
         leftButton: {
           label: "Cancel",
           variant: "outline",
-          onClick: () => {
-            onClose();
-          },
+          onClick: onClose,
         },
         rightButton: {
           label: "Add skills",


### PR DESCRIPTION
Step 1 of implementing https://github.com/dust-tt/tasks/issues/5565

Splitting https://github.com/dust-tt/dust/pull/19233/changes in 5 PRs

## Description

Here I only duplicate tool selection logic of `MCPServerViewsSheet` in a custom hook and define the page types that will be used for the tool views (info, edit, configuration)

## Tests

Local, shouldn't do anything as the new hook is not called

## Risk

Low

## Deploy Plan

Front