### PR TITLE
Universal Search: Deduplicate Github results

### DIFF
--- a/front/lib/search/tools/search.ts
+++ b/front/lib/search/tools/search.ts
@@ -61,6 +61,7 @@ const TOOL_TO_CONNECTOR_PROVIDER: Partial<
   google_drive: "google_drive",
   notion: "notion",
   microsoft_drive: "microsoft",
+  github: "github",
 };
 
 function _isSearchableTool(


### PR DESCRIPTION
## Description

To not search on both a Connector and a Tool on universal search, we've added some logic to maintain some kind of mapping between both. It was missing for Github. 

I should refactor and add it as part of SEARCHABLE_TOOLS to make sure we always have to specify it. 
Handling it as is first as quick fix. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 