### PR TITLE
[front] chore(programmatic usage): visually align $ sign vertically

### DIFF
--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -262,7 +262,7 @@ export function BuyCreditDialog({
                 Credits amount
               </label>
               <div className="relative">
-                <span className="absolute left-3 top-[11px] text-muted-foreground dark:text-muted-foreground-night">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
                   $
                 </span>
                 <Input


### PR DESCRIPTION
## Description

- This PR implements a small fix on the UI for buying credits.
- The fix consists in centering the dollar sign vertically (still not perfect).

Before
<img width="501" height="348" alt="Screenshot 2025-12-23 at 5 19 31 PM" src="https://github.com/user-attachments/assets/d40060ac-1185-43c2-8389-6b791a66b9e3" />

After
<img width="501" height="348" alt="Screenshot 2025-12-23 at 5 18 28 PM" src="https://github.com/user-attachments/assets/2c7e48d4-81b1-4575-960c-2ee4f497ce8b" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
