### PR TITLE
[Poke] Improve credits tab with all credits and excess sum

### DIFF
--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "@dust-tt/sparkle";
 import type Stripe from "stripe";
 
 import { makeColumnsForCredits } from "@app/components/poke/credits/columns";
@@ -5,8 +6,11 @@ import { PokeProgrammaticCostChart } from "@app/components/poke/credits/PokeProg
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
+import type { PokeCreditsData } from "@app/poke/swr/credits";
 import { usePokeCredits } from "@app/poke/swr/credits";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
+
+const ONE_DOLLAR_MICRO_USD = 1_000_000;
 
 interface CreditsDataTableProps {
   owner: WorkspaceType;
@@ -15,23 +19,27 @@ interface CreditsDataTableProps {
   loadOnInit?: boolean;
 }
 
-function sortByExpirationDate(credits: PokeCreditType[]): PokeCreditType[] {
+function sortByStartDateDescending(
+  credits: PokeCreditType[]
+): PokeCreditType[] {
   return [...credits].sort((a, b) => {
-    // Null expiration dates go last
-    if (!a.expirationDate && !b.expirationDate) {
+    // Null start dates go first (pending credits)
+    if (!a.startDate && !b.startDate) {
       return 0;
     }
-    if (!a.expirationDate) {
-      return 1;
-    }
-    if (!b.expirationDate) {
+    if (!a.startDate) {
       return -1;
     }
-    return (
-      new Date(a.expirationDate).getTime() -
-      new Date(b.expirationDate).getTime()
-    );
+    if (!b.startDate) {
+      return 1;
+    }
+    // Most recent first (descending order)
+    return new Date(b.startDate).getTime() - new Date(a.startDate).getTime();
   });
+}
+
+function formatMicroUsdToUsd(microUsd: number): string {
+  return (microUsd / 1_000_000).toFixed(2);
 }
 
 export function CreditsDataTable({
@@ -54,18 +62,35 @@ export function CreditsDataTable({
 
   return (
     <>
-      <PokeDataTableConditionalFetch
+      <PokeDataTableConditionalFetch<PokeCreditsData, PokeCreditsData>
         header="Credits"
         owner={owner}
         loadOnInit={loadOnInit}
         useSWRHook={usePokeCredits}
       >
         {(data) => (
-          <PokeDataTable
-            columns={makeColumnsForCredits()}
-            data={sortByExpirationDate(data)}
-            defaultFilterColumn="type"
-          />
+          <div className="space-y-4">
+            {data.excessCreditsLast30DaysMicroUsd > ONE_DOLLAR_MICRO_USD && (
+              <div className="rounded-md border border-warning-200 bg-warning-50 p-3 dark:border-warning-200-night dark:bg-warning-50-night">
+                <Tooltip
+                  label="Excess credits are created when programmatic usage exceeds available credits. This tracks over-consumption that needs to be billed."
+                  trigger={
+                    <p className="cursor-help text-sm font-medium text-warning-800 dark:text-warning-800-night">
+                      Excess credits (last 30 days): $
+                      {formatMicroUsdToUsd(
+                        data.excessCreditsLast30DaysMicroUsd
+                      )}
+                    </p>
+                  }
+                />
+              </div>
+            )}
+            <PokeDataTable
+              columns={makeColumnsForCredits()}
+              data={sortByStartDateDescending(data.credits)}
+              defaultFilterColumn="type"
+            />
+          </div>
         )}
       </PokeDataTableConditionalFetch>
 

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -227,6 +227,38 @@ export class CreditResource extends BaseResource<CreditModel> {
   }
 
   /**
+   * Returns the sum of excess credits (over-consumption) for the given period.
+   * Excess credits are created when usage exceeds available credits.
+   */
+  static async sumExcessCreditsInPeriod(
+    auth: Authenticator,
+    { periodStart, periodEnd }: { periodStart: Date; periodEnd: Date }
+  ): Promise<number> {
+    const result = await this.model.findOne({
+      attributes: [
+        [
+          Sequelize.fn(
+            "COALESCE",
+            Sequelize.fn("SUM", Sequelize.col("consumedAmountMicroUsd")),
+            0
+          ),
+          "total",
+        ],
+      ],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        type: "excess",
+        startDate: {
+          [Op.gte]: periodStart,
+          [Op.lt]: periodEnd,
+        },
+      },
+      raw: true,
+    });
+    return parseInt((result as unknown as { total: string })?.total ?? "0", 10);
+  }
+
+  /**
    * Consume a given amount of credits, allowing for over-consumption.
    * This is because users consume credits after Dust has spent the tokens,
    * so it's not possible to preemptively block consumption.

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -8,6 +8,11 @@ import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListCreditsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 
+export type PokeCreditsData = {
+  credits: PokeListCreditsResponseBody["credits"];
+  excessCreditsLast30DaysMicroUsd: number;
+};
+
 export function usePokeCredits({ disabled, owner }: PokeConditionalFetchProps) {
   const creditsFetcher: Fetcher<PokeListCreditsResponseBody> = fetcher;
 
@@ -17,8 +22,13 @@ export function usePokeCredits({ disabled, owner }: PokeConditionalFetchProps) {
     { disabled }
   );
 
+  const creditsData: PokeCreditsData = {
+    credits: data?.credits ?? emptyArray(),
+    excessCreditsLast30DaysMicroUsd: data?.excessCreditsLast30DaysMicroUsd ?? 0,
+  };
+
   return {
-    data: data?.credits ?? emptyArray(),
+    data: creditsData,
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,


### PR DESCRIPTION
## Description

Improves the Poke credits tab:
- Shows all credits (not just active ones), paginated using the existing pagination system
- Sorted by start date descending (most recently started first), with pending credits at the bottom
- Displays sum of excess credits for the last 30 days as a warning banner when there is over-consumption

## Risks

Blast radius: Poke credits tab only (admin tool)
Risk: low

## Deploy Plan
- pmrr
- deploy front