### PR TITLE
[front] feat: Add poke api to retrieve / run production checks

### DIFF
--- a/front/lib/api/poke/production_checks.ts
+++ b/front/lib/api/poke/production_checks.ts
@@ -1,0 +1,63 @@
+import {
+  getLatestProductionCheckResults,
+  getProductionCheckHistory,
+  statusToSummaryStatus,
+} from "@app/lib/production_checks/history";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import { REGISTERED_CHECKS } from "@app/temporal/production_checks/activities";
+import type {
+  Check,
+  CheckHistoryRun,
+  CheckSummary,
+  CheckSummaryStatus,
+} from "@app/types";
+
+export function getRegisteredCheck(checkName: string): Check | null {
+  return REGISTERED_CHECKS.find((c) => c.name === checkName) ?? null;
+}
+
+export async function getCheckSummaries(): Promise<CheckSummary[]> {
+  const client = await getTemporalClientForFrontNamespace();
+  const checkResultsByName = await getLatestProductionCheckResults(client);
+
+  const checks: CheckSummary[] = REGISTERED_CHECKS.map((registeredCheck) => {
+    const latestResult = checkResultsByName.get(registeredCheck.name);
+
+    if (!latestResult) {
+      return {
+        name: registeredCheck.name,
+        everyHour: registeredCheck.everyHour,
+        status: "no-data" as const,
+        lastRun: null,
+      };
+    }
+
+    return {
+      name: registeredCheck.name,
+      everyHour: registeredCheck.everyHour,
+      status: statusToSummaryStatus(latestResult.status),
+      lastRun: {
+        timestamp: latestResult.timestamp,
+        errorMessage: latestResult.errorMessage,
+        payload: latestResult.payload,
+        actionLinks: latestResult.actionLinks,
+      },
+    };
+  });
+
+  const statusOrder: Record<CheckSummaryStatus, number> = {
+    alert: 0,
+    ok: 1,
+    "no-data": 2,
+  };
+  checks.sort((a, b) => statusOrder[a.status] - statusOrder[b.status]);
+
+  return checks;
+}
+
+export async function getCheckHistoryRuns(
+  checkName: string
+): Promise<CheckHistoryRun[]> {
+  const client = await getTemporalClientForFrontNamespace();
+  return getProductionCheckHistory(client, checkName);
+}

