### PR TITLE
[front] refactor(skills): store MCP server views on resource

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -412,6 +412,22 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return views.find((view) => view.space.kind === "global") ?? null;
   }
 
+  static async listMCPServerViewsAutoInternalForSpaces(
+    auth: Authenticator,
+    name: AutoInternalMCPServerNameType,
+    spaceModelIds: ModelId[]
+  ) {
+    const views = await this.listByMCPServer(
+      auth,
+      autoInternalMCPServerNameToSId({
+        name,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      })
+    );
+
+    return views.filter((view) => spaceModelIds.includes(view.vaultId));
+  }
+
   static async getMCPServerViewForSystemSpace(
     auth: Authenticator,
     mcpServerId: string

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -425,7 +425,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       })
     );
 
-    return views.filter((view) => spaceModelIds.includes(view.vaultId));
+    // We include the global space, which is omitted from the requested space IDs of an agent.
+    return views.filter(
+      (view) =>
+        spaceModelIds.includes(view.vaultId) || view.space.kind === "global"
+    );
   }
 
   static async getMCPServerViewForSystemSpace(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -684,7 +684,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         )
       : [];
 
-    // TODO(SKILLS 2025-12-12): Consider doing on single call with all ids.
     if (def.internalMCPServerNames) {
       const mcpServerViewsByName = await concurrentExecutor(
         def.internalMCPServerNames,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1,3 +1,4 @@
+import groupBy from "lodash/groupBy";
 import omit from "lodash/omit";
 import type {
   Attributes,
@@ -53,22 +54,17 @@ import type {
   SkillType,
 } from "@app/types/assistant/skill_configuration";
 
-type SkillMCPServerAttributes = Omit<
-  Attributes<SkillMCPServerConfigurationModel>,
-  "id" | "skillConfigurationId"
->;
-
 type SkillResourceConstructorOptions =
   | {
       // For global skills, there is no editor group.
       editorGroup?: undefined;
       globalSId: string;
-      mcpServerConfigurations?: SkillMCPServerAttributes[];
+      mcpServerViews: MCPServerViewResource[];
     }
   | {
       editorGroup?: GroupResource;
       globalSId?: undefined;
-      mcpServerConfigurations?: SkillMCPServerAttributes[];
+      mcpServerViews: MCPServerViewResource[];
     };
 
 type SkillVersionCreationAttributes =
@@ -145,21 +141,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static model: ModelStatic<SkillConfigurationModel> = SkillConfigurationModel;
 
   readonly editorGroup: GroupResource | null = null;
-  readonly mcpServerConfigurations: SkillMCPServerAttributes[];
+  readonly mcpServerViews: MCPServerViewResource[];
 
   private readonly globalSId: string | null;
 
   private constructor(
     model: ModelStatic<SkillConfigurationModel>,
     blob: Attributes<SkillConfigurationModel>,
-    options: SkillResourceConstructorOptions = {}
+    { globalSId, mcpServerViews, editorGroup }: SkillResourceConstructorOptions
   ) {
-    const { globalSId, mcpServerConfigurations, editorGroup } = options;
     super(SkillConfigurationModel, blob);
 
     this.editorGroup = editorGroup ?? null;
     this.globalSId = globalSId ?? null;
-    this.mcpServerConfigurations = mcpServerConfigurations ?? [];
+    this.mcpServerViews = mcpServerViews;
   }
 
   get sId(): string {
@@ -202,7 +197,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       );
 
-      return new this(this.model, skill.get(), { editorGroup });
+      return new this(this.model, skill.get(), {
+        editorGroup,
+        mcpServerViews: [],
+      });
     });
 
     return skillResource;
@@ -210,7 +208,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   private static async baseFetch(
     auth: Authenticator,
-    options: SkillConfigurationFindOptions = {}
+    options: SkillConfigurationFindOptions = {},
+    context: { agentConfiguration?: LightAgentConfigurationType } = {}
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -237,22 +236,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           },
         });
 
