### PR TITLE
[front] fix(mcp): add back error in log

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -453,13 +453,13 @@ async function connectToRemoteMCPServer(
     const streamableHttpTransport = new StreamableHTTPClientTransport(url, req);
     await mcpClient.connect(streamableHttpTransport);
   } catch (error) {
-    // Check if error message contains "HTTP 4xx" as suggested by the official doc.
-    // Doc is here https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#client-side-compatibility.
+    // Check if the error is an HTTP error with a 4xx status code.
+    // Doc here https://github.com/modelcontextprotocol/typescript-sdk/blob/1.25.1/docs/client.md#transports-and-backwards-compatibility.
     if (error instanceof Error && /HTTP 4\d\d/.test(error.message)) {
       logger.info(
         {
           url: url.toString(),
-          error,
+          error: normalizeError(error),
         },
         "Error establishing connection to remote MCP server via streamableHttpTransport, falling back to sseTransport."
       );


### PR DESCRIPTION
## Description

- This PR updates the link to MCP's documentation and fixes the error log, which now appears as `error: { type: Error }` ([example](https://app.datadoghq.eu/logs?query=%22Error%20establishing%20connection%20to%20remote%20MCP%20server%20via%20streamableHttpTransport%2C%20falling%20back%20to%20sseTransport%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZtGtVLGi8YumAAAABhBWnRHdFdSQUFBQnBVS1ZzUlRTY2F3QUcAAAAkMDE5YjQ2YjUtYzE0NC00M2FhLTlmNzAtM2M3ZmJkOWRkMmRiAALY_w&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1766417098451&to_ts=1766417998451&live=true)).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
