### PR TITLE
[front] feat(skills): add `MCPActionDetails` for skill enablement

### DIFF
--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -3,7 +3,7 @@ import type { ComponentType } from "react";
 
 interface ActionDetailsWrapperProps {
   actionName: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   viewType: "conversation" | "sidebar";
   visual: ComponentType<{ className?: string }>;
 }

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -285,10 +285,11 @@ export function MCPActionDetails({
     return <MCPListToolsActionDetails {...toolOutputDetailsProps} />;
   }
 
-  if (internalMCPServerName === SKILL_MANAGEMENT_SERVER_NAME) {
-    if (toolName === ENABLE_SKILL_TOOL_NAME) {
-      return <MCPSkillEnableActionDetails {...toolOutputDetailsProps} />;
-    }
+  if (
+    internalMCPServerName === SKILL_MANAGEMENT_SERVER_NAME &&
+    toolName === ENABLE_SKILL_TOOL_NAME
+  ) {
+    return <MCPSkillEnableActionDetails {...toolOutputDetailsProps} />;
   }
 
   if (internalMCPServerName === "agent_management") {

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -62,7 +62,6 @@ import {
   INTERNAL_SERVERS_WITH_WEBSEARCH,
   PROCESS_TOOL_NAME,
   SEARCH_TOOL_NAME,
-  SKILL_MANAGEMENT_SERVER_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
   WEBBROWSER_TOOL_NAME,
   WEBSEARCH_TOOL_NAME,
@@ -286,7 +285,7 @@ export function MCPActionDetails({
   }
 
   if (
-    internalMCPServerName === SKILL_MANAGEMENT_SERVER_NAME &&
+    internalMCPServerName === "skill_management" &&
     toolName === ENABLE_SKILL_TOOL_NAME
   ) {
     return <MCPSkillEnableActionDetails {...toolOutputDetailsProps} />;

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -36,12 +36,16 @@ import { MCPExtractActionDetails } from "@app/components/actions/mcp/details/MCP
 import { MCPGetDatabaseSchemaActionDetails } from "@app/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails";
 import { MCPListToolsActionDetails } from "@app/components/actions/mcp/details/MCPListToolsActionDetails";
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
+import { MCPSkillEnableActionDetails } from "@app/components/actions/mcp/details/MCPSkillEnableActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
 import { MCPToolsetsEnableActionDetails } from "@app/components/actions/mcp/details/MCPToolsetsEnableActionDetails";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
-import { DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME } from "@app/lib/actions/constants";
+import {
+  DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME,
+  ENABLE_SKILL_TOOL_NAME,
+} from "@app/lib/actions/constants";
 import {
   DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME,
   DATA_WAREHOUSES_FIND_TOOL_NAME,
@@ -58,6 +62,7 @@ import {
   INTERNAL_SERVERS_WITH_WEBSEARCH,
   PROCESS_TOOL_NAME,
   SEARCH_TOOL_NAME,
+  SKILL_MANAGEMENT_SERVER_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
   WEBBROWSER_TOOL_NAME,
   WEBSEARCH_TOOL_NAME,
@@ -278,6 +283,12 @@ export function MCPActionDetails({
       return <MCPToolsetsEnableActionDetails {...toolOutputDetailsProps} />;
     }
     return <MCPListToolsActionDetails {...toolOutputDetailsProps} />;
+  }
+
+  if (internalMCPServerName === SKILL_MANAGEMENT_SERVER_NAME) {
+    if (toolName === ENABLE_SKILL_TOOL_NAME) {
+      return <MCPSkillEnableActionDetails {...toolOutputDetailsProps} />;
+    }
   }
 
   if (internalMCPServerName === "agent_management") {

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -1,21 +1,13 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import { isSkillEnableInputType } from "@app/lib/actions/mcp_internal_actions/types";
 import { SKILL_ICON } from "@app/lib/skill";
-
-function isSkillEnableParams(params: unknown): params is { skillName: string } {
-  return (
-    typeof params === "object" &&
-    params !== null &&
-    "skillName" in params &&
-    typeof (params as { skillName: unknown }).skillName === "string"
-  );
-}
 
 export function MCPSkillEnableActionDetails({
   viewType,
   toolParams,
 }: ToolExecutionDetailsProps) {
-  const skillName = isSkillEnableParams(toolParams)
+  const skillName = isSkillEnableInputType(toolParams)
     ? toolParams.skillName
     : null;
 

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -1,0 +1,35 @@
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import { SKILL_ICON } from "@app/lib/skill";
+
+function isSkillEnableParams(params: unknown): params is { skillName: string } {
+  return (
+    typeof params === "object" &&
+    params !== null &&
+    "skillName" in params &&
+    typeof (params as { skillName: unknown }).skillName === "string"
+  );
+}
+
+export function MCPSkillEnableActionDetails({
+  viewType,
+  toolParams,
+}: ToolExecutionDetailsProps) {
+  const skillName = isSkillEnableParams(toolParams)
+    ? toolParams.skillName
+    : null;
+
+  const actionName =
+    (viewType === "conversation" ? "Enabling skill" : "Enable skill") +
+    (skillName ? `: ${skillName}` : "");
+
+  return (
+    <ActionDetailsWrapper
+      viewType={viewType}
+      actionName={actionName}
+      visual={SKILL_ICON}
+    >
+      <></>
+    </ActionDetailsWrapper>
+  );
+}

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -20,8 +20,6 @@ export function MCPSkillEnableActionDetails({
       viewType={viewType}
       actionName={actionName}
       visual={SKILL_ICON}
-    >
-      <></>
-    </ActionDetailsWrapper>
+    />
   );
 }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -58,7 +58,6 @@ export const SEARCH_SERVER_NAME = "search";
 export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2"; // Do not change the name until we fixed the extension
 export const DATA_WAREHOUSE_SERVER_NAME = "data_warehouses";
 export const AGENT_MEMORY_SERVER_NAME = "agent_memory";
-export const SKILL_MANAGEMENT_SERVER_NAME = "skill_management";
 
 // IDs of internal MCP servers that are no longer present.
 // We need to keep them to avoid breaking previous output that might reference sId that mapped to these servers.
@@ -123,7 +122,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "zendesk",
   SEARCH_SERVER_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
-  SKILL_MANAGEMENT_SERVER_NAME,
+  "skill_management",
   "schedules_management",
 ] as const;
 
@@ -1675,7 +1674,7 @@ export const INTERNAL_MCP_SERVERS = {
       developerSecretSelection: "required",
     },
   },
-  [SKILL_MANAGEMENT_SERVER_NAME]: {
+  skill_management: {
     id: 1019,
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
@@ -1687,7 +1686,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
-      name: SKILL_MANAGEMENT_SERVER_NAME,
+      name: "skill_management",
       version: "1.0.0",
       description: "",
       // TODO(skill): Add proper skill icon here once in ActionsIcons

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -1,9 +1,9 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 
 import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import { SkillEnableInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -21,9 +21,7 @@ function createServer(
     ENABLE_SKILL_TOOL_NAME,
     "Enable a skill for the current conversation. " +
       "The skill will be available for subsequent messages from the same agent in this conversation.",
-    {
-      skillName: z.string().describe("The name of the skill to enable"),
-    },
+    SkillEnableInputSchema.shape,
     withToolLogging(
       auth,
       {

--- a/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/skill_management.ts
@@ -2,7 +2,6 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { SkillEnableInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -15,7 +14,7 @@ function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = makeInternalMCPServer(SKILL_MANAGEMENT_SERVER_NAME);
+  const server = makeInternalMCPServer("skill_management");
 
   server.tool(
     ENABLE_SKILL_TOOL_NAME,

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -262,3 +262,15 @@ export const DataSourceFilesystemLocateTreeInputSchema = z.object({
 export type DataSourceFilesystemLocateTreeInputType = z.infer<
   typeof DataSourceFilesystemLocateTreeInputSchema
 >;
+
+export const SkillEnableInputSchema = z.object({
+  skillName: z.string().describe("The name of the skill to enable"),
+});
+
+export type SkillEnableInputType = z.infer<typeof SkillEnableInputSchema>;
+
+export function isSkillEnableInputType(
+  input: Record<string, unknown>
+): input is SkillEnableInputType {
+  return SkillEnableInputSchema.safeParse(input).success;
+}

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -9,7 +9,6 @@ import type {
   MCPServerConfigurationType,
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
-import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   DataSourceConfiguration,
   TableDataSourceConfiguration,
@@ -157,7 +156,7 @@ export async function getJITServers(
       const skillManagementView =
         await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
           auth,
-          SKILL_MANAGEMENT_SERVER_NAME
+          "skill_management"
         );
 
       if (!skillManagementView) {
@@ -173,7 +172,7 @@ export async function getJITServers(
           id: -1,
           sId: generateRandomModelSId(),
           type: "mcp_server_configuration",
-          name: SKILL_MANAGEMENT_SERVER_NAME,
+          name: "skill_management",
           description: "Enable skills for the conversation.",
           dataSources: null,
           tables: null,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5624.
- This PR adds a custom `MCPActionDetails` for the skill enablement tool.
- Will check in with the design team to tweak the exact UI and copy.

<img width="893" height="419" alt="Screenshot 2025-12-22 at 3 40 36 PM" src="https://github.com/user-attachments/assets/266769e3-80ce-42c5-8b7b-99284edb0f38" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
