### PR TITLE
[Credits] Add excess credit type for tracking over-consumption

### DIFF
--- a/front/components/poke/credits/columns.tsx
+++ b/front/components/poke/credits/columns.tsx
@@ -34,10 +34,14 @@ export function makeColumnsForCredits(): ColumnDef<PokeCreditType>[] {
       },
       cell: ({ row }) => {
         const { type } = row.original;
-        const colorMap: Record<CreditType, "blue" | "primary" | "green"> = {
+        const colorMap: Record<
+          CreditType,
+          "blue" | "primary" | "green" | "warning"
+        > = {
           free: "blue",
           payg: "primary",
           committed: "green",
+          excess: "warning",
         };
         return (
           <Chip color={colorMap[type] ?? "highlight"} size="xs">

--- a/front/components/poke/credits/columns.tsx
+++ b/front/components/poke/credits/columns.tsx
@@ -2,9 +2,9 @@ import { Chip, IconButton } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { TYPE_COLORS } from "@app/components/workspace/CreditsList";
 import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import { dateToHumanReadable } from "@app/types";
-import type { CreditType } from "@app/types/credits";
 
 function formatMicroUsdToUsd(microUsdAmount: number): string {
   return `$${(microUsdAmount / 1_000_000).toFixed(2)}`;
@@ -34,17 +34,8 @@ export function makeColumnsForCredits(): ColumnDef<PokeCreditType>[] {
       },
       cell: ({ row }) => {
         const { type } = row.original;
-        const colorMap: Record<
-          CreditType,
-          "blue" | "primary" | "green" | "warning"
-        > = {
-          free: "blue",
-          payg: "primary",
-          committed: "green",
-          excess: "warning",
-        };
         return (
-          <Chip color={colorMap[type] ?? "highlight"} size="xs">
+          <Chip color={TYPE_COLORS[type] ?? "highlight"} size="xs">
             {type}
           </Chip>
         );

--- a/front/components/workspace/CreditHistorySheet.tsx
+++ b/front/components/workspace/CreditHistorySheet.tsx
@@ -18,10 +18,12 @@ import {
 import type { CreditDisplayData, CreditType } from "@app/types/credits";
 
 // Sorting priority for credit types: free -> committed -> payg
+// Note: excess credits should never be displayed in the UI
 const TYPE_SORT_ORDER: Record<CreditType, number> = {
   free: 1,
   committed: 2,
   payg: 3,
+  excess: 4,
 };
 
 function sortCredits(credits: CreditDisplayData[]): CreditDisplayData[] {

--- a/front/components/workspace/CreditHistorySheet.tsx
+++ b/front/components/workspace/CreditHistorySheet.tsx
@@ -14,17 +14,9 @@ import React, { useMemo, useState } from "react";
 import {
   creditColumns,
   getTableRows,
+  TYPE_SORT_ORDER,
 } from "@app/components/workspace/CreditsList";
-import type { CreditDisplayData, CreditType } from "@app/types/credits";
-
-// Sorting priority for credit types: free -> committed -> payg
-// Note: excess credits should never be displayed in the UI
-const TYPE_SORT_ORDER: Record<CreditType, number> = {
-  free: 1,
-  committed: 2,
-  payg: 3,
-  excess: 4,
-};
+import type { CreditDisplayData } from "@app/types/credits";
 
 function sortCredits(credits: CreditDisplayData[]): CreditDisplayData[] {
   return [...credits].sort((a, b) => {

--- a/front/components/workspace/CreditHistorySheet.tsx
+++ b/front/components/workspace/CreditHistorySheet.tsx
@@ -14,9 +14,9 @@ import React, { useMemo, useState } from "react";
 import {
   creditColumns,
   getTableRows,
-  TYPE_SORT_ORDER,
 } from "@app/components/workspace/CreditsList";
 import type { CreditDisplayData } from "@app/types/credits";
+import { CREDIT_TYPE_SORT_ORDER } from "@app/types/credits";
 
 function sortCredits(credits: CreditDisplayData[]): CreditDisplayData[] {
   return [...credits].sort((a, b) => {
@@ -29,7 +29,7 @@ function sortCredits(credits: CreditDisplayData[]): CreditDisplayData[] {
     }
 
     // Then sort by type priority
-    return TYPE_SORT_ORDER[a.type] - TYPE_SORT_ORDER[b.type];
+    return CREDIT_TYPE_SORT_ORDER[a.type] - CREDIT_TYPE_SORT_ORDER[b.type];
   });
 }
 

--- a/front/components/workspace/CreditsList.tsx
+++ b/front/components/workspace/CreditsList.tsx
@@ -23,7 +23,7 @@ type Info = CellContext<RowData, string>;
 
 // Sorting priority for credit types: free -> committed -> payg
 // Note: excess credits should never be displayed in the UI
-const TYPE_SORT_ORDER: Record<CreditType, number> = {
+export const TYPE_SORT_ORDER: Record<CreditType, number> = {
   free: 1,
   committed: 2,
   payg: 3,
@@ -39,7 +39,7 @@ const TYPE_LABELS: Record<CreditType, string> = {
 };
 
 // Chip colors for credit types
-const TYPE_COLORS: Record<
+export const TYPE_COLORS: Record<
   CreditType,
   "green" | "blue" | "primary" | "warning"
 > = {

--- a/front/components/workspace/CreditsList.tsx
+++ b/front/components/workspace/CreditsList.tsx
@@ -22,10 +22,12 @@ type RowData = {
 type Info = CellContext<RowData, string>;
 
 // Sorting priority for credit types: free -> committed -> payg
+// Note: excess credits should never be displayed in the UI
 const TYPE_SORT_ORDER: Record<CreditType, number> = {
   free: 1,
   committed: 2,
   payg: 3,
+  excess: 4,
 };
 
 // Display labels for credit types
@@ -33,13 +35,18 @@ const TYPE_LABELS: Record<CreditType, string> = {
   free: "Free",
   committed: "Committed",
   payg: "Pay-as-you-go",
+  excess: "Excess",
 };
 
 // Chip colors for credit types
-const TYPE_COLORS: Record<CreditType, "green" | "blue" | "primary"> = {
+const TYPE_COLORS: Record<
+  CreditType,
+  "green" | "blue" | "primary" | "warning"
+> = {
   free: "green",
   committed: "blue",
   payg: "primary",
+  excess: "warning",
 };
 
 function sortCredits(credits: CreditDisplayData[]): CreditDisplayData[] {

--- a/front/components/workspace/CreditsList.tsx
+++ b/front/components/workspace/CreditsList.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from "react";
 
 import { getPriceAsString } from "@app/lib/client/subscription";
 import type { CreditDisplayData, CreditType } from "@app/types/credits";
+import { CREDIT_TYPE_SORT_ORDER } from "@app/types/credits";
 import type { EditedByUser } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 
@@ -20,15 +21,6 @@ type RowData = {
 };
 
 type Info = CellContext<RowData, string>;
-
-// Sorting priority for credit types: free -> committed -> payg
-// Note: excess credits should never be displayed in the UI
-export const TYPE_SORT_ORDER: Record<CreditType, number> = {
-  free: 1,
-  committed: 2,
-  payg: 3,
-  excess: 4,
-};
 
 // Display labels for credit types
 const TYPE_LABELS: Record<CreditType, string> = {
@@ -52,7 +44,8 @@ export const TYPE_COLORS: Record<
 function sortCredits(credits: CreditDisplayData[]): CreditDisplayData[] {
   return [...credits].sort((a, b) => {
     // First sort by type priority
-    const typeDiff = TYPE_SORT_ORDER[a.type] - TYPE_SORT_ORDER[b.type];
+    const typeDiff =
+      CREDIT_TYPE_SORT_ORDER[a.type] - CREDIT_TYPE_SORT_ORDER[b.type];
     if (typeDiff !== 0) {
       return typeDiff;
     }

--- a/front/pages/api/w/[wId]/credits/index.ts
+++ b/front/pages/api/w/[wId]/credits/index.ts
@@ -38,8 +38,11 @@ async function handler(
       });
 
       // Transform started credits to display format with computed consumed amount.
+      // Exclude excess credits as they are internal accounting records.
       const creditsData: CreditDisplayData[] = credits
-        .filter((credit) => credit.startDate !== null)
+        .filter(
+          (credit) => credit.startDate !== null && credit.type !== "excess"
+        )
         .map((credit) => credit.toJSON());
 
       // Find pending committed credits (not yet started, awaiting payment).

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -357,6 +357,8 @@ export default function CreditsUsagePage({
       free: { consumed: 0, total: 0, expirationDate: null },
       committed: { consumed: 0, total: 0, expirationDate: null },
       payg: { consumed: 0, total: 0, expirationDate: null },
+      // Excess credits are filtered out in the API and should never appear here.
+      excess: { consumed: 0, total: 0, expirationDate: null },
     };
 
     for (const credit of activeCredits) {

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -4,6 +4,15 @@ export const CREDIT_TYPES = ["free", "payg", "committed", "excess"] as const;
 
 export type CreditType = (typeof CREDIT_TYPES)[number];
 
+// Consumption priority: free credits first, then committed, then pay-as-you-go.
+// Excess credits are never active and should not be consumed.
+export const CREDIT_TYPE_SORT_ORDER: Record<CreditType, number> = {
+  free: 1,
+  committed: 2,
+  payg: 3,
+  excess: 4,
+};
+
 export function isCreditType(value: unknown): value is CreditType {
   return CREDIT_TYPES.includes(value as CreditType);
 }

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -1,6 +1,6 @@
 import type { EditedByUser } from "@app/types/user";
 
-export const CREDIT_TYPES = ["free", "payg", "committed"] as const;
+export const CREDIT_TYPES = ["free", "payg", "committed", "excess"] as const;
 
 export type CreditType = (typeof CREDIT_TYPES)[number];
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5556

Adds an "excess" credit type to enforce the invariant that `sum(consumed credits) = total usage`.

When programmatic usage exhausts all active credits, an excess credit is created with:
- `initialAmountMicroUsd = consumedAmountMicroUsd = remainingCost`
- `startDate = expirationDate = now`

This ensures excess credits are never active (already fully consumed and expired at creation) but serve as accounting records.

Excess credits are filtered from user-facing UI but visible in Poke for admin visibility.

## Risks

Blast radius: Programmatic credit consumption tracking
Risk: low

## Deploy Plan

- deploy front