### PR TITLE
[front] chore(agent-loop): add max number of retries

### DIFF
--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -6,7 +6,6 @@ import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import logger from "@app/logger/logger";
 import { logAgentLoopStepStart } from "@app/temporal/agent_loop/activities/instrumentation";
 import type { ActionBlob } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_tool_actions";
@@ -76,9 +75,7 @@ export async function runModelAndCreateActionsActivity({
     }
   }
 
-  // Otherwise, run both activities.
-  const localLogger = logger.child({ step });
-  localLogger.info("Running model and creating actions - normal path");
+  // Otherwise, run the model and create actions.
 
   // Track step content IDs by function call ID for later use in actions.
   const functionCallStepContentIds: Record<string, ModelId> = {};

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -34,6 +34,8 @@ const toolActivityStartToCloseTimeout = `${DEFAULT_MCP_REQUEST_TIMEOUT_MS / 1000
 export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60_000;
 const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60_000;
 
+export const RUN_MODEL_MAX_RETRIES = 10;
+
 import {
   OpenTelemetryInboundInterceptor,
   OpenTelemetryInternalsInterceptor,
@@ -52,6 +54,9 @@ const { runModelAndCreateActionsActivity } = proxyActivities<
 >({
   startToCloseTimeout: "10 minutes",
   heartbeatTimeout: MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
+  retry: {
+    maximumAttempts: RUN_MODEL_MAX_RETRIES,
+  },
 });
 
 const { runToolActivity } = proxyActivities<typeof runToolActivities>({


### PR DESCRIPTION
## Description

- This PR adds a sane max number of retries on `runModelAndCreateActionsActivity`.
- Also removes an unused log `Running model and creating actions - normal path` that is always redundant with `Starting multi-action loop iteration` and was used during the move from the sync loop to the async loop.

## Tests

- Tested locally with a debug throw in the middle of `runModelActivity`.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
