### PR TITLE
[front] - fix(SkillBuilder): fields

### DIFF
--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -1,5 +1,4 @@
 import { Input } from "@dust-tt/sparkle";
-import { forwardRef } from "react";
 
 import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
 
@@ -14,51 +13,33 @@ interface NameSectionProps {
 
 export const NAME_FIELD_NAME = "name";
 
-export const NameSection = forwardRef<HTMLInputElement, NameSectionProps>(
-  (
-    {
-      title,
-      description,
-      label,
-      placeholder,
-      helpText,
-      triggerValidationOnChange = false,
-    },
-    ref
-  ) => {
-    return (
-      <BaseFormFieldSection
-        title={title}
-        description={description}
-        helpText={helpText}
-        fieldName={NAME_FIELD_NAME}
-        triggerValidationOnChange={triggerValidationOnChange}
-      >
-        {({ registerRef, registerProps, onChange, errorMessage, hasError }) => {
-          return (
-            <Input
-              ref={(e) => {
-                registerRef(e);
-                if (ref) {
-                  if (typeof ref === "function") {
-                    ref(e);
-                  } else {
-                    ref.current = e;
-                  }
-                }
-              }}
-              placeholder={placeholder}
-              label={label}
-              onChange={onChange}
-              message={errorMessage}
-              messageStatus={hasError ? "error" : "default"}
-              {...registerProps}
-            />
-          );
-        }}
-      </BaseFormFieldSection>
-    );
-  }
-);
-
-NameSection.displayName = "NameSection";
+export function NameSection({
+  title,
+  description,
+  label,
+  placeholder,
+  helpText,
+  triggerValidationOnChange = false,
+}: NameSectionProps) {
+  return (
+    <BaseFormFieldSection
+      title={title}
+      description={description}
+      helpText={helpText}
+      fieldName={NAME_FIELD_NAME}
+      triggerValidationOnChange={triggerValidationOnChange}
+    >
+      {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
+        <Input
+          ref={registerRef}
+          placeholder={placeholder}
+          label={label}
+          onChange={onChange}
+          message={errorMessage}
+          messageStatus={hasError ? "error" : "default"}
+          {...registerProps}
+        />
+      )}
+    </BaseFormFieldSection>
+  );
+}

--- a/front/components/shared/BaseFormFieldSection.tsx
+++ b/front/components/shared/BaseFormFieldSection.tsx
@@ -16,6 +16,7 @@ interface BaseFormFieldSectionProps<
     registerProps: {
       name: string;
       onBlur: () => void;
+      value: string;
     };
     onChange: (e: ChangeEvent<E>) => void;
     errorMessage?: string;
@@ -75,6 +76,7 @@ export function BaseFormFieldSection<
           registerProps: {
             name: field.name,
             onBlur: field.onBlur,
+            value: field.value ?? "",
           },
           onChange,
           errorMessage: fieldState.error?.message,


### PR DESCRIPTION
## Description

Fixes form field handling in `NameSection` by including `value` in `registerProps` and simplifying the component. Following the refactoring in #19472 where `BaseFormFieldSection` was updated to use only `useController()`, the `value` field was missing from `registerProps`, requiring workarounds like `forwardRef` in `NameSection`. This PR completes the migration by adding `value` to `registerProps` and refactoring `NameSection` to a simple functional component, removing the unnecessary ref forwarding logic.

## Risk

Low

## Tests

Manually tested locally agent builder and skill builder

## Deploy Plan

Deploy front