### PR TITLE
fix: adjust disclaimer + oauth component flags to depend on whether we migrate old slack connections or not

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -271,7 +271,6 @@ function UpdateConnectionOAuthModal({
   const { connectorProvider, editedByUser } = dataSource;
 
   const isSlack = connectorProvider === "slack";
-  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
   const { configValue: slackCredentialId } = useConnectorConfig({
     configKey: "privateIntegrationCredentialId",
@@ -285,6 +284,13 @@ function UpdateConnectionOAuthModal({
     credentialId: slackCredentialId,
     disabled: !isSlack || !slackCredentialId,
   });
+
+  // TODO(slackstorm 2025-12-18): Decide if we want to migrate existing slack connections to the new model. Remove all those flags if it's the case.
+  const MIGRATE_LEGACY_SLACK_APPS = false;
+  const showSlackAppMigrationDisclaimer =
+    MIGRATE_LEGACY_SLACK_APPS && isLegacySlackApp;
+  const showSlackOauthExtraComponent =
+    MIGRATE_LEGACY_SLACK_APPS || !isLegacySlackApp;
 
   if (!connectorProvider || !user) {
     return null;
@@ -314,7 +320,7 @@ function UpdateConnectionOAuthModal({
             />
           </div>
 
-          {isLegacySlackApp && (
+          {showSlackAppMigrationDisclaimer && (
             <div className="mt-4">
               <ContentMessage
                 size="md"
@@ -423,11 +429,7 @@ function UpdateConnectionOAuthModal({
           </div>
         )}
         {connectorUIConfiguration.oauthExtraConfigComponent &&
-          // TODO(slackstorm) fabien: remove flag and rely on isLegacySlackApp
-          !(
-            isSlack &&
-            !featureFlags.includes("self_created_slack_app_connector_rollout")
-          ) && (
+          showSlackOauthExtraComponent && (
             <connectorUIConfiguration.oauthExtraConfigComponent
               extraConfig={extraConfig}
               setExtraConfig={setExtraConfig}


### PR DESCRIPTION
## Description

[Discussion](https://dust4ai.slack.com/archives/C091PN4EK52/p1765304808025549) is still ongoing on whether or not we want to migrate old slack connections to the new self-created app flow.

This PR adds flags that depends on this decision to hide disclaimer for now and show oauth component only to non legacy slack apps

This will allow to remove the `self_created_slack_app_connector_rollout` feature flag regardless of the decision above

## Tests

Local

## Risk

Low

## Deploy Plan

Front