### PR TITLE
[Programmatic Usage] Move API pricing page to public URL

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -159,7 +159,6 @@ export const getTopNavigationTabs = (
           "/w/[wId]/subscription",
           "/w/[wId]/analytics",
           "/w/[wId]/actions",
-          "/w/[wId]/developers/api-pricing",
           "/w/[wId]/developers/credits-usage",
           "/w/[wId]/developers/providers",
           "/w/[wId]/developers/api-keys",

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -453,14 +453,15 @@ export default function CreditsUsagePage({
                 automated workflows, etc.). Usage cost is based on token
                 consumption, according to our{" "}
                 <a
-                  href={`/w/${owner.sId}/developers/api-pricing`}
+                  href="/home/api-pricing"
+                  target="_blank"
                   className="text-primary underline hover:text-primary-dark"
                 >
                   pricing page
                 </a>
                 . Learn more in the{" "}
                 <a
-                  href="https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e?pvs=74"
+                  href="https://docs.dust.tt/docs/programmatic-usage"
                   target="_blank"
                   className="text-primary underline hover:text-primary-dark"
                 >


### PR DESCRIPTION
## Description
Move API pricing page from `/w/[wId]/developers/api-pricing` to `/home/api-pricing` as a public page accessible without authentication. This allows external sites (like docs.dust.tt) to link directly to the pricing page.

Also updates the programmatic usage documentation link to point to docs.dust.tt.

## Risks
Blast radius: API pricing page visibility, programmatic usage admin section
Risk: low

## Deploy Plan
- deploy front