### PR TITLE
[SKILLS] Show extended skill name in builder title

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -33,14 +33,19 @@ import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSkillTools } from "@app/lib/swr/actions";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type {
+  ExtendedSkillType,
+  SkillType,
+} from "@app/types/assistant/skill_configuration";
 
 interface SkillBuilderProps {
   skillConfiguration?: SkillType;
+  extendedSkill?: ExtendedSkillType;
 }
 
 export default function SkillBuilder({
   skillConfiguration,
+  extendedSkill,
 }: SkillBuilderProps) {
   const { owner, user } = useSkillBuilderContext();
   const router = useRouter();
@@ -155,7 +160,8 @@ export default function SkillBuilder({
               title={
                 skillConfiguration
                   ? `Edit skill ${skillConfiguration.name}`
-                  : "Create new skill"
+                  : "Create new skill" +
+                    (extendedSkill ? ` - extending ${extendedSkill.name}` : "")
               }
               rightActions={
                 <Button

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -24,56 +24,50 @@ export function SkillDetailsButtonBar({
   skill,
   owner,
 }: SkillDetailsButtonBarProps) {
-  return (
-    <div className="flex flex-row items-center gap-2 px-1.5">
-      <Button
-        size="sm"
-        tooltip="Edit agent"
-        href={getSkillBuilderRoute(owner.sId, skill.sId)}
-        variant="outline"
-        icon={PencilSquareIcon}
-      />
-      <SkillDetailsDropdownMenu skill={skill} owner={owner} />
-    </div>
-  );
-}
-
-interface SkillDetailsDropdownMenuProps {
-  skill: SkillType;
-  owner: WorkspaceType;
-}
-
-export function SkillDetailsDropdownMenu({
-  skill,
-  owner,
-}: SkillDetailsDropdownMenuProps) {
   const router = useRouter();
 
+  if (!skill.canWrite && !skill.isExtendable) {
+    return null;
+  }
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button icon={MoreIcon} size="sm" variant="ghost" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <DropdownMenuItem
-          label="Copy skill ID"
-          onClick={async (e) => {
-            e.stopPropagation();
-            await navigator.clipboard.writeText(skill.sId);
-          }}
-          icon={BracesIcon}
+    <div className="flex flex-row items-center gap-2 px-1.5">
+      {skill.canWrite && (
+        <Button
+          size="sm"
+          tooltip="Edit agent"
+          href={getSkillBuilderRoute(owner.sId, skill.sId)}
+          variant="outline"
+          icon={PencilSquareIcon}
         />
-        <DropdownMenuItem
-          label="Clone (New)"
-          icon={ClipboardIcon}
-          onClick={async (e) => {
-            e.stopPropagation();
-            await router.push(
-              getSkillBuilderRoute(owner.sId, "new", `duplicate=${skill.sId}`)
-            );
-          }}
-        />
-      </DropdownMenuContent>
-    </DropdownMenu>
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button icon={MoreIcon} size="sm" variant="ghost" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem
+            label="Copy skill ID"
+            onClick={async (e) => {
+              e.stopPropagation();
+              await navigator.clipboard.writeText(skill.sId);
+            }}
+            icon={BracesIcon}
+          />
+          {skill.isExtendable && (
+            <DropdownMenuItem
+              label="Extend (New)"
+              icon={ClipboardIcon}
+              onClick={async (e) => {
+                e.stopPropagation();
+                await router.push(
+                  getSkillBuilderRoute(owner.sId, "new", `extends=${skill.sId}`)
+                );
+              }}
+            />
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -160,7 +160,7 @@ const DescriptionSection = ({
         )}
       </div>
 
-      {skill.status === "active" && skill.canWrite && (
+      {skill.status === "active" && (
         <SkillDetailsButtonBar owner={owner} skill={skill} />
       )}
 

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -1,7 +1,7 @@
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
-import type { RESOURCES_PREFIX } from "@app/lib/resources/string_ids";
+import type { ResourceSId } from "@app/lib/resources/string_ids";
 
 export interface GlobalSkillDefinition {
   readonly agentFacingDescription: string;
@@ -29,8 +29,8 @@ function ensureUniqueSIds<T extends readonly GlobalSkillDefinition[]>(
           ? // If current sId matches any other element's sId, return error.
             `ERROR: Duplicate sId detected: \${T[I][K] & string}`
           : // Ensure it does not start with skl_ to avoid conflicts with custom skills.
-            T[I][K] extends `${(typeof RESOURCES_PREFIX)["skill"]}_${string}`
-            ? `ERROR: sId cannot start with "skl_": \${T[I][K] & string}`
+            T[I][K] extends ResourceSId
+            ? "ERROR: sId cannot start with resource prefix"
             : // Otherwise, return the original sId type.
               T[I][K]
         : // For non-sId properties, just pass through unchanged.

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -1,6 +1,7 @@
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
+import type { RESOURCES_PREFIX } from "@app/lib/resources/string_ids";
 
 export interface GlobalSkillDefinition {
   readonly agentFacingDescription: string;
@@ -27,8 +28,11 @@ function ensureUniqueSIds<T extends readonly GlobalSkillDefinition[]>(
           }[number]["sId"] // Extract their sId values as a union.
           ? // If current sId matches any other element's sId, return error.
             `ERROR: Duplicate sId detected: \${T[I][K] & string}`
-          : // Otherwise, return the original sId type.
-            T[I][K]
+          : // Ensure it does not start with skl_ to avoid conflicts with custom skills.
+            T[I][K] extends `${(typeof RESOURCES_PREFIX)["skill"]}_${string}`
+            ? `ERROR: sId cannot start with "skl_": \${T[I][K] & string}`
+            : // Otherwise, return the original sId type.
+              T[I][K]
         : // For non-sId properties, just pass through unchanged.
           T[I][K];
     };

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -590,6 +590,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this.editorGroup.canWrite(auth);
   }
 
+  isExtendable(): boolean {
+    return this.isGlobal;
+  }
+
   async fetchUsage(auth: Authenticator): Promise<AgentsUsageType> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -1025,6 +1029,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       icon: this.icon ?? null,
       tools,
       canWrite: this.canWrite(auth),
+      isExtendable: this.isExtendable(),
     };
   }
 

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -19,7 +19,7 @@ const sqids = new Sqids({
 export const LEGACY_REGION_BIT = 1; // Previously indicated US region.
 const LEGACY_SHARD_BIT = 1;
 
-const RESOURCES_PREFIX = {
+export const RESOURCES_PREFIX = {
   file: "fil",
   group: "grp",
   // TODO(2024-10-31 flav) Add new prefix for space.

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -59,13 +59,17 @@ export const RESOURCES_PREFIX = {
 
   // Skills.
   skill: "skl",
-};
+} as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;
 
-const ALL_RESOURCES_PREFIXES = Object.values(RESOURCES_PREFIX);
+const ALL_RESOURCES_PREFIXES = Object.values<string>(RESOURCES_PREFIX);
 
 type ResourceNameType = keyof typeof RESOURCES_PREFIX;
+
+export type ResourceSId = {
+  [key in keyof typeof RESOURCES_PREFIX]: `${(typeof RESOURCES_PREFIX)[key]}_${string}`;
+}[keyof typeof RESOURCES_PREFIX];
 
 const sIdCache = new Map<string, string>();
 

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
+import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -69,3 +70,7 @@ export default function CreateSkill({
     </SkillBuilderProvider>
   );
 }
+
+CreateSkill.getLayout = (page: React.ReactElement) => {
+  return <AppRootLayout>{page}</AppRootLayout>;
+};

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -16,7 +16,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   user: UserType;
   subscription: SubscriptionType;
-  extendedSkill?: ExtendedSkillType;
+  extendedSkill: ExtendedSkillType | null;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -27,7 +27,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       : null;
   const extendedSkill = skillToExtend?.isExtendable
     ? { name: skillToExtend.name }
-    : undefined;
+    : null;
 
   if (!owner || !auth.isBuilder() || !subscription) {
     return {
@@ -65,7 +65,7 @@ export default function CreateSkill({
         <Head>
           <title>Dust - New Skill</title>
         </Head>
-        <SkillBuilder extendedSkill={extendedSkill} />
+        <SkillBuilder extendedSkill={extendedSkill ?? undefined} />
       </SpacesProvider>
     </SkillBuilderProvider>
   );

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -19,6 +19,7 @@ export type SkillType = {
   requestedSpaceIds: string[];
   tools: { mcpServerViewId: string }[];
   canWrite: boolean;
+  isExtendable: boolean;
 };
 
 export type SkillRelations = {

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -32,3 +32,5 @@ export type SkillRelations = {
 export type SkillWithRelationsType = SkillType & {
   relations: SkillRelations;
 };
+
+export type ExtendedSkillType = { name: string };


### PR DESCRIPTION
## Description

[Task](https://github.com/dust-tt/tasks/issues/5668) 

- allow to extend from global skill
- display the extended global skill name in builder dialog
- ensure global skill sIds do not start with skl_ to avoid conflict

<img width="1674" height="618" alt="image" src="https://github.com/user-attachments/assets/c950c441-5d01-4cc5-b925-1735960051fd" />


## Tests

local

## Risk

low

## Deploy Plan

front
