### PR TITLE
[Front] feat(skills): add migration script to link agents with frames/go-deep tools to skills

### DIFF
--- a/front/migrations/20251229_add_global_skill_to_agents_with_tool.ts
+++ b/front/migrations/20251229_add_global_skill_to_agents_with_tool.ts
@@ -68,6 +68,15 @@ async function addGlobalSkillToAgentsWithTool(
   });
 
   if (agentsWithTool.length === 0) {
+    logger.info(
+      {
+        workspaceId: workspace.id,
+        workspaceName: workspace.name,
+        agentCount: agentsWithTool.length,
+        mcpServerViewId: mcpServerView.id,
+      },
+      `No agents found with tool ${mcpServerName}`
+    );
     return;
   }
 
@@ -76,10 +85,9 @@ async function addGlobalSkillToAgentsWithTool(
       workspaceId: workspace.id,
       workspaceName: workspace.name,
       agentCount: agentsWithTool.length,
-      mcpServerName,
       mcpServerViewId: mcpServerView.id,
     },
-    "Found agents with tool"
+    `Found agents with tool ${mcpServerName}`
   );
 
   // 3. Get existing agent-skill links to avoid duplicates (chunked for large IN clauses).
@@ -122,7 +130,7 @@ async function addGlobalSkillToAgentsWithTool(
       toCreate: agentsToCreate.length,
       alreadyHasSkill: agentsWithSkill.size,
     },
-    "Creating skills"
+    "Creating skills for agents"
   );
 
   if (execute) {

--- a/front/migrations/20251229_add_global_skill_to_agents_with_tool.ts
+++ b/front/migrations/20251229_add_global_skill_to_agents_with_tool.ts
@@ -1,0 +1,159 @@
+import chunk from "lodash/chunk";
+import type { Logger } from "pino";
+
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { Authenticator } from "@app/lib/auth";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types";
+
+const CHUNK_SIZE = 100;
+const CONCURRENCY = 5;
+
+const TOOL_TO_SKILL_MAP: Record<string, string> = {
+  interactive_content: "frames",
+  deep_dive: "go-deep",
+};
+
+async function addGlobalSkillToAgentsWithTool(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  {
+    execute,
+    mcpServerName,
+  }: {
+    execute: boolean;
+    mcpServerName: AutoInternalMCPServerNameType;
+  }
+) {
+  const globalSkillId = TOOL_TO_SKILL_MAP[mcpServerName];
+  if (!globalSkillId) {
+    throw new Error(`No skill mapping for MCP server: ${mcpServerName}`);
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // 1. Get the MCP server view for this tool.
+  const mcpServerView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      mcpServerName
+    );
+
+  if (!mcpServerView) {
+    logger.info(
+      { mcpServerName, workspaceId: workspace.sId },
+      "MCP server view not found, skipping"
+    );
+    return;
+  }
+
+  // 2. Find all agent configs using this MCP server view.
+  const agentsWithTool = await AgentMCPServerConfigurationModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      mcpServerViewId: mcpServerView.id,
+    },
+  });
+
+  if (agentsWithTool.length === 0) {
+    return;
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.id,
+      workspaceName: workspace.name,
+      agentCount: agentsWithTool.length,
+      mcpServerName,
+      mcpServerViewId: mcpServerView.id,
+    },
+    "Found agents with tool"
+  );
+
+  // 3. Get existing agent-skill links to avoid duplicates.
+  const existingSkillLinks = await AgentSkillModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      globalSkillId,
+      agentConfigurationId: agentsWithTool.map((a) => a.agentConfigurationId),
+    },
+  });
+  const agentsWithSkill = new Set(
+    existingSkillLinks.map((l) => l.agentConfigurationId)
+  );
+
+  // 4. Process in chunks with concurrency.
+  const agentChunks = chunk(agentsWithTool, CHUNK_SIZE);
+
+  await concurrentExecutor(
+    agentChunks,
+    async (agentChunk) => {
+      await concurrentExecutor(
+        agentChunk,
+        async (agent) => {
+          if (agentsWithSkill.has(agent.agentConfigurationId)) {
+            logger.info(
+              {
+                agentConfigurationId: agent.agentConfigurationId,
+                globalSkillId,
+              },
+              "Already has skill"
+            );
+            return;
+          }
+
+          if (execute) {
+            await AgentSkillModel.create({
+              workspaceId: workspace.id,
+              agentConfigurationId: agent.agentConfigurationId,
+              globalSkillId,
+              customSkillId: null,
+            });
+          }
+
+          logger.info(
+            { agentConfigurationId: agent.agentConfigurationId, globalSkillId },
+            "Added skill"
+          );
+        },
+        { concurrency: CONCURRENCY }
+      );
+    },
+    { concurrency: CONCURRENCY }
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Optional workspace sId to run on single workspace",
+    },
+    mcpServerName: {
+      type: "string",
+      required: true,
+      description: "MCP server name (interactive_content or deep_dive)",
+    },
+  },
+  async ({ execute, workspaceId, mcpServerName }, logger) => {
+    const opts = {
+      execute,
+      mcpServerName: mcpServerName as AutoInternalMCPServerNameType,
+    };
+
+    if (workspaceId) {
+      const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+      const workspace = auth.getNonNullableWorkspace();
+      await addGlobalSkillToAgentsWithTool(workspace, logger, opts);
+    } else {
+      await runOnAllWorkspaces(async (workspace) =>
+        addGlobalSkillToAgentsWithTool(workspace, logger, opts)
+      );
+    }
+  }
+);


### PR DESCRIPTION
## Description

Closes:
- https://github.com/dust-tt/tasks/issues/5715
- https://github.com/dust-tt/tasks/issues/5716

This PR:
- Adds a migration script to link agents using Frames/Go-deep tools to their corresponding global skills
- Prepares for tool → skill transition without removing existing tool configurations
- Supports `--mcp-server-name` (interactive_content or deep_dive) and optional `--workspace-id` params

## Tests

Dry run without `--execute` flag to verify agent discovery.

## Risk

Low. Only creates new AgentSkillModel records, doesn't modify or delete existing data.

## Deploy Plan

1. Deploy front
2. Run migration on Dust workspace first: `npx tsx migrations/20251229_add_global_skill_to_agents_with_tool.ts --mcp-server-name=interactive_content --workspace-id=<dust-sid> --execute`
3. Validate, then run on all workspaces
