### PR TITLE
[front] fix: prevent image duplication in conversations

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -935,10 +935,15 @@ function AgentMessageContent({
       progress: progress.progress?.progress,
     }));
 
-  // Get completed images.
-  const completedImages = agentMessage.generatedFiles.filter((file) =>
-    isSupportedImageContentType(file.contentType)
+  // Extract file IDs already referenced inline (to avoid duplicate rendering).
+  const referencedFileIds = new Set(
+    (agentMessage.content ?? "").match(/\bfil_[A-Za-z0-9]{10,}\b/g) ?? []
   );
+
+  // Get completed images that are not already referenced in the Markdown content.
+  const completedImages = agentMessage.generatedFiles
+    .filter((file) => isSupportedImageContentType(file.contentType))
+    .filter((file) => !referencedFileIds.has(file.fileId));
 
   const generatedFiles = agentMessage.generatedFiles
     .filter((file) => !file.hidden)
@@ -990,7 +995,7 @@ function AgentMessageContent({
               isStreaming={streaming && lastTokenClassification === "tokens"}
               isLastMessage={isLastMessage}
               additionalMarkdownComponents={additionalMarkdownComponents}
-            ></AgentMessageMarkdown>
+            />
           </CitationsContext.Provider>
         </div>
       )}


### PR DESCRIPTION
## Description

- Images can be shown at two locations: in the `InteractiveImageGrid` in `AgentMessageContent` (where we show the placeholder while it's generating), which is above the `AgentMessage`, and in the `AgentMessage` itself if referenced by the model (`Img` component). This can cause an image to appear twice. 
- This PR prevents duplicates and prioritizes the inline image over the one above the message, which will still show if the model does not reference the image at all.

<img width="422" alt="Screenshot 2025-12-25 at 10 42 41 PM" src="https://github.com/user-attachments/assets/1d7aece1-c0c2-40f3-9366-c39d3af7080f" />

- Closes https://github.com/dust-tt/tasks/issues/5748. Images may still appear above the content if the model does not specify where to put it. If this happens too often we can add some prompting or show in the tool output the exact Markdown image reference to put.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
