### PR TITLE
[Front] feat(agent-builder): add mcp server configuration page

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
@@ -83,4 +83,5 @@ export type CapabilitiesSheetContentProps = {
   alreadyRequestedSpaceIds: Set<string>;
   alreadyAddedSkillIds: Set<string>;
   selectedActions: BuilderAction[];
+  getAgentInstructions: () => string;
 };

--- a/front/components/agent_builder/capabilities/mcp/MCPServerConfigurationPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerConfigurationPage.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from "react";
+import type { UseFormReturn } from "react-hook-form";
+
+import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { AdditionalConfigurationSection } from "@app/components/agent_builder/capabilities/shared/AdditionalConfigurationSection";
+import { ChildAgentSection } from "@app/components/agent_builder/capabilities/shared/ChildAgentSection";
+import { DustAppSection } from "@app/components/agent_builder/capabilities/shared/DustAppSection";
+import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/shared/JsonSchemaSection";
+import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
+import { SecretSection } from "@app/components/agent_builder/capabilities/shared/SecretSection";
+import { TimeFrameSection } from "@app/components/agent_builder/capabilities/shared/TimeFrameSection";
+import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
+import { FormProvider } from "@app/components/sparkle/FormProvider";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { LightWorkspaceType } from "@app/types";
+
+export interface MCPServerConfigurationPageProps {
+  owner: LightWorkspaceType;
+  form: UseFormReturn<MCPFormData>;
+  action: BuilderAction;
+  mcpServerView: MCPServerViewTypeWithLabel;
+  getAgentInstructions: () => string;
+}
+
+export function MCPServerConfigurationPage({
+  owner,
+  form,
+  action,
+  mcpServerView,
+  getAgentInstructions,
+}: MCPServerConfigurationPageProps) {
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+
+  const requirements = useMemo(() => {
+    return getMCPServerRequirements(mcpServerView, featureFlags);
+  }, [mcpServerView, featureFlags]);
+
+  return (
+    <FormProvider form={form} className="h-full">
+      <div className="h-full space-y-6 pt-3">
+        {action.configurationRequired && (
+          <NameSection
+            title="Name"
+            placeholder="My tool name…"
+            triggerValidationOnChange
+          />
+        )}
+        {requirements.requiresChildAgentConfiguration && <ChildAgentSection />}
+        {requirements.mayRequireTimeFrameConfiguration && (
+          <TimeFrameSection actionType="search" />
+        )}
+        {requirements.requiresDustAppConfiguration && <DustAppSection />}
+        {requirements.developerSecretSelection && (
+          <SecretSection
+            customDescription={
+              mcpServerView.server.developerSecretSelectionDescription ??
+              undefined
+            }
+          />
+        )}
+        {requirements.mayRequireJsonSchemaConfiguration && (
+          <JsonSchemaSection getAgentInstructions={getAgentInstructions} />
+        )}
+        <AdditionalConfigurationSection
+          requiredStrings={requirements.requiredStrings}
+          requiredNumbers={requirements.requiredNumbers}
+          requiredBooleans={requirements.requiredBooleans}
+          requiredEnums={requirements.requiredEnums}
+          requiredLists={requirements.requiredLists}
+        />
+      </div>
+    </FormProvider>
+  );
+}

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -390,6 +390,7 @@ export function AgentBuilderSkillsBlock({
         alreadyRequestedSpaceIds={alreadyRequestedSpaceIds}
         alreadyAddedSkillIds={alreadyAddedSkillIds}
         selectedActions={actionFields}
+        getAgentInstructions={() => getValues("instructions")}
       />
     </AgentBuilderSectionContainer>
   );


### PR DESCRIPTION
Step 6 of implementing https://github.com/dust-tt/tasks/issues/5565

Splitting https://github.com/dust-tt/dust/pull/19233/changes in X PRs

## Description

This PR focuses on the `tool_configuration` page :
- Add MCP server configuration page in capabilities sheet
- Wire up form validation & save logic for tool configuration

## Tests

Local.

## Risk

Low.

## Deploy Plan

Deploy front.
