### PR TITLE
[front] - fix(analytics_queue): store MCP server configuration id

### DIFF
--- a/front/lib/analytics/indices/agent_document_outputs_1.mappings.json
+++ b/front/lib/analytics/indices/agent_document_outputs_1.mappings.json
@@ -19,7 +19,7 @@
       "type": "date"
     },
     "mcp_server_configuration_id": {
-      "type": "keyword"
+      "type": "integer"
     },
     "mcp_server_name": {
       "type": "keyword"

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -425,7 +425,7 @@ async function extractRetrievalDocuments(
 
       partialDocuments.push({
         ...baseDocument,
-        mcp_server_configuration_id: config.sId,
+        mcp_server_configuration_id: config.id.toString(),
         mcp_server_name: mcpServerName,
         data_source_view_id: dataSourceViewId,
         data_source_id: dataSourceId,


### PR DESCRIPTION
## Description

This PR changes `mcp_server_configuration_id` from `config.sId` to string using `config.id.toString()` ensuring stable configuration pointer.

## Tests

Locally

## Risk

Low - behind FF

## Deploy Plan

Deploy front