### PR TITLE
fix: html tags in agent builder

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -24,6 +24,7 @@ import { EmojiExtension } from "@app/components/editor/extensions/EmojiExtension
 import { EmptyLineParagraphExtension } from "@app/components/editor/extensions/EmptyLineParagraphExtension";
 import { KeyboardShortcutsExtension } from "@app/components/editor/extensions/input_bar/KeyboardShortcutsExtension";
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
+import { RawHtmlExtension } from "@app/components/editor/extensions/RawHtmlExtension";
 import { createMentionSuggestion } from "@app/components/editor/input_bar/mentionSuggestion";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LightAgentConfigurationType } from "@app/types";
@@ -128,6 +129,7 @@ export function AgentBuilderInstructionsEditor({
         },
       }),
       KeyboardShortcutsExtension,
+      RawHtmlExtension,
       InstructionBlockExtension,
       AgentInstructionDiffExtension,
       BlockInsertExtension.configure({

--- a/front/components/editor/extensions/RawHtmlExtension.test.ts
+++ b/front/components/editor/extensions/RawHtmlExtension.test.ts
@@ -1,0 +1,53 @@
+import type { Editor } from "@tiptap/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
+
+describe("RawHtmlExtension", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    // extension already added to the editor factor
+    editor = EditorFactory([]);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("should preserve anchor tags as HTML not markdown links", () => {
+    editor.commands.setContent('<a href="https://example.com">Link</a>', {
+      contentType: "markdown",
+    });
+    const result = editor.getMarkdown();
+    // Should preserve as HTML, not convert to [Link](https://example.com)
+    expect(result).toBe('<a href="https://example.com">Link</a>');
+  });
+
+  it("should preserve span with style", () => {
+    editor.commands.setContent('<span style="color: red">text</span>', {
+      contentType: "markdown",
+    });
+    const result = editor.getMarkdown();
+    expect(result).toBe('<span style="color: red">text</span>');
+  });
+
+  it("should preserve div tags", () => {
+    editor.commands.setContent('<div class="container">content</div>', {
+      contentType: "markdown",
+    });
+    const result = editor.getMarkdown();
+    expect(result).toBe('<div class="container">content</div>');
+  });
+
+  it("should handle complex attributes", () => {
+    editor.commands.setContent(
+      '<button onclick="doSomething()" class="btn" data-id="123">Click</button>',
+      { contentType: "markdown" }
+    );
+    const result = editor.getMarkdown();
+    expect(result).toBe(
+      '<button onclick="doSomething()" class="btn" data-id="123">Click</button>'
+    );
+  });
+});

--- a/front/components/editor/extensions/RawHtmlExtension.ts
+++ b/front/components/editor/extensions/RawHtmlExtension.ts
@@ -1,0 +1,82 @@
+import { Node } from "@tiptap/core";
+
+export interface RawHtmlAttributes {
+  html: string;
+}
+
+/**
+ * Extension to preserve raw HTML in markdown round-trips.
+ *
+ * When markdown containing HTML (like <a>, <span>, <div> tags) is parsed,
+ * this extension captures the HTML via parseHTML and stores the element's
+ * outerHTML, ensuring it gets serialized back to HTML format in markdown.
+ *
+ * Note: The HTML is reconstructed from the DOM, so formatting may change
+ * slightly (e.g., <br/> becomes <br />), but the semantic content is preserved.
+ */
+export const RawHtmlExtension = Node.create<RawHtmlAttributes>({
+  name: "rawHtml",
+  group: "inline",
+  inline: true,
+
+  addAttributes() {
+    return {
+      html: {
+        default: "",
+      },
+    };
+  },
+
+  parseHTML() {
+    // List of HTML tags we want to preserve as raw HTML
+    // For a, li, ul tags, we use priority 1001 to override the associated extension (priority 1000)
+    const tags = [
+      { tag: "a", priority: 1001 },
+      { tag: "ul", priority: 1001 },
+      { tag: "li", priority: 1001 },
+      { tag: "span" },
+      { tag: "div" },
+      { tag: "section" },
+      { tag: "article" },
+      { tag: "aside" },
+      { tag: "nav" },
+      { tag: "img" },
+      { tag: "button" },
+      { tag: "input" },
+      { tag: "form" },
+      { tag: "label" },
+      { tag: "select" },
+      { tag: "textarea" },
+      { tag: "table" },
+      { tag: "thead" },
+      { tag: "tbody" },
+      { tag: "tr" },
+      { tag: "td" },
+      { tag: "th" },
+    ];
+
+    return tags.map((config) => ({
+      ...config,
+      getAttrs: (element) => ({
+        html: (element as HTMLElement).outerHTML,
+      }),
+    }));
+  },
+
+  renderHTML({ node }) {
+    // In the editor, we display the HTML as text inside a styled span
+    // This makes it visible but doesn't actually render the HTML
+    return [
+      "span",
+      {
+        "data-raw-html": node.attrs.html,
+      },
+      node.attrs.html,
+    ];
+  },
+
+  renderMarkdown: (node) => {
+    // Output the original HTML in the markdown
+    return node.attrs?.html ?? "";
+  },
+});

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
@@ -361,4 +361,36 @@ Toto:
 
 <br>`);
   });
+
+  it("should serialize instruction with HTML to markdown", () => {
+    editor.commands.setContent(
+      `
+<instructions>
+
+<a href="https://www.google.com">Google</a>
+<span style="color: red"></span>
+<div/>
+
+</instructions>`,
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const result = editor.getMarkdown();
+    // Note: HTML is reconstructed from DOM, so formatting may change slightly
+    // (e.g., <div/> becomes <div></div>), but semantic content is preserved
+    expect(result).toBe(`<instructions>
+
+<a href="https://www.google.com">Google</a>
+<span style="color: red"></span>
+
+<div>
+
+</div>
+
+</instructions>
+
+<br>`);
+  });
 });

--- a/front/components/editor/extensions/tests/utils.ts
+++ b/front/components/editor/extensions/tests/utils.ts
@@ -4,6 +4,7 @@ import { Editor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 
 import { EmptyLineParagraphExtension } from "@app/components/editor/extensions/EmptyLineParagraphExtension";
+import { RawHtmlExtension } from "@app/components/editor/extensions/RawHtmlExtension";
 
 export const EditorFactory = (extensions: Extensions) => {
   return new Editor({
@@ -16,6 +17,7 @@ export const EditorFactory = (extensions: Extensions) => {
       }),
       EmptyLineParagraphExtension,
       Markdown,
+      RawHtmlExtension,
       ...extensions,
     ],
   });

--- a/front/components/editor/extensions/tiptap.test.ts
+++ b/front/components/editor/extensions/tiptap.test.ts
@@ -1,0 +1,21 @@
+import { readPackageUpSync } from "read-pkg-up";
+import { expect, it } from "vitest";
+
+const MESSAGE = `
+You upgraded tiptap, that's cool of you thanks a lot! 
+
+Could you please check that we still need the:
+1. EmptyLineParagraphExtension
+2. RawHtmlExtension 
+
+For 1) look here https://github.com/ueberdosis/tiptap/issues/7269
+For 2) tiptap markdown doesn't display raw HTML it can't parse to a plugin
+`;
+
+it("should fail when upgrading tiptap", () => {
+  const result = readPackageUpSync({
+    cwd: require.resolve("@tiptap/core"),
+  });
+
+  expect(result?.packageJson.version, MESSAGE).toEqual("3.13.0");
+});

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -234,6 +234,7 @@
         "nodemon": "^3.1.11",
         "prettier": "^3.0",
         "prettier-plugin-tailwindcss": "^0.6.14",
+        "read-pkg-up": "^11.0.0",
         "tsx": "^4.10.2",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.48.0",
@@ -11790,6 +11791,13 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/pako": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
@@ -14643,18 +14651,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/contentful/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/convert-source-map": {
@@ -18137,6 +18133,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -20113,6 +20122,26 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/hot-shots": {
       "version": "10.0.0",
       "license": "MIT",
@@ -20436,6 +20465,19 @@
       "devOptional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/infer-owner": {
@@ -25013,6 +25055,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -27342,6 +27399,63 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-11.0.0.tgz",
+      "integrity": "sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==",
+      "deprecated": "Renamed to read-package-up",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/readable-stream": {
@@ -29799,6 +29913,28 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
@@ -31161,6 +31297,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/type-flag/-/type-flag-3.0.0.tgz",
@@ -31388,6 +31536,19 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unified": {
       "version": "10.1.2",
@@ -31862,6 +32023,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/validator": {

--- a/front/package.json
+++ b/front/package.json
@@ -207,6 +207,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "read-pkg-up": "^11.0.0",
     "@biomejs/biome": "2.3.8",
     "@eslint/js": "^9.39.1",
     "@faker-js/faker": "^9.3.0",

--- a/front/vite.config.mjs
+++ b/front/vite.config.mjs
@@ -5,6 +5,12 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [react()],
   test: {
+    testTimeout: (function getTestTimeout() {
+      const isDebug =
+        process.env.VITEST_DEBUG === "1" ||
+        process.execArgv?.some((a) => a.includes("--inspect")) === true;
+      return isDebug ? Infinity : 5_000;
+    })(),
     globals: true,
     environment: "jsdom",
     setupFiles: "./vite.setup.ts",


### PR DESCRIPTION
## Description

This fixes an issue with tiptap markdown. By default it tries to match html tags with an extension, and if it can't find it doesn't render the tags. 

ex: 
* if it finds `<ul>` it will display it as a list. 
* if it finds `<span>a</span` it will display `a` (removing the `span` tag)

Some of our users have html tags in their instructions, so we don't want to loose it.

To fix this, I've added a tiptap extension that preempts this behavior so we can just display them
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
