### PR TITLE
[front] fix(agent-loop): stop cancellation on `conversation_not_found`

### DIFF
--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -281,11 +281,11 @@ export async function finalizeCancellation(
 ): Promise<void> {
   const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
   if (runAgentDataRes.isErr()) {
+    // We ignore conversation_not_found errors; the conversation might have been deleted since.
     if (
       runAgentDataRes.error instanceof ConversationError &&
       runAgentDataRes.error.type === "conversation_not_found"
     ) {
-      // We ignore conversation_not_found errors; the conversation might have been deleted since.
       return;
     }
 

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -18,6 +18,7 @@ import type {
   ConversationWithoutContentType,
   ToolErrorEvent,
 } from "@app/types";
+import { ConversationError } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { getAgentLoopData } from "@app/types/assistant/agent_run";
 
@@ -280,6 +281,13 @@ export async function finalizeCancellation(
 ): Promise<void> {
   const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
   if (runAgentDataRes.isErr()) {
+    if (
+      runAgentDataRes.error instanceof ConversationError &&
+      runAgentDataRes.error.type === "conversation_not_found"
+    ) {
+      return;
+    }
+
     throw new Error(
       `Failed to get run agent data: ${runAgentDataRes.error.message}`
     );

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -285,6 +285,7 @@ export async function finalizeCancellation(
       runAgentDataRes.error instanceof ConversationError &&
       runAgentDataRes.error.type === "conversation_not_found"
     ) {
+      // We ignore conversation_not_found errors; the conversation might have been deleted since.
       return;
     }
 


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5751
- This PR early returns in the `finalizeCancellation` (only code path is in `finalizeCancelledAgentLoopActivity`) on `conversation_not_found` errors.

## Tests

- Tested locally

## Risk

- Low.

## Deploy Plan

- Deploy front.
