### PR TITLE
[front] enh(skills): add icons for global skills

### DIFF
--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -11,4 +11,5 @@ export const framesSkill = {
   instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
   internalMCPServerNames: ["interactive_content"],
   version: 1,
+  icon: "ActionFrameIcon",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/go_deep.ts
+++ b/front/lib/resources/skill/global/go_deep.ts
@@ -19,4 +19,5 @@ export const goDeepSkill = {
   instructions: DEEP_DIVE_SERVER_INSTRUCTIONS,
   internalMCPServerNames: ["deep_dive"],
   version: 1,
+  icon: "ActionAtomIcon",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -12,7 +12,7 @@ export interface GlobalSkillDefinition {
   readonly name: string;
   readonly sId: string;
   readonly version: number;
-  readonly icon?: string;
+  readonly icon: string;
 }
 
 // Helper function that enforces unique sIds.

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -714,7 +714,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         status: "active",
         updatedAt: new Date(),
         workspaceId: auth.getNonNullableWorkspace().id,
-        icon: null,
+        icon: def.icon,
         extendedSkillId: null,
       },
       { globalSId: def.sId, mcpServerConfigurations }


### PR DESCRIPTION
## Description

- This PR adds icons to global skills and makes it mandatory to define one.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
