### PR TITLE
Replace <br> tags with break lines

### DIFF
--- a/sparkle/src/components/markdown/utils.ts
+++ b/sparkle/src/components/markdown/utils.ts
@@ -45,9 +45,9 @@ export function detectLanguage(children: React.ReactNode) {
  * Inserts an empty line with a non-breaking space to create visual spacing.
  */
 export function preserveLineBreaks(content: string): string {
-  // Replace \n\n with \n&nbsp;\n\n to insert an empty line with content
+  // Replace <br> and \n\n with \n&nbsp;\n\n to insert an empty line with content
   // This creates visual spacing between paragraphs
-  return content.replace(/\n\n\n\n/g, "\n\n&nbsp;\n\n");
+  return content.replace(/(\n\n\n\n|<br>)/g, "\n\n&nbsp;\n\n");
 }
 
 /**


### PR DESCRIPTION
## Description

When using the input bar and creating new lines (pressing Enter), `<br>` tags are being rendered as literal text in the user message instead of being properly converted to line breaks.

<img width="321" height="302" alt="image" src="https://github.com/user-attachments/assets/b8ed5dbd-48ca-4253-b2f1-972bb9f29181" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Publish Sparkle
