### PR TITLE
Fix Temporal Workflow Interceptors In Bundle

### DIFF
--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -97,9 +97,7 @@ async function buildBundles() {
 
       const { code } = await bundleWorkflowCode({
         workflowsPath: require.resolve(workflowsPath),
-        workflowInterceptorModules: [
-          require.resolve(workflowsPath),
-        ],
+        workflowInterceptorModules: [require.resolve(workflowsPath)],
         webpackConfigHook: (config) => {
           const plugins = config.resolve?.plugins ?? [];
           config.resolve!.plugins = [...plugins, new TsconfigPathsPlugin({})];

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -98,7 +98,7 @@ async function buildBundles() {
       const { code } = await bundleWorkflowCode({
         workflowsPath: require.resolve(workflowsPath),
         workflowInterceptorModules: [
-          "@temporalio/interceptors-opentelemetry/lib/workflow",
+          require.resolve(workflowsPath),
         ],
         webpackConfigHook: (config) => {
           const plugins = config.resolve?.plugins ?? [];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes a nesting issue we have been observing on traces in Langfuse where workflow and each activities are different traces without any relation ship. Originally introduced in https://github.com/dust-tt/dust/pull/19123.

The issue was linked to the bundled version of our workflow which does not account for `workflowModules`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally, with agent loop workflow bundled version.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
