### PR TITLE
[front] - refactor: streamline MCP action handling

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -32,8 +32,10 @@ import type { AgentBuilderMCPConfigurationWithId } from "@app/components/agent_b
 import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import type { BuilderAction } from "@app/components/shared/tools_picker/types";
-import type { AdditionalConfigurationInBuilderType } from "@app/components/shared/tools_picker/types";
+import type {
+  AdditionalConfigurationInBuilderType,
+  BuilderAction,
+} from "@app/components/shared/tools_picker/types";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
@@ -55,18 +57,15 @@ function processActionsFromStorage(
 ): BuilderAction[] {
   return [
     ...actions.map((action) => {
-      if (action.type === "MCP") {
-        return {
-          ...action,
-          configuration: {
-            ...action.configuration,
-            additionalConfiguration: processAdditionalConfigurationFromStorage(
-              action.configuration.additionalConfiguration
-            ),
-          },
-        };
-      }
-      return action;
+      return {
+        ...action,
+        configuration: {
+          ...action.configuration,
+          additionalConfiguration: processAdditionalConfigurationFromStorage(
+            action.configuration.additionalConfiguration
+          ),
+        },
+      };
     }),
   ];
 }
@@ -277,9 +276,7 @@ export default function AgentBuilder({
   const { showDialog, ...dialogProps } = useAwaitableDialog({
     owner,
     mcpServerViewToCheckIds: removeNulls(
-      form
-        .getValues("actions")
-        .map((a) => (a.type === "MCP" ? a.configuration.mcpServerViewId : null))
+      form.getValues("actions").map((a) => a.configuration.mcpServerViewId)
     ),
     mcpServerViews,
   });

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -19,7 +19,6 @@ import { useRemoveSpaceConfirm } from "@app/components/shared/RemoveSpaceDialog"
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
 import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { SpaceType } from "@app/types";
 import { removeNulls } from "@app/types";
 
@@ -84,9 +83,7 @@ export function AgentBuilderSpacesBlock() {
 
   const handleRemoveSpace = async (space: SpaceType) => {
     // Compute items to remove for the dialog
-    const actionsToRemove = (spaceIdToActions[space.sId] || []).filter(
-      (action): action is BuilderAction => action.type === "MCP"
-    );
+    const actionsToRemove = spaceIdToActions[space.sId] || [];
 
     const skillsToRemove = selectedSkills.filter((skill) =>
       allSkills

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -79,8 +79,7 @@ export function AgentBuilderCapabilitiesBlock({
     const mcpServerView = mcpServerViewsWithKnowledge.find(
       (view) => view.sId === action.configuration?.mcpServerViewId
     );
-    const isDataSourceSelectionRequired =
-      action.type === "MCP" && Boolean(mcpServerView);
+    const isDataSourceSelectionRequired = Boolean(mcpServerView);
 
     if (isDataSourceSelectionRequired) {
       setKnowledgeAction({ action, index });

--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -178,7 +178,6 @@ export const useToolSelection = ({
       const selectedServerIds = new Set<string>();
       for (const action of actions) {
         if (
-          action.type === "MCP" &&
           action.configuration &&
           action.configuration.mcpServerViewId &&
           !action.configurationRequired
@@ -231,7 +230,7 @@ export const useToolSelection = ({
 
   const handleToolToggle = useCallback(
     (mcpServerView: MCPServerViewTypeWithLabel) => {
-      const tool = { type: "MCP", view: mcpServerView } satisfies SelectedTool;
+      const tool = { view: mcpServerView } satisfies SelectedTool;
       const requirements = getMCPServerRequirements(
         mcpServerView,
         featureFlags
@@ -252,18 +251,12 @@ export const useToolSelection = ({
       // No configuration required, add to selected tools
       setLocalSelectedTools((prev) => {
         const isAlreadySelected = prev.some((selected) => {
-          if (tool.type === "MCP" && selected.type === "MCP") {
-            return tool.view.sId === selected.view.sId;
-          }
-          return false;
+          return tool.view.sId === selected.view.sId;
         });
 
         if (isAlreadySelected) {
           return prev.filter((selected) => {
-            if (tool.type === "MCP" && selected.type === "MCP") {
-              return tool.view.sId !== selected.view.sId;
-            }
-            return true;
+            return tool.view.sId !== selected.view.sId;
           });
         }
 
@@ -302,16 +295,13 @@ export const useToolSelection = ({
       };
 
       const updatedTool: SelectedTool = {
-        type: "MCP",
         view: mode.mcpServerView,
         configuredAction,
       };
 
       setLocalSelectedTools((prev) => {
         const existingToolIndex = prev.findIndex(
-          (tool) =>
-            tool.type === "MCP" &&
-            tool.configuredAction?.name === configuredAction.name
+          (tool) => tool.configuredAction?.name === configuredAction.name
         );
 
         if (existingToolIndex !== -1) {

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.tsx
@@ -5,7 +5,7 @@ import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/
 import type {
   SkillType,
   SkillWithRelationsType,
-} from "@app/types/assistant/skill_configuration";
+} from "@app/types/assistant/skill_configuration"; // TODO(skills 2025-12-18): duplicated from MCPServerViewsSheet, to cleanup later
 
 // TODO(skills 2025-12-18): duplicated from MCPServerViewsSheet, to cleanup later
 export const TOP_MCP_SERVER_VIEWS = [
@@ -19,7 +19,6 @@ export const TOP_MCP_SERVER_VIEWS = [
   "google_calendar",
 ];
 export type SelectedTool = {
-  type: "MCP";
   view: MCPServerViewTypeWithLabel;
   configuredAction?: BuilderAction;
 };

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -186,7 +186,6 @@ function KnowledgeConfigurationSheetForm({
 
     const newAction: BuilderAction = {
       id: uniqueId(),
-      type: "MCP",
       name: newName,
       description,
       configuration: {

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -10,8 +10,10 @@ import type { ComponentType } from "react";
 import { transformSelectionConfigurationsToTree } from "@app/components/agent_builder/capabilities/knowledge/transformations";
 import { nameToDisplayFormat } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
 import { getDefaultConfiguration } from "@app/components/agent_builder/capabilities/mcp/utils/formDefaults";
-import { DESCRIPTION_MAX_LENGTH } from "@app/components/agent_builder/types";
-import { CONFIGURATION_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";
+import {
+  CONFIGURATION_SHEET_PAGE_IDS,
+  DESCRIPTION_MAX_LENGTH,
+} from "@app/components/agent_builder/types";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { getMCPServerNameForTemplateAction } from "@app/lib/actions/mcp_helper";
 import {
@@ -126,9 +128,9 @@ export function getKnowledgeDefaultValues({
       : { in: [], notIn: [] };
 
   const selectedMCPServerView = (() => {
-    if (isEditing && action?.type === "MCP") {
+    if (isEditing) {
       return mcpServerViews.find(
-        (view) => view.sId === action.configuration.mcpServerViewId
+        (view) => view.sId === action?.configuration.mcpServerViewId
       );
     }
 

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -105,9 +105,7 @@ export function MCPServerSelectionPage({
   const selectedMCPIds = useMemo(() => {
     const mcpIds = new Set<string>();
     selectedToolsInSheet.forEach((tool) => {
-      if (tool.type === "MCP") {
-        mcpIds.add(tool.view.sId);
-      }
+      mcpIds.add(tool.view.sId);
     });
     return mcpIds;
   }, [selectedToolsInSheet]);
@@ -145,7 +143,7 @@ export function MCPServerSelectionPage({
             onClick={() => onItemClick(view)}
             onToolInfoClick={() => {
               if (onToolDetailsClick) {
-                onToolDetailsClick({ type: "MCP", view });
+                onToolDetailsClick({ view });
               }
             }}
             featureFlags={featureFlags}
@@ -164,7 +162,7 @@ export function MCPServerSelectionPage({
             onClick={() => onItemClick(view)}
             onToolInfoClick={() => {
               if (onToolDetailsClick) {
-                onToolDetailsClick({ type: "MCP", view });
+                onToolDetailsClick({ view });
               }
             }}
             featureFlags={featureFlags}

--- a/front/components/agent_builder/capabilities/mcp/utils/actionNameUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/actionNameUtils.ts
@@ -36,8 +36,7 @@ export function generateUniqueActionName({
     (action) => action.name === newActionName
   );
   let isNameUsedInNonSavedActions = selectedToolsInSheet.some(
-    (action) =>
-      action.type === "MCP" && action.configuredAction?.name === newActionName
+    (action) => action.configuredAction?.name === newActionName
   );
 
   while (isNameUsedInAddedActions || isNameUsedInNonSavedActions) {
@@ -47,8 +46,7 @@ export function generateUniqueActionName({
       (action) => action.name === newActionName
     );
     isNameUsedInNonSavedActions = selectedToolsInSheet.some(
-      (action) =>
-        action.type === "MCP" && action.configuredAction?.name === newActionName
+      (action) => action.configuredAction?.name === newActionName
     );
   }
 

--- a/front/components/agent_builder/capabilities/mcp/utils/formStateUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formStateUtils.ts
@@ -26,7 +26,7 @@ export function createFormResetHandler(
         return;
       }
 
-      if (configurationTool?.type === "MCP") {
+      if (configurationTool) {
         // Edit mode: reset with existing tool data
         form.reset({
           name: configurationTool.name ?? "",

--- a/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
@@ -209,16 +209,13 @@ export function handleConfigurationSave({
 
   setSelectedToolsInSheet((prev) => {
     const existingToolIndex = prev.findIndex(
-      (tool) =>
-        tool.type === "MCP" &&
-        tool.configuredAction?.name === configuredAction.name
+      (tool) => tool.configuredAction?.name === configuredAction.name
     );
 
     if (existingToolIndex >= 0) {
       // Update existing tool with configuration
       const updated = [...prev];
       updated[existingToolIndex] = {
-        type: "MCP",
         view: mcpServerView,
         configuredAction,
       };
@@ -228,7 +225,6 @@ export function handleConfigurationSave({
       return [
         ...prev,
         {
-          type: "MCP",
           view: mcpServerView,
           configuredAction,
         },

--- a/front/components/agent_builder/capabilities/usePresetActionHandler.ts
+++ b/front/components/agent_builder/capabilities/usePresetActionHandler.ts
@@ -81,9 +81,7 @@ export function usePresetActionHandler({
 
       if (!allowsMultiple) {
         const toolAlreadyAdded = fields.some(
-          (field) =>
-            field.type === "MCP" &&
-            field.configuration?.mcpServerViewId === mcpServerView.sId
+          (field) => field.configuration?.mcpServerViewId === mcpServerView.sId
         );
 
         if (toolAlreadyAdded) {

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -207,8 +207,7 @@ export function AgentBuilderSkillsBlock() {
     const mcpServerViewWithKnowledge = mcpServerViewsWithKnowledge.find(
       (view) => view.sId === action.configuration?.mcpServerViewId
     );
-    const isDataSourceSelectionRequired =
-      action.type === "MCP" && Boolean(mcpServerViewWithKnowledge);
+    const isDataSourceSelectionRequired = Boolean(mcpServerViewWithKnowledge);
 
     if (isDataSourceSelectionRequired) {
       setKnowledgeAction({ action, index });
@@ -259,7 +258,7 @@ export function AgentBuilderSkillsBlock() {
     }) => {
       // Validate any configured tools before adding
       for (const tool of tools) {
-        if (tool.type === "MCP" && tool.configuredAction) {
+        if (tool.configuredAction) {
           const validation = validateMCPActionConfiguration(
             tool.configuredAction,
             tool.view

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -399,7 +399,7 @@ export async function submitAgentBuilderForm({
     formData.agentSettings.pictureUrl ?? getRandomDefaultAvatar();
 
   // Process actions asynchronously to handle folder-to-table expansion
-  const mcpActions = formData.actions.filter((action) => action.type === "MCP");
+  const mcpActions = formData.actions;
 
   let processedActions;
   try {

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -137,7 +137,6 @@ export function getDefaultMCPAction(
 
   return {
     id: uniqueId(),
-    type: "MCP",
     configuration,
     // Ensure default name always matches validation regex (^[a-z0-9_]+$)
     name: sanitizedName,
@@ -176,7 +175,6 @@ export type AgentBuilderMCPServerConfiguration = {
 };
 
 export type AgentBuilderMCPConfiguration = {
-  type: "MCP";
   configuration: AgentBuilderMCPServerConfiguration;
   name: string;
   description: string;
@@ -194,7 +192,6 @@ export function getDefaultMCPServerActionConfiguration(
   const requirements = getMCPServerRequirements(mcpServerView);
 
   return {
-    type: "MCP",
     configuration: {
       mcpServerViewId: mcpServerView?.sId ?? "not-a-valid-sId",
       dataSourceConfigurations: null,

--- a/front/components/shared/getSpaceIdToActionsMap.test.ts
+++ b/front/components/shared/getSpaceIdToActionsMap.test.ts
@@ -14,7 +14,6 @@ const createMockMCPAction = (
   tablesConfigurations?: any
 ): BuilderAction => ({
   id,
-  type: "MCP",
   name,
   description: `Description for ${name}`,
   configuration: {

--- a/front/components/shared/getSpaceIdToActionsMap.ts
+++ b/front/components/shared/getSpaceIdToActionsMap.ts
@@ -1,7 +1,6 @@
 import type { AgentBuilderMCPConfigurationWithId } from "@app/components/agent_builder/types";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { assertNever } from "@app/types";
 
 type ActionType = AgentBuilderMCPConfigurationWithId | BuilderAction;
 
@@ -17,44 +16,36 @@ export const getSpaceIdToActionsMap = (
       }
     };
 
-    const actionType = action.type;
-
-    switch (actionType) {
-      case "MCP":
-        if (action.configuration.dataSourceConfigurations) {
-          Object.values(action.configuration.dataSourceConfigurations).forEach(
-            (config) => {
-              if (config) {
-                addActionToSpace(config.dataSourceView.spaceId);
-              }
-            }
-          );
-        }
-
-        if (action.configuration.tablesConfigurations) {
-          Object.values(action.configuration.tablesConfigurations).forEach(
-            (config) => {
-              if (config) {
-                addActionToSpace(config.dataSourceView.spaceId);
-              }
-            }
-          );
-        }
-
-        if (action.configuration.mcpServerViewId) {
-          const mcpServerView = mcpServerViews.find(
-            (v) => v.sId === action.configuration.mcpServerViewId
-          );
-
-          if (mcpServerView && mcpServerView.server.availability === "manual") {
-            addActionToSpace(mcpServerView.spaceId);
+    if (action.configuration.dataSourceConfigurations) {
+      Object.values(action.configuration.dataSourceConfigurations).forEach(
+        (config) => {
+          if (config) {
+            addActionToSpace(config.dataSourceView.spaceId);
           }
         }
-        break;
-
-      default:
-        assertNever(actionType);
+      );
     }
+
+    if (action.configuration.tablesConfigurations) {
+      Object.values(action.configuration.tablesConfigurations).forEach(
+        (config) => {
+          if (config) {
+            addActionToSpace(config.dataSourceView.spaceId);
+          }
+        }
+      );
+    }
+
+    if (action.configuration.mcpServerViewId) {
+      const mcpServerView = mcpServerViews.find(
+        (v) => v.sId === action.configuration.mcpServerViewId
+      );
+
+      if (mcpServerView && mcpServerView.server.availability === "manual") {
+        addActionToSpace(mcpServerView.spaceId);
+      }
+    }
+
     return acc;
   }, {});
 };

--- a/front/components/shared/tools_picker/ActionCard.tsx
+++ b/front/components/shared/tools_picker/ActionCard.tsx
@@ -8,10 +8,7 @@ import { getAvatar } from "@app/lib/actions/mcp_icons";
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
-function actionIcon(
-  action: BuilderAction,
-  mcpServerView: MCPServerViewType | null
-) {
+function actionIcon(mcpServerView: MCPServerViewType | null) {
   if (mcpServerView?.server) {
     return getAvatar(mcpServerView.server, "xs");
   }
@@ -21,7 +18,7 @@ function actionDisplayName(
   action: BuilderAction,
   mcpServerView: MCPServerViewType | null
 ) {
-  if (mcpServerView && action.type === "MCP") {
+  if (mcpServerView) {
     return getMcpServerViewDisplayName(mcpServerView, action);
   }
 
@@ -40,13 +37,12 @@ export function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
 
-  const mcpServerView =
-    action.type === "MCP" && !isMCPServerViewsLoading
-      ? (mcpServerViews.find(
-          (mcpServerView) =>
-            mcpServerView.sId === action.configuration.mcpServerViewId
-        ) ?? null)
-      : null;
+  const mcpServerView = !isMCPServerViewsLoading
+    ? (mcpServerViews.find(
+        (mcpServerView) =>
+          mcpServerView.sId === action.configuration.mcpServerViewId
+      ) ?? null)
+    : null;
 
   const displayName = actionDisplayName(action, mcpServerView);
   const description = action.description ?? "";
@@ -69,7 +65,7 @@ export function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
     >
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
-          {actionIcon(action, mcpServerView)}
+          {actionIcon(mcpServerView)}
           <span className="truncate">{displayName}</span>
         </div>
 

--- a/front/components/shared/tools_picker/types.ts
+++ b/front/components/shared/tools_picker/types.ts
@@ -118,7 +118,6 @@ export type MCPServerConfigurationType = z.infer<
 >;
 
 export const actionSchema = baseActionSchema.extend({
-  type: z.literal("MCP"),
   configuration: mcpServerConfigurationSchema,
 });
 

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -6,7 +6,6 @@ import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActio
 import { useRemoveSpaceConfirm } from "@app/components/shared/RemoveSpaceDialog";
 import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import type { SpaceType } from "@app/types";
 import { removeNulls } from "@app/types";
@@ -35,9 +34,7 @@ export function SkillBuilderRequestedSpacesSection() {
   }, [spaceIdToActions, spaces]);
 
   const handleRemoveSpace = async (space: SpaceType) => {
-    const actionsToRemove = (spaceIdToActions[space.sId] || []).filter(
-      (action): action is BuilderAction => action.type === "MCP"
-    );
+    const actionsToRemove = spaceIdToActions[space.sId] || [];
 
     const confirmed = await confirmRemoveSpace(space, actionsToRemove);
 

--- a/front/lib/agent_builder/server_side_props_helpers.ts
+++ b/front/lib/agent_builder/server_side_props_helpers.ts
@@ -79,14 +79,6 @@ export async function buildInitialActions({
     );
 
     if (builderAction) {
-      // TODO(durable agents, 2025-06-24): remove this once we have a proper
-      // type for the builder action. Namely, initializeBuilderAction return
-      // type should be AgentBuilderMCPConfiguration.
-      assert(
-        builderAction.type === "MCP",
-        "Builder action is not a MCP server configuration"
-      );
-
       if (action.name) {
         builderAction.name = action.name;
       }
@@ -109,10 +101,6 @@ async function getMCPServerActionConfiguration(
   assert(isServerSideMCPServerConfiguration(action));
 
   const builderAction = getDefaultMCPServerActionConfiguration(mcpServerView);
-  if (builderAction.type !== "MCP") {
-    throw new Error("MCP action configuration is not valid");
-  }
-
   builderAction.configuration.mcpServerViewId = action.mcpServerViewId;
 
   builderAction.name = "";


### PR DESCRIPTION
\## Description

This PR streamlines MCP action handling by removing the explicit `type: "MCP"` field from `BuilderAction` and related types. Previously, actions were discriminated using a type field, requiring conditional checks throughout the codebase (`action.type === "MCP"`). Now all actions are treated uniformly, simplifying the codebase:

- Removes `type: "MCP"` from `BuilderAction`, `AgentBuilderMCPConfiguration`, and `SelectedTool`
- Eliminates unnecessary type checks and conditionals across components and utilities
- Processes action configurations uniformly without MCP-specific branches
- Optimizes imports and removes redundant type assertions

This change reflects that all actions in the agent builder are now MCP-based, making the type discrimination unnecessary.

## Risk

High - touches a bunch of code everywhere 

## Tests

- [x] Locally
- [x] Front-edge

## Deploy Plan
Deploy front
