### PR TITLE
[front] chore(skills): hide Frames and deep dive as a tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -780,7 +780,11 @@ export const INTERNAL_MCP_SERVERS = {
     id: 23,
     availability: "auto",
     allowMultipleInstances: false,
-    isRestricted: undefined,
+    isRestricted: ({ featureFlags }) => {
+      // TODO(skills-GA 2025-12-24): change availability to auto_hidden_builder and remove this.
+      // We hide interactive_content as a tool and expose it only through a skill.
+      return featureFlags.includes("skills");
+    },
     isPreview: false,
     tools_stakes: undefined,
     tools_retry_policies: undefined,
@@ -978,9 +982,10 @@ export const INTERNAL_MCP_SERVERS = {
   deep_dive: {
     id: 29,
     availability: "auto",
-    isRestricted: ({ isDeepDiveDisabled }) => {
-      // If the workspace has disable the deep dive agent, the tool is not available.
-      return isDeepDiveDisabled;
+    isRestricted: ({ isDeepDiveDisabled, featureFlags }) => {
+      // TODO(skills-GA 2025-12-24): change availability to auto_hidden_builder and remove this.
+      // We hide deep dive as a tool and expose it only through a skill.
+      return isDeepDiveDisabled || featureFlags.includes("skills");
     },
     allowMultipleInstances: false,
     isPreview: false,


### PR DESCRIPTION
## Description

This PR hides `interactive_content` and `deep_dive` as tools when the skills feature flag is enabled.
These capabilities will only be available through global skills instead.

## Tests

- Tested locally (with and without the FF).

## Risk

- Low.

## Deploy Plan

- Deploy front.
