### PR TITLE
[front] chore(agent-loop): remove deprecate patches

### DIFF
--- a/front/temporal/agent_loop/activities/analytics.ts
+++ b/front/temporal/agent_loop/activities/analytics.ts
@@ -7,7 +7,7 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 /**
  * Launch agent message analytics workflow in fire-and-forget mode.
  */
-export async function launchAgentMessageAnalyticsActivity(
+export async function launchAgentMessageAnalytics(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -207,17 +207,8 @@ export async function updateResourceAndPublishEvent(
 
 export async function notifyWorkflowError(
   authType: AuthenticatorType,
-  {
-    conversationId,
-    agentMessageId,
-    agentMessageVersion,
-    error,
-  }: {
-    conversationId: string;
-    agentMessageId: string;
-    agentMessageVersion: number;
-    error: Error;
-  }
+  { conversationId, agentMessageId, agentMessageVersion }: AgentLoopArgs,
+  error: Error
 ): Promise<void> {
   const authResult = await AuthenticatorClass.fromJSON(authType);
   if (authResult.isErr()) {

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -283,7 +283,7 @@ export async function notifyWorkflowError(
 /**
  * Activity executed after a cancel signal
  */
-export async function finalizeCancellationActivity(
+export async function finalizeCancellation(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -15,11 +15,11 @@ export async function finalizeSuccessfulAgentLoopActivity(
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
   await Promise.all([
+    snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
     handleMentions(authType, agentLoopArgs),
-    snapshotAgentMessageSkills(authType, agentLoopArgs),
   ]);
 }
 
@@ -27,11 +27,12 @@ export async function finalizeCancelledAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
+  await finalizeCancellation(authType, agentLoopArgs);
+
   await Promise.all([
+    snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
-    finalizeCancellation(authType, agentLoopArgs),
-    snapshotAgentMessageSkills(authType, agentLoopArgs),
   ]);
 }
 
@@ -40,15 +41,16 @@ export async function finalizeErroredAgentLoopActivity(
   agentLoopArgs: AgentLoopArgs,
   error: Error
 ): Promise<void> {
+  await notifyWorkflowError(authType, {
+    conversationId: agentLoopArgs.conversationId,
+    agentMessageId: agentLoopArgs.agentMessageId,
+    agentMessageVersion: agentLoopArgs.agentMessageVersion,
+    error,
+  });
+
   await Promise.all([
+    snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
-    notifyWorkflowError(authType, {
-      conversationId: agentLoopArgs.conversationId,
-      agentMessageId: agentLoopArgs.agentMessageId,
-      agentMessageVersion: agentLoopArgs.agentMessageVersion,
-      error,
-    }),
-    snapshotAgentMessageSkills(authType, agentLoopArgs),
   ]);
 }

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -7,7 +7,7 @@ import {
 import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
 import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
 import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
-import { launchTrackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
+import { launchTrackProgrammaticUsage } from "@app/temporal/agent_loop/activities/usage_tracking";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 export async function finalizeSuccessfulAgentLoopActivity(
@@ -17,7 +17,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
   await Promise.all([
     snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
-    launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
+    launchTrackProgrammaticUsage(authType, agentLoopArgs),
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
     handleMentions(authType, agentLoopArgs),
   ]);
@@ -32,7 +32,7 @@ export async function finalizeCancelledAgentLoopActivity(
   await Promise.all([
     snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
-    launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
+    launchTrackProgrammaticUsage(authType, agentLoopArgs),
   ]);
 }
 
@@ -46,6 +46,6 @@ export async function finalizeErroredAgentLoopActivity(
   await Promise.all([
     snapshotAgentMessageSkills(authType, agentLoopArgs),
     launchAgentMessageAnalytics(authType, agentLoopArgs),
-    launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
+    launchTrackProgrammaticUsage(authType, agentLoopArgs),
   ]);
 }

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -41,12 +41,7 @@ export async function finalizeErroredAgentLoopActivity(
   agentLoopArgs: AgentLoopArgs,
   error: Error
 ): Promise<void> {
-  await notifyWorkflowError(authType, {
-    conversationId: agentLoopArgs.conversationId,
-    agentMessageId: agentLoopArgs.agentMessageId,
-    agentMessageVersion: agentLoopArgs.agentMessageVersion,
-    error,
-  });
+  await notifyWorkflowError(authType, agentLoopArgs, error);
 
   await Promise.all([
     snapshotAgentMessageSkills(authType, agentLoopArgs),

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -1,10 +1,10 @@
 import type { AuthenticatorType } from "@app/lib/auth";
-import { launchAgentMessageAnalyticsActivity } from "@app/temporal/agent_loop/activities/analytics";
+import { launchAgentMessageAnalytics } from "@app/temporal/agent_loop/activities/analytics";
 import {
-  finalizeCancellationActivity,
+  finalizeCancellation,
   notifyWorkflowError,
 } from "@app/temporal/agent_loop/activities/common";
-import { handleMentionsActivity } from "@app/temporal/agent_loop/activities/mentions";
+import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
 import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
 import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
 import { launchTrackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
@@ -15,10 +15,10 @@ export async function finalizeSuccessfulAgentLoopActivity(
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
   await Promise.all([
-    launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
+    launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
     conversationUnreadNotificationActivity(authType, agentLoopArgs),
-    handleMentionsActivity(authType, agentLoopArgs),
+    handleMentions(authType, agentLoopArgs),
     snapshotAgentMessageSkills(authType, agentLoopArgs),
   ]);
 }
@@ -28,9 +28,9 @@ export async function finalizeCancelledAgentLoopActivity(
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
   await Promise.all([
-    launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
+    launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
-    finalizeCancellationActivity(authType, agentLoopArgs),
+    finalizeCancellation(authType, agentLoopArgs),
     snapshotAgentMessageSkills(authType, agentLoopArgs),
   ]);
 }
@@ -41,7 +41,7 @@ export async function finalizeErroredAgentLoopActivity(
   error: Error
 ): Promise<void> {
   await Promise.all([
-    launchAgentMessageAnalyticsActivity(authType, agentLoopArgs),
+    launchAgentMessageAnalytics(authType, agentLoopArgs),
     launchTrackProgrammaticUsageActivity(authType, agentLoopArgs),
     notifyWorkflowError(authType, {
       conversationId: agentLoopArgs.conversationId,

--- a/front/temporal/agent_loop/activities/mentions.ts
+++ b/front/temporal/agent_loop/activities/mentions.ts
@@ -9,7 +9,7 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 /**
  * Handle mentions in the agent message content.
  */
-export async function handleMentionsActivity(
+export async function handleMentions(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {

--- a/front/temporal/agent_loop/activities/usage_tracking.ts
+++ b/front/temporal/agent_loop/activities/usage_tracking.ts
@@ -7,7 +7,7 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 /**
  * Launch agent message analytics workflow in fire-and-forget mode.
  */
-export async function launchTrackProgrammaticUsageActivity(
+export async function launchTrackProgrammaticUsage(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -29,7 +29,6 @@ import {
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
-import { launchTrackProgrammaticUsageActivity } from "@app/temporal/agent_loop/activities/usage_tracking";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import { isDevelopment, removeNulls } from "@app/types";
@@ -61,7 +60,6 @@ export async function runAgentLoopWorker() {
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,
       runToolActivity,
-      launchTrackProgrammaticUsageActivity,
     },
     taskQueue: QUEUE_NAME,
     connection,

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -15,11 +15,7 @@ import {
 import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { launchAgentMessageAnalyticsActivity } from "@app/temporal/agent_loop/activities/analytics";
-import {
-  finalizeCancellationActivity,
-  notifyWorkflowError,
-} from "@app/temporal/agent_loop/activities/common";
+import { notifyWorkflowError } from "@app/temporal/agent_loop/activities/common";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {
   finalizeCancelledAgentLoopActivity,
@@ -31,8 +27,6 @@ import {
   logAgentLoopPhaseStartActivity,
   logAgentLoopStepCompletionActivity,
 } from "@app/temporal/agent_loop/activities/instrumentation";
-import { handleMentionsActivity } from "@app/temporal/agent_loop/activities/mentions";
-import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
@@ -58,14 +52,10 @@ export async function runAgentLoopWorker() {
       getWorkflowsPath: () => require.resolve("./workflows"),
     }),
     activities: {
-      conversationUnreadNotificationActivity,
       ensureConversationTitleActivity,
       finalizeSuccessfulAgentLoopActivity,
       finalizeCancelledAgentLoopActivity,
       finalizeErroredAgentLoopActivity,
-      finalizeCancellationActivity,
-      handleMentionsActivity,
-      launchAgentMessageAnalyticsActivity,
       logAgentLoopPhaseCompletionActivity,
       logAgentLoopPhaseStartActivity,
       logAgentLoopStepCompletionActivity,

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -15,7 +15,6 @@ import {
 import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { notifyWorkflowError } from "@app/temporal/agent_loop/activities/common";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {
   finalizeCancelledAgentLoopActivity,
@@ -59,7 +58,6 @@ export async function runAgentLoopWorker() {
       logAgentLoopPhaseCompletionActivity,
       logAgentLoopPhaseStartActivity,
       logAgentLoopStepCompletionActivity,
-      notifyWorkflowError,
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,
       runToolActivity,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -5,7 +5,6 @@ import type {
 } from "@temporalio/workflow";
 import {
   CancellationScope,
-  deprecatePatch,
   proxyActivities,
   setHandler,
   startChild,
@@ -109,8 +108,6 @@ const {
     maximumAttempts: 5,
   },
 });
-
-const PATCH_NAME = "finalize-activity-consolidation";
 
 export async function agentLoopConversationTitleWorkflow({
   authType,
@@ -238,7 +235,6 @@ export async function agentLoopWorkflow({
 
       // Ensure analytics runs even if workflow is cancelled
       await CancellationScope.nonCancellable(async () => {
-        deprecatePatch(PATCH_NAME);
         await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);
       });
     });
@@ -253,12 +249,10 @@ export async function agentLoopWorkflow({
     await CancellationScope.nonCancellable(async () => {
       if (cancelRequested) {
         // Ensure analytics runs even when workflow is cancelled
-        deprecatePatch(PATCH_NAME);
         await finalizeCancelledAgentLoopActivity(authType, agentLoopArgs);
         return;
       } else {
         // Ensure analytics runs even when workflow errors
-        deprecatePatch(PATCH_NAME);
         await finalizeErroredAgentLoopActivity(
           authType,
           agentLoopArgs,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -233,7 +233,6 @@ export async function agentLoopWorkflow({
         },
       });
 
-      // Ensure analytics runs even if workflow is canceled.
       await CancellationScope.nonCancellable(async () => {
         await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);
       });
@@ -248,10 +247,8 @@ export async function agentLoopWorkflow({
     // Notify error in a non-cancellable scope to ensure it runs even if the workflow is canceled.
     await CancellationScope.nonCancellable(async () => {
       if (cancelRequested) {
-        // Ensure analytics runs even when workflow is canceled.
         return finalizeCancelledAgentLoopActivity(authType, agentLoopArgs);
       }
-      // Ensure analytics runs even when workflow errors.
       await finalizeErroredAgentLoopActivity(
         authType,
         agentLoopArgs,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -233,7 +233,7 @@ export async function agentLoopWorkflow({
         },
       });
 
-      // Ensure analytics runs even if workflow is cancelled
+      // Ensure analytics runs even if workflow is canceled.
       await CancellationScope.nonCancellable(async () => {
         await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);
       });
@@ -245,20 +245,18 @@ export async function agentLoopWorkflow({
   } catch (err) {
     const workflowError = err instanceof Error ? err : new Error(String(err));
 
-    // Notify error in a non-cancellable scope to ensure it runs even if workflow is cancelled
+    // Notify error in a non-cancellable scope to ensure it runs even if the workflow is canceled.
     await CancellationScope.nonCancellable(async () => {
       if (cancelRequested) {
-        // Ensure analytics runs even when workflow is cancelled
-        await finalizeCancelledAgentLoopActivity(authType, agentLoopArgs);
-        return;
-      } else {
-        // Ensure analytics runs even when workflow errors
-        await finalizeErroredAgentLoopActivity(
-          authType,
-          agentLoopArgs,
-          workflowError
-        );
+        // Ensure analytics runs even when workflow is canceled.
+        return finalizeCancelledAgentLoopActivity(authType, agentLoopArgs);
       }
+      // Ensure analytics runs even when workflow errors
+      await finalizeErroredAgentLoopActivity(
+        authType,
+        agentLoopArgs,
+        workflowError
+      );
       throw err;
     });
   }

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -251,7 +251,7 @@ export async function agentLoopWorkflow({
         // Ensure analytics runs even when workflow is canceled.
         return finalizeCancelledAgentLoopActivity(authType, agentLoopArgs);
       }
-      // Ensure analytics runs even when workflow errors
+      // Ensure analytics runs even when workflow errors.
       await finalizeErroredAgentLoopActivity(
         authType,
         agentLoopArgs,


### PR DESCRIPTION
## Description

- A patch was added in https://github.com/dust-tt/dust/pull/19167 to the agent loop workflow to consolidate several activities into a single one.
- This patch was deprecated in https://github.com/dust-tt/dust/pull/19206.
- This PR removes the patch deprecation.
- The functions that used to be activities are also renamed to remove the `Activity` suffix.

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
