### PR TITLE
[front] enh(skills): update dropdown list items in `SkillsTable`/`SkillDetails`

### DIFF
--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -1,5 +1,4 @@
 import {
-  BracesIcon,
   Button,
   ClipboardIcon,
   DropdownMenu,
@@ -8,23 +7,29 @@ import {
   DropdownMenuTrigger,
   MoreIcon,
   PencilSquareIcon,
+  TrashIcon,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
+import { useState } from "react";
 
+import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 
 interface SkillDetailsButtonBarProps {
-  skill: SkillType;
+  skill: SkillWithRelationsType;
   owner: WorkspaceType;
+  onClose: () => void;
 }
 
 export function SkillDetailsButtonBar({
   skill,
   owner,
+  onClose,
 }: SkillDetailsButtonBarProps) {
   const router = useRouter();
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
 
   if (!skill.canWrite && !skill.isExtendable) {
     return null;

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -31,43 +31,61 @@ export function SkillDetailsButtonBar({
   }
 
   return (
-    <div className="flex flex-row items-center gap-2 px-1.5">
-      {skill.canWrite && (
-        <Button
-          size="sm"
-          tooltip="Edit agent"
-          href={getSkillBuilderRoute(owner.sId, skill.sId)}
-          variant="outline"
-          icon={PencilSquareIcon}
-        />
-      )}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button icon={MoreIcon} size="sm" variant="ghost" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuItem
-            label="Copy skill ID"
-            onClick={async (e) => {
-              e.stopPropagation();
-              await navigator.clipboard.writeText(skill.sId);
-            }}
-            icon={BracesIcon}
+    <>
+      <ArchiveSkillDialog
+        owner={owner}
+        isOpen={showArchiveDialog}
+        skillConfiguration={skill}
+        onClose={() => {
+          setShowArchiveDialog(false);
+          onClose();
+        }}
+      />
+      <div className="flex flex-row items-center gap-2 px-1.5">
+        {skill.canWrite && (
+          <Button
+            size="sm"
+            tooltip="Edit agent"
+            href={getSkillBuilderRoute(owner.sId, skill.sId)}
+            variant="outline"
+            icon={PencilSquareIcon}
           />
-          {skill.isExtendable && (
-            <DropdownMenuItem
-              label="Extend (New)"
-              icon={ClipboardIcon}
-              onClick={async (e) => {
-                e.stopPropagation();
-                await router.push(
-                  getSkillBuilderRoute(owner.sId, "new", `extends=${skill.sId}`)
-                );
-              }}
-            />
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button icon={MoreIcon} size="sm" variant="ghost" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            {skill.isExtendable && (
+              <DropdownMenuItem
+                label="Extend (New)"
+                icon={ClipboardIcon}
+                onClick={async (e) => {
+                  e.stopPropagation();
+                  await router.push(
+                    getSkillBuilderRoute(
+                      owner.sId,
+                      "new",
+                      `extends=${skill.sId}`
+                    )
+                  );
+                }}
+              />
+            )}
+            {skill.canWrite && (
+              <DropdownMenuItem
+                label="Archive"
+                icon={TrashIcon}
+                variant="warning"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowArchiveDialog(true);
+                }}
+              />
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </>
   );
 }

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -171,7 +171,7 @@ const DescriptionSection = ({
       </div>
 
       {skill.status === "active" && (
-        <SkillDetailsButtonBar owner={owner} skill={skill} />
+        <SkillDetailsButtonBar owner={owner} skill={skill} onClose={onClose} />
       )}
 
       {skill.status === "archived" && (

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -1,5 +1,6 @@
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
+  ClipboardIcon,
   DataTable,
   EyeIcon,
   PencilSquareIcon,
@@ -185,6 +186,22 @@ export function SkillsTable({
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
                     onSkillClick(skill);
+                  },
+                  kind: "item" as const,
+                },
+                {
+                  label: "Extend (New)",
+                  icon: ClipboardIcon,
+                  disabled: !skill.isExtendable,
+                  onClick: (e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    void router.push(
+                      getSkillBuilderRoute(
+                        owner.sId,
+                        "new",
+                        `extends=${skill.sId}`
+                      )
+                    );
                   },
                   kind: "item" as const,
                 },


### PR DESCRIPTION
## Description

This PR updates the list of actions available on each skill in the Skills table or on the `SkillDetails` sheet.
- `SkillsTable`: add button to extend global skill (if `isExtendable`).
- `SkillDetails`: add button to archive skill (if `canWrite`).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
