### PR TITLE
[front] refactor(skills): move tool creation to `makeNew`

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -174,14 +174,21 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async makeNew(
     auth: Authenticator,
-    blob: Omit<CreationAttributes<SkillConfigurationModel>, "workspaceId">
+    blob: Omit<CreationAttributes<SkillConfigurationModel>, "workspaceId">,
+    {
+      mcpServerViews,
+    }: {
+      mcpServerViews: MCPServerViewResource[];
+    }
   ): Promise<SkillResource> {
-    // Use a transaction to ensure all creates succeed or all are rolled back.
-    const skillResource = await withTransaction(async (transaction) => {
+    const owner = auth.getNonNullableWorkspace();
+
+    // Use a transaction to ensure all creations succeed or all are rolled back.
+    return withTransaction(async (transaction) => {
       const skill = await this.model.create(
         {
           ...blob,
-          workspaceId: auth.getNonNullableWorkspace().id,
+          workspaceId: owner.id,
         },
         {
           transaction,
@@ -196,13 +203,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       );
 
+      await SkillMCPServerConfigurationModel.bulkCreate(
+        mcpServerViews.map((mcpServerView) => ({
+          workspaceId: owner.id,
+          skillConfigurationId: skill.id,
+          mcpServerViewId: mcpServerView.id,
+        })),
+        { transaction }
+      );
+
       return new this(this.model, skill.get(), {
         editorGroup,
-        mcpServerViews: [],
+        mcpServerViews,
       });
     });
-
-    return skillResource;
   }
 
   private static async baseFetch(

--- a/front/tests/utils/SkillConfigurationFactory.ts
+++ b/front/tests/utils/SkillConfigurationFactory.ts
@@ -27,15 +27,21 @@ export class SkillConfigurationFactory {
     const instructions = overrides.instructions ?? "Test skill instructions";
     const status = overrides.status ?? "active";
 
-    return SkillResource.makeNew(auth, {
-      authorId: user.id,
-      agentFacingDescription,
-      userFacingDescription,
-      instructions,
-      name,
-      requestedSpaceIds: [],
-      status,
-    });
+    return SkillResource.makeNew(
+      auth,
+      {
+        authorId: user.id,
+        agentFacingDescription,
+        userFacingDescription,
+        instructions,
+        name,
+        requestedSpaceIds: [],
+        status,
+      },
+      {
+        mcpServerViews: [],
+      }
+    );
   }
 
   static async linkToAgent(


### PR DESCRIPTION
## Description

- This PR moves the creation of `SkillMCPServerConfigurations` to `SkillResource.makeNew` instead of doing it in the endpoint.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
