### PR TITLE
[front] feat: Delete credits on voided invoices for pro

### DIFF
--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -476,7 +476,7 @@ export class CreditResource extends BaseResource<CreditModel> {
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
-  ): Promise<Result<number | undefined, Error>> {
+  ): Promise<Result<number, Error>> {
     assert(
       this.startDate === null || this.type === "free",
       "Cannot delete a credit that has been started. Use freeze() instead."
@@ -486,6 +486,7 @@ export class CreditResource extends BaseResource<CreditModel> {
       where: { id: this.id, workspaceId: auth.getNonNullableWorkspace().id },
       transaction,
     });
+
     return new Ok(deletedCount);
   }
 }

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -15,6 +15,7 @@ import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import {
+  deleteCreditFromVoidedInvoice,
   startCreditFromProOneOffInvoice,
   voidFailedProCreditPurchaseInvoice,
 } from "@app/lib/credits/committed";
@@ -636,6 +637,119 @@ async function handler(
               },
               "[Stripe Webhook] Successfully froze credit due to payment dispute."
             );
+          }
+
+          break;
+        }
+
+        case "invoice.voided": {
+          const voidedInvoice = event.data.object as Stripe.Invoice;
+
+          if (!isCreditPurchaseInvoice(voidedInvoice)) {
+            break;
+          }
+
+          if (!isString(voidedInvoice.subscription)) {
+            logger.warn(
+              { invoiceId: voidedInvoice.id, stripeError: true },
+              "[Stripe Webhook] Voided credit purchase invoice has no subscription."
+            );
+            break;
+          }
+
+          const voidedSubscription = await SubscriptionModel.findOne({
+            where: { stripeSubscriptionId: voidedInvoice.subscription },
+            include: [WorkspaceModel],
+          });
+
+          if (!voidedSubscription) {
+            logger.warn(
+              {
+                invoiceId: voidedInvoice.id,
+                stripeSubscriptionId: voidedInvoice.subscription,
+              },
+              "[Stripe Webhook] Subscription not found for voided credit purchase invoice."
+            );
+            break;
+          }
+
+          const stripeSubscription = await getStripeSubscription(
+            voidedInvoice.subscription
+          );
+
+          if (!stripeSubscription) {
+            logger.warn(
+              {
+                invoiceId: voidedInvoice.id,
+                stripeSubscriptionId: voidedInvoice.subscription,
+                stripeError: true,
+              },
+              "[Stripe Webhook] Stripe subscription not found for voided invoice."
+            );
+            break;
+          }
+
+          // Skip enterprise subscriptions - they handle credit purchases differently
+          if (isEnterpriseSubscription(stripeSubscription)) {
+            break;
+          }
+
+          const auth = await Authenticator.internalAdminForWorkspace(
+            voidedSubscription.workspace.sId
+          );
+
+          const deleteResult = await deleteCreditFromVoidedInvoice({
+            auth,
+            invoice: voidedInvoice,
+          });
+
+          if (deleteResult.isOk()) {
+            logger.info(
+              {
+                invoiceId: voidedInvoice.id,
+                workspaceId: voidedSubscription.workspace.sId,
+              },
+              "[Stripe Webhook] Successfully deleted credit for voided credit purchase invoice."
+            );
+            break;
+          }
+
+          const error = deleteResult.error;
+
+          switch (error.type) {
+            case "credit_already_started": {
+              // Unexpected: credit was started but invoice was voided. Freeze it.
+              const freezeResult = await error.credit.freeze(auth);
+              if (freezeResult.isErr()) {
+                logger.error(
+                  {
+                    panic: true,
+                    invoiceId: voidedInvoice.id,
+                    creditId: error.credit.id,
+                    workspaceId: voidedSubscription.workspace.sId,
+                    error: freezeResult.error.message,
+                    stripeError: true,
+                  },
+                  "[Stripe Webhook] Failed to freeze started credit for voided invoice."
+                );
+              } else {
+                logger.warn(
+                  {
+                    invoiceId: voidedInvoice.id,
+                    creditId: error.credit.id,
+                    workspaceId: voidedSubscription.workspace.sId,
+                  },
+                  "[Stripe Webhook] Froze started credit for voided invoice (unexpected state)."
+                );
+              }
+              break;
+            }
+            case "credit_not_found":
+              // Possible race condition with voidFailedProCreditPurchaseInvoice
+              // no-op
+              break;
+            default:
+              assertNever(error);
           }
 
           break;


### PR DESCRIPTION
## Description

Delete credits when an invoice gets voided in stripe. This is to handle the case when invoice get voided from stripe for customers reaching out to support when they have a pending purchase. To avoid having dangling credits in the DB

## Tests

Tested manually

## Risk

Low
Blast radius: Stripe new webhook

## Deploy Plan

- [ ] Deploy front
- [ ] Add stripe webhook