### PR TITLE
[front] fix(skills): fix `SkillDetails` closing animation

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
@@ -14,7 +14,7 @@ import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 type CapabilitiesSelectionPageProps = {
-  onModeChange: (mode: CapabilitiesSheetMode | null) => void;
+  onModeChange: (mode: CapabilitiesSheetMode) => void;
   handleSkillToggle: (skill: SkillType) => void;
   filteredSkills: SkillType[];
   searchQuery: string;
@@ -53,6 +53,7 @@ export function CapabilitiesSelectionPageContent({
         pageId: "skill_info",
         capability: skill,
         hasPreviousPage: true,
+        open: true,
       });
     },
   });

--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSheet.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSheet.tsx
@@ -1,25 +1,18 @@
 import { MultiPageSheet, MultiPageSheetContent } from "@dust-tt/sparkle";
 import React from "react";
 
-import type {
-  CapabilitiesSheetContentProps,
-  CapabilitiesSheetMode,
-} from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
+import type { CapabilitiesSheetContentProps } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
 import { useCapabilitiesPageAndFooter } from "@app/components/agent_builder/capabilities/capabilities_sheet/utils";
 
-export function CapabilitiesSheet(
-  props: Omit<CapabilitiesSheetContentProps, "mode"> & {
-    mode: CapabilitiesSheetMode | null;
-  }
-) {
+export function CapabilitiesSheet(props: CapabilitiesSheetContentProps) {
   const { mode, onClose } = props;
 
   return (
     <MultiPageSheet
-      open={mode !== null}
+      open={mode.open}
       onOpenChange={(open) => !open && onClose()}
     >
-      {mode && <CapabilitiesSheetContent {...props} mode={mode} />}
+      <CapabilitiesSheetContent {...props} mode={mode} />
     </MultiPageSheet>
   );
 }

--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -32,7 +32,7 @@ function isGlobalSkillWithSpaceSelection(skill: SkillType): boolean {
 }
 
 type UseSkillSelectionProps = {
-  onModeChange: (mode: CapabilitiesSheetMode | null) => void;
+  onModeChange: (mode: CapabilitiesSheetMode) => void;
   alreadyAddedSkillIds: Set<string>;
   initialAdditionalSpaces: string[];
   searchQuery: string;
@@ -97,6 +97,7 @@ export const useSkillSelection = ({
         onModeChange({
           pageId: "skill_space_selection",
           capability: skill,
+          open: true,
         });
         return;
       }
@@ -128,7 +129,7 @@ export const useSkillSelection = ({
           icon: skill.icon,
         },
       ]);
-      onModeChange({ pageId: "selection" });
+      onModeChange({ pageId: "selection", open: true });
     },
     [
       onModeChange,
@@ -157,7 +158,7 @@ export const useToolSelection = ({
   searchQuery,
 }: {
   selectedActions: BuilderAction[];
-  onModeChange: (mode: CapabilitiesSheetMode | null) => void;
+  onModeChange: (mode: CapabilitiesSheetMode) => void;
   searchQuery: string;
 }) => {
   const { owner } = useBuilderContext();
@@ -249,6 +250,7 @@ export const useToolSelection = ({
           pageId: "tool_configuration",
           capability: action,
           mcpServerView,
+          open: true,
         });
         return;
       }
@@ -284,6 +286,7 @@ export const useToolSelection = ({
         pageId: "tool_info",
         capability: action,
         hasPreviousPage: true,
+        open: true,
       });
     },
     [onModeChange]
@@ -326,7 +329,7 @@ export const useToolSelection = ({
         }
       });
 
-      onModeChange({ pageId: "selection" });
+      onModeChange({ pageId: "selection", open: true });
     },
     [selectedActions, localSelectedTools, onModeChange]
   );

