### PR TITLE
get_database_schema: do not track 'Error retrieving database schema'

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/index.ts
@@ -197,7 +197,8 @@ function createServer(
         if (schemaResult.isErr()) {
           return new Err(
             new MCPError(
-              `Error retrieving database schema: ${schemaResult.error.message}`
+              `Error retrieving database schema: ${schemaResult.error.message}`,
+              { tracked: false }
             )
           );
         }


### PR DESCRIPTION
## Description

This specific error is quite flaky and I don't think it's very useful to track it. Represents 50% of monitors over the past 24h

Logs: https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40toolName%3Aget_database_schema%20%22Tool%20execution%20error%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1766491488526&to_ts=1766577888526&live=true

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `front`