### PR TITLE
Universal Search supports Jira tickets. 

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -26,6 +26,7 @@ import {
   ADFDocumentSchema,
   JiraAttachmentsResultSchema,
   JiraCommentSchema,
+  JiraCommentsListSchema,
   JiraCreateMetaSchema,
   JiraFieldsSchema,
   JiraIssueLinkTypeSchema,
@@ -442,6 +443,34 @@ export async function createComment(
   );
 
   return handleResults(result, null);
+}
+
+export async function getIssueComments({
+  baseUrl,
+  accessToken,
+  issueKey,
+  maxResults = 100,
+}: {
+  baseUrl: string;
+  accessToken: string;
+  issueKey: string;
+  maxResults?: number;
+}): Promise<Result<z.infer<typeof JiraCommentsListSchema>, JiraErrorResult>> {
+  const params = new URLSearchParams({
+    maxResults: String(maxResults),
+    orderBy: "created",
+  });
+
+  const result = await jiraApiCall(
+    {
+      endpoint: `/rest/api/3/issue/${issueKey}/comment?${params.toString()}`,
+      accessToken,
+    },
+    JiraCommentsListSchema,
+    { baseUrl }
+  );
+
+  return handleResults(result, { comments: [] });
 }
 
 export async function searchIssues(

--- a/front/lib/actions/mcp_internal_actions/servers/jira/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/rendering.ts
@@ -1,0 +1,288 @@
+import { format } from "date-fns";
+
+import type { ADFContentNode, JiraComment, JiraIssue } from "./types";
+
+function formatDateTime(dateString: string): string {
+  return format(new Date(dateString), "yyyy-MM-dd HH:mm");
+}
+
+export function renderIssue(issue: JiraIssue, comments: JiraComment[]): string {
+  const lines: string[] = [];
+  const fields = issue.fields;
+
+  lines.push(`# ${issue.key}: ${fields?.summary ?? "No summary"}`);
+  lines.push("");
+
+  if (issue.browseUrl) {
+    lines.push(`**URL:** ${issue.browseUrl}`);
+  }
+
+  if (fields?.project?.key) {
+    lines.push(`**Project:** ${fields.project.key}`);
+  }
+
+  if (fields?.issuetype?.name) {
+    lines.push(`**Type:** ${fields.issuetype.name}`);
+  }
+
+  if (fields?.status?.name) {
+    lines.push(`**Status:** ${fields.status.name}`);
+  }
+
+  if (fields?.priority?.name) {
+    lines.push(`**Priority:** ${fields.priority.name}`);
+  }
+
+  if (fields?.assignee) {
+    const assigneeName =
+      fields.assignee.displayName ?? fields.assignee.accountId ?? "Unknown";
+    lines.push(`**Assignee:** ${assigneeName}`);
+  }
+
+  if (fields?.reporter) {
+    const reporterName =
+      fields.reporter.displayName ?? fields.reporter.accountId ?? "Unknown";
+    lines.push(`**Reporter:** ${reporterName}`);
+  }
+
+  if (fields?.labels && fields.labels.length > 0) {
+    lines.push(`**Labels:** ${fields.labels.join(", ")}`);
+  }
+
+  if (fields?.duedate) {
+    lines.push(`**Due Date:** ${fields.duedate}`);
+  }
+
+  if (fields?.parent?.key) {
+    lines.push(`**Parent:** ${fields.parent.key}`);
+  }
+
+  if (fields?.created) {
+    lines.push(`**Created:** ${formatDateTime(fields.created)}`);
+  }
+
+  if (fields?.updated) {
+    lines.push(`**Updated:** ${formatDateTime(fields.updated)}`);
+  }
+
+  lines.push("");
+
+  if (fields?.description) {
+    lines.push("## Description");
+    lines.push("");
+    lines.push(renderADFToMarkdown(fields.description));
+    lines.push("");
+  }
+
+  if (comments.length > 0) {
+    lines.push("## Comments");
+    lines.push("");
+
+    for (const comment of comments) {
+      const authorName =
+        comment.author?.displayName ?? comment.author?.accountId ?? "Unknown";
+      const date = comment.created
+        ? formatDateTime(comment.created)
+        : "Unknown date";
+
+      lines.push(`### ${authorName} - ${date}`);
+      lines.push("");
+      lines.push(renderADFToMarkdown(comment.body));
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Converts Atlassian Document Format (ADF) to Markdown.
+ * ADF is a JSON-based document format used by Jira and Confluence.
+ */
+export function renderADFToMarkdown(
+  adf: { content?: ADFContentNode[] } | null | undefined
+): string {
+  if (!adf || !adf.content) {
+    return "";
+  }
+
+  return adf.content.map((node) => renderADFContentNode(node)).join("\n\n");
+}
+
+function renderADFContentNode(node: ADFContentNode): string {
+  switch (node.type) {
+    case "text":
+      return renderTextNode(node);
+
+    case "paragraph":
+      return renderChildren(node.content);
+
+    case "heading": {
+      const level = Number(node.attrs?.level) || 1;
+      const prefix = "#".repeat(Math.min(level + 2, 6));
+      return `${prefix} ${renderChildren(node.content)}`;
+    }
+
+    case "bulletList":
+      return (node.content ?? [])
+        .map((item: ADFContentNode) => renderADFContentNode(item))
+        .join("\n");
+
+    case "orderedList":
+      return (node.content ?? [])
+        .map((item: ADFContentNode, index: number) => {
+          const itemContent = (item.content ?? [])
+            .map((child: ADFContentNode) => renderADFContentNode(child))
+            .join(" ");
+          return `${index + 1}. ${itemContent}`;
+        })
+        .join("\n");
+
+    case "listItem": {
+      const content = (node.content ?? [])
+        .map((child: ADFContentNode) => renderADFContentNode(child))
+        .join(" ");
+      return `- ${content}`;
+    }
+
+    case "blockquote":
+      return renderChildren(node.content)
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+
+    case "codeBlock": {
+      const language = String(node.attrs?.language ?? "");
+      const code = (node.content ?? [])
+        .map((textNode: ADFContentNode) => String(textNode.text ?? ""))
+        .join("");
+      return `\`\`\`${language}\n${code}\n\`\`\``;
+    }
+
+    case "rule":
+      return "---";
+
+    case "hardBreak":
+      return "\n";
+
+    case "panel": {
+      const panelType = String(node.attrs?.panelType ?? "info");
+      return `> **${panelType.toUpperCase()}:** ${renderChildren(node.content)}`;
+    }
+
+    case "table":
+      return renderTable(node);
+
+    case "mediaSingle":
+    case "media":
+      return "[Media attachment]";
+
+    case "mention":
+      return String(node.attrs?.text ?? "@mention");
+
+    case "emoji":
+      return String(node.attrs?.shortName ?? "");
+
+    case "inlineCard":
+    case "blockCard": {
+      const url = String(node.attrs?.url ?? "");
+      return url ? `[Link](${url})` : "[Link]";
+    }
+
+    default:
+      if (node.content) {
+        return renderChildren(node.content);
+      }
+      return "";
+  }
+}
+
+function renderTextNode(node: ADFContentNode): string {
+  let text = node.text ?? "";
+
+  if (node.marks) {
+    for (const mark of node.marks) {
+      switch (mark.type) {
+        case "strong":
+          text = `**${text}**`;
+          break;
+        case "em":
+          text = `*${text}*`;
+          break;
+        case "code":
+          text = `\`${text}\``;
+          break;
+        case "strike":
+          text = `~~${text}~~`;
+          break;
+        case "link": {
+          const href = String(mark.attrs?.href ?? "");
+          text = href ? `[${text}](${href})` : text;
+          break;
+        }
+        case "underline":
+          text = `_${text}_`;
+          break;
+        case "subsup": {
+          const subSupType = String(mark.attrs?.type ?? "");
+          if (subSupType === "sub") {
+            text = `~${text}~`;
+          } else if (subSupType === "sup") {
+            text = `^${text}^`;
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return text;
+}
+
+function renderChildren(content: ADFContentNode[] | undefined): string {
+  if (!content) {
+    return "";
+  }
+  return content.map((child) => renderADFContentNode(child)).join("");
+}
+
+function renderTable(node: ADFContentNode): string {
+  if (!node.content) {
+    return "";
+  }
+
+  const rows: string[][] = [];
+
+  for (const row of node.content) {
+    if (row.type === "tableRow" && row.content) {
+      const cells: string[] = [];
+      for (const cell of row.content) {
+        const cellContent = renderChildren(cell.content);
+        cells.push(cellContent.replace(/\|/g, "\\|").replace(/\n/g, " "));
+      }
+      rows.push(cells);
+    }
+  }
+
+  if (rows.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [];
+  const columnCount = Math.max(...rows.map((r) => r.length));
+
+  const headerRow = rows[0] ?? [];
+  lines.push(`| ${headerRow.join(" | ")} |`);
+
+  const separator = Array(columnCount).fill("---").join(" | ");
+  lines.push(`| ${separator} |`);
+
+  for (const row of rows.slice(1)) {
+    while (row.length < columnCount) {
+      row.push("");
+    }
+    lines.push(`| ${row.join(" | ")} |`);
+  }
+
+  return lines.join("\n");
+}

--- a/front/lib/providers/jira/search.ts
+++ b/front/lib/providers/jira/search.ts
@@ -1,0 +1,141 @@
+import {
+  getIssue,
+  getIssueComments,
+  getJiraBaseUrl,
+  searchJiraIssuesUsingJql,
+} from "@app/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper";
+import { renderIssue } from "@app/lib/actions/mcp_internal_actions/servers/jira/rendering";
+import { PROVIDER_DOWNLOAD_MAX_FILE_SIZE } from "@app/lib/providers/constants";
+import type {
+  ToolDownloadParams,
+  ToolDownloadResult,
+  ToolSearchParams,
+  ToolSearchRawResult,
+} from "@app/lib/search/tools/types";
+
+const ISSUE_MIME_TYPE = "application/vnd.jira.issue";
+const FILE_TRUNCATION_MESSAGE =
+  "\n\n---\n\n**Note:** Content was truncated due to size limits.";
+
+export async function search({
+  accessToken,
+  query,
+  pageSize,
+}: ToolSearchParams): Promise<ToolSearchRawResult[]> {
+  const baseUrl = await getJiraBaseUrl(accessToken);
+  if (!baseUrl) {
+    return [];
+  }
+
+  const issueKeyMatch = query.match(/^#?([A-Z][A-Z0-9]*-\d+)$/i);
+
+  if (issueKeyMatch) {
+    const issueKey = issueKeyMatch[1].toUpperCase();
+    const issueResult = await getIssue({
+      baseUrl,
+      accessToken,
+      issueKey,
+    });
+
+    if (issueResult.isErr() || issueResult.value === null) {
+      return [];
+    }
+
+    const issue = issueResult.value;
+    return [
+      {
+        externalId: issue.key,
+        title: `${issue.key}: ${issue.fields?.summary ?? "No summary"}`,
+        mimeType: ISSUE_MIME_TYPE,
+        type: "document" as const,
+        sourceUrl: issue.browseUrl ?? null,
+      },
+    ];
+  }
+
+  const jql = `summary ~ "${query.replace(/"/g, '\\"')}" ORDER BY updated DESC`;
+  const result = await searchJiraIssuesUsingJql(baseUrl, accessToken, jql, {
+    maxResults: pageSize,
+    fields: ["summary"],
+  });
+
+  if (result.isErr()) {
+    return [];
+  }
+
+  return result.value.issues.map((issue) => ({
+    externalId: issue.key,
+    title: `${issue.key}: ${issue.fields?.summary ?? "No summary"}`,
+    mimeType: ISSUE_MIME_TYPE,
+    type: "document" as const,
+    sourceUrl: issue.browseUrl ?? null,
+  }));
+}
+
+export async function download({
+  accessToken,
+  externalId,
+}: ToolDownloadParams): Promise<ToolDownloadResult> {
+  const baseUrl = await getJiraBaseUrl(accessToken);
+  if (!baseUrl) {
+    throw new Error("Failed to get Jira base URL");
+  }
+
+  const issueResult = await getIssue({
+    baseUrl,
+    accessToken,
+    issueKey: externalId,
+    fields: [
+      "summary",
+      "description",
+      "issuetype",
+      "priority",
+      "assignee",
+      "reporter",
+      "labels",
+      "duedate",
+      "parent",
+      "project",
+      "status",
+      "created",
+      "updated",
+    ],
+  });
+
+  if (issueResult.isErr()) {
+    throw new Error(issueResult.error);
+  }
+
+  if (issueResult.value === null) {
+    throw new Error(`Issue ${externalId} not found`);
+  }
+
+  const commentsResult = await getIssueComments({
+    baseUrl,
+    accessToken,
+    issueKey: externalId,
+  });
+
+  const comments = commentsResult.isOk() ? commentsResult.value.comments : [];
+
+  const issue = issueResult.value;
+  let content = renderIssue(issue, comments);
+
+  const contentSize = Buffer.byteLength(content, "utf8");
+  if (contentSize > PROVIDER_DOWNLOAD_MAX_FILE_SIZE) {
+    const truncatedContent = content.slice(
+      0,
+      PROVIDER_DOWNLOAD_MAX_FILE_SIZE - FILE_TRUNCATION_MESSAGE.length
+    );
+    content = truncatedContent + FILE_TRUNCATION_MESSAGE;
+  }
+
+  const summary = issue.fields?.summary ?? "No summary";
+  const fileName = `${externalId}: ${summary}`;
+
+  return {
+    content,
+    fileName,
+    contentType: "text/markdown",
+  };
+}

--- a/front/lib/search/tools/search.ts
+++ b/front/lib/search/tools/search.ts
@@ -14,6 +14,10 @@ import {
   search as googleDriveSearch,
 } from "@app/lib/providers/google_drive/search";
 import {
+  download as jiraDownload,
+  search as jiraSearch,
+} from "@app/lib/providers/jira/search";
+import {
   download as microsoftDownload,
   search as microsoftSearch,
 } from "@app/lib/providers/microsoft/search";
@@ -42,6 +46,7 @@ import { Err, Ok } from "@app/types";
 const SEARCHABLE_TOOLS = {
   github: { search: githubSearch, download: githubDownload },
   google_drive: { search: googleDriveSearch, download: googleDriveDownload },
+  jira: { search: jiraSearch, download: jiraDownload },
   notion: { search: notionSearch, download: notionDownload },
   microsoft_drive: { search: microsoftSearch, download: microsoftDownload },
   zendesk: { search: zendeskSearch, download: zendeskDownload },


### PR DESCRIPTION
## Description

Supports JIRA in search/ attach. 
Quite some code because we're calling the API manually so most of the code of the diff is either the rendering code (render the json like format of Atlassian to markdown) + some moving in the types defined since we're manually calling the API. 

I did not want to refactor the tool to use an SDK, out of scope.  

## Tests

Locally I can search in Jira from issues name and codes. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 