### PR TITLE
[connectors] fix: Add urlMd5 in webcrawler column to make upsert work

### DIFF
--- a/connectors/migrations/db/migration_111.sql
+++ b/connectors/migrations/db/migration_111.sql
@@ -1,0 +1,10 @@
+-- Migration created on Dec 19, 2025
+-- Drop indexes from migration_110, add urlMd5 columns (nullable for now)
+
+-- Drop the md5-based indexes created in migration_110
+DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_id";
+DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_folders_url_md5_connector_id_webcrawler_configuration_id";
+
+-- Add urlMd5 columns (nullable)
+ALTER TABLE "webcrawler_pages" ADD COLUMN "urlMd5" VARCHAR(32);
+ALTER TABLE "webcrawler_folders" ADD COLUMN "urlMd5" VARCHAR(32);

--- a/connectors/migrations/db/migration_112.sql
+++ b/connectors/migrations/db/migration_112.sql
@@ -1,0 +1,24 @@
+-- Migration created on Dec 19, 2025
+-- Backfill urlMd5, add constraints, set NOT NULL
+
+-- Backfill urlMd5 for webcrawler_pages
+UPDATE "webcrawler_pages" SET "urlMd5" = md5("url") WHERE "urlMd5" IS NULL;
+ALTER TABLE "webcrawler_pages" ALTER COLUMN "urlMd5" SET NOT NULL;
+
+-- Add new constraint, drop old constraint for webcrawler_pages
+ALTER TABLE "webcrawler_pages"
+  ADD CONSTRAINT "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_id"
+  UNIQUE ("urlMd5", "connectorId", "webcrawlerConfigurationId");
+
+ALTER TABLE "webcrawler_pages" DROP CONSTRAINT IF EXISTS "webcrawler_pages_url_connector_id_webcrawler_configuration_id";
+
+-- Backfill urlMd5 for webcrawler_folders
+UPDATE "webcrawler_folders" SET "urlMd5" = md5("url") WHERE "urlMd5" IS NULL;
+ALTER TABLE "webcrawler_folders" ALTER COLUMN "urlMd5" SET NOT NULL;
+
+-- Add new constraint, drop old constraint for webcrawler_folders
+ALTER TABLE "webcrawler_folders"
+  ADD CONSTRAINT "webcrawler_folders_url_md5_connector_id_webcrawler_configuration_id"
+  UNIQUE ("urlMd5", "connectorId", "webcrawlerConfigurationId");
+
+ALTER TABLE "webcrawler_folders" DROP CONSTRAINT IF EXISTS "webcrawler_folders_url_connector_id_webcrawler_configuration_id";

--- a/connectors/scripts/launch_firecrawl_crawl_page_workflow.ts
+++ b/connectors/scripts/launch_firecrawl_crawl_page_workflow.ts
@@ -1,0 +1,35 @@
+import { launchFirecrawlCrawlPageWorkflow } from "@connectors/connectors/webcrawler/temporal/client";
+
+import { makeScript } from "./helpers";
+
+makeScript(
+  {
+    connectorId: {
+      type: "number",
+      demandOption: true,
+      description: "Connector ID",
+    },
+    crawlId: {
+      type: "string",
+      demandOption: true,
+      description: "Crawl ID from Firecrawl",
+    },
+    scrapeId: {
+      type: "string",
+      demandOption: true,
+      description: "Scrape ID from Firecrawl",
+    },
+  },
+  async (args, logger) => {
+    const result = await launchFirecrawlCrawlPageWorkflow(
+      args.connectorId,
+      args.crawlId,
+      args.scrapeId
+    );
+    if (result.isErr()) {
+      logger.error({ error: result.error }, "Failed to launch workflow");
+      throw result.error;
+    }
+    logger.info({ workflowId: result.value }, "Workflow launched");
+  }
+);

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -7,7 +7,7 @@ import type {
 import type FirecrawlApp from "@mendable/firecrawl-js";
 import { FirecrawlError } from "@mendable/firecrawl-js";
 import { Context } from "@temporalio/activity";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import path from "path";
 import type { Logger } from "pino";
 import { Op } from "sequelize";
@@ -567,6 +567,7 @@ export async function firecrawlCrawlPage(
       : getFolderForUrl(folder);
     const [webCrawlerFolder] = await WebCrawlerFolderModel.upsert({
       url: folder,
+      urlMd5: createHash("md5").update(folder).digest("hex"),
       parentUrl: logicalParent,
       connectorId: connector.id,
       webcrawlerConfigurationId: webCrawlerConfig.id,
@@ -599,6 +600,7 @@ export async function firecrawlCrawlPage(
 
   await WebCrawlerPageModel.upsert({
     url: sourceUrl,
+    urlMd5: createHash("md5").update(sourceUrl).digest("hex"),
     parentUrl: isTopFolder(sourceUrl) ? null : getFolderForUrl(sourceUrl),
     connectorId: connector.id,
     webcrawlerConfigurationId: webCrawlerConfig.id,

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -132,6 +132,7 @@ export class WebCrawlerFolderModel extends ConnectorBaseModel<WebCrawlerFolderMo
   declare updatedAt: CreationOptional<Date>;
   declare parentUrl: string | null;
   declare url: string;
+  declare urlMd5: string;
   // Folders are not upserted to the data source but their ids are
   // used as parent to WebCrawlerPage.
   declare internalId: string;
@@ -157,6 +158,10 @@ WebCrawlerFolderModel.init(
       type: DataTypes.TEXT,
       allowNull: false,
     },
+    urlMd5: {
+      type: DataTypes.STRING(32),
+      allowNull: false,
+    },
     parentUrl: {
       type: DataTypes.TEXT,
       allowNull: true,
@@ -177,7 +182,7 @@ WebCrawlerFolderModel.init(
       // Index uses md5(url) in the database (see migration_110.sql)
       {
         unique: true,
-        fields: ["url", "connectorId", "webcrawlerConfigurationId"],
+        fields: ["urlMd5", "connectorId", "webcrawlerConfigurationId"],
       },
       {
         unique: true,
@@ -195,6 +200,7 @@ export class WebCrawlerPageModel extends ConnectorBaseModel<WebCrawlerPageModel>
   declare title: string | null;
   declare parentUrl: string | null;
   declare url: string;
+  declare urlMd5: string;
   declare documentId: string;
   declare depth: number;
   declare lastSeenAt: Date;
@@ -217,6 +223,10 @@ WebCrawlerPageModel.init(
     },
     url: {
       type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    urlMd5: {
+      type: DataTypes.STRING(32),
       allowNull: false,
     },
     title: {
@@ -247,7 +257,7 @@ WebCrawlerPageModel.init(
       // Index uses md5(url) in the database (see migration_110.sql)
       {
         unique: true,
-        fields: ["url", "connectorId", "webcrawlerConfigurationId"],
+        fields: ["urlMd5", "connectorId", "webcrawlerConfigurationId"],
       },
       {
         unique: true,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/dust/pull/19320 that introduced an index based on a md5(hash) at index read/write, however that type of index cannot be used as a constraint, which a sequelize `upsert` implicitly does (actually 2 places found) 
This PR introduces a new column + backfill to compute md5 on runtime, and use a plain varchar for index.

## Tests

Added a small script to launch a workflow that reproduces the bug in production

## Risk

Low
Blast radius: webcrawler connector temporal workflows

## Deploy Plan

- [ ] run migration_111 and 112
- [ ] deploy connectors