### PR TITLE
[connectors] fix(Intercom): add fallback name for collections

### DIFF
--- a/connectors/src/connectors/intercom/lib/help_center_permissions.ts
+++ b/connectors/src/connectors/intercom/lib/help_center_permissions.ts
@@ -26,9 +26,11 @@ import type {
   ConnectorPermission,
   ContentNode,
   ContentNodesViewType,
+  ModelId,
 } from "@connectors/types";
-import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
+
+export const UNTITLED_COLLECTION_NAME = "Untitled Collection";
 
 // A Help Center contains collections and articles:
 // - Level 1: Collections (parent_id is null)
@@ -212,7 +214,7 @@ export async function allowSyncCollection({
         intercomWorkspaceId: intercomCollection.workspace_id,
         helpCenterId: hpId,
         parentId: intercomCollection.parent_id,
-        name: intercomCollection.name,
+        name: intercomCollection.name?.trim() ?? "Untitled Collection",
         description: intercomCollection.description,
         url:
           intercomCollection.url ||
@@ -459,7 +461,7 @@ export async function retrieveIntercomHelpCentersPermissions({
               )
             : null,
           type: "folder",
-          title: collection.name,
+          title: collection.name?.trim() ?? "Untitled Collection",
           sourceUrl: collection.url,
           expandable: false, // WE DO NOT LET EXPAND BELOW LEVEL 1 WHEN SELECTING NODES
           permission: matchingCollectionInDb ? "read" : "none",

--- a/connectors/src/connectors/intercom/lib/types.ts
+++ b/connectors/src/connectors/intercom/lib/types.ts
@@ -11,7 +11,7 @@ export type IntercomHelpCenterType = {
 export type IntercomCollectionType = {
   id: string;
   workspace_id: string;
-  name: string;
+  name: string | null;
   url: string | null;
   order: number;
   created_at: number;

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -40,6 +40,8 @@ import {
 
 const turndownService = new TurndownService();
 
+const UNTITLED_COLLECTION_NAME = "Untitled Collection";
+
 /**
  * If our rights were revoked or the help center is not on intercom anymore we delete it
  */
@@ -192,7 +194,7 @@ export async function upsertCollectionWithChildren({
 
   if (collectionOnDb) {
     await collectionOnDb.update({
-      name: collection.name,
+      name: collection.name?.trim() ?? UNTITLED_COLLECTION_NAME,
       description: collection.description,
       parentId: collection.parent_id,
       url: collection.url || fallbackCollectionUrl,
@@ -205,7 +207,7 @@ export async function upsertCollectionWithChildren({
       intercomWorkspaceId: collection.workspace_id,
       helpCenterId: helpCenterId,
       parentId: collection.parent_id,
-      name: collection.name,
+      name: collection.name?.trim() ?? UNTITLED_COLLECTION_NAME,
       description: collection.description,
       url: collection.url || fallbackCollectionUrl,
       permission: "read",
@@ -230,7 +232,7 @@ export async function upsertCollectionWithChildren({
   await upsertDataSourceFolder({
     dataSourceConfig,
     folderId: internalCollectionId,
-    title: collection.name.trim() || "Untitled Collection",
+    title: collection.name?.trim() ?? "UNTITLED_COLLECTION_NAME",
     parents: collectionParents,
     parentId: collectionParents[1] || null,
     mimeType: INTERNAL_MIME_TYPES.INTERCOM.COLLECTION,

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -1,5 +1,6 @@
 import TurndownService from "turndown";
 
+import { UNTITLED_COLLECTION_NAME } from "@connectors/connectors/intercom/lib/help_center_permissions";
 import { getIntercomAccessToken } from "@connectors/connectors/intercom/lib/intercom_access_token";
 import { fetchIntercomCollections } from "@connectors/connectors/intercom/lib/intercom_api";
 import type {
@@ -39,8 +40,6 @@ import {
 } from "@connectors/types";
 
 const turndownService = new TurndownService();
-
-const UNTITLED_COLLECTION_NAME = "Untitled Collection";
 
 /**
  * If our rights were revoked or the help center is not on intercom anymore we delete it


### PR DESCRIPTION
## Description

- Intercom collection can have no name, logs [here](https://app.datadoghq.eu/logs?query=%22intercom_collections.name%20cannot%20be%20null%20%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1765986206746&to_ts=1766159006746&live=true).
- This PR adds a fallback for the name.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
