### PR TITLE
Consistency between "message deleted" and "Agent interrupted" UI

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -229,6 +229,8 @@ export function AgentMessage({
   });
 
   const isDeleted = agentMessage.visibility === "deleted";
+  const isCancelled = agentMessage.status === "cancelled";
+  const isCancelledOrDeleted = isDeleted || isCancelled;
   const cancelMessage = useCancelMessage({ owner, conversationId });
 
   const references = useMemo(
@@ -671,7 +673,7 @@ export function AgentMessage({
           name={agentConfiguration.name}
           timestamp={timestamp}
           completionStatus={
-            isDeleted ? undefined : (
+            isCancelledOrDeleted ? undefined : (
               <AgentMessageCompletionStatus agentMessage={agentMessage} />
             )
           }
@@ -694,7 +696,7 @@ export function AgentMessage({
           name={agentConfiguration.name}
           timestamp={timestamp}
           completionStatus={
-            isDeleted ? undefined : (
+            isCancelledOrDeleted ? undefined : (
               <AgentMessageCompletionStatus agentMessage={agentMessage} />
             )
           }
@@ -727,9 +729,11 @@ export function AgentMessage({
             />
           )}
         </ConversationMessageContent>
-        {messageButtons && messageButtons.length > 0 && (
-          <div className="flex justify-start gap-3">{messageButtons}</div>
-        )}
+        {!isCancelledOrDeleted &&
+          messageButtons &&
+          messageButtons.length > 0 && (
+            <div className="flex justify-start gap-3">{messageButtons}</div>
+          )}
       </div>
     </NewConversationMessageContainer>
   );
@@ -1017,12 +1021,8 @@ function AgentMessageContent({
         </div>
       )}
       {agentMessage.status === "cancelled" && (
-        <div>
-          <Chip
-            label="The message generation was interrupted"
-            size="xs"
-            className="mt-4"
-          />
+        <div className="text-faint dark:text-faint-night">
+          Message generation was interrupted
         </div>
       )}
     </div>

--- a/front/components/assistant/conversation/DeletedMessage.tsx
+++ b/front/components/assistant/conversation/DeletedMessage.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 
 export const DeletedMessage = () => (
-  <div className="italic text-muted-foreground dark:text-muted-foreground-night">
-    This message has been deleted
-  </div>
+  <div className="text-faint dark:text-faint-night">Message was deleted</div>
 );


### PR DESCRIPTION
## Description

This PR harmonizes the UI between the "Message deleted" and the "Message generation interrupted" states:
- "faint" color text in both cases
- Remove actions and breakdown in both cases

**Before**:
<img width="804" height="284" alt="image" src="https://github.com/user-attachments/assets/f80f37cf-5b97-4eca-a4e7-3e542780b869" /> <img width="1838" height="294" alt="image" src="https://github.com/user-attachments/assets/015d04c4-636a-4495-a4d7-591c9dd6d2d5" />

**After**:
<img width="913" height="302" alt="image" src="https://github.com/user-attachments/assets/3b37ffcf-ee19-4d5c-a382-c4c68d4f1210" />




## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
