### PR TITLE
[Front] chore(agent-builder): fix agent builder skill block title & description

### DIFF
--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -6,6 +6,7 @@ import {
   CardGrid,
   ContentMessage,
   EmptyCTA,
+  Hoverable,
   Spinner,
   ToolsIcon,
   XMarkIcon,
@@ -305,8 +306,21 @@ export function AgentBuilderSkillsBlock() {
 
   return (
     <AgentBuilderSectionContainer
-      title="Skills"
-      description="Give your agent a custom capability for specific tasks"
+      title="Knowledge and capabilities"
+      description={
+        <>
+          "Add knowledge, tools and skills to enhance your agent’s abilities.
+          Need help? Check our{" "}
+          <Hoverable
+            variant="primary"
+            href="https://docs.dust.tt/docs/tools"
+            target="_blank"
+          >
+            guide
+          </Hoverable>
+          .
+        </>
+      }
       headerActions={
         hasCapabilitiesConfigured && (
           <ActionButtons


### PR DESCRIPTION
## Description

Re-align agent builder skill block with wording of the [figma](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=860-53744&t=NRdZN9TcFx5YlIrQ-4)
It was merged with knowledge and tools.

## Tests

Local.

## Risk

Low.

## Deploy Plan

Front.