### PR TITLE
[front] - fix(AttachmentPicker): hover

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -452,21 +452,24 @@ export const InputBarAttachmentsPicker = ({
       >
         {searchQuery ? (
           <div ref={itemsContainerRef}>
-            <div className="flex flex-wrap items-center gap-0.5 p-2">
-              {showLoader && (
-                <div className="flex h-7 items-center justify-center last:grow">
-                  <Spinner size="xs" />
+            {showLoader ||
+              (availableSources.length > 1 && (
+                <div className="flex flex-wrap items-center gap-0.5 p-2">
+                  {showLoader && (
+                    <div className="flex h-7 items-center justify-center last:grow">
+                      <Spinner size="xs" />
+                    </div>
+                  )}
+                  {availableSources.length > 1 && (
+                    <DropdownMenuFilters
+                      filters={availableSources}
+                      selectedValues={selectedFilterKeys}
+                      onSelectFilter={handleFilterClick}
+                      className="grow"
+                    />
+                  )}
                 </div>
-              )}
-              {availableSources.length > 1 && (
-                <DropdownMenuFilters
-                  filters={availableSources}
-                  selectedValues={selectedFilterKeys}
-                  onSelectFilter={handleFilterClick}
-                  className="grow"
-                />
-              )}
-            </div>
+              ))}
             {Object.keys(serversWithResults).length === 0 ? (
               // No tools results, show knowledge nodes as returned by the search.
               dataSourcesNodes


### PR DESCRIPTION
## Description

This PR aims at fixing an unwanted behaviour from Radix: when hovering a `DropdownMenuItem` it traps focus. It turns out that as soon as an element gets the focus it triggers immediately the opening of a tooltip. This way when hover (or navigating with keys) the dropdown menu items we would see a tooltip popping immediately.

To add a hover delay without breaking that contract, I leave Radix's focus handling alone and wrap the trigger in `asChild`. Pointer enter/leave events on the trigger simply toggle a `isPointerHovering` flag; a `useEffect` starts a 500 ms timer and sets the tooltip open state only after the delay, while pointer leave (or Radix closing) cancels it. Keyboard users still rely on Radix’s own focus driven `TooltipRoot`, but hovering now see a delayed tooltip.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
