### PR TITLE
[front] - chore(analytics): handle blocking analytics and ES write failures

### DIFF
--- a/front/temporal/agent_loop/activities/analytics.ts
+++ b/front/temporal/agent_loop/activities/analytics.ts
@@ -18,6 +18,7 @@ export async function launchAgentMessageAnalytics(
       { workspaceId: authType.workspaceId },
       "Failed to fetch workspace infos for agent message analytics"
     );
+
     return;
   }
 


### PR DESCRIPTION
## Description

This PR:
- Log a message when ingestion is skipped due to blocked actions
- Implement error handling for analytics document writes to Elasticsearch
- Add logging for failures in writing retrieval outputs to Elasticsearch

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front