### PR TITLE
[front] fix: namespace MCP servers by space

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -602,7 +602,11 @@ export function getPrefixedToolName(
   config: MCPServerConfigurationType,
   originalName: string
 ): Result<string, Error> {
-  const slugifiedConfigName = slugify(config.name);
+  // Slugify each part separately to preserve __ separators (used for space disambiguation notably).
+  const slugifiedConfigName = config.name
+    .split(TOOL_NAME_SEPARATOR)
+    .map(slugify)
+    .join(TOOL_NAME_SEPARATOR);
   const slugifiedOriginalName = slugify(originalName).replaceAll(
     // Remove anything that is not a-zA-Z0-9_.- because it's not supported by the LLMs.
     /[^a-zA-Z0-9_.-]/g,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -673,6 +673,7 @@ async function disambiguateServerNamesBySpace(
     return configs;
   }
 
+  // We fetch the views to get the space names.
   const mcpServerViews = await MCPServerViewResource.fetchByIds(
     auth,
     viewIdsToFetch
@@ -691,7 +692,7 @@ async function disambiguateServerNamesBySpace(
       if (spaceName) {
         return {
           ...config,
-          name: `${spaceName}${TOOL_NAME_SEPARATOR}${config.name}`,
+          name: `${slugify(spaceName)}${TOOL_NAME_SEPARATOR}${config.name}`,
         };
       }
     }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -644,7 +644,7 @@ type AgentLoopListToolsContextWithoutConfigurationType = Omit<
 
 /**
  * When multiple server-side configs share the same name but have different viewIds (e.g.,
- * same server in different spaces), prepends the space name to disambiguate them.
+ * the same server in different spaces), prepends the space name to disambiguate them.
  */
 async function disambiguateServerNamesBySpace(
   auth: Authenticator,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -682,7 +682,6 @@ async function disambiguateServerNamesBySpace(
   );
 
   // Apply space prefix to colliding server-side configs.
-  const collidingNames = new Set(Object.keys(collidingGroups));
   return configs.map((config) => {
     if (
       isServerSideMCPServerConfiguration(config) &&

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -602,7 +602,7 @@ export function getPrefixedToolName(
   config: MCPServerConfigurationType,
   originalName: string
 ): Result<string, Error> {
-  // Slugify each part separately to preserve __ separators (used for space disambiguation notably).
+  // Slugify each part separately to preserve separators (used for space disambiguation notably).
   const slugifiedConfigName = config.name
     .split(TOOL_NAME_SEPARATOR)
     .map(slugify)


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5596.
- This PR namespaces MCP servers by space if multiple instances of the same MCP server are added but from different spaces to avoid having multiple specifications with the same function call name.
- The namespacing consists in adding `${spaceName}__` at the beginning of the function call name.
- Example

```
{
        "name": "asd_zendesk__draft_reply",
        "description": "Draft a reply to a Zendesk ticket. Creates a private comment (not visible to the end user) that can be edited before being published. This is useful for preparing responses before making them public.",
        "inputSchema": {
			...
        }
      },
      {
        "name": "company_data_zendesk__draft_reply",
        "description": "Draft a reply to a Zendesk ticket. Creates a private comment (not visible to the end user) that can be edited before being published. This is useful for preparing responses before making them public.",
        "inputSchema": {
				....
        }
      },
```

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
