### PR TITLE
Polish quick replies

### DIFF
--- a/front/components/markdown/QuickReplyBlock.tsx
+++ b/front/components/markdown/QuickReplyBlock.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@dust-tt/sparkle";
+import { Button, ChatBubbleLeftRightIcon } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 import { visit } from "unist-util-visit";
 
@@ -42,14 +42,18 @@ export function QuickReplyBlock({
   };
 
   return (
-    <Button
-      size="sm"
-      variant="outline"
-      label={label}
-      onClick={handleClick}
-      disabled={disabled || isSending}
-      isLoading={isSending}
-    />
+    <span className="float-left clear-left my-0.5">
+      <Button
+        size="sm"
+        variant="outline"
+        label={label}
+        icon={ChatBubbleLeftRightIcon}
+        onClick={handleClick}
+        disabled={disabled || isSending}
+        isLoading={isSending}
+        className="h-auto whitespace-normal py-1.5 text-left" // Prevent whitespace-nowrap from Button: here we want to go on multiple lines if needed.
+      />
+    </span>
   );
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5676

-> Went with Option A which was Ed's favorite. 
-> Made sure it renders correctly on mobile. 

Web: 
<kbd>
<img width="546" height="376" alt="Screenshot 2025-12-29 at 16 12 05" src="https://github.com/user-attachments/assets/200758c7-7413-4a0c-b476-6c57baed0e01" />
</kbd>
Web-mobile: 
<kbd>
<img width="372" height="566" alt="Screenshot 2025-12-29 at 16 12 13" src="https://github.com/user-attachments/assets/b611c333-9397-42a3-8044-c85309794d6f" />
</kbd>


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 