### PR TITLE
[Agent Loop] Implement heartbeat for runModel activity and restore 10mn timeout

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1,3 +1,4 @@
+import { heartbeat } from "@temporalio/activity";
 import assert from "assert";
 
 import { fetchSkillMCPServerConfigurations } from "@app/lib/actions/configuration/mcp";
@@ -490,6 +491,11 @@ export async function runModelActivity(
   }
 
   const modelInteractionStartDate = performance.now();
+
+  // Heartbeat before starting the LLM stream to ensure the activity is still
+  // considered alive after potentially long setup operations (MCP tools
+  // listing, conversation rendering, etc.).
+  heartbeat();
 
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
     modelConversationRes,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -32,6 +32,7 @@ import type {
 
 const toolActivityStartToCloseTimeout = `${DEFAULT_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1} minutes`;
 export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60_000;
+const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60_000;
 
 import {
   OpenTelemetryInboundInterceptor,
@@ -49,7 +50,8 @@ export const interceptors: WorkflowInterceptorsFactory = () => ({
 const { runModelAndCreateActionsActivity } = proxyActivities<
   typeof runModelAndCreateWrapperActivities
 >({
-  startToCloseTimeout: "5 minutes",
+  startToCloseTimeout: "10 minutes",
+  heartbeatTimeout: MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
 });
 
 const { runToolActivity } = proxyActivities<typeof runToolActivities>({


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5672

Context: [slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1765967907749079) | [related issue #5661](https://github.com/dust-tt/tasks/issues/5661) | [PR #19206](https://github.com/dust-tt/dust/pull/19206)

Implements heartbeat mechanism for the runModel activity similar to what exists for runTool:
- Adds `MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS` constant (60 seconds)
- Updates `startToCloseTimeout` from 5 minutes to 10 minutes
- Adds `heartbeatTimeout` configuration to the activity proxy
- Adds a heartbeat call before `getOutputFromLLMStream` to cover potentially long setup operations (MCP tools listing, conversation rendering)

The heartbeat during LLM streaming is already handled in `get_output_from_llm.ts`.

## Risks

Blast radius: Agent loop model activity timeouts
Risk: low (configuration change matching existing runTool pattern)

## Deploy Plan

- Deploy front