--- a/front/lib/production_checks/history.ts
+++ b/front/lib/production_checks/history.ts
@@ -1,0 +1,190 @@
+import type { Client, WorkflowExecutionInfo } from "@temporalio/client";
+import assert from "assert";
+
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { REGISTERED_CHECKS } from "@app/temporal/production_checks/activities";
+import {
+  isProductionCheckWorkflowType,
+  WORKFLOW_TYPE_RUN_ALL_CHECKS,
+  WORKFLOW_TYPE_RUN_SINGLE_CHECK,
+} from "@app/temporal/production_checks/config";
+import type {
+  runAllChecksWorkflow,
+  runSingleCheckWorkflow,
+} from "@app/temporal/production_checks/workflows";
+import type {
+  CheckActivityResult,
+  CheckHistoryRun,
+  CheckResultStatus,
+  CheckSummaryStatus,
+} from "@app/types";
+import { assertNever } from "@app/types";
+
+const COMPLETED_CHECKS_QUERY = `(WorkflowType = "${WORKFLOW_TYPE_RUN_ALL_CHECKS}" OR WorkflowType = "${WORKFLOW_TYPE_RUN_SINGLE_CHECK}") AND ExecutionStatus = "Completed"`;
+
+const WORKFLOW_LIST_BATCH_SIZE = 50;
+const MAX_SEARCH_BREADTH = 200;
+
+export function statusToSummaryStatus(
+  status: CheckResultStatus
+): CheckSummaryStatus {
+  switch (status) {
+    case "success":
+    case "skipped":
+      return "ok";
+    case "failure":
+      return "alert";
+    case "running":
+      return "ok";
+    default:
+      assertNever(status);
+  }
+}
+
+async function getProductionCheckWorkflowResults(
+  client: Client,
+  workflowInfo: WorkflowExecutionInfo
+): Promise<CheckActivityResult[]> {
+  assert(
+    isProductionCheckWorkflowType(workflowInfo.type),
+    `Unexpected workflow type: ${workflowInfo.type}`
+  );
+
+  switch (workflowInfo.type) {
+    case WORKFLOW_TYPE_RUN_ALL_CHECKS: {
+      const handle = client.workflow.getHandle<typeof runAllChecksWorkflow>(
+        workflowInfo.workflowId,
+        workflowInfo.runId
+      );
+      return handle.result();
+    }
+    case WORKFLOW_TYPE_RUN_SINGLE_CHECK: {
+      const handle = client.workflow.getHandle<typeof runSingleCheckWorkflow>(
+        workflowInfo.workflowId,
+        workflowInfo.runId
+      );
+      const result = await handle.result();
+      return [result];
+    }
+    default:
+      assertNever(workflowInfo.type);
+  }
+}
+
+async function* fetchWorkflowResultsBatched(client: Client): AsyncGenerator<{
+  workflow: WorkflowExecutionInfo;
+  checks: CheckActivityResult[];
+}> {
+  const workflowIterator = client.workflow.list({
+    query: COMPLETED_CHECKS_QUERY,
+    pageSize: WORKFLOW_LIST_BATCH_SIZE,
+  });
+
+  let batch: WorkflowExecutionInfo[] = [];
+
+  for await (const workflowInfo of workflowIterator) {
+    batch.push(workflowInfo);
+
+    if (batch.length >= WORKFLOW_LIST_BATCH_SIZE) {
+      const results = await concurrentExecutor(
+        batch,
+        (wf) => getProductionCheckWorkflowResults(client, wf),
+        { concurrency: 8 }
+      );
+
+      for (let i = 0; i < batch.length; i++) {
+        yield { workflow: batch[i], checks: results[i] };
+      }
+      batch = [];
+    }
+  }
+
+  if (batch.length > 0) {
+    const results = await concurrentExecutor(
+      batch,
+      (wf) => getProductionCheckWorkflowResults(client, wf),
+      { concurrency: 8 }
+    );
+
+    for (let i = 0; i < batch.length; i++) {
+      yield { workflow: batch[i], checks: results[i] };
+    }
+  }
+}
+
+export async function getLatestProductionCheckResults(
+  client: Client,
+  limit: number = MAX_SEARCH_BREADTH
+): Promise<Map<string, CheckActivityResult>> {
+  const checkResultsByName = new Map<string, CheckActivityResult>();
+  const registeredCheckCount = REGISTERED_CHECKS.length;
+  let processedCount = 0;
+
+  for await (const { checks } of fetchWorkflowResultsBatched(client)) {
+    processedCount++;
+
+    for (const check of checks) {
+      if (check.status === "skipped") {
+        continue;
+      }
+      if (!checkResultsByName.has(check.checkName)) {
+        checkResultsByName.set(check.checkName, check);
+      }
+    }
+
+    if (checkResultsByName.size >= registeredCheckCount) {
+      break;
+    }
+
+    if (processedCount >= limit) {
+      logger.warn(
+        {
+          limit,
+          foundChecks: checkResultsByName.size,
+          registeredChecks: registeredCheckCount,
+        },
+        "Reached workflow limit before finding all registered checks"
+      );
+      break;
+    }
+  }
+
+  return checkResultsByName;
+}
+
+export async function getProductionCheckHistory(
+  client: Client,
+  checkName: string,
+  limit: number = MAX_SEARCH_BREADTH
+): Promise<CheckHistoryRun[]> {
+  const runs: CheckHistoryRun[] = [];
+
+  for await (const { workflow, checks } of fetchWorkflowResultsBatched(
+    client
+  )) {
+    const checkResult = checks.find((c) => c.checkName === checkName);
+
+    if (checkResult) {
+      const isManual = workflow.workflowId.startsWith(
+        "production_check_manual_"
+      );
+      runs.push({
+        workflowId: workflow.workflowId,
+        runId: workflow.runId ?? "",
+        timestamp: checkResult.timestamp,
+        status: checkResult.status,
+        errorMessage: checkResult.errorMessage,
+        payload: checkResult.payload,
+        actionLinks: checkResult.actionLinks,
+        workflowType: isManual ? "manual" : "scheduled",
+      });
+    }
+
+    if (runs.length >= limit) {
+      break;
+    }
+  }
+
+  return runs;
+}

--- a/front/lib/production_checks/history.ts
+++ b/front/lib/production_checks/history.ts
@@ -59,7 +59,22 @@ async function getProductionCheckWorkflowResults(
         workflowInfo.workflowId,
         workflowInfo.runId
       );
