### PR TITLE
[Front] feat(agent-builder): implement tool edit page in capabilities sheet

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -8,6 +8,7 @@ import type {
 import type {
   CapabilitiesSheetMode,
   SelectedTool,
+  ToolConfigurationMode,
 } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
 import { TOP_MCP_SERVER_VIEWS } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
 import {
@@ -165,10 +166,6 @@ export const useToolSelection = ({
   const [localSelectedTools, setLocalSelectedTools] = useState<SelectedTool[]>(
     []
   );
-  const [localMCPServerViewToConfigure, setLocalMCPServerViewToConfigure] =
-    useState<MCPServerViewTypeWithLabel | null>(null);
-  const [localActionToConfigure, setLocalActionToConfigure] =
-    useState<BuilderAction | null>(null);
 
   const selectedMCPServerViewIds = useMemo(() => {
     return new Set(localSelectedTools.map((t) => t.view.sId));
@@ -248,8 +245,6 @@ export const useToolSelection = ({
       if (!requirements.noRequirement) {
         const action = getDefaultMCPAction(mcpServerView);
 
-        setLocalMCPServerViewToConfigure(mcpServerView);
-        setLocalActionToConfigure(action);
         onModeChange({
           pageId: "tool_configuration",
           capability: action,
@@ -294,12 +289,8 @@ export const useToolSelection = ({
     [onModeChange]
   );
 
-  const handleMCPServerConfigurationSave = useCallback(
-    (formData: MCPFormData) => {
-      if (!localMCPServerViewToConfigure || !localActionToConfigure) {
-        return;
-      }
-
+  const handleToolConfigurationSave = useCallback(
+    (mode: ToolConfigurationMode) => (formData: MCPFormData) => {
       const newActionName = generateUniqueActionName({
         baseName: nameToStorageFormat(formData.name),
         existingActions: selectedActions,
@@ -307,7 +298,7 @@ export const useToolSelection = ({
       });
 
       const configuredAction: BuilderAction = {
-        ...localActionToConfigure,
+        ...mode.capability,
         name: newActionName,
         description: formData.description,
         configuration: formData.configuration,
@@ -315,7 +306,7 @@ export const useToolSelection = ({
 
       const updatedTool: SelectedTool = {
         type: "MCP",
-        view: localMCPServerViewToConfigure,
+        view: mode.mcpServerView,
         configuredAction,
       };
 
@@ -337,13 +328,7 @@ export const useToolSelection = ({
 
       onModeChange({ pageId: "selection" });
     },
-    [
-      selectedActions,
-      localSelectedTools,
-      onModeChange,
-      localMCPServerViewToConfigure,
-      localActionToConfigure,
-    ]
+    [selectedActions, localSelectedTools, onModeChange]
   );
 
   return {
@@ -354,8 +339,6 @@ export const useToolSelection = ({
     isMCPServerViewsLoading,
     selectedMCPServerViewIds,
     allMcpServerViews,
-    localMCPServerViewToConfigure,
-    localActionToConfigure,
-    handleMCPServerConfigurationSave,
+    handleToolConfigurationSave,
   };
 };

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
@@ -48,15 +48,16 @@ type ToolInfoMode = {
   hasPreviousPage: boolean;
 };
 
-type ToolConfigurationMode = {
+export type ToolConfigurationMode = {
   pageId: "tool_configuration";
   capability: BuilderAction;
   mcpServerView: MCPServerViewTypeWithLabel;
 };
 
-type ToolEditMode = {
+export type ToolEditMode = {
   pageId: "tool_edit";
   capability: BuilderAction;
+  mcpServerView: MCPServerViewTypeWithLabel;
   index: number;
 };
 
@@ -72,11 +73,12 @@ export type CapabilitiesSheetContentProps = {
   mode: CapabilitiesSheetMode;
   onModeChange: (mode: CapabilitiesSheetMode | null) => void;
   onClose: () => void;
-  onSave: (data: {
+  onCapabilitiesSave: (data: {
     skills: AgentBuilderSkillsType[];
     additionalSpaces: string[];
     tools: SelectedTool[];
   }) => void;
+  onToolEditSave: (updatedAction: BuilderAction) => void;
   owner: WorkspaceType;
   user: UserType;
   initialAdditionalSpaces: string[];
@@ -85,3 +87,9 @@ export type CapabilitiesSheetContentProps = {
   selectedActions: BuilderAction[];
   getAgentInstructions: () => string;
 };
+
+export function isToolConfigurationOrEditPage(
+  mode: CapabilitiesSheetMode
+): mode is ToolConfigurationMode | ToolEditMode {
+  return mode.pageId === "tool_configuration" || mode.pageId === "tool_edit";
+}


### PR DESCRIPTION
Step 7 of implementing https://github.com/dust-tt/tasks/issues/5565

Splitting https://github.com/dust-tt/dust/pull/19233/changes in X PRs

## Description

- Implement tool edit page in capabilities sheet for MCP server configurations
- Refactor to derive form state from mode instead of storing separately (`localMCPServerViewToConfigure`, `localActionToConfigure` removed)
- Add `mcpServerView` to `ToolEditMode` type for form schema/reset
- Split `onSave` into `onCapabilitiesSave` and `onToolEditSave` for clearer responsibilities
- Add `isToolConfigurationOrEditPage` typeguard

## Tests

Manual testing of edit flow for configurable MCP tools.

## Risk

Low.

## Deploy Plan

Deploy front.
