### PR TITLE
[front] feat(skills): display skills enabled for message in side panel

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@dust-tt/sparkle";
+import { Chip, Spinner } from "@dust-tt/sparkle";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -8,7 +8,11 @@ import { PanelAgentStep } from "@app/components/assistant/conversation/actions/P
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { useAgentMessageStreamLegacy } from "@app/hooks/useAgentMessageStreamLegacy";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
-import { useConversationMessage } from "@app/lib/swr/conversations";
+import { getSkillIcon } from "@app/lib/skill";
+import {
+  useAgentMessageSkills,
+  useConversationMessage,
+} from "@app/lib/swr/conversations";
 import type {
   AgentMessageType,
   ConversationWithoutContentType,
@@ -39,6 +43,13 @@ function AgentActionsPanelContent({
   mutateMessage,
 }: AgentActionsPanelContentProps) {
   const [currentStreamingStep, setCurrentStreamingStep] = useState(1);
+
+  const { skills } = useAgentMessageSkills({
+    conversationId: conversation?.sId ?? "",
+    owner,
+    messageId,
+    options: { disabled: !conversation },
+  });
 
   const { messageStreamState, shouldStream, isFreshMountWithContent } =
     useAgentMessageStreamLegacy({
@@ -239,6 +250,19 @@ function AgentActionsPanelContent({
           <div>&nbsp;</div>
         </div>
       </div>
+      {skills.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1 border-t border-separator bg-background p-4 dark:border-separator-night dark:bg-background-night">
+          {skills.map((skill) => (
+            <Chip
+              key={skill.sId}
+              size="xs"
+              label={skill.name}
+              icon={getSkillIcon(skill.icon)}
+              className="bg-muted-background text-foreground dark:bg-muted-background-night dark:text-foreground-night"
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -251,16 +251,19 @@ function AgentActionsPanelContent({
         </div>
       </div>
       {skills.length > 0 && (
-        <div className="flex flex-wrap items-center gap-1 border-t border-separator bg-background p-4 dark:border-separator-night dark:bg-background-night">
-          {skills.map((skill) => (
-            <Chip
-              key={skill.sId}
-              size="xs"
-              label={skill.name}
-              icon={getSkillIcon(skill.icon)}
-              className="bg-muted-background text-foreground dark:bg-muted-background-night dark:text-foreground-night"
-            />
-          ))}
+        <div className="flex flex-col gap-4 border-t border-separator bg-background p-4 dark:border-separator-night dark:bg-background-night">
+          <span className="text-sm">Enabled skills</span>
+          <div className="flex flex-wrap items-center gap-1">
+            {skills.map((skill) => (
+              <Chip
+                key={skill.sId}
+                size="xs"
+                label={skill.name}
+                icon={getSkillIcon(skill.icon)}
+                className="bg-muted-background text-foreground dark:bg-muted-background-night dark:text-foreground-night"
+              />
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -259,7 +259,6 @@ function AgentActionsPanelContent({
                 size="xs"
                 label={skill.name}
                 icon={getSkillIcon(skill.icon)}
-                className="bg-muted-background text-foreground dark:bg-muted-background-night dark:text-foreground-night"
               />
             ))}
           </div>

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -45,10 +45,9 @@ function AgentActionsPanelContent({
   const [currentStreamingStep, setCurrentStreamingStep] = useState(1);
 
   const { skills } = useAgentMessageSkills({
-    conversationId: conversation?.sId ?? "",
+    conversation,
     owner,
     messageId,
-    options: { disabled: !conversation },
   });
 
   const { messageStreamState, shouldStream, isFreshMountWithContent } =

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -720,12 +720,12 @@ export function useConversationMessage({
 
 export function useAgentMessageSkills({
   owner,
-  conversationId,
+  conversation,
   messageId,
   options,
 }: {
   owner: LightWorkspaceType;
-  conversationId: string;
+  conversation: ConversationWithoutContentType | null;
   messageId: string | null;
   options?: {
     disabled: boolean;
@@ -734,8 +734,8 @@ export function useAgentMessageSkills({
   const skillsFetcher: Fetcher<GetAgentMessageSkillsResponseBody> = fetcher;
 
   const { data, error, isLoading } = useSWRWithDefaults(
-    messageId
-      ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/skills`
+    conversation && messageId
+      ? `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}/messages/${messageId}/skills`
       : null,
     skillsFetcher,
     options


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5463.
- This PR shows which skills were enabled for a certain agent message at the bottom of the side panel.

<img width="493" alt="Screenshot 2025-12-22 at 1 08 46 PM" src="https://github.com/user-attachments/assets/d42df31f-ada7-4363-b41e-7ff8e8e8581b" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
