### PR TITLE
[front] chore(skills): hide space configuration sheet

### DIFF
--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -8,7 +8,6 @@ import {
   isInternalAllowedIcon,
   ResourceAvatar,
 } from "@app/components/resources/resources_icons";
-import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import type {
   SkillRelations,
   SkillType,
@@ -54,7 +53,9 @@ export function getSkillIcon(
 }
 
 const IDS_OF_SKILLS_TRIGGERING_SELECT_SPACES_OPTIONS: string[] = [
-  framesSkill.sId, // TODO(skills) Remove frames from this list when we have real global skills with space selection
+  // We don't trigger this flow for now.
+  // TODO(skills 2025-12-24): confirm whether we need this flow of space selection or not,
+  //  if we do, then add the skill IDs here, otherwise remove it from Agent Builder.
 ];
 
 export function doesSkillTriggerSelectSpaces(sId: string): boolean {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5717.
- We currently have a [space configuration sheet](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=860-54095&t=XsdgJ5pjSHaQh3oz-0) opened when selecting certain global skills.
- This sheet is a screen for configuring spaces. There's a risk that it may be interpreted as a configuration on the skill (for tools if we click on the card we open the configuration for this tool) and that it therefore may be confusing that changing the spaces from elsewhere will affect the previous selection.
- We've come to the conclusion that we should hide it for now as it may be interpreted as a configuration on the skill rather than a configuration global to the agent, to reassess after some beta testing.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
