### PR TITLE
Fix notification delay preferences

### DIFF
--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -192,7 +192,13 @@ export const NotificationPreferences = forwardRef<
         setEmailDelay(originalEmailDelayRef.current);
       },
     }),
-    [globalPreferences, emailDelay]
+    [
+      globalPreferences,
+      emailDelay,
+      mutateEmailDelay,
+      novuClient,
+      sendNotification,
+    ]
   );
 
   useEffect(() => {

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -339,7 +339,7 @@ export const conversationUnreadWorkflow = workflow(
     const { events } = await step.digest(
       "digest",
       async () => {
-        const digestKey = `${subscriber.subscriberId}-workspace-${payload.workspaceId}-unread-conversations`;
+        const digestKey = `workspace-${payload.workspaceId}-unread-conversations`;
         const userPreferences = userNotificationDelayStep.delay;
         return {
           ...NOTIFICATION_PREFERENCES_DELAYS[userPreferences],


### PR DESCRIPTION
## Description

For some reason, Novu doesn't pass the `subscriberId` parameter to "digest" steps.
We were using this `subscriberId` (which maps to the Dust `userId`) to fetch user notification preferences, so this was breaking our flow.
This PR fixes the issue by adding a custom step that retrieves the notification preferences upfront and passes them to the "digest" step.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
