### PR TITLE
Pass key name in run agents for analytics

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_dive.ts
@@ -12,7 +12,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { DEEP_DIVE_NAME } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { getApiKeyNameHeader, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import logger from "@app/logger/logger";
 import {
@@ -59,6 +59,7 @@ function createServer(
               // on personal actions that have to be operated in the name of the user initiating the
               // interaction.
               ...getHeaderFromUserEmail(user?.email),
+              ...getApiKeyNameHeader(auth),
             },
           },
           logger

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -42,7 +42,7 @@ import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/glo
 import { cancelMessageGenerationEvent } from "@app/lib/api/assistant/pubsub";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { getApiKeyNameHeader, prodAPICredentialsForOwner } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getResourcePrefix } from "@app/lib/resources/string_ids";
@@ -357,6 +357,7 @@ export default async function createServer(
               // on personal actions that have to be operated in the name of the user initiating the
               // interaction.
               ...getHeaderFromUserEmail(user?.email),
+              ...getApiKeyNameHeader(auth),
             },
           },
           logger

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -422,6 +422,8 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
           )) ?? workspaceAuth;
       }
 
+      // If we have a system key, we can override the key name from http headers.
+      // This is only used for run_agent API call, to keep the original key name and get proper analytics.
       const apiKeyNameFromHeader = getApiKeyNameFromHeaders(req.headers);
       const key = workspaceAuth.key();
       if (apiKeyNameFromHeader && key && key.isSystem) {

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -6,6 +6,7 @@ import { getUserFromWorkOSToken, verifyWorkOSToken } from "@app/lib/api/workos";
 import {
   Authenticator,
   getAPIKey,
+  getApiKeyNameFromHeaders,
   getBearerToken,
   getSession,
   isOAuthToken,
@@ -421,6 +422,16 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
           )) ?? workspaceAuth;
       }
 
+      const apiKeyNameFromHeader = getApiKeyNameFromHeaders(req.headers);
+      const key = workspaceAuth.key();
+      if (apiKeyNameFromHeader && key) {
+        workspaceAuth = workspaceAuth.exchangeKey({
+          id: key.id,
+          name: apiKeyNameFromHeader,
+          isSystem: key.isSystem,
+          role: key.role,
+        });
+      }
       return handler(
         req,
         res,

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -424,7 +424,7 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
 
       const apiKeyNameFromHeader = getApiKeyNameFromHeaders(req.headers);
       const key = workspaceAuth.key();
-      if (apiKeyNameFromHeader && key) {
+      if (apiKeyNameFromHeader && key && key.isSystem) {
         workspaceAuth = workspaceAuth.exchangeKey({
           id: key.id,
           name: apiKeyNameFromHeader,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -46,6 +46,7 @@ import {
   isAdmin,
   isBuilder,
   isDevelopment,
+  isString,
   isUser,
   Ok,
   WHITELISTABLE_FEATURES,
@@ -1227,7 +1228,7 @@ export function getApiKeyNameFromHeaders(headers: {
   [key: string]: string | string[] | undefined;
 }) {
   const apiKeyName = headers[DustApiKeyNameHeader];
-  if (typeof apiKeyName === "string") {
+  if (isString(apiKeyName)) {
     return apiKeyName;
   }
   return undefined;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -55,7 +55,7 @@ const { ACTIVATE_ALL_FEATURES_DEV = false } = process.env;
 
 const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;
 
-const DustApiKeyNameHeader = "x-api-key-name";
+const DustApiKeyNameHeader = "x-dust-api-key-name";
 
 export type AuthMethodType =
   | "system_api_key"

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -55,6 +55,8 @@ const { ACTIVATE_ALL_FEATURES_DEV = false } = process.env;
 
 const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;
 
+const DustApiKeyNameHeader = "x-api-key-name";
+
 export type AuthMethodType =
   | "system_api_key"
   | "api_key"
@@ -673,6 +675,18 @@ export class Authenticator {
     });
   }
 
+  exchangeKey(key: KeyAuthType) {
+    return new Authenticator({
+      authMethod: this.authMethod(),
+      key,
+      role: this._role,
+      groups: this._groups,
+      user: this._user,
+      subscription: this._subscription,
+      workspace: this._workspace,
+    });
+  }
+
   role(): RoleType {
     return this._role;
   }
@@ -1207,4 +1221,25 @@ export async function isRestrictedFromAgentCreation(
     featureFlags.includes("disallow_agent_creation_to_users") &&
     !isBuilder(owner)
   );
+}
+
+export function getApiKeyNameFromHeaders(headers: {
+  [key: string]: string | string[] | undefined;
+}) {
+  const apiKeyName = headers[DustApiKeyNameHeader];
+  if (typeof apiKeyName === "string") {
+    return apiKeyName;
+  }
+  return undefined;
+}
+
+export function getApiKeyNameHeader(auth: Authenticator) {
+  const key = auth.key();
+  if (!key || !key.name) {
+    return undefined;
+  }
+
+  return {
+    [DustApiKeyNameHeader]: key.name,
+  };
 }


### PR DESCRIPTION
## Description

Allow to override api key name in headers, when using system key. Used in run_agent / deep_dive to get better analytics.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low
## Deploy Plan

deploy front