### PR TITLE
Convo creator can delete it

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -24,7 +24,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import {
   useConversationParticipants,
-  useConversationParticipationOption,
+  useConversationParticipationOptions,
   useJoinConversation,
 } from "@app/lib/swr/conversations";
 import { useUser } from "@app/lib/swr/user";
@@ -137,7 +137,7 @@ export function ConversationMenu({
 
   const shouldWaitBeforeFetching =
     activeConversationId === null || user?.sId === undefined || !isOpen;
-  const conversationParticipationOptions = useConversationParticipationOption({
+  const conversationParticipationOptions = useConversationParticipationOptions({
     ownerId: owner.sId,
     conversationId: activeConversationId,
     userId: user?.sId ?? null,

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -137,7 +137,7 @@ export function ConversationMenu({
 
   const shouldWaitBeforeFetching =
     activeConversationId === null || user?.sId === undefined || !isOpen;
-  const conversationParticipationOption = useConversationParticipationOption({
+  const conversationParticipationOptions = useConversationParticipationOption({
     ownerId: owner.sId,
     conversationId: activeConversationId,
     userId: user?.sId ?? null,
@@ -170,13 +170,16 @@ export function ConversationMenu({
       : undefined;
 
   const doDelete = useDeleteConversation(owner);
-  const leaveOrDelete = useCallback(async () => {
-    const res = await doDelete(conversation);
-    // eslint-disable-next-line no-unused-expressions
-    isConversationDisplayed &&
-      res &&
-      void router.push(getConversationRoute(owner.sId));
-  }, [conversation, doDelete, owner.sId, router, isConversationDisplayed]);
+  const leaveOrDelete = useCallback(
+    async (forceDelete: boolean = false) => {
+      const res = await doDelete(conversation, forceDelete);
+      // eslint-disable-next-line no-unused-expressions
+      isConversationDisplayed &&
+        res &&
+        void router.push(getConversationRoute(owner.sId));
+    },
+    [conversation, doDelete, owner.sId, router, isConversationDisplayed]
+  );
 
   const copyConversationLink = useCallback(async () => {
     await navigator.clipboard.writeText(shareLink ?? "");
@@ -188,34 +191,38 @@ export function ConversationMenu({
   }
 
   const ConversationActionMenuItem = () => {
-    switch (conversationParticipationOption) {
-      case "delete":
-        return (
-          <DropdownMenuItem
-            label="Delete"
-            onClick={() => setShowDeleteDialog(true)}
-            icon={TrashIcon}
-          />
-        );
-      case "leave":
-        return (
-          <DropdownMenuItem
-            label="Leave"
-            onClick={() => setShowLeaveDialog(true)}
-            icon={XMarkIcon}
-          />
-        );
-      case "join":
-        return (
-          <DropdownMenuItem
-            label="Join"
-            onClick={joinConversation}
-            icon={PlusCircleIcon}
-          />
-        );
-      default:
-        return null;
-    }
+    return conversationParticipationOptions.map(
+      (conversationParticipationOption) => {
+        switch (conversationParticipationOption) {
+          case "delete":
+            return (
+              <DropdownMenuItem
+                label="Delete"
+                onClick={() => setShowDeleteDialog(true)}
+                icon={TrashIcon}
+              />
+            );
+          case "leave":
+            return (
+              <DropdownMenuItem
+                label="Leave"
+                onClick={() => setShowLeaveDialog(true)}
+                icon={XMarkIcon}
+              />
+            );
+          case "join":
+            return (
+              <DropdownMenuItem
+                label="Join"
+                onClick={joinConversation}
+                icon={PlusCircleIcon}
+              />
+            );
+          default:
+            return null;
+        }
+      }
+    );
   };
 
   return (
@@ -230,7 +237,7 @@ export function ConversationMenu({
         onClose={() => setShowDeleteDialog(false)}
         onDelete={() => {
           setShowDeleteDialog(false);
-          void leaveOrDelete();
+          void leaveOrDelete(true);
         }}
       />
       <LeaveConversationDialog

--- a/front/hooks/useDeleteConversation.ts
+++ b/front/hooks/useDeleteConversation.ts
@@ -18,14 +18,15 @@ export function useDeleteConversation(owner: LightWorkspaceType) {
 
   return useCallback(
     async (
-      conversation: ConversationWithoutContentType | null
+      conversation: ConversationWithoutContentType | null,
+      forceDelete: boolean = false
     ): Promise<boolean> => {
       if (!conversation) {
         return false;
       }
 
       const res = await clientFetch(
-        `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}`,
+        `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}?forceDelete=${forceDelete}`,
         {
           method: "DELETE",
         }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -215,7 +215,7 @@ export async function deleteOrLeaveConversation(
   }
 
   let isConversationCreator = false;
-  const isCreatorRes = await conversation.isUserCreator(auth);
+  const isCreatorRes = await conversation.isConversationCreator(auth);
   if (!isCreatorRes.isErr()) {
     isConversationCreator = isCreatorRes.value;
   }
@@ -230,6 +230,16 @@ export async function deleteOrLeaveConversation(
     (leaveRes.value.affectedCount === 0 && leaveRes.value.wasLastMember) ||
     (forceDelete && isConversationCreator)
   ) {
+    auditLog(
+      {
+        author: user.toJSON(),
+        workspaceId: conversation.workspaceId,
+        conversationId,
+        wasLastMember: leaveRes.value.wasLastMember,
+        isConversationCreator,
+      },
+      "Conversation soft-deleted"
+    );
     await conversation.updateVisibilityToDeleted();
   }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -183,15 +183,18 @@ export async function updateConversationTitle(
 
 /**
  * Delete-or-Leave:
- * - If the user is the last participant: perform a soft-delete
+ * - If forceDelete is true and the user is the conversation creator: perform a soft-delete
+ * - If forceDelete is false and the user is the last participant: perform a soft-delete
  * - Otherwise just remove the user from the participants
  */
 export async function deleteOrLeaveConversation(
   auth: Authenticator,
   {
     conversationId,
+    forceDelete = false,
   }: {
     conversationId: string;
+    forceDelete?: boolean;
   }
 ): Promise<Result<{ success: true }, Error>> {
   const conversation = await ConversationResource.fetchById(
@@ -210,15 +213,26 @@ export async function deleteOrLeaveConversation(
   if (!user) {
     return new Err(new Error("User not authenticated."));
   }
+
+  let isConversationCreator = false;
+  const isCreatorRes = await conversation.isUserCreator(auth);
+  if (!isCreatorRes.isErr()) {
+    isConversationCreator = isCreatorRes.value;
+  }
+
   const leaveRes = await conversation.leaveConversation(auth);
   if (leaveRes.isErr()) {
     return new Err(leaveRes.error);
   }
 
-  // If the user was the last member, soft-delete the conversation.
-  if (leaveRes.value.affectedCount === 0 && leaveRes.value.wasLastMember) {
+  // If the user was the last member or it was a delete by the conversation creator, soft-delete the conversation.
+  if (
+    (leaveRes.value.affectedCount === 0 && leaveRes.value.wasLastMember) ||
+    (forceDelete && isConversationCreator)
+  ) {
     await conversation.updateVisibilityToDeleted();
   }
+
   return new Ok({ success: true });
 }
 

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -147,6 +147,7 @@ export async function fetchConversationParticipants(
       conversationId: conversation.id,
       workspaceId: owner.id,
     },
+    order: [["createdAt", "ASC"]],
   });
   const userIds = participants.map((p) => p.userId);
 
@@ -170,13 +171,14 @@ export async function fetchConversationParticipants(
       ...a,
       lastActivityAt: agentLastActivityMap.get(a.configurationId),
     })),
-    users: users.map((u) => ({
+    users: users.map((u, index) => ({
       sId: u.sId,
       fullName: u.fullName,
       pictureUrl: u.pictureUrl,
       username: u.username,
       action: userIdToAction.get(u.id) ?? "posted",
       lastActivityAt: userLastActivityMap.get(u.id),
+      isCreator: index === 0, // The current participant who was added first in the conversation is considered as the creator
     })),
   });
 }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1438,6 +1438,29 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return new Ok({ wasLastMember: remaining <= 1, affectedCount });
   }
 
+  async isUserCreator(auth: Authenticator): Promise<Result<boolean, Error>> {
+    const user = auth.user();
+    if (!user) {
+      return new Err(new Error("user_not_authenticated"));
+    }
+
+    // Get the first participant added to the conversation (the creator)
+    const firstParticipants = await ConversationParticipantModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: this.id,
+      },
+      order: [["createdAt", "ASC"]],
+    });
+
+    const firstParticipant = firstParticipants[0];
+
+    if (!firstParticipant) {
+      return new Err(new Error("No participants found for conversation"));
+    }
+    return new Ok(firstParticipant.userId === user.id);
+  }
+
   async listParticipants(
     auth: Authenticator,
     unreadOnly: boolean = false

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1438,22 +1438,22 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return new Ok({ wasLastMember: remaining <= 1, affectedCount });
   }
 
-  async isUserCreator(auth: Authenticator): Promise<Result<boolean, Error>> {
+  async isConversationCreator(
+    auth: Authenticator
+  ): Promise<Result<boolean, Error>> {
     const user = auth.user();
     if (!user) {
       return new Err(new Error("user_not_authenticated"));
     }
 
     // Get the first participant added to the conversation (the creator)
-    const firstParticipants = await ConversationParticipantModel.findAll({
+    const firstParticipant = await ConversationParticipantModel.findOne({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         conversationId: this.id,
       },
       order: [["createdAt", "ASC"]],
     });
-
-    const firstParticipant = firstParticipants[0];
 
     if (!firstParticipant) {
       return new Err(new Error("No participants found for conversation"));

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -864,7 +864,7 @@ export function useConversationMarkAsRead({
   };
 }
 
-type ConversationParticipationOption = "join" | "leave" | "delete";
+export type ConversationParticipationOption = "join" | "leave" | "delete";
 
 export const useConversationParticipationOption = ({
   ownerId,
@@ -882,13 +882,11 @@ export const useConversationParticipationOption = ({
     workspaceId: ownerId,
     options: { disabled },
   });
-  const [option, setOption] = useState<ConversationParticipationOption | null>(
-    null
-  );
+  const [options, setOptions] = useState<ConversationParticipationOption[]>([]);
 
   useEffect(() => {
     if (conversationParticipants === undefined) {
-      setOption(null);
+      setOptions([]);
       return;
     }
     const isUserParticipating =
@@ -900,12 +898,24 @@ export const useConversationParticipationOption = ({
     const isLastParticipant =
       isUserParticipating && conversationParticipants?.users.length === 1;
 
-    setOption(
-      isLastParticipant ? "delete" : isUserParticipating ? "leave" : "join"
-    );
+    const isConversationCreator =
+      userId !== null &&
+      conversationParticipants?.users.find(
+        (participant) => participant.sId === userId && participant.isCreator
+      );
+
+    if (isLastParticipant) {
+      setOptions(["delete"]);
+    } else if (isConversationCreator) {
+      setOptions(["leave", "delete"]);
+    } else if (isUserParticipating) {
+      setOptions(["leave"]);
+    } else {
+      setOptions(["join"]);
+    }
   }, [conversationParticipants, userId]);
 
-  return option;
+  return options;
 };
 
 export const useJoinConversation = ({

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -866,7 +866,7 @@ export function useConversationMarkAsRead({
 
 export type ConversationParticipationOption = "join" | "leave" | "delete";
 
-export const useConversationParticipationOption = ({
+export const useConversationParticipationOptions = ({
   ownerId,
   conversationId,
   userId,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -87,8 +87,10 @@ async function handler(
     }
 
     case "DELETE": {
+      const { forceDelete } = req.query;
       const result = await deleteOrLeaveConversation(auth, {
         conversationId: cId,
+        forceDelete: forceDelete === "true",
       });
       if (result.isErr()) {
         return apiErrorForConversation(req, res, result.error);

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -316,6 +316,7 @@ export interface UserParticipantType {
   username: string;
   action: ParticipantActionType;
   lastActivityAt?: number;
+  isCreator?: boolean;
 }
 
 export interface ConversationParticipantsType {


### PR DESCRIPTION
## Description

This PR allows the creator of a conversation to delete it even if there are still other participants.
The creator is the current participant who was added first to the conversation.

The PR is divided in two parts:
- display the right buttons depending on the participant situation (creator or not, last participant or not). To do that, we transform `conversationParticipationOptions` to an array
- distinguish the "leave" and the "delete" actions once he decided to apply one of them. To do that, a `forceDelete` has been introduced. It is sent sent by the frontend and processed by the backend.

<img width="159" height="400" alt="image" src="https://github.com/user-attachments/assets/356cf92c-6e0a-445a-8582-69f8c77bb2ff" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
