### PR TITLE
Move spreadsheet read-only tools to google_drive server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -607,6 +607,9 @@ export const INTERNAL_MCP_SERVERS = {
     },
     isPreview: true,
     tools_stakes: {
+      list_spreadsheets: "never_ask",
+      get_spreadsheet: "never_ask",
+      get_worksheet: "never_ask",
       update_cells: "low",
       append_data: "low",
       clear_range: "low",
@@ -917,7 +920,7 @@ export const INTERNAL_MCP_SERVERS = {
       list_drives: "never_ask",
       search_files: "never_ask",
       get_file_content: "never_ask",
-      get_spreadsheet_metadata: "never_ask",
+      get_spreadsheet: "never_ask",
       get_worksheet: "never_ask",
     },
     tools_retry_policies: { default: "retry_on_interrupt" },

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -607,9 +607,6 @@ export const INTERNAL_MCP_SERVERS = {
     },
     isPreview: true,
     tools_stakes: {
-      list_spreadsheets: "never_ask",
-      get_spreadsheet: "never_ask",
-      get_worksheet: "never_ask",
       update_cells: "low",
       append_data: "low",
       clear_range: "low",
@@ -920,6 +917,8 @@ export const INTERNAL_MCP_SERVERS = {
       list_drives: "never_ask",
       search_files: "never_ask",
       get_file_content: "never_ask",
+      get_spreadsheet_metadata: "never_ask",
+      get_worksheet: "never_ask",
     },
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -358,7 +358,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
   );
 
   server.tool(
-    "get_spreadsheet_metadata",
+    "get_spreadsheet",
     "Get metadata and properties of a specific Google Sheets spreadsheet.",
     {
       spreadsheetId: z

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -9,12 +9,15 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import {
   getGoogleDriveClient,
+  getGoogleSheetsClient,
   MAX_CONTENT_SIZE,
   MAX_FILE_SIZE,
   SUPPORTED_MIMETYPES,
 } from "@app/lib/providers/google_drive/utils";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+const GOOGLE_DRIVE_TOOL_NAME = "google_drive";
 
 function createServer(
   auth: Authenticator,
@@ -30,6 +33,14 @@ function createServer(
     return getGoogleDriveClient(accessToken);
   }
 
+  async function getSheetsClient(authInfo?: AuthInfo) {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return null;
+    }
+    return getGoogleSheetsClient(accessToken);
+  }
+
   server.tool(
     "list_drives",
     "List all shared drives accessible by the user.",
@@ -39,7 +50,7 @@ function createServer(
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: "google_drive",
+        toolNameForMonitoring: GOOGLE_DRIVE_TOOL_NAME,
         agentLoopContext,
       },
       async ({ pageToken }, { authInfo }) => {
@@ -133,7 +144,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: "google_drive",
+        toolNameForMonitoring: GOOGLE_DRIVE_TOOL_NAME,
         agentLoopContext,
       },
       async (
@@ -222,7 +233,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: "google_drive",
+        toolNameForMonitoring: GOOGLE_DRIVE_TOOL_NAME,
         agentLoopContext,
       },
       async ({ fileId, offset, limit }, { authInfo }) => {
@@ -339,6 +350,110 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
           return new Err(
             new MCPError(
               normalizeError(err).message || "Failed to get file content"
+            )
+          );
+        }
+      }
+    )
+  );
+
+  server.tool(
+    "get_spreadsheet_metadata",
+    "Get metadata and properties of a specific Google Sheets spreadsheet.",
+    {
+      spreadsheetId: z
+        .string()
+        .describe("The ID of the spreadsheet to retrieve."),
+      includeGridData: z
+        .boolean()
+        .default(false)
+        .describe("Whether to include grid data in the response."),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: GOOGLE_DRIVE_TOOL_NAME,
+        agentLoopContext,
+      },
+      async ({ spreadsheetId, includeGridData }, { authInfo }) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
+        }
+
+        try {
+          const res = await sheets.spreadsheets.get({
+            spreadsheetId,
+            includeGridData,
+          });
+
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
+        } catch (err) {
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to get spreadsheet"
+            )
+          );
+        }
+      }
+    )
+  );
+
+  server.tool(
+    "get_worksheet",
+    "Get data from a specific worksheet in a Google Sheets spreadsheet.",
+    {
+      spreadsheetId: z.string().describe("The ID of the spreadsheet."),
+      range: z
+        .string()
+        .describe(
+          "The A1 notation of the range to retrieve (e.g., 'Sheet1!A1:D10' or 'A1:D10')."
+        ),
+      majorDimension: z
+        .enum(["ROWS", "COLUMNS"])
+        .default("ROWS")
+        .describe("The major dimension of the values."),
+      valueRenderOption: z
+        .enum(["FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA"])
+        .default("FORMATTED_VALUE")
+        .describe("How values should be represented in the output."),
+    },
+    withToolLogging(
+      auth,
+      {
+        toolNameForMonitoring: GOOGLE_DRIVE_TOOL_NAME,
+        agentLoopContext,
+      },
+      async (
+        { spreadsheetId, range, majorDimension, valueRenderOption },
+        { authInfo }
+      ) => {
+        const sheets = await getSheetsClient(authInfo);
+        if (!sheets) {
+          return new Err(
+            new MCPError("Failed to authenticate with Google Sheets")
+          );
+        }
+
+        try {
+          const res = await sheets.spreadsheets.values.get({
+            spreadsheetId,
+            range,
+            majorDimension,
+            valueRenderOption,
+          });
+
+          return new Ok([
+            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
+          ]);
+        } catch (err) {
+          return new Err(
+            new MCPError(
+              normalizeError(err).message || "Failed to get worksheet data"
             )
           );
         }

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -1,6 +1,5 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { google } from "googleapis";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
@@ -10,6 +9,10 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import {
+  getGoogleDriveClient,
+  getGoogleSheetsClient,
+} from "@app/lib/providers/google_drive/utils";
 
 // We use a single tool name for monitoring given the high granularity (can be revisited).
 const GOOGLE_SHEET_TOOL_NAME = "google_sheets";

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -7,12 +7,12 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
-import { Err, Ok } from "@app/types";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   getGoogleDriveClient,
   getGoogleSheetsClient,
 } from "@app/lib/providers/google_drive/utils";
+import { Err, Ok } from "@app/types";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 // We use a single tool name for monitoring given the high granularity (can be revisited).
 const GOOGLE_SHEET_TOOL_NAME = "google_sheets";

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -1,6 +1,5 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { google } from "googleapis";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
@@ -8,6 +7,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
+import { getGoogleSheetsClient } from "@app/lib/providers/google_drive/utils";
 import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -25,192 +25,8 @@ function createServer(
     if (!accessToken) {
       return null;
     }
-
-    const oauth2Client = new google.auth.OAuth2();
-    oauth2Client.setCredentials({ access_token: accessToken });
-    return google.sheets({
-      version: "v4",
-      auth: oauth2Client,
-    });
+    return getGoogleSheetsClient(accessToken);
   }
-
-  async function getDriveClient(authInfo?: AuthInfo) {
-    const accessToken = authInfo?.token;
-    if (!accessToken) {
-      return null;
-    }
-
-    const oauth2Client = new google.auth.OAuth2();
-    oauth2Client.setCredentials({ access_token: accessToken });
-    return google.drive({
-      version: "v3",
-      auth: oauth2Client,
-    });
-  }
-
-  server.tool(
-    "list_spreadsheets",
-    "List Google Sheets spreadsheets accessible by the user from both personal drive and shared drives. Supports pagination and search.",
-    {
-      nameFilter: z
-        .string()
-        .optional()
-        .describe(
-          "The text to search for in file names. Uses Google Drive's 'contains' operator which is case-insensitive and performs prefix matching only. For example, searching 'hello' will match 'HelloWorld' but not 'WorldHello'."
-        ),
-      pageToken: z.string().optional().describe("Page token for pagination."),
-      pageSize: z
-        .number()
-        .optional()
-        .describe("Maximum number of spreadsheets to return (max 1000)."),
-    },
-    withToolLogging(
-      auth,
-      {
-        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        agentLoopContext,
-      },
-      async ({ nameFilter, pageToken, pageSize }, { authInfo }) => {
-        const drive = await getDriveClient(authInfo);
-        if (!drive) {
-          return new Err(
-            new MCPError("Failed to authenticate with Google Drive")
-          );
-        }
-
-        try {
-          const query = nameFilter
-            ? `mimeType='application/vnd.google-apps.spreadsheet' and name contains '${nameFilter}'`
-            : "mimeType='application/vnd.google-apps.spreadsheet'";
-
-          const res = await drive.files.list({
-            q: query,
-            pageToken,
-            pageSize: pageSize ? Math.min(pageSize, 1000) : undefined,
-            fields:
-              "nextPageToken, files(id, name, createdTime, modifiedTime, owners, webViewLink)",
-            includeItemsFromAllDrives: true,
-            supportsAllDrives: true,
-            corpora: "allDrives",
-          });
-
-          return new Ok([
-            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
-          ]);
-        } catch (err) {
-          return new Err(
-            new MCPError(
-              normalizeError(err).message || "Failed to list spreadsheets"
-            )
-          );
-        }
-      }
-    )
-  );
-
-  server.tool(
-    "get_spreadsheet",
-    "Get metadata and properties of a specific Google Sheets spreadsheet.",
-    {
-      spreadsheetId: z
-        .string()
-        .describe("The ID of the spreadsheet to retrieve."),
-      includeGridData: z
-        .boolean()
-        .default(false)
-        .describe("Whether to include grid data in the response."),
-    },
-    withToolLogging(
-      auth,
-      {
-        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        agentLoopContext,
-      },
-      async ({ spreadsheetId, includeGridData }, { authInfo }) => {
-        const sheets = await getSheetsClient(authInfo);
-        if (!sheets) {
-          return new Err(
-            new MCPError("Failed to authenticate with Google Sheets")
-          );
-        }
-
-        try {
-          const res = await sheets.spreadsheets.get({
-            spreadsheetId,
-            includeGridData,
-          });
-
-          return new Ok([
-            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
-          ]);
-        } catch (err) {
-          return new Err(
-            new MCPError(
-              normalizeError(err).message || "Failed to get spreadsheet"
-            )
-          );
-        }
-      }
-    )
-  );
-
-  server.tool(
-    "get_worksheet",
-    "Get data from a specific worksheet in a Google Sheets spreadsheet.",
-    {
-      spreadsheetId: z.string().describe("The ID of the spreadsheet."),
-      range: z
-        .string()
-        .describe(
-          "The A1 notation of the range to retrieve (e.g., 'Sheet1!A1:D10' or 'A1:D10')."
-        ),
-      majorDimension: z
-        .enum(["ROWS", "COLUMNS"])
-        .default("ROWS")
-        .describe("The major dimension of the values."),
-      valueRenderOption: z
-        .enum(["FORMATTED_VALUE", "UNFORMATTED_VALUE", "FORMULA"])
-        .default("FORMATTED_VALUE")
-        .describe("How values should be represented in the output."),
-    },
-    withToolLogging(
-      auth,
-      {
-        toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
-        agentLoopContext,
-      },
-      async (
-        { spreadsheetId, range, majorDimension, valueRenderOption },
-        { authInfo }
-      ) => {
-        const sheets = await getSheetsClient(authInfo);
-        if (!sheets) {
-          return new Err(
-            new MCPError("Failed to authenticate with Google Sheets")
-          );
-        }
-
-        try {
-          const res = await sheets.spreadsheets.values.get({
-            spreadsheetId,
-            range,
-            majorDimension,
-            valueRenderOption,
-          });
-
-          return new Ok([
-            { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
-          ]);
-        } catch (err) {
-          return new Err(
-            new MCPError(
-              normalizeError(err).message || "Failed to get worksheet data"
-            )
-          );
-        }
-      }
-    )
-  );
 
   server.tool(
     "update_cells",

--- a/front/lib/providers/google_drive/utils.ts
+++ b/front/lib/providers/google_drive/utils.ts
@@ -17,3 +17,12 @@ export function getGoogleDriveClient(accessToken: string) {
   oauth2Client.setCredentials({ access_token: accessToken });
   return google.drive({ version: "v3", auth: oauth2Client });
 }
+
+export function getGoogleSheetsClient(accessToken: string) {
+  const oauth2Client = new google.auth.OAuth2();
+  oauth2Client.setCredentials({ access_token: accessToken });
+  return google.sheets({
+    version: "v4",
+    auth: oauth2Client,
+  });
+}


### PR DESCRIPTION
## Description

fixes: https://github.com/dust-tt/tasks/issues/5528

Adds spreadsheet read operations to google_drive server while keeping them in google_sheets to avoid breaking existing agents.

Moves spreadsheet read operations from google_sheets to google_drive :
- Add `get_spreadsheet` and `get_worksheet` to `google_drive` (these work with drive.readonly scope)
- Keep existing tools in google_sheets unchanged

Rationale:
- drive.readonly (already approved) can read spreadsheets - no need for the gated spreadsheets scope
- Customers using only google_drive can now read spreadsheet data without enabling google_sheets
- Existing agents using google_sheets continue working without modification


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low
## Deploy Plan

deploy front
