### PR TITLE
Move Space Priority Logic in Search Endpoint

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -39,7 +39,6 @@ import type {
   ToolSearchResult,
   ToolSearchServerResult,
 } from "@app/lib/search/tools/types";
-import { getSpaceAccessPriority } from "@app/lib/spaces";
 import { useUnifiedSearch } from "@app/lib/swr/search";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type {
@@ -233,6 +232,7 @@ export const InputBarAttachmentsPicker = ({
     includeDataSources: true,
     searchSourceUrls: true,
     includeTools: true,
+    prioritizeSpaceAccess: true,
   });
 
   const spacesMap = useMemo(
@@ -251,18 +251,10 @@ export const InputBarAttachmentsPicker = ({
       removeNulls(
         searchResultNodes.map((node) => {
           const { dataSourceViews, ...rest } = node;
-          const dataSourceView = dataSourceViews
-            .filter((view) => spacesMap[view.spaceId])
-            .map((view) => ({
-              ...view,
-              spaceName: spacesMap[view.spaceId].name,
-              spacePriority: getSpaceAccessPriority(spacesMap[view.spaceId]),
-            }))
-            .sort(
-              (a, b) =>
-                b.spacePriority - a.spacePriority ||
-                a.spaceName.localeCompare(b.spaceName)
-            )[0];
+          // Backend now returns only the highest priority data source view
+          const dataSourceView = dataSourceViews.find(
+            (view) => spacesMap[view.spaceId]
+          );
 
           if (!dataSourceView) {
             return null;

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -251,7 +251,7 @@ export const InputBarAttachmentsPicker = ({
       removeNulls(
         searchResultNodes.map((node) => {
           const { dataSourceViews, ...rest } = node;
-          // Backend now returns only the highest priority data source view
+
           const dataSourceView = dataSourceViews.find(
             (view) => spacesMap[view.spaceId]
           );

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -463,7 +463,7 @@ const InputBarContainer = ({
     if (searchResultNodes.length > 0) {
       const nodesWithViews = searchResultNodes.flatMap((node) => {
         const { dataSourceViews, ...rest } = node;
-        // Backend now returns only the highest priority data source view
+
         return dataSourceViews.map((view) => ({
           ...rest,
           dataSourceView: view,
@@ -479,7 +479,6 @@ const InputBarContainer = ({
       );
 
       if (nodes.length > 0) {
-        // Backend prioritization means we can just take the first result
         const node = nodes[0];
         onNodeSelect(node);
         setSelectedNode(node);

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -35,7 +35,6 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { getSkillIcon } from "@app/lib/skill";
-import { getSpaceAccessPriority } from "@app/lib/spaces";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
@@ -436,6 +435,7 @@ const InputBarContainer = ({
           viewType: "all",
           disabled: isSpacesLoading || !nodeOrUrlCandidate,
           spaceIds: spaces.map((s) => s.sId),
+          prioritizeSpaceAccess: true,
         }
       : {
           // TextSearchParams
@@ -446,6 +446,7 @@ const InputBarContainer = ({
           viewType: "all",
           disabled: isSpacesLoading || !nodeOrUrlCandidate,
           spaceIds: spaces.map((s) => s.sId),
+          prioritizeSpaceAccess: true,
         }
   );
 
@@ -462,11 +463,10 @@ const InputBarContainer = ({
     if (searchResultNodes.length > 0) {
       const nodesWithViews = searchResultNodes.flatMap((node) => {
         const { dataSourceViews, ...rest } = node;
+        // Backend now returns only the highest priority data source view
         return dataSourceViews.map((view) => ({
           ...rest,
           dataSourceView: view,
-          spacePriority: getSpaceAccessPriority(spacesMap[view.spaceId]),
-          spaceName: spacesMap[view.spaceId]?.name,
         }));
       });
 
@@ -479,12 +479,8 @@ const InputBarContainer = ({
       );
 
       if (nodes.length > 0) {
-        const sortedNodes = nodes.sort(
-          (a, b) =>
-            b.spacePriority - a.spacePriority ||
-            a.spaceName.localeCompare(b.spaceName)
-        );
-        const node = sortedNodes[0];
+        // Backend prioritization means we can just take the first result
+        const node = nodes[0];
         onNodeSelect(node);
         setSelectedNode(node);
         return;

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -127,14 +127,22 @@ export const SearchRequestBody = t.union([TextSearchBody, NodeIdSearchBody]);
 export type SearchRequestBodyType = t.TypeOf<typeof SearchRequestBody>;
 
 function getSpaceAccessPriority(space: SpaceResource) {
+  // Global spaces have highest priority.
   if (space.isGlobal()) {
+    return 3;
+  }
+
+  // Open spaces have second highest priority.
+  if (space.isRegularAndOpen()) {
     return 2;
   }
 
-  if (!space.isRegularAndOpen()) {
+  // For restricted spaces: provisioned groups get higher priority than manual membership.
+  if (space.groups.some((g) => g.isProvisioned())) {
     return 1;
   }
 
+  // Restriced spaces with manual membership have lowest priority.
   return 0;
 }
 

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -138,13 +138,3 @@ export const CATEGORY_DETAILS: {
     icon: BoltIcon,
   },
 };
-
-export const getSpaceAccessPriority = (space: SpaceType) => {
-  if (space.kind === "global") {
-    return 2;
-  }
-  if (!space.isRestricted) {
-    return 1;
-  }
-  return 0;
-};

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -35,6 +35,7 @@ export function useUnifiedSearch({
   includeDataSources = true,
   searchSourceUrls = false,
   includeTools = true,
+  prioritizeSpaceAccess = false,
 }: {
   owner: LightWorkspaceType;
   query: string;
@@ -45,6 +46,7 @@ export function useUnifiedSearch({
   includeDataSources?: boolean;
   searchSourceUrls?: boolean;
   includeTools?: boolean;
+  prioritizeSpaceAccess?: boolean;
 }) {
   const [knowledgeResults, setKnowledgeResults] = useState<
     DataSourceViewContentNode[]
@@ -78,6 +80,7 @@ export function useUnifiedSearch({
       params.append("viewType", viewType);
       params.append("includeDataSources", includeDataSources.toString());
       params.append("searchSourceUrls", searchSourceUrls.toString());
+      params.append("prioritizeSpaceAccess", prioritizeSpaceAccess.toString());
       // Only include tools on first page
       params.append(
         "includeTools",
@@ -144,14 +147,15 @@ export function useUnifiedSearch({
     },
     [
       disabled,
-      query,
-      pageSize,
-      viewType,
       includeDataSources,
       includeTools,
+      owner.sId,
+      pageSize,
+      prioritizeSpaceAccess,
+      query,
       searchSourceUrls,
       spaceIds,
-      owner.sId,
+      viewType,
     ]
   );
 

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -669,6 +669,7 @@ type BaseSearchParams = {
   allowAdminSearch?: boolean;
   dataSourceViewIdsBySpaceId?: Record<string, string[]>;
   parentId?: string;
+  prioritizeSpaceAccess?: boolean;
 };
 
 // Text search variant
@@ -701,6 +702,7 @@ export function useSpacesSearch({
   allowAdminSearch = false,
   dataSourceViewIdsBySpaceId,
   parentId,
+  prioritizeSpaceAccess = false,
 }: SpacesSearchParams): {
   isSearchLoading: boolean;
   isSearchError: boolean;
@@ -731,6 +733,7 @@ export function useSpacesSearch({
     allowAdminSearch,
     dataSourceViewIdsBySpaceId,
     parentId,
+    prioritizeSpaceAccess,
   };
 
   // Only perform a query if we have a valid search

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -53,6 +53,7 @@ async function handleStreamingSearch(
     includeDataSources = "true",
     searchSourceUrls,
     includeTools = "true",
+    prioritizeSpaceAccess = "false",
   } = req.query;
 
   // Transform query parameters to match SearchRequestBodySchema format
@@ -79,6 +80,7 @@ async function handleStreamingSearch(
     includeDataSources: includeDataSources === "true",
     limit,
     searchSourceUrls: searchSourceUrls === "true" ? true : undefined,
+    prioritizeSpaceAccess: prioritizeSpaceAccess === "true",
   };
 
   // Validate using SearchRequestBody


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR moves the existing logic used in the input bar to prioritize some spaces over others on search. This. logic is now moved to the search endpoint to ensure we can re-use it in the skill builder view when attaching knowledge.

It's achieved using a `prioritizeSpaceAccess` flag in the request body to only return the views from the space with the highest priority if several spaces match.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested on front-edge

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
