### PR TITLE
[front] feat: Highlight subscription status in poke

### DIFF
--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -76,22 +76,26 @@ const STATUS_CONFIG: Record<
   paymentFailed: {
     chipColor: "info",
     chipLabel: "Past Due",
-    cardClass: "border-info-200 bg-info-50",
+    cardClass:
+      "border-info-200 bg-info-50 dark:border-info-200-night dark:bg-info-50-night",
   },
   trialing: {
     chipColor: "blue",
     chipLabel: "Trialing",
-    cardClass: "border-blue-200 bg-blue-50",
+    cardClass:
+      "border-blue-200 bg-blue-50 dark:border-blue-200-night dark:bg-blue-50-night",
   },
   ended: {
     chipColor: "warning",
     chipLabel: "Ended",
-    cardClass: "border-warning-200 bg-warning-50",
+    cardClass:
+      "border-warning-200 bg-warning-50 dark:border-warning-200-night dark:bg-warning-50-night",
   },
   active: {
     chipColor: "success",
     chipLabel: "Active",
-    cardClass: "border-success-200 bg-success-50",
+    cardClass:
+      "border-success-200 bg-success-50 dark:border-success-200-night dark:bg-success-50-night",
   },
 };
 

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Chip,
   ConfluenceLogo,
   GithubLogo,
   GlobeAltIcon,
@@ -43,6 +44,56 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { isDevelopment } from "@app/types";
+
+type SubscriptionStatus = "paymentFailed" | "trialing" | "ended" | "active";
+
+function getSubscriptionDisplayStatus(
+  subscription: SubscriptionType
+): SubscriptionStatus {
+  if (subscription.paymentFailingSince !== null) {
+    return "paymentFailed";
+  }
+  if (subscription.trialing) {
+    return "trialing";
+  }
+  if (
+    subscription.plan.code === FREE_NO_PLAN_CODE ||
+    subscription.endDate !== null
+  ) {
+    return "ended";
+  }
+  return "active";
+}
+
+const STATUS_CONFIG: Record<
+  SubscriptionStatus,
+  {
+    chipColor: "info" | "blue" | "warning" | "success";
+    chipLabel: string;
+    cardClass: string;
+  }
+> = {
+  paymentFailed: {
+    chipColor: "info",
+    chipLabel: "Past Due",
+    cardClass: "border-info-200 bg-info-50",
+  },
+  trialing: {
+    chipColor: "blue",
+    chipLabel: "Trialing",
+    cardClass: "border-blue-200 bg-blue-50",
+  },
+  ended: {
+    chipColor: "warning",
+    chipLabel: "Ended",
+    cardClass: "border-warning-200 bg-warning-50",
+  },
+  active: {
+    chipColor: "success",
+    chipLabel: "Active",
+    cardClass: "border-success-200 bg-success-50",
+  },
+};
 
 interface SubscriptionsDataTableProps {
   owner: WorkspaceType;
@@ -103,13 +154,19 @@ export function ActiveSubscriptionTable({
   subscriptions,
   programmaticUsageConfig,
 }: ActiveSubscriptionTableProps) {
+  const status = getSubscriptionDisplayStatus(subscription);
+  const { chipColor, chipLabel, cardClass } = STATUS_CONFIG[status];
+
   return (
     <div className="flex flex-col">
       <div className="flex justify-between gap-3">
-        <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4 pb-2">
+        <div
+          className={`flex flex-grow flex-col rounded-lg border p-4 pb-2 ${cardClass}`}
+        >
           <div className="flex items-center justify-between gap-3">
-            <h2 className="text-md flex-grow pb-4 font-bold">
-              Active Subscription
+            <h2 className="text-md flex flex-grow items-center gap-2 pb-4 font-bold">
+              Subscription
+              <Chip color={chipColor} label={chipLabel} size="xs" />
             </h2>
             <SubscriptionsHistoryModal
               owner={owner}


### PR DESCRIPTION
## Description

Update subscription panel in poke to highlight the status.

<img width="533" height="328" alt="image" src="https://github.com/user-attachments/assets/0e3cc273-f0dd-4b24-a1c1-c59620b72599" />

<img width="530" height="307" alt="image" src="https://github.com/user-attachments/assets/24ffbe0b-6d03-4e0a-aa5e-ad9cff3524d2" />

<img width="544" height="320" alt="image" src="https://github.com/user-attachments/assets/35352f6e-9fa5-41a7-8429-79a9c580564e" />

<img width="531" height="316" alt="image" src="https://github.com/user-attachments/assets/84f9c913-7193-4e82-bef5-5e7316f62529" />

## Tests

Tested manually

## Risk

Low

## Deploy Plan

- [ ] Deploy front