### PR TITLE
Fix Workspace Isolation Violation on Space Resource And Associated

### DIFF
--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -144,6 +144,9 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
         ...this.getOptions(fetchDataSourceOptions),
         ...options,
         includeDeleted,
+        // WORKSPACE_ISOLATION_BYPASS: Data sources can be public, preventing to enforce a
+        // workspaceId clause in the SQL query. Permissions are enforced at a higher level.
+        dangerouslyBypassWorkspaceIsolationSecurity: true,
       },
       transaction
     );
@@ -302,6 +305,9 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
       where: {
         id: ids,
       },
+      // WORKSPACE_ISOLATION_BYPASS: Data sources can be public, preventing to enforce a
+      // workspaceId clause in the SQL query. Permissions are enforced at a higher level.
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
   }
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -251,6 +251,9 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       ...this.getOptions(fetchDataSourceViewOptions),
       ...options,
       includeDeleted,
+      // WORKSPACE_ISOLATION_BYPASS: Data source views can be public, preventing to enforce a
+      // workspaceId clause in the SQL query. Permissions are enforced at a higher level.
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 
     const dataSourceIds = removeNulls(

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -198,8 +198,21 @@ export type ModelStaticSoftDeletable<
   M extends SoftDeletableWorkspaceAwareModel,
 > = ModelStatic<M> & {
   findAll(
-    options: WithIncludeDeleted<FindOptions<Attributes<M>>>
+    options: WithIncludeDeleted<
+      WorkspaceTenantIsolationSecurityBypassOptions<Attributes<M>>
+    >
   ): Promise<M[]>;
+  findOne(
+    options: WithIncludeDeleted<
+      WorkspaceTenantIsolationSecurityBypassOptions<Attributes<M>>
+    >
+  ): Promise<M | null>;
+  findByPk(
+    identifier: any,
+    options: WithIncludeDeleted<
+      WorkspaceTenantIsolationSecurityBypassOptions<Attributes<M>>
+    >
+  ): Promise<M | null>;
 };
 
 type WithHardDelete<T> = T & {

--- a/front/lib/resources/types.ts
+++ b/front/lib/resources/types.ts
@@ -62,6 +62,7 @@ export type ResourceFindOptions<M extends Model> = {
   offset?: number;
   order?: FindOptions<M>["order"];
   where?: WhereOptions<M>;
+  dangerouslyBypassWorkspaceIsolationSecurity?: boolean;
 } & (M extends SoftDeletableWorkspaceAwareModel
   ? { includeDeleted?: boolean }
   : { includeDeleted?: never });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes workspace isolation violation on `SpaceResource` and two resources that belongs to a space `DataSourceResource` and `DataSourceViewResource`. Since those can be public and/or live in a public space we can't enforce the `workspaceId` clause in the SQL query. However, the permission checks is enforced at a higher level in the code. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