-      const mcpServerConfigsBySkillId = new Map<
-        number,
-        Attributes<SkillMCPServerConfigurationModel>[]
-      >();
-      for (const config of mcpServerConfigurations) {
-        const existing = mcpServerConfigsBySkillId.get(
-          config.skillConfigurationId
-        );
-        if (existing) {
-          existing.push(config.get());
-        } else {
-          mcpServerConfigsBySkillId.set(config.skillConfigurationId, [
-            config.get(),
-          ]);
-        }
-      }
+      const skillMCPServerConfigsBySkillId = groupBy(
+        mcpServerConfigurations,
+        "skillConfigurationId"
+      );
 
       // Fetch editor groups for all skills.
       const skillEditorGroupsMap = new Map<number, GroupResource>();
@@ -293,13 +280,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       }
 
-      customSkillsRes = customSkills.map(
-        (c) =>
-          new this(this.model, c.get(), {
-            mcpServerConfigurations: mcpServerConfigsBySkillId.get(c.id) ?? [],
-            editorGroup: skillEditorGroupsMap.get(c.id),
-          })
+      const allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
+        auth,
+        removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId))
       );
+
+      customSkillsRes = customSkills.map((customSkill) => {
+        const skillMCPServerViewIds = skillMCPServerConfigsBySkillId[
+          customSkill.id
+        ]?.map((skillConfig) => skillConfig.mcpServerViewId);
+
+        return new this(this.model, customSkill.get(), {
+          mcpServerViews: allMCPServerViews.filter((view) =>
+            skillMCPServerViewIds?.includes(view.id)
+          ),
+          editorGroup: skillEditorGroupsMap.get(customSkill.id),
+        });
+      });
     }
 
     // Only include global skills if onlyCustom is not true.
@@ -314,7 +311,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     await concurrentExecutor(
       globalSkillDefinitions,
       async (def) => {
-        const skill = await this.fromGlobalSkill(auth, def);
+        const skill = await this.fromGlobalSkill(auth, def, context);
         globalSkills.push(skill);
       },
       { concurrency: 5 }
@@ -367,7 +364,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async fetchByIds(
     auth: Authenticator,
-    sIds: string[]
+    sIds: string[],
+    context: { agentConfiguration?: LightAgentConfigurationType } = {}
   ): Promise<SkillResource[]> {
     if (sIds.length === 0) {
       return [];
@@ -392,12 +390,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       { customSkillIds: [], globalSkillIds: [] }
     );
 
-    return this.baseFetch(auth, {
-      where: {
-        id: customSkillIds,
-        sId: globalSkillIds,
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          id: customSkillIds,
+          sId: globalSkillIds,
+        },
       },
-    });
+      context
+    );
   }
 
   static async fetchActiveByName(
@@ -519,7 +521,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return [];
     }
 
