### PR TITLE
<br> tags rendered as text in user messages when using new lines

### DIFF
--- a/front/components/editor/extensions/EmptyLineParagraphExtension.ts
+++ b/front/components/editor/extensions/EmptyLineParagraphExtension.ts
@@ -28,7 +28,7 @@ export const EmptyLineParagraphExtension = Paragraph.extend({
     if (!content || content.trim() === "") {
       // Render as <br> tag instead of empty paragraph
       // This will be preserved in markdown and parsed back correctly
-      return "<br>";
+      return "\n\n";
     }
 
     // Normal paragraph rendering

--- a/front/components/editor/extensions/EmptyLineParagraphExtension.ts
+++ b/front/components/editor/extensions/EmptyLineParagraphExtension.ts
@@ -7,8 +7,8 @@
  * See: https://github.com/ueberdosis/tiptap/issues/7269
  *
  * Strategy:
- * - When serializing to markdown, convert empty paragraphs to <br> tags
- * - When parsing markdown, convert <br> tags back to empty paragraphs
+ * - When serializing to markdown, convert empty paragraphs to double line breaks
+ * - When parsing markdown, convert double line breaks back to empty paragraphs
  * - This preserves empty lines through the round-trip conversion
  */
 
@@ -19,14 +19,14 @@ export const EmptyLineParagraphExtension = Paragraph.extend({
    * Override Markdown rendering to preserve empty paragraphs.
    *
    * Normal paragraphs are rendered as usual, but empty paragraphs are
-   * converted to <br> tags which are preserved by markdown parsers.
+   * converted to double line breakstags which are preserved by markdown parsers.
    */
   renderMarkdown: (node, helpers) => {
     const content = helpers.renderChildren(node.content ?? []);
 
     // Check if this is an empty paragraph
     if (!content || content.trim() === "") {
-      // Render as <br> tag instead of empty paragraph
+      // Render as double line breaks instead of empty paragraph
       // This will be preserved in markdown and parsed back correctly
       return "\n\n";
     }


### PR DESCRIPTION
## Description

When using the input bar and creating new lines (pressing Enter), `<br>` tags are being rendered as literal text in the user message instead of being properly converted to line breaks.
This is due to the`EmptyLineParagraphExtension` adding <br> to the message content. This PR replaces it by line breaks `\n\n`.

<img width="321" height="302" alt="image" src="https://github.com/user-attachments/assets/6c99e924-8c84-4de1-8879-b8faabc329bd" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