-      return handle.result();
+      const result = await handle.result();
+
+      if (!Array.isArray(result)) {
+        logger.warn(
+          {
+            workflowId: workflowInfo.workflowId,
+            runId: workflowInfo.runId,
+            resultType: typeof result,
+            result,
+          },
+          "runAllChecksWorkflow returned non-array result - skipping historical workflow data"
+        );
+        return [];
+      }
+
+      return result;
     }
     case WORKFLOW_TYPE_RUN_SINGLE_CHECK: {
       const handle = client.workflow.getHandle<typeof runSingleCheckWorkflow>(

--- a/front/pages/api/poke/production-checks/[checkName]/history.ts
+++ b/front/pages/api/poke/production-checks/[checkName]/history.ts
@@ -1,0 +1,74 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { getProductionCheckHistory } from "@app/lib/production_checks/history";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import { apiError } from "@app/logger/withlogging";
+import { REGISTERED_CHECKS } from "@app/temporal/production_checks/activities";
+import type { CheckHistoryRun } from "@app/types";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+export type GetCheckHistoryResponseBody = {
+  runs: CheckHistoryRun[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetCheckHistoryResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const { checkName } = req.query;
+
+  if (!isString(checkName)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "checkName is required.",
+      },
+    });
+  }
+
+  const registeredCheck = REGISTERED_CHECKS.find((c) => c.name === checkName);
+  if (!registeredCheck) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "action_not_found",
+        message: `Check "${checkName}" not found.`,
+      },
+    });
+  }
+
+  const client = await getTemporalClientForFrontNamespace();
+  const runs = await getProductionCheckHistory(client, checkName);
+
+  return res.status(200).json({ runs });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/production-checks/index.ts
+++ b/front/pages/api/poke/production-checks/index.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import {
+  getLatestProductionCheckResults,
+  statusToSummaryStatus,
+} from "@app/lib/production_checks/history";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import { apiError } from "@app/logger/withlogging";
+import { REGISTERED_CHECKS } from "@app/temporal/production_checks/activities";
+import type { CheckSummary, CheckSummaryStatus } from "@app/types";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type GetProductionChecksResponseBody = {
+  checks: CheckSummary[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetProductionChecksResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const client = await getTemporalClientForFrontNamespace();
+  const checkResultsByName = await getLatestProductionCheckResults(client);
+
+  // Build check summaries for all registered checks
+  const checks: CheckSummary[] = REGISTERED_CHECKS.map((registeredCheck) => {
+    const latestResult = checkResultsByName.get(registeredCheck.name);
+
+    if (!latestResult) {
+      return {
+        name: registeredCheck.name,
+        everyHour: registeredCheck.everyHour,
+        status: "no-data" as const,
+        lastRun: null,
+      };
+    }
+
+    return {
+      name: registeredCheck.name,
+      everyHour: registeredCheck.everyHour,
+      status: statusToSummaryStatus(latestResult.status),
+      lastRun: {
+        timestamp: latestResult.timestamp,
+        errorMessage: latestResult.errorMessage,
+        payload: latestResult.payload,
+        actionLinks: latestResult.actionLinks,
+      },
+    };
+  });
+
+  // Sort: alerts first, then ok, then no-data
+  const statusOrder: Record<CheckSummaryStatus, number> = {
+    alert: 0,
+    ok: 1,
+    "no-data": 2,
+  };
+  checks.sort((a, b) => statusOrder[a.status] - statusOrder[b.status]);
+
+  return res.status(200).json({ checks });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/production-checks/run.ts
+++ b/front/pages/api/poke/production-checks/run.ts
@@ -1,0 +1,77 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import { startManualCheckWorkflow } from "@app/temporal/production_checks/client";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type RunProductionCheckResponseBody = {
+  workflowId: string;
+  checkName: string;
+};
+
+const RunCheckRequestSchema = t.type({
+  checkName: t.string,
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<RunProductionCheckResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const bodyValidation = RunCheckRequestSchema.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  const { checkName } = bodyValidation.right;
+
+  const result = await startManualCheckWorkflow(checkName);
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: result.error.message,
+      },
+    });
+  }
+
+  return res.status(200).json({ workflowId: result.value, checkName });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/production-checks/run.ts
+++ b/front/pages/api/poke/production-checks/run.ts
@@ -62,8 +62,9 @@ async function handler(
 
   const result = await startManualCheckWorkflow(checkName);
   if (result.isErr()) {
+    const isUnknownCheck = result.error.message.startsWith("Unknown check:");
     return apiError(req, res, {
-      status_code: 400,
+      status_code: isUnknownCheck ? 400 : 500,
       api_error: {
         type: "invalid_request_error",
         message: result.error.message,

--- a/front/temporal/production_checks/client.ts
+++ b/front/temporal/production_checks/client.ts
@@ -6,7 +6,7 @@ import type { Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 
 import { REGISTERED_CHECKS } from "./activities";
-import { QUEUE_NAME } from "./config";
+import { MANUAL_CHECK_WORKFLOW_ID_PREFIX, QUEUE_NAME } from "./config";
 import { runAllChecksWorkflow, runSingleCheckWorkflow } from "./workflows";
 
 export async function launchProductionChecksWorkflow(): Promise<
@@ -62,7 +62,7 @@ export async function startManualCheckWorkflow(
   }
 
   const client = await getTemporalClientForFrontNamespace();
-  const workflowId = `production_check_manual_${checkName}_${Date.now()}`;
+  const workflowId = `${MANUAL_CHECK_WORKFLOW_ID_PREFIX}${checkName}_${Date.now()}`;
 
   try {
     await client.workflow.start(runSingleCheckWorkflow, {

--- a/front/temporal/production_checks/config.ts
+++ b/front/temporal/production_checks/config.ts
@@ -1,2 +1,18 @@
 const QUEUE_VERSION = 1;
 export const QUEUE_NAME = `production_checks-v${QUEUE_VERSION}`;
+
+export const WORKFLOW_TYPE_RUN_ALL_CHECKS = "runAllChecksWorkflow";
+export const WORKFLOW_TYPE_RUN_SINGLE_CHECK = "runSingleCheckWorkflow";
+
+export type ProductionCheckWorkflowType =
+  | typeof WORKFLOW_TYPE_RUN_ALL_CHECKS
+  | typeof WORKFLOW_TYPE_RUN_SINGLE_CHECK;
+
+export function isProductionCheckWorkflowType(
+  type: string | undefined
+): type is ProductionCheckWorkflowType {
+  return (
+    type === WORKFLOW_TYPE_RUN_ALL_CHECKS ||
+    type === WORKFLOW_TYPE_RUN_SINGLE_CHECK
+  );
+}

--- a/front/temporal/production_checks/config.ts
+++ b/front/temporal/production_checks/config.ts
@@ -3,6 +3,7 @@ export const QUEUE_NAME = `production_checks-v${QUEUE_VERSION}`;
 
 export const WORKFLOW_TYPE_RUN_ALL_CHECKS = "runAllChecksWorkflow";
 export const WORKFLOW_TYPE_RUN_SINGLE_CHECK = "runSingleCheckWorkflow";
+export const MANUAL_CHECK_WORKFLOW_ID_PREFIX = "production_check_manual_";
 
 export type ProductionCheckWorkflowType =
   | typeof WORKFLOW_TYPE_RUN_ALL_CHECKS

--- a/front/types/production_checks.ts
+++ b/front/types/production_checks.ts
@@ -65,3 +65,28 @@ export interface CheckActivityResult {
   errorMessage: string | null;
   actionLinks: ActionLink[];
 }
+
+export type CheckSummaryStatus = "ok" | "alert" | "no-data";
+
+export interface CheckSummary {
+  name: string;
+  everyHour: number;
+  status: CheckSummaryStatus;
+  lastRun: {
+    timestamp: string;
+    errorMessage: string | null;
+    payload: unknown;
+    actionLinks: ActionLink[];
+  } | null;
+}
+
+export interface CheckHistoryRun {
+  workflowId: string;
+  runId: string;
+  timestamp: string;
+  status: CheckResultStatus;
+  errorMessage: string | null;
+  payload: unknown;
+  actionLinks: ActionLink[];
+  workflowType: "manual" | "scheduled";
+}


### PR DESCRIPTION
## Description

Add poke api to retrieve production checks from temporal workflow runs and run a single check

## Tests

Tested through https://github.com/dust-tt/dust/pull/19485

## Risk

Low
Blast radius : unused poke api

## Deploy Plan

- [ ] Deploy front