### PR TITLE
[front] chore(skills): remove redundant `mcpServerViews` field on `SkillRelations`

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -23,7 +23,7 @@ import { useBuilderContext } from "@app/components/shared/useBuilderContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { doesSkillTriggerSelectSpaces } from "@app/lib/skill";
-import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
@@ -37,6 +37,7 @@ type UseSkillSelectionProps = {
   initialAdditionalSpaces: string[];
   searchQuery: string;
 };
+
 export const useSkillSelection = ({
   onModeChange,
   alreadyAddedSkillIds,
@@ -57,11 +58,10 @@ export const useSkillSelection = ({
     localAdditionalSpaces
   );
 
-  const { skillsWithRelations, isSkillsWithRelationsLoading } =
-    useSkillsWithRelations({
-      owner,
-      status: "active",
-    });
+  const { skills, isSkillsLoading } = useSkills({
+    owner,
+    status: "active",
+  });
 
   const selectedSkillIds = useMemo(
     () => new Set(localSelectedSkills.map((s) => s.sId)),
@@ -69,7 +69,7 @@ export const useSkillSelection = ({
   );
 
   const filteredSkills = useMemo(() => {
-    const notAlreadyAddedSkills = skillsWithRelations.filter(
+    const notAlreadyAddedSkills = skills.filter(
       (skill) => !alreadyAddedSkillIds.has(skill.sId)
     );
 
@@ -82,7 +82,7 @@ export const useSkillSelection = ({
         skill.name.toLowerCase().includes(query) ||
         skill.userFacingDescription.toLowerCase().includes(query)
     );
-  }, [skillsWithRelations, searchQuery, alreadyAddedSkillIds]);
+  }, [skills, searchQuery, alreadyAddedSkillIds]);
 
   const handleSkillToggle = useCallback(
     (skill: SkillType) => {
@@ -143,7 +143,7 @@ export const useSkillSelection = ({
     localAdditionalSpaces,
     handleSkillToggle,
     filteredSkills,
-    isSkillsLoading: isSkillsWithRelationsLoading,
+    isSkillsLoading,
     selectedSkillIds,
     handleSpaceSelectionSave,
     draftSelectedSpaces,

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -5,23 +5,12 @@ import { useMemo } from "react";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import type {
-  SkillRelations,
-  SkillType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-export function SkillInfoTab({
-  skill,
-}: {
-  skill: SkillType & { relations?: SkillRelations };
-}) {
+export function SkillInfoTab({ skill }: { skill: SkillType }) {
   const sortedMCPServerViews = useMemo(
-    () =>
-      sortBy(
-        (skill.relations?.mcpServerViews ?? []).map(renderMCPServerView),
-        "title"
-      ),
-    [skill.relations?.mcpServerViews]
+    () => sortBy(skill.tools.map(renderMCPServerView), "title"),
+    [skill.tools]
   );
 
   return (

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -141,9 +141,6 @@ async function handler(
           relations: {
             usage,
             editors: editors ? editors.map((e) => e.toJSON()) : null,
-            mcpServerViews: skillResource.mcpServerViews.map((view) =>
-              view.toJSON()
-            ),
             author: author ? author.toJSON() : null,
             extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,
           },

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -126,7 +126,6 @@ async function handler(
               relations: {
                 usage,
                 editors: editors ? editors.map((e) => e.toJSON()) : null,
-                mcpServerViews: sc.mcpServerViews.map((view) => view.toJSON()),
                 author: author ? author.toJSON() : null,
                 extendedSkill: extendedSkill
                   ? extendedSkill.toJSON(auth)

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -26,7 +26,6 @@ export type SkillType = {
 export type SkillRelations = {
   usage: AgentsUsageType;
   editors: UserType[] | null;
-  mcpServerViews: MCPServerViewType[];
   author: UserType | null;
   extendedSkill: SkillType | null;
 };


### PR DESCRIPTION
## Description

- Following changes in https://github.com/dust-tt/dust/pull/19446 we now store the `MCPServerViewType` on `SkillType`.
- This PR removes the duplicate field in `SkillRelations`.
- This PR also replaces a `useSkillsWithRelations` with a `useSkills`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
