### PR TITLE
Fix Jira create issue

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_utils.ts
@@ -138,6 +138,10 @@ export function shouldConvertToADF(
   return false;
 }
 
+// Fields that cannot be set when creating/updating issues.
+// These are either auto-generated or must be changed via workflow transitions.
+const READ_ONLY_FIELDS = ["status", "id", "key", "self"];
+
 export function processFieldsForJira(
   fields: Record<string, unknown>,
   fieldsMetadata?: Record<
@@ -148,6 +152,11 @@ export function processFieldsForJira(
   >
 ): Record<string, unknown> {
   const processedFields = { ...fields };
+
+  // Remove read-only fields that cannot be set via the API.
+  for (const field of READ_ONLY_FIELDS) {
+    delete processedFields[field];
+  }
 
   for (const [fieldKey, fieldValue] of Object.entries(processedFields)) {
     const fieldMetadata = fieldsMetadata?.[fieldKey];


### PR DESCRIPTION
## Description

When creating a Jira issue with a status field, the API returns:
Field 'status' cannot be set. It is not on the appropriate screen, or unknown.
This is expected Jira behavior - status can only be changed via workflow transitions, not set directly.

I went for the quick fix: Automatically strip read-only fields before sending to the Jira API. This applies to both createIssue and updateIssue operations: Filter out read-only fields (status, id, key, self) in processFieldsForJira() before sending requests to the Jira API


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 