### PR TITLE
feat(builder): allow admins to delete any trigger in AB

### DIFF
--- a/front/components/agent_builder/AgentBuilderContext.tsx
+++ b/front/components/agent_builder/AgentBuilderContext.tsx
@@ -12,6 +12,7 @@ import type { TemplateActionPreset, UserType, WorkspaceType } from "@app/types";
 type AgentBuilderContextType = {
   owner: WorkspaceType;
   user: UserType;
+  isAdmin: boolean;
   assistantTemplate: FetchAgentTemplateResponse | null;
   presetActionToAdd: TemplateActionPreset | null;
   setPresetActionToAdd: (preset: TemplateActionPreset | null) => void;
@@ -24,6 +25,7 @@ export const AgentBuilderContext = createContext<
 interface AgentBuilderProviderProps {
   owner: WorkspaceType;
   user: UserType;
+  isAdmin: boolean;
   assistantTemplate: FetchAgentTemplateResponse | null;
   children: ReactNode;
 }
@@ -31,6 +33,7 @@ interface AgentBuilderProviderProps {
 export function AgentBuilderProvider({
   owner,
   user,
+  isAdmin,
   assistantTemplate,
   children,
 }: AgentBuilderProviderProps) {
@@ -41,11 +44,12 @@ export function AgentBuilderProvider({
     () => ({
       owner,
       user,
+      isAdmin,
       assistantTemplate,
       presetActionToAdd,
       setPresetActionToAdd,
     }),
-    [owner, user, assistantTemplate, presetActionToAdd]
+    [owner, user, isAdmin, assistantTemplate, presetActionToAdd]
   );
 
   return (

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -79,12 +79,7 @@ export const TriggerCard = ({
         webhookSourceView,
       });
     }
-  }, [
-    trigger.kind,
-    trigger.configuration,
-    webhookSourceView?.customName,
-    webhookSourceView?.webhookSource.name,
-  ]);
+  }, [trigger, webhookSourceView]);
 
   return (
     <Card

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -8,13 +8,13 @@ import {
 import cronstrue from "cronstrue";
 import { useMemo } from "react";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { useUser } from "@app/lib/swr/user";
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
-import { useAgentBuilderContext } from "../AgentBuilderContext";
 
 function getTriggerIcon(trigger: AgentBuilderTriggerType) {
   switch (trigger.kind) {

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -39,6 +39,24 @@ interface TriggerCardProps {
   onEdit?: () => void;
 }
 
+function getWebhookCardDescription({
+  webhookTrigger,
+  webhookSourceView,
+}: {
+  webhookTrigger: AgentBuilderTriggerType & { kind: "webhook" };
+  webhookSourceView: WebhookSourceViewType | undefined;
+}) {
+  return (
+    "Triggered " +
+    (webhookTrigger.configuration.event
+      ? "by " + webhookTrigger.configuration.event + " events"
+      : "") +
+    " on " +
+    (webhookSourceView?.customName ?? webhookSourceView?.webhookSource.name) +
+    "'s source."
+  );
+}
+
 export const TriggerCard = ({
   trigger,
   webhookSourceView,
@@ -49,27 +67,17 @@ export const TriggerCard = ({
   const { user } = useUser();
   const isEditor = trigger.editor === user?.id;
   const description = useMemo(() => {
-    if (
-      trigger.kind === "schedule" &&
-      trigger.configuration &&
-      "cron" in trigger.configuration
-    ) {
+    if (trigger.kind === "schedule") {
       try {
         return `Runs ${cronstrue.toString(trigger.configuration.cron)}.`;
       } catch {
         return;
       }
     } else if (trigger.kind === "webhook") {
-      return (
-        "Triggered " +
-        (trigger.configuration.event
-          ? "by " + trigger.configuration.event + " events"
-          : "") +
-        " on " +
-        (webhookSourceView?.customName ??
-          webhookSourceView?.webhookSource.name) +
-        "'s source."
-      );
+      return getWebhookCardDescription({
+        webhookTrigger: trigger,
+        webhookSourceView,
+      });
     }
   }, [
     trigger.kind,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -139,7 +139,9 @@ async function handler(
 
       // Batch delete triggers
       for (const triggerId of triggerIds) {
-        const triggerToDelete = userTriggers.find((t) => t.sId === triggerId);
+        const triggerToDelete = auth.isAdmin()
+          ? allTriggers.find((t) => t.sId === triggerId)
+          : userTriggers.find((t) => t.sId === triggerId);
 
         if (!triggerToDelete) {
           // Skip triggers that the user cannot delete

--- a/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
@@ -18,6 +18,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   agentConfiguration: LightAgentConfigurationType;
   owner: WorkspaceType;
   user: UserType;
+  isAdmin: boolean;
 }>(async (context, auth) => {
   return tracer.trace("getServerSideProps", async () => {
     const owner = auth.workspace();
@@ -58,12 +59,14 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     }
 
     const user = auth.getNonNullableUser().toJSON();
+    const isAdmin = auth.isAdmin();
 
     return {
       props: {
         agentConfiguration: configuration,
         owner,
         user,
+        isAdmin,
       },
     };
   });
@@ -73,6 +76,7 @@ export default function EditAgent({
   agentConfiguration,
   owner,
   user,
+  isAdmin,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   if (agentConfiguration.scope === "global") {
     throw new Error("Cannot edit global agent");
@@ -83,7 +87,12 @@ export default function EditAgent({
   }
 
   return (
-    <AgentBuilderProvider owner={owner} user={user} assistantTemplate={null}>
+    <AgentBuilderProvider
+      owner={owner}
+      user={user}
+      isAdmin={isAdmin}
+      assistantTemplate={null}
+    >
       <Head>
         <title>{`Dust - @${agentConfiguration.name}`}</title>
       </Head>

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -36,6 +36,7 @@ function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
   user: UserType;
+  isAdmin: boolean;
   subscription: SubscriptionType;
   plan: PlanType;
   agentConfiguration:
@@ -95,6 +96,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const user = auth.getNonNullableUser().toJSON();
+  const isAdmin = auth.isAdmin();
 
   return {
     props: {
@@ -107,6 +109,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       templateId,
       duplicateAgentId: duplicate,
       user,
+      isAdmin,
     },
   };
 });
@@ -115,6 +118,7 @@ export default function CreateAgent({
   agentConfiguration,
   owner,
   user,
+  isAdmin,
   templateId,
   duplicateAgentId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
@@ -132,6 +136,7 @@ export default function CreateAgent({
     <AgentBuilderProvider
       owner={owner}
       user={user}
+      isAdmin={isAdmin}
       assistantTemplate={assistantTemplate}
     >
       <Head>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

For now, only the editor of a trigger can delete a trigger from an agent. We want to authorize admin to delete any trigger.

This PR : 
- adds a isAdmin bool to the AB Context
- uses it in the trigger card to allow admins to delete
- changes the api endpoint to delete to allow admins to delete triggers

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front