### PR TITLE
[Front] feat(agent-builder): add tools & filters to capabilities selection page

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
@@ -1,74 +1,154 @@
-import { SearchInput, Spinner } from "@dust-tt/sparkle";
-import React from "react";
+import { Button, SearchInput, Spinner } from "@dust-tt/sparkle";
+import React, { useMemo, useState } from "react";
 
 import { SkillCard } from "@app/components/agent_builder/capabilities/capabilities_sheet/SkillCard";
-import type { PageContentProps } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
+import type { CapabilityFilterType } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
+import { MCPServerCard } from "@app/components/agent_builder/capabilities/mcp/MCPServerSelectionPage";
+import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { LightWorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-type SelectionPageProps = PageContentProps & {
+type CapabilitiesSelectionPageProps = {
+  owner: LightWorkspaceType;
   handleSkillToggle: (skill: SkillType) => void;
+  handleSkillInfoClick: (skill: SkillType) => void;
   filteredSkills: SkillType[];
-  isSkillsLoading: boolean;
   searchQuery: string;
   selectedSkillIds: Set<string>;
   setSearchQuery: (query: string) => void;
+  isCapabilitiesLoading: boolean;
+  filteredMCPServerViews: {
+    topViews: MCPServerViewTypeWithLabel[];
+    nonTopViews: MCPServerViewTypeWithLabel[];
+  };
+  selectedMCPServerViewIds: Set<string>;
+  handleToolToggle: (view: MCPServerViewTypeWithLabel) => void;
+  handleToolInfoClick: (view: MCPServerViewTypeWithLabel) => void;
 };
 
-export function SelectionPageContent({
-  onModeChange,
+export function CapabilitiesSelectionPageContent({
+  owner,
   handleSkillToggle,
+  handleSkillInfoClick,
   filteredSkills,
-  isSkillsLoading,
   searchQuery,
   selectedSkillIds,
   setSearchQuery,
-}: SelectionPageProps) {
+  isCapabilitiesLoading,
+  filteredMCPServerViews,
+  selectedMCPServerViewIds,
+  handleToolToggle,
+  handleToolInfoClick,
+}: CapabilitiesSelectionPageProps) {
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+
+  const [filter, setFilter] = useState<CapabilityFilterType>("all");
+
+  const sortedMCPServerViews = useMemo(
+    () => [
+      // Show top views first
+      ...filteredMCPServerViews.topViews,
+      ...filteredMCPServerViews.nonTopViews,
+    ],
+    [filteredMCPServerViews.topViews, filteredMCPServerViews.nonTopViews]
+  );
+
+  const showSkillsSection = filter === "all" || filter === "skills";
+  const showToolsSection = filter === "all" || filter === "tools";
+
+  const hasSkills = filteredSkills.length > 0;
+  const hasTools = sortedMCPServerViews.length > 0;
+
+  const hasAnyResults =
+    (showSkillsSection && hasSkills) || (showToolsSection && hasTools);
+
   return (
     <div className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        <Button
+          label="All"
+          variant={filter === "all" ? "primary" : "outline"}
+          size="sm"
+          onClick={() => setFilter("all")}
+        />
+        <Button
+          label="Skills"
+          variant={filter === "skills" ? "primary" : "outline"}
+          size="sm"
+          onClick={() => setFilter("skills")}
+        />
+        <Button
+          label="Tools"
+          variant={filter === "tools" ? "primary" : "outline"}
+          size="sm"
+          onClick={() => setFilter("tools")}
+        />
+      </div>
+
       <SearchInput
-        placeholder="Search skills..."
+        placeholder="Search capabilities..."
         value={searchQuery}
         onChange={setSearchQuery}
-        name="skill-search"
+        name="capability-search"
       />
 
-      {isSkillsLoading ? (
+      {isCapabilitiesLoading ? (
         <div className="flex h-40 items-center justify-center">
           <Spinner />
         </div>
-      ) : filteredSkills.length === 0 ? (
+      ) : !hasAnyResults ? (
         <div className="flex flex-1 items-center justify-center py-12">
           <div className="px-4 text-center">
             <div className="mb-2 text-lg font-medium text-foreground dark:text-foreground-night">
               {searchQuery
-                ? "No skills match your search"
-                : "No skills available"}
+                ? "No capability match your search"
+                : "No capabilities available"}
             </div>
             <div className="max-w-sm text-muted-foreground dark:text-muted-foreground-night">
               {searchQuery
                 ? "Try a different search term."
-                : "Create a skill to add custom capabilities to your agents."}
+                : "Add tools or create skills to enhance your agents."}
             </div>
           </div>
         </div>
       ) : (
-        <div className="grid grid-cols-2 gap-3">
-          {filteredSkills.map((skill) => (
-            <SkillCard
-              key={skill.sId}
-              skill={skill}
-              isSelected={selectedSkillIds.has(skill.sId)}
-              onClick={() => handleSkillToggle(skill)}
-              onMoreInfoClick={() => {
-                onModeChange({
-                  pageId: "skill_info",
-                  capability: skill,
-                  hasPreviousPage: true,
-                });
-              }}
-            />
-          ))}
-        </div>
+        <>
+          {showSkillsSection && hasSkills && (
+            <>
+              <span className="text-lg font-semibold">Skills</span>
+              <div className="grid grid-cols-2 gap-3">
+                {filteredSkills.map((skill) => (
+                  <SkillCard
+                    key={skill.sId}
+                    skill={skill}
+                    isSelected={selectedSkillIds.has(skill.sId)}
+                    onClick={() => handleSkillToggle(skill)}
+                    onMoreInfoClick={() => handleSkillInfoClick(skill)}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+
+          {showToolsSection && hasTools && (
+            <>
+              <span className="text-lg font-semibold">Tools</span>
+              <div className="grid grid-cols-2 gap-3">
+                {sortedMCPServerViews.map((view) => (
+                  <MCPServerCard
+                    key={view.id}
+                    view={view}
+                    isSelected={selectedMCPServerViewIds.has(view.sId)}
+                    onClick={() => handleToolToggle(view)}
+                    onToolInfoClick={() => handleToolInfoClick(view)}
+                    featureFlags={featureFlags}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </>
       )}
     </div>
   );

--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSheet.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSheet.tsx
@@ -1,27 +1,17 @@
 import { MultiPageSheet, MultiPageSheetContent } from "@dust-tt/sparkle";
-import React, { useCallback, useState } from "react";
+import React from "react";
 
-import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
-import type { CapabilitiesSheetMode } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
-import { getPageAndFooter } from "@app/components/agent_builder/capabilities/capabilities_sheet/utils";
-import type { UserType, WorkspaceType } from "@app/types";
+import type {
+  CapabilitiesSheetContentProps,
+  CapabilitiesSheetMode,
+} from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
+import { useCapabilitiesPageAndFooter } from "@app/components/agent_builder/capabilities/capabilities_sheet/utils";
 
-interface CapabilitiesSheetProps {
-  mode: CapabilitiesSheetMode | null;
-  onClose: () => void;
-  onSave: (
-    skills: AgentBuilderSkillsType[],
-    additionalSpaces: string[]
-  ) => void;
-  onModeChange: (mode: CapabilitiesSheetMode | null) => void;
-  owner: WorkspaceType;
-  user: UserType;
-  initialAdditionalSpaces: string[];
-  alreadyRequestedSpaceIds: Set<string>;
-  alreadyAddedSkillIds: Set<string>;
-}
-
-export function CapabilitiesSheet(props: CapabilitiesSheetProps) {
+export function CapabilitiesSheet(
+  props: Omit<CapabilitiesSheetContentProps, "mode"> & {
+    mode: CapabilitiesSheetMode | null;
+  }
+) {
   const { mode, onClose } = props;
 
   return (
@@ -34,48 +24,13 @@ export function CapabilitiesSheet(props: CapabilitiesSheetProps) {
   );
 }
 
-function CapabilitiesSheetContent({
-  mode,
-  onClose,
-  onSave,
-  onModeChange,
-  owner,
-  user,
-  initialAdditionalSpaces,
-  alreadyRequestedSpaceIds,
-  alreadyAddedSkillIds,
-}: CapabilitiesSheetProps & { mode: CapabilitiesSheetMode }) {
-  const [localSelectedSkills, setLocalSelectedSkills] = useState<
-    AgentBuilderSkillsType[]
-  >([]);
-  const [localAdditionalSpaces, setLocalAdditionalSpaces] = useState<string[]>(
-    initialAdditionalSpaces
-  );
-
-  const handleSave = useCallback(() => {
-    onSave(localSelectedSkills, localAdditionalSpaces);
-    onClose();
-  }, [localSelectedSkills, localAdditionalSpaces, onSave, onClose]);
-
-  const { page, leftButton, rightButton } = getPageAndFooter({
-    mode,
-    onModeChange,
-    onClose,
-    handleSave,
-    owner,
-    user,
-    alreadyRequestedSpaceIds,
-    alreadyAddedSkillIds,
-    localSelectedSkills,
-    setLocalSelectedSkills,
-    localAdditionalSpaces,
-    setLocalAdditionalSpaces,
-  });
+function CapabilitiesSheetContent(props: CapabilitiesSheetContentProps) {
+  const { page, leftButton, rightButton } = useCapabilitiesPageAndFooter(props);
 
   return (
     <MultiPageSheetContent
       pages={[page]}
-      currentPageId={mode.pageId}
+      currentPageId={props.mode.pageId}
       onPageChange={() => {}}
       size="xl"
       addFooterSeparator

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
@@ -1,5 +1,3 @@
-import type React from "react";
-
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
@@ -67,19 +65,19 @@ export type CapabilitiesSheetMode =
   | ToolConfigurationMode
   | ToolEditMode;
 
-export type PageContentProps = {
+export type CapabilitiesSheetContentProps = {
   mode: CapabilitiesSheetMode;
   onModeChange: (mode: CapabilitiesSheetMode | null) => void;
   onClose: () => void;
-  handleSave: () => void;
+  onSave: (data: {
+    skills: AgentBuilderSkillsType[];
+    additionalSpaces: string[];
+    tools: SelectedTool[];
+  }) => void;
   owner: WorkspaceType;
   user: UserType;
+  initialAdditionalSpaces: string[];
   alreadyRequestedSpaceIds: Set<string>;
   alreadyAddedSkillIds: Set<string>;
-  localSelectedSkills: AgentBuilderSkillsType[];
-  setLocalSelectedSkills: React.Dispatch<
-    React.SetStateAction<AgentBuilderSkillsType[]>
-  >;
-  localAdditionalSpaces: string[];
-  setLocalAdditionalSpaces: React.Dispatch<React.SetStateAction<string[]>>;
+  selectedActions: BuilderAction[];
 };

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -24,7 +24,7 @@ export interface MCPServerCardProps {
   featureFlags?: WhitelistableFeature[];
 }
 
-function MCPServerCard({
+export function MCPServerCard({
   view,
   isSelected,
   onClick,


### PR DESCRIPTION
Step 4 of implementing https://github.com/dust-tt/tasks/issues/5565

Splitting https://github.com/dust-tt/dust/pull/19233/changes in X PRs

## Description

This one mainly focuses on the selection page, leaving tool info & config for later PRs :
- Add tools to agent builder capabilities selection page
- Wire form logic with the useToolSelection hook
- Filter buttons (All/Skills/Tools) to toggle between capability types

## Tests

Manual testing in agent builder flow

https://github.com/user-attachments/assets/025313f2-1c6a-4727-bebf-16ed9db5bf90

## Risk

Low.

## Deploy Plan

Deploy front.
