### PR TITLE
[SKILLS] Save extended skill id

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -158,10 +158,10 @@ export default function SkillBuilder({
               variant="default"
               className="mx-4"
               title={
-                skillConfiguration
+                (skillConfiguration
                   ? `Edit skill ${skillConfiguration.name}`
-                  : "Create new skill" +
-                    (extendedSkill ? ` - extending ${extendedSkill.name}` : "")
+                  : "Create new skill") +
+                (extendedSkill ? ` - extending ${extendedSkill.name}` : "")
               }
               rightActions={
                 <Button

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -64,8 +64,11 @@ export default function SkillBuilder({
       return transformSkillConfigurationToFormData(skillConfiguration);
     }
 
-    return getDefaultSkillFormData({ user });
-  }, [skillConfiguration, user]);
+    return getDefaultSkillFormData({
+      user,
+      extendedSkillId: extendedSkill?.sId ?? null,
+    });
+  }, [skillConfiguration, user, extendedSkill]);
 
   const form = useForm<SkillBuilderFormData>({
     resolver: zodResolver(skillBuilderFormSchema),

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -33,14 +33,11 @@ import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSkillTools } from "@app/lib/swr/actions";
 import { useSkillEditors } from "@app/lib/swr/skill_editors";
-import type {
-  ExtendedSkillType,
-  SkillType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 interface SkillBuilderProps {
   skillConfiguration?: SkillType;
-  extendedSkill?: ExtendedSkillType;
+  extendedSkill?: SkillType;
 }
 
 export default function SkillBuilder({

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -18,6 +18,7 @@ export const skillBuilderFormSchema = z.object({
   editors: z.array(editorUserSchema),
   tools: z.array(actionSchema),
   icon: z.string().nullable(),
+  extendedSkillId: z.string().nullable(),
 });
 
 export type SkillBuilderFormData = z.infer<typeof skillBuilderFormSchema>;

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -40,6 +40,7 @@ export async function submitSkillBuilderForm({
         userFacingDescription: formData.userFacingDescription,
         instructions: formData.instructions,
         icon: formData.icon,
+        extendedSkillId: formData.extendedSkillId,
         tools: formData.tools.map((tool) => ({
           mcpServerViewId: tool.configuration.mcpServerViewId,
         })),

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -18,6 +18,7 @@ export function transformSkillConfigurationToFormData(
     editors: [], // Will be populated reactively from useEditors hook
     tools: [], // Will be populated reactively from MCP server views context
     icon: skillConfiguration.icon ?? null,
+    extendedSkillId: skillConfiguration.extendedSkillId,
   };
 }
 

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -26,8 +26,10 @@ export function transformSkillConfigurationToFormData(
  */
 export function getDefaultSkillFormData({
   user,
+  extendedSkillId = null,
 }: {
   user: UserType;
+  extendedSkillId?: string | null;
 }): SkillBuilderFormData {
   return {
     name: "",
@@ -37,5 +39,6 @@ export function getDefaultSkillFormData({
     editors: [user],
     tools: [],
     icon: null,
+    extendedSkillId,
   };
 }

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -46,6 +46,10 @@ const SKILL_MODEL_ATTRIBUTES = {
     type: DataTypes.TEXT,
     allowNull: true,
   },
+  extendedSkillId: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  },
 } as const satisfies ModelAttributes;
 
 export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurationModel> {
@@ -61,6 +65,8 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   declare icon: string | null;
 
   declare authorId: ForeignKey<UserModel["id"]>;
+  // Not a foreign key, only global skills can be extended.
+  declare extendedSkillId: string | null;
 
   declare requestedSpaceIds: number[];
 }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -577,6 +577,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         updatedAt: new Date(),
         workspaceId: auth.getNonNullableWorkspace().id,
         icon: null,
+        extendedSkillId: null,
       },
       { globalSId: def.sId, mcpServerConfigurations }
     );
@@ -680,6 +681,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             instructions: versionModel.instructions,
             icon: versionModel.icon,
             requestedSpaceIds: versionModel.requestedSpaceIds,
+            extendedSkillId: versionModel.extendedSkillId,
           },
           {
             editorGroup: this.editorGroup ?? undefined,
@@ -1030,6 +1032,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       tools,
       canWrite: this.canWrite(auth),
       isExtendable: this.isExtendable(),
+      extendedSkillId: this.extendedSkillId,
     };
   }
 

--- a/front/migrations/db/migration_455.sql
+++ b/front/migrations/db/migration_455.sql
@@ -1,0 +1,3 @@
+-- Migration created on Dec 18, 2025
+ALTER TABLE "public"."skill_configurations" ADD COLUMN "extendedSkillId" TEXT;
+ALTER TABLE "public"."skill_versions" ADD COLUMN "extendedSkillId" TEXT;

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -125,6 +125,12 @@ async function handler(
         const editors = await skillResource.listEditors(auth);
         const mcpServerViews = await skillResource.listMCPServerViews(auth);
         const author = await skillResource.fetchAuthor(auth);
+        const extendedSkill = skillConfiguration.extendedSkillId
+          ? await SkillResource.fetchById(
+              auth,
+              skillConfiguration.extendedSkillId
+            )
+          : null;
 
         const skillConfigurationWithRelations: SkillWithRelationsType = {
           ...skillConfiguration,
@@ -133,6 +139,7 @@ async function handler(
             editors: editors ? editors.map((e) => e.toJSON()) : null,
             mcpServerViews: mcpServerViews.map((view) => view.toJSON()),
             author: author ? author.toJSON() : null,
+            extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,
           },
         };
 

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -379,6 +379,7 @@ describe("POST /api/w/[wId]/skills", () => {
       instructions: "Simple instructions",
       icon: null,
       tools: [],
+      extendedSkillId: null,
     };
 
     await handler(req, res);
@@ -436,6 +437,7 @@ describe("POST /api/w/[wId]/skills", () => {
         { mcpServerViewId: serverView1.sId },
         { mcpServerViewId: serverView2.sId },
       ],
+      extendedSkillId: null,
     };
 
     await handler(req, res);
@@ -515,6 +517,7 @@ describe("POST /api/w/[wId]/skills", () => {
       instructions: "Instructions",
       icon: null,
       tools: [{ mcpServerViewId: serverView.sId }],
+      extendedSkillId: null,
     };
 
     await handler(req, res);

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -54,6 +54,7 @@ const PostSkillConfigurationRequestBodySchema = t.type({
       mcpServerViewId: t.string,
     })
   ),
+  extendedSkillId: t.union([t.string, t.null]),
 });
 
 type PostSkillConfigurationRequestBody = t.TypeOf<
@@ -212,6 +213,24 @@ async function handler(
         mcpServerViewIds
       );
 
+      const extendedSkill = body.extendedSkillId
+        ? await SkillResource.fetchById(auth, body.extendedSkillId)
+        : null;
+
+      // Only global skills can be extended
+      if (
+        extendedSkill !== null &&
+        (extendedSkill === null || !extendedSkill.isExtendable)
+      ) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `The extended skill with id "${body.extendedSkillId}" cannot be extended.`,
+          },
+        });
+      }
+
       // Use a transaction to ensure all creates succeed or all are rolled back
       const skillResource = await SkillResource.makeNew(auth, {
         status: "active",
@@ -222,6 +241,7 @@ async function handler(
         instructions: body.instructions,
         authorId: user.id,
         requestedSpaceIds,
+        extendedSkillId: body.extendedSkillId,
       });
 
       // Create MCP server configurations (tools) for this skill

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -122,6 +122,9 @@ async function handler(
             const editors = await sc.listEditors(auth);
             const mcpServerViews = await sc.listMCPServerViews(auth);
             const author = await sc.fetchAuthor(auth);
+            const extendedSkill = sc.extendedSkillId
+              ? await SkillResource.fetchById(auth, sc.extendedSkillId)
+              : null;
 
             return {
               ...sc.toJSON(auth),
@@ -130,6 +133,9 @@ async function handler(
                 editors: editors ? editors.map((e) => e.toJSON()) : null,
                 mcpServerViews: mcpServerViews.map((view) => view.toJSON()),
                 author: author ? author.toJSON() : null,
+                extendedSkill: extendedSkill
+                  ? extendedSkill.toJSON(auth)
+                  : null,
               },
             } satisfies SkillWithRelationsType;
           },

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -13,6 +13,7 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   skillConfiguration: SkillType;
+  extendedSkill: SkillType | null;
   owner: WorkspaceType;
   user: UserType;
   subscription: SubscriptionType;
@@ -52,9 +53,16 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
+  const extendedSkillResource = skillResource.extendedSkillId
+    ? await SkillResource.fetchById(auth, skillResource.extendedSkillId)
+    : null;
+
   return {
     props: {
       skillConfiguration: skillResource.toJSON(auth),
+      extendedSkill: extendedSkillResource
+        ? extendedSkillResource.toJSON(auth)
+        : null,
       owner,
       subscription,
       user: auth.getNonNullableUser().toJSON(),
@@ -64,6 +72,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
 export default function EditSkill({
   skillConfiguration,
+  extendedSkill,
   owner,
   user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
@@ -81,7 +90,10 @@ export default function EditSkill({
         <Head>
           <title>{`Dust - ${skillConfiguration.name}`}</title>
         </Head>
-        <SkillBuilder skillConfiguration={skillConfiguration} />
+        <SkillBuilder
+          skillConfiguration={skillConfiguration}
+          extendedSkill={extendedSkill ?? undefined}
+        />
       </>
     </SkillBuilderProvider>
   );

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -10,13 +10,13 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
-import type { ExtendedSkillType } from "@app/types/assistant/skill_configuration";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   user: UserType;
   subscription: SubscriptionType;
-  extendedSkill: ExtendedSkillType | null;
+  extendedSkill: SkillType | null;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -26,7 +26,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       ? await SkillResource.fetchById(auth, query.extends)
       : null;
   const extendedSkill = skillToExtend?.isExtendable
-    ? { name: skillToExtend.name }
+    ? skillToExtend.toJSON(auth)
     : null;
 
   if (!owner || !auth.isBuilder() || !subscription) {

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -28,6 +28,7 @@ export type SkillRelations = {
   editors: UserType[] | null;
   mcpServerViews: MCPServerViewType[];
   author: UserType | null;
+  extendedSkill: SkillType | null;
 };
 
 export type SkillWithRelationsType = SkillType & {

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -34,5 +34,3 @@ export type SkillRelations = {
 export type SkillWithRelationsType = SkillType & {
   relations: SkillRelations;
 };
-
-export type ExtendedSkillType = { name: string };

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -20,6 +20,7 @@ export type SkillType = {
   tools: { mcpServerViewId: string }[];
   canWrite: boolean;
   isExtendable: boolean;
+  extendedSkillId: string | null;
 };
 
 export type SkillRelations = {


### PR DESCRIPTION
## Description

- Save an extendedSkill Id, 
- Return it in skill with relations
- display extended skill name in edit skill builder

<img width="1677" height="1023" alt="image" src="https://github.com/user-attachments/assets/556c9000-a073-4af6-bd2f-6c494c9d22d3" />


## Tests

Local

## Risk

Low

## Deploy Plan

Block front
Merge
Migrate
Deploy
