### PR TITLE
[skills] Avoid suggesting current skill as similar skill when editing the skill

### DIFF
--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -47,9 +47,10 @@ export function SkillBuilderAgentFacingDescriptionSection() {
         setIsLoading(false);
         if (result.isOk()) {
           const similarSkillIds = result.value;
+          const similarSkillIdsSet = new Set(similarSkillIds);
           const matchedSkills = skills.filter(
             (skill) =>
-              similarSkillIds.includes(skill.sId) &&
+              similarSkillIdsSet.has(skill.sId) &&
               skill.sId !== skillConfigurationId
           );
           setSimilarSkills(matchedSkills);

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -15,7 +15,7 @@ const DEBOUNCE_DELAY_MS = 250;
 const MIN_DESCRIPTION_LENGTH = 10;
 
 export function SkillBuilderAgentFacingDescriptionSection() {
-  const { owner } = useSkillBuilderContext();
+  const { owner, skillConfigurationId } = useSkillBuilderContext();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   const isSimilarSkillsEnabled = hasFeature("skills_similar_display");
 
@@ -47,14 +47,16 @@ export function SkillBuilderAgentFacingDescriptionSection() {
         setIsLoading(false);
         if (result.isOk()) {
           const similarSkillIds = result.value;
-          const matchedSkills = skills.filter((skill) =>
-            similarSkillIds.includes(skill.sId)
+          const matchedSkills = skills.filter(
+            (skill) =>
+              similarSkillIds.includes(skill.sId) &&
+              skill.sId !== skillConfigurationId
           );
           setSimilarSkills(matchedSkills);
         }
       }
     },
-    [getSimilarSkills, isSimilarSkillsEnabled, skills]
+    [getSimilarSkills, isSimilarSkillsEnabled, skillConfigurationId, skills]
   );
 
   const triggerSimilarSkillsFetch = useDebounceWithAbort(fetchSimilarSkills, {

--- a/front/components/skill_builder/SkillBuilderContext.tsx
+++ b/front/components/skill_builder/SkillBuilderContext.tsx
@@ -8,6 +8,8 @@ import type { UserType, WorkspaceType } from "@app/types";
 export type SkillBuilderContextType = {
   owner: WorkspaceType;
   user: UserType;
+  /** Id of the current skill being edited, or null if the skill is not yet created. */
+  skillConfigurationId: string | null;
 };
 
 export const SkillBuilderContext =
@@ -16,16 +18,18 @@ export const SkillBuilderContext =
 interface SkillBuilderProviderProps {
   owner: WorkspaceType;
   user: UserType;
+  skillConfigurationId: string | null;
   children: ReactNode;
 }
 
 export function SkillBuilderProvider({
   owner,
   user,
+  skillConfigurationId,
   children,
 }: SkillBuilderProviderProps) {
   return (
-    <SkillBuilderContext.Provider value={{ owner, user }}>
+    <SkillBuilderContext.Provider value={{ owner, user, skillConfigurationId }}>
       <SpacesProvider owner={owner}>
         <MCPServerViewsProvider owner={owner}>
           {children}

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -72,7 +72,11 @@ export default function EditSkill({
   }
 
   return (
-    <SkillBuilderProvider owner={owner} user={user}>
+    <SkillBuilderProvider
+      owner={owner}
+      user={user}
+      skillConfigurationId={skillConfiguration.sId}
+    >
       <>
         <Head>
           <title>{`Dust - ${skillConfiguration.name}`}</title>

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -47,7 +47,7 @@ export default function CreateSkill({
   user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
-    <SkillBuilderProvider owner={owner} user={user}>
+    <SkillBuilderProvider owner={owner} user={user} skillConfigurationId={null}>
       <SpacesProvider owner={owner}>
         <Head>
           <title>Dust - New Skill</title>


### PR DESCRIPTION
## Description

Add the currently edited skill id in the SkillBuilderContext so we can ignore it when listing the similar skills.

## Tests

manual test

## Risk

low

## Deploy Plan

deploy front
