### PR TITLE
[front] chore(agent-loop): lower timeout for finalizing activities

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -102,10 +102,7 @@ const {
   finalizeCancelledAgentLoopActivity,
   finalizeErroredAgentLoopActivity,
 } = proxyActivities<typeof finalizeActivities>({
-  startToCloseTimeout: "5 minutes",
-  retry: {
-    maximumAttempts: 5,
-  },
+  startToCloseTimeout: "1 minutes",
 });
 
 export async function agentLoopConversationTitleWorkflow({

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -102,7 +102,7 @@ const {
   finalizeCancelledAgentLoopActivity,
   finalizeErroredAgentLoopActivity,
 } = proxyActivities<typeof finalizeActivities>({
-  startToCloseTimeout: "1 minutes",
+  startToCloseTimeout: "1 minute",
 });
 
 export async function agentLoopConversationTitleWorkflow({


### PR DESCRIPTION
## Description

- We have three finalizing activities for the agent loop (success, cancel, error).
- The timeout for these was historically set to 5 minutes with 5 retries due to the activities doing a lot of work.
- The content of the activities was reworked to offload the work to dedicated workflows.

## Tests

- Tested locally.
- Sampled a few completed workflows, and the activities take in average ~100 ms.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
