### PR TITLE
[skills] Allow to store suggested skills in database

### DIFF
--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -64,7 +64,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   declare instructions: string;
   declare icon: string | null;
 
-  declare authorId: ForeignKey<UserModel["id"]>;
+  declare authorId: ForeignKey<UserModel["id"]> | null;
   // Not a foreign key, only global skills can be extended.
   declare extendedSkillId: string | null;
 
@@ -116,11 +116,11 @@ SkillVersionModel.init(
 
 // Skill config <> Author
 UserModel.hasMany(SkillConfigurationModel, {
-  foreignKey: { name: "authorId", allowNull: false },
+  foreignKey: { name: "authorId", allowNull: true },
   onDelete: "RESTRICT",
 });
 SkillConfigurationModel.belongsTo(UserModel, {
-  foreignKey: { name: "authorId", allowNull: false },
+  foreignKey: { name: "authorId", allowNull: true },
   as: "author",
 });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -898,6 +898,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async fetchAuthor(auth: Authenticator): Promise<UserResource | null> {
+    if (this.authorId === null) {
+      return null;
+    }
+
     const author = await UserResource.fetchByModelId(this.authorId);
 
     if (!author) {

--- a/front/migrations/db/migration_457.sql
+++ b/front/migrations/db/migration_457.sql
@@ -1,0 +1,3 @@
+-- Migration created on Dec 29, 2025
+ALTER TABLE "skill_configurations"
+    ALTER COLUMN "authorId" DROP NOT NULL;

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -34,6 +34,7 @@ export type PostSkillConfigurationResponseBody = {
 const SkillStatusSchema = t.union([
   t.literal("active"),
   t.literal("archived"),
+  t.literal("suggested"),
   t.undefined,
 ]);
 
@@ -100,7 +101,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid status: ${status}. Expected "active" or "archived".`,
+            message: `Invalid status: ${status}. Expected "active", "archived", or "suggested".`,
           },
         });
       }

--- a/front/tests/utils/SkillConfigurationFactory.ts
+++ b/front/tests/utils/SkillConfigurationFactory.ts
@@ -4,6 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ModelId } from "@app/types";
+import type { SkillStatus } from "@app/types/assistant/skill_configuration";
 
 export class SkillConfigurationFactory {
   static async create(
@@ -13,7 +14,7 @@ export class SkillConfigurationFactory {
       agentFacingDescription: string;
       userFacingDescription: string;
       instructions: string;
-      status: "active" | "archived";
+      status: SkillStatus;
     }> = {}
   ): Promise<SkillResource> {
     const user = auth.user();
@@ -26,11 +27,12 @@ export class SkillConfigurationFactory {
       overrides.userFacingDescription ?? "Test skill user facing description";
     const instructions = overrides.instructions ?? "Test skill instructions";
     const status = overrides.status ?? "active";
+    const authorId = overrides.status === "suggested" ? null : user.id;
 
     return SkillResource.makeNew(
       auth,
       {
-        authorId: user.id,
+        authorId,
         agentFacingDescription,
         userFacingDescription,
         instructions,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -2,7 +2,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { UserType } from "@app/types/user";
 
-export type SkillStatus = "active" | "archived";
+export type SkillStatus = "active" | "archived" | "suggested";
 
 export type SkillType = {
   id: number;


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/5755

This add a new status "suggested" in the skills.
Also allows auythorId to be null as we won't have authors to store for suggested skills.

## Tests

Added unit tests

## Risk

low

## Deploy Plan

block front
merge PR
apply migration
deploy front
release front
