### PR TITLE
[front] Update copy on duplicate tools error message

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -359,8 +359,8 @@ export async function runModelActivity(
       await publishAgentError({
         code: "duplicate_specification_name",
         message:
-          `Duplicate action name in agent configuration: ${spec.name}. ` +
-          "Your agents actions must have unique names.",
+          `Found multiple tools named "${spec.name}". ` +
+          "Each tool needs a unique name so the agent can specify which one to use.",
         metadata: null,
       });
 


### PR DESCRIPTION
## Description

- This PR updates the copy on the error message displayed when duplicate tools are detected.
- Should not happen following https://github.com/dust-tt/dust/pull/19342, this is a cleanup more than a fix.
- The existing message is slightly incorrect; the agent configuration can be fine but create conflicts due to JIT tools.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
