### PR TITLE
[front] enh(`MCPActionDetails`): improve details for image gen

### DIFF
--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -1,4 +1,4 @@
-import { ActionImageIcon, Chip } from "@dust-tt/sparkle";
+import { ActionImageIcon, Chip, cn } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
@@ -41,7 +41,12 @@ export function MCPImageGenerationActionDetails({
             <Chip label={`${quality} quality`} color="success" />
           )}
         </div>
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        <p
+          className={cn(
+            "text-sm text-muted-foreground dark:text-muted-foreground-night",
+            viewType === "conversation" ? "line-clamp-3" : ""
+          )}
+        >
           {prompt}
         </p>
       </div>
@@ -81,7 +86,12 @@ export function MCPImageEditingActionDetails({
             <Chip label={`${quality} quality`} color="success" />
           )}
         </div>
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        <p
+          className={cn(
+            "text-sm text-muted-foreground dark:text-muted-foreground-night",
+            viewType === "conversation" ? "line-clamp-3" : ""
+          )}
+        >
           {editPrompt}
         </p>
       </div>

--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -33,7 +33,12 @@ export function MCPImageGenerationActionDetails({
       }
       visual={ActionImageIcon}
     >
-      <div className="flex flex-col gap-3 pl-6 pt-4">
+      <div
+        className={cn(
+          "flex flex-col gap-3",
+          viewType === "conversation" ? "pl-6" : "pt-2"
+        )}
+      >
         <p
           className={cn(
             "text-sm text-muted-foreground dark:text-muted-foreground-night",
@@ -71,7 +76,12 @@ export function MCPImageEditingActionDetails({
       actionName={viewType === "conversation" ? "Editing image" : "Edit image"}
       visual={ActionImageIcon}
     >
-      <div className="flex flex-col gap-3 pl-6 pt-4">
+      <div
+        className={cn(
+          "flex flex-col gap-3",
+          viewType === "conversation" ? "pl-6" : "pt-2"
+        )}
+      >
         <p
           className={cn(
             "text-sm text-muted-foreground dark:text-muted-foreground-night",

--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -1,11 +1,30 @@
-import { ActionImageIcon } from "@dust-tt/sparkle";
+import { ActionImageIcon, Chip } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import {
+  isEditImageInputType,
+  isGenerateImageInputType,
+} from "@app/lib/actions/mcp_internal_actions/types";
 
 export function MCPImageGenerationActionDetails({
   viewType,
+  toolParams,
 }: ToolExecutionDetailsProps) {
+  if (!isGenerateImageInputType(toolParams)) {
+    return (
+      <ActionDetailsWrapper
+        viewType={viewType}
+        actionName={
+          viewType === "conversation" ? "Generating image" : "Generate image"
+        }
+        visual={ActionImageIcon}
+      />
+    );
+  }
+
+  const { prompt, name, quality, size } = toolParams;
+
   return (
     <ActionDetailsWrapper
       viewType={viewType}
@@ -13,18 +32,59 @@ export function MCPImageGenerationActionDetails({
         viewType === "conversation" ? "Generating image" : "Generate image"
       }
       visual={ActionImageIcon}
-    />
+    >
+      <div className="flex flex-col gap-3 pl-6 pt-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip label={name} color="primary" />
+          {size && <Chip label={size} color="highlight" />}
+          {quality && quality !== "auto" && (
+            <Chip label={`${quality} quality`} color="success" />
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {prompt}
+        </p>
+      </div>
+    </ActionDetailsWrapper>
   );
 }
 
 export function MCPImageEditingActionDetails({
   viewType,
+  toolParams,
 }: ToolExecutionDetailsProps) {
+  if (!isEditImageInputType(toolParams)) {
+    return (
+      <ActionDetailsWrapper
+        viewType={viewType}
+        actionName={
+          viewType === "conversation" ? "Editing image" : "Edit image"
+        }
+        visual={ActionImageIcon}
+      />
+    );
+  }
+
+  const { editPrompt, outputName, quality, aspectRatio } = toolParams;
+
   return (
     <ActionDetailsWrapper
       viewType={viewType}
       actionName={viewType === "conversation" ? "Editing image" : "Edit image"}
       visual={ActionImageIcon}
-    />
+    >
+      <div className="flex flex-col gap-3 pl-6 pt-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip label={outputName} color="primary" />
+          {aspectRatio && <Chip label={aspectRatio} color="highlight" />}
+          {quality && quality !== "auto" && (
+            <Chip label={`${quality} quality`} color="success" />
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {editPrompt}
+        </p>
+      </div>
+    </ActionDetailsWrapper>
   );
 }

--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -1,4 +1,4 @@
-import { ActionImageIcon, Chip, cn } from "@dust-tt/sparkle";
+import { ActionImageIcon, cn } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
@@ -23,7 +23,7 @@ export function MCPImageGenerationActionDetails({
     );
   }
 
-  const { prompt, name, quality, size } = toolParams;
+  const { prompt } = toolParams;
 
   return (
     <ActionDetailsWrapper
@@ -34,13 +34,6 @@ export function MCPImageGenerationActionDetails({
       visual={ActionImageIcon}
     >
       <div className="flex flex-col gap-3 pl-6 pt-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <Chip label={name} color="primary" />
-          {size && <Chip label={size} color="highlight" />}
-          {quality && quality !== "auto" && (
-            <Chip label={`${quality} quality`} color="success" />
-          )}
-        </div>
         <p
           className={cn(
             "text-sm text-muted-foreground dark:text-muted-foreground-night",
@@ -70,7 +63,7 @@ export function MCPImageEditingActionDetails({
     );
   }
 
-  const { editPrompt, outputName, quality, aspectRatio } = toolParams;
+  const { editPrompt } = toolParams;
 
   return (
     <ActionDetailsWrapper
@@ -79,13 +72,6 @@ export function MCPImageEditingActionDetails({
       visual={ActionImageIcon}
     >
       <div className="flex flex-col gap-3 pl-6 pt-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <Chip label={outputName} color="primary" />
-          {aspectRatio && <Chip label={aspectRatio} color="highlight" />}
-          {quality && quality !== "auto" && (
-            <Chip label={`${quality} quality`} color="success" />
-          )}
-        </div>
         <p
           className={cn(
             "text-sm text-muted-foreground dark:text-muted-foreground-night",

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -9,6 +9,10 @@ import {
   GENERATE_IMAGE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import {
+  EditImageInputSchema,
+  GenerateImageInputSchema,
+} from "@app/lib/actions/mcp_internal_actions/types";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { streamToBuffer } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -274,35 +278,7 @@ function createServer(
     "Generate an image from text descriptions. The more detailed and specific your prompt is, the" +
       " better the result will be. You can customize the output through various parameters to" +
       " match your needs.",
-    {
-      prompt: z
-        .string()
-        .max(4000)
-        .describe(
-          "A text description of the desired image. The maximum length is 32000 characters."
-        ),
-      name: z
-        .string()
-        .max(64)
-        .describe(
-          "The filename that will be used to save the generated image. Must be 64 characters or less."
-        ),
-      quality: z
-        .enum(["auto", "low", "medium", "high"])
-        .optional()
-        .default("auto")
-        .describe(
-          "The quality of the generated image. Must be one of auto, low, medium, or high. Auto" +
-            " will automatically choose the best quality for the size."
-        ),
-      size: z
-        .enum(["1024x1024", "1536x1024", "1024x1536"])
-        .optional()
-        .default("1024x1024")
-        .describe(
-          "The size of the generated image. Must be one of 1024x1024, 1536x1024, or 1024x1536"
-        ),
-    },
+    GenerateImageInputSchema.shape,
     withToolLogging(
       auth,
       { toolNameForMonitoring: GENERATE_IMAGE_TOOL_NAME, agentLoopContext },

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -405,40 +405,7 @@ function createServer(
     "Edit an existing image using text instructions. Provide the file ID of an image from Dust" +
       " file storage and describe the changes you want to make. The tool preserves the original" +
       " image's aspect ratio by default, but you can optionally change it.",
-    {
-      imageFileId: z
-        .string()
-        .describe(
-          "The ID of the image file to edit (e.g. fil_abc1234) from conversation attachments. Must be a valid image file (PNG, JPEG, etc.)."
-        ),
-      editPrompt: z
-        .string()
-        .max(4000)
-        .describe(
-          "A text description of the desired edits. Be specific about what should change and what should remain unchanged. The maximum length is 4000 characters."
-        ),
-      outputName: z
-        .string()
-        .max(64)
-        .describe(
-          "The filename that will be used to save the edited image. Must be 64 characters or less."
-        ),
-      quality: z
-        .enum(["auto", "low", "medium", "high"])
-        .optional()
-        .default("auto")
-        .describe(
-          "The quality of the edited image. Must be one of auto, low, medium, or high. Auto" +
-            " will automatically choose the best quality."
-        ),
-      aspectRatio: z
-        .enum(["1:1", "3:2", "2:3"])
-        .optional()
-        .describe(
-          "Optional aspect ratio override for the edited image. If not specified, preserves the" +
-            " original image's aspect ratio. Must be one of 1:1, 3:2, or 2:3."
-        ),
-    },
+    EditImageInputSchema.shape,
     withToolLogging(
       auth,
       { toolNameForMonitoring: EDIT_IMAGE_TOOL_NAME, agentLoopContext },

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -274,3 +274,83 @@ export function isSkillEnableInputType(
 ): input is SkillEnableInputType {
   return SkillEnableInputSchema.safeParse(input).success;
 }
+
+export const GenerateImageInputSchema = z.object({
+  prompt: z
+    .string()
+    .max(4000)
+    .describe(
+      "A text description of the desired image. The maximum length is 32000 characters."
+    ),
+  name: z
+    .string()
+    .max(64)
+    .describe(
+      "The filename that will be used to save the generated image. Must be 64 characters or less."
+    ),
+  quality: z
+    .enum(["auto", "low", "medium", "high"])
+    .optional()
+    .default("auto")
+    .describe(
+      "The quality of the generated image. Must be one of auto, low, medium, or high. Auto" +
+        " will automatically choose the best quality for the size."
+    ),
+  size: z
+    .enum(["1024x1024", "1536x1024", "1024x1536"])
+    .optional()
+    .default("1024x1024")
+    .describe(
+      "The size of the generated image. Must be one of 1024x1024, 1536x1024, or 1024x1536"
+    ),
+});
+
+export type GenerateImageInputType = z.infer<typeof GenerateImageInputSchema>;
+
+export function isGenerateImageInputType(
+  input: Record<string, unknown>
+): input is GenerateImageInputType {
+  return GenerateImageInputSchema.safeParse(input).success;
+}
+
+export const EditImageInputSchema = z.object({
+  imageFileId: z
+    .string()
+    .describe(
+      "The ID of the image file to edit (e.g. fil_abc1234) from conversation attachments. Must be a valid image file (PNG, JPEG, etc.)."
+    ),
+  editPrompt: z
+    .string()
+    .max(4000)
+    .describe(
+      "A text description of the desired edits. Be specific about what should change and what should remain unchanged. The maximum length is 4000 characters."
+    ),
+  outputName: z
+    .string()
+    .max(64)
+    .describe(
+      "The filename that will be used to save the edited image. Must be 64 characters or less."
+    ),
+  quality: z
+    .enum(["auto", "low", "medium", "high"])
+    .optional()
+    .default("auto")
+    .describe(
+      "The quality of the edited image. Must be one of auto, low, medium, or high. Auto" +
+        " will automatically choose the best quality."
+    ),
+  aspectRatio: z
+    .enum(["1:1", "3:2", "2:3"])
+    .optional()
+    .describe(
+      "Optional aspect ratio override for the edited image. If not specified, preserves the" +
+        " original image's aspect ratio. Must be one of 1:1, 3:2, or 2:3."
+    ),
+});
+export type EditImageInputType = z.infer<typeof EditImageInputSchema>;
+
+export function isEditImageInputType(
+  input: Record<string, unknown>
+): input is EditImageInputType {
+  return EditImageInputSchema.safeParse(input).success;
+}


### PR DESCRIPTION
## Description

- This PR further improves the `MCPActionDetails` for the image generation/editing tools by exposing the prompt that was used to generate the image, the size, quality, etc...

<img width="732" height="568" alt="Screenshot 2025-12-29 at 11 06 36 AM" src="https://github.com/user-attachments/assets/eea7ede1-8cc7-4120-9361-9fb437f4cd53" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
