### PR TITLE
[front] - feat(obs): image generation tracing

### DIFF
--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -285,6 +285,11 @@ const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
 // Pricing for legacy/deprecated models that are no longer in BaseModelIdType.
 // These are kept to ensure we can still compute token usage for historical runs.
 const LEGACY_MODEL_PRICING: Record<string, PricingEntry> = {
+  // Image generation model - not user-selectable, used internally by MCP tools
+  "gemini-2.5-flash-image": {
+    input: 0.15,
+    output: 0.6,
+  },
   "gpt-4-32k": {
     input: 60.0,
     output: 120.0,

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -287,8 +287,8 @@ const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
 const LEGACY_MODEL_PRICING: Record<string, PricingEntry> = {
   // Image generation model - not user-selectable, used internally by MCP tools
   "gemini-2.5-flash-image": {
-    input: 0.15,
-    output: 0.6,
+    input: 0.3,
+    output: 30.0,
   },
   "gpt-4-32k": {
     input: 60.0,

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -1,5 +1,8 @@
 import type { RunUsageType } from "@app/lib/resources/run_resource";
-import type { ModelIdType as BaseModelIdType, ModelIdType } from "@app/types";
+import type {
+  ImageModelIdType,
+  ModelIdType as BaseModelIdType,
+} from "@app/types";
 
 // All pricing are in USD per million tokens (equivalent to micro-USD per token).
 type PricingEntry = {
@@ -282,14 +285,16 @@ const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
   },
 };
 
-// Pricing for legacy/deprecated models that are no longer in BaseModelIdType.
-// These are kept to ensure we can still compute token usage for historical runs.
-const LEGACY_MODEL_PRICING: Record<string, PricingEntry> = {
-  // Image generation model - not user-selectable, used internally by MCP tools
+const IMAGE_MODEL_PRICING: Record<string, PricingEntry> = {
   "gemini-2.5-flash-image": {
     input: 0.3,
     output: 30.0,
   },
+};
+
+// Pricing for legacy/deprecated models that are no longer in BaseModelIdType.
+// These are kept to ensure we can still compute token usage for historical runs.
+const LEGACY_MODEL_PRICING: Record<string, PricingEntry> = {
   "gpt-4-32k": {
     input: 60.0,
     output: 120.0,
@@ -432,10 +437,11 @@ const LEGACY_MODEL_PRICING: Record<string, PricingEntry> = {
   },
 };
 
-// Combined pricing record for all models (current + legacy).
+// Combined pricing record for all models (current + legacy + image).
 // This is the exported record used throughout the codebase.
 export const MODEL_PRICING: Record<string, PricingEntry> = {
   ...CURRENT_MODEL_PRICING,
+  ...IMAGE_MODEL_PRICING,
   ...LEGACY_MODEL_PRICING,
 };
 
@@ -456,7 +462,7 @@ export function computeTokensCostForUsageInMicroUsd({
   cachedTokens,
   cacheCreationTokens,
 }: {
-  modelId: ModelIdType;
+  modelId: BaseModelIdType | ImageModelIdType;
   promptTokens: number;
   completionTokens: number;
   cachedTokens: number | null;

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -625,42 +625,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
-  static async fetchOutputItemsByActionIds(
-    auth: Authenticator,
-    actionIds: ModelId[]
-  ): Promise<Map<ModelId, AgentMCPActionOutputItemModel[]>> {
-    if (actionIds.length === 0) {
-      return new Map();
-    }
-
-    const workspaceId = auth.getNonNullableWorkspace().id;
-
-    const outputItems = await AgentMCPActionOutputItemModel.findAll({
-      where: {
-        workspaceId,
-        agentMCPActionId: {
-          [Op.in]: actionIds,
-        },
-      },
-    });
-
-    const outputItemsByActionId = new Map<
-      ModelId,
-      AgentMCPActionOutputItemModel[]
-    >();
-
-    for (const item of outputItems) {
-      const existing = outputItemsByActionId.get(item.agentMCPActionId);
-      if (existing) {
-        existing.push(item);
-      } else {
-        outputItemsByActionId.set(item.agentMCPActionId, [item]);
-      }
-    }
-
-    return outputItemsByActionId;
-  }
-
   toJSON(): AgentMCPActionType {
     assert(
       this.stepContent.value.type === "function_call",

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -625,6 +625,42 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
+  static async fetchOutputItemsByActionIds(
+    auth: Authenticator,
+    actionIds: ModelId[]
+  ): Promise<Map<ModelId, AgentMCPActionOutputItemModel[]>> {
+    if (actionIds.length === 0) {
+      return new Map();
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const outputItems = await AgentMCPActionOutputItemModel.findAll({
+      where: {
+        workspaceId,
+        agentMCPActionId: {
+          [Op.in]: actionIds,
+        },
+      },
+    });
+
+    const outputItemsByActionId = new Map<
+      ModelId,
+      AgentMCPActionOutputItemModel[]
+    >();
+
+    for (const item of outputItems) {
+      const existing = outputItemsByActionId.get(item.agentMCPActionId);
+      if (existing) {
+        existing.push(item);
+      } else {
+        outputItemsByActionId.set(item.agentMCPActionId, [item]);
+      }
+    }
+
+    return outputItemsByActionId;
+  }
+
   toJSON(): AgentMCPActionType {
     assert(
       this.stepContent.value.type === "function_call",

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -41,6 +41,7 @@ import {
   FIREWORKS_KIMI_K2_INSTRUCT_MODEL_ID,
 } from "./fireworks";
 import {
+  GEMINI_2_5_FLASH_IMAGE_MODEL_ID,
   GEMINI_2_5_FLASH_LITE_MODEL_CONFIG,
   GEMINI_2_5_FLASH_LITE_MODEL_ID,
   GEMINI_2_5_FLASH_MODEL_CONFIG,
@@ -192,6 +193,11 @@ export const isModelId = (modelId: string): modelId is ModelIdType =>
   MODEL_IDS.includes(modelId as ModelIdType);
 
 export const ModelIdCodec = ioTsEnum<(typeof MODEL_IDS)[number]>(MODEL_IDS);
+
+// Image generation model IDs (internal-only, not user-selectable)
+export const IMAGE_MODEL_IDS = [GEMINI_2_5_FLASH_IMAGE_MODEL_ID] as const;
+
+export type ImageModelIdType = (typeof IMAGE_MODEL_IDS)[number];
 export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,


### PR DESCRIPTION
## Description
Adds observability tracing for image generation and editing MCP tools using Langfuse. The PR instruments both `generate_image` and `edit_image` tools with traces capturing input parameters, token usage metrics, and cost computation. Error cases are also tracked with appropriate metadata. Additionally includes the `gemini-2.5-flash-image` model in legacy pricing to support cost calculations.

<img width="1539" height="648" alt="Screenshot 2025-12-22 at 15 40 43" src="https://github.com/user-attachments/assets/03ebbf63-8751-47b6-8cbe-960df83eef7e" />

## Risk
Low. The changes are purely additive tracing instrumentation that don't alter the existing image generation/editing logic.

## Tests

Locally

## Deploy Plan

Deploy front