### PR TITLE
[Front] feat(agent-builder): capabilities sheet improvements

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -5,7 +5,10 @@ import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type {
+  AgentBuilderFormData,
+  AgentBuilderSkillsType,
+} from "@app/components/agent_builder/AgentBuilderFormContext";
 import {
   AgentBuilderFormContext,
   agentBuilderFormSchema,
@@ -145,11 +148,12 @@ export default function AgentBuilder({
     return processActionsFromStorage(actions ?? emptyArray());
   }, [actions]);
 
-  const processedSkills = useMemo(() => {
+  const processedSkills: AgentBuilderSkillsType[] = useMemo(() => {
     return skills.map((skill) => ({
       sId: skill.sId,
       name: skill.name,
       description: skill.userFacingDescription,
+      icon: skill.icon,
     }));
   }, [skills]);
 

--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSheet.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSheet.tsx
@@ -16,9 +16,9 @@ interface CapabilitiesSheetProps {
   onModeChange: (mode: CapabilitiesSheetMode | null) => void;
   owner: WorkspaceType;
   user: UserType;
-  initialSelectedSkills: AgentBuilderSkillsType[];
   initialAdditionalSpaces: string[];
   alreadyRequestedSpaceIds: Set<string>;
+  alreadyAddedSkillIds: Set<string>;
 }
 
 export function CapabilitiesSheet(props: CapabilitiesSheetProps) {
@@ -41,13 +41,13 @@ function CapabilitiesSheetContent({
   onModeChange,
   owner,
   user,
-  initialSelectedSkills,
   initialAdditionalSpaces,
   alreadyRequestedSpaceIds,
+  alreadyAddedSkillIds,
 }: CapabilitiesSheetProps & { mode: CapabilitiesSheetMode }) {
   const [localSelectedSkills, setLocalSelectedSkills] = useState<
     AgentBuilderSkillsType[]
-  >(initialSelectedSkills);
+  >([]);
   const [localAdditionalSpaces, setLocalAdditionalSpaces] = useState<string[]>(
     initialAdditionalSpaces
   );
@@ -65,6 +65,7 @@ function CapabilitiesSheetContent({
     owner,
     user,
     alreadyRequestedSpaceIds,
+    alreadyAddedSkillIds,
     localSelectedSkills,
     setLocalSelectedSkills,
     localAdditionalSpaces,

--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -2,7 +2,6 @@ import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useMemo, useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type {
   CapabilitiesSheetMode,
   PageContentProps,
@@ -31,6 +30,7 @@ export const useSkillSelection = ({
   setLocalSelectedSkills,
   localAdditionalSpaces,
   setLocalAdditionalSpaces,
+  alreadyAddedSkillIds,
 }: PageContentProps) => {
   const { owner } = useAgentBuilderContext();
   const [searchQuery, setSearchQuery] = useState("");
@@ -52,47 +52,49 @@ export const useSkillSelection = ({
   );
 
   const filteredSkills = useMemo(() => {
+    const notAlreadyAddedSkills = skillsWithRelations.filter(
+      (skill) => !alreadyAddedSkillIds.has(skill.sId)
+    );
+
     if (!searchQuery.trim()) {
-      return skillsWithRelations;
+      return notAlreadyAddedSkills;
     }
     const query = searchQuery.toLowerCase();
-    return skillsWithRelations.filter(
+    return notAlreadyAddedSkills.filter(
       (skill) =>
         skill.name.toLowerCase().includes(query) ||
         skill.userFacingDescription.toLowerCase().includes(query)
     );
-  }, [skillsWithRelations, searchQuery]);
+  }, [skillsWithRelations, searchQuery, alreadyAddedSkillIds]);
 
   const handleSkillToggle = useCallback(
     (skill: SkillType) => {
-      const isAlreadySelected = localSelectedSkills.some(
-        (s) => s.sId === skill.sId
-      );
-
-      if (isAlreadySelected) {
+      if (selectedSkillIds.has(skill.sId)) {
         setLocalSelectedSkills((prev) =>
           prev.filter((s) => s.sId !== skill.sId)
         );
-      } else {
-        if (isGlobalSkillWithSpaceSelection(skill)) {
-          onModeChange({
-            pageId: "skill_space_selection",
-            capability: skill,
-          });
-        } else {
-          setLocalSelectedSkills((prev) => [
-            ...prev,
-            {
-              sId: skill.sId,
-              name: skill.name,
-              description: skill.userFacingDescription,
-              icon: skill.icon,
-            },
-          ]);
-        }
+        return;
       }
+
+      if (isGlobalSkillWithSpaceSelection(skill)) {
+        onModeChange({
+          pageId: "skill_space_selection",
+          capability: skill,
+        });
+        return;
+      }
+
+      setLocalSelectedSkills((prev) => [
+        ...prev,
+        {
+          sId: skill.sId,
+          name: skill.name,
+          description: skill.userFacingDescription,
+          icon: skill.icon,
+        },
+      ]);
     },
-    [localSelectedSkills, onModeChange, setLocalSelectedSkills]
+    [selectedSkillIds, onModeChange, setLocalSelectedSkills]
   );
 
   const handleSpaceSelectionSave = useCallback(
@@ -100,7 +102,7 @@ export const useSkillSelection = ({
       // Commit draft spaces to actual state
       setLocalAdditionalSpaces(draftSelectedSpaces);
       // Add the skill
-      setLocalSelectedSkills((prev: AgentBuilderSkillsType[]) => [
+      setLocalSelectedSkills((prev) => [
         ...prev,
         {
           sId: skill.sId,

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
@@ -75,6 +75,7 @@ export type PageContentProps = {
   owner: WorkspaceType;
   user: UserType;
   alreadyRequestedSpaceIds: Set<string>;
+  alreadyAddedSkillIds: Set<string>;
   localSelectedSkills: AgentBuilderSkillsType[];
   setLocalSelectedSkills: React.Dispatch<
     React.SetStateAction<AgentBuilderSkillsType[]>

--- a/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
@@ -30,7 +30,7 @@ export function getPageAndFooter(props: PageContentProps): {
     case "selection":
       return {
         page: {
-          title: "Add skills",
+          title: "Add capabilities",
           id: mode.pageId,
           content: (
             <SelectionPageContent
@@ -51,7 +51,11 @@ export function getPageAndFooter(props: PageContentProps): {
           onClick: onClose,
         },
         rightButton: {
-          label: "Add skills",
+          label:
+            skillSelection.selectedSkillIds.size > 0
+              ? `Add ${skillSelection.selectedSkillIds.size} ${skillSelection.selectedSkillIds.size === 1 ? "capability" : "capabilities"}`
+              : "Add capabilities",
+          disabled: skillSelection.selectedSkillIds.size === 0,
           onClick: handleSave,
           variant: "primary",
         },


### PR DESCRIPTION
Step 3 of implementing https://github.com/dust-tt/tasks/issues/5565

Splitting https://github.com/dust-tt/dust/pull/19233/changes in X PRs

## Description

Re-align CapabilitesSheet behaviour with McpServerViewsSheet :
- filter out selected skills from capabilities sheet
- make skill cards clickable
- fix agent builder form skill loading (was missing icon)
- display number of capabilities added in add button, disable it if none selected

## Tests

Local

## Risk

Low, FF disabled

## Deploy Plan

Front