### PR TITLE
[front] fix(skill): fix check on availability for interactive_content and deep_dive

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1815,41 +1815,19 @@ export const isAutoInternalMCPServerName = (
 };
 
 export const getAvailabilityOfInternalMCPServerByName = (
-  name: InternalMCPServerNameType,
-  {
-    featureFlags,
-  }: {
-    featureFlags?: WhitelistableFeature[];
-  } = {}
+  name: InternalMCPServerNameType
 ): MCPServerAvailability => {
-  // TODO(skills-GA): Remove this temporary override once skills are GA.
-  // When skills feature flag is enabled, hide interactive_content and deep_dive from the builder
-  // since they are exposed through skills instead.
-  if (
-    (name === "interactive_content" || name === "deep_dive") &&
-    featureFlags?.includes("skills")
-  ) {
-    return "auto_hidden_builder";
-  }
-
   return INTERNAL_MCP_SERVERS[name].availability;
 };
 
 export const getAvailabilityOfInternalMCPServerById = (
-  sId: string,
-  {
-    featureFlags,
-  }: {
-    featureFlags?: WhitelistableFeature[];
-  } = {}
+  sId: string
 ): MCPServerAvailability => {
   const r = getInternalMCPServerNameAndWorkspaceId(sId);
   if (r.isErr()) {
     return "manual";
   }
-  return getAvailabilityOfInternalMCPServerByName(r.value.name, {
-    featureFlags,
-  });
+  return getAvailabilityOfInternalMCPServerByName(r.value.name);
 };
 
 export const allowsMultipleInstancesOfInternalMCPServerByName = (

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -2,12 +2,10 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -67,34 +65,9 @@ async function handler(
 
       const { availability = "manual" } = r.right;
 
-      // TODO(skills-GA): Remove this temporary override once skills are GA.
-      // When skills feature flag is enabled, hide interactive_content and deep_dive from the builder
-      // since they are exposed through skills instead.
-      const featureFlags = await getFeatureFlags(
-        auth.getNonNullableWorkspace()
-      );
-      const hasSkillsFlag = featureFlags.includes("skills");
-
       const serverViews = (
         await MCPServerViewResource.listBySpace(auth, space)
-      ).map((view) => {
-        const json = view.toJSON();
-        const serverName = getInternalMCPServerNameFromSId(json.server.sId);
-        if (
-          hasSkillsFlag &&
-          (serverName === "interactive_content" || serverName === "deep_dive")
-        ) {
-          return {
-            ...json,
-            server: {
-              ...json.server,
-              availability: "auto_hidden_builder" as const,
-            },
-          };
-        }
-        return json;
-      });
-
+      ).map((view) => view.toJSON());
       return res.status(200).json({
         success: true,
         serverViews: serverViews.filter(


### PR DESCRIPTION
## Description

- This PR updates the restriction check on the `deep_dive` and `interactive_content` MCP servers, turning it into an availability check (temporary change, localized in the endpoint to list MCP server views).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
