### PR TITLE
[front] refactor(skills): cleanup availability override

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -15,11 +15,9 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import type {
   AutoInternalMCPServerNameType,
-  MCPServerAvailability,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
-  getAvailabilityOfInternalMCPServerById,
   getAvailabilityOfInternalMCPServerByName,
   isAutoInternalMCPServerName,
   isValidInternalMCPServerId,
@@ -652,14 +650,6 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     } else {
       assertNever(this.serverType);
     }
-  }
-
-  get availability(): MCPServerAvailability {
-    if (this.serverType !== "internal" || !this.internalMCPServerId) {
-      return "manual";
-    }
-
-    return getAvailabilityOfInternalMCPServerById(this.internalMCPServerId);
   }
 
   static async ensureAllAutoToolsAreCreated(auth: Authenticator): Promise<{

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -13,9 +13,7 @@ import {
   getServerTypeAndIdFromSId,
   remoteMCPServerNameToSId,
 } from "@app/lib/actions/mcp_helper";
-import type {
-  AutoInternalMCPServerNameType,
-} from "@app/lib/actions/mcp_internal_actions/constants";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
   getAvailabilityOfInternalMCPServerByName,


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/19457.
- This PR moves the availability override from the endpoint to the `InternalMCPServerInMemoryResource` inititialization.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
