### PR TITLE
[front] fix(tests): fix workspace isolation errors in tests

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -1285,6 +1285,7 @@ describe("createUserMentions", () => {
         where: {
           messageId: messageRow.id,
           userId: mentionedUser.id,
+          workspaceId: workspace.id,
         },
       });
       expect(mentionInDb).not.toBeNull();

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -148,6 +148,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - additionalRe
       where: {
         sId: data.agentConfiguration.sId,
         version: data.agentConfiguration.version,
+        workspaceId: workspace.id,
       },
     });
     expect(agentConfigurationModel).not.toBeNull();


### PR DESCRIPTION
## Description

- Tests are failing with the error `Query attempted without workspaceId on agent_configuration/mention. All workspace-aware model queries must be scoped to a specific workspaceId for query isolation.`.
- This PR fixes the affected tests.

## Tests

## Risk

- None.

## Deploy Plan

- Deploy front.
