### PR TITLE
Move handleMentionsActivity to a new queue

### DIFF
--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -53,6 +53,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/labs/transcripts");
     case "mentions_count":
       return path.join(baseDir, "temporal/mentions_count_queue");
+    case "mentions_queue":
+      return path.join(baseDir, "temporal/mentions_queue");
     case "notifications_queue":
       return path.join(baseDir, "temporal/notifications_queue");
     case "poke":

--- a/front/temporal/agent_loop/activities/mentions.ts
+++ b/front/temporal/agent_loop/activities/mentions.ts
@@ -1,89 +1,39 @@
-import { handleAgentMessage } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { AuthenticatorType } from "@app/lib/auth";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { isAgentMessageType } from "@app/types";
+import { launchHandleMentionsWorkflow } from "@app/temporal/mentions_queue/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 /**
- * Handle mentions in the agent message content.
+ * Launch mentions workflow in fire-and-forget mode.
  */
 export async function handleMentions(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  // Contruct back an authenticator from the auth type.
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    logger.error(
-      { authType, error: authResult.error },
-      "Failed to construct authenticator from auth type"
-    );
-    return;
-  }
-  const auth = authResult.value;
-
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-  if (!featureFlags.includes("mentions_v2")) {
-    return;
-  }
-
-  const conversationRes = await getConversation(
-    auth,
-    agentLoopArgs.conversationId
-  );
-
-  if (conversationRes.isErr()) {
-    logger.error(
-      {
-        conversationId: agentLoopArgs.conversationId,
-        agentMessageId: agentLoopArgs.agentMessageId,
-        error: conversationRes.error,
-      },
-      "Failed to fetch conversation while handling mentions"
+  // Use `getWorkspaceInfos` for lightweight workspace info.
+  const owner = await getWorkspaceInfos(authType.workspaceId);
+  if (!owner) {
+    logger.warn(
+      { workspaceId: authType.workspaceId },
+      "Failed to fetch workspace infos for mentions"
     );
     return;
   }
 
-  const conversation = conversationRes.value;
-
-  const agentMessage = conversation.content
-    .flat()
-    .find((message) => message.sId === agentLoopArgs.agentMessageId);
-
-  if (!agentMessage) {
-    logger.error(
-      {
-        conversationId: agentLoopArgs.conversationId,
-        agentMessageId: agentLoopArgs.agentMessageId,
-      },
-      "Agent message not found while handling mentions"
-    );
-    return;
-  }
-
-  if (!isAgentMessageType(agentMessage)) {
-    logger.error(
-      {
-        conversationId: agentLoopArgs.conversationId,
-        agentMessageId: agentLoopArgs.agentMessageId,
-      },
-      "Message is not an agent message while handling mentions"
-    );
-    return;
-  }
-
-  if (!agentMessage.content) {
-    return;
-  }
-
-  if (agentMessage.status !== "succeeded") {
-    return;
-  }
-
-  await handleAgentMessage(auth, {
-    conversation,
-    agentMessage,
+  const result = await launchHandleMentionsWorkflow({
+    authType,
+    agentLoopArgs,
   });
+
+  if (result.isErr()) {
+    logger.warn(
+      {
+        agentMessageId: agentLoopArgs.agentMessageId,
+        error: result.error,
+        workspaceId: authType.workspaceId,
+      },
+      "Failed to launch mentions workflow"
+    );
+  }
 }

--- a/front/temporal/mentions_queue/activities.ts
+++ b/front/temporal/mentions_queue/activities.ts
@@ -1,0 +1,89 @@
+import { handleAgentMessage } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { isAgentMessageType } from "@app/types";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+/**
+ * Handle mentions in the agent message content.
+ */
+export async function handleMentionsActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  // Construct back an authenticator from the auth type.
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    logger.error(
+      { authType, error: authResult.error },
+      "Failed to construct authenticator from auth type"
+    );
+    return;
+  }
+  const auth = authResult.value;
+
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  if (!featureFlags.includes("mentions_v2")) {
+    return;
+  }
+
+  const conversationRes = await getConversation(
+    auth,
+    agentLoopArgs.conversationId
+  );
+
+  if (conversationRes.isErr()) {
+    logger.error(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+        error: conversationRes.error,
+      },
+      "Failed to fetch conversation while handling mentions"
+    );
+    return;
+  }
+
+  const conversation = conversationRes.value;
+
+  const agentMessage = conversation.content
+    .flat()
+    .find((message) => message.sId === agentLoopArgs.agentMessageId);
+
+  if (!agentMessage) {
+    logger.error(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+      },
+      "Agent message not found while handling mentions"
+    );
+    return;
+  }
+
+  if (!isAgentMessageType(agentMessage)) {
+    logger.error(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+      },
+      "Message is not an agent message while handling mentions"
+    );
+    return;
+  }
+
+  if (!agentMessage.content) {
+    return;
+  }
+
+  if (agentMessage.status !== "succeeded") {
+    return;
+  }
+
+  await handleAgentMessage(auth, {
+    conversation,
+    agentMessage,
+  });
+}

