### PR TITLE
Ext: Univ search preserves source provider and icon, and sourceUrl

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
-        "@dust-tt/client": "^1.2.1",
+        "@dust-tt/client": "^1.2.2",
         "@dust-tt/sparkle": "^0.4.27",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
@@ -234,13 +234,12 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.2.1.tgz",
-      "integrity": "sha512-sRHg9DhQqh1hsCFsLWepAXEj9v4hXJPMJSG5fOU0hWR7u548Q29TUlxWfkxEAmcSJeYUEnS+gnUb1Twh8Ryj6A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.2.2.tgz",
+      "integrity": "sha512-RYihGL03+scWAMFjV85qjArMWsbdPHHrtexxCzP4Vo7Tv+dj5LFjgpbkvhv26c+4fEVcVnF1oxzYoKplSlCJ3w==",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],
-      "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "git://github.com/dust-tt/typescript-sdk.git#628ebe48388549faae7e35504611af9ac2c6f5e4",
         "@types/json-schema": "^7.0.15",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
-    "@dust-tt/client": "^1.2.1",
+    "@dust-tt/client": "^1.2.2",
     "@dust-tt/sparkle": "^0.4.27",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",

--- a/extension/ui/components/conversation/AttachmentCitation.tsx
+++ b/extension/ui/components/conversation/AttachmentCitation.tsx
@@ -1,4 +1,9 @@
 import { getConnectorProviderLogoWithFallback } from "@app/shared/lib/connector_providers";
+import {
+  getIcon,
+  isCustomResourceIconType,
+  isInternalAllowedIcon,
+} from "@app/shared/lib/resources_icons";
 import type { ContentFragmentType } from "@dust-tt/client";
 import {
   Citation,
@@ -25,6 +30,9 @@ export type FileAttachment = {
   preview?: string;
   isUploading: boolean;
   onRemove: () => void;
+  iconName?: string;
+  provider?: string;
+  sourceUrl?: string;
 };
 
 export type NodeAttachment = {
@@ -145,6 +153,33 @@ function isExpiredContentFragment(
   return arg.expiredReason !== null;
 }
 
+function getFileVisual({
+  isImage,
+  iconName,
+}: {
+  isImage: boolean;
+  iconName?: string | null;
+}): React.ReactNode {
+  if (isImage) {
+    return <Icon visual={ImageIcon} size="md" />;
+  }
+
+  if (
+    iconName &&
+    (isCustomResourceIconType(iconName) || isInternalAllowedIcon(iconName))
+  ) {
+    return (
+      <DoubleIcon
+        mainIcon={DocumentIcon}
+        secondaryIcon={getIcon(iconName)}
+        size="md"
+      />
+    );
+  }
+
+  return <Icon visual={DocumentIcon} size="md" />;
+}
+
 export function contentFragmentToAttachmentCitation(
   contentFragment: ContentFragmentType
 ): AttachmentCitation | null {
@@ -185,13 +220,15 @@ export function contentFragmentToAttachmentCitation(
     };
   }
 
-  const isImageType = contentFragment.contentType.startsWith("image/");
   return {
     type: "file",
     id: contentFragment.sId,
     title: contentFragment.title,
     sourceUrl: contentFragment.sourceUrl,
-    visual: <Icon visual={isImageType ? ImageIcon : DocumentIcon} size="md" />,
+    visual: getFileVisual({
+      isImage: contentFragment.contentType.startsWith("image/"),
+      iconName: contentFragment.sourceIcon,
+    }),
   };
 }
 
@@ -205,13 +242,11 @@ export function attachmentToAttachmentCitation(
       title: attachment.title,
       preview: attachment.preview,
       isUploading: attachment.isUploading,
-      visual: (
-        <Icon
-          visual={attachment.preview ? ImageIcon : DocumentIcon}
-          size="md"
-        />
-      ),
-      sourceUrl: null,
+      visual: getFileVisual({
+        isImage: !!attachment.preview,
+        iconName: attachment.iconName,
+      }),
+      sourceUrl: attachment.sourceUrl,
     };
   } else {
     return {

--- a/extension/ui/components/input_bar/InputBar.tsx
+++ b/extension/ui/components/input_bar/InputBar.tsx
@@ -269,7 +269,7 @@ export function AssistantInputBar({
     const newFiles = getFileBlobs().map((cf) => ({
       title: cf.filename,
       fileId: cf.fileId,
-      url: cf.publicUrl,
+      url: cf.sourceUrl,
       kind: cf.kind,
     }));
 
@@ -290,7 +290,7 @@ export function AssistantInputBar({
           ...files.map((cf) => ({
             title: cf.filename,
             fileId: cf.fileId || "",
-            url: cf.publicUrl,
+            url: cf.sourceUrl,
             kind: cf.kind,
           }))
         );

--- a/extension/ui/components/input_bar/InputBarAttachment.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachment.tsx
@@ -50,6 +50,9 @@ export function InputBarAttachments({
         preview: blob.preview,
         isUploading: blob.isUploading,
         onRemove: () => files.service.removeFile(blob.id),
+        iconName: blob.iconName,
+        provider: blob.provider,
+        sourceUrl: blob.sourceUrl,
       })) || []
     );
   }, [files?.service]);

--- a/extension/ui/hooks/useFileUploaderService.ts
+++ b/extension/ui/hooks/useFileUploaderService.ts
@@ -185,16 +185,20 @@ export function useFileUploaderService(
   ): Promise<Result<FileBlob, FileBlobUploadError>[]> => {
     const uploadPromises = newFileBlobs.map(async (fileBlob) => {
       // Get upload URL from server.
+      let useCaseMetadata = undefined;
+      if (conversationId) {
+        useCaseMetadata = {
+          conversationId,
+          ...(fileBlob.provider && { sourceProvider: fileBlob.provider }),
+          ...(fileBlob.iconName && { sourceIcon: fileBlob.iconName }),
+        };
+      }
       const fileRes = await dustAPI.uploadFile({
         contentType: fileBlob.contentType,
         fileName: fileBlob.filename,
         fileSize: fileBlob.size,
         useCase: "conversation",
-        useCaseMetadata: conversationId
-          ? {
-              conversationId: conversationId,
-            }
-          : undefined,
+        useCaseMetadata,
         fileObject: fileBlob.file,
       });
       if (fileRes.isErr()) {

--- a/extension/ui/hooks/useToolFileUpload.ts
+++ b/extension/ui/hooks/useToolFileUpload.ts
@@ -53,6 +53,8 @@ export function useToolFileUpload({
             serverViewId: toolFile.serverViewId,
             externalId: toolFile.externalId,
             conversationId,
+            serverName: toolFile.serverName,
+            serverIcon: toolFile.serverIcon,
           },
         });
 


### PR DESCRIPTION
## Description

We want to preserve the sourceProvider and sourceIcon once the content fragment is uploaded (after having attached from a tool)

## Tests

Locally. 

## Risk

Break doc upload. 
Can be rolled back. 

## Deploy Plan

Merge. 