### PR TITLE
[sdk] Add tool name to public action type

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -109,7 +109,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -261,7 +261,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -768,6 +768,7 @@ const AgentActionTypeSchema = z.object({
   createdAt: z.number(),
   mcpServerId: z.string().nullable(),
   internalMCPServerName: z.string().nullable(),
+  toolName: z.string(),
   agentMessageId: ModelIdSchema,
   functionCallName: z.string(),
   functionCallId: z.string(),


### PR DESCRIPTION
## Description

- This PR adds the tool name to the public type for actions `AgentActionPublicType`.
- End goal is to do the same as https://github.com/dust-tt/dust/pull/19329 but for the extension, which requires publishing a new version of the SDK.
- This PR will unblock https://github.com/dust-tt/dust/pull/19355

## Tests

## Risk

- Low.

## Deploy Plan

- Publish SDK.
