### PR TITLE
[front] enh(`mcp_actions`): expose tool names to front end

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -56,7 +56,6 @@ import {
   getInternalMCPServerIconByName,
   INCLUDE_TOOL_NAME,
   INTERNAL_SERVERS_WITH_WEBSEARCH,
-  isInternalMCPServerOfName,
   PROCESS_TOOL_NAME,
   SEARCH_TOOL_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
@@ -98,11 +97,11 @@ export function MCPActionDetails({
   messageStatus,
 }: MCPActionDetailsProps) {
   const {
-    functionCallName,
     params,
     status,
     output: baseOutput,
-    mcpServerId,
+    internalMCPServerName,
+    toolName,
   } = action;
 
   const [output, setOutput] = useState(baseOutput);
@@ -124,9 +123,6 @@ export function MCPActionDetails({
     }
   }, [status, baseOutput]);
 
-  const parts = functionCallName ? functionCallName.split("__") : [];
-  const toolName = parts[parts.length - 1];
-
   const toolOutputDetailsProps: ToolExecutionDetailsProps = {
     lastNotification,
     messageStatus,
@@ -137,8 +133,8 @@ export function MCPActionDetails({
   };
 
   if (
-    isInternalMCPServerOfName(mcpServerId, "search") ||
-    isInternalMCPServerOfName(mcpServerId, "data_sources_file_system")
+    internalMCPServerName === "search" ||
+    internalMCPServerName === "data_sources_file_system"
   ) {
     if (toolName === SEARCH_TOOL_NAME) {
       return (
@@ -192,7 +188,7 @@ export function MCPActionDetails({
     }
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, "include_data")) {
+  if (internalMCPServerName === "include_data") {
     if (toolName === INCLUDE_TOOL_NAME) {
       return (
         <SearchResultDetails
@@ -211,8 +207,8 @@ export function MCPActionDetails({
   }
 
   if (
-    INTERNAL_SERVERS_WITH_WEBSEARCH.some((n) =>
-      isInternalMCPServerOfName(mcpServerId, n)
+    INTERNAL_SERVERS_WITH_WEBSEARCH.some(
+      (name) => internalMCPServerName === name
     )
   ) {
     if (toolName === WEBSEARCH_TOOL_NAME) {
@@ -233,7 +229,7 @@ export function MCPActionDetails({
     }
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, TABLE_QUERY_V2_SERVER_NAME)) {
+  if (internalMCPServerName === TABLE_QUERY_V2_SERVER_NAME) {
     if (toolName === GET_DATABASE_SCHEMA_TOOL_NAME) {
       return <MCPGetDatabaseSchemaActionDetails {...toolOutputDetailsProps} />;
     }
@@ -242,21 +238,21 @@ export function MCPActionDetails({
     }
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, "extract_data")) {
+  if (internalMCPServerName === "extract_data") {
     if (toolName === PROCESS_TOOL_NAME) {
       return <MCPExtractActionDetails {...toolOutputDetailsProps} />;
     }
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, "run_agent")) {
+  if (internalMCPServerName === "run_agent") {
     return <MCPRunAgentActionDetails {...toolOutputDetailsProps} />;
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, "deep_dive")) {
+  if (internalMCPServerName === "deep_dive") {
     return <MCPDeepDiveActionDetails {...toolOutputDetailsProps} />;
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, "agent_memory")) {
+  if (internalMCPServerName === "agent_memory") {
     if (toolName === "retrieve") {
       return (
         <MCPAgentMemoryRetrieveActionDetails {...toolOutputDetailsProps} />
@@ -277,18 +273,18 @@ export function MCPActionDetails({
       );
     }
   }
-  if (isInternalMCPServerOfName(mcpServerId, "toolsets")) {
+  if (internalMCPServerName === "toolsets") {
     if (toolName === "enable") {
       return <MCPToolsetsEnableActionDetails {...toolOutputDetailsProps} />;
     }
     return <MCPListToolsActionDetails {...toolOutputDetailsProps} />;
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, "agent_management")) {
+  if (internalMCPServerName === "agent_management") {
     return <MCPAgentManagementActionDetails {...toolOutputDetailsProps} />;
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, "data_warehouses")) {
+  if (internalMCPServerName === "data_warehouses") {
     if (
       [DATA_WAREHOUSES_LIST_TOOL_NAME, DATA_WAREHOUSES_FIND_TOOL_NAME].includes(
         toolName
@@ -304,7 +300,7 @@ export function MCPActionDetails({
     }
   }
 
-  if (isInternalMCPServerOfName(mcpServerId, "conversation_files")) {
+  if (internalMCPServerName === "conversation_files") {
     if (toolName === DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME) {
       return <MCPConversationCatFileDetails {...toolOutputDetailsProps} />;
     }

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -57,7 +57,7 @@ export function getCitationsFromActions(
     AgentMCPActionWithOutputType,
     // TODO(2025-09-22 aubin): add proper typing for the statuses in the SDK (not really needed but
     //  nice to have IMHO).
-    "internalMCPServerName" | "status"
+    "internalMCPServerName" | "toolName" | "status"
   >[]
 ): Record<string, CitationType> {
   const searchResultsWithDocs = removeNulls(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -640,6 +640,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       functionCallName: this.functionCallName,
       functionCallId: this.stepContent.value.value.id,
       internalMCPServerName: this.metadata.internalMCPServerName,
+      toolName: this.toolConfiguration.originalName,
       mcpServerId: this.metadata.mcpServerId,
       params: this.augmentedInputs,
       status: this.status,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -208,8 +208,6 @@ async function createActionForTool(
       created: Date.now(),
       configurationId: agentConfiguration.sId,
       messageId: agentMessage.sId,
-      // TODO: cleanup the type field from the public API users and remove everywhere.
-      // TODO: move the output field to a separate field.
       action: { ...action.toJSON(), output: null, generatedFiles: [] },
       runIds,
     },

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -12,6 +12,7 @@ export type AgentMCPActionType = {
 
   agentMessageId: ModelId;
   internalMCPServerName: InternalMCPServerNameType | null;
+  toolName: string;
   mcpServerId: string | null;
   // TODO(MCPActionDetails): prevent exposing the function call name
   //  currently used in the extension to guess the tool name but quite brittle.

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -14,8 +14,6 @@ export type AgentMCPActionType = {
   internalMCPServerName: InternalMCPServerNameType | null;
   toolName: string;
   mcpServerId: string | null;
-  // TODO(MCPActionDetails): prevent exposing the function call name
-  //  currently used in the extension to guess the tool name but quite brittle.
   functionCallName: string;
   functionCallId: string;
 


### PR DESCRIPTION
## Description

- We currently don't surface the tool name to the front end, which re-computes it from the function call name (splits on `__` and takes the last part).
- This PR adds the tool name to `AgentMCPActionType`.
- Also replaces calls to `isInternalMCPServerOfName` on the MCP server ID, which parses an sId under the hood, with direct comparison on the MCP server name (both are equivalent, the name is generated from the id using `getInternalMCPServerNameFromSId`).
- Follow up PRs will port to extension and remove the function call name from the serialized output.

## Tests

- Tested on front edge, tested with the extension locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
