### PR TITLE
chore(skills): cleanup skills on workspace deletion

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -12,6 +12,10 @@ import {
   MessageReactionModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import {
+  AgentMessageSkillModel,
+  ConversationSkillModel,
+} from "@app/lib/models/skill/conversation_skill";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -23,6 +27,7 @@ import type {
   Result,
 } from "@app/types";
 import { Err, Ok, removeNulls } from "@app/types";
+import { WhereOptions } from "sequelize";
 
 const DESTROY_MESSAGE_BATCH = 50;
 
@@ -192,6 +197,14 @@ export async function destroyConversation(
     await AgentMessageFeedbackModel.destroy({
       where: { agentMessageId: agentMessageIds },
     });
+
+    const whereAgentMessageSkill: WhereOptions<AgentMessageSkillModel> = {
+      agentMessageId: agentMessageIds,
+    };
+    await AgentMessageSkillModel.destroy({
+      where: whereAgentMessageSkill,
+    });
+
     await AgentMessageModel.destroy({
       where: { id: agentMessageIds },
     });
@@ -204,6 +217,10 @@ export async function destroyConversation(
   }
 
   await destroyConversationDataSource(auth, { conversation });
+
+  await ConversationSkillModel.destroy({
+    where: { conversationId: conversation.id },
+  });
 
   const c = await ConversationResource.fetchById(auth, conversation.sId, {
     includeDeleted: true,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,4 +1,5 @@
 import chunk from "lodash/chunk";
+import type { WhereOptions } from "sequelize";
 
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
@@ -27,7 +28,6 @@ import type {
   Result,
 } from "@app/types";
 import { Err, Ok, removeNulls } from "@app/types";
-import { WhereOptions } from "sequelize";
 
 const DESTROY_MESSAGE_BATCH = 50;
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1157,14 +1157,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    await AgentMessageSkillModel.destroy({
-      where: { workspaceId },
-    });
-
-    await ConversationSkillModel.destroy({
-      where: { workspaceId },
-    });
-
     await AgentSkillModel.destroy({
       where: { workspaceId },
     });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -94,7 +94,8 @@ type ConversationSkillCreationAttributes =
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface SkillResource extends ReadonlyAttributesType<SkillConfigurationModel> {}
+export interface SkillResource
+  extends ReadonlyAttributesType<SkillConfigurationModel> {}
 
 /**
  * SkillResource handles both custom (database-backed) and global (code-defined)
@@ -1151,6 +1152,38 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
 
     return [...customSkills, ...globalSkills];
+  }
+
+  static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    await AgentMessageSkillModel.destroy({
+      where: { workspaceId },
+    });
+
+    await ConversationSkillModel.destroy({
+      where: { workspaceId },
+    });
+
+    await AgentSkillModel.destroy({
+      where: { workspaceId },
+    });
+
+    await GroupSkillModel.destroy({
+      where: { workspaceId },
+    });
+
+    await SkillMCPServerConfigurationModel.destroy({
+      where: { workspaceId },
+    });
+
+    await SkillVersionModel.destroy({
+      where: { workspaceId },
+    });
+
+    await SkillConfigurationModel.destroy({
+      where: { workspaceId },
+    });
   }
 
   toJSON(auth: Authenticator): SkillType {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -94,8 +94,7 @@ type ConversationSkillCreationAttributes =
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface SkillResource
-  extends ReadonlyAttributesType<SkillConfigurationModel> {}
+export interface SkillResource extends ReadonlyAttributesType<SkillConfigurationModel> {}
 
 /**
  * SkillResource handles both custom (database-backed) and global (code-defined)

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -43,6 +43,7 @@ import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";
@@ -484,6 +485,18 @@ export async function deleteMembersActivity({
       await membership.delete(auth, {});
     }
   }
+}
+
+export async function deleteSkillsActivity({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+  await SkillResource.deleteAllForWorkspace(auth);
+
+  hardDeleteLogger.info({ workspaceId }, "Deleted all skills");
 }
 
 export async function deleteWebhookSourcesActivity({

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -69,7 +69,6 @@ export async function deleteWorkspaceWorkflow({
     return;
   }
 
-  await deleteSkillsActivity({ workspaceId });
   await deleteConversationsActivity({ workspaceId });
   await deleteRemoteMCPServersActivity({ workspaceId });
   await deleteAgentsActivity({ workspaceId });
@@ -82,6 +81,7 @@ export async function deleteWorkspaceWorkflow({
   await deleteWebhookSourcesActivity({ workspaceId });
   await deleteTranscriptsActivity({ workspaceId });
   await deletePluginRunsActivity({ workspaceId });
+  await deleteSkillsActivity({ workspaceId });
   await deleteWorkspaceActivity({ workspaceId });
   await deleteWorkOSOrganization({ workspaceId, workspaceHasBeenRelocated });
 }

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -16,6 +16,7 @@ const {
   deleteMembersActivity,
   deletePluginRunsActivity,
   deleteRemoteMCPServersActivity,
+  deleteSkillsActivity,
   deleteSpacesActivity,
   deleteWebhookSourcesActivity,
   deleteTagsActivity,
@@ -68,6 +69,7 @@ export async function deleteWorkspaceWorkflow({
     return;
   }
 
+  await deleteSkillsActivity({ workspaceId });
   await deleteConversationsActivity({ workspaceId });
   await deleteRemoteMCPServersActivity({ workspaceId });
   await deleteAgentsActivity({ workspaceId });

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -70,6 +70,7 @@ export async function deleteWorkspaceWorkflow({
   }
 
   await deleteConversationsActivity({ workspaceId });
+  await deleteSkillsActivity({ workspaceId });
   await deleteRemoteMCPServersActivity({ workspaceId });
   await deleteAgentsActivity({ workspaceId });
   await deleteRunOnDustAppsActivity({ workspaceId });
@@ -81,7 +82,6 @@ export async function deleteWorkspaceWorkflow({
   await deleteWebhookSourcesActivity({ workspaceId });
   await deleteTranscriptsActivity({ workspaceId });
   await deletePluginRunsActivity({ workspaceId });
-  await deleteSkillsActivity({ workspaceId });
   await deleteWorkspaceActivity({ workspaceId });
   await deleteWorkOSOrganization({ workspaceId, workspaceHasBeenRelocated });
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/5590

Adding a new step in the workspace deletion workflow that deletes all skill related entries.
We first delete all of the conversation-related skill entries in the first deleteConversation activity.

Then later in the workflow delete all other skill related entries.

The deleteAllForWorkspace method goes first through the child tables before removing the SkillConfigs.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

No

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low - block workspace deletion on a potential edge case but should not be the case

## Deploy Plan

Deploy front