### PR TITLE
[Slack MCP] replace list_channels, list_joined_channels and get_channel_details by search_channel

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -565,13 +565,10 @@ export const INTERNAL_MCP_SERVERS = {
       search_messages: "never_ask",
       semantic_search_messages: "never_ask",
       list_users: "never_ask",
-      list_public_channels: "never_ask",
-      list_channels: "never_ask",
-      list_joined_channels: "never_ask",
+      search_channels: "never_ask",
       list_threads: "never_ask",
       read_thread_messages: "never_ask",
       get_user: "never_ask",
-      get_channel_details: "never_ask",
 
       // Write operations - low stakes
       post_message: "low",

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -463,36 +463,6 @@ export async function hasSlackScope(
   );
 }
 
-// Used by slack_bot
-export async function executeListPublicChannels(
-  nameFilter: string | undefined,
-  accessToken: string,
-  mcpServerId: string
-) {
-  const slackClient = await getSlackClient(accessToken);
-  const channels = await getCachedPublicChannels({
-    slackClient,
-    mcpServerId,
-  });
-
-  return buildFilteredListResponse<ChannelWithIdAndName, MinimalChannelInfo>(
-    channels,
-    nameFilter,
-    (channel, normalizedFilter) =>
-      removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
-        normalizedFilter
-      ) ||
-      removeDiacritics(channel.topic?.value?.toLowerCase() ?? "").includes(
-        normalizedFilter
-      ),
-    (count, hasFilter, filterText) =>
-      hasFilter
-        ? `The workspace has ${count} channels containing "${filterText}"`
-        : `The workspace has ${count} channels`,
-    cleanChannelPayload
-  );
-}
-
 // Helper function to filter channels by substring matching on name, topic, and purpose.
 function filterChannels(
   channels: ChannelWithIdAndName[],
@@ -691,6 +661,36 @@ export async function executeSearchChannels(
   } catch (error) {
     return new Err(new MCPError(`Error searching channels: ${error}`));
   }
+}
+
+// Used by slack_bot
+export async function executeListPublicChannels(
+  nameFilter: string | undefined,
+  accessToken: string,
+  mcpServerId: string
+) {
+  const slackClient = await getSlackClient(accessToken);
+  const channels = await getCachedPublicChannels({
+    slackClient,
+    mcpServerId,
+  });
+
+  return buildFilteredListResponse<ChannelWithIdAndName, MinimalChannelInfo>(
+    channels,
+    nameFilter,
+    (channel, normalizedFilter) =>
+      removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
+        normalizedFilter
+      ) ||
+      removeDiacritics(channel.topic?.value?.toLowerCase() ?? "").includes(
+        normalizedFilter
+      ),
+    (count, hasFilter, filterText) =>
+      hasFilter
+        ? `The workspace has ${count} channels containing "${filterText}"`
+        : `The workspace has ${count} channels`,
+    cleanChannelPayload
+  );
 }
 
 export async function executePostMessage(

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -19,6 +19,7 @@ import { Err, normalizeError, Ok } from "@app/types";
 // Constants for Slack API limits and pagination.
 export const SLACK_API_PAGE_SIZE = 100;
 export const MAX_CHANNELS_LIMIT = 500;
+export const MAX_CHANNEL_SEARCH_RESULTS = 20;
 export const MAX_THREAD_MESSAGES = 200;
 export const DEFAULT_THREAD_MESSAGES = 20;
 export const SLACK_THREAD_LISTING_LIMIT = 100;
@@ -513,7 +514,11 @@ export async function executeSearchChannels(
         scope: "joined",
       });
 
