### PR TITLE
Univ search upload route supports sourceProvider and Icon

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -109,7 +109,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -256,7 +256,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/front/pages/api/v1/w/[wId]/search/tools/upload.ts
+++ b/front/pages/api/v1/w/[wId]/search/tools/upload.ts
@@ -46,6 +46,12 @@ import type { WithAPIErrorResponse } from "@app/types";
  *               conversationId:
  *                 type: string
  *                 description: Optional conversation ID for context
+ *               serverName:
+ *                 type: string
+ *                 description: Optional name of the MCP server (e.g., "Notion", "GitHub")
+ *               serverIcon:
+ *                 type: string
+ *                 description: Optional icon identifier for the MCP server
  *     responses:
  *       200:
  *         description: File uploaded successfully
@@ -73,7 +79,8 @@ async function handler(
     });
   }
 
-  const { serverViewId, externalId, conversationId } = req.body;
+  const { serverViewId, externalId, conversationId, serverName, serverIcon } =
+    req.body;
 
   if (typeof serverViewId !== "string" || serverViewId.length < 1) {
     return apiError(req, res, {
@@ -105,6 +112,26 @@ async function handler(
     });
   }
 
+  if (serverName !== undefined && typeof serverName !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "serverName must be a string.",
+      },
+    });
+  }
+
+  if (serverIcon !== undefined && typeof serverIcon !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "serverIcon must be a string.",
+      },
+    });
+  }
+
   const tokenResult = await getToolAccessToken({ auth, serverViewId });
   if (tokenResult.isErr()) {
     return apiError(req, res, {
@@ -124,6 +151,8 @@ async function handler(
     externalId,
     conversationId,
     metadata,
+    serverName,
+    serverIcon,
   });
 
   if (result.isErr()) {

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -909,6 +909,8 @@ const FileContentFragmentSchema = z.union([
     generatedTables: z.array(z.string()),
     textUrl: z.string(),
     textBytes: z.number().nullable(),
+    sourceProvider: z.string().nullable(),
+    sourceIcon: z.string().nullable(),
   }),
   BaseContentFragmentSchema.extend({
     contentFragmentType: z.literal("file"),
@@ -918,6 +920,8 @@ const FileContentFragmentSchema = z.union([
     generatedTables: z.array(z.never()),
     textUrl: z.null(),
     textBytes: z.null(),
+    sourceProvider: z.null(),
+    sourceIcon: z.null(),
   }),
 ]);
 
@@ -2662,6 +2666,8 @@ export const FileUploadUrlRequestSchema = z.object({
   useCaseMetadata: z
     .object({
       conversationId: z.string(),
+      sourceProvider: z.string().optional(),
+      sourceIcon: z.string().optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## Description

To get the Icon and Provider saved when we upload a ContentFragment from universal search, we need to allow them on the public api (as we do on the private). 

This also updates the SDK and bumps it. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 