### PR TITLE
[front] - fix: display user messages with multiple citations larger

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -322,6 +322,9 @@ export function UserMessage({
   const timestamp = formatTimestring(message.created);
   const name = message.context.fullName ?? undefined;
 
+  // When there are multiple citations, we want to show the message bigger even if the message itself is short
+  const shouldShowBiggerUserMessage = citations && citations.length > 2;
+
   return (
     <>
       {shouldShowEditor ? (
@@ -398,7 +401,11 @@ export function UserMessage({
                 </DropdownMenu>
               )}
             </div>
-            <ConversationMessageContent citations={citations} type="user">
+            <ConversationMessageContent
+              citations={citations}
+              type="user"
+              className={cn(shouldShowBiggerUserMessage && "@sm:min-w-100")}
+            >
               <UserMessageContent
                 message={message}
                 isDeleted={isDeleted}


### PR DESCRIPTION
## Description

This PR picks up https://github.com/dust-tt/dust/pull/19397:
 - Ensure user messages with more than two citations appear bigger to accommodate content
 - Apply conditional styling based on the number of citations linked to the message

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
