### PR TITLE
Add ability to click on user names to view their details

### DIFF
--- a/front/components/assistant/conversation/UserHandle.tsx
+++ b/front/components/assistant/conversation/UserHandle.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+interface UserHandleProps {
+  user: {
+    sId: string;
+    name: string | null;
+  };
+}
+
+export function UserHandle({ user }: UserHandleProps) {
+  const router = useRouter();
+
+  const href = {
+    pathname: router.pathname,
+    query: { ...router.query, userDetails: user.sId },
+  };
+
+  if (!user.name) {
+    return <span>Unknown User</span>;
+  }
+
+  return (
+    <Link
+      href={href}
+      shallow
+      className="max-w-[14rem] cursor-pointer truncate transition duration-200 hover:text-highlight active:text-highlight-600 sm:max-w-fit"
+    >
+      {user.name}
+    </Link>
+  );
+}

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -36,6 +36,7 @@ import {
   isTriggeredOrigin,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
+import { UserHandle } from "@app/components/assistant/conversation/UserHandle";
 import { ConfirmContext } from "@app/components/Confirm";
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
@@ -231,9 +232,22 @@ export function UserMessage({
     []
   );
 
-  const renderName = useCallback((name: string | null) => {
-    return <div>{name}</div>;
-  }, []);
+  const renderName = useCallback(
+    (name: string | null) => {
+      if (!message.user) {
+        return <div>{name}</div>;
+      }
+      return (
+        <UserHandle
+          user={{
+            sId: message.user.sId,
+            name: message.user.fullName,
+          }}
+        />
+      );
+    },
+    [message.user]
+  );
 
   const methods = useVirtuosoMethods<VirtuosoMessage>();
 


### PR DESCRIPTION
## Description

With this PR, tou can now click on a user name in the conversation to get to their details, similar to the functionality we have for agents.

<img width="261" height="100" alt="image" src="https://github.com/user-attachments/assets/cab373bf-24e3-4e89-9dd0-53415d0629b9" />
<img width="996" height="910" alt="image" src="https://github.com/user-attachments/assets/c070354e-ee18-4868-a54f-5decfce61a8e" />




## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
