### PR TITLE
[extension] chore: remove function call name parsing for tool name

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
-        "@dust-tt/client": "^1.2.2",
+        "@dust-tt/client": "^1.2.3",
         "@dust-tt/sparkle": "^0.4.27",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
@@ -234,12 +234,13 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.2.2.tgz",
-      "integrity": "sha512-RYihGL03+scWAMFjV85qjArMWsbdPHHrtexxCzP4Vo7Tv+dj5LFjgpbkvhv26c+4fEVcVnF1oxzYoKplSlCJ3w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.2.3.tgz",
+      "integrity": "sha512-dKVKn46yQjMofLFIOyuxvG5bGkDN6a2pyCxfILEQ8xpSloWjKkoXDe439z0xdVUUK17IVY1ti4BGt5Yo4TfTwA==",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],
+      "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "git://github.com/dust-tt/typescript-sdk.git#628ebe48388549faae7e35504611af9ac2c6f5e4",
         "@types/json-schema": "^7.0.15",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
-    "@dust-tt/client": "^1.2.2",
+    "@dust-tt/client": "^1.2.3",
     "@dust-tt/sparkle": "^0.4.27",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",

--- a/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
@@ -62,12 +62,9 @@ export const FILESYSTEM_LIST_TOOL_NAME = "list";
 
 export function MCPActionDetails(props: MCPActionDetailsProps) {
   const {
-    action: { functionCallName, internalMCPServerName, params },
+    action: { toolName, internalMCPServerName, params },
     viewType,
   } = props;
-
-  const parts = functionCallName ? functionCallName.split("__") : [];
-  const toolName = parts[parts.length - 1];
 
   if (
     internalMCPServerName === "search" ||


### PR DESCRIPTION
## Description

- Same as https://github.com/dust-tt/dust/pull/19329 but for the extension.
- This PR exposes the tool names in the action type to the extension and uses it instead of parsing the function call name.
- Purely a refactoring so no particular reason to publish the extension.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Publish SDK.
