### PR TITLE
[Poke] Add production check for excess credits

### DIFF
--- a/front/lib/production_checks/checks/check_excess_credits.ts
+++ b/front/lib/production_checks/checks/check_excess_credits.ts
@@ -32,7 +32,7 @@ export const checkExcessCredits: CheckFunction = async (
         w."sId" as "workspaceSId",
         w."name" as "workspaceName",
         SUM(c."consumedAmountMicroUsd") as "totalExcessMicroUsd"
-      FROM credit c
+      FROM credits c
       JOIN workspaces w ON c."workspaceId" = w.id
       WHERE c."type" = 'excess'
         AND c."startDate" >= :thirtyDaysAgo

--- a/front/lib/production_checks/checks/check_excess_credits.ts
+++ b/front/lib/production_checks/checks/check_excess_credits.ts
@@ -1,0 +1,71 @@
+import { QueryTypes } from "sequelize";
+
+import type { CheckFunction } from "@app/lib/production_checks/types";
+import { getFrontReplicaDbConnection } from "@app/lib/production_checks/utils";
+
+const FIFTY_DOLLARS_MICRO_USD = 50_000_000;
+const DAYS_30_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface WorkspaceExcessCredits {
+  workspaceId: number;
+  workspaceSId: string;
+  workspaceName: string;
+  totalExcessMicroUsd: number;
+}
+
+export const checkExcessCredits: CheckFunction = async (
+  _checkName,
+  logger,
+  reportSuccess,
+  reportFailure
+) => {
+  const frontDb = getFrontReplicaDbConnection();
+  const thirtyDaysAgo = new Date(Date.now() - DAYS_30_MS);
+
+  // Query for workspaces with excess credits > $50 in the last 30 days.
+  const workspacesWithExcessCredits: WorkspaceExcessCredits[] =
+    // eslint-disable-next-line dust/no-raw-sql -- Production check using read replica
+    await frontDb.query(
+      `
+      SELECT
+        c."workspaceId" as "workspaceId",
+        w."sId" as "workspaceSId",
+        w."name" as "workspaceName",
+        SUM(c."consumedAmountMicroUsd") as "totalExcessMicroUsd"
+      FROM credit c
+      JOIN workspaces w ON c."workspaceId" = w.id
+      WHERE c."type" = 'excess'
+        AND c."startDate" >= :thirtyDaysAgo
+      GROUP BY c."workspaceId", w."sId", w."name"
+      HAVING SUM(c."consumedAmountMicroUsd") > :threshold
+      ORDER BY SUM(c."consumedAmountMicroUsd") DESC
+      `,
+      {
+        type: QueryTypes.SELECT,
+        replacements: {
+          thirtyDaysAgo: thirtyDaysAgo.toISOString(),
+          threshold: FIFTY_DOLLARS_MICRO_USD,
+        },
+      }
+    );
+
+  if (workspacesWithExcessCredits.length > 0) {
+    const formattedWorkspaces = workspacesWithExcessCredits.map((w) => ({
+      workspaceSId: w.workspaceSId,
+      workspaceName: w.workspaceName,
+      totalExcessUsd: (Number(w.totalExcessMicroUsd) / 1_000_000).toFixed(2),
+    }));
+
+    logger.warn(
+      { workspaces: formattedWorkspaces },
+      `Found ${workspacesWithExcessCredits.length} workspace(s) with excess credits > $50 in the last 30 days`
+    );
+
+    reportFailure(
+      { workspaces: formattedWorkspaces },
+      `${workspacesWithExcessCredits.length} workspace(s) have excess credits > $50 in the last 30 days`
+    );
+  } else {
+    reportSuccess({});
+  }
+};

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -5,6 +5,7 @@ import { checkActiveWorkflows } from "@app/lib/production_checks/checks/check_ac
 import { checkActiveWorkflowsForFront } from "@app/lib/production_checks/checks/check_active_workflows_for_front";
 import { checkConnectorsLastSyncSuccess } from "@app/lib/production_checks/checks/check_connectors_last_sync_success";
 import { checkDataSourcesConsistency } from "@app/lib/production_checks/checks/check_data_sources_consistency";
+import { checkExcessCredits } from "@app/lib/production_checks/checks/check_excess_credits";
 import { checkExtraneousWorkflows } from "@app/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors";
 import { checkNotionActiveWorkflows } from "@app/lib/production_checks/checks/check_notion_active_workflows";
 import { checkPausedConnectors } from "@app/lib/production_checks/checks/check_paused_connectors";
@@ -58,6 +59,11 @@ export const REGISTERED_CHECKS: Check[] = [
     name: "checked_paused_connectors",
     check: checkPausedConnectors,
     everyHour: 8,
+  },
+  {
+    name: "check_excess_credits",
+    check: checkExcessCredits,
+    everyHour: 24,
   },
 ];
 


### PR DESCRIPTION
## Description

Adds a daily production check that warns when any workspace has more than $50 in excess credits over the last 30 days.

- Queries the front read replica for workspaces with excess credits above threshold
- Runs once per day (everyHour: 24)
- Reports failure with workspace details (sId, name, total excess amount)

## Risks

Blast radius: Production checks only (monitoring)
Risk: low

## Deploy Plan

- deploy front