### PR TITLE
[RAG prompts] Improve instructions for data source filesystem server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/instructions.ts
@@ -112,7 +112,7 @@ export const DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS =
   "It can be used to explore the filesystem structure step by step " +
   "by being called recursively with the 'nodeId' output in a step passed to the next step's nodeId.\n" +
   "The `find` tool finds a node based on its title starting from a specific root node, like using 'find' in Unix.\n" +
-  "The \`cat\` tool reads the actual content in a document node, like 'cat' in Unix.\n" +
+  "The `cat` tool reads the actual content in a document node, like 'cat' in Unix.\n" +
   "The `locate_in_tree` tool finds the path to a node in the filesystem tree.\n" +
   "The `semantic_search` tool performs a semantic search within the folders and files designated by `nodeIds`.\n" +
   "Note: these tools are specific to data in the space denoted by the server name. For attachments and conversation files " +

--- a/front/lib/actions/mcp_internal_actions/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/instructions.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME,
+  DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
+  DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
+} from "@app/lib/actions/constants";
+
 export const SALESFORCE_SERVER_INSTRUCTIONS = `You have access to the following tools: execute_read_query, list_objects, and describe_object.
 
 # General Workflow for Salesforce Data:
@@ -99,13 +105,16 @@ export const FRESHSERVICE_SERVER_INSTRUCTIONS = `
     `;
 
 export const DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS =
-  "The tools can be used to browse and search content with a filesystem-like navigation.\n" +
-  "Content is structured in nodes. Nodes are identified by a unique ID called `nodeId`.\n" +
+  "This server contains tools to browse and search data in the space denoted by the server name, with a filesystem-like navigation.\n" +
+  "The space's contents are structured in nodes, similar to files and folders in a filesystem. Nodes are identified by a unique ID called `nodeId`.\n" +
   "Node IDs are exposed in the outputs of the tools described below.\n" +
-  "The `list` tool can be used to list the direct content under a node, like 'ls' in Unix.\n" +
-  "Can be used to explore the filesystem structure step by step " +
+  "The `list` tool lists child nodes of a given node, like 'ls' in Unix.\n" +
+  "It can be used to explore the filesystem structure step by step " +
   "by being called recursively with the 'nodeId' output in a step passed to the next step's nodeId.\n" +
-  "The `find` tool can be used to find content based on their title starting from a specific root node, like using 'find' in Unix.\n" +
-  "The `cat` tool can be used to read the actual content in a document node, like 'cat in Unix.\n" +
-  "The `locate_in_tree` tool can be used to find the path to a node in the filesystem tree.\n" +
-  "The `semantic_search` tool can be used to perform a semantic search within the folders and files designated by `nodeIds`.";
+  "The `find` tool finds a node based on its title starting from a specific root node, like using 'find' in Unix.\n" +
+  "The \`cat\` tool reads the actual content in a document node, like 'cat' in Unix.\n" +
+  "The `locate_in_tree` tool finds the path to a node in the filesystem tree.\n" +
+  "The `semantic_search` tool performs a semantic search within the folders and files designated by `nodeIds`.\n" +
+  "Note: these tools are specific to data in the space denoted by the server name. For attachments and conversation files " +
+  `prefer using the \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\`, \`${DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME}\` and ` +
+  `\`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\` tools instead.`;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -201,9 +201,10 @@ function constructAttachmentsSection(): string {
     "Attachments may originate from the user directly or from tool outputs. " +
     "These tags indicate when the file was attached but often do not contain the full contents (it may contain a small snippet or description of the file).\n" +
     "Three flags indicate how an attachment can be used:\n\n" +
-    `- isIncludable: includable content, that can be retrieved using conversation files tool \`${DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME}\`\n` +
-    `- isQueryable: queryable content, representing tabular data that can be queried alongside other queryable conversation files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`\n` +
-    `- isSearchable: searchable content, that can be searched alongside other searchable conversation files' content using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`\n` +
+    `- isIncludable: attachment contents can be retrieved directly, using conversation tool \`${DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME}\`;\n` +
+    `- isQueryable: attachment contents are tabular data that can be queried alongside other queryable conversation files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`;\n` +
+    `- isSearchable: attachment contents are available for semantic search, i.e. when semantically searching conversation files\' content, using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`,` +
+    " contents of this attachment will be considered in the search.\n" +
     "Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files' types to decide which tool to use on which file.\n"
   );
 }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -203,7 +203,7 @@ function constructAttachmentsSection(): string {
     "Three flags indicate how an attachment can be used:\n\n" +
     `- isIncludable: attachment contents can be retrieved directly, using conversation tool \`${DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME}\`;\n` +
     `- isQueryable: attachment contents are tabular data that can be queried alongside other queryable conversation files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`;\n` +
-    `- isSearchable: attachment contents are available for semantic search, i.e. when semantically searching conversation files\' content, using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`,` +
+    `- isSearchable: attachment contents are available for semantic search, i.e. when semantically searching conversation files' content, using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`,` +
     " contents of this attachment will be considered in the search.\n" +
     "Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files' types to decide which tool to use on which file.\n"
   );


### PR DESCRIPTION
Description
---
Follows #19149 

In multiple cases it was observed that the model was unclear about the fact that filesystem tools are specific to the data of a given space, and should not be used on other spaces or attachments.

This PR changes instructions to explain that distinction and generally clarify.

Risks
---
low

Deploy
---
pmrr (small, not urgent)
deploy front
