### PR TITLE
fix: handle nullable users in suggestion of mentions

### DIFF
--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -130,7 +130,8 @@ export const suggestionsOfMentions = async (
   }
 ): Promise<RichMention[]> => {
   const normalizedQuery = query.toLowerCase();
-  const currentUserSId = auth.getNonNullableUser().sId;
+  // can be called from the public API, so user may be null
+  const currentUser = auth.user();
 
   // Id of the last user or agent mentioned by the current user in the conversation
   let lastMentionedId: string | null = null;
@@ -160,7 +161,7 @@ export const suggestionsOfMentions = async (
 
         // Convert participants to RichMention format
         participantUsers = participants.users
-          .filter((u) => current || u.sId !== currentUserSId)
+          .filter((u) => current || u.sId !== currentUser?.sId)
           .map((u) => ({
             type: "user" as const,
             id: u.sId,
@@ -232,7 +233,7 @@ export const suggestionsOfMentions = async (
       const { users } = res.value;
 
       const filteredUsers: RichUserMentionInConversation[] = users
-        .filter((u) => current || u.sId !== currentUserSId)
+        .filter((u) => current || u.sId !== currentUser?.sId)
         .map((u) => ({
           ...toRichUserMentionType(u.toJSON()),
           isParticipant: participantUsers.some((pu) => pu.id === u.sId),


### PR DESCRIPTION
## Description

Fix when called from the public API the currentUser can be `null`
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
