### PR TITLE
[mentions] do not pre-fill user mention

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -29,7 +29,12 @@ import { useCancelMessage, useConversation } from "@app/lib/swr/conversations";
 import { emptyArray } from "@app/lib/swr/swr";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { RichMention } from "@app/types";
-import { pluralize, toRichAgentMentionType } from "@app/types";
+import {
+  isRichAgentMention,
+  isRichUserMention,
+  pluralize,
+  toRichAgentMentionType,
+} from "@app/types";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 
@@ -82,8 +87,19 @@ export const AgentInputBar = ({
     if (draftAgent) {
       return [toRichAgentMentionType(draftAgent)];
     }
+
+    // we only prefill if there is only one agent mention in user's previous message
+    const shouldPrefill =
+      lastUserMessage &&
+      lastUserMessage.richMentions.length === 1 &&
+      isRichAgentMention(lastUserMessage.richMentions[0]);
+
     if (!lastUserMessage || lastUserMessage.richMentions.length > 1) {
-      return emptyArray<RichMention>();
+      return [];
+    }
+
+    if (!shouldPrefill) {
+      return [];
     }
 
     return lastUserMessage.richMentions;

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -26,12 +26,9 @@ import {
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
 import { useCancelMessage, useConversation } from "@app/lib/swr/conversations";
-import { emptyArray } from "@app/lib/swr/swr";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
-import type { RichMention } from "@app/types";
 import {
   isRichAgentMention,
-  isRichUserMention,
   pluralize,
   toRichAgentMentionType,
 } from "@app/types";

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -94,10 +94,6 @@ export const AgentInputBar = ({
       lastUserMessage.richMentions.length === 1 &&
       isRichAgentMention(lastUserMessage.richMentions[0]);
 
-    if (!lastUserMessage || lastUserMessage.richMentions.length > 1) {
-      return [];
-    }
-
     if (!shouldPrefill) {
       return [];
     }


### PR DESCRIPTION
## Description
This PR is closing https://github.com/dust-tt/tasks/issues/5687, we should not pre fill the input if the last user message mentioning a user 
 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
