### PR TITLE
Do not use mentioning system in Slack and Teams

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GET_MENTION_MARKDOWN_TOOL_NAME,
+  SEARCH_AVAILABLE_USERS_TOOL_NAME,
+} from "@app/lib/actions/constants";
+import { constructGuidelinesSection } from "@app/lib/api/assistant/generation";
+import type {
+  AgentConfigurationType,
+  UserMessageType,
+  WhitelistableFeature,
+} from "@app/types";
+
+describe("constructGuidelinesSection", () => {
+  describe("MENTIONING USERS section with Slack/Teams origin handling", () => {
+    const baseAgentConfiguration: Pick<
+      AgentConfigurationType,
+      "actions" | "name"
+    > = {
+      actions: [],
+      name: "test-agent",
+    };
+
+    const featureFlags: WhitelistableFeature[] = ["mentions_v2"];
+
+    it("should include mention tools for web origin", () => {
+      const userMessage = {
+        context: {
+          origin: "web" as const,
+          timezone: "UTC",
+        },
+      } as UserMessageType;
+
+      const result = constructGuidelinesSection({
+        agentConfiguration: baseAgentConfiguration as AgentConfigurationType,
+        featureFlags,
+        userMessage,
+      });
+
+      // For web origin, should use the tool-based approach
+      expect(result).toContain(
+        `Use the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` tool to search for users`
+      );
+      expect(result).toContain(
+        `Use the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tool to get the markdown directive`
+      );
+
+      // Should NOT tell to use simple @username
+      expect(result).not.toContain("Use a simple @username to mention users");
+    });
+
+    it("should use simple @username for Slack origin", () => {
+      for (const origin of ["slack", "teams"] as const) {
+        const userMessage = {
+          context: {
+            origin: origin,
+            timezone: "UTC",
+          },
+        } as UserMessageType;
+
+        const result = constructGuidelinesSection({
+          agentConfiguration: baseAgentConfiguration as AgentConfigurationType,
+          featureFlags,
+          userMessage,
+        });
+
+        // For Slack, should explicitly tell NOT to use the tools
+        expect(result).toContain(
+          `Do not use the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` or the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tools to mention users.`
+        );
+        expect(result).toContain(
+          "Use a simple @username to mention users in your messages in this conversation."
+        );
+
+        // Should NOT contain instructions to use the tools
+        expect(result).not.toContain(
+          `Use the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` tool to search for users that are available`
+        );
+        expect(result).not.toContain(
+          `Use the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tool to get the markdown directive to use`
+        );
+      }
+    });
+  });
+});

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -216,7 +216,7 @@ function constructPastedContentSection(): string {
   );
 }
 
-function constructGuidelinesSection({
+export function constructGuidelinesSection({
   agentConfiguration,
   featureFlags,
   userMessage,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -219,9 +219,11 @@ function constructPastedContentSection(): string {
 function constructGuidelinesSection({
   agentConfiguration,
   featureFlags,
+  userMessage,
 }: {
   agentConfiguration: AgentConfigurationType;
   featureFlags: WhitelistableFeature[];
+  userMessage: UserMessageType;
 }): string {
   let guidelinesSection = "# GUIDELINES\n";
 
@@ -255,15 +257,27 @@ function constructGuidelinesSection({
     "\nEvery image markdown should follow this pattern ![{TITLE}]({FILE_ID}).\n";
 
   if (featureFlags.includes("mentions_v2")) {
-    guidelinesSection +=
-      `\n## MENTIONNING USERS\n` +
-      "You have the abillity to mention users in a message using the markdown directive." +
-      '\nUsers can also refer to mention as "ping".' +
-      `\nUse the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` tool to search for users that are available to the conversation.` +
-      `\nUse the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tool to get the markdown directive to use to mention a user in a message.` +
-      "\nImportant:" +
-      "\n - In conversation with more than one user talking, always answer to users by prefixing your message with their markdown mention directive in order to address them directly, avoid confusion and ensure users are happy." +
-      "\n - Use the markdown directive only when you want to ping the user, if you just want to refer to them, use their name only.";
+    const isSlackOrTeams =
+      userMessage.context.origin === "slack" ||
+      userMessage.context.origin === "teams";
+    if (!isSlackOrTeams) {
+      guidelinesSection +=
+        `\n## MENTIONING USERS\n` +
+        "You have the abillity to mention users in a message using the markdown directive." +
+        '\nUsers can also refer to mention as "ping".' +
+        `\nUse the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` tool to search for users that are available to the conversation.` +
+        `\nUse the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tool to get the markdown directive to use to mention a user in a message.` +
+        "\nImportant:" +
+        "\n - In conversation with more than one user talking, always answer to users by prefixing your message with their markdown mention directive in order to address them directly, avoid confusion and ensure users are happy." +
+        "\n - Use the markdown directive only when you want to ping the user, if you just want to refer to them, use their name only.";
+    } else {
+      guidelinesSection +=
+        `\n## MENTIONING USERS\n` +
+        "You have the abillity to mention users in a message using the markdown directive." +
+        '\nUsers can also refer to mention as "ping".' +
+        `\nDo not use the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` or the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tools to mention users.\n` +
+        "\nUse a simple @username to mention users in your messages in this conversation.";
+    }
   }
 
   return guidelinesSection;
@@ -379,6 +393,7 @@ export function constructPromptMultiActions(
     constructGuidelinesSection({
       agentConfiguration,
       featureFlags,
+      userMessage,
     }),
     constructInstructionsSection({
       agentConfiguration,


### PR DESCRIPTION
## Description

When the users talk to an agent from Slack or Microsoft Teams, we don't want agents to use the Dust's mentioning system to mention humans.
This PR adapts the agents guidelines when the user message comes from Slack or Teams, in order to mention humans simply by "@username" them, instead of `:mention_user[username](user_id)`

## Tests

Test conducted on the Slack test workspace

## Risk

Low

## Deploy Plan

Deploy front
