### PR TITLE
[front] chore: add custom `MCPActionDetails` for image generation

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -34,6 +34,7 @@ import { MCPDataWarehousesBrowseDetails } from "@app/components/actions/mcp/deta
 import { MCPDeepDiveActionDetails } from "@app/components/actions/mcp/details/MCPDeepDiveActionDetails";
 import { MCPExtractActionDetails } from "@app/components/actions/mcp/details/MCPExtractActionDetails";
 import { MCPGetDatabaseSchemaActionDetails } from "@app/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails";
+import { MCPImageGenerationActionDetails } from "@app/components/actions/mcp/details/MCPImageGenerationActionDetails";
 import { MCPListToolsActionDetails } from "@app/components/actions/mcp/details/MCPListToolsActionDetails";
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
 import { MCPSkillEnableActionDetails } from "@app/components/actions/mcp/details/MCPSkillEnableActionDetails";
@@ -251,6 +252,10 @@ export function MCPActionDetails({
     toolName === PROCESS_TOOL_NAME
   ) {
     return <MCPExtractActionDetails {...toolOutputDetailsProps} />;
+  }
+
+  if (internalMCPServerName === "image_generation") {
+    return <MCPImageGenerationActionDetails {...toolOutputDetailsProps} />;
   }
 
   if (internalMCPServerName === "run_agent") {

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -34,7 +34,10 @@ import { MCPDataWarehousesBrowseDetails } from "@app/components/actions/mcp/deta
 import { MCPDeepDiveActionDetails } from "@app/components/actions/mcp/details/MCPDeepDiveActionDetails";
 import { MCPExtractActionDetails } from "@app/components/actions/mcp/details/MCPExtractActionDetails";
 import { MCPGetDatabaseSchemaActionDetails } from "@app/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails";
-import { MCPImageGenerationActionDetails } from "@app/components/actions/mcp/details/MCPImageGenerationActionDetails";
+import {
+  MCPImageEditingActionDetails,
+  MCPImageGenerationActionDetails,
+} from "@app/components/actions/mcp/details/MCPImageGenerationActionDetails";
 import { MCPListToolsActionDetails } from "@app/components/actions/mcp/details/MCPListToolsActionDetails";
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
 import { MCPSkillEnableActionDetails } from "@app/components/actions/mcp/details/MCPSkillEnableActionDetails";
@@ -57,11 +60,13 @@ import {
   DATA_WAREHOUSES_FIND_TOOL_NAME,
   DATA_WAREHOUSES_LIST_TOOL_NAME,
   DATA_WAREHOUSES_QUERY_TOOL_NAME,
+  EDIT_IMAGE_TOOL_NAME,
   EXECUTE_DATABASE_QUERY_TOOL_NAME,
   FILESYSTEM_CAT_TOOL_NAME,
   FILESYSTEM_FIND_TOOL_NAME,
   FILESYSTEM_LIST_TOOL_NAME,
   FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
+  GENERATE_IMAGE_TOOL_NAME,
   GET_DATABASE_SCHEMA_TOOL_NAME,
   getInternalMCPServerIconByName,
   INCLUDE_TOOL_NAME,
@@ -255,7 +260,12 @@ export function MCPActionDetails({
   }
 
   if (internalMCPServerName === "image_generation") {
-    return <MCPImageGenerationActionDetails {...toolOutputDetailsProps} />;
+    switch (toolName) {
+      case GENERATE_IMAGE_TOOL_NAME:
+        return <MCPImageGenerationActionDetails {...toolOutputDetailsProps} />;
+      case EDIT_IMAGE_TOOL_NAME:
+        return <MCPImageEditingActionDetails {...toolOutputDetailsProps} />;
+    }
   }
 
   if (internalMCPServerName === "run_agent") {

--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -1,0 +1,18 @@
+import { ActionImageIcon } from "@dust-tt/sparkle";
+
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+
+export function MCPImageGenerationActionDetails({
+  viewType,
+}: ToolExecutionDetailsProps) {
+  return (
+    <ActionDetailsWrapper
+      viewType={viewType}
+      actionName={
+        viewType === "conversation" ? "Generating image" : "Generate image"
+      }
+      visual={ActionImageIcon}
+    />
+  );
+}

--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -16,3 +16,15 @@ export function MCPImageGenerationActionDetails({
     />
   );
 }
+
+export function MCPImageEditingActionDetails({
+  viewType,
+}: ToolExecutionDetailsProps) {
+  return (
+    <ActionDetailsWrapper
+      viewType={viewType}
+      actionName={viewType === "conversation" ? "Editing image" : "Edit image"}
+      visual={ActionImageIcon}
+    />
+  );
+}

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -70,6 +70,9 @@ export const TOOLSETS_LIST_TOOL_NAME = "list";
 
 export const SKILL_MANAGEMENT_SERVER_NAME = "skill_management";
 
+export const GENERATE_IMAGE_TOOL_NAME = "generate_image";
+export const EDIT_IMAGE_TOOL_NAME = "edit_image";
+
 export const SEARCH_SERVER_NAME = "search";
 
 export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2"; // Do not change the name until we fixed the extension

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -4,6 +4,10 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  EDIT_IMAGE_TOOL_NAME,
+  GENERATE_IMAGE_TOOL_NAME,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { streamToBuffer } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
@@ -266,7 +270,7 @@ function createServer(
   const server = makeInternalMCPServer("image_generation");
 
   server.tool(
-    "generate_image",
+    GENERATE_IMAGE_TOOL_NAME,
     "Generate an image from text descriptions. The more detailed and specific your prompt is, the" +
       " better the result will be. You can customize the output through various parameters to" +
       " match your needs.",
@@ -301,7 +305,7 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "generate_image", agentLoopContext },
+      { toolNameForMonitoring: GENERATE_IMAGE_TOOL_NAME, agentLoopContext },
       async ({ prompt, name, quality, size }, { sendNotification, _meta }) => {
         const workspace = auth.getNonNullableWorkspace();
 
@@ -421,7 +425,7 @@ function createServer(
   );
 
   server.tool(
-    "edit_image",
+    EDIT_IMAGE_TOOL_NAME,
     "Edit an existing image using text instructions. Provide the file ID of an image from Dust" +
       " file storage and describe the changes you want to make. The tool preserves the original" +
       " image's aspect ratio by default, but you can optionally change it.",
@@ -461,7 +465,7 @@ function createServer(
     },
     withToolLogging(
       auth,
-      { toolNameForMonitoring: "edit_image", agentLoopContext },
+      { toolNameForMonitoring: EDIT_IMAGE_TOOL_NAME, agentLoopContext },
       async (
         {
           imageFileId: inputImageFileId,


### PR DESCRIPTION
## Description

- This PR adds custom `MCPActionDetails` for `image_generation`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