-      const matchedInJoined = filterChannels(joinedChannels, query, 10);
+      const matchedInJoined = filterChannels(
+        joinedChannels,
+        query,
+        MAX_CHANNEL_SEARCH_RESULTS
+      );
 
       if (matchedInJoined.length > 0) {
         return new Ok([
@@ -537,7 +542,11 @@ export async function executeSearchChannels(
         scope: "public",
       });
 
-      const matchedInAll = filterChannels(allChannels, query, 10);
+      const matchedInAll = filterChannels(
+        allChannels,
+        query,
+        MAX_CHANNEL_SEARCH_RESULTS
+      );
 
       return new Ok([
         {
@@ -564,7 +573,11 @@ export async function executeSearchChannels(
       scope: "public",
     });
 
-    const matched = filterChannels(allChannels, query, 10);
+    const matched = filterChannels(
+      allChannels,
+      query,
+      MAX_CHANNEL_SEARCH_RESULTS
+    );
 
     return new Ok([
       {

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -204,7 +204,7 @@ export const getChannels = async ({
     cursor = response.response_metadata?.next_cursor;
 
     // We can't handle a huge list of channels, and even if we could, it would be unusable.
-    // in the UI. So we arbitrarily cap it to MAX_CHANNELS_LIMIT channels.
+    // So we arbitrarily cap it to MAX_CHANNELS_LIMIT channels.
     if (channels.length >= MAX_CHANNELS_LIMIT) {
       logger.warn(
         `Channel list truncated after reaching over ${MAX_CHANNELS_LIMIT} channels.`
@@ -454,7 +454,7 @@ export async function hasSlackScope(
 function filterChannels(
   channels: ChannelWithIdAndName[],
   query: string,
-  limit: number = 10
+  limit: number = MAX_CHANNEL_SEARCH_RESULTS
 ): ChannelWithIdAndName[] {
   if (!query || query.trim() === "") {
     return channels
@@ -482,7 +482,7 @@ async function searchAndProcessChannels(
 ): Promise<Ok<Array<{ type: "text"; text: string }>> | Err<MCPError>> {
   try {
     const channels = await getChannels({ slackClient, scope });
-    const matched = filterChannels(channels, query, MAX_CHANNEL_SEARCH_RESULTS);
+    const matched = filterChannels(channels, query);
     const cleaned = matched.map(cleanChannelPayload);
     const markdown = cleaned.map(formatChannelAsMarkdown).join("\n");
     return new Ok([

--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -413,6 +413,7 @@ export async function hasSlackScope(
   );
 }
 
+// Used by slack_bot
 export async function executeListPublicChannels(
   nameFilter: string | undefined,
   accessToken: string,
@@ -442,34 +443,6 @@ export async function executeListPublicChannels(
   );
 }
 
-export async function executeListJoinedChannels(
-  nameFilter: string | undefined,
-  accessToken: string
-) {
-  const slackClient = await getSlackClient(accessToken);
-  const channels = await getChannels({
-    slackClient,
-    scope: "joined",
-  });
-
-  return buildFilteredListResponse<ChannelWithIdAndName, MinimalChannelInfo>(
-    channels,
-    nameFilter,
-    (channel, normalizedFilter) =>
-      removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
-        normalizedFilter
-      ) ||
-      removeDiacritics(channel.topic?.value?.toLowerCase() ?? "").includes(
-        normalizedFilter
-      ),
-    (count, hasFilter, filterText) =>
-      hasFilter
-        ? `You are a member of ${count} channels containing "${filterText}"`
-        : `You are a member of ${count} channels`,
-    cleanChannelPayload
-  );
-}
-
 // Helper function to filter channels by substring matching on name, topic, and purpose.
 function filterChannels(
   channels: ChannelWithIdAndName[],
@@ -488,7 +461,7 @@ function filterChannels(
     const nameMatch = c.name.toLowerCase().includes(queryLower);
     const topicMatch = c.topic?.value?.toLowerCase().includes(queryLower);
     const purposeMatch = c.purpose?.value?.toLowerCase().includes(queryLower);
-    return nameMatch || topicMatch || purposeMatch;
+    return nameMatch ?? topicMatch ?? purposeMatch;
   });
 
   return matched.sort((a, b) => a.name.localeCompare(b.name)).slice(0, limit);

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -8,8 +8,8 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   executeGetUser,
-  executeListChannels,
   executeListJoinedChannels,
+  executeListPublicChannels,
   executeListUsers,
   executePostMessage,
   executeReadThreadMessages,
@@ -868,7 +868,7 @@ async function createServer(
         }
 
         try {
-          return await executeListChannels(
+          return await executeListPublicChannels(
             nameFilter,
             accessToken,
             mcpServerId
@@ -906,11 +906,7 @@ async function createServer(
         }
 
         try {
-          return await executeListJoinedChannels(
-            nameFilter,
-            accessToken,
-            mcpServerId
-          );
+          return await executeListJoinedChannels(nameFilter, accessToken);
         } catch (error) {
           const authError = handleSlackAuthError(error);
           if (authError) {
@@ -1020,7 +1016,6 @@ async function createServer(
           channelId = await resolveChannelId({
             channelNameOrId: channel,
             accessToken,
-            mcpServerId,
           });
         } catch (error) {
           const authError = handleSlackAuthError(error);
@@ -1194,7 +1189,6 @@ async function createServer(
           oldest,
           latest,
           accessToken,
-          mcpServerId,
         });
       }
     )

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -15,6 +15,7 @@ import {
   executeSearchChannels,
   getSlackClient,
   isSlackMissingScope,
+  MAX_CHANNEL_SEARCH_RESULTS,
   resolveChannelDisplayName,
   resolveChannelId,
   resolveUserDisplayName,
@@ -847,17 +848,20 @@ async function createServer(
 
   server.tool(
     "search_channels",
-    "Search for Slack channels using two strategies. Returns JSON.\n\n" +
-      "1. EXACT QUERY (lookup_type='exact'): ONLY use when you have a Slack channel ID (e.g., 'C01234ABCD'). " +
-      "This does NOT work with channel names - only with channel IDs. Returns full channel object as JSON.\n\n" +
-      "2. SEARCH QUERY (lookup_type='search'): Use for channel names or vague queries. " +
-      "Searches across channel names, topics, and purpose descriptions. Returns top 10 matches as JSON array.\n\n" +
-      "SCOPE BEHAVIOR (only applies to lookup_type='search'):\n" +
-      "IMPORTANT: ALWAYS start with scope='joined' (the default). This searches the user's joined channels (public + private) first, " +
-      "then automatically falls back to all public workspace channels if no results are found.\n\n" +
-      "Only use scope='all' in these two cases:\n" +
-      "1. The user explicitly asks to search non-joined or public workspace channels\n" +
-      "2. You already tried scope='joined' and got no results (though the fallback handles this automatically)\n\n",
+    `Search for Slack channels using two strategies. Returns JSON.
+
+1. EXACT QUERY (lookup_type='exact'): ONLY use when you have a Slack channel ID (e.g., 'C01234ABCD'). This does NOT work with channel names - only with channel IDs. Returns full channel object as JSON.
+
+2. SEARCH QUERY (lookup_type='search'): Use for channel names or vague queries. Searches across channel names, topics, and purpose descriptions. Returns top ${MAX_CHANNEL_SEARCH_RESULTS} matches as JSON array.
+
+SCOPE BEHAVIOR (only applies to lookup_type='search'):
+IMPORTANT: ALWAYS start with scope='joined' (the default). This searches the user's joined channels (public + private) first, then automatically falls back to all public workspace channels if no results are found.
+
+Only use scope='all' in these two cases:
+1. The user explicitly asks to search non-joined or public workspace channels
+2. You already tried scope='joined' and got no results (though the fallback handles this automatically)
+
+`,
     {
       query: z
         .string()


### PR DESCRIPTION
## Description


Consolidates three separate Slack MCP channel tools (`list_channels`, `list_joined_channels`, `get_channel_details`) into a single unified `search_channels` tool that automatically detects whether the query is a channel ID or text search. Search fetches channel lists and filters locally. 
- For text search with `scope="auto"`, it searches joined channels first and automatically falls back to all workspace channels if no results are found. 
- For text search with `scope="joined"`, it searches in joined channels only using `users.conversations ` endpoint (more favorable rate limits) for joined channels over `conversations.list`, reducing timeout issues for most use cases.  
- For text search with `scope="all"`, it searches using `conversations.list` endpoint.

The refactoring simplifies the `getChannels` helper to use `users.conversations` directly when fetching joined channels instead of `conversations.list` with post-filtering. This removes the `mcpServerId` parameter from multiple helper functions including `getChannels`, `resolveChannelId`, and `executeReadThreadMessages`.

## Risk

Previous agent using `list_channels`, `list_joined_channels`, `get_channel_details` will automatically switch to `search_channels`, prompt can be suboptimal but it shouldn't break agents.

## Tests

Manual testing locally

## Deploy Plan

Run front
