### PR TITLE
fix: render emoji dropdown after 2 chars

### DIFF
--- a/front/components/editor/input_bar/emojiSuggestion.tsx
+++ b/front/components/editor/input_bar/emojiSuggestion.tsx
@@ -1,3 +1,5 @@
+import type { Range } from "@tiptap/core";
+import type { EditorState } from "@tiptap/pm/state";
 import { PluginKey } from "@tiptap/pm/state";
 import { ReactRenderer } from "@tiptap/react";
 import type {
@@ -20,6 +22,14 @@ export function createEmojiSuggestion() {
     char: ":",
     // Emoji shortcodes don't have spaces, so disable allowSpaces
     allowSpaces: false,
+
+    // Require at least 2 characters before triggering dropdown
+    allow: ({ state, range }: { state: EditorState; range: Range }) => {
+      const text = state.doc.textBetween(range.from, range.to);
+      // Remove the trigger character ":" and check the remaining length
+      const query = text.slice(1);
+      return query.length >= 2;
+    },
 
     render: () => {
       let component: ReactRenderer<


### PR DESCRIPTION
## Description

Render the emoji dropdown after 2 chars like in slack
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
