### PR TITLE
[front] - refactor(BaseFormFieldSection): follow RHF best practices

### DIFF
--- a/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
@@ -1,5 +1,4 @@
 import { TextArea } from "@dust-tt/sparkle";
-import { useFormContext } from "react-hook-form";
 
 import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 
@@ -22,8 +21,6 @@ export function DescriptionSection({
   maxLength,
   triggerValidationOnChange = false,
 }: DescriptionSectionProps) {
-  const { formState } = useFormContext();
-
   return (
     <BaseFormFieldSection
       title={title}
@@ -31,7 +28,7 @@ export function DescriptionSection({
       fieldName={DESCRIPTION_FIELD_NAME}
       triggerValidationOnChange={triggerValidationOnChange}
     >
-      {({ registerRef, registerProps, onChange, errorMessage }) => (
+      {({ registerRef, registerProps, onChange, errorMessage, fieldState }) => (
         <>
           {label && <label className="text-sm font-medium">{label}</label>}
           <TextArea
@@ -39,9 +36,9 @@ export function DescriptionSection({
             placeholder={placeholder}
             rows={4}
             maxLength={maxLength}
-            showErrorLabel={formState.isSubmitted || formState.isDirty}
+            showErrorLabel={fieldState.isDirty || fieldState.isTouched}
             error={
-              formState.isSubmitted || formState.isDirty
+              fieldState.isDirty || fieldState.isTouched
                 ? errorMessage
                 : undefined
             }

--- a/front/components/agent_builder/capabilities/shared/TimeFrameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/TimeFrameSection.tsx
@@ -8,7 +8,6 @@ import {
   DropdownMenuTrigger,
   Input,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
@@ -46,10 +45,7 @@ interface TimeFrameSectionProps {
 }
 
 export function TimeFrameSection({ actionType }: TimeFrameSectionProps) {
-  const { setValue, getValues } = useFormContext();
-  const [isChecked, setIsChecked] = useState(
-    () => !!getValues("configuration.timeFrame")
-  );
+  const { setValue } = useFormContext();
 
   const { field: timeFrameField } = useController<
     CapabilityFormData,
@@ -58,6 +54,7 @@ export function TimeFrameSection({ actionType }: TimeFrameSectionProps) {
     name: "configuration.timeFrame",
   });
 
+  const isChecked = timeFrameField.value !== null;
   const { actionText, contextText } = ACTION_CONFIG[actionType];
 
   return (
@@ -75,7 +72,6 @@ export function TimeFrameSection({ actionType }: TimeFrameSectionProps) {
         <Checkbox
           checked={isChecked}
           onCheckedChange={(checked) => {
-            setIsChecked(Boolean(checked));
             setValue(
               "configuration.timeFrame",
               checked ? DEFAULT_TIME_FRAME : null
@@ -85,7 +81,7 @@ export function TimeFrameSection({ actionType }: TimeFrameSectionProps) {
         <div
           className={classNames(
             "text-sm font-semibold",
-            !getValues("configuration.timeFrame")
+            !isChecked
               ? "text-muted-foreground dark:text-muted-foreground-night"
               : "text-foreground dark:text-foreground-night"
           )}


### PR DESCRIPTION
## Description

**Problem: Performance Anti-Patterns**

We identified three issues causing unnecessary re-renders:
1. Double subscription - `BaseFormFieldSection` used both `register()` and `useController()` for the same field, creating two subscriptions when one suffices
2. Duplicated state - `TimeFrameSection` stored checkbox state in both form state and local useState
3. Over-subscription - `DescriptionSection` subscribed to the entire form's state, re-rendering on any field change

**Changes Made**

1. `BaseFormFieldSection`

  Removed register() and now use only useController(), which provides both field value and validation state in one subscription. Also exposed fieldState to child components so they can access field-specific information without subscribing to the entire form.

2. `TimeFrameSection`

Removed local `useState` for checkbox state. Now derives it directly from form value: `isChecked = timeFrameField.value !== null`. Single source of truth.

3. `DescriptionSection`

Replaced form-wide state subscription with field-specific state from `BaseFormFieldSection`. Now only re-renders when the description field changes, not when any field in the form changes.

## Tests

Locally

## Risk

Medium - touches one core component of the agent builder form

## Deploy Plan

Deploy front
