### PR TITLE
[front] - chore: extend SearchResultOutput

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -292,6 +292,8 @@ export const SearchResultResourceSchema = z.object({
   chunks: z.array(z.string()),
   source: z.object({
     provider: z.string().optional(),
+    data_source_id: z.string().optional(),
+    data_source_view_id: z.string().optional(),
   }),
 });
 

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -197,6 +197,8 @@ export async function searchFunction({
         id: doc.document_id,
         source: {
           provider: dataSourceView.dataSource.connectorProvider ?? undefined,
+          data_source_id: dataSourceView.dataSource.sId,
+          data_source_view_id: dataSourceView.sId,
         },
         tags: doc.tags,
         ref: refs.shift() as string,

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search.ts
@@ -284,6 +284,8 @@ async function searchCallback(
         id: doc.document_id,
         source: {
           provider: dataSourceView.dataSource.connectorProvider ?? undefined,
+          data_source_id: dataSourceView.dataSource.sId,
+          data_source_view_id: dataSourceView.sId,
         },
         tags: doc.tags,
         ref: refs.shift() as string,


### PR DESCRIPTION
## Description

This PR:
- Adds optional `data_source_id` and `data_source_view_id` to the search result resource schema
- Populates new schema fields with the respective IDs in the search function output

## Tests

Locally

## Risk

Low, field is optional

## Deploy Plan

Deploy front
