### PR TITLE
[Security] Warn admins when modifying spaces they don't belong to

### DIFF
--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -211,6 +211,22 @@ export function CreateOrEditSpaceModal({
       return;
     }
 
+    // Warn admin if they are modifying a space they don't belong to.
+    if (space && spaceInfo && !spaceInfo.isMember) {
+      const confirmed = await confirm({
+        title: "Security notice",
+        message:
+          "You are modifying this space's settings while not being a member yourself. " +
+          "This action will be logged for security purposes. Do you want to proceed?",
+        validateLabel: "Proceed",
+        validateVariant: "warning",
+      });
+
+      if (!confirmed) {
+        return;
+      }
+    }
+
     setIsSaving(true);
 
     if (space) {
@@ -261,6 +277,7 @@ export function CreateOrEditSpaceModal({
 
     handleClose();
   }, [
+    confirm,
     doCreate,
     doUpdate,
     handleClose,
@@ -268,6 +285,7 @@ export function CreateOrEditSpaceModal({
     mutateSpaceInfo,
     onCreated,
     space,
+    spaceInfo,
     selectedMembers,
     spaceName,
     managementType,

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -104,16 +104,20 @@ export function SpaceLayout({
     >
       <div className="flex w-full flex-col">
         <Page.Vertical gap="lg" align="stretch">
-          {!canReadInSpace && (
-            <div>
-              <Chip
-                color="rose"
-                label="You are not a member of this space."
-                size="sm"
-                icon={InformationCircleIcon}
-              />
-            </div>
-          )}
+          {
+            // Message to admins that are not members of the space.
+            // No need to show it for system space since it's a no-member space.
+            !canReadInSpace && space.kind !== "system" && (
+              <div>
+                <Chip
+                  color="rose"
+                  label="You are not a member of this space."
+                  size="sm"
+                  icon={InformationCircleIcon}
+                />
+              </div>
+            )
+          }
           <SpaceSearchInput
             category={category}
             canReadInSpace={canReadInSpace}

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -1,10 +1,12 @@
 import {
+  Chip,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  InformationCircleIcon,
   Page,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
@@ -102,6 +104,16 @@ export function SpaceLayout({
     >
       <div className="flex w-full flex-col">
         <Page.Vertical gap="lg" align="stretch">
+          {!canReadInSpace && (
+            <div>
+              <Chip
+                color="rose"
+                label="You are not a member of this space."
+                size="sm"
+                icon={InformationCircleIcon}
+              />
+            </div>
+          )}
           <SpaceSearchInput
             category={category}
             canReadInSpace={canReadInSpace}

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -158,7 +158,7 @@ export async function handler(
         auditLog(
           {
             author: user ? user.toJSON() : "no-author",
-            workspaceId: auth.getNonNullableWorkspace().id,
+            workspaceId: auth.getNonNullableWorkspace().sId,
             spaceId: space.sId,
             spaceName: space.name,
             action: "space_permissions_updated_by_non_member",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -7,6 +7,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { auditLog } from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { SpaceType, WithAPIErrorResponse } from "@app/types";
 import { assertNever } from "@app/types";
@@ -149,6 +150,21 @@ export async function handler(
           default:
             assertNever(updateRes.error.code);
         }
+      }
+
+      // Audit log when an admin who is not a member of the space updates its permissions.
+      if (!space.canRead(auth)) {
+        const user = auth.user();
+        auditLog(
+          {
+            author: user ? user.toJSON() : "no-author",
+            workspaceId: auth.getNonNullableWorkspace().id,
+            spaceId: space.sId,
+            spaceName: space.name,
+            action: "space_permissions_updated_by_non_member",
+          },
+          "[Security] Admin updated space permissions without being a member"
+        );
       }
 
       return res.status(200).json({ space: space.toJSON() });

--- a/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
@@ -1,4 +1,4 @@
-import { Chip, InformationCircleIcon, Page } from "@dust-tt/sparkle";
+import { Page } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
@@ -11,7 +11,6 @@ import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { useSpaceInfo } from "@app/lib/swr/spaces";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<
   SpaceLayoutPageProps & {
@@ -76,27 +75,10 @@ export default function Space({
   const [showSpaceEditionModal, setShowSpaceEditionModal] =
     React.useState(false);
 
-  const { spaceInfo } = useSpaceInfo({
-    workspaceId: owner.sId,
-    spaceId: space.sId,
-  });
-
   const router = useRouter();
-  const isMember = spaceInfo?.isMember ?? false;
 
   return (
     <Page.Vertical gap="xl" align="stretch">
-      {spaceInfo && !isMember && (
-        <div>
-          {/* TODO: Should we move this to the SpaceLayout? */}
-          <Chip
-            color="rose"
-            label="You are not a member of this space."
-            size="sm"
-            icon={InformationCircleIcon}
-          />
-        </div>
-      )}
       <SpaceCategoriesList
         owner={owner}
         canWriteInSpace={canWriteInSpace}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5335

Implements security measures when admins modify space settings for spaces they do not belong to:

1. **Warning Dialog (Frontend)**: When an admin attempts to save changes to a space they are not a member of, a warning dialog appears informing them the action will be logged.

2. **Audit Logging (Backend)**: When a non-member admin updates space permissions, an audit log entry is created with `[Security]` prefix, including workspace ID, space ID, space name, and the admin details.

3. **Non-member banner on all space pages**: Moved the "You are not a member of this space" warning banner from the space index page to the SpaceLayout so it appears on all pages within the space (excludes system spaces since they have no regular members).

Note: The third item from the issue (sending notifications to admins) was marked as TBD and is not included in this PR.

## Risks

Blast radius: Space settings modal and space browsing for admins
Risk: low

## Deploy Plan

- deploy front