### PR TITLE
[front] Add cumulative/daily toggle to programmatic cost chart

### DIFF
--- a/front/components/poke/credits/PokeProgrammaticCostChart.tsx
+++ b/front/components/poke/credits/PokeProgrammaticCostChart.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import type { DisplayMode } from "@app/components/workspace/ProgrammaticCostChart";
 import {
   BaseProgrammaticCostChart,
   formatPeriod,
@@ -26,6 +27,7 @@ export function PokeProgrammaticCostChart({
   const [filter, setFilter] = useState<Partial<Record<GroupByType, string[]>>>(
     {}
   );
+  const [displayMode, setDisplayMode] = useState<DisplayMode>("cumulative");
 
   // Initialize selectedPeriod to a date within the current billing cycle.
   // Using just formatPeriod(now) would create a date on the 1st of the month,
@@ -65,6 +67,8 @@ export function PokeProgrammaticCostChart({
       selectedPeriod={selectedPeriod}
       setSelectedPeriod={setSelectedPeriod}
       billingCycleStartDay={billingCycleStartDay}
+      displayMode={displayMode}
+      setDisplayMode={setDisplayMode}
     />
   );
 }

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -12,6 +12,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Area,
   AreaChart,
+  Bar,
+  BarChart,
   CartesianGrid,
   Line,
   LineChart,
@@ -435,7 +437,9 @@ export function BaseProgrammaticCostChart({
     return dataPoint;
   });
 
-  const ChartComponent = groupBy ? AreaChart : LineChart;
+  // Daily mode uses BarChart, cumulative mode uses AreaChart (grouped) or LineChart (global)
+  const ChartComponent =
+    displayMode === "daily" ? BarChart : groupBy ? AreaChart : LineChart;
 
   // Filter to only show ticks for midnight dates
   const midnightTicks = useMemo(() => {
@@ -665,6 +669,18 @@ export function BaseProgrammaticCostChart({
             groupKey,
             allGroupKeys
           );
+
+          if (displayMode === "daily") {
+            return (
+              <Bar
+                key={groupKey}
+                dataKey={groupKey}
+                stackId={groupBy ? "cost" : undefined}
+                fill="currentColor"
+                className={colorClassName}
+              />
+            );
+          }
 
           return groupBy ? (
             <Area

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -154,11 +154,6 @@ function GroupedTooltip(
       };
     });
 
-  // Don't show tooltip if no data (e.g., hovering on empty space in bar chart)
-  if (rows.length === 0) {
-    return null;
-  }
-
   // Add credits row only in cumulative mode
   if (shouldShowTotalCredits) {
     rows.push({
@@ -166,6 +161,11 @@ function GroupedTooltip(
       value: `$${(data.totalCreditsMicroUsd / 1_000_000).toFixed(2)}`,
       colorClassName: COST_PALETTE.totalCredits,
     });
+  }
+
+  // Don't show tooltip if no data at all (e.g., empty bar), but allow Total Credits-only tooltip
+  if (rows.length === 0) {
+    return null;
   }
 
   const date = new Date(data.timestamp).toLocaleDateString("en-US", {


### PR DESCRIPTION
## Description

Adds a display mode toggle to switch between "Cumulative" and "Daily" views in the programmatic cost chart. The API already provides both `costMicroUsd` (per-period) and `cumulatedCostMicroUsd` fields - this change wires up a dropdown to switch between them.

- Total Credits line is hidden in daily mode (only makes sense in cumulative view)
- Both `ProgrammaticCostChart` and `PokeProgrammaticCostChart` support the new toggle

## Risks

Blast radius: Programmatic cost chart on credits-usage page and poke
Risk: low

## Deploy Plan
- pmrr
- deploy front