### PR TITLE
Change gmail get_messages to never_ask

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -481,7 +481,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_stakes: {
       get_drafts: "never_ask",
       create_draft: "low",
-      get_messages: "low",
+      get_messages: "never_ask",
       create_reply_draft: "low",
     },
     tools_retry_policies: undefined,


### PR DESCRIPTION
## Description

The fact that the stake was 'low' before was an anomaly compared to similar tools that just read data. Changing it to never_ask for consistency and to reduce onboarding friction.

## Tests

Manual

## Risk

Low

## Deploy Plan

Front