### PR TITLE
Poké: Data Retention display (workspace, conversations, agents)

### DIFF
--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -8,6 +8,7 @@ import {
   PokeTableCellWithCopy,
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
+import type { DataRetentionConfig } from "@app/lib/data_retention";
 import { usePokeWorkOSDSyncStatus } from "@app/lib/swr/poke";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import type {
@@ -22,14 +23,14 @@ export function WorkspaceInfoTable({
   workspaceVerifiedDomains,
   workspaceCreationDay,
   extensionConfig,
-  workspaceRetention,
+  dataRetention,
   workosEnvironmentId,
 }: {
   owner: WorkspaceType;
   workspaceVerifiedDomains: WorkspaceDomain[];
   workspaceCreationDay: string;
   extensionConfig: ExtensionConfigurationType | null;
-  workspaceRetention: number | null;
+  dataRetention: DataRetentionConfig | undefined;
   workosEnvironmentId: string;
 }) {
   const { dsyncStatus } = usePokeWorkOSDSyncStatus({ owner });
@@ -41,9 +42,9 @@ export function WorkspaceInfoTable({
       case "configuring":
         return "warning";
       case "not_configured":
-        return "primary";
+        return "info";
       default:
-        return "primary";
+        return "info";
     }
   };
 
@@ -60,9 +61,13 @@ export function WorkspaceInfoTable({
       case "draft":
         return "blue";
       default:
-        return "primary";
+        return "info";
     }
   };
+
+  const nbAgentsWithRetention = dataRetention
+    ? Object.entries(dataRetention.agents).length
+    : 0;
 
   return (
     <div className="flex justify-between gap-3">
@@ -109,12 +114,6 @@ export function WorkspaceInfoTable({
             <PokeTableRow>
               <PokeTableCell>Creation</PokeTableCell>
               <PokeTableCell>{workspaceCreationDay}</PokeTableCell>
-            </PokeTableRow>
-            <PokeTableRow>
-              <PokeTableCell>Conversations retention</PokeTableCell>
-              <PokeTableCell>
-                {workspaceRetention ? `${workspaceRetention} days` : "❌"}
-              </PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>SSO Enforced</PokeTableCell>
@@ -176,6 +175,32 @@ export function WorkspaceInfoTable({
                   </Chip>
                 </PokeTableCell>
               </PokeTableRow>
+            )}
+            {dataRetention !== undefined && (
+              <>
+                <PokeTableRow>
+                  <PokeTableCell>✂️ Conversations retention</PokeTableCell>
+                  <PokeTableCell>
+                    {dataRetention.conversations !== null
+                      ? `${dataRetention.conversations} days inactive`
+                      : "No retention policy"}
+                  </PokeTableCell>
+                </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>✂️ Workspace retention</PokeTableCell>
+                  <PokeTableCell>
+                    {dataRetention.workspace} days post downgrade
+                  </PokeTableCell>
+                </PokeTableRow>
+                <PokeTableRow>
+                  <PokeTableCell>✂️ Agents retention</PokeTableCell>
+                  <PokeTableCell>
+                    {nbAgentsWithRetention === 0
+                      ? "No agents with policies"
+                      : `${nbAgentsWithRetention} with policies`}
+                  </PokeTableCell>
+                </PokeTableRow>
+              </>
             )}
           </PokeTableBody>
         </PokeTable>

--- a/front/lib/api/poke/plugins/workspaces/conversations_retention.ts
+++ b/front/lib/api/poke/plugins/workspaces/conversations_retention.ts
@@ -1,5 +1,5 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { getWorkspaceDataRetention } from "@app/lib/data_retention";
+import { getConversationsDataRetention } from "@app/lib/data_retention";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { Err, Ok } from "@app/types";
 
@@ -20,7 +20,7 @@ export const conversationsRetentionPlugin = createPlugin({
     },
   },
   populateAsyncArgs: async (auth) => {
-    const retentionDays = await getWorkspaceDataRetention(auth);
+    const retentionDays = await getConversationsDataRetention(auth);
 
     return new Ok({
       retentionDays: retentionDays ?? -1,

--- a/front/lib/data_retention.ts
+++ b/front/lib/data_retention.ts
@@ -1,10 +1,19 @@
 import assert from "assert";
+import isNumber from "lodash/isNumber";
 
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataRetentionModel } from "@app/lib/models/agent/agent_data_retention";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 
-export const getWorkspaceDataRetention = async (
+const WORKSPACE_DEFAULT_RETENTION_DAYS = 30;
+
+export type DataRetentionConfig = {
+  workspace: number;
+  conversations: number | null;
+  agents: Record<string, number>;
+};
+
+export const getConversationsDataRetention = async (
   auth: Authenticator
 ): Promise<number | null> => {
   const workspace = auth.getNonNullableWorkspace();
@@ -29,4 +38,20 @@ export const getAgentsDataRetention = async (
     acc[retention.agentConfigurationId] = retention.retentionDays;
     return acc;
   }, {});
+};
+
+export const getWorkspaceDataRetention = async (
+  auth: Authenticator
+): Promise<number> => {
+  const workspace = auth.getNonNullableWorkspace();
+  const customRetention = workspace.metadata?.workspaceRetentionDays;
+
+  if (
+    isNumber(customRetention) &&
+    customRetention >= 0 &&
+    customRetention <= 1000
+  ) {
+    return customRetention;
+  }
+  return WORKSPACE_DEFAULT_RETENTION_DAYS;
 };

--- a/front/pages/api/poke/workspaces/[wId]/data_retention.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_retention.ts
@@ -2,8 +2,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
+import type { DataRetentionConfig } from "@app/lib/data_retention";
 import {
   getAgentsDataRetention,
+  getConversationsDataRetention,
   getWorkspaceDataRetention,
 } from "@app/lib/data_retention";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -11,10 +13,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
 export type PokeGetDataRetentionResponseBody = {
-  data: {
-    workspace: number | null;
-    agents: Record<string, number>;
-  };
+  data: DataRetentionConfig;
 };
 
 async function handler(
@@ -50,11 +49,13 @@ async function handler(
   }
 
   const workspaceRetention = await getWorkspaceDataRetention(auth);
+  const convosRetention = await getConversationsDataRetention(auth);
   const agentsRetention = await getAgentsDataRetention(auth);
 
   const response: PokeGetDataRetentionResponseBody = {
     data: {
       workspace: workspaceRetention,
+      conversations: convosRetention,
       agents: agentsRetention,
     },
   };

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -205,7 +205,6 @@ const WorkspacePage = ({
     disabled: false,
   });
 
-  const workspaceRetention = dataRetention?.workspace ?? null;
   const agentsRetention = dataRetention?.agents ?? {};
   const isInMaintenance = owner.metadata?.maintenance;
 
@@ -278,7 +277,7 @@ const WorkspacePage = ({
                   workspaceVerifiedDomains={workspaceVerifiedDomains}
                   workspaceCreationDay={workspaceCreationDay}
                   extensionConfig={extensionConfig}
-                  workspaceRetention={workspaceRetention}
+                  dataRetention={dataRetention}
                   workosEnvironmentId={workosEnvironmentId}
                 />
               </TabsContent>

--- a/front/temporal/scrub_workspace/config.ts
+++ b/front/temporal/scrub_workspace/config.ts
@@ -4,5 +4,5 @@ export const QUEUE_NAME = `scrub-workspace-queue-v${QUEUE_VERSION}`;
 export const DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID =
   "downgrade-and-scrub-free-ended-workspaces";
 
-export const DATA_RETENTION_PERIOD_IN_DAYS = 30;
+export const DATA_RETENTION_PERIOD_IN_DAYS = 30; // To be deprecated soon by calling getWorkspaceDataRetention
 export const LAST_EMAIL_BEFORE_SCRUB_IN_DAYS = 3;


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/5589

We currently support specific retentions for conversations and agents. 
We want to add support for workspace retention configuration. 
We'll use the workspace metadata, in a field called `workspaceRetentionDays`.

This PR properly displays on Poké the 3 types of retention: 

<kbd>
<img width="409" height="616" alt="Screenshot 2025-12-29 at 19 26 31" src="https://github.com/user-attachments/assets/d0af8ed8-1fcf-4798-b6ff-0765be658da1" />
</kbd>

Next PRs are: 
- Update the scrub workspace workflow to use the new `workspaceRetentionDays`. 
- Let Poké users edit the workspace data retention with a new poké plugin. 


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 