### PR TITLE
[Front] refactor(agent-builder): use context over prop drilling, show skills xor capabilities

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -453,7 +453,6 @@ export default function AgentBuilder({
               }}
               // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               agentConfigurationId={agentConfiguration?.sId || null}
-              isSkillsLoading={isSkillsLoading}
               isActionsLoading={isActionsLoading}
               isTriggersLoading={isTriggersLoading}
             />

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -23,7 +23,6 @@ interface AgentBuilderLeftPanelProps {
   agentConfigurationId: string | null;
   saveButtonProps?: ButtonProps;
   isActionsLoading: boolean;
-  isSkillsLoading?: boolean;
   isTriggersLoading?: boolean;
 }
 
@@ -34,10 +33,9 @@ export function AgentBuilderLeftPanel({
   agentConfigurationId,
   saveButtonProps,
   isActionsLoading,
-  isSkillsLoading,
   isTriggersLoading,
 }: AgentBuilderLeftPanelProps) {
-  const { owner, user } = useAgentBuilderContext();
+  const { owner } = useAgentBuilderContext();
 
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
@@ -65,14 +63,13 @@ export function AgentBuilderLeftPanel({
             agentConfigurationId={agentConfigurationId}
           />
           {hasFeature("skills") && <AgentBuilderSpacesBlock />}
-          {hasFeature("skills") && (
-            <AgentBuilderSkillsBlock
-              isSkillsLoading={isSkillsLoading}
-              owner={owner}
-              user={user}
+          {hasFeature("skills") ? (
+            <AgentBuilderSkillsBlock />
+          ) : (
+            <AgentBuilderCapabilitiesBlock
+              isActionsLoading={isActionsLoading}
             />
           )}
-          <AgentBuilderCapabilitiesBlock isActionsLoading={isActionsLoading} />
           <AgentBuilderTriggersBlock
             owner={owner}
             isTriggersLoading={isTriggersLoading}

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -11,7 +11,6 @@ import {
 import React, { useMemo, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { AgentBuilderSectionContainer } from "@app/components/agent_builder/AgentBuilderSectionContainer";
 import { KnowledgeConfigurationSheet } from "@app/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet";
@@ -25,7 +24,6 @@ import { ActionCard } from "@app/components/shared/tools_picker/ActionCard";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { BACKGROUND_IMAGE_STYLE_PROPS } from "@app/components/shared/tools_picker/util";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { TemplateActionPreset } from "@app/types";
 import { pluralize } from "@app/types";
 
@@ -51,8 +49,6 @@ export function AgentBuilderCapabilitiesBlock({
   } = useMCPServerViewsContext();
 
   const { spaces } = useSpacesContext();
-  const { owner } = useAgentBuilderContext();
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
   const [dialogMode, setDialogMode] = useState<SheetMode | null>(null);
   const [knowledgeAction, setKnowledgeAction] = useState<{
@@ -198,22 +194,19 @@ export function AgentBuilderCapabilitiesBlock({
           />
         ) : (
           <>
-            {!hasFeature("skills") &&
-              nonGlobalSpacesUsedInActions.length > 0 && (
-                <div className="mb-4 w-full">
-                  <ContentMessage variant="golden" size="lg">
-                    Based on your selection, this agent can only be used by
-                    users with access to space
-                    {pluralize(nonGlobalSpacesUsedInActions.length)} :{" "}
-                    <strong>
-                      {nonGlobalSpacesUsedInActions
-                        .map((v) => v.name)
-                        .join(", ")}
-                    </strong>
-                    .
-                  </ContentMessage>
-                </div>
-              )}
+            {nonGlobalSpacesUsedInActions.length > 0 && (
+              <div className="mb-4 w-full">
+                <ContentMessage variant="golden" size="lg">
+                  Based on your selection, this agent can only be used by users
+                  with access to space
+                  {pluralize(nonGlobalSpacesUsedInActions.length)} :{" "}
+                  <strong>
+                    {nonGlobalSpacesUsedInActions.map((v) => v.name).join(", ")}
+                  </strong>
+                  .
+                </ContentMessage>
+              </div>
+            )}
             <CardGrid>
               {fields.map((field, index) => (
                 <ActionCard

--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
@@ -1,6 +1,7 @@
 import { Button, SearchInput, Spinner } from "@dust-tt/sparkle";
 import React, { useMemo, useState } from "react";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { SkillCard } from "@app/components/agent_builder/capabilities/capabilities_sheet/SkillCard";
 import type {
   CapabilitiesSheetMode,
@@ -10,12 +11,10 @@ import { MCPServerCard } from "@app/components/agent_builder/capabilities/mcp/MC
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useSkillWithRelations } from "@app/lib/swr/skill_configurations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { LightWorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 type CapabilitiesSelectionPageProps = {
   onModeChange: (mode: CapabilitiesSheetMode | null) => void;
-  owner: LightWorkspaceType;
   handleSkillToggle: (skill: SkillType) => void;
   filteredSkills: SkillType[];
   searchQuery: string;
@@ -32,7 +31,6 @@ type CapabilitiesSelectionPageProps = {
 };
 
 export function CapabilitiesSelectionPageContent({
-  owner,
   handleSkillToggle,
   filteredSkills,
   searchQuery,
@@ -45,6 +43,7 @@ export function CapabilitiesSelectionPageContent({
   handleToolInfoClick,
   onModeChange,
 }: CapabilitiesSelectionPageProps) {
+  const { owner } = useAgentBuilderContext();
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
   const [filter, setFilter] = useState<CapabilityFilterType>("all");
 

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
@@ -2,7 +2,6 @@ import type { AgentBuilderSkillsType } from "@app/components/agent_builder/Agent
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { UserType, WorkspaceType } from "@app/types";
 import type {
   SkillType,
   SkillWithRelationsType,
@@ -79,8 +78,6 @@ export type CapabilitiesSheetContentProps = {
     tools: SelectedTool[];
   }) => void;
   onToolEditSave: (updatedAction: BuilderAction) => void;
-  owner: WorkspaceType;
-  user: UserType;
   initialAdditionalSpaces: string[];
   alreadyRequestedSpaceIds: Set<string>;
   alreadyAddedSkillIds: Set<string>;

--- a/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { useForm } from "react-hook-form";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { CapabilitiesSelectionPageContent } from "@app/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage";
 import {
@@ -35,8 +36,6 @@ import { getSkillIcon } from "@app/lib/skill";
 import { assertNever } from "@app/types";
 
 export function useCapabilitiesPageAndFooter({
-  owner,
-  user,
   mode,
   onModeChange,
   onClose,
@@ -52,6 +51,7 @@ export function useCapabilitiesPageAndFooter({
   leftButton?: ButtonProps & React.RefAttributes<HTMLButtonElement>;
   rightButton?: ButtonProps & React.RefAttributes<HTMLButtonElement>;
 } {
+  const { owner, user } = useAgentBuilderContext();
   const [searchQuery, setSearchQuery] = useState("");
 
   const skillSelection = useSkillSelection({
@@ -153,7 +153,6 @@ export function useCapabilitiesPageAndFooter({
           id: mode.pageId,
           content: (
             <CapabilitiesSelectionPageContent
-              owner={owner}
               isCapabilitiesLoading={
                 skillSelection.isSkillsLoading ||
                 toolSelection.isMCPServerViewsLoading
@@ -293,7 +292,6 @@ export function useCapabilitiesPageAndFooter({
           id: mode.pageId,
           content: (
             <MCPServerConfigurationPage
-              owner={owner}
               form={form}
               action={mode.capability}
               mcpServerView={mode.mcpServerView}
@@ -325,7 +323,6 @@ export function useCapabilitiesPageAndFooter({
           id: mode.pageId,
           content: (
             <MCPServerConfigurationPage
-              owner={owner}
               form={form}
               action={mode.capability}
               mcpServerView={mode.mcpServerView}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerConfigurationPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerConfigurationPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { AdditionalConfigurationSection } from "@app/components/agent_builder/capabilities/shared/AdditionalConfigurationSection";
 import { ChildAgentSection } from "@app/components/agent_builder/capabilities/shared/ChildAgentSection";
@@ -14,10 +15,8 @@ import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { LightWorkspaceType } from "@app/types";
 
 export interface MCPServerConfigurationPageProps {
-  owner: LightWorkspaceType;
   form: UseFormReturn<MCPFormData>;
   action: BuilderAction;
   mcpServerView: MCPServerViewTypeWithLabel;
@@ -25,12 +24,12 @@ export interface MCPServerConfigurationPageProps {
 }
 
 export function MCPServerConfigurationPage({
-  owner,
   form,
   action,
   mcpServerView,
   getAgentInstructions,
 }: MCPServerConfigurationPageProps) {
+  const { owner } = useAgentBuilderContext();
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
   const requirements = useMemo(() => {

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -13,6 +13,7 @@ import {
 import React, { useCallback, useMemo, useState } from "react";
 import { useController, useFieldArray, useFormContext } from "react-hook-form";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type {
   AgentBuilderFormData,
   AgentBuilderSkillsType,
@@ -37,7 +38,7 @@ import { BACKGROUND_IMAGE_STYLE_PROPS } from "@app/components/shared/tools_picke
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getSkillIcon } from "@app/lib/skill";
 import { useSkillWithRelations } from "@app/lib/swr/skill_configurations";
-import type { TemplateActionPreset, UserType, WorkspaceType } from "@app/types";
+import type { TemplateActionPreset } from "@app/types";
 import { pluralize } from "@app/types";
 
 interface SkillCardProps {
@@ -106,19 +107,11 @@ function ActionButtons({
   );
 }
 
-interface AgentBuilderSkillsBlockProps {
-  isSkillsLoading?: boolean;
-  owner: WorkspaceType;
-  user: UserType;
-}
-
-export function AgentBuilderSkillsBlock({
-  isSkillsLoading,
-  owner,
-  user,
-}: AgentBuilderSkillsBlockProps) {
-  const { getValues } = useFormContext<AgentBuilderFormData>();
+export function AgentBuilderSkillsBlock() {
   const sendNotification = useSendNotification();
+  const { owner } = useAgentBuilderContext();
+
+  const { getValues } = useFormContext<AgentBuilderFormData>();
   const {
     fields: skillFields,
     remove: removeSkill,
@@ -147,7 +140,7 @@ export function AgentBuilderSkillsBlock({
     mcpServerViewsWithoutKnowledge,
     mcpServerViews,
   } = useMCPServerViewsContext();
-  const { skills: allSkills } = useSkillsContext();
+  const { skills: allSkills, isSkillsLoading } = useSkillsContext();
   const { spaces } = useSpacesContext();
 
   const alreadyAddedSkillIds = useMemo(
@@ -393,8 +386,6 @@ export function AgentBuilderSkillsBlock({
         onCapabilitiesSave={handleCapabilitiesSave}
         onToolEditSave={handleToolEditSave}
         onModeChange={setCapabilitiesSheetMode}
-        owner={owner}
-        user={user}
         initialAdditionalSpaces={additionalSpacesField.value}
         alreadyRequestedSpaceIds={alreadyRequestedSpaceIds}
         alreadyAddedSkillIds={alreadyAddedSkillIds}


### PR DESCRIPTION
Final step 🥳  of implementing https://github.com/dust-tt/tasks/issues/5565

Splitting https://github.com/dust-tt/dust/pull/19233/changes in 8 PRs

## Description

- Show either Skills block OR Capabilities block in agent builder (not both) based on `skills` feature flag
- Reduce prop drilling by using `useAgentBuilderContext` instead of passing `owner`/`user` through props

## Tests

Local.

## Risk

Low.

## Deploy Plan

Deploy front.