--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
 
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type {
   AgentBuilderSkillsType,
   MCPFormData,
@@ -16,6 +15,7 @@ import {
   nameToStorageFormat,
 } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
+import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
@@ -23,7 +23,6 @@ import { useBuilderContext } from "@app/components/shared/useBuilderContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { doesSkillTriggerSelectSpaces } from "@app/lib/skill";
-import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
@@ -44,8 +43,6 @@ export const useSkillSelection = ({
   initialAdditionalSpaces,
   searchQuery,
 }: UseSkillSelectionProps) => {
-  const { owner } = useAgentBuilderContext();
-
   const [localSelectedSkills, setLocalSelectedSkills] = useState<
     AgentBuilderSkillsType[]
   >([]);
@@ -58,10 +55,7 @@ export const useSkillSelection = ({
     localAdditionalSpaces
   );
 
-  const { skills, isSkillsLoading } = useSkills({
-    owner,
-    status: "active",
-  });
+  const { skills, isSkillsLoading } = useSkillsContext();
 
   const selectedSkillIds = useMemo(
     () => new Set(localSelectedSkills.map((s) => s.sId)),

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
@@ -26,39 +26,41 @@ export type SelectedTool = {
 
 export type CapabilityFilterType = "all" | "tools" | "skills";
 
-type SelectionMode = {
-  pageId: "selection";
-};
+type OpenState = { open: boolean };
 
-type SkillInfoMode = {
+interface SelectionMode extends OpenState {
+  pageId: "selection";
+}
+
+interface SkillInfoMode extends OpenState {
   pageId: "skill_info";
   capability: SkillWithRelationsType;
   hasPreviousPage: boolean;
-};
+}
 
-type SkillSpaceSelectionMode = {
+interface SkillSpaceSelectionMode extends OpenState {
   pageId: "skill_space_selection";
   capability: SkillType;
-};
+}
 
-type ToolInfoMode = {
+interface ToolInfoMode extends OpenState {
   pageId: "tool_info";
   capability: BuilderAction;
   hasPreviousPage: boolean;
-};
+}
 
-export type ToolConfigurationMode = {
+export interface ToolConfigurationMode extends OpenState {
   pageId: "tool_configuration";
   capability: BuilderAction;
   mcpServerView: MCPServerViewTypeWithLabel;
-};
+}
 
-export type ToolEditMode = {
+export interface ToolEditMode extends OpenState {
   pageId: "tool_edit";
   capability: BuilderAction;
   mcpServerView: MCPServerViewTypeWithLabel;
   index: number;
-};
+}
 
 export type CapabilitiesSheetMode =
   | SelectionMode
@@ -70,7 +72,7 @@ export type CapabilitiesSheetMode =
 
 export type CapabilitiesSheetContentProps = {
   mode: CapabilitiesSheetMode;
-  onModeChange: (mode: CapabilitiesSheetMode | null) => void;
+  onModeChange: (mode: CapabilitiesSheetMode) => void;
   onClose: () => void;
   onCapabilitiesSave: (data: {
     skills: AgentBuilderSkillsType[];

--- a/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
@@ -205,7 +205,7 @@ export function useCapabilitiesPageAndFooter({
               label: "Back",
               variant: "outline",
               onClick: () => {
-                onModeChange({ pageId: "selection" });
+                onModeChange({ pageId: "selection", open: true });
               },
             }
           : {
@@ -237,7 +237,7 @@ export function useCapabilitiesPageAndFooter({
             skillSelection.setDraftSelectedSpaces(
               skillSelection.localAdditionalSpaces
             );
-            onModeChange({ pageId: "selection" });
+            onModeChange({ pageId: "selection", open: true });
           },
         },
         rightButton: {
@@ -273,7 +273,7 @@ export function useCapabilitiesPageAndFooter({
               label: "Back",
               variant: "outline",
               onClick: () => {
-                onModeChange({ pageId: "selection" });
+                onModeChange({ pageId: "selection", open: true });
               },
             }
           : {
@@ -303,7 +303,7 @@ export function useCapabilitiesPageAndFooter({
           label: "Cancel",
           variant: "outline",
           onClick: () => {
-            onModeChange({ pageId: "selection" });
+            onModeChange({ pageId: "selection", open: true });
           },
         },
         rightButton: {

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -184,7 +184,7 @@ export function AgentBuilderSkillsBlock() {
   }, [spaceIdToActions, spaces]);
 
   const [capabillitiesSheetMode, setCapabilitiesSheetMode] =
-    useState<CapabilitiesSheetMode | null>(null);
+    useState<CapabilitiesSheetMode>({ open: false, pageId: "selection" });
   const [knowledgeAction, setKnowledgeAction] = useState<{
     action: BuilderAction;
     index: number | null;
@@ -199,7 +199,7 @@ export function AgentBuilderSkillsBlock() {
     } else {
       appendActions(updatedAction);
     }
-    setCapabilitiesSheetMode(null);
+    setCapabilitiesSheetMode((prevMode) => ({ ...prevMode, open: false }));
     setKnowledgeAction(null);
   };
 
@@ -226,8 +226,14 @@ export function AgentBuilderSkillsBlock() {
             capability: action,
             mcpServerView: mcpServerViewWithoutKnowledge,
             index,
+            open: true,
           }
-        : { pageId: "tool_info", capability: action, hasPreviousPage: false }
+        : {
+            pageId: "tool_info",
+            capability: action,
+            hasPreviousPage: false,
+            open: true,
+          }
     );
   };
 
@@ -237,6 +243,7 @@ export function AgentBuilderSkillsBlock() {
         pageId: "skill_info",
         capability: skill,
         hasPreviousPage: false,
+        open: true,
       }),
   });
 
@@ -293,11 +300,11 @@ export function AgentBuilderSkillsBlock() {
   };
 
   const handleClickCapability = () => {
-    setCapabilitiesSheetMode({ pageId: "selection" });
+    setCapabilitiesSheetMode({ pageId: "selection", open: true });
   };
 
   const handleCloseSheet = useCallback(() => {
-    setCapabilitiesSheetMode(null);
+    setCapabilitiesSheetMode((prevMode) => ({ ...prevMode, open: false }));
     setKnowledgeAction(null);
   }, []);
 

--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -224,7 +224,7 @@ export function AgentDetails({
 
   return (
     <Sheet open={!!agentId} onOpenChange={onClose}>
-      <SheetContent size="lg">
+      <SheetContent size="lg" className="outline-none">
         <VisuallyHidden>
           <SheetTitle />
         </VisuallyHidden>

--- a/front/components/shared/skills/SkillsContext.tsx
+++ b/front/components/shared/skills/SkillsContext.tsx
@@ -33,6 +33,7 @@ export const SkillsProvider = ({ owner, children }: SkillsProviderProps) => {
 
   const { skills, isSkillsLoading, isSkillsError } = useSkills({
     owner,
+    status: "active",
     disabled: !hasSkillsFeature,
   });
 

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -31,7 +31,7 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 
 type SkillDetailsProps = {
-  skill: SkillWithRelationsType;
+  skill: SkillWithRelationsType | null;
   onClose: () => void;
   owner: WorkspaceType;
   user: UserType;
@@ -44,24 +44,29 @@ export function SkillDetailsSheet({
   owner,
 }: SkillDetailsProps) {
   return (
-    <Sheet
-      open={!!skill}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Sheet open={skill !== null} onOpenChange={onClose}>
       <SheetContent size="lg">
         <VisuallyHidden>
           <SheetTitle />
         </VisuallyHidden>
-        <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
-          <DescriptionSection skill={skill} owner={owner} onClose={onClose} />
-        </SheetHeader>
-        <SheetContainer className="pb-4">
-          <SkillDetailsSheetContent skill={skill} user={user} owner={owner} />
-        </SheetContainer>
+        {skill && (
+          <>
+            <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
+              <DescriptionSection
+                skill={skill}
+                owner={owner}
+                onClose={onClose}
+              />
+            </SheetHeader>
+            <SheetContainer className="pb-4">
+              <SkillDetailsSheetContent
+                skill={skill}
+                user={user}
+                owner={owner}
+              />
+            </SheetContainer>
+          </>
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -198,14 +198,12 @@ export default function WorkspaceSkills({
 
   return (
     <>
-      {!!selectedSkill && (
-        <SkillDetailsSheet
-          skill={selectedSkill}
-          onClose={() => setSelectedSkill(null)}
-          user={user}
-          owner={owner}
-        />
-      )}
+      <SkillDetailsSheet
+        skill={selectedSkill}
+        onClose={() => setSelectedSkill(null)}
+        user={user}
+        owner={owner}
+      />
 
       <AgentDetails
         owner={owner}


### PR DESCRIPTION
## Description

- There is currently no animation upon closing the `SkillsDetailsSheet`.
- This is due to the component being unmounted immediately on close.
- This PR fixes that.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
