### PR TITLE
[mentions] fix mobile layout

### DIFF
--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -85,7 +85,7 @@ export function MCPServerPersonalAuthenticationRequired({
           : `${mcpServer && mcpServer.name ? getMcpServerDisplayName(mcpServer) : "Personal authentication required"}`
       }
       variant={isConnected ? "success" : "primary"}
-      className="flex w-80 min-w-[500px] flex-col gap-3"
+      className="flex w-80 min-w-[300px] flex-col gap-3 sm:min-w-[500px]"
       icon={icon}
     >
       {isTriggeredByCurrentUser ? (

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -91,7 +91,7 @@ export function MCPToolValidationRequired({
     <ContentMessage
       title={title}
       variant="primary"
-      className="flex w-80 min-w-[500px] flex-col gap-3"
+      className="flex w-80 min-w-[300px] flex-col gap-3 sm:min-w-[500px]"
       icon={icon}
     >
       {isTriggeredByCurrentUser ? (
@@ -115,7 +115,7 @@ export function MCPToolValidationRequired({
               {errorMessage}
             </div>
           )}
-          <div className="mt-3 flex flex-row gap-3">
+          <div className="mt-3 flex flex-row items-center gap-3">
             {blockedAction.stake === "low" && (
               <div className="flex flex-row justify-end gap-2">
                 <Label className="flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 text-xs">

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -62,7 +62,7 @@ export function MentionValidationRequired({
   }
 
   return (
-    <div className="mx-auto flex w-80 min-w-[500px] flex-col rounded-xl bg-muted-background p-3 dark:bg-muted-background-night">
+    <div className="mx-auto flex w-80 min-w-[300px] flex-col rounded-xl bg-muted-background p-3 dark:bg-muted-background-night sm:min-w-[500px]">
       <div className="flex flex-row gap-3 text-foreground dark:text-foreground-night">
         <Avatar
           visual={pendingMention.pictureUrl}


### PR DESCRIPTION
## Description
This PR is to fix the layout for personal auth required message:
<img width="574" height="384" alt="CleanShot 2025-12-22 at 10 15 30@2x" src="https://github.com/user-attachments/assets/62e47bb6-f8f1-465e-827f-7d223744b78a" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
