### PR TITLE
[connectors] fix: Add md5 hash of url in webcrawler

### DIFF
--- a/connectors/migrations/db/migration_110.sql
+++ b/connectors/migrations/db/migration_110.sql
@@ -1,0 +1,14 @@
+-- Migration created on Dec 19, 2025
+-- Replace URL-based indexes with MD5(url)-based indexes to handle long URLs
+
+-- webcrawler_pages: create new MD5 index, drop old index
+CREATE UNIQUE INDEX CONCURRENTLY "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_id"
+  ON "webcrawler_pages" (md5("url"), "connectorId", "webcrawlerConfigurationId");
+
+DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_pages_url_connector_id_webcrawler_configuration_id";
+
+-- webcrawler_folders: create new MD5 index, drop old index
+CREATE UNIQUE INDEX CONCURRENTLY "webcrawler_folders_url_md5_connector_id_webcrawler_configuration_id"
+  ON "webcrawler_folders" (md5("url"), "connectorId", "webcrawlerConfigurationId");
+
+DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_folders_url_connector_id_webcrawler_configuration_id";

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -174,6 +174,7 @@ WebCrawlerFolderModel.init(
   {
     sequelize: connectorsSequelize,
     indexes: [
+      // Index uses md5(url) in the database (see migration_110.sql)
       {
         unique: true,
         fields: ["url", "connectorId", "webcrawlerConfigurationId"],
@@ -243,6 +244,7 @@ WebCrawlerPageModel.init(
   {
     sequelize: connectorsSequelize,
     indexes: [
+      // Index uses md5(url) in the database (see migration_110.sql)
       {
         unique: true,
         fields: ["url", "connectorId", "webcrawlerConfigurationId"],


### PR DESCRIPTION
## Description

Hash md5 of url to avoid btree index size issues in web_crawler connector
We have a bunch of very long url blocking some connectors right now because of it.

## Tests

N/A

## Risk

Low

## Deploy Plan

- [ ] Run migration