### PR TITLE
feat(onboarding): allow users to delete triggers on dust global agent

### DIFF
--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -35,7 +35,6 @@ import { AgentTriggersTab } from "@app/components/assistant/details/tabs/AgentTr
 import { RestoreAgentDialog } from "@app/components/assistant/RestoreAgentDialog";
 import { isMCPConfigurationForAgentMemory } from "@app/lib/actions/types/guards";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   AgentConfigurationScope,
   UserType,
@@ -86,10 +85,6 @@ export function AgentDetails({
   owner,
   user,
 }: AgentDetailsProps) {
-  const { featureFlags } = useFeatureFlags({
-    workspaceId: owner.sId,
-  });
-
   const [selectedTab, setSelectedTab] = useState<
     | "info"
     | "insights"
@@ -120,9 +115,7 @@ export function AgentDetails({
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const showEditorsTabs = agentId != null && !isGlobalAgent;
   const showTriggersTabs =
-    agentId != null &&
-    !isGlobalAgent &&
-    featureFlags.includes("hootl_subscriptions");
+    agentId != null && agentId === GLOBAL_AGENTS_SID.DUST;
   const showAgentMemory = !!agentConfiguration?.actions.find(
     isMCPConfigurationForAgentMemory
   );

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -74,6 +74,9 @@ export function AgentTriggersTab({
     }
   };
 
+  // TODO(adrien): for now, we only show the user's triggers.
+  // We might reconsider it, and display a "My triggers" section,
+  // and a "How others automate this" section in the future.
   const filteredTriggers = triggers.filter((t) => t.isEditor);
 
   return (

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -1,24 +1,29 @@
 import {
-  ArrowRightIcon,
   Avatar,
   BellIcon,
   ClockIcon,
-  PencilSquareIcon,
-  XMarkIcon,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  TrashIcon,
 } from "@dust-tt/sparkle";
 import { Button } from "@dust-tt/sparkle";
 import { Spinner } from "@dust-tt/sparkle";
 import cronstrue from "cronstrue";
 import { useState } from "react";
 
+import { useSendNotification } from "@app/hooks/useNotification";
 import {
-  useAddTriggerSubscriber,
   useAgentTriggers,
-  useRemoveTriggerSubscriber,
+  useDeleteTrigger,
 } from "@app/lib/swr/agent_triggers";
-import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
 import type { LightAgentConfigurationType } from "@app/types";
+import type { TriggerType } from "@app/types/assistant/triggers";
 
 interface AgentTriggersTabProps {
   agentConfiguration: LightAgentConfigurationType;
@@ -34,18 +39,40 @@ export function AgentTriggersTab({
     agentConfigurationId: agentConfiguration.sId,
   });
 
-  const [isLoading, setIsLoading] = useState(false);
+  const [triggerToDelete, setTriggerToDelete] = useState<TriggerType | null>(
+    null
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
+  const sendNotification = useSendNotification();
 
-  const subscribe = useAddTriggerSubscriber({
+  const deleteTrigger = useDeleteTrigger({
     workspaceId: owner.sId,
     agentConfigurationId: agentConfiguration.sId,
   });
-  const unsubscribe = useRemoveTriggerSubscriber({
-    workspaceId: owner.sId,
-    agentConfigurationId: agentConfiguration.sId,
-  });
 
-  const editionURL = getAgentBuilderRoute(owner.sId, agentConfiguration.sId);
+  const handleDeleteTrigger = async () => {
+    if (!triggerToDelete) {
+      return;
+    }
+    setIsDeleting(true);
+    const success = await deleteTrigger(triggerToDelete.sId);
+    setIsDeleting(false);
+    setTriggerToDelete(null);
+
+    if (success) {
+      sendNotification({
+        type: "success",
+        title: "Trigger deleted",
+        description: `The trigger "${triggerToDelete.name}" has been deleted.`,
+      });
+    } else {
+      sendNotification({
+        type: "error",
+        title: "Failed to delete trigger",
+        description: "An error occurred while deleting the trigger.",
+      });
+    }
+  };
 
   return (
     <>
@@ -81,43 +108,14 @@ export function AgentTriggersTab({
                     <div className="font-semibold">{trigger.name}</div>
                   </div>
                   <div className="self-end">
-                    {trigger.isEditor ? (
-                      <Button
-                        label="Manage"
-                        icon={PencilSquareIcon}
-                        href={editionURL}
-                        variant="outline"
-                        size="sm"
-                      />
-                    ) : trigger.isSubscriber ? (
-                      <Button
-                        label="Unsubscribe"
-                        icon={XMarkIcon}
-                        variant="outline"
-                        size="sm"
-                        isLoading={isLoading}
-                        disabled={isLoading}
-                        onClick={async () => {
-                          setIsLoading(true);
-                          await unsubscribe(trigger.sId);
-                          setIsLoading(false);
-                        }}
-                      />
-                    ) : (
-                      <Button
-                        label="Subscribe"
-                        icon={ArrowRightIcon}
-                        variant="outline"
-                        size="sm"
-                        isLoading={isLoading}
-                        disabled={isLoading}
-                        onClick={async () => {
-                          setIsLoading(true);
-                          await subscribe(trigger.sId);
-                          setIsLoading(false);
-                        }}
-                      />
-                    )}
+                    <Button
+                      label="Delete"
+                      disabled={!trigger.isEditor}
+                      icon={TrashIcon}
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setTriggerToDelete(trigger)}
+                    />
                   </div>
                 </div>
                 {trigger.kind === "schedule" && (
@@ -130,6 +128,43 @@ export function AgentTriggersTab({
           ))}
         </div>
       )}
+
+      <Dialog
+        open={triggerToDelete !== null}
+        onOpenChange={(open) => !open && setTriggerToDelete(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete trigger</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete the trigger "
+              {triggerToDelete?.name}"?
+            </DialogDescription>
+          </DialogHeader>
+          {isDeleting ? (
+            <div className="flex justify-center py-8">
+              <Spinner variant="dark" size="md" />
+            </div>
+          ) : (
+            <>
+              <DialogContainer>
+                <b>This action cannot be undone.</b>
+              </DialogContainer>
+              <DialogFooter
+                leftButtonProps={{
+                  label: "Cancel",
+                  variant: "outline",
+                }}
+                rightButtonProps={{
+                  label: "Delete",
+                  variant: "warning",
+                  onClick: handleDeleteTrigger,
+                }}
+              />
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -74,6 +74,8 @@ export function AgentTriggersTab({
     }
   };
 
+  const filteredTriggers = triggers.filter((t) => t.isEditor);
+
   return (
     <>
       {isTriggersLoading ? (
@@ -82,12 +84,12 @@ export function AgentTriggersTab({
         </div>
       ) : (
         <div className="flex w-full flex-col gap-2">
-          {triggers.length === 0 && (
+          {filteredTriggers.length === 0 && (
             <div className="text-muted-foreground">
-              No triggers setup for this agent, yet.
+              You have no triggers setup for this agent, yet.
             </div>
           )}
-          {triggers.map((trigger) => (
+          {filteredTriggers.map((trigger) => (
             <div
               key={trigger.sId}
               className="flex w-full flex-row items-center justify-between border-b pb-2"

--- a/front/components/me/ProfileTriggersTab.tsx
+++ b/front/components/me/ProfileTriggersTab.tsx
@@ -17,6 +17,7 @@ import { useUserTriggers } from "@app/lib/swr/agent_triggers";
 import { classNames } from "@app/lib/utils";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
+import { isGlobalAgentId } from "@app/types";
 
 interface ProfileTriggersTabProps {
   owner: WorkspaceType;
@@ -111,19 +112,20 @@ export function ProfileTriggersTab({ owner }: ProfileTriggersTabProps) {
       {
         header: "Action",
         accessorKey: "actions",
-        cell: ({ row }) => (
-          <DataTable.CellContent>
-            <div className="flex justify-end">
-              <Button
-                label="Manage"
-                href={getEditionURL(row.original.agentConfigurationId)}
-                variant="outline"
-                size="sm"
-                icon={PencilSquareIcon}
-              />
-            </div>
-          </DataTable.CellContent>
-        ),
+        cell: ({ row }) =>
+          !isGlobalAgentId(row.original.agentConfigurationId) && (
+            <DataTable.CellContent>
+              <div className="flex justify-end">
+                <Button
+                  label="Manage"
+                  href={getEditionURL(row.original.agentConfigurationId)}
+                  variant="outline"
+                  size="sm"
+                  icon={PencilSquareIcon}
+                />
+              </div>
+            </DataTable.CellContent>
+          ),
         meta: {
           className: "w-32",
         },

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -78,6 +78,50 @@ export function useUserTriggers({
   };
 }
 
+export function useDeleteTrigger({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}) {
+  const { mutateTriggers } = useAgentTriggers({
+    workspaceId,
+    agentConfigurationId,
+    disabled: true,
+  });
+
+  const deleteTrigger = useCallback(
+    async (triggerId: string): Promise<boolean> => {
+      try {
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/triggers`,
+          {
+            method: "DELETE",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ triggerIds: [triggerId] }),
+          }
+        );
+
+        if (response.ok) {
+          void mutateTriggers();
+          return true;
+        } else {
+          return false;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (error) {
+        return false;
+      }
+    },
+    [workspaceId, agentConfigurationId, mutateTriggers]
+  );
+
+  return deleteTrigger;
+}
+
 export function useTextAsCronRule({
   workspace,
 }: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -122,16 +122,6 @@ async function handler(
     }
 
     case "DELETE": {
-      if (!agentConfiguration.canEdit) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message: "Only editors can delete triggers for this agent.",
-          },
-        });
-      }
-
       const deleteDecoded = DeleteTriggersRequestBodyCodec.decode(req.body);
       if (isLeft(deleteDecoded)) {
         const pathError = reporter.formatValidationErrors(deleteDecoded.left);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

With the new onboarding convo, users can set up triggers on dust via an mcp server. Though, there's no UI to list them or remove them because of the Agent Builder not existing in Dust.

While we wait to have a full fledged triggers management interface (https://www.notion.so/dust-tt/Design-Doc-Triggers-Management-and-Subscription-29a28599d94180deb9c8f7a1142d37c3?d=2ce28599d94180da9b4a001c917bb088#2b628599d94180c6ad2cc207b0440f69 ^^), we add a tab for this specific use-case in the agent details, re-using previous code that was behind a feature flag, for the trigger subscription.

<img width="1624" height="1060" alt="Capture d’écran 2025-12-19 à 17 15 05" src="https://github.com/user-attachments/assets/73caab82-6cef-4bf8-9990-ece3c70edf5c" />

Also prevent from accessing Dust's AB from profile page.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand. You can remove your triggers, you can't remove other people Dust's triggers.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.