--- a/front/temporal/mentions_queue/activities.ts
+++ b/front/temporal/mentions_queue/activities.ts
@@ -1,7 +1,7 @@
 import { handleAgentMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { Authenticator } from "@app/lib/auth";
 import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { isAgentMessageType } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";

--- a/front/temporal/mentions_queue/activities.ts
+++ b/front/temporal/mentions_queue/activities.ts
@@ -1,7 +1,6 @@
 import { handleAgentMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import type { AuthenticatorType } from "@app/lib/auth";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { isAgentMessageType } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -10,25 +9,9 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
  * Handle mentions in the agent message content.
  */
 export async function handleMentionsActivity(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  // Construct back an authenticator from the auth type.
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    logger.error(
-      { authType, error: authResult.error },
-      "Failed to construct authenticator from auth type"
-    );
-    return;
-  }
-  const auth = authResult.value;
-
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-  if (!featureFlags.includes("mentions_v2")) {
-    return;
-  }
-
   const conversationRes = await getConversation(
     auth,
     agentLoopArgs.conversationId

--- a/front/temporal/mentions_queue/activities.ts
+++ b/front/temporal/mentions_queue/activities.ts
@@ -1,6 +1,7 @@
 import { handleAgentMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { AuthenticatorType } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { isAgentMessageType } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -9,9 +10,17 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
  * Handle mentions in the agent message content.
  */
 export async function handleMentionsActivity(
-  auth: Authenticator,
+  authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
+
   const conversationRes = await getConversation(
     auth,
     agentLoopArgs.conversationId

--- a/front/temporal/mentions_queue/client.ts
+++ b/front/temporal/mentions_queue/client.ts
@@ -47,7 +47,7 @@ export async function launchHandleMentionsWorkflow({
 
   try {
     await client.workflow.start(handleMentionsWorkflow, {
-      args: [auth, { agentLoopArgs }],
+      args: [authType, { agentLoopArgs }],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: {

--- a/front/temporal/mentions_queue/client.ts
+++ b/front/temporal/mentions_queue/client.ts
@@ -1,0 +1,56 @@
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+import type { AuthenticatorType } from "@app/lib/auth";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/mentions_queue/config";
+import { makeMentionsWorkflowId } from "@app/temporal/mentions_queue/helpers";
+import { handleMentionsWorkflow } from "@app/temporal/mentions_queue/workflows";
+import type { Result } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+export async function launchHandleMentionsWorkflow({
+  authType,
+  agentLoopArgs,
+}: {
+  authType: AuthenticatorType;
+  agentLoopArgs: AgentLoopArgs;
+}): Promise<Result<undefined, Error>> {
+  const { workspaceId } = authType;
+  const { agentMessageId, conversationId } = agentLoopArgs;
+
+  const client = await getTemporalClientForFrontNamespace();
+
+  const workflowId = makeMentionsWorkflowId({
+    agentMessageId,
+    conversationId,
+    workspaceId,
+  });
+
+  try {
+    await client.workflow.start(handleMentionsWorkflow, {
+      args: [authType, { agentLoopArgs }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: {
+        agentMessageId,
+        workspaceId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
+      logger.error(
+        {
+          workflowId,
+          agentMessageId,
+          error: e,
+        },
+        "Failed starting mentions workflow"
+      );
+    }
+
+    return new Err(normalizeError(e));
+  }
+}

--- a/front/temporal/mentions_queue/config.ts
+++ b/front/temporal/mentions_queue/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `mentions-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/mentions_queue/helpers.ts
+++ b/front/temporal/mentions_queue/helpers.ts
@@ -1,0 +1,11 @@
+export function makeMentionsWorkflowId({
+  agentMessageId,
+  conversationId,
+  workspaceId,
+}: {
+  agentMessageId: string;
+  conversationId: string;
+  workspaceId: string;
+}): string {
+  return `mentions-${workspaceId}-${conversationId}-${agentMessageId}`;
+}

--- a/front/temporal/mentions_queue/worker.ts
+++ b/front/temporal/mentions_queue/worker.ts
@@ -7,8 +7,8 @@ import {
 } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import * as activities from "@app/temporal/mentions_queue/activities";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/mentions_queue/activities";
 
 import { QUEUE_NAME } from "./config";
 

--- a/front/temporal/mentions_queue/worker.ts
+++ b/front/temporal/mentions_queue/worker.ts
@@ -1,0 +1,39 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/temporal/mentions_queue/activities";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runMentionsQueueWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "mentions_queue",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 16,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [
+        (ctx: Context) => {
+          return new ActivityInboundLogInterceptor(ctx, logger);
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/mentions_queue/workflows.ts
+++ b/front/temporal/mentions_queue/workflows.ts
@@ -1,6 +1,6 @@
 import { proxyActivities } from "@temporalio/workflow";
 
-import type { Authenticator } from "@app/lib/auth";
+import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/mentions_queue/activities";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
@@ -12,12 +12,12 @@ const { handleMentionsActivity } = proxyActivities<typeof activities>({
 });
 
 export async function handleMentionsWorkflow(
-  auth: Authenticator,
+  authType: AuthenticatorType,
   {
     agentLoopArgs,
   }: {
     agentLoopArgs: AgentLoopArgs;
   }
 ): Promise<void> {
-  await handleMentionsActivity(auth, agentLoopArgs);
+  await handleMentionsActivity(authType, agentLoopArgs);
 }

--- a/front/temporal/mentions_queue/workflows.ts
+++ b/front/temporal/mentions_queue/workflows.ts
@@ -1,0 +1,23 @@
+import { proxyActivities } from "@temporalio/workflow";
+
+import type { AuthenticatorType } from "@app/lib/auth";
+import type * as activities from "@app/temporal/mentions_queue/activities";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+
+const { handleMentionsActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "1 minute",
+  retry: {
+    maximumAttempts: 2,
+  },
+});
+
+export async function handleMentionsWorkflow(
+  authType: AuthenticatorType,
+  {
+    agentLoopArgs,
+  }: {
+    agentLoopArgs: AgentLoopArgs;
+  }
+): Promise<void> {
+  await handleMentionsActivity(authType, agentLoopArgs);
+}

--- a/front/temporal/mentions_queue/workflows.ts
+++ b/front/temporal/mentions_queue/workflows.ts
@@ -1,6 +1,6 @@
 import { proxyActivities } from "@temporalio/workflow";
 
-import type { AuthenticatorType } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import type * as activities from "@app/temporal/mentions_queue/activities";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
@@ -12,12 +12,12 @@ const { handleMentionsActivity } = proxyActivities<typeof activities>({
 });
 
 export async function handleMentionsWorkflow(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   {
     agentLoopArgs,
   }: {
     agentLoopArgs: AgentLoopArgs;
   }
 ): Promise<void> {
-  await handleMentionsActivity(authType, agentLoopArgs);
+  await handleMentionsActivity(auth, agentLoopArgs);
 }

--- a/front/temporal/notifications_queue/activities.ts
+++ b/front/temporal/notifications_queue/activities.ts
@@ -1,4 +1,5 @@
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import type { AuthenticatorType } from "@app/lib/auth";
 import { triggerConversationUnreadNotifications } from "@app/lib/notifications/workflows/conversation-unread";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
@@ -8,9 +9,17 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
  * Activity to send conversation unread notifications.
  */
 export async function sendUnreadConversationNotificationActivity(
-  auth: Authenticator,
+  authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
+
   // Get conversation participants
   const conversation = await ConversationResource.fetchById(
     auth,

--- a/front/temporal/notifications_queue/activities.ts
+++ b/front/temporal/notifications_queue/activities.ts
@@ -1,5 +1,5 @@
-import { Authenticator } from "@app/lib/auth";
 import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { triggerConversationUnreadNotifications } from "@app/lib/notifications/workflows/conversation-unread";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";

--- a/front/temporal/notifications_queue/client.ts
+++ b/front/temporal/notifications_queue/client.ts
@@ -63,7 +63,7 @@ export async function launchConversationUnreadNotificationWorkflow({
 
   try {
     await client.workflow.start(sendUnreadConversationNotificationWorkflow, {
-      args: [auth, { agentLoopArgs }],
+      args: [authType, { agentLoopArgs }],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: {

--- a/front/temporal/notifications_queue/workflows.ts
+++ b/front/temporal/notifications_queue/workflows.ts
@@ -1,6 +1,6 @@
 import { proxyActivities, sleep } from "@temporalio/workflow";
 
-import type { Authenticator } from "@app/lib/auth";
+import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/notifications_queue/activities";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
@@ -16,7 +16,7 @@ const { sendUnreadConversationNotificationActivity } = proxyActivities<
 });
 
 export async function sendUnreadConversationNotificationWorkflow(
-  auth: Authenticator,
+  authType: AuthenticatorType,
   {
     agentLoopArgs,
   }: {
@@ -26,5 +26,5 @@ export async function sendUnreadConversationNotificationWorkflow(
   // Wait before triggering the notification.
   await sleep(NOTIFICATION_DELAY_MS);
 
-  await sendUnreadConversationNotificationActivity(auth, agentLoopArgs);
+  await sendUnreadConversationNotificationActivity(authType, agentLoopArgs);
 }

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -7,6 +7,7 @@ import { runESIndexationQueueWorker } from "@app/temporal/es_indexation/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runLabsTranscriptsWorker } from "@app/temporal/labs/transcripts/worker";
 import { runMentionsCountWorker } from "@app/temporal/mentions_count_queue/worker";
+import { runMentionsQueueWorker } from "@app/temporal/mentions_queue/worker";
 import { runNotificationsQueueWorker } from "@app/temporal/notifications_queue/worker";
 import { runProductionChecksWorker } from "@app/temporal/production_checks/worker";
 import { runRelocationWorker } from "@app/temporal/relocation/worker";
@@ -35,6 +36,7 @@ export type WorkerName =
   | "hard_delete"
   | "labs"
   | "mentions_count"
+  | "mentions_queue"
   | "notifications_queue"
   | "poke"
   | "production_checks"
@@ -58,6 +60,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   hard_delete: runHardDeleteWorker,
   labs: runLabsTranscriptsWorker,
   mentions_count: runMentionsCountWorker,
+  mentions_queue: runMentionsQueueWorker,
   notifications_queue: runNotificationsQueueWorker,
   poke: runPokeWorker,
   production_checks: runProductionChecksWorker,


### PR DESCRIPTION
## Description

`handleMentionsActivity` was recently added to the agent loop workflow and adds a 30-second delay, which is not acceptable (agent loop should be fast).
`handleMentionsActivity` should be moved to its own queue to maintain performance.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Need to add a new queue in dust-infra

## Deploy Plan

Deploy front
