### PR TITLE
[front] fix(skills): only show skills on global space in JIT skills

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -227,6 +227,7 @@ export function ToolsPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
+    spaces: globalSpaces,
     disabled: !shouldFetchToolsData || !hasSkillsFeature,
   });
 

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -227,7 +227,7 @@ export function ToolsPicker({
   const { skills, isSkillsLoading } = useSkills({
     owner,
     status: "active",
-    spaces: globalSpaces,
+    globalSpaceOnly: true,
     disabled: !shouldFetchToolsData || !hasSkillsFeature,
   });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -482,20 +482,22 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       status = "active",
       limit,
-      spaceIds,
-    }: { status?: SkillStatus; limit?: number; spaceIds?: string[] } = {}
+      globalSpaceOnly,
+    }: {
+      status?: SkillStatus;
+      limit?: number;
+      globalSpaceOnly?: boolean;
+    } = {}
   ): Promise<SkillResource[]> {
     const skills = await this.baseFetch(auth, {
       where: { status },
       ...(limit ? { limit } : {}),
     });
 
-    if (spaceIds && spaceIds.length > 0) {
-      const spaceModelIds = new Set(
-        removeNulls(spaceIds.map(getResourceIdFromSId))
-      );
+    if (globalSpaceOnly) {
+      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
       return skills.filter((skill) =>
-        skill.requestedSpaceIds.every((id) => spaceModelIds.has(id))
+        skill.requestedSpaceIds.every((id) => id === globalSpace.id)
       );
     }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -479,12 +479,27 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async listSkills(
     auth: Authenticator,
-    { status = "active", limit }: { status?: SkillStatus; limit?: number } = {}
+    {
+      status = "active",
+      limit,
+      spaceIds,
+    }: { status?: SkillStatus; limit?: number; spaceIds?: string[] } = {}
   ): Promise<SkillResource[]> {
-    return this.baseFetch(auth, {
+    const skills = await this.baseFetch(auth, {
       where: { status },
       ...(limit ? { limit } : {}),
     });
+
+    if (spaceIds && spaceIds.length > 0) {
+      const spaceModelIds = new Set(
+        removeNulls(spaceIds.map(getResourceIdFromSId))
+      );
+      return skills.filter((skill) =>
+        skill.requestedSpaceIds.every((id) => spaceModelIds.has(id))
+      );
+    }
+
+    return skills;
   }
 
   /**

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -18,7 +18,7 @@ import type {
 import type { GetSkillWithRelationsResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]";
 import type { GetSkillConfigurationsHistoryResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]/history";
 import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
-import type { LightWorkspaceType, SpaceType } from "@app/types";
+import type { LightWorkspaceType } from "@app/types";
 import { Ok } from "@app/types";
 import type {
   SkillStatus,
@@ -29,12 +29,12 @@ export function useSkills({
   owner,
   disabled,
   status,
-  spaces,
+  globalSpaceOnly,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
   status?: SkillStatus;
-  spaces?: SpaceType[];
+  globalSpaceOnly?: boolean;
 }) {
   const skillsFetcher: Fetcher<GetSkillConfigurationsResponseBody> = fetcher;
 
@@ -42,8 +42,8 @@ export function useSkills({
   if (status) {
     queryParams.set("status", status);
   }
-  if (spaces && spaces.length > 0) {
-    queryParams.set("spaceIds", spaces.map((s) => s.sId).join(","));
+  if (globalSpaceOnly) {
+    queryParams.set("globalSpaceOnly", "true");
   }
   const queryString = queryParams.toString();
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -18,7 +18,7 @@ import type {
 import type { GetSkillWithRelationsResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]";
 import type { GetSkillConfigurationsHistoryResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]/history";
 import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
-import type { LightWorkspaceType } from "@app/types";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
 import { Ok } from "@app/types";
 import type {
   SkillStatus,
@@ -29,17 +29,26 @@ export function useSkills({
   owner,
   disabled,
   status,
+  spaces,
 }: {
   owner: LightWorkspaceType;
   disabled?: boolean;
   status?: SkillStatus;
+  spaces?: SpaceType[];
 }) {
   const skillsFetcher: Fetcher<GetSkillConfigurationsResponseBody> = fetcher;
 
-  const statusQueryParam = status ? `?status=${status}` : "";
+  const queryParams = new URLSearchParams();
+  if (status) {
+    queryParams.set("status", status);
+  }
+  if (spaces && spaces.length > 0) {
+    queryParams.set("spaceIds", spaces.map((s) => s.sId).join(","));
+  }
+  const queryString = queryParams.toString();
 
   const { data, error, isLoading, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/skills${statusQueryParam}`,
+    `/api/w/${owner.sId}/skills${queryString ? `?${queryString}` : ""}`,
     skillsFetcher,
     { disabled }
   );

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -92,7 +92,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { withRelations, status } = req.query;
+      const { withRelations, status, spaceIds } = req.query;
 
       const statusValidation = SkillStatusSchema.decode(status);
       if (isLeft(statusValidation)) {
@@ -106,8 +106,14 @@ async function handler(
       }
       const skillStatus = statusValidation.right;
 
+      const spaceIdsList =
+        typeof spaceIds === "string" && spaceIds.length > 0
+          ? spaceIds.split(",")
+          : undefined;
+
       const skillConfigurations = await SkillResource.listSkills(auth, {
         status: skillStatus,
+        spaceIds: spaceIdsList,
       });
 
       if (withRelations === "true") {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -92,7 +92,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { withRelations, status, spaceIds } = req.query;
+      const { withRelations, status, globalSpaceOnly } = req.query;
 
       const statusValidation = SkillStatusSchema.decode(status);
       if (isLeft(statusValidation)) {
@@ -106,14 +106,9 @@ async function handler(
       }
       const skillStatus = statusValidation.right;
 
-      const spaceIdsList =
-        typeof spaceIds === "string" && spaceIds.length > 0
-          ? spaceIds.split(",")
-          : undefined;
-
       const skillConfigurations = await SkillResource.listSkills(auth, {
         status: skillStatus,
-        spaceIds: spaceIdsList,
+        globalSpaceOnly: globalSpaceOnly === "true",
       });
 
       if (withRelations === "true") {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5730.
- The `ToolsPicker` in the input bar currently lists all skills the user has access to.
- This PR filters out the list to only show the ones accessible from the global space only, in order to align with the behavior for tools. The current situation without this filter raises the issue that using a skill does not update the conversation's requested spaces (this update is not needed if we only allow skills on the global space).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
