### PR TITLE
Clarify dust purpose and knowledge/tool access

### DIFF
--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -2,6 +2,7 @@ import {
   BracesIcon,
   Button,
   Chip,
+  cn,
   DocumentIcon,
   ExternalLinkIcon,
   FolderIcon,
@@ -210,7 +211,7 @@ export function AssistantKnowledgeSection({
         Knowledge
       </div>
       {hasDocuments && hasTables ? (
-        <Tree isBoxed>
+        <Tree isBoxed className={cn("max-h-[400px] overflow-y-auto")}>
           <Tree.Item label="Documents" visual={DocumentIcon}>
             {dataSourcesDocuments}
           </Tree.Item>
@@ -219,7 +220,7 @@ export function AssistantKnowledgeSection({
           </Tree.Item>
         </Tree>
       ) : (
-        <Tree isBoxed>
+        <Tree isBoxed className={cn("max-h-[400px] overflow-y-auto")}>
           {hasDocuments && dataSourcesDocuments}
           {hasTables && dataSourcesTables}
         </Tree>

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection.tsx
@@ -2,7 +2,6 @@ import {
   BracesIcon,
   Button,
   Chip,
-  cn,
   DocumentIcon,
   ExternalLinkIcon,
   FolderIcon,
@@ -211,7 +210,7 @@ export function AssistantKnowledgeSection({
         Knowledge
       </div>
       {hasDocuments && hasTables ? (
-        <Tree isBoxed className={cn("max-h-[400px] overflow-y-auto")}>
+        <Tree isBoxed className="max-h-[400px] overflow-y-auto">
           <Tree.Item label="Documents" visual={DocumentIcon}>
             {dataSourcesDocuments}
           </Tree.Item>
@@ -220,7 +219,7 @@ export function AssistantKnowledgeSection({
           </Tree.Item>
         </Tree>
       ) : (
-        <Tree isBoxed className={cn("max-h-[400px] overflow-y-auto")}>
+        <Tree isBoxed className="max-h-[400px] overflow-y-auto">
           {hasDocuments && dataSourcesDocuments}
           {hasTables && dataSourcesTables}
         </Tree>

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
@@ -112,6 +112,7 @@ export function AssistantToolsSection({
                       <div className="truncate">{action.title}</div>
                     </div>
                   }
+                  tooltipTriggerAsChild
                 />
               ))
             )}
@@ -129,6 +130,7 @@ export function AssistantToolsSection({
                       <div className="truncate">{displayName}</div>
                     </div>
                   }
+                  tooltipTriggerAsChild
                 />
               );
             })}

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
@@ -1,55 +1,64 @@
-import { Avatar, CommandIcon, Spinner } from "@dust-tt/sparkle";
+import { Avatar, CommandIcon, Spinner, Tooltip } from "@dust-tt/sparkle";
 import _ from "lodash";
 import { useMemo } from "react";
 
-import { getModelProviderLogo } from "@app/components/providers/types";
-import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import {
   getMcpServerDisplayName,
+  getMcpServerViewDescription,
   getMcpServerViewDisplayName,
   getServerTypeAndIdFromSId,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
+import { isInternalMCPServerOfName } from "@app/lib/actions/mcp_internal_actions/constants";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import {
   isMCPServerConfiguration,
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
 import type { MCPServerTypeWithViews } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
-import { useMCPServers } from "@app/lib/swr/mcp_servers";
+import { useMCPServers, useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
+import { useSpaces } from "@app/lib/swr/spaces";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { AgentConfigurationType, LightWorkspaceType } from "@app/types";
-import {
-  asDisplayName,
-  assertNever,
-  GLOBAL_AGENTS_SID,
-  removeNulls,
-  SUPPORTED_MODEL_CONFIGS,
-} from "@app/types";
+import { asDisplayName, assertNever, removeNulls } from "@app/types";
 
 interface AssistantToolsSectionProps {
   agentConfiguration: AgentConfigurationType;
   owner: LightWorkspaceType;
+  isDustAgent: boolean;
 }
+
+const HIDDEN_DUST_ACTIONS = [
+  "toolsets",
+  "agent_router",
+  "data_sources_file_system",
+  "data_warehouses",
+] as const;
 
 // Since Dust is configured with one search for all, plus individual searches for each managed data source,
 // we hide these additional searches from the user in the UI to avoid displaying the same data source twice.
 // We use the `hidden_dust_search_` prefix to identify these additional searches.
-const isHiddenDustAction = (
-  agentConfiguration: AgentConfigurationType,
-  action: MCPServerConfigurationType
-) => {
-  const isDustGlobalAgent = agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST;
-  return isDustGlobalAgent && action.name.startsWith("hidden_dust_search_");
+const isHiddenDustAction = (action: MCPServerConfigurationType) => {
+  if (action.name.startsWith("hidden_dust_search_")) {
+    return true;
+  }
+  if (isServerSideMCPServerConfiguration(action)) {
+    return HIDDEN_DUST_ACTIONS.some((serverName) =>
+      isInternalMCPServerOfName(action.internalMCPServerId, serverName)
+    );
+  }
+  return false;
 };
 
 export function AssistantToolsSection({
   agentConfiguration,
   owner,
+  isDustAgent,
 }: AssistantToolsSectionProps) {
-  const { isDark } = useTheme();
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
   const { mcpServers, isMCPServersLoading: isToolsLoading } = useMCPServers({
     owner,
@@ -60,68 +69,69 @@ export function AssistantToolsSection({
     disabled: !featureFlags.includes("skills"),
   });
 
-  const nonHiddenActions = agentConfiguration.actions.filter(
-    (action) => !isHiddenDustAction(agentConfiguration, action)
-  );
-  const actions = removeNulls(
-    nonHiddenActions.map((action) => renderOtherAction(action, mcpServers))
-  );
+  const { availableToolsets, isLoading: isToolsetsLoading } =
+    useAvailableToolsets({
+      owner,
+      agentConfiguration,
+    });
 
-  const sortedActions = useMemo(
-    () => _.sortBy(_.uniqBy(actions, "title"), ["order", "title"]),
-    [actions]
-  );
+  const sortedActions = useMemo(() => {
+    const actions = removeNulls(
+      agentConfiguration.actions
+        .filter((action) => (isDustAgent ? !isHiddenDustAction(action) : true))
+        .map((action) => renderOtherAction(action, mcpServers))
+    );
+    return _.sortBy(_.uniqBy(actions, "title"), ["order", "title"]);
+  }, [agentConfiguration.actions, mcpServers, isDustAgent]);
+
   const sortedSkills = useMemo(() => _.sortBy(skills, "name"), [skills]);
 
-  const model = SUPPORTED_MODEL_CONFIGS.find(
-    (m) =>
-      m.modelId === agentConfiguration.model.modelId &&
-      m.providerId === agentConfiguration.model.providerId
-  );
-
-  const hasTools = nonHiddenActions.length > 0;
+  const hasTools = sortedActions.length > 0 || availableToolsets.length > 0;
   const hasSkills = featureFlags.includes("skills") && skills.length > 0;
 
   return (
     <div className="flex flex-col gap-5">
-      {model && (
-        <>
-          <div className="heading-lg text-foreground dark:text-foreground-night">
-            Model
-          </div>
-          <div className="flex flex-row items-center gap-2">
-            <Avatar
-              icon={getModelProviderLogo(model.providerId, isDark)}
-              size="xs"
-            />
-            <div>{model.displayName}</div>
-          </div>
-        </>
-      )}
-
       {hasTools && (
         <div className="flex flex-col gap-5">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Tools
           </div>
           <div className="grid grid-cols-2 gap-2">
-            {isToolsLoading ? (
+            {isToolsLoading || isToolsetsLoading ? (
               <div className="flex flex-row items-center gap-2">
                 <Spinner size="xs" />
               </div>
             ) : (
               sortedActions.map((action) => (
-                <div
-                  className="flex min-w-0 flex-row items-center gap-2"
+                <Tooltip
                   key={action.title}
-                >
-                  {action.avatar}
-                  <div className="truncate" title={action.title}>
-                    {action.title}
-                  </div>
-                </div>
+                  label={action.description ?? action.title}
+                  trigger={
+                    <div className="flex min-w-0 flex-row items-center gap-2">
+                      <div className="flex-shrink-0">{action.avatar}</div>
+                      <div className="truncate">{action.title}</div>
+                    </div>
+                  }
+                />
               ))
             )}
+            {availableToolsets.map((view) => {
+              const avatar = getAvatarFromIcon(view.server.icon, "xs");
+              const displayName = getMcpServerViewDisplayName(view);
+              const description = getMcpServerViewDescription(view);
+              return (
+                <Tooltip
+                  key={view.sId}
+                  label={description ?? displayName}
+                  trigger={
+                    <div className="flex min-w-0 flex-row items-center gap-2">
+                      <div className="flex-shrink-0">{avatar}</div>
+                      <div className="truncate">{displayName}</div>
+                    </div>
+                  }
+                />
+              );
+            })}
           </div>
         </div>
       )}
@@ -158,10 +168,70 @@ export function AssistantToolsSection({
   );
 }
 
+/**
+ * Hook to fetch available toolsets for an agent configuration.
+ * Only fetches data if the agent has a toolsets action configured.
+ */
+function useAvailableToolsets({
+  owner,
+  agentConfiguration,
+}: {
+  owner: LightWorkspaceType;
+  agentConfiguration: AgentConfigurationType;
+}) {
+  const toolsetsAction = useMemo(
+    () =>
+      agentConfiguration.actions.find(
+        (action) =>
+          isServerSideMCPServerConfiguration(action) &&
+          isInternalMCPServerOfName(action.internalMCPServerId, "toolsets")
+      ),
+    [agentConfiguration.actions]
+  );
+
+  const { spaces } = useSpaces({
+    workspaceId: owner.sId,
+    disabled: !toolsetsAction,
+  });
+  const globalSpace = spaces.find((s) => s.kind === "global");
+
+  const { serverViews: globalServerViews, isMCPServerViewsLoading } =
+    useMCPServerViews({
+      owner,
+      space: globalSpace,
+      disabled: !toolsetsAction || !globalSpace,
+    });
+
+  const availableToolsets = useMemo(() => {
+    if (!toolsetsAction) {
+      return [];
+    }
+    const agentMcpServerViewIds = new Set(
+      agentConfiguration.actions
+        .filter(isServerSideMCPServerConfiguration)
+        .map((action) => action.mcpServerViewId)
+    );
+    return globalServerViews
+      .filter((view) => !agentMcpServerViewIds.has(view.sId))
+      .filter((view) => getMCPServerRequirements(view).noRequirement)
+      .filter((view) => view.server.availability !== "auto_hidden_builder");
+  }, [toolsetsAction, globalServerViews, agentConfiguration.actions]);
+
+  return {
+    availableToolsets,
+    isLoading: isMCPServerViewsLoading,
+  };
+}
+
 function renderOtherAction(
   action: MCPServerConfigurationType,
   mcpServers: MCPServerTypeWithViews[]
-) {
+): {
+  title: string;
+  description: string | null;
+  avatar: React.ReactNode;
+  order: number;
+} | null {
   if (isServerSideMCPServerConfiguration(action)) {
     const mcpServer = mcpServers.find((s) =>
       s.views.some((v) => v.sId === action.mcpServerViewId)
@@ -175,14 +245,20 @@ function renderOtherAction(
     const title = view
       ? getMcpServerViewDisplayName(view, action)
       : getMcpServerDisplayName(mcpServer, action);
+    const description = view
+      ? getMcpServerViewDescription(view)
+      : mcpServer.description;
+
     return {
       title,
+      description,
       avatar,
       order: serverType === "internal" ? 1 : 3,
     };
   } else if (isMCPServerConfiguration(action)) {
     return {
       title: asDisplayName(action.name),
+      description: action.description,
       avatar: <Avatar icon={CommandIcon} size="xs" />,
       order: 3,
     };

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -1,10 +1,13 @@
-import { Chip, cn, Page } from "@dust-tt/sparkle";
-import React from "react";
+import { Avatar, Chip, cn, Markdown, Page } from "@dust-tt/sparkle";
+import isString from "lodash/isString";
 
 import { AgentMessageMarkdown } from "@app/components/assistant/AgentMessageMarkdown";
 import { AssistantKnowledgeSection } from "@app/components/assistant/details/tabs/AgentInfoTab/AssistantKnowledgeSection";
 import { AssistantToolsSection } from "@app/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection";
+import { getModelProviderLogo } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { AgentConfigurationType, WorkspaceType } from "@app/types";
+import { GLOBAL_AGENTS_SID, SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 export function AgentInfoTab({
   agentConfiguration,
@@ -13,6 +16,25 @@ export function AgentInfoTab({
   agentConfiguration: AgentConfigurationType;
   owner: WorkspaceType;
 }) {
+  const { isDark } = useTheme();
+  const isDustAgent =
+    agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST ||
+    agentConfiguration.sId === GLOBAL_AGENTS_SID.DEEP_DIVE ||
+    agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST_EDGE;
+
+  const isGlobalAgent = agentConfiguration.scope === "global";
+  const displayKnowledge = !isGlobalAgent || isDustAgent;
+  const displayInstructions =
+    !isGlobalAgent &&
+    isString(agentConfiguration?.instructions) &&
+    agentConfiguration.instructions.length > 0;
+
+  const model = SUPPORTED_MODEL_CONFIGS.find(
+    (m) =>
+      m.modelId === agentConfiguration.model.modelId &&
+      m.providerId === agentConfiguration.model.providerId
+  );
+
   return (
     <div className="flex flex-col gap-5">
       {agentConfiguration.tags.length > 0 && (
@@ -25,45 +47,61 @@ export function AgentInfoTab({
 
       {agentConfiguration.description && (
         <div className="text-sm text-foreground dark:text-foreground-night">
-          {agentConfiguration.description}
+          <Markdown
+            content={agentConfiguration.description}
+            forcedTextSize="text-sm"
+          />
         </div>
       )}
 
-      {agentConfiguration.scope !== "global" && (
+      {displayKnowledge && (
         <>
           <Page.Separator />
           <AssistantKnowledgeSection
             agentConfiguration={agentConfiguration}
             owner={owner}
           />
-
-          {agentConfiguration?.instructions ? (
-            <div className="dd-privacy-mask flex flex-col gap-4">
-              <div className="heading-lg text-foreground dark:text-foreground-night">
-                Instructions
-              </div>
-              <div
-                className={cn(
-                  "max-h-[400px] overflow-y-auto rounded-lg border border-border bg-muted-background px-3 py-2 " +
-                    "dark:border-border-night dark:bg-muted-background-night"
-                )}
-              >
-                <AgentMessageMarkdown
-                  content={agentConfiguration.instructions}
-                  owner={owner}
-                />
-              </div>
-            </div>
-          ) : (
-            <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Instructions
-            </div>
-          )}
         </>
       )}
+
+      {displayInstructions && isString(agentConfiguration.instructions) && (
+        <div className="dd-privacy-mask flex flex-col gap-4">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Instructions
+          </div>
+          <div
+            className={cn(
+              "max-h-[400px] overflow-y-auto rounded-lg border border-border bg-muted-background px-3 py-2 " +
+                "dark:border-border-night dark:bg-muted-background-night"
+            )}
+          >
+            <AgentMessageMarkdown
+              content={agentConfiguration.instructions}
+              owner={owner}
+            />
+          </div>
+        </div>
+      )}
+
+      {model && (
+        <div className="flex flex-col gap-5">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Model
+          </div>
+          <div className="flex flex-row items-center gap-2">
+            <Avatar
+              icon={getModelProviderLogo(model.providerId, isDark)}
+              size="xs"
+            />
+            <div>{model.displayName}</div>
+          </div>
+        </div>
+      )}
+
       <AssistantToolsSection
         agentConfiguration={agentConfiguration}
         owner={owner}
+        isDustAgent={isDustAgent}
       />
     </div>
   );

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -351,7 +351,10 @@ function _getDustLikeGlobalAgent(
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
 
-  const description = "An agent with context on your company data.";
+  const description = `Dust is your general purpose agent. It has access to all of your company data and tools available in the Company space. Dust can help you:
+- Find and analyze data across your company knowledge
+- Research topics by searching the web
+- Create content like documents, presentations, images, and dashboards`;
   const pictureUrl = DUST_AVATAR_URL;
 
   let isPreferredModel = false;


### PR DESCRIPTION
## Description

| Before  | After |
| ------------- | ------------- |
| <img width="570" height="1536" alt="Screenshot 2025-12-23 at 11 54 04" src="https://github.com/user-attachments/assets/9ae4de04-059f-4136-860f-b004819d6b7c" /> | <img width="570" height="1528" alt="Screenshot 2025-12-23 at 11 53 46" src="https://github.com/user-attachments/assets/df9f2ef3-4231-4877-a3ce-de5bd5b5867b" />  |


- Change dust agent description.
- Limit the heigh of the Knowledge section.
- Display Knowledge section for dust agents.
- Hide some tools for dust agents that brings nothing to the user.
- Display the tool description on hover on a tooltip. 
- For toolset tool, display the actual tools activated and available as part of toolset tool. 


## Tests

Locally.

## Risk

Break this modal. 

## Deploy Plan

Deploy front. 