### PR TITLE
[Credits] Improve programmatic usage error messages

### DIFF
--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -193,12 +193,11 @@ export async function sendCreditUsageAlertEmail({
         <li>Consumed: ${formatCents(totalConsumedMicroUsd)}</li>
         <li>Remaining: ${formatCents(remainingMicroUsd)}</li>
       </ul>
-      <p>To avoid service interruption, consider:</p>
+      <p>To avoid service interruption:</p>
       <ul>
-        <li>Purchasing additional credits</li>
-        <li>Reviewing your <a href="https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e">programmatic usage</a></li>
+        <li><strong><a href="https://dust.tt/w/${workspaceSId}/developers/credits-usage">Purchase additional credits</a></strong> in the Developers > Credits section</li>
+        <li>Learn more about <a href="https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e">programmatic usage at Dust</a></li>
       </ul>
-      <p>View your usage details at: <a href="https://dust.tt/w/${workspaceSId}/developers/credits-usage">https://dust.tt/w/${workspaceSId}/developers/credits-usage</a></p>
       <p>Please reply to this email if you have any questions.</p>`,
   });
 }

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -277,8 +277,11 @@ async function checkWorkspaceRateLimit({
     }
   } else {
     if (await hasReachedProgrammaticUsageLimits(auth)) {
-      errorMessage =
-        "Workspace has reached its public API limits for the current billing period.";
+      errorMessage = auth.isAdmin()
+        ? "Your workspace has run out of programmatic usage credits. " +
+          "Please purchase more credits in the Developers > Credits section of the Dust dashboard."
+        : "Your workspace has run out of programmatic usage credits. " +
+          "Please ask a Dust workspace admin to purchase more credits.";
     }
   }
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -143,13 +143,16 @@ async function handler(
         ? await hasReachedProgrammaticUsageLimits(auth)
         : false;
       if (hasReachedLimits) {
+        const errorMessage = auth.isAdmin()
+          ? "Your workspace has run out of programmatic usage credits. " +
+            "Please purchase more credits in the Developers > Credits section of the Dust dashboard."
+          : "Your workspace has run out of programmatic usage credits. " +
+            "Please ask a Dust workspace admin to purchase more credits.";
         return apiError(req, res, {
           status_code: 429,
           api_error: {
             type: "rate_limit_error",
-            message:
-              "Monthly API usage limit exceeded. Please upgrade your plan or wait until your " +
-              "limit resets next billing period.",
+            message: errorMessage,
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -169,13 +169,16 @@ async function handler(
             userMessageOrigin: origin,
           }) && (await hasReachedProgrammaticUsageLimits(auth));
         if (hasReachedLimits) {
+          const errorMessage = auth.isAdmin()
+            ? "Your workspace has run out of programmatic usage credits. " +
+              "Please purchase more credits in the Developers > Credits section of the Dust dashboard."
+            : "Your workspace has run out of programmatic usage credits. " +
+              "Please ask a Dust workspace admin to purchase more credits.";
           return apiError(req, res, {
             status_code: 429,
             api_error: {
               type: "rate_limit_error",
-              message:
-                "Monthly API usage limit exceeded. Please upgrade your plan or wait until your " +
-                "limit resets next billing period.",
+              message: errorMessage,
             },
           });
         }


### PR DESCRIPTION
## Description

Improves error messages when a workspace runs out of programmatic usage credits:

- **API endpoints** (`conversations/index.ts`, `messages/index.ts`): Show role-appropriate messages using `auth.isAdmin()`:
  - Admins: directed to purchase credits in the Developers > Credits section
  - Non-admins: told to ask a workspace admin to purchase credits
- **Webhook triggers**: Same role-aware messaging
- **Credit alert email**: Streamlined with a prominent, direct link to purchase credits

## Risks

Blast radius: Programmatic usage error messages (API, webhooks, email alerts)
Risk: low

## Deploy Plan
- pmrr (not urgent)
- deploy front