### PR TITLE
[MCP Gmail] Read full mail content instead of snippet + md output instead of json

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -428,8 +428,7 @@ function createServer(
             error: detail.error,
           }));
 
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        const totalRequested = result.messages?.length || 0;
+        const totalRequested = result.messages?.length ?? 0;
         const totalSuccessful = successfulMessages.length;
         const totalFailed = failedMessages.length;
 

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -403,7 +403,6 @@ function createServer(
                 id: messageData.id,
                 threadId: messageData.threadId,
                 labelIds: messageData.labelIds,
-                internalDate: messageData.internalDate,
                 from,
                 to,
                 cc,
@@ -416,41 +415,19 @@ function createServer(
           { concurrency: 10 }
         );
 
-        // Separate successful and failed message details
+        // Extract successful message details
         const successfulMessages = messageDetails
           .filter((detail: MessageDetail) => detail.success)
           .map((detail: MessageDetail) => detail.data);
 
-        const failedMessages = messageDetails
-          .filter((detail: MessageDetail) => !detail.success)
-          .map((detail: MessageDetail) => ({
-            messageId: detail.messageId,
-            error: detail.error,
-          }));
-
-        const totalRequested = result.messages?.length ?? 0;
-        const totalSuccessful = successfulMessages.length;
-        const totalFailed = failedMessages.length;
-
-        const responseData = {
-          messages: successfulMessages,
-          failedMessages,
-          summary: {
-            totalRequested,
-            totalSuccessful,
-            totalFailed,
-          },
-        };
-
-        const markdownOutput = jsonToMarkdown(responseData, "id", "Mail");
-
-        let statusMessage = "Messages fetched successfully";
-        if (totalFailed > 0) {
-          statusMessage = `Messages fetched with ${totalFailed} failures out of ${totalRequested} total messages`;
-        }
+        const markdownOutput = jsonToMarkdown(
+          successfulMessages,
+          "id",
+          "Mail id"
+        );
 
         return new Ok([
-          { type: "text" as const, text: statusMessage },
+          { type: "text" as const, text: "Messages fetched successfully" },
           {
             type: "text" as const,
             text: markdownOutput,

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -426,7 +426,7 @@ function createServer(
           },
         };
 
-        const markdownOutput = jsonToMarkdown(responseData);
+        const markdownOutput = jsonToMarkdown(responseData, "id", "Mail");
 
         let statusMessage = "Messages fetched successfully";
         if (totalFailed > 0) {

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -60,6 +60,15 @@ interface MessageDetail {
   error?: string;
 }
 
+// Typeguard for GmailMessage
+function isGmailMessage(data: unknown): data is GmailMessage {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  const obj = data as Record<string, unknown>;
+  return typeof obj.id === "string";
+}
+
 function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
@@ -367,7 +376,15 @@ function createServer(
               };
             }
 
-            const messageData: GmailMessage = await messageResponse.json();
+            const messageData = await messageResponse.json();
+
+            if (!isGmailMessage(messageData)) {
+              return {
+                success: false,
+                messageId: message.id,
+                error: "Invalid message format received from Gmail API",
+              };
+            }
 
             // Extract headers for easy access
             const headers = messageData.payload?.headers ?? [];

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -202,8 +202,8 @@ export function isJITMCPServerView(view: MCPServerViewType): boolean {
 // Converts a JSON object to Markdown format with bullet points.
 // Recursively handles nested objects and arrays with proper indentation.
 // Includes protections against circular references and excessive depth.
-export function jsonToMarkdown(
-  data: any,
+export function jsonToMarkdown<T = unknown>(
+  data: T,
   primaryKey: string,
   primaryKeyPrefix: string = "",
   indent: number = 0,
@@ -218,7 +218,7 @@ export function jsonToMarkdown(
   }
 
   // Helper to format primitive values
-  const formatValue = (value: any): string => {
+  const formatValue = (value: unknown): string => {
     if (value === null || value === undefined) {
       return "(empty)";
     }
@@ -285,13 +285,14 @@ export function jsonToMarkdown(
   visited.add(data);
 
   // Check if this object has the primaryKey
-  const hasPrimaryKey = data[primaryKey] !== undefined;
+  const dataAsRecord = data as Record<string, unknown>;
+  const hasPrimaryKey = dataAsRecord[primaryKey] !== undefined;
   let entriesToProcess = entries;
   let headerLine = "";
 
   if (hasPrimaryKey) {
     // Create title from primaryKey
-    const primaryValue = formatValue(data[primaryKey]);
+    const primaryValue = formatValue(dataAsRecord[primaryKey]);
     const title = primaryKeyPrefix
       ? `${primaryKeyPrefix} ${primaryValue}`
       : primaryValue;

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -198,3 +198,61 @@ export function isJITMCPServerView(view: MCPServerViewType): boolean {
     getMCPServerRequirements(view).noRequirement
   );
 }
+
+// Converts a JSON object to Markdown format with bullet points.
+// Recursively handles nested objects and arrays.
+export function jsonToMarkdown(data: any, indent: number = 0): string {
+  const indentStr = "  ".repeat(indent);
+
+  if (data === null || data === undefined) {
+    return `${indentStr}- (empty)`;
+  }
+
+  if (
+    typeof data === "string" ||
+    typeof data === "number" ||
+    typeof data === "boolean"
+  ) {
+    return `${indentStr}- ${data}`;
+  }
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      return `${indentStr}- []`;
+    }
+    return data.map((item) => jsonToMarkdown(item, indent)).join("\n");
+  }
+
+  if (typeof data === "object") {
+    return Object.entries(data)
+      .map(([key, value]) => {
+        if (value === null || value === undefined) {
+          return `${indentStr}- **${key}:** (empty)`;
+        }
+
+        if (
+          typeof value === "string" ||
+          typeof value === "number" ||
+          typeof value === "boolean"
+        ) {
+          return `${indentStr}- **${key}:** ${value}`;
+        }
+
+        if (Array.isArray(value)) {
+          if (value.length === 0) {
+            return `${indentStr}- **${key}:** []`;
+          }
+          return `${indentStr}- **${key}:**\n${jsonToMarkdown(value, indent + 1)}`;
+        }
+
+        if (typeof value === "object") {
+          return `${indentStr}- **${key}:**\n${jsonToMarkdown(value, indent + 1)}`;
+        }
+
+        return `${indentStr}- **${key}:** ${String(value)}`;
+      })
+      .join("\n");
+  }
+
+  return `${indentStr}- ${String(data)}`;
+}


### PR DESCRIPTION
## Description

The Gmail MCP `get_messages` tool now fetches full email content instead of just metadata snippets. This addresses issue raise by Léna where agents couldn't accurately extract information from emails because only snippets were available.

Changes:
- Switched Gmail API format from `metadata` to `full` to retrieve complete email bodies
- Implemented `jsonToMarkdown` utility to convert tool output to markdown format instead of JSON for better LLM readability
- Restructured message response to include parsed headers (from, to, cc, subject, date) and decoded body content

## Risk

Low

## Tests

Local

## Deploy Plan

Run front
