### PR TITLE
Poké: New button to resend an invitation

### DIFF
--- a/front/components/poke/invitations/columns.tsx
+++ b/front/components/poke/invitations/columns.tsx
@@ -1,11 +1,17 @@
-import { ClipboardIcon, IconButton, TrashIcon } from "@dust-tt/sparkle";
+import {
+  ClipboardIcon,
+  IconButton,
+  MovingMailIcon,
+  TrashIcon,
+} from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { MembershipInvitationTypeWithLink } from "@app/types";
 
 export function makeColumnsForInvitations(
-  onRevokeInvitation: (email: string) => Promise<void>
+  onRevokeInvitation: (email: string) => Promise<void>,
+  onResendInvitation: (invitationId: string) => Promise<void>
 ): ColumnDef<MembershipInvitationTypeWithLink>[] {
   return [
     {
@@ -49,6 +55,25 @@ export function makeColumnsForInvitations(
               }
             />
           </>
+        );
+      },
+    },
+    {
+      id: "resend",
+      header: "Resend",
+      cell: ({ row }) => {
+        const invitation = row.original;
+
+        return (
+          <IconButton
+            icon={MovingMailIcon}
+            size="xs"
+            variant="outline"
+            tooltip="Resend invitation email"
+            onClick={async () => {
+              await onResendInvitation(invitation.sId);
+            }}
+          />
         );
       },
     },

--- a/front/components/poke/invitations/table.tsx
+++ b/front/components/poke/invitations/table.tsx
@@ -19,6 +19,31 @@ export function InvitationsDataTable({
   invitations,
 }: InvitationsDataTableProps) {
   const router = useRouter();
+
+  async function onResendInvitation(invitationId: string): Promise<void> {
+    if (!window.confirm("Are you sure you want to resend this invitation?")) {
+      return;
+    }
+
+    try {
+      const r = await clientFetch(
+        `/api/poke/workspaces/${owner.sId}/invitations/${invitationId}`,
+        {
+          method: "PATCH",
+        }
+      );
+      if (!r.ok) {
+        throw new Error(`Failed to resend invitation: ${r.statusText}`);
+      }
+      const response = await r.json();
+      window.alert("Invitation resent successfully to " + response.email + ".");
+      router.reload();
+    } catch (e) {
+      console.error(e);
+      window.alert("An error occurred while resending the invitation.");
+    }
+  }
+
   async function onRevokeInvitation(email: string): Promise<void> {
     if (!window.confirm(`Are you sure you want to revoke ${email}?`)) {
       return;
@@ -54,7 +79,10 @@ export function InvitationsDataTable({
           <h2 className="text-md mb-4 font-bold">Pending Invitations:</h2>
         </div>
         <PokeDataTable
-          columns={makeColumnsForInvitations(onRevokeInvitation)}
+          columns={makeColumnsForInvitations(
+            onRevokeInvitation,
+            onResendInvitation
+          )}
           data={invitations}
           defaultFilterColumn="inviteEmail"
         />

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -184,7 +184,7 @@ interface MembershipInvitationBlob {
   role: ActiveRoleType;
 }
 
-interface HandleMembershipInvitationResult {
+export interface HandleMembershipInvitationResult {
   success: boolean;
   email: string;
   error_message?: string;

--- a/front/pages/api/poke/workspaces/[wId]/invitations/[iId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations/[iId].ts
@@ -1,0 +1,110 @@
+import isString from "lodash/isString";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { HandleMembershipInvitationResult } from "@app/lib/api/invitation";
+import { handleMembershipInvitations } from "@app/lib/api/invitation";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<HandleMembershipInvitationResult>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSession(
+    session,
+    req.query.wId as string
+  );
+
+  const owner = auth.workspace();
+  const user = auth.user();
+  if (!owner || !user || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  const invitationId = req.query.iId;
+  if (!isString(invitationId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `iId` (string) is required.",
+      },
+    });
+  }
+
+  const workspaceAdminAuth = await Authenticator.internalAdminForWorkspace(
+    owner.sId
+  );
+
+  const subscription = workspaceAdminAuth.subscription();
+  if (!subscription) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The subscription was not found.",
+      },
+    });
+  }
+
+  const invitation = await MembershipInvitationResource.fetchById(
+    workspaceAdminAuth,
+    invitationId
+  );
+  if (!invitation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "invitation_not_found",
+        message: "The invitation was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "PATCH": {
+      const invitationRes = await handleMembershipInvitations(
+        workspaceAdminAuth,
+        {
+          owner,
+          user: user.toJSON(), // This expects the inviter.
+          subscription,
+          invitationRequests: [
+            { email: invitation.inviteEmail, role: invitation.initialRole },
+          ],
+          force: true,
+        }
+      );
+
+      if (invitationRes.isErr()) {
+        return apiError(req, res, invitationRes.error);
+      }
+
+      const result = invitationRes.value[0];
+      res.status(200).json(result);
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, PATCH is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/invitations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations/index.ts
@@ -97,8 +97,7 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message:
-            "The method passed is not supported, POST or DELETE are expected.",
+          message: "The method passed is not supported, DELETE is expected.",
         },
       });
   }


### PR DESCRIPTION
## Description

This PR adds a "Resend" button to pending invitations table in Poké memberships page.
I created new PATCH endpoint `/api/poke/workspaces/[wId]/invitations/[iId]` to resend invitations that reuses existing `handleMembershipInvitations` business logic with force: true to bypass 24-hour cooldown

<img width="1746" height="310" alt="Screenshot 2025-12-23 at 16 21 24" src="https://github.com/user-attachments/assets/c559e5e7-8848-48a8-a6ec-9766f001b465" />

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 