-    return SkillResource.fetchByIds(auth, allSkillIds);
+    return SkillResource.fetchByIds(auth, allSkillIds, { agentConfiguration });
   }
 
   /**
@@ -671,37 +673,30 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   private static async fromGlobalSkill(
     auth: Authenticator,
-    def: GlobalSkillDefinition
+    def: GlobalSkillDefinition,
+    context: { agentConfiguration?: LightAgentConfigurationType } = {}
   ): Promise<SkillResource> {
     // Fetch MCP server configurations if the global skill has an internal MCP server.
-    let mcpServerConfigurations: SkillMCPServerAttributes[] = [];
+    let mcpServerViews: MCPServerViewResource[] = [];
+    const requestedSpaceIds = context?.agentConfiguration?.requestedSpaceIds
+      ? removeNulls(
+          context.agentConfiguration.requestedSpaceIds.map(getResourceIdFromSId)
+        )
+      : [];
 
     // TODO(SKILLS 2025-12-12): Consider doing on single call with all ids.
     if (def.internalMCPServerNames) {
-      const mscs = await concurrentExecutor(
+      const mcpServerViewsByName = await concurrentExecutor(
         def.internalMCPServerNames,
-        async (name) => {
-          const mcpServerView =
-            await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-              auth,
-              name
-            );
-
-          if (mcpServerView) {
-            return {
-              workspaceId: auth.getNonNullableWorkspace().id,
-              mcpServerViewId: mcpServerView.id,
-              createdAt: new Date(),
-              updatedAt: new Date(),
-            };
-          }
-
-          return null;
-        },
+        async (name) =>
+          MCPServerViewResource.listMCPServerViewsAutoInternalForSpaces(
+            auth,
+            name,
+            requestedSpaceIds
+          ),
         { concurrency: 5 }
       );
-
-      mcpServerConfigurations = removeNulls(mscs);
+      mcpServerViews = mcpServerViewsByName.flat();
     }
 
     return new SkillResource(
@@ -715,14 +710,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         id: -1,
         instructions: def.instructions,
         name: def.name,
-        requestedSpaceIds: [],
+        requestedSpaceIds,
         status: "active",
         updatedAt: new Date(),
         workspaceId: auth.getNonNullableWorkspace().id,
         icon: def.icon,
         extendedSkillId: null,
       },
-      { globalSId: def.sId, mcpServerConfigurations }
+      { globalSId: def.sId, mcpServerViews }
     );
   }
 
@@ -797,17 +792,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
 
     // Convert version models to SkillResource instances
-    const historicalVersions: SkillResource[] = sortedVersionModels.map(
-      (versionModel) => {
-        const mcpServerConfigurations =
-          versionModel.mcpServerConfigurationIds.map((mcpServerId) => ({
-            id: -1,
-            workspaceId: workspace.id,
-            skillConfigurationId: this.id,
-            mcpServerViewId: mcpServerId,
-            createdAt: versionModel.createdAt,
-            updatedAt: versionModel.updatedAt,
-          }));
+    const historicalVersions: SkillResource[] = await concurrentExecutor(
+      sortedVersionModels,
+      async (versionModel) => {
+        // TODO(skills 2025-12-23): add caching on the MCP server views across versions.
+        const mcpServerViews = await MCPServerViewResource.fetchByModelIds(
+          auth,
+          versionModel.mcpServerConfigurationIds
+        );
 
         return new SkillResource(
           this.model,
@@ -828,10 +820,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           },
           {
             editorGroup: this.editorGroup ?? undefined,
-            mcpServerConfigurations,
+            mcpServerViews,
           }
         );
-      }
+      },
+      { concurrency: 5 }
     );
 
     // Return current version + all historical versions
@@ -940,25 +933,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     return new Ok(updated);
-  }
-
-  async listMCPServerViews(
-    auth: Authenticator
-  ): Promise<MCPServerViewResource[]> {
-    const mcpServerViewIds = this.mcpServerConfigurations.map(
-      (config) => config.mcpServerViewId
-    );
-
-    if (mcpServerViewIds.length === 0) {
-      return [];
-    }
-
-    const mcpServerViews = await MCPServerViewResource.fetchByModelIds(
-      auth,
-      mcpServerViewIds
-    );
-
-    return mcpServerViews;
   }
 
   async updateTools(
@@ -1155,13 +1129,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   toJSON(auth: Authenticator): SkillType {
-    const tools = this.mcpServerConfigurations.map((config) => ({
-      mcpServerViewId: makeSId("mcp_server_view", {
-        id: config.mcpServerViewId,
-        workspaceId: this.workspaceId,
-      }),
-    }));
-
     const requestedSpaceIds = this.requestedSpaceIds.map((spaceId) =>
       SpaceResource.modelIdToSId({
         id: Number(spaceId), // Note: Sequelize returns BIGINT arrays as strings
@@ -1183,7 +1150,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       instructions: this.globalSId ? null : this.instructions,
       requestedSpaceIds: requestedSpaceIds,
       icon: this.icon ?? null,
-      tools,
+      // TODO(skills: 2025-12-23): return entire MCPServerViewType here and update call sites.
+      tools: this.mcpServerViews.map((view) => ({
+        mcpServerViewId: view.sId,
+      })),
       canWrite: this.canWrite(auth),
       isExtendable: this.isExtendable(),
       extendedSkillId: this.extendedSkillId,
@@ -1235,6 +1205,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       instructions: this.instructions,
       requestedSpaceIds: this.requestedSpaceIds,
       authorId: this.authorId,
+      // TODO(skills 2025-12-23): rename into mcpServerViewIds.
       mcpServerConfigurationIds,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -173,7 +173,8 @@ async function handler(
       // Fetch MCP server configurations from enabled skills.
       const skillServers = await fetchSkillMCPServerConfigurations(
         auth,
-        enabledSkills
+        enabledSkills,
+        agentConfiguration
       );
 
       const clientSideMCPActionConfigurations =

--- a/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/[sId]/actions.ts
@@ -86,10 +86,9 @@ async function handler(
 
   // Build actions from skill's MCP server configurations
   const actions: AgentBuilderMCPConfiguration[] = [];
-  for (const mcpConfig of skillResource.mcpServerConfigurations) {
-    /**/
+  for (const mcpConfig of skillResource.mcpServerViews) {
     const mcpServerView = mcpServerViewsJSON.find(
-      (view) => view.id === mcpConfig.mcpServerViewId
+      (view) => view.id === mcpConfig.id
     );
     if (!mcpServerView) {
       continue;

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -128,7 +128,6 @@ async function handler(
       if (withRelations === "true") {
         const usage = await skillResource.fetchUsage(auth);
         const editors = await skillResource.listEditors(auth);
-        const mcpServerViews = await skillResource.listMCPServerViews(auth);
         const author = await skillResource.fetchAuthor(auth);
         const extendedSkill = skillConfiguration.extendedSkillId
           ? await SkillResource.fetchById(
@@ -142,7 +141,9 @@ async function handler(
           relations: {
             usage,
             editors: editors ? editors.map((e) => e.toJSON()) : null,
-            mcpServerViews: mcpServerViews.map((view) => view.toJSON()),
+            mcpServerViews: skillResource.mcpServerViews.map((view) =>
+              view.toJSON()
+            ),
             author: author ? author.toJSON() : null,
             extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,
           },

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -121,7 +121,6 @@ async function handler(
           async (sc) => {
             const usage = await sc.fetchUsage(auth);
             const editors = await sc.listEditors(auth);
-            const mcpServerViews = await sc.listMCPServerViews(auth);
             const author = await sc.fetchAuthor(auth);
             const extendedSkill = sc.extendedSkillId
               ? await SkillResource.fetchById(auth, sc.extendedSkillId)
@@ -132,7 +131,7 @@ async function handler(
               relations: {
                 usage,
                 editors: editors ? editors.map((e) => e.toJSON()) : null,
-                mcpServerViews: mcpServerViews.map((view) => view.toJSON()),
+                mcpServerViews: sc.mcpServerViews.map((view) => view.toJSON()),
                 author: author ? author.toJSON() : null,
                 extendedSkill: extendedSkill
                   ? extendedSkill.toJSON(auth)

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -206,7 +206,8 @@ export async function runModelActivity(
   // Fetch MCP server configurations from enabled skills.
   const skillServers = await fetchSkillMCPServerConfigurations(
     auth,
-    enabledSkills
+    enabledSkills,
+    agentConfiguration
   );
 
   const {


### PR DESCRIPTION
## Description

- This PR updates the `SkillResource` to store the MCP server views on the resource instead of the `SkillMCPServerConfigurationModel`.
- This PR also updates the global skill instantiation to fetch the MCP server views contextualized by agent within the agent loop, meaning that the requested spaces are inherited from the agent's.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
