### PR TITLE
[front] enh(skills): improve typing for conversation skills + cleanup

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -186,7 +186,6 @@ export const InputBar = React.memo(function InputBar({
   const { addSkill, deleteSkill } = useAddDeleteConversationSkill({
     conversationId,
     workspaceId: owner.sId,
-    agentConfigurationId: null,
   });
 
   const handleMCPServerViewSelect = (serverView: MCPServerViewType) => {

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -49,7 +49,6 @@ function createServer(
 
         const enableResult = await skill.enableForAgent(auth, {
           agentConfiguration,
-          agentMessage,
           conversation,
         });
 

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -47,7 +47,7 @@ function createServer(
           );
         }
 
-        const enableResult = await skill.enableForAgentMessage(auth, {
+        const enableResult = await skill.enableForAgent(auth, {
           agentConfiguration,
           agentMessage,
           conversation,

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -35,7 +35,7 @@ function createServer(
           return new Err(new MCPError("No conversation context available"));
         }
 
-        const { conversation, agentConfiguration, agentMessage } =
+        const { conversation, agentConfiguration } =
           agentLoopContext.runContext;
 
         const skill = await SkillResource.fetchActiveByName(auth, skillName);

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -47,11 +47,10 @@ function createServer(
           );
         }
 
-        const enableResult = await skill.enableForMessage(auth, {
+        const enableResult = await skill.enableForAgentMessage(auth, {
           agentConfiguration,
           agentMessage,
           conversation,
-          source: "agent_enabled",
         });
 
         if (enableResult.isErr()) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -40,7 +40,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   AgentConfigurationType,
-  AgentMessageType,
   AgentsUsageType,
   ConversationType,
   LightAgentConfigurationType,
@@ -1028,15 +1027,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
-  async enableForAgentMessage(
+  async enableForAgent(
     auth: Authenticator,
     {
       agentConfiguration,
-      agentMessage,
       conversation,
     }: {
       agentConfiguration: AgentConfigurationType;
-      agentMessage: AgentMessageType;
       conversation: ConversationType;
     }
   ): Promise<Result<void, Error>> {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -79,6 +79,19 @@ type SkillVersionCreationAttributes =
     mcpServerConfigurationIds: number[];
   };
 
+type ConversationSkillCreationAttributes =
+  CreationAttributes<ConversationSkillModel> &
+    (
+      | {
+          source: "conversation";
+          agentConfigurationId: null;
+        }
+      | {
+          source: "agent_enabled";
+          agentConfigurationId: string;
+        }
+    );
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -606,7 +619,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         globalSkillId: this.globalSId ?? null,
         source: "conversation",
         addedByUserId: user.id,
-      });
+      } satisfies ConversationSkillCreationAttributes);
       return new Ok(undefined);
     }
 
@@ -1047,14 +1060,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       );
     }
 
-    const conversationSkillBlob = {
+    const conversationSkillBlob: ConversationSkillCreationAttributes = {
       workspaceId: workspace.id,
       customSkillId: this.isGlobal ? null : this.id,
       globalSkillId: this.isGlobal ? this.globalSId : null,
-      agentMessageId: agentMessage.agentMessageId,
       conversationId: conversation.id,
-      source: "agent_enabled" as const,
       addedByUserId: null,
+      source: "agent_enabled",
+      agentConfigurationId: agentConfiguration.sId,
     };
 
     await ConversationSkillModel.create(conversationSkillBlob);

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -463,11 +463,9 @@ export function useAddDeleteConversationTool({
 export function useAddDeleteConversationSkill({
   conversationId,
   workspaceId,
-  agentConfigurationId,
 }: {
   conversationId: string | null;
   workspaceId: string;
-  agentConfigurationId: string | null;
 }) {
   const sendNotification = useSendNotification();
   const addSkill = useCallback(
@@ -487,7 +485,6 @@ export function useAddDeleteConversationSkill({
             body: JSON.stringify({
               action: "add",
               skillId,
-              agentConfigurationId,
             } satisfies ConversationSkillActionRequest),
           }
         );
@@ -516,7 +513,7 @@ export function useAddDeleteConversationSkill({
         return false;
       }
     },
-    [conversationId, workspaceId, agentConfigurationId, sendNotification]
+    [conversationId, workspaceId, sendNotification]
   );
 
   const deleteSkill = useCallback(
@@ -536,7 +533,6 @@ export function useAddDeleteConversationSkill({
             body: JSON.stringify({
               action: "delete",
               skillId,
-              agentConfigurationId,
             } satisfies ConversationSkillActionRequest),
           }
         );
@@ -566,7 +562,7 @@ export function useAddDeleteConversationSkill({
         return false;
       }
     },
-    [conversationId, workspaceId, agentConfigurationId, sendNotification]
+    [conversationId, workspaceId, sendNotification]
   );
 
   return { addSkill, deleteSkill };

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -225,7 +225,6 @@ async function handler(
             conversationId: conversation.id,
             skills,
             enabled: true,
-            agentConfigurationId: null, // JIT skills apply to all agents in conversation
           });
 
           if (r.isErr()) {


### PR DESCRIPTION
## Description

- The endpoint to upsert a conversation skill currently allows passing an `agentConfigurationId`.
- This PR prevents that to enforce that conversation skills apply to all agents in a conversation (`origin === "conversation" <=> "agentConfigurationId" === null`).
- The creation attributes are now a discrimative union.
- This PR also cleans up the skill enablement.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
