### PR TITLE
[front] enh(mcp): update transport selection logic for remote MCP

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -459,7 +459,7 @@ async function connectToRemoteMCPServer(
       logger.info(
         {
           url: url.toString(),
-          error: error.message,
+          error,
         },
         "Error establishing connection to remote MCP server via streamableHttpTransport, falling back to sseTransport."
       );

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -446,8 +446,7 @@ async function connectToRemoteMCPServer(
   // If the URL path ends with /sse, use SSE transport directly.
   if (url.pathname.endsWith("/sse")) {
     const sseTransport = new SSEClientTransport(url, req);
-    await mcpClient.connect(sseTransport);
-    return;
+    return mcpClient.connect(sseTransport);
   }
 
   try {

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -437,11 +437,19 @@ export const connectToMCPServer = async (
 };
 
 // Try to connect via streamableHttpTransport first, and if that fails, fall back to sseTransport.
+// If the URL path ends with /sse, skip HTTP streaming and use SSE directly.
 async function connectToRemoteMCPServer(
   mcpClient: Client,
   url: URL,
   req: SSEClientTransportOptions | StreamableHTTPClientTransportOptions
 ) {
+  // If the URL path ends with /sse, use SSE transport directly.
+  if (url.pathname.endsWith("/sse")) {
+    const sseTransport = new SSEClientTransport(url, req);
+    await mcpClient.connect(sseTransport);
+    return;
+  }
+
   try {
     const streamableHttpTransport = new StreamableHTTPClientTransport(url, req);
     await mcpClient.connect(streamableHttpTransport);


### PR DESCRIPTION
## Description

- When connecting to a remote MCP server, we currently try streamable HTTP first, and then use sse as a fallback.
- If the server only supports SSE this adds an overhead systematically.
- Most of the time we can already tell that the server only supports SSE by looking at the URL, which ends up `/sse` ([logs](https://app.datadoghq.eu/logs?query=%22Error%20establishing%20connection%20to%20remote%20MCP%20server%20via%20streamableHttpTransport%2C%20falling%20back%20to%20sseTransport%22&agg_m=count&agg_m_source=base&agg_q=%40url&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40url&flat_group_bys=true&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=count&sort_t=count&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1765803917992&to_ts=1766408717992&live=true)).
- This PR uses SSE directly if the URL ends with SSE (ignores query params).
- We also want to improve the fallback mechanism: if the error code is different than 404 or 405 then the fallback has low chances of working (example [here](https://app.datadoghq.eu/logs?query=host%3Afront-agent-loop-worker-deployment-7dbf5576d-w7dsm%20service%3Afront-agent-loop-worker%20container_id%3A90201fd712e3230c09512f75f60407dbd5dbd53447ffafed38350960d99f27fa%20filename%3A0.log&agg_m=count&agg_m_source=base&agg_q=%40url&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40url&context_event=AZtFgFheAABmJBhnBT0CTQAX&event=AwAAAZtFgEtome6mQQAAABhBWnRGZ0ZoZUFBQm1KQmhuQlQwQ1RRQVgAAAAkMDE5YjQ1ODAtNjBmZi00NTA4LWJlOTYtMjllZWI1NWFmMGM2AAi0Wg&flat_group_bys=true&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=count&sort_t=count&storage=hot&stream_sort=time%2Cdesc&to_event=AwAAAZtFgFeJme6mUgAAABhBWnRGZ0ZoZUFBQm1KQmhuQlQwQ1RRQW8AAAAkMDE5YjQ1ODAtNjBmZi00NTA4LWJlOTYtMjllZWI1NWFmMGM2AAixQA&top_n=30&top_o=top&viz=&x_missing=true&from_ts=1766397294472&to_ts=1766397597578&live=false) where we have a 429, try SSE and it doesn't work because the server does not support SSE).

## Tests

## Risk

- Medium (impacts all remote MCP servers).

## Deploy Plan

- Deploy front.
