### PR TITLE
[front] chore: add dark mode support in `BlockInsertDropdown`

### DIFF
--- a/front/components/agent_builder/instructions/BlockInsertDropdown.tsx
+++ b/front/components/agent_builder/instructions/BlockInsertDropdown.tsx
@@ -86,23 +86,21 @@ export const BlockInsertDropdown = ({
             No matching blocks
           </div>
         ) : (
-          <>
-            {suggestions.map((suggestion, index) => {
-              const Icon = suggestion.icon;
-              return (
-                <DropdownMenuItem
-                  key={suggestion.id}
-                  icon={() => <Icon className="h-3.5 w-3.5" />}
-                  label={suggestion.label}
-                  className={cn(
-                    index === selectedIndex && "bg-muted dark:bg-muted-night"
-                  )}
-                  onClick={() => onSelect(suggestion)}
-                  onMouseEnter={() => onSelectedIndexChange(index)}
-                />
-              );
-            })}
-          </>
+          suggestions.map((suggestion, index) => {
+            const Icon = suggestion.icon;
+            return (
+              <DropdownMenuItem
+                key={suggestion.id}
+                icon={() => <Icon className="h-3.5 w-3.5" />}
+                label={suggestion.label}
+                className={cn(
+                  index === selectedIndex && "bg-muted dark:bg-muted-night"
+                )}
+                onClick={() => onSelect(suggestion)}
+                onMouseEnter={() => onSelectedIndexChange(index)}
+              />
+            );
+          })
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/front/components/agent_builder/instructions/BlockInsertDropdown.tsx
+++ b/front/components/agent_builder/instructions/BlockInsertDropdown.tsx
@@ -77,12 +77,12 @@ export const BlockInsertDropdown = ({
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         <div className="px-2 pb-0.5 pt-1">
-          <span className="text-xs font-medium text-muted-foreground">
+          <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
             Insert
           </span>
         </div>
         {suggestions.length === 0 ? (
-          <div className="flex h-12 w-full items-center justify-center text-sm text-muted-foreground">
+          <div className="flex h-12 w-full items-center justify-center text-sm text-muted-foreground dark:text-muted-foreground-night">
             No matching blocks
           </div>
         ) : (
@@ -95,8 +95,7 @@ export const BlockInsertDropdown = ({
                   icon={() => <Icon className="h-3.5 w-3.5" />}
                   label={suggestion.label}
                   className={cn(
-                    index === selectedIndex &&
-                      "bg-muted-background dark:bg-muted-background-night"
+                    index === selectedIndex && "bg-muted dark:bg-muted-night"
                   )}
                   onClick={() => onSelect(suggestion)}
                   onMouseEnter={() => onSelectedIndexChange(index)}


### PR DESCRIPTION
## Description

This PR improves dark mode support for the `BlockInsertDropdown`, which is the dropdown that opens when typing `/` in the instructions of Agent Builder.
Navigating with the 

Before
<img width="781" height="252" alt="Screenshot 2025-12-18 at 7 00 05 PM" src="https://github.com/user-attachments/assets/8a54e245-e156-4a18-b7ff-4f4030ac1a2f" />

After
<img width="781" height="252" alt="Screenshot 2025-12-18 at 6 58 48 PM" src="https://github.com/user-attachments/assets/ff5286c7-993b-4d89-b7d2-bc7e94d389da" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
