### PR TITLE
[LLM] Improve finish reason logging for Google

### DIFF
--- a/front/lib/api/llm/clients/google/utils/google_to_events.ts
+++ b/front/lib/api/llm/clients/google/utils/google_to_events.ts
@@ -211,6 +211,7 @@ export async function* streamLLMEvents({
               type: "stop_error",
               isRetryable: false,
               message: "An error occurred during completion",
+              originalError: { finishReason: candidate.finishReason },
             },
             metadata
           ),


### PR DESCRIPTION
## Description

Google LLM does not handle all finish reasons
This PR logs the actual finish reason to see if it's relevant to transform it as error

## Tests

no

## Risk

low

## Deploy Plan